### PR TITLE
sql: fix race in type change

### DIFF
--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -209,6 +209,14 @@ func (t *typeSchemaChanger) exec(ctx context.Context) error {
 		}
 	}
 
+	// Make sure all of the leases have dropped before attempting to validate.
+	if err := WaitToUpdateLeases(ctx, leaseMgr, t.typeID); err != nil {
+		if errors.Is(err, catalog.ErrDescriptorNotFound) {
+			return nil
+		}
+		return err
+	}
+
 	// For all the read only members the current job is responsible for, either
 	// promote them to writeable or remove them from the descriptor entirely,
 	// as dictated by the direction.


### PR DESCRIPTION
Sometimes the logic test would flake like:

```
        testdata/logic_test/alter_type:375:
        expected:
        pq: could not validate enum value removal for "d": count-value-usage: enum label "d" is not yet public
        got:
        pq: could not remove enum value "d" as it is being used by "v" in row: alphabets='d'
```

This happens because the validation query ends up using the old version of the
type descriptor. FWIW this error is garbage but that's a different story.

It used to fail under stress within a minute. Now it does not.

Fixes #59849.

Release note: None