### PR TITLE
delegate: gate estimated_row_count on SHOW TABLES behind cluster setting

### DIFF
--- a/pkg/sql/delegate/BUILD.bazel
+++ b/pkg/sql/delegate/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/keys",
+        "//pkg/settings",
         "//pkg/sql/catalog/catconstants",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/lex",

--- a/pkg/sql/logictest/testdata/logic_test/show_tables
+++ b/pkg/sql/logictest/testdata/logic_test/show_tables
@@ -1,0 +1,17 @@
+# LogicTest: local
+
+statement ok
+SET CLUSTER SETTING sql.show_tables.estimated_row_count.enabled = false
+
+statement ok
+CREATE TABLE show_this_table()
+
+query TTTTT
+SHOW TABLES
+----
+public  show_this_table  table  root  NULL
+
+query TTTTTT
+SHOW TABLES WITH COMMENT
+----
+public  show_this_table  table  root  NULL  ·


### PR DESCRIPTION
 Refs: #58189

Release note (sql change): Introduced a cluster setting
sql.show_tables.estimated_row_count.enabled, which defaults to true. If
false, estimated_row_count will not display on SHOW TABLES which
improves performance.