### PR TITLE
sql: mark all PARTITION BY columns as NOT NULL on CREATE

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -88,7 +88,7 @@ SELECT create_statement FROM [SHOW CREATE TABLE t]
 ----
 CREATE TABLE public.t (
   pk INT8 NOT NULL,
-  a INT8 NULL,
+  a INT8 NOT NULL,
   b INT8 NULL,
   c INT8 NULL,
   d INT8 NULL,
@@ -122,7 +122,7 @@ SELECT create_statement FROM [SHOW CREATE TABLE t]
 ----
 CREATE TABLE public.t (
   pk INT8 NOT NULL,
-  a INT8 NULL,
+  a INT8 NOT NULL,
   b INT8 NULL,
   c INT8 NULL,
   d INT8 NULL,
@@ -375,7 +375,7 @@ SELECT create_statement FROM [SHOW CREATE TABLE t]
 CREATE TABLE public.t (
   pk INT8 NOT NULL,
   pk2 INT8 NOT NULL,
-  partition_by INT8 NULL,
+  partition_by INT8 NOT NULL,
   a INT8 NOT NULL,
   b INT8 NOT NULL,
   c INT8 NOT NULL,
@@ -426,7 +426,7 @@ SELECT create_statement FROM [SHOW CREATE TABLE t]
 CREATE TABLE public.t (
   pk INT8 NOT NULL,
   pk2 INT8 NOT NULL,
-  partition_by INT8 NULL,
+  partition_by INT8 NOT NULL,
   a INT8 NOT NULL,
   b INT8 NOT NULL,
   c INT8 NOT NULL,
@@ -524,7 +524,7 @@ SELECT create_statement FROM [SHOW CREATE TABLE t]
 CREATE TABLE public.t (
   pk INT8 NOT NULL,
   pk2 INT8 NOT NULL,
-  partition_by INT8 NULL,
+  partition_by INT8 NOT NULL,
   a INT8 NULL,
   b INT8 NULL,
   c INT8 NULL,

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -632,7 +632,7 @@ CREATE TABLE public.regional_by_row_table_as (
   pk INT8 NOT NULL,
   a INT8 NULL,
   b INT8 NULL,
-  crdb_region_col public.crdb_internal_region NULL AS (CASE WHEN pk <= 10:::INT8 THEN 'us-east-1':::public.crdb_internal_region ELSE 'ap-southeast-2':::public.crdb_internal_region END) STORED,
+  crdb_region_col public.crdb_internal_region NOT NULL AS (CASE WHEN pk <= 10:::INT8 THEN 'us-east-1':::public.crdb_internal_region ELSE 'ap-southeast-2':::public.crdb_internal_region END) STORED,
   CONSTRAINT "primary" PRIMARY KEY (pk ASC),
   INDEX regional_by_row_table_as_a_idx (a ASC),
   UNIQUE INDEX regional_by_row_table_as_b_key (b ASC),

--- a/pkg/sql/alter_table_locality.go
+++ b/pkg/sql/alter_table_locality.go
@@ -270,7 +270,6 @@ func (n *alterTableSetLocalityNode) alterTableLocalityNonRegionalByRowToRegional
 					pgcode.InvalidTableDefinition,
 					"cannot use column %s for REGIONAL BY ROW table as it may contain NULL values",
 					partColName,
-					tree.RegionEnum,
 				),
 				"Add the NOT NULL constraint first using ALTER TABLE %s ALTER COLUMN %s SET NOT NULL.",
 				tree.Name(n.tableDesc.Name),


### PR DESCRIPTION

Release note (sql change): To match the behaviour of PRIMARY KEY
creations setting all relevant fields to NOT NULL, all PARTITION BY
/ REGIONAL BY ROW columns will also have their fields set to NOT NULL on
CREATE TABLE time.

