### PR TITLE
colexec: miscellaneous cleanups

### DIFF
--- a/pkg/sql/colcontainer/diskqueue_test.go
+++ b/pkg/sql/colcontainer/diskqueue_test.go
@@ -189,7 +189,6 @@ func TestDiskQueueCloseOnErr(t *testing.T) {
 	require.NoError(t, err)
 
 	b := coldata.NewMemBatch(typs, coldata.StandardColumnFactory)
-	b.SetLength(0)
 
 	err = q.Enqueue(ctx, b)
 	require.Error(t, err, "expected Enqueue to produce an error given a disk limit of one byte")

--- a/pkg/sql/colexec/count.go
+++ b/pkg/sql/colexec/count.go
@@ -51,10 +51,10 @@ func (c *countOp) Init() {
 }
 
 func (c *countOp) Next(ctx context.Context) coldata.Batch {
-	c.internalBatch.ResetInternalBatch()
 	if c.done {
 		return coldata.ZeroBatch
 	}
+	c.internalBatch.ResetInternalBatch()
 	for {
 		bat := c.input.Next(ctx)
 		length := bat.Length()

--- a/pkg/sql/colexec/external_hash_aggregator.go
+++ b/pkg/sql/colexec/external_hash_aggregator.go
@@ -21,6 +21,17 @@ import (
 	"github.com/marusama/semaphore"
 )
 
+const (
+	// This limit comes from the fallback strategy where we are using an
+	// external sort.
+	ehaNumRequiredActivePartitions = ExternalSorterMinPartitions
+	// ehaNumRequiredFDs is the minimum number of file descriptors that are
+	// needed for the machinery of the external aggregator (plus 1 is needed for
+	// the in-memory hash aggregator in order to track tuples in a spilling
+	// queue).
+	ehaNumRequiredFDs = ehaNumRequiredActivePartitions + 1
+)
+
 // NewExternalHashAggregator returns a new disk-backed hash aggregator. It uses
 // the in-memory hash aggregator as the "main" strategy for the hash-based
 // partitioner and the external sort + ordered aggregator as the "fallback".
@@ -59,7 +70,6 @@ func NewExternalHashAggregator(
 		}
 		return diskBackedFallbackOp
 	}
-	numRequiredActivePartitions := ExternalSorterMinPartitions
 	return newHashBasedPartitioner(
 		newAggArgs.Allocator,
 		flowCtx,
@@ -71,7 +81,7 @@ func NewExternalHashAggregator(
 		inMemMainOpConstructor,
 		diskBackedFallbackOpConstructor,
 		diskAcc,
-		numRequiredActivePartitions,
+		ehaNumRequiredActivePartitions,
 	)
 }
 

--- a/pkg/sql/colexec/external_hash_aggregator_test.go
+++ b/pkg/sql/colexec/external_hash_aggregator_test.go
@@ -91,7 +91,7 @@ func TestExternalHashAggregator(t *testing.T) {
 					tc.expected,
 					unorderedVerifier,
 					func(input []colexecbase.Operator) (colexecbase.Operator, error) {
-						sem := colexecbase.NewTestingSemaphore(ExternalSorterMinPartitions)
+						sem := colexecbase.NewTestingSemaphore(ehaNumRequiredFDs)
 						semsToCheck = append(semsToCheck, sem)
 						op, accs, mons, closers, err := createExternalHashAggregator(
 							ctx, flowCtx, &colexecagg.NewAggregatorArgs{

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -261,7 +261,6 @@ func (op *hashAggregator) Next(ctx context.Context) coldata.Batch {
 				continue
 			}
 			op.bufferingState.tuples.ResetInternalBatch()
-			op.bufferingState.tuples.SetLength(0)
 			op.state = hashAggregatorBuffering
 
 		case hashAggregatorOutputting:
@@ -483,7 +482,6 @@ func (op *hashAggregator) reset(ctx context.Context) {
 		r.reset(ctx)
 	}
 	op.bufferingState.tuples.ResetInternalBatch()
-	op.bufferingState.tuples.SetLength(0)
 	op.bufferingState.pendingBatch = nil
 	op.bufferingState.unprocessedIdx = 0
 	op.buckets = op.buckets[:0]

--- a/pkg/sql/colexec/hashtable.go
+++ b/pkg/sql/colexec/hashtable.go
@@ -713,7 +713,6 @@ func (ht *hashTable) reset(_ context.Context) {
 	for n := 0; n < len(ht.buildScratch.first); n += copy(ht.buildScratch.first[n:], zeroUint64Column) {
 	}
 	ht.vals.ResetInternalBatch()
-	ht.vals.SetLength(0)
 	// ht.probeScratch.next, ht.same and ht.visited are reset separately before
 	// they are used (these slices are not used in all of the code paths).
 	// ht.probeScratch.headID, ht.probeScratch.differs, and

--- a/pkg/sql/colexec/operator.go
+++ b/pkg/sql/colexec/operator.go
@@ -255,10 +255,10 @@ func (s *fixedNumTuplesNoInputOp) Init() {
 }
 
 func (s *fixedNumTuplesNoInputOp) Next(context.Context) coldata.Batch {
-	s.batch.ResetInternalBatch()
 	if s.numTuplesLeft == 0 {
 		return coldata.ZeroBatch
 	}
+	s.batch.ResetInternalBatch()
 	length := s.numTuplesLeft
 	if length > coldata.BatchSize() {
 		length = coldata.BatchSize()

--- a/pkg/sql/colexec/sort.go
+++ b/pkg/sql/colexec/sort.go
@@ -179,7 +179,6 @@ func (p *allSpooler) reset(ctx context.Context) {
 		r.reset(ctx)
 	}
 	p.spooled = false
-	p.bufferedTuples.SetLength(0)
 	p.bufferedTuples.ResetInternalBatch()
 }
 

--- a/pkg/sql/colexec/sort_chunks.go
+++ b/pkg/sql/colexec/sort_chunks.go
@@ -492,6 +492,5 @@ func (s *chunker) getWindowedBatch(startIdx, endIdx int) coldata.Batch {
 }
 
 func (s *chunker) emptyBuffer() {
-	s.bufferedTuples.SetLength(0)
 	s.bufferedTuples.ResetInternalBatch()
 }

--- a/pkg/sql/colexec/utils.go
+++ b/pkg/sql/colexec/utils.go
@@ -128,7 +128,7 @@ func newAppendOnlyBufferedBatch(
 	}
 	batch := allocator.NewMemBatchWithFixedCapacity(typs, 0 /* capacity */)
 	return &appendOnlyBufferedBatch{
-		Batch:       batch,
+		batch:       batch,
 		colVecs:     batch.ColVecs(),
 		colsToStore: colsToStore,
 	}
@@ -146,7 +146,9 @@ func newAppendOnlyBufferedBatch(
 // using utility append() method); however, this batch prohibits appending and
 // replacing of the vectors themselves.
 type appendOnlyBufferedBatch struct {
-	coldata.Batch
+	// We intentionally do not simply embed the batch so that we have to think
+	// through the implementation of each method of coldata.Batch interface.
+	batch coldata.Batch
 
 	length      int
 	colVecs     []coldata.Vec
@@ -167,6 +169,18 @@ func (b *appendOnlyBufferedBatch) SetLength(n int) {
 	b.length = n
 }
 
+func (b *appendOnlyBufferedBatch) Capacity() int {
+	// We assume that the appendOnlyBufferedBatch has unlimited capacity, so all
+	// callers should use that assumption instead of calling Capacity().
+	colexecerror.InternalError(errors.AssertionFailedf("Capacity is prohibited on appendOnlyBufferedBatch"))
+	// This code is unreachable, but the compiler cannot infer that.
+	return 0
+}
+
+func (b *appendOnlyBufferedBatch) Width() int {
+	return b.batch.Width()
+}
+
 func (b *appendOnlyBufferedBatch) ColVec(i int) coldata.Vec {
 	return b.colVecs[i]
 }
@@ -176,14 +190,14 @@ func (b *appendOnlyBufferedBatch) ColVecs() []coldata.Vec {
 }
 
 func (b *appendOnlyBufferedBatch) Selection() []int {
-	if b.Batch.Selection() != nil {
+	if b.batch.Selection() != nil {
 		return b.sel
 	}
 	return nil
 }
 
 func (b *appendOnlyBufferedBatch) SetSelection(useSel bool) {
-	b.Batch.SetSelection(useSel)
+	b.batch.SetSelection(useSel)
 	if useSel {
 		// Make sure that selection vector is of the appropriate length.
 		if cap(b.sel) < b.length {
@@ -200,6 +214,22 @@ func (b *appendOnlyBufferedBatch) AppendCol(coldata.Vec) {
 
 func (b *appendOnlyBufferedBatch) ReplaceCol(coldata.Vec, int) {
 	colexecerror.InternalError(errors.AssertionFailedf("ReplaceCol is prohibited on appendOnlyBufferedBatch"))
+}
+
+func (b *appendOnlyBufferedBatch) Reset([]*types.T, int, coldata.ColumnFactory) {
+	colexecerror.InternalError(errors.AssertionFailedf("Reset is prohibited on appendOnlyBufferedBatch"))
+}
+
+func (b *appendOnlyBufferedBatch) ResetInternalBatch() {
+	b.SetLength(0 /* n */)
+	b.batch.ResetInternalBatch()
+}
+
+func (b *appendOnlyBufferedBatch) String() string {
+	// String should not be used in the fast paths, so we will set the length on
+	// the wrapped batch (which might be a bit expensive but is ok).
+	b.batch.SetLength(b.length)
+	return b.batch.String()
 }
 
 // append is a helper method that appends all tuples with indices in range

--- a/pkg/sql/colexec/utils_test.go
+++ b/pkg/sql/colexec/utils_test.go
@@ -347,11 +347,20 @@ func runTestsWithTyps(
 				"non-nulls in the input tuples, we expect for all nulls injection to "+
 				"change the output")
 		}
-		if c, ok := originalOp.(colexecbase.Closer); ok {
-			require.NoError(t, c.Close(ctx))
-		}
-		if c, ok := opWithNulls.(colexecbase.Closer); ok {
-			require.NoError(t, c.Close(ctx))
+		closeIfCloser(ctx, t, originalOp)
+		closeIfCloser(ctx, t, opWithNulls)
+	}
+}
+
+// closeIfCloser is a testing utility function that checks whether op is a
+// colexecbase.Closer and closes it if so.
+//
+// runTests harness needs to do that once it is done with op. In non-test
+// setting, the closing happens at the end of the query execution.
+func closeIfCloser(ctx context.Context, t *testing.T, op colexecbase.Operator) {
+	if c, ok := op.(colexecbase.Closer); ok {
+		if err := c.Close(ctx); err != nil {
+			t.Fatal(err)
 		}
 	}
 }
@@ -395,6 +404,7 @@ func runTestsWithoutAllNullsInjection(
 				t.Fatal(err)
 			}
 		}
+		closeIfCloser(ctx, t, op)
 	})
 
 	if !skipVerifySelAndNullsResets {
@@ -465,11 +475,7 @@ func runTestsWithoutAllNullsInjection(
 					assert.False(t, maybeHasNulls(b))
 				}
 			}
-			if c, ok := op.(colexecbase.Closer); ok {
-				// Some operators need an explicit Close if not drained completely of
-				// input.
-				assert.NoError(t, c.Close(ctx))
-			}
+			closeIfCloser(ctx, t, op)
 		}
 	}
 
@@ -494,6 +500,7 @@ func runTestsWithoutAllNullsInjection(
 		op.Init()
 		for b := op.Next(ctx); b.Length() > 0; b = op.Next(ctx) {
 		}
+		closeIfCloser(ctx, t, op)
 	}
 }
 

--- a/pkg/sql/colexec/utils_test.go
+++ b/pkg/sql/colexec/utils_test.go
@@ -742,10 +742,10 @@ func (s *opTestInput) Init() {
 }
 
 func (s *opTestInput) Next(context.Context) coldata.Batch {
-	s.batch.ResetInternalBatch()
 	if len(s.tuples) == 0 {
 		return coldata.ZeroBatch
 	}
+	s.batch.ResetInternalBatch()
 	batchSize := s.batchSize
 	if len(s.tuples) < batchSize {
 		batchSize = len(s.tuples)

--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -624,7 +624,6 @@ func TestOutboxStreamIDPropagation(t *testing.T) {
 	nextDone := make(chan struct{})
 	input := &colexecbase.CallbackOperator{NextCb: func(ctx context.Context) coldata.Batch {
 		b := testAllocator.NewMemBatchWithFixedCapacity(typs, 0)
-		b.SetLength(0)
 		inTags = logtags.FromContext(ctx)
 		nextDone <- struct{}{}
 		return b

--- a/pkg/sql/colflow/colrpc/outbox_test.go
+++ b/pkg/sql/colflow/colrpc/outbox_test.go
@@ -115,7 +115,6 @@ func TestOutboxDrainsMetadataSources(t *testing.T) {
 		require.NoError(t, err)
 
 		b := testAllocator.NewMemBatchWithMaxCapacity(typs)
-		b.SetLength(0)
 		input.Add(b, typs)
 
 		// Close the csChan to unblock the Recv goroutine (we don't need it for this


### PR DESCRIPTION
**coldata: make ResetInternalBatch also set length to 0**

Previously, `ResetInternalBatch` would only reset the selection and any
of the vectors (like Bytes) if present. Now the method will also set the
length of the batch to 0, for convenience. This commit also removes
a few `SetLength(0)` calls where they didn't matter.

This commit also modifies `appendOnlyBufferedBatch` slightly to have the
same behavior on `ResetInternalBatch` (this batch-wrapper tracks the
length separately, so we need to intercept `ResetInternalBatch` calls
for correctness).

Release note: None

**colexec: close operators when needed in runTests harness**

This commit introduces a testing utility function that checks whether an
operator is a Closer and closes it if so. We need to do it once we're
done with the operator to simulate the production setting (in which the
closing occurs at the end of the query execution).

Release note: None

**colexec: enqueue zero batch when spilling in the hash aggregator**

This commit makes sure that the in-memory hash aggregator when it is
about to spill to disk adheres to the contract of the spilling queue
that a zero-length batch is enqueued once no more batches will be
enqueued.

Release note: None