### PR TITLE
colserde: precise slicing when deserializing arrow.Data

### DIFF
--- a/pkg/col/colserde/record_batch.go
+++ b/pkg/col/colserde/record_batch.go
@@ -284,7 +284,11 @@ func (s *RecordBatchSerializer) Deserialize(data *[]*array.Data, bytes []byte) (
 		buffers := make([]*memory.Buffer, s.numBuffers[fieldIdx])
 		for i := 0; i < s.numBuffers[fieldIdx]; i++ {
 			header.Buffers(&buf, bufferIdx)
-			bufData := bodyBytes[int(buf.Offset()):int(buf.Offset()+buf.Length())]
+			bufStart := buf.Offset()
+			bufEnd := bufStart + buf.Length()
+			// We need to cap the slice so that bufData's capacity doesn't
+			// extend into the data of the next buffer.
+			bufData := bodyBytes[bufStart:bufEnd:bufEnd]
 			buffers[i] = memory.NewBufferBytes(bufData)
 			bufferIdx++
 		}


### PR DESCRIPTION
When we are deserializing data from Arrow format, we have a long `[]byte`
that contains several buffers within it (either 2 or 3, depending on the
encoding format). When we have 3 buffers, the second one is used for
offsets and the third one is the actual data. Previously, when slicing
out the second buffer we would not cap it which would result in that
buffer's capacity extending into the third buffer.

This shouldn't create any issues from the perspective of GC (since the
lifecycle of both buffers is the same), but it does trip up our memory
accounting system when it is estimating the footprint of the vectors
like Bytes that use 3 buffers because we're looking at the capacities of
the underlying data. Effectively, we would be double-counting the third
buffer.

This is now fixed by capping the slice for each of the buffers. As
a result, the memory estimate will likely become smaller after
round-tripping through a converter and a serializer (in the original
batch there might be extra capacity in the underlying slices that will
no longer be present after deserialization).

Release note: None