### PR TITLE
sql: include sampled stats in TestSampledStatsCollection

### DIFF
--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -454,7 +454,7 @@ func (a *appStats) recordTransaction(
 	if collectedExecStats {
 		s.mu.data.ExecStats.Count++
 		s.mu.data.ExecStats.NetworkBytes.Record(s.mu.data.ExecStats.Count, float64(execStats.NetworkBytesSent))
-		s.mu.data.ExecStats.NetworkBytes.Record(s.mu.data.ExecStats.Count, float64(execStats.NetworkBytesSent))
+		s.mu.data.ExecStats.MaxMemUsage.Record(s.mu.data.ExecStats.Count, float64(execStats.MaxMemUsage))
 		s.mu.data.ExecStats.ContentionTime.Record(s.mu.data.ExecStats.Count, execStats.ContentionTime.Seconds())
 	}
 }

--- a/pkg/sql/instrumentation_test.go
+++ b/pkg/sql/instrumentation_test.go
@@ -80,6 +80,7 @@ func TestSampledStatsCollection(t *testing.T) {
 		require.Equal(t, int64(2), stats.mu.data.Count, "expected to have collected two sets of general stats")
 		require.Equal(t, int64(1), stats.mu.data.ExecStatCollectionCount, "expected to have collected exactly one set of execution stats")
 		require.Greater(t, stats.mu.data.RowsRead.Mean, float64(0), "expected statement to have read at least one row")
+		require.Greater(t, stats.mu.data.MaxMemUsage.Mean, float64(0), "expected statement to have used RAM")
 	})
 
 	t.Run("ExplicitTxn", func(t *testing.T) {
@@ -107,12 +108,14 @@ func TestSampledStatsCollection(t *testing.T) {
 		require.Equal(t, int64(2), aggStats.mu.data.Count, "expected to have collected two sets of general stats")
 		require.Equal(t, int64(1), aggStats.mu.data.ExecStatCollectionCount, "expected to have collected exactly one set of execution stats")
 		require.Greater(t, aggStats.mu.data.RowsRead.Mean, float64(0), "expected statement to have read at least one row")
+		require.Greater(t, aggStats.mu.data.MaxMemUsage.Mean, float64(0), "expected statement to have used RAM")
 
 		selectStats.mu.Lock()
 		defer selectStats.mu.Unlock()
 		require.Equal(t, int64(2), selectStats.mu.data.Count, "expected to have collected two sets of general stats")
 		require.Equal(t, int64(1), selectStats.mu.data.ExecStatCollectionCount, "expected to have collected exactly one set of execution stats")
 		require.Greater(t, selectStats.mu.data.RowsRead.Mean, float64(0), "expected statement to have read at least one row")
+		require.Greater(t, selectStats.mu.data.MaxMemUsage.Mean, float64(0), "expected statement to have used RAM")
 
 		key := util.MakeFNV64()
 		key.Add(uint64(aggID))
@@ -134,5 +137,6 @@ func TestSampledStatsCollection(t *testing.T) {
 			txStats.mu.data.RowsRead.Mean,
 			"expected txn to report having read the sum of rows read in both its statements",
 		)
+		require.Greater(t, txStats.mu.data.ExecStats.MaxMemUsage.Mean, float64(0), "expected MaxMemUsage to be set on the txn")
 	})
 }


### PR DESCRIPTION
Depends on #59992, which is required for this new regression test to pass.

TestSampledStatsCollection would previously only check that stats that are
collected regardless of the sample rate are returned. These types of stats
(rows/bytes read) are propagated using metadata, rather than the trace.

This resulted in us silently failing to collect any stats when sampling was
enabled once the tracing mode was reverted back to legacy. To avoid this kind
of thing happening again, this commit adds a check that max memory usage is
reported to be non-zero.

Release note: None (this is a new feature that has no user impact yet)