### PR TITLE
sql/pgwire: send placeholder BackendKeyData

### DIFF
--- a/pkg/ccl/sqlproxyccl/authentication.go
+++ b/pkg/ccl/sqlproxyccl/authentication.go
@@ -49,6 +49,9 @@ func authenticate(clientConn, crdbConn net.Conn) error {
 		case *pgproto3.ParameterStatus:
 			// Server sent status message; keep reading messages until
 			// `pgproto3.ReadyForQuery` is encountered.
+		case *pgproto3.BackendKeyData:
+		// Server sent backend key data; keep reading messages until
+		// `pgproto3.ReadyForQuery` is encountered.
 		case *pgproto3.ErrorResponse:
 			// Server has rejected the authentication response from the client and
 			// has closed the connection.

--- a/pkg/ccl/sqlproxyccl/authentication_test.go
+++ b/pkg/ccl/sqlproxyccl/authentication_test.go
@@ -108,11 +108,11 @@ func TestAuthenticateUnexpectedMessage(t *testing.T) {
 	fe := pgproto3.NewFrontend(pgproto3.NewChunkReader(cli), cli)
 
 	go func() {
-		err := be.Send(&pgproto3.BackendKeyData{})
+		err := be.Send(&pgproto3.BindComplete{})
 		require.NoError(t, err)
 		beMsg, err := fe.Receive()
 		require.NoError(t, err)
-		require.Equal(t, beMsg, &pgproto3.BackendKeyData{})
+		require.Equal(t, beMsg, &pgproto3.BindComplete{})
 	}()
 
 	err := authenticate(srv, cli)

--- a/pkg/sql/pgwire/pgwirebase/msg.go
+++ b/pkg/sql/pgwire/pgwirebase/msg.go
@@ -37,6 +37,7 @@ const (
 	ClientMsgTerminate   ClientMessageType = 'X'
 
 	ServerMsgAuth                 ServerMessageType = 'R'
+	ServerMsgBackendKeyData       ServerMessageType = 'K'
 	ServerMsgBindComplete         ServerMessageType = '2'
 	ServerMsgCommandComplete      ServerMessageType = 'C'
 	ServerMsgCloseComplete        ServerMessageType = '3'

--- a/pkg/sql/pgwire/pgwirebase/servermessagetype_string.go
+++ b/pkg/sql/pgwire/pgwirebase/servermessagetype_string.go
@@ -9,6 +9,7 @@ func _() {
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
 	_ = x[ServerMsgAuth-82]
+	_ = x[ServerMsgBackendKeyData-75]
 	_ = x[ServerMsgBindComplete-50]
 	_ = x[ServerMsgCommandComplete-67]
 	_ = x[ServerMsgCloseComplete-51]
@@ -31,18 +32,19 @@ const (
 	_ServerMessageType_name_1 = "ServerMsgCommandCompleteServerMsgDataRowServerMsgErrorResponse"
 	_ServerMessageType_name_2 = "ServerMsgCopyInResponse"
 	_ServerMessageType_name_3 = "ServerMsgEmptyQuery"
-	_ServerMessageType_name_4 = "ServerMsgNoticeResponse"
-	_ServerMessageType_name_5 = "ServerMsgAuthServerMsgParameterStatusServerMsgRowDescription"
-	_ServerMessageType_name_6 = "ServerMsgReady"
-	_ServerMessageType_name_7 = "ServerMsgNoData"
-	_ServerMessageType_name_8 = "ServerMsgPortalSuspendedServerMsgParameterDescription"
+	_ServerMessageType_name_4 = "ServerMsgBackendKeyData"
+	_ServerMessageType_name_5 = "ServerMsgNoticeResponse"
+	_ServerMessageType_name_6 = "ServerMsgAuthServerMsgParameterStatusServerMsgRowDescription"
+	_ServerMessageType_name_7 = "ServerMsgReady"
+	_ServerMessageType_name_8 = "ServerMsgNoData"
+	_ServerMessageType_name_9 = "ServerMsgPortalSuspendedServerMsgParameterDescription"
 )
 
 var (
 	_ServerMessageType_index_0 = [...]uint8{0, 22, 43, 65}
 	_ServerMessageType_index_1 = [...]uint8{0, 24, 40, 62}
-	_ServerMessageType_index_5 = [...]uint8{0, 13, 37, 60}
-	_ServerMessageType_index_8 = [...]uint8{0, 24, 53}
+	_ServerMessageType_index_6 = [...]uint8{0, 13, 37, 60}
+	_ServerMessageType_index_9 = [...]uint8{0, 24, 53}
 )
 
 func (i ServerMessageType) String() string {
@@ -57,18 +59,20 @@ func (i ServerMessageType) String() string {
 		return _ServerMessageType_name_2
 	case i == 73:
 		return _ServerMessageType_name_3
-	case i == 78:
+	case i == 75:
 		return _ServerMessageType_name_4
+	case i == 78:
+		return _ServerMessageType_name_5
 	case 82 <= i && i <= 84:
 		i -= 82
-		return _ServerMessageType_name_5[_ServerMessageType_index_5[i]:_ServerMessageType_index_5[i+1]]
+		return _ServerMessageType_name_6[_ServerMessageType_index_6[i]:_ServerMessageType_index_6[i+1]]
 	case i == 90:
-		return _ServerMessageType_name_6
-	case i == 110:
 		return _ServerMessageType_name_7
+	case i == 110:
+		return _ServerMessageType_name_8
 	case 115 <= i && i <= 116:
 		i -= 115
-		return _ServerMessageType_name_8[_ServerMessageType_index_8[i]:_ServerMessageType_index_8[i+1]]
+		return _ServerMessageType_name_9[_ServerMessageType_index_9[i]:_ServerMessageType_index_9[i+1]]
 	default:
 		return "ServerMessageType(" + strconv.FormatInt(int64(i), 10) + ")"
 	}


### PR DESCRIPTION
fixes #13191 

Some tools expect this message to be returned at connection time and
will not connect without it. CockroachDB does not support pgwire
cancellation, but we can still send a placeholder value here, and
continue ignoring cancellation requests like we already do.

Added a small test to make sure nothing broke.

Release note (sql change): When a connection is established, CockroachDB
will now return a placeholder BackendKeyData message in the response.
This is for compatibility with some tools, but using the BackendKeyData
to cancel a query will still have no effect, just the same as before.

