### PR TITLE
colexec: enqueue zero batches when finishing partitions in external sort

### DIFF
--- a/pkg/sql/colcontainer/partitionedqueue.go
+++ b/pkg/sql/colcontainer/partitionedqueue.go
@@ -26,7 +26,8 @@ type PartitionedQueue interface {
 	// Enqueue adds the batch to the end of the partitionIdx'th partition. If a
 	// partition at that index does not exist, a new one is created. Existing
 	// partitions may not be Enqueued to after calling
-	// CloseAllOpenWriteFileDescriptors.
+	// CloseAllOpenWriteFileDescriptors. A zero-length batch must be enqueued as
+	// the last one.
 	// WARNING: Selection vectors are ignored.
 	Enqueue(ctx context.Context, partitionIdx int, batch coldata.Batch) error
 	// Dequeue removes and returns the batch from the front of the

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -459,15 +459,13 @@ func (r opResult) createDiskBackedSort(
 				ctx, flowCtx, monitorNamePrefix,
 			)
 			diskAccount := r.createDiskAccount(ctx, flowCtx, monitorNamePrefix)
-			if args.TestingKnobs.NumForcedRepartitions != 0 {
-				maxNumberPartitions = args.TestingKnobs.NumForcedRepartitions
-			}
 			es := colexec.NewExternalSorter(
 				unlimitedAllocator,
 				standaloneMemAccount,
 				input, inputTypes, ordering,
 				execinfra.GetWorkMemLimit(flowCtx.Cfg),
 				maxNumberPartitions,
+				args.TestingKnobs.NumForcedRepartitions,
 				args.TestingKnobs.DelegateFDAcquisitions,
 				args.DiskQueueCfg,
 				args.FDSemaphore,


### PR DESCRIPTION
**colexec: fix testing knob usage in the external sort**

Previously, we incorrectly implemented the "forced merging" testing knob
in the external sort, and this is now fixed.

Release note: None

**colexec: enqueue zero batches when finishing partitions in external sort**

Previously, we forgot to enqueue zero-length batches as the last ones in
each partition in the external sort. That is required by the contract of
the disk queue (used by the partitioned queue) and is now fixed.

Additionally, FDs are now acquired before the first call to Enqueue
(previously it would have been done before the second call).

Release note: None