### PR TITLE
sqlsmith: fix interleaved table failures

### DIFF
--- a/pkg/internal/sqlsmith/setup.go
+++ b/pkg/internal/sqlsmith/setup.go
@@ -64,6 +64,7 @@ func randTables(r *rand.Rand) string {
 	sb.WriteString(`
 		SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;
 		SET CLUSTER SETTING sql.stats.histogram_collection.enabled = false;
+		SET CLUSTER SETTING sql.defaults.interleaved_tables.enabled = true;
 	`)
 
 	// Create the random tables.


### PR DESCRIPTION
This commit sets the `sql.defaults.interleaved_tables.enabled` session
setting to `true` during sqlsmith tests. This fixes failures in sqlsmith
tests that randomly generate interleaved tables.

Release note: None