### PR TITLE
sql: use kv_node_status to determine node liveness for multiregion

### DIFF
--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -161,7 +161,7 @@ func (n *alterDatabaseAddRegionNode) startExec(params runParams) error {
 	// Add the region to the database descriptor. This function validates that the region
 	// we're adding is an active member of the cluster and isn't already present in the
 	// RegionConfig.
-	if err := params.p.addRegionToRegionConfig(n.desc, n.n); err != nil {
+	if err := params.p.addRegionToRegionConfig(params.ctx, n.desc, n.n); err != nil {
 		return err
 	}
 

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -261,9 +261,9 @@ func validateDatabaseRegionConfig(regionConfig descpb.DatabaseDescriptor_RegionC
 // addRegionToRegionConfig adds the supplied region to the RegionConfig in the
 // supplied database descriptor.
 func (p *planner) addRegionToRegionConfig(
-	desc *dbdesc.Mutable, regionToAdd *tree.AlterDatabaseAddRegion,
+	ctx context.Context, desc *dbdesc.Mutable, regionToAdd *tree.AlterDatabaseAddRegion,
 ) error {
-	liveRegions, err := p.getLiveClusterRegions()
+	liveRegions, err := p.getLiveClusterRegions(ctx)
 	if err != nil {
 		return err
 	}
@@ -320,7 +320,7 @@ func (p *planner) createRegionConfig(
 	if err != nil {
 		return nil, err
 	}
-	liveRegions, err := p.getLiveClusterRegions()
+	liveRegions, err := p.getLiveClusterRegions(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This was a relic before the decision was made -- node liveness was
detected by gossip instead. This changes the code to use SHOW REGIONS
FROM CLUSTER, which aggregates from kv_node_status.

Release note: None