### PR TITLE
sql: implement ALTER TABLE LOCALITY REGIONAL BY ROW -> !(REGIONAL BY ROW)

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
+++ b/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
@@ -28,6 +28,7 @@ statement ok
 CREATE TABLE regional_by_row (
   pk INT PRIMARY KEY,
   i INT,
+  INDEX(i),
   FAMILY (pk, i)
 ) LOCALITY REGIONAL BY ROW
 
@@ -39,9 +40,14 @@ regional_by_row  CREATE TABLE public.regional_by_row (
                  i INT8 NULL,
                  crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT gateway_region()::public.crdb_internal_region,
                  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                 INDEX regional_by_row_i_idx (i ASC),
                  FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
 ) LOCALITY REGIONAL BY ROW;
 ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=ap-southeast-2]',
+  lease_preferences = '[[+region=ap-southeast-2]]';
+ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_row@regional_by_row_i_idx CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ap-southeast-2]',
   lease_preferences = '[[+region=ap-southeast-2]]';
@@ -49,13 +55,79 @@ ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_r
   num_voters = 3,
   voter_constraints = '[+region=ca-central-1]',
   lease_preferences = '[[+region=ca-central-1]]';
+ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_row@regional_by_row_i_idx CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=ca-central-1]',
+  lease_preferences = '[[+region=ca-central-1]]';
 ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=us-east-1]',
+  lease_preferences = '[[+region=us-east-1]]';
+ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_row@regional_by_row_i_idx CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=us-east-1]',
   lease_preferences = '[[+region=us-east-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
+----
+DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 90000,
+                              num_replicas = 5,
+                              num_voters = 3,
+                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              voter_constraints = '[+region=ca-central-1]',
+                              lease_preferences = '[[+region=ca-central-1]]'
+
+statement ok
+CREATE TABLE regional_by_row_as (
+  pk INT PRIMARY KEY,
+  i INT,
+  cr crdb_internal_region NOT NULL DEFAULT 'ap-southeast-2',
+  INDEX(i),
+  FAMILY (cr, pk, i)
+) LOCALITY REGIONAL BY ROW AS "cr";
+
+query TT
+SHOW CREATE TABLE regional_by_row_as
+----
+regional_by_row_as  CREATE TABLE public.regional_by_row_as (
+                    pk INT8 NOT NULL,
+                    i INT8 NULL,
+                    cr public.crdb_internal_region NOT NULL DEFAULT 'ap-southeast-2':::public.crdb_internal_region,
+                    CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                    INDEX regional_by_row_as_i_idx (i ASC),
+                    FAMILY fam_0_cr_pk_i (cr, pk, i)
+) LOCALITY REGIONAL BY ROW AS cr;
+ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_row_as@primary CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=ap-southeast-2]',
+  lease_preferences = '[[+region=ap-southeast-2]]';
+ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_row_as@regional_by_row_as_i_idx CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=ap-southeast-2]',
+  lease_preferences = '[[+region=ap-southeast-2]]';
+ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_row_as@primary CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=ca-central-1]',
+  lease_preferences = '[[+region=ca-central-1]]';
+ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_row_as@regional_by_row_as_i_idx CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=ca-central-1]',
+  lease_preferences = '[[+region=ca-central-1]]';
+ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_row_as@primary CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=us-east-1]',
+  lease_preferences = '[[+region=us-east-1]]';
+ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_row_as@regional_by_row_as_i_idx CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=us-east-1]',
+  lease_preferences = '[[+region=us-east-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_as
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -184,56 +256,7 @@ TABLE created_as_global  ALTER TABLE created_as_global CONFIGURE ZONE USING
                          voter_constraints = '[+region=ca-central-1]',
                          lease_preferences = '[[+region=ca-central-1]]'
 
-statement error unimplemented: implementation pending
-ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY TABLE
-
-statement error unimplemented: implementation pending
-ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY TABLE in "ap-southeast-2"
-
-statement error unimplemented: implementation pending
-ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY TABLE in PRIMARY REGION
-
-statement error unimplemented: implementation pending
-ALTER TABLE regional_by_row SET LOCALITY GLOBAL
-
-statement error unimplemented: implementation pending
-ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY ROW
-
-query TT
-SHOW CREATE TABLE regional_by_row
-----
-regional_by_row  CREATE TABLE public.regional_by_row (
-                 pk INT8 NOT NULL,
-                 i INT8 NULL,
-                 crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT gateway_region()::public.crdb_internal_region,
-                 CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                 FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
-) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
-
-query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
-----
-DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+# Altering from GLOBAL
 
 statement ok
 ALTER TABLE created_as_global SET LOCALITY REGIONAL BY TABLE
@@ -296,7 +319,7 @@ statement ok
 ALTER TABLE created_as_global SET LOCALITY GLOBAL
 
 statement ok
-ALTER TABLE created_as_global SET LOCALITY REGIONAL BY TABLE in PRIMARY REGION
+ALTER TABLE created_as_global SET LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
 query TT
 SHOW CREATE TABLE created_as_global
@@ -695,6 +718,8 @@ DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE 
                               voter_constraints = '[+region=ca-central-1]',
                               lease_preferences = '[[+region=ca-central-1]]'
 
+# Altering from REGIONAL BY ROW IN PRIMARY REGION
+
 statement error region "invalid-region" has not been added to database "alter_locality_test"
 ALTER TABLE regional_by_table_in_primary_region SET LOCALITY REGIONAL BY TABLE in "invalid-region"
 
@@ -726,7 +751,7 @@ TABLE regional_by_table_in_primary_region  ALTER TABLE regional_by_table_in_prim
 
 # Alter back to original state
 statement ok
-ALTER TABLE regional_by_table_in_primary_region SET LOCALITY REGIONAL BY TABLE in PRIMARY REGION
+ALTER TABLE regional_by_table_in_primary_region SET LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
 query TT
 SHOW CREATE TABLE regional_by_table_in_primary_region
@@ -753,7 +778,7 @@ DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE 
 
 # Alter to same state
 statement ok
-ALTER TABLE regional_by_table_in_primary_region SET LOCALITY REGIONAL BY TABLE in PRIMARY REGION
+ALTER TABLE regional_by_table_in_primary_region SET LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
 query TT
 SHOW CREATE TABLE regional_by_table_in_primary_region
@@ -843,6 +868,8 @@ CREATE TABLE regional_by_table_in_primary_region (
   FAMILY (pk, i)
 ) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
+# Altering from REGIONAL BY ROW
+
 statement ok
 ALTER TABLE regional_by_table_no_region SET LOCALITY REGIONAL BY TABLE
 
@@ -914,7 +941,7 @@ statement ok
 CREATE TABLE regional_by_table_no_region (i int)
 
 statement ok
-ALTER TABLE regional_by_table_no_region SET LOCALITY REGIONAL BY TABLE in PRIMARY REGION
+ALTER TABLE regional_by_table_no_region SET LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
 query TT
 SHOW CREATE TABLE regional_by_table_no_region
@@ -1041,7 +1068,7 @@ CREATE TABLE regional_by_table_no_region (
   b int,
   index(b),
   unique(i),
-  cr crdb_internal_region NOT NULL,
+  cr crdb_internal_region NOT NULL NOT NULL,
   FAMILY (pk, i, b, cr)
 ) LOCALITY REGIONAL BY TABLE;
 INSERT INTO regional_by_table_no_region VALUES (0, 1, 2, 'us-east-1')
@@ -1067,7 +1094,7 @@ CREATE TABLE regional_by_table_no_region (
   pk int primary key,
   i int,
   b int,
-  cr crdb_internal_region NOT NULL,
+  cr crdb_internal_region NOT NULL NOT NULL,
   index(b),
   unique(i),
   FAMILY (pk, i, b, cr)
@@ -1140,6 +1167,8 @@ DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE 
                               voter_constraints = '[+region=ca-central-1]',
                               lease_preferences = '[[+region=ca-central-1]]'
 
+# Altering from REGIONAL BY ROW IN "us-east-1"
+
 statement ok
 ALTER TABLE regional_by_table_in_us_east SET LOCALITY REGIONAL BY TABLE
 
@@ -1199,7 +1228,7 @@ statement ok
 ALTER TABLE regional_by_table_in_us_east SET LOCALITY REGIONAL BY TABLE in "us-east-1"
 
 statement ok
-ALTER TABLE regional_by_table_in_us_east SET LOCALITY REGIONAL BY TABLE in PRIMARY REGION
+ALTER TABLE regional_by_table_in_us_east SET LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
 query TT
 SHOW CREATE TABLE regional_by_table_in_us_east
@@ -1339,7 +1368,7 @@ CREATE TABLE regional_by_table_in_us_east (
   b int,
   index(b),
   unique(i),
-  cr crdb_internal_region NOT NULL,
+  cr crdb_internal_region NOT NULL NOT NULL,
   FAMILY (pk, i, b, cr)
 ) LOCALITY REGIONAL BY TABLE IN "us-east-1";
 INSERT INTO regional_by_table_in_us_east VALUES (0, 1, 2, 'us-east-1');
@@ -1407,6 +1436,336 @@ DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE 
                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
                               voter_constraints = '[+region=ca-central-1]',
                               lease_preferences = '[[+region=ca-central-1]]'
+
+# Altering from REGIONAL BY ROW
+
+statement ok
+INSERT INTO regional_by_row (pk, i) VALUES (1, 1);
+ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY TABLE
+
+query TT
+SHOW CREATE TABLE regional_by_row
+----
+regional_by_row                                 CREATE TABLE public.regional_by_row (
+                                                pk INT8 NOT NULL,
+                                                i INT8 NULL,
+                                                crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT gateway_region()::public.crdb_internal_region,
+                                                CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                                                INDEX regional_by_row_i_idx (i ASC),
+                                                FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
+) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
+----
+TABLE regional_by_row  ALTER TABLE regional_by_row CONFIGURE ZONE USING
+                       range_min_bytes = 134217728,
+                       range_max_bytes = 536870912,
+                       gc.ttlseconds = 90000,
+                       num_replicas = 5,
+                       num_voters = 3,
+                       constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                       voter_constraints = '[+region=ca-central-1]',
+                       lease_preferences = '[[+region=ca-central-1]]'
+
+statement ok
+DROP TABLE regional_by_row;
+CREATE TABLE regional_by_row (
+  pk INT PRIMARY KEY,
+  i INT,
+  INDEX(i),
+  FAMILY (pk, i)
+) LOCALITY REGIONAL BY ROW;
+INSERT INTO regional_by_row (pk, i) VALUES (1, 1);
+ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY TABLE in "ap-southeast-2"
+
+query TT
+SHOW CREATE TABLE regional_by_row
+----
+regional_by_row                                   CREATE TABLE public.regional_by_row (
+                                                  pk INT8 NOT NULL,
+                                                  i INT8 NULL,
+                                                  crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT gateway_region()::public.crdb_internal_region,
+                                                  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                                                  INDEX regional_by_row_i_idx (i ASC),
+                                                  FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
+) LOCALITY REGIONAL BY TABLE IN "ap-southeast-2"
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
+----
+TABLE regional_by_row  ALTER TABLE regional_by_row CONFIGURE ZONE USING
+                       range_min_bytes = 134217728,
+                       range_max_bytes = 536870912,
+                       gc.ttlseconds = 90000,
+                       num_replicas = 5,
+                       num_voters = 3,
+                       constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                       voter_constraints = '[+region=ap-southeast-2]',
+                       lease_preferences = '[[+region=ap-southeast-2]]'
+
+statement ok
+DROP TABLE regional_by_row;
+CREATE TABLE regional_by_row (
+  pk INT PRIMARY KEY,
+  i INT,
+  INDEX(i),
+  FAMILY (pk, i)
+) LOCALITY REGIONAL BY ROW;
+INSERT INTO regional_by_row (pk, i) VALUES (1, 1);
+ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
+
+query TT
+SHOW CREATE TABLE regional_by_row
+----
+regional_by_row                                 CREATE TABLE public.regional_by_row (
+                                                pk INT8 NOT NULL,
+                                                i INT8 NULL,
+                                                crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT gateway_region()::public.crdb_internal_region,
+                                                CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                                                INDEX regional_by_row_i_idx (i ASC),
+                                                FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
+) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
+----
+TABLE regional_by_row  ALTER TABLE regional_by_row CONFIGURE ZONE USING
+                       range_min_bytes = 134217728,
+                       range_max_bytes = 536870912,
+                       gc.ttlseconds = 90000,
+                       num_replicas = 5,
+                       num_voters = 3,
+                       constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                       voter_constraints = '[+region=ca-central-1]',
+                       lease_preferences = '[[+region=ca-central-1]]'
+
+statement ok
+DROP TABLE regional_by_row;
+CREATE TABLE regional_by_row (
+  pk INT PRIMARY KEY,
+  i INT,
+  INDEX(i),
+  FAMILY (pk, i)
+) LOCALITY REGIONAL BY ROW;
+INSERT INTO regional_by_row (pk, i) VALUES (1, 1);
+ALTER TABLE regional_by_row SET LOCALITY GLOBAL
+
+query TT
+SHOW CREATE TABLE regional_by_row
+----
+regional_by_row    CREATE TABLE public.regional_by_row (
+                   pk INT8 NOT NULL,
+                   i INT8 NULL,
+                   crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT gateway_region()::public.crdb_internal_region,
+                   CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                   INDEX regional_by_row_i_idx (i ASC),
+                   FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
+) LOCALITY GLOBAL
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
+----
+TABLE regional_by_row  ALTER TABLE regional_by_row CONFIGURE ZONE USING
+                       range_min_bytes = 134217728,
+                       range_max_bytes = 536870912,
+                       gc.ttlseconds = 90000,
+                       global_reads = true,
+                       num_replicas = 5,
+                       num_voters = 3,
+                       constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                       voter_constraints = '[+region=ca-central-1]',
+                       lease_preferences = '[[+region=ca-central-1]]'
+
+statement error unimplemented: implementation pending
+DROP TABLE regional_by_row;
+CREATE TABLE regional_by_row (
+  pk INT PRIMARY KEY,
+  i INT,
+  INDEX(i),
+  FAMILY (pk, i)
+) LOCALITY REGIONAL BY ROW;
+INSERT INTO regional_by_row (pk, i) VALUES (1, 1);
+ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY ROW
+
+statement error unimplemented: implementation pending
+DROP TABLE regional_by_row;
+CREATE TABLE regional_by_row (
+  pk INT PRIMARY KEY,
+  i INT,
+  cr crdb_internal_region NOT NULL DEFAULT 'ap-southeast-2',
+  INDEX(i),
+  FAMILY (pk, i)
+) LOCALITY REGIONAL BY ROW;
+INSERT INTO regional_by_row (pk, i) VALUES (1, 1);
+ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY ROW AS "cr"
+
+# Altering from REGIONAL BY ROW AS
+
+statement ok
+INSERT INTO regional_by_row_as (pk, i) VALUES (1, 1);
+ALTER TABLE regional_by_row_as SET LOCALITY REGIONAL BY TABLE
+
+query TT
+SHOW CREATE TABLE regional_by_row_as
+----
+regional_by_row_as                              CREATE TABLE public.regional_by_row_as (
+                                                pk INT8 NOT NULL,
+                                                i INT8 NULL,
+                                                cr public.crdb_internal_region NOT NULL DEFAULT 'ap-southeast-2':::public.crdb_internal_region,
+                                                CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                                                INDEX regional_by_row_as_i_idx (i ASC),
+                                                FAMILY fam_0_cr_pk_i (cr, pk, i)
+) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_as
+----
+TABLE regional_by_row_as  ALTER TABLE regional_by_row_as CONFIGURE ZONE USING
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 90000,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ca-central-1]',
+                          lease_preferences = '[[+region=ca-central-1]]'
+
+statement ok
+DROP TABLE regional_by_row_as;
+CREATE TABLE regional_by_row_as (
+  pk INT PRIMARY KEY,
+  i INT,
+  cr crdb_internal_region NOT NULL DEFAULT 'ap-southeast-2',
+  INDEX(i),
+  FAMILY (cr, pk, i)
+) LOCALITY REGIONAL BY ROW AS "cr";
+INSERT INTO regional_by_row_as (pk, i) VALUES (1, 1);
+ALTER TABLE regional_by_row_as SET LOCALITY REGIONAL BY TABLE in "ap-southeast-2"
+
+query TT
+SHOW CREATE TABLE regional_by_row_as
+----
+regional_by_row_as                                CREATE TABLE public.regional_by_row_as (
+                                                  pk INT8 NOT NULL,
+                                                  i INT8 NULL,
+                                                  cr public.crdb_internal_region NOT NULL DEFAULT 'ap-southeast-2':::public.crdb_internal_region,
+                                                  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                                                  INDEX regional_by_row_as_i_idx (i ASC),
+                                                  FAMILY fam_0_cr_pk_i (cr, pk, i)
+) LOCALITY REGIONAL BY TABLE IN "ap-southeast-2"
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_as
+----
+TABLE regional_by_row_as  ALTER TABLE regional_by_row_as CONFIGURE ZONE USING
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 90000,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ap-southeast-2]',
+                          lease_preferences = '[[+region=ap-southeast-2]]'
+
+statement ok
+DROP TABLE regional_by_row_as;
+CREATE TABLE regional_by_row_as (
+  pk INT PRIMARY KEY,
+  i INT,
+  cr crdb_internal_region NOT NULL DEFAULT 'ap-southeast-2',
+  INDEX(i),
+  FAMILY (cr, pk, i)
+) LOCALITY REGIONAL BY ROW AS "cr";
+INSERT INTO regional_by_row_as (pk, i) VALUES (1, 1);
+ALTER TABLE regional_by_row_as SET LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
+
+query TT
+SHOW CREATE TABLE regional_by_row_as
+----
+regional_by_row_as                              CREATE TABLE public.regional_by_row_as (
+                                                pk INT8 NOT NULL,
+                                                i INT8 NULL,
+                                                cr public.crdb_internal_region NOT NULL DEFAULT 'ap-southeast-2':::public.crdb_internal_region,
+                                                CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                                                INDEX regional_by_row_as_i_idx (i ASC),
+                                                FAMILY fam_0_cr_pk_i (cr, pk, i)
+) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_as
+----
+TABLE regional_by_row_as  ALTER TABLE regional_by_row_as CONFIGURE ZONE USING
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 90000,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ca-central-1]',
+                          lease_preferences = '[[+region=ca-central-1]]'
+
+statement ok
+DROP TABLE regional_by_row_as;
+CREATE TABLE regional_by_row_as (
+  pk INT PRIMARY KEY,
+  i INT,
+  cr crdb_internal_region NOT NULL DEFAULT 'ap-southeast-2',
+  INDEX(i),
+  FAMILY (cr, pk, i)
+) LOCALITY REGIONAL BY ROW AS "cr";
+INSERT INTO regional_by_row_as (pk, i) VALUES (1, 1);
+ALTER TABLE regional_by_row_as SET LOCALITY GLOBAL
+
+query TT
+SHOW CREATE TABLE regional_by_row_as
+----
+regional_by_row_as  CREATE TABLE public.regional_by_row_as (
+                    pk INT8 NOT NULL,
+                    i INT8 NULL,
+                    cr public.crdb_internal_region NOT NULL DEFAULT 'ap-southeast-2':::public.crdb_internal_region,
+                    CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                    INDEX regional_by_row_as_i_idx (i ASC),
+                    FAMILY fam_0_cr_pk_i (cr, pk, i)
+) LOCALITY GLOBAL
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_as
+----
+TABLE regional_by_row_as  ALTER TABLE regional_by_row_as CONFIGURE ZONE USING
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 90000,
+                          global_reads = true,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ca-central-1]',
+                          lease_preferences = '[[+region=ca-central-1]]'
+
+statement error unimplemented: implementation pending
+DROP TABLE regional_by_row_as;
+CREATE TABLE regional_by_row_as (
+  pk INT PRIMARY KEY,
+  i INT,
+  cr crdb_internal_region NOT NULL DEFAULT 'ap-southeast-2',
+  INDEX(i),
+  FAMILY (cr, pk, i)
+) LOCALITY REGIONAL BY ROW AS "cr";
+INSERT INTO regional_by_row_as (pk, i) VALUES (1, 1);
+ALTER TABLE regional_by_row_as SET LOCALITY REGIONAL BY ROW
+
+statement error unimplemented: implementation pending
+DROP TABLE regional_by_row_as;
+CREATE TABLE regional_by_row_as (
+  pk INT PRIMARY KEY,
+  i INT,
+  cr crdb_internal_region NOT NULL DEFAULT 'ap-southeast-2',
+  INDEX(i),
+  FAMILY (cr, pk, i)
+) LOCALITY REGIONAL BY ROW AS "cr";
+INSERT INTO regional_by_row_as (pk, i) VALUES (1, 1);
+ALTER TABLE regional_by_row_as SET LOCALITY REGIONAL BY ROW AS "cr"
 
 
 # Set a table with a gc.ttlseconds to be a non-default value, and check this is

--- a/pkg/ccl/partitionccl/BUILD.bazel
+++ b/pkg/ccl/partitionccl/BUILD.bazel
@@ -51,7 +51,6 @@ go_test(
         "//pkg/server",
         "//pkg/settings/cluster",
         "//pkg/sql",
-        "//pkg/sql/catalog",
         "//pkg/sql/catalog/catalogkv",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/tabledesc",

--- a/pkg/ccl/partitionccl/regional_by_row_test.go
+++ b/pkg/ccl/partitionccl/regional_by_row_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
@@ -36,9 +35,11 @@ import (
 // REGIONAL BY ROW tests are defined in partitionccl as REGIONAL BY ROW
 // requires CCL to operate.
 
-// TestAlterTableLocalityToRegionalByRowError tests an alteration to REGIONAL
-// BY ROW which gets interrupted.
-func TestAlterTableLocalityToRegionalByRowError(t *testing.T) {
+// TestAlterTableLocalityRegionalByRowError tests an alteration involving
+// REGIONAL BY ROW which gets its async job interrupted by some sort of
+// error or cancellation. After this, we expect the table to retain
+// its original form with no extra columns or implicit partitioning added.
+func TestAlterTableLocalityRegionalByRowError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -52,269 +53,279 @@ func TestAlterTableLocalityToRegionalByRowError(t *testing.T) {
 		maxValue = 200
 		chunkSize = 5
 	}
-	// BulkInsertIntoTable adds from 0 to maxValue inclusive, so
+	// BulkInsertIntoTable adds testCase 0 to maxValue inclusive, so
 	// we round (maxValue + 1) / chunkSize to the nearest int.
 	// To round up x / y using integers, we do (x + y - 1) / y.
 	// In this case, since x=maxValue+1, we do (maxValue + chunkSize) / chunkSize.
 	var chunksPerBackfill = (maxValue + int(chunkSize)) / int(chunkSize)
 	ctx := context.Background()
 
-	checkGlobal := func(sqlDB *gosql.DB, tableDesc catalog.TableDescriptor) error {
-		if !tableDesc.IsLocalityGlobal() {
-			return errors.Errorf("expected locality to be global")
-		}
+	const showCreateTableStringSQL = `SELECT create_statement FROM [SHOW CREATE TABLE t.test]`
+	const showZoneConfigurationSQL = `SHOW ZONE CONFIGURATION FROM TABLE t.test`
 
-		zoneConfigRow := sqlDB.QueryRow("SHOW ZONE CONFIGURATION FROM TABLE t.test")
-		var target string
-		var rawZoneSQL string
-		require.NoError(t, zoneConfigRow.Scan(&target, &rawZoneSQL))
-		const expectedRawZoneSQL = `ALTER TABLE t.public.test CONFIGURE ZONE USING
-	range_min_bytes = 134217728,
-	range_max_bytes = 536870912,
-	gc.ttlseconds = 90000,
-	global_reads = true,
-	num_replicas = 3,
-	num_voters = 3,
-	constraints = '{+region=ajstorm-1: 1}',
-	voter_constraints = '[+region=ajstorm-1]',
-	lease_preferences = '[[+region=ajstorm-1]]'`
-		if !(target == "TABLE t.public.test" && rawZoneSQL == expectedRawZoneSQL) {
-			return errors.Errorf(
-				"expected zone configuration to not have changed, got %s, sql %s",
-				target,
-				rawZoneSQL,
-			)
-		}
-		return nil
-	}
-
-	checkRegionalByTable := func(sqlDB *gosql.DB, tableDesc catalog.TableDescriptor) error {
-		if !tableDesc.IsLocalityRegionalByTable() {
-			return errors.Errorf("expected locality to be regional by table")
-		}
-
-		zoneConfigRow := sqlDB.QueryRow("SHOW ZONE CONFIGURATION FROM TABLE t.test")
-		var target string
-		var rawZoneSQL string
-		require.NoError(t, zoneConfigRow.Scan(&target, &rawZoneSQL))
-		const expectedRawZoneSQL = `ALTER DATABASE t CONFIGURE ZONE USING
-	range_min_bytes = 134217728,
-	range_max_bytes = 536870912,
-	gc.ttlseconds = 90000,
-	num_replicas = 3,
-	num_voters = 3,
-	constraints = '{+region=ajstorm-1: 1}',
-	voter_constraints = '[+region=ajstorm-1]',
-	lease_preferences = '[[+region=ajstorm-1]]'`
-		if !(target == "DATABASE t" && rawZoneSQL == expectedRawZoneSQL) {
-			return errors.Errorf(
-				"expected zone configuration to not have changed, got %s, sql %s",
-				target,
-				rawZoneSQL,
-			)
-		}
-		return nil
-	}
-	const showCreateTableGlobal = `CREATE TABLE public.test (
-	k INT8 NOT NULL,
-	v INT8 NULL,
-	rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-	cr public.crdb_internal_region NOT NULL DEFAULT gateway_region()::public.crdb_internal_region,
-	CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
-	FAMILY "primary" (k, v, rowid, cr)
-) LOCALITY GLOBAL`
-	const showCreateTableRegionalByRow = `CREATE TABLE public.test (
-	k INT8 NOT NULL,
-	v INT8 NULL,
-	rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-	cr public.crdb_internal_region NOT NULL DEFAULT gateway_region()::public.crdb_internal_region,
-	CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
-	FAMILY "primary" (k, v, rowid, cr)
-) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION`
-
-	testCases := []struct {
-		desc                  string
-		setupQuery            string
-		toRegionalByRowQuery  string
-		checkAfterCancel      func(*gosql.DB, catalog.TableDescriptor) error
-		showCreateTableOutput string
+	// alterState is a struct that contains an action for a base test case
+	// to execute ALTER TABLE t.test SET LOCALITY <locality> against.
+	type alterState struct {
+		desc       string
+		alterQuery string
 		// cancelOnBackfillChunk on which chunk the cancel query should run.
 		cancelOnBackfillChunk int
-	}{
-		{
-			desc:                  "cancel after backfilling one chunk from GLOBAL to REGIONAL BY ROW AS",
-			setupQuery:            `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY GLOBAL`,
-			toRegionalByRowQuery:  `ALTER TABLE t.test SET LOCALITY REGIONAL BY ROW AS cr`,
-			checkAfterCancel:      checkGlobal,
-			cancelOnBackfillChunk: 1,
-			showCreateTableOutput: showCreateTableGlobal,
-		},
-		{
-			desc:                  "cancel during ADD COLUMN stage of from GLOBAL to REGIONAL BY ROW",
-			setupQuery:            `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY GLOBAL`,
-			toRegionalByRowQuery:  `ALTER TABLE t.test SET LOCALITY REGIONAL BY ROW`,
-			checkAfterCancel:      checkGlobal,
-			cancelOnBackfillChunk: 1,
-			showCreateTableOutput: showCreateTableGlobal,
-		},
-		{
-			desc:                  "cancel during ALTER PRIMARY KEY stage from GLOBAL to REGIONAL BY ROW",
-			setupQuery:            `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY GLOBAL`,
-			toRegionalByRowQuery:  `ALTER TABLE t.test SET LOCALITY REGIONAL BY ROW`,
-			checkAfterCancel:      checkGlobal,
-			cancelOnBackfillChunk: chunksPerBackfill + 1,
-			showCreateTableOutput: showCreateTableGlobal,
-		},
+	}
 
+	// nonRegionalByRowAlterStates contains SET LOCALITY operations that exercise
+	// the async ALTER PRIMARY KEY path for non-REGIONAL BY ROW base test cases.
+	nonRegionalByRowAlterStates := []alterState{
 		{
-			desc:                  "cancel after backfilling one chunk from REGIONAL BY TABLE to REGIONAL BY ROW AS",
-			setupQuery:            `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY REGIONAL BY TABLE`,
-			toRegionalByRowQuery:  `ALTER TABLE t.test SET LOCALITY REGIONAL BY ROW AS cr`,
-			checkAfterCancel:      checkRegionalByTable,
+			desc:                  "alter to REGIONAL BY ROW AS cr",
+			alterQuery:            `ALTER TABLE t.test SET LOCALITY REGIONAL BY ROW AS cr`,
 			cancelOnBackfillChunk: 1,
-			showCreateTableOutput: showCreateTableRegionalByRow,
 		},
 		{
-			desc:                  "cancel during ADD COLUMN stage of from REGIONAL BY TABLE to REGIONAL BY ROW",
-			setupQuery:            `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY REGIONAL BY TABLE`,
-			toRegionalByRowQuery:  `ALTER TABLE t.test SET LOCALITY REGIONAL BY ROW`,
-			checkAfterCancel:      checkRegionalByTable,
+			desc:                  "alter to REGIONAL BY ROW, interrupt during add column",
+			alterQuery:            `ALTER TABLE t.test SET LOCALITY REGIONAL BY ROW`,
 			cancelOnBackfillChunk: 1,
-			showCreateTableOutput: showCreateTableRegionalByRow,
 		},
 		{
-			desc:                  "cancel during ALTER PRIMARY KEY stage from REGIONAL BY TABLE to REGIONAL BY ROW",
-			setupQuery:            `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY REGIONAL BY TABLE`,
-			toRegionalByRowQuery:  `ALTER TABLE t.test SET LOCALITY REGIONAL BY ROW`,
-			checkAfterCancel:      checkRegionalByTable,
+			desc:                  "alter to REGIONAL BY ROW, interrupt during pk swap",
+			alterQuery:            `ALTER TABLE t.test SET LOCALITY REGIONAL BY ROW`,
 			cancelOnBackfillChunk: chunksPerBackfill + 1,
-			showCreateTableOutput: showCreateTableRegionalByRow,
+		},
+	}
+	// nonRegionalByRowAlterStates contains SET LOCALITY operations that exercise
+	// the async ALTER PRIMARY KEY path for REGIONAL BY ROW base test cases.
+	regionalByRowAlterStates := []alterState{
+		{
+			desc:                  "alter to GLOBAL",
+			alterQuery:            `ALTER TABLE t.test SET LOCALITY GLOBAL`,
+			cancelOnBackfillChunk: 1,
+		},
+		{
+			desc:                  "alter to REGIONAL BY TABLE",
+			alterQuery:            `ALTER TABLE t.test SET LOCALITY REGIONAL BY TABLE`,
+			cancelOnBackfillChunk: 1,
+		},
+		{
+			desc:                  "alter to REGIONAL BY TABLE IN ajstorm-1",
+			alterQuery:            `ALTER TABLE t.test SET LOCALITY REGIONAL BY TABLE IN "ajstorm-1"`,
+			cancelOnBackfillChunk: 1,
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			for _, errorMode := range []struct {
-				desc          string
-				runOnChunk    func(db *gosql.DB) error
-				errorContains string
-			}{
-				{
-					desc: "cancel",
-					runOnChunk: func(db *gosql.DB) error {
-						_, err := db.Exec(`CANCEL JOB (
+	// testCases contain a base table structure to start off as.
+	// For each of these test cases, we pick either the alter state corresponding
+	// to the base table's locality -- for REGIONAL BY ROW tables we pick
+	// regionalyByRowAlterStates and for GLOBAL/REGIONAL BY TABLE tables we pick
+	// nonRegionalByRowAlterStates.
+	testCases := []struct {
+		desc           string
+		setupQuery     string
+		rowidIdx       int
+		alterStates    []alterState
+		originalPKCols []string
+	}{
+		{
+			desc:           "GLOBAL",
+			setupQuery:     `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY GLOBAL`,
+			originalPKCols: []string{"rowid"},
+			alterStates:    nonRegionalByRowAlterStates,
+		},
+		{
+			desc:           "REGIONAL BY TABLE",
+			setupQuery:     `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY REGIONAL BY TABLE`,
+			originalPKCols: []string{"rowid"},
+			alterStates:    nonRegionalByRowAlterStates,
+		},
+		{
+			desc:           "REGIONAL BY TABLE IN ajstorm-1",
+			setupQuery:     `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY REGIONAL BY TABLE IN "ajstorm-1"`,
+			originalPKCols: []string{"rowid"},
+			alterStates:    nonRegionalByRowAlterStates,
+		},
+		{
+			desc:           "REGIONAL BY ROW",
+			setupQuery:     `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY REGIONAL BY ROW`,
+			originalPKCols: []string{"crdb_region", "rowid"},
+			alterStates:    regionalByRowAlterStates,
+		},
+		{
+			desc: "REGIONAL BY ROW AS",
+			setupQuery: `CREATE TABLE t.test (
+				k INT NOT NULL, v INT, cr2 t.public.crdb_internal_region NOT NULL DEFAULT 'ajstorm-1'
+			) LOCALITY REGIONAL BY ROW AS cr2`,
+			originalPKCols: []string{"cr2", "rowid"},
+			alterStates:    regionalByRowAlterStates,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.desc, func(t *testing.T) {
+			for _, alterState := range testCase.alterStates {
+				t.Run(alterState.desc, func(t *testing.T) {
+					for _, errorMode := range []struct {
+						desc          string
+						runOnChunk    func(db *gosql.DB) error
+						errorContains string
+					}{
+						{
+							desc: "cancel",
+							runOnChunk: func(db *gosql.DB) error {
+								_, err := db.Exec(`CANCEL JOB (
 					SELECT job_id FROM [SHOW JOBS]
 					WHERE
 						job_type = 'SCHEMA CHANGE' AND
 						status = $1 AND
 						description NOT LIKE 'ROLL BACK%'
 				)`, jobs.StatusRunning)
-						return err
-					},
-					errorContains: "job canceled by user",
-				},
-				{
-					desc: "arbitrary error",
-					runOnChunk: func(db *gosql.DB) error {
-						return errors.Newf("arbitrary error during backfill")
-					},
-					errorContains: "arbitrary error during backfill",
-				},
-			} {
-				t.Run(errorMode.desc, func(t *testing.T) {
-					var db *gosql.DB
-					// set backfill chunk to -chunksPerBackfill, to allow the ALTER TABLE ... ADD COLUMN
-					// to backfill successfully.
-					currentBackfillChunk := -(chunksPerBackfill + 1)
-					params, _ := tests.CreateTestServerParams()
-					params.Locality.Tiers = []roachpb.Tier{
-						{Key: "region", Value: "ajstorm-1"},
-					}
-					params.Knobs = base.TestingKnobs{
-						SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
-							BackfillChunkSize: chunkSize,
-						},
-						DistSQL: &execinfra.TestingKnobs{
-							RunBeforeBackfillChunk: func(sp roachpb.Span) error {
-								currentBackfillChunk += 1
-								if currentBackfillChunk != tc.cancelOnBackfillChunk {
-									return nil
-								}
-								return errorMode.runOnChunk(db)
+								return err
 							},
+							errorContains: "job canceled by user",
 						},
-					}
-					s, sqlDB, kvDB := serverutils.StartServer(t, params)
-					db = sqlDB
-					defer s.Stopper().Stop(ctx)
+						{
+							desc: "arbitrary error",
+							runOnChunk: func(db *gosql.DB) error {
+								return errors.Newf("arbitrary error during backfill")
+							},
+							errorContains: "arbitrary error during backfill",
+						},
+					} {
+						t.Run(errorMode.desc, func(t *testing.T) {
+							var db *gosql.DB
+							// set backfill chunk to -chunksPerBackfill, to allow the ALTER TABLE ... ADD COLUMN
+							// to backfill successfully.
+							currentBackfillChunk := -(chunksPerBackfill + 1)
+							params, _ := tests.CreateTestServerParams()
+							params.Locality.Tiers = []roachpb.Tier{
+								{Key: "region", Value: "ajstorm-1"},
+							}
+							params.Knobs = base.TestingKnobs{
+								SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+									BackfillChunkSize: chunkSize,
+								},
+								DistSQL: &execinfra.TestingKnobs{
+									RunBeforeBackfillChunk: func(sp roachpb.Span) error {
+										currentBackfillChunk += 1
+										if currentBackfillChunk != alterState.cancelOnBackfillChunk {
+											return nil
+										}
+										return errorMode.runOnChunk(db)
+									},
+								},
+							}
+							s, sqlDB, kvDB := serverutils.StartServer(t, params)
+							db = sqlDB
+							defer s.Stopper().Stop(ctx)
 
-					// Disable strict GC TTL enforcement because we're going to shove a zero-value
-					// TTL into the system with AddImmediateGCZoneConfig.
-					defer sqltestutils.DisableGCTTLStrictEnforcement(t, sqlDB)()
+							// Disable strict GC TTL enforcement because we're going to shove a zero-value
+							// TTL into the system with AddImmediateGCZoneConfig.
+							defer sqltestutils.DisableGCTTLStrictEnforcement(t, sqlDB)()
 
-					if _, err := sqlDB.Exec(fmt.Sprintf(`
+							if _, err := sqlDB.Exec(fmt.Sprintf(`
 SET experimental_enable_implicit_column_partitioning = true;
 CREATE DATABASE t PRIMARY REGION "ajstorm-1";
 %s;
-`, tc.setupQuery)); err != nil {
-						t.Fatal(err)
-					}
+`, testCase.setupQuery)); err != nil {
+								t.Fatal(err)
+							}
 
-					if err := sqltestutils.BulkInsertIntoTable(sqlDB, maxValue); err != nil {
-						t.Fatal(err)
-					}
+							if err := sqltestutils.BulkInsertIntoTable(sqlDB, maxValue); err != nil {
+								t.Fatal(err)
+							}
 
-					// We add the "cr" column, which can be used for REGIONAL BY ROW AS.
-					if _, err := sqlDB.Exec(`
+							// We add the "cr" column, which can be used for REGIONAL BY ROW AS.
+							if _, err := sqlDB.Exec(`
 		ALTER TABLE t.test ADD COLUMN cr t.crdb_internal_region
 		NOT NULL
 		DEFAULT gateway_region()::t.crdb_internal_region
 	`); err != nil {
-						t.Fatal(err)
-					}
-					// This will fail, so we don't want to check the error.
-					_, err := sqlDB.Exec(tc.toRegionalByRowQuery)
-					require.Error(t, err)
-					require.Contains(t, err.Error(), errorMode.errorContains)
+								t.Fatal(err)
+							}
+							// This will fail, so we don't want to check the error.
+							_, err := sqlDB.Exec(alterState.alterQuery)
+							require.Error(t, err)
+							require.Contains(t, err.Error(), errorMode.errorContains)
 
-					// Ensure that the mutations corresponding to the primary key change are cleaned up and
-					// that the job did not succeed even though it was canceled.
-					testutils.SucceedsSoon(t, func() error {
-						tableDesc := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "test")
-						if len(tableDesc.GetMutations()) != 0 {
-							return errors.Errorf("expected 0 mutations after cancellation, found %d", len(tableDesc.GetMutations()))
-						}
-						if tableDesc.GetPrimaryIndex().NumColumns() != 1 || tableDesc.GetPrimaryIndex().GetColumnName(0) != "rowid" {
-							return errors.Errorf("expected primary key change to not succeed after cancellation")
-						}
-
-						// Ensure SHOW CREATE TABLE for the table has not changed.
-						createTableRow := sqlDB.QueryRow(
-							"SELECT create_statement FROM [SHOW CREATE TABLE t.test]",
-						)
-						var createTableString string
-						if err := createTableRow.Scan(&createTableString); err != nil {
-							return err
-						}
-						if createTableString != tc.showCreateTableOutput {
-							return errors.Errorf(
-								"expected SHOW CREATE TABLE to be %s\ngot %s",
-								tc.showCreateTableOutput,
-								createTableString,
+							// Grab a copy of SHOW CREATE TABLE and SHOW ZONE CONFIGURATION before we run
+							// any ALTER query. The result should match if the operation fails.
+							var originalCreateTableOutput string
+							require.NoError(
+								t,
+								sqlDB.QueryRow(showCreateTableStringSQL).Scan(&originalCreateTableOutput),
 							)
-						}
 
-						return tc.checkAfterCancel(sqlDB, tableDesc)
-					})
+							var originalTarget, originalZoneConfig string
+							require.NoError(
+								t,
+								sqlDB.QueryRow(showZoneConfigurationSQL).Scan(&originalTarget, &originalZoneConfig),
+							)
 
-					tableDesc := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "test")
-					if _, err := sqltestutils.AddImmediateGCZoneConfig(db, tableDesc.GetID()); err != nil {
-						t.Fatal(err)
+							// Ensure that the mutations corresponding to the primary key change are cleaned up and
+							// that the job did not succeed even though it was canceled.
+							testutils.SucceedsSoon(t, func() error {
+								tableDesc := catalogkv.TestingGetTableDescriptor(
+									kvDB, keys.SystemSQLCodec, "t", "test",
+								)
+								if len(tableDesc.GetMutations()) != 0 {
+									return errors.Errorf(
+										"expected 0 mutations after cancellation, found %d",
+										len(tableDesc.GetMutations()),
+									)
+								}
+								if tableDesc.GetPrimaryIndex().NumColumns() != len(testCase.originalPKCols) {
+									return errors.Errorf("expected primary key change to not succeed after cancellation")
+								}
+								for i, name := range testCase.originalPKCols {
+									if tableDesc.GetPrimaryIndex().GetColumnName(i) != name {
+										return errors.Errorf(
+											"expected primary key change to not succeed after cancellation\nmismatch idx %d: exp %s, got %s",
+											i,
+											name,
+											tableDesc.GetPrimaryIndex().GetColumnName(i),
+										)
+									}
+								}
+
+								// Ensure SHOW CREATE TABLE for the table has not changed.
+								var createTableString string
+								if err := sqlDB.QueryRow(showCreateTableStringSQL).Scan(&createTableString); err != nil {
+									return err
+								}
+								if createTableString != originalCreateTableOutput {
+									return errors.Errorf(
+										"expected SHOW CREATE TABLE to be %s\ngot %s",
+										originalCreateTableOutput,
+										createTableString,
+									)
+								}
+
+								// Ensure SHOW ZONE CONFIGURATION has not changed.
+								var target, zoneConfig string
+								require.NoError(
+									t,
+									sqlDB.QueryRow(showZoneConfigurationSQL).Scan(&target, &zoneConfig),
+								)
+								if !(target == originalTarget && zoneConfig == originalZoneConfig) {
+									return errors.Errorf(
+										"expected zone configuration to not have changed, got %s/%s, sql %s/%s",
+										originalTarget,
+										target,
+										originalZoneConfig,
+										zoneConfig,
+									)
+								}
+
+								return nil
+							})
+
+							tableDesc := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "test")
+							if _, err := sqltestutils.AddImmediateGCZoneConfig(db, tableDesc.GetID()); err != nil {
+								t.Fatal(err)
+							}
+							// Ensure that the writes from the partial new indexes are cleaned up.
+							testutils.SucceedsSoon(t, func() error {
+								return sqltestutils.CheckTableKeyCount(ctx, kvDB, 1, maxValue)
+							})
+						})
 					}
-					// Ensure that the writes from the partial new indexes are cleaned up.
-					testutils.SucceedsSoon(t, func() error {
-						return sqltestutils.CheckTableKeyCount(ctx, kvDB, 1, maxValue)
-					})
 				})
 			}
 		})

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1188,6 +1188,9 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 							),
 						)
 						switch lcSwap.NewLocalityConfig.Locality.(type) {
+						case *descpb.TableDescriptor_LocalityConfig_Global_,
+							*descpb.TableDescriptor_LocalityConfig_RegionalByTable_:
+							// Just the table re-writing the locality config change will suffice.
 						case *descpb.TableDescriptor_LocalityConfig_RegionalByRow_:
 							// Apply new zone configurations for all newly partitioned indexes.
 							opts = append(

--- a/pkg/sql/sqltestutils/sql_test_utils.go
+++ b/pkg/sql/sqltestutils/sql_test_utils.go
@@ -78,7 +78,7 @@ func BulkInsertIntoTable(sqlDB *gosql.DB, maxValue int) error {
 	for i := 0; i < maxValue+1; i++ {
 		inserts[i] = fmt.Sprintf(`(%d, %d)`, i, maxValue-i)
 	}
-	_, err := sqlDB.Exec(`INSERT INTO t.test VALUES ` + strings.Join(inserts, ","))
+	_, err := sqlDB.Exec(`INSERT INTO t.test (k, v) VALUES ` + strings.Join(inserts, ","))
 	return err
 }
 


### PR DESCRIPTION
Migrating from REGIONAL BY ROW is a matter of removing the partition by
column, which is another ALTER PRIMARY KEY style re-index. This is the
technique we use to implement this functionality in this commit.

Release note (sql change): Implemented functionality to ALTER TABLE SET
LOCALITY from REGIONAL BY ROW to REGIONAL BY TABLE or GLOBAL.