### PR TITLE
colexec: partially fix memory accounting in the external sorter

### DIFF
--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -376,7 +376,12 @@ func (b *Bytes) Size() uintptr {
 // ProportionalSize returns the size of the receiver in bytes that is
 // attributed to only first n out of Len() elements.
 func (b *Bytes) ProportionalSize(n int64) uintptr {
-	return FlatBytesOverhead + uintptr(len(b.data[:b.offsets[n]])) + uintptr(n)*sizeOfInt32
+	if n == 0 {
+		return 0
+	}
+	// It is possible that we have a "window" into the vector that doesn't start
+	// from the offset of 0, so we have to look at the first actual offset.
+	return FlatBytesOverhead + uintptr(len(b.data[b.offsets[0]:b.offsets[n]])) + uintptr(n)*sizeOfInt32
 }
 
 var zeroInt32Slice = make([]int32, BytesInitialAllocationFactor*BatchSize())

--- a/pkg/sql/colexec/external_hash_joiner_test.go
+++ b/pkg/sql/colexec/external_hash_joiner_test.go
@@ -163,8 +163,11 @@ func TestExternalHashJoinerFallbackToSortMergeJoin(t *testing.T) {
 	// of 0.
 	hj, accounts, monitors, _, err := createDiskBackedHashJoiner(
 		ctx, flowCtx, spec, []colexecbase.Operator{leftSource, rightSource},
-		func() { spilled = true }, queueCfg, 0 /* numForcedRepartitions */, true, /* delegateFDAcquisitions */
-		sem,
+		func() { spilled = true }, queueCfg,
+		// Force a repartition so that the recursive repartitioning always
+		// occurs.
+		1, /* numForcedRepartitions */
+		true /* delegateFDAcquisitions */, sem,
 	)
 	defer func() {
 		for _, acc := range accounts {

--- a/pkg/sql/colexec/external_sort.go
+++ b/pkg/sql/colexec/external_sort.go
@@ -227,6 +227,12 @@ func NewExternalSorter(
 		// acquiring.
 		partitionedDiskQueueSemaphore = nil
 	}
+	if memoryLimit == 1 {
+		// If memory limit is 1, we're likely in a "force disk spill"
+		// scenario, but we don't want to artificially limit batches when we
+		// have already spilled, so we'll use a larger limit.
+		memoryLimit = defaultMemoryLimit
+	}
 	es := &externalSorter{
 		OneInputNode:       NewOneInputNode(inMemSorter),
 		unlimitedAllocator: unlimitedAllocator,

--- a/pkg/sql/colexec/external_sort.go
+++ b/pkg/sql/colexec/external_sort.go
@@ -158,12 +158,6 @@ var _ closableOperator = &externalSorter{}
 // from an unlimited memory monitor. It will be used by several internal
 // components of the external sort which is responsible for making sure that
 // the components stay within the memory limit.
-// - standaloneMemAccount must be a memory account derived from an unlimited
-// memory monitor with a standalone budget. It will be used by
-// inputPartitioningOperator to "partition" the input according to memory
-// limit. The budget *must* be standalone because we don't want to double
-// count the memory (the memory under the batches will be accounted for with
-// the unlimitedAllocator).
 // - maxNumberPartitions (when non-zero) overrides the semi-dynamically
 // computed maximum number of partitions to have at once.
 // - numForcedMerges (when non-zero) specifies the number of times the repeated
@@ -174,7 +168,6 @@ var _ closableOperator = &externalSorter{}
 // them up front in Next. This should only be true in tests.
 func NewExternalSorter(
 	unlimitedAllocator *colmem.Allocator,
-	standaloneMemAccount *mon.BoundAccount,
 	input colexecbase.Operator,
 	inputTypes []*types.T,
 	ordering execinfrapb.Ordering,
@@ -211,7 +204,7 @@ func NewExternalSorter(
 		// a zero-length batch, so make it at least 1.
 		singlePartitionSize = 1
 	}
-	inputPartitioner := newInputPartitioningOperator(input, standaloneMemAccount, singlePartitionSize)
+	inputPartitioner := newInputPartitioningOperator(input, singlePartitionSize)
 	inMemSorter, err := newSorter(
 		unlimitedAllocator, newAllSpooler(unlimitedAllocator, inputPartitioner, inputTypes),
 		inputTypes, ordering.Columns,
@@ -460,24 +453,26 @@ func (s *externalSorter) createMergerForPartitions(
 }
 
 func newInputPartitioningOperator(
-	input colexecbase.Operator, standaloneMemAccount *mon.BoundAccount, memoryLimit int64,
+	input colexecbase.Operator, memoryLimit int64,
 ) ResettableOperator {
 	return &inputPartitioningOperator{
-		OneInputNode:         NewOneInputNode(input),
-		standaloneMemAccount: standaloneMemAccount,
-		memoryLimit:          memoryLimit,
+		OneInputNode: NewOneInputNode(input),
+		memoryLimit:  memoryLimit,
 	}
 }
 
 // inputPartitioningOperator is an operator that returns the batches from its
-// input until the standalone allocator reaches the memory limit. From that
-// point, the operator returns a zero-length batch (until it is reset).
+// input until the memory footprint of all emitted batches reaches the memory
+// limit. From that point, the operator returns a zero-length batch (until it is
+// reset).
 type inputPartitioningOperator struct {
 	OneInputNode
 	NonExplainable
 
-	standaloneMemAccount *mon.BoundAccount
-	memoryLimit          int64
+	// memoryLimit determines the size of each partition.
+	memoryLimit int64
+	// alreadyUsedMemory tracks the size of the current partition so far.
+	alreadyUsedMemory int64
 	// interceptReset determines whether the reset method will be called on
 	// the input to this operator when the latter is being reset. This field is
 	// managed by externalSorter.
@@ -486,7 +481,7 @@ type inputPartitioningOperator struct {
 	//
 	// The reason for having this knob is that we need two kinds of behaviors
 	// when resetting the inputPartitioningOperator:
-	// 1. ("shallow" reset) we need to clear the memory account because the
+	// 1. ("shallow" reset) we need to reset alreadyUsedMemory because the
 	// external sorter is moving on spilling the data into a new partition.
 	// However, we *cannot* propagate the reset further up because it might
 	// delete the data that the external sorter has not yet spilled. This
@@ -505,25 +500,20 @@ func (o *inputPartitioningOperator) Init() {
 }
 
 func (o *inputPartitioningOperator) Next(ctx context.Context) coldata.Batch {
-	if o.standaloneMemAccount.Used() >= o.memoryLimit {
+	if o.alreadyUsedMemory >= o.memoryLimit {
 		return coldata.ZeroBatch
 	}
 	b := o.input.Next(ctx)
 	if b.Length() == 0 {
 		return b
 	}
-	// We cannot use Allocator.RetainBatch here because that method looks at the
-	// capacities of the vectors. However, this operator is an input to sortOp
-	// which will spool all the tuples and buffer them (by appending into the
-	// buffered batch), so we need to account for memory proportionally to the
-	// length of the batch. (Note: this is not exactly true for Bytes type, but
-	// it's ok if we have some deviation. This numbers matter only to understand
-	// when to start a new partition, and the memory will be actually accounted
-	// for correctly.)
-	batchMemSize := colmem.GetProportionalBatchMemSize(b, int64(b.Length()))
-	if err := o.standaloneMemAccount.Grow(ctx, batchMemSize); err != nil {
-		colexecerror.InternalError(err)
-	}
+	// This operator is an input to sortOp which will spool all the tuples and
+	// buffer them (by appending into the buffered batch), so we need to account
+	// for memory proportionally to the length of the batch. (Note: this is not
+	// exactly true for Bytes type, but it's ok if we have some deviation. This
+	// numbers matter only to understand when to start a new partition, and the
+	// memory will be actually accounted for correctly.)
+	o.alreadyUsedMemory += colmem.GetProportionalBatchMemSize(b, int64(b.Length()))
 	return b
 }
 
@@ -534,10 +524,10 @@ func (o *inputPartitioningOperator) reset(ctx context.Context) {
 		}
 	}
 	o.interceptReset = false
-	o.standaloneMemAccount.Clear(ctx)
+	o.alreadyUsedMemory = 0
 }
 
 func (o *inputPartitioningOperator) Close(ctx context.Context) error {
-	o.standaloneMemAccount.Clear(ctx)
+	o.alreadyUsedMemory = 0
 	return nil
 }

--- a/pkg/sql/colexec/external_sort.go
+++ b/pkg/sql/colexec/external_sort.go
@@ -534,7 +534,7 @@ func (o *inputPartitioningOperator) reset(ctx context.Context) {
 		}
 	}
 	o.interceptReset = false
-	o.standaloneMemAccount.Shrink(ctx, o.standaloneMemAccount.Used())
+	o.standaloneMemAccount.Clear(ctx)
 }
 
 func (o *inputPartitioningOperator) Close(ctx context.Context) error {

--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -342,14 +342,14 @@ func TestExternalSortMemoryAccounting(t *testing.T) {
 	// In an ideal world:
 	// - all of the memory would be accounted for (this is not done at the
 	//   moment)
-	// - no memory is double-counted (this is not done at the moment)
+	// - no memory is double-counted
 	// - the reported usage is very close to 2 x memoryLimit (the monitor for
 	//   the in-memory sorter reports slightly below and the monitor for the
 	//   external sorter reports slightly above memoryLimit usage).
 	// TODO(yuzefovich): fix known deficiencies of the memory accounting and
 	// tighten the bounds.
 	expMin := memoryLimit * 3 / 2
-	expMax := memoryLimit * 4
+	expMax := memoryLimit * 3
 	require.GreaterOrEqualf(t, totalMaxMemUsage, expMin, "minimum memory bound not satisfied: "+
 		"actual %d, expected min %d", totalMaxMemUsage, expMin)
 	require.GreaterOrEqualf(t, expMax, totalMaxMemUsage, "maximum memory bound not satisfied: "+

--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/colcontainerutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -223,6 +224,146 @@ func TestExternalSortRandomized(t *testing.T) {
 	}
 	for _, m := range monitors {
 		m.Stop(ctx)
+	}
+}
+
+// TestExternalSortMemoryAccounting is a sanity check for the memory accounting
+// done throughout the external sort operation. At the moment there are a lot of
+// known problems with the memory accounting, so the test is not very strict.
+// The goal of the test is to make sure that the total maximum reported memory
+// usage (as would have been collected as stats) is within reasonable range. It
+// additionally checks that the number of partitions created is as expected too.
+//
+// It is impossible to come up with the exact numbers here due to the randomness
+// of appends (which happen when setting values on Bytes vectors) and due to the
+// randomization of coldata.BatchSize() value.
+func TestExternalSortMemoryAccounting(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	skip.UnderStress(t, "the test is very memory-intensive and is likely to OOM under stress")
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+	flowCtx := &execinfra.FlowCtx{
+		EvalCtx: &evalCtx,
+		Cfg: &execinfra.ServerConfig{
+			Settings:    st,
+			DiskMonitor: testDiskMonitor,
+		},
+	}
+
+	// Use the Bytes type because we can control the size of values with it
+	// easily.
+	typs := []*types.T{types.Bytes}
+	ordCols := []execinfrapb.Ordering_Column{{ColIdx: 0}}
+
+	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
+	defer cleanup()
+
+	// TODO(yuzefovich): randomize some of these values once the memory
+	// accounting is as expected.
+	numInMemoryBufferedBatches := 8
+	// numNewPartitions determines the expected number of partitions created as
+	// a result of consuming the input (i.e. not as a result of the repeated
+	// merging).
+	numNewPartitions := 4
+	numTotalBatches := numInMemoryBufferedBatches * numNewPartitions
+	batchLength := coldata.BatchSize()
+	batch := testAllocator.NewMemBatchWithFixedCapacity(typs, batchLength)
+	// Use such a size for a single value that the memory footprint of a single
+	// batch is relatively large.
+	singleTupleSize := mon.DefaultPoolAllocationSize
+	singleTupleValue := make([]byte, singleTupleSize)
+	for i := 0; i < batchLength; i++ {
+		batch.ColVec(0).Bytes().Set(i, singleTupleValue)
+	}
+	batch.SetLength(batchLength)
+	memoryLimit := colmem.GetBatchMemSize(batch) * int64(numInMemoryBufferedBatches)
+	flowCtx.Cfg.TestingKnobs.MemoryLimitBytes = memoryLimit
+	input := newFiniteBatchSource(batch, typs, numTotalBatches)
+
+	var spilled bool
+	// TODO(yuzefovich): randomize number of available FDs.
+	sem := colexecbase.NewTestingSemaphore(ExternalSorterMinPartitions)
+	sorter, accounts, monitors, closers, err := createDiskBackedSorter(
+		ctx, flowCtx, []colexecbase.Operator{input}, typs, ordCols,
+		0 /* matchLen */, 0 /* k */, func() { spilled = true },
+		0 /* numForcedRepartitions */, false, /* delegateFDAcquisition */
+		queueCfg, sem,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(closers))
+
+	sorter.Init()
+	for b := sorter.Next(ctx); b.Length() > 0; b = sorter.Next(ctx) {
+	}
+	require.NoError(t, closers[0].Close(ctx))
+
+	require.True(t, spilled)
+	require.Zero(t, sem.GetCount(), "sem still reports open FDs")
+
+	// Currently, because of a bug in Bytes.ProportionalSize, the behavior is as
+	// follows:
+	// - all batches buffered in the in-memory sorter constitute the first
+	//   partition (often, not always)
+	// - each batch read from the input creates a new partition
+	// - two partitions are merged right away into a larger one (because of the
+	//   limit in the semaphore).
+	// TODO(yuzefovich): tighten the bounds here.
+	// In the ideal world, given the limit in the semaphore, we expect that each
+	// newly created partition contains about numInMemoryBufferedBatches number
+	// of batches with only the partition that is the result of the repeated
+	// merge growing with count as a multiple of numInMemoryBufferedBatches
+	// (first merge = 2x, second merge = 3x, third merge 4x, etc, so we expect
+	// 2*numNewPartitions-1 partitions).
+	externalSorter := sorter.(*diskSpillerBase).diskBackedOp.(*externalSorter)
+	numPartitionsCreated := externalSorter.firstPartitionIdx + externalSorter.numPartitions
+	expMinTotalPartitionsCreated := 2*numNewPartitions - 1
+	expMaxTotalPartitionsCreated := 23
+	require.GreaterOrEqualf(t, numPartitionsCreated, expMinTotalPartitionsCreated,
+		"didn't create enough partitions: actual %d, min expected %d",
+		numPartitionsCreated, expMinTotalPartitionsCreated,
+	)
+	require.GreaterOrEqualf(t, expMaxTotalPartitionsCreated, numPartitionsCreated,
+		"created too many partitions: actual %d, max expected %d",
+		numPartitionsCreated, expMaxTotalPartitionsCreated,
+	)
+
+	// Check that the monitor for the in-memory sorter reports lower than
+	// memoryLimit max usage (the allocation that would put the monitor over the
+	// limit must have been denied with OOM error).
+	require.Greater(t, memoryLimit, monitors[0].MaximumBytes())
+
+	// Use the same calculation as we have when computing stats (maximums are
+	// summed).
+	var totalMaxMemUsage int64
+	for i := range monitors {
+		totalMaxMemUsage += monitors[i].MaximumBytes()
+	}
+	// We cannot guarantee a fixed value, so we use an allowed range.
+	//
+	// In an ideal world:
+	// - all of the memory would be accounted for (this is not done at the
+	//   moment)
+	// - no memory is double-counted (this is not done at the moment)
+	// - the reported usage is very close to 2 x memoryLimit (the monitor for
+	//   the in-memory sorter reports slightly below and the monitor for the
+	//   external sorter reports slightly above memoryLimit usage).
+	// TODO(yuzefovich): fix known deficiencies of the memory accounting and
+	// tighten the bounds.
+	expMin := memoryLimit * 2
+	expMax := memoryLimit * 5
+	require.GreaterOrEqualf(t, totalMaxMemUsage, expMin, "minimum memory bound not satisfied: "+
+		"actual %d, expected min %d", totalMaxMemUsage, expMin)
+	require.GreaterOrEqualf(t, expMax, totalMaxMemUsage, "maximum memory bound not satisfied: "+
+		"actual %d, expected max %d", totalMaxMemUsage, expMax)
+
+	for i := range accounts {
+		accounts[i].Close(ctx)
+	}
+	for i := range monitors {
+		monitors[i].Stop(ctx)
 	}
 }
 

--- a/pkg/sql/colmem/allocator.go
+++ b/pkg/sql/colmem/allocator.go
@@ -86,6 +86,9 @@ func GetBatchMemSize(b coldata.Batch) int64 {
 // proportional to given 'length'. This method returns the estimated memory
 // footprint *only* of the first 'length' tuples in 'b'.
 func GetProportionalBatchMemSize(b coldata.Batch, length int64) int64 {
+	if length == 0 {
+		return 0
+	}
 	usesSel := b.Selection() != nil
 	b.SetSelection(true)
 	selCapacity := cap(b.Selection())


### PR DESCRIPTION
**colexec: speed up external operator tests**

We recently merged several changes to improve the handling of memory
limits, including by the external operators. However, this caused those
operators to use very low (1 byte) memory limits which can result in
some tests taking really long time. This commit updates the memory limit
in "force disk spill" scenarios to be the default one to speed the tests
up (this is acceptable because the limit only matters after the spilling
has already occurred).

Additionally, this commit fixes the test which exercises the fallback to
sort + merge join in the external hash joiner so that the fallback
always occurs (via forced repartitioning).

Release note: None

**colexec: add simple test of memory accounting in external sort**

This commit adds a sanity check for the memory accounting done
throughout the external sort operation. At the moment there
are a lot of known problems with the memory accounting, so the
test is not very strict. The goal of the test is to make sure
that the total maximum reported memory usage (as would have
been collected as stats) is within reasonable range. It additionally
checks that the number of partitions created is as expected too.

Release note: None

**coldata: fix ProportionalSize calculation for windows into Bytes vectors**

Previously, we were incorrectly computing `ProportionalSize` for Bytes
vectors that are actually "windows". In such cases, it is likely that
the start of the relevant chunk of data is not from the beginning of
`data` slice, but rather from the first offset value. This resulted in
incorrectly determining the size of a partition for the external sort.

The impact of this mistake is that we would report higher memory usage
by the external sorter than it actually is since all of the memory usage
registered with the standalone memory account is actually
double-counting of the memory used by the in-memory sort operator that
has just spilled because all batches are windows into the buffered batch
(i.e. we don't allocate any new memory). Therefore, the more precise
accounting we have, the lower double-counting is.

Another issue is that we would make partitions of smaller size than we
could.

Release note: None

**colexec: remove double-counting of some memory in external sort**

Previously, we would be registering the memory usage of the partition
that is currently being spilled twice:
- in a standalone memory account in `inputPartitioningOperator`, this is
needed to know when to start a new partition
- in the in-memory sorter used by the external sort to sort each
partition, this would happen during "spooling" phase.

However, the first usage is "fake" - we don't actually buffer all of the
data flowing through the input partitioning operator, so we would
effectively double-count some memory. This commit fixes that behavior by
removing the memory account altogether because a simple variable is
sufficient to determine where the partitions' boundaries are.

Release note: None