### PR TITLE
sql: validate implicit partitioned columns on CREATE UNIQUE INDEX

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -726,3 +726,38 @@ SELECT * FROM t@new_idx
 ----
 1   2   3   4   5
 11  12  13  14  15
+
+# Tests adding a new UNIQUE index with implicit partitioning.
+statement ok
+DROP TABLE t;
+CREATE TABLE t (partition_by INT, v INT);
+INSERT INTO t VALUES (1, 1), (2, 1);
+
+statement error could not create unique constraint "uniq_on_t"\nDETAIL: Key \(v\)=\(1\) is duplicated
+CREATE UNIQUE INDEX uniq_on_t ON t(v) PARTITION BY LIST (partition_by) (
+   PARTITION one VALUES IN (1),
+   PARTITION two VALUES IN (2)
+)
+
+statement ok
+DELETE FROM t WHERE partition_by = 2;
+CREATE UNIQUE INDEX uniq_on_t ON t(v) PARTITION BY LIST (partition_by) (
+   PARTITION one VALUES IN (1),
+   PARTITION two VALUES IN (2)
+)
+
+# Tests adding a UNIQUE index with PARTITION ALL BY implicit partitioning.
+statement ok
+DROP TABLE t;
+CREATE TABLE t (partition_by INT, v INT) PARTITION ALL BY LIST (partition_by) (
+   PARTITION one VALUES IN (1),
+   PARTITION two VALUES IN (2)
+);
+INSERT INTO t VALUES (1, 1), (2, 1);
+
+statement error could not create unique constraint "uniq_on_t"\nDETAIL: Key \(v\)=\(1\) is duplicated
+CREATE UNIQUE INDEX uniq_on_t ON t(v)
+
+statement ok
+DELETE FROM t WHERE partition_by = 2;
+CREATE UNIQUE INDEX uniq_on_t ON t(v)

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -78,7 +78,6 @@ CREATE TABLE regional_by_row_table (
 )
 LOCALITY REGIONAL BY ROW
 
-
 statement ok
 CREATE TABLE regional_by_row_table (
   pk int PRIMARY KEY,
@@ -186,6 +185,37 @@ RETURNING crdb_region, pk
 ----
 ap-southeast-2  1
 ap-southeast-2  4
+
+# Insert duplicate row for column a.
+statement ok
+INSERT INTO multi_region_test_db.regional_by_row_table (crdb_region, pk, pk2, a, b) VALUES ('ca-central-1', 5, 5, 5, 5)
+
+statement error could not create unique constraint "uniq_idx"\nDETAIL: Key \(a\)=\(5\) is duplicated
+CREATE UNIQUE INDEX uniq_idx ON regional_by_row_table(a)
+
+statement ok
+DELETE FROM regional_by_row_table WHERE pk = 5;
+CREATE UNIQUE INDEX uniq_idx ON regional_by_row_table(a)
+
+query TTB colnames
+SELECT index_name, column_name, implicit FROM crdb_internal.index_columns
+WHERE descriptor_name = 'regional_by_row_table' AND column_type = 'key'
+ORDER BY 1, 2
+----
+index_name                   column_name  implicit
+primary                      crdb_region  true
+primary                      pk           false
+regional_by_row_table_a_idx  a            false
+regional_by_row_table_a_idx  crdb_region  true
+regional_by_row_table_b_key  b            false
+regional_by_row_table_b_key  crdb_region  true
+regional_by_row_table_j_idx  crdb_region  true
+regional_by_row_table_j_idx  j            false
+uniq_idx                     a            false
+uniq_idx                     crdb_region  true
+
+statement ok
+DROP INDEX uniq_idx
 
 query TI
 INSERT INTO regional_by_row_table (crdb_region, pk, pk2, a, b) VALUES

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -755,7 +755,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 						return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
 							"constraint %q in the middle of being added, try again later", t.Constraint)
 					}
-					if err := validateUniqueConstraintInTxn(
+					if err := validateUniqueWithoutIndexConstraintInTxn(
 						params.ctx, params.p.LeaseMgr(), params.EvalContext(), n.tableDesc, params.EvalContext().Txn, name,
 					); err != nil {
 						return err


### PR DESCRIPTION
This commit modifies CREATE UNIQUE INDEX to check whether the
non-implicit columns in an implicitly partitioned index are unique.

Resolves #59726 

Release note: None