### PR TITLE
sqlutil: remove Query and QueryEx from InternalExecutor interface

### DIFF
--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -46,7 +46,7 @@ const (
 // available.
 func (r *Registry) claimJobs(ctx context.Context, s sqlliveness.Session) error {
 	return r.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		rows, err := r.ex.Query(
+		numRows, err := r.ex.Exec(
 			ctx, "claim-jobs", txn, `
    UPDATE system.jobs
       SET claim_session_id = $1, claim_instance_id = $2
@@ -60,8 +60,8 @@ RETURNING id;`,
 		if err != nil {
 			return errors.Wrap(err, "could not query jobs table")
 		}
-		if log.ExpensiveLogEnabled(ctx, 1) || len(rows) > 0 {
-			log.Infof(ctx, "claimed %d jobs", len(rows))
+		if log.ExpensiveLogEnabled(ctx, 1) || numRows > 0 {
+			log.Infof(ctx, "claimed %d jobs", numRows)
 		}
 		return nil
 	})
@@ -69,7 +69,7 @@ RETURNING id;`,
 
 // processClaimedJobs processes all jobs currently claimed by the registry.
 func (r *Registry) processClaimedJobs(ctx context.Context, s sqlliveness.Session) error {
-	rows, err := r.ex.QueryEx(
+	it, err := r.ex.QueryIteratorEx(
 		ctx, "select-running/get-claimed-jobs", nil,
 		sessiondata.InternalExecutorOverride{User: security.NodeUserName()}, `
 SELECT id FROM system.jobs
@@ -77,16 +77,21 @@ WHERE (status = $1 OR status = $2) AND (claim_session_id = $3 AND claim_instance
 		StatusRunning, StatusReverting, s.ID().UnsafeBytes(), r.ID(),
 	)
 	if err != nil {
-		return errors.Wrapf(err, "could query for claimed jobs")
+		return errors.Wrapf(err, "could not query for claimed jobs")
 	}
 
 	// This map will eventually contain the job ids that must be resumed.
-	claimedToResume := make(map[int64]struct{}, len(rows))
+	claimedToResume := make(map[int64]struct{})
 	// Initially all claimed jobs are supposed to be resumed but some may be
 	// running on this registry already so we will filter them out later.
-	for _, row := range rows {
+	var ok bool
+	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
+		row := it.Cur()
 		id := int64(*row[0].(*tree.DInt))
 		claimedToResume[id] = struct{}{}
+	}
+	if err != nil {
+		return errors.Wrapf(err, "could not query for claimed jobs")
 	}
 
 	r.filterAlreadyRunningAndCancelFromPreviousSessions(ctx, s, claimedToResume)
@@ -255,7 +260,7 @@ func (r *Registry) runJob(
 
 func (r *Registry) servePauseAndCancelRequests(ctx context.Context, s sqlliveness.Session) error {
 	return r.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		rows, err := r.ex.QueryEx(
+		it, err := r.ex.QueryIteratorEx(
 			ctx, "cancel/pause-requested", txn, sessiondata.InternalExecutorOverride{User: security.NodeUserName()}, `
 UPDATE system.jobs
 SET status =
@@ -270,6 +275,20 @@ RETURNING id, status`,
 			StatusCancelRequested, StatusReverting,
 			s.ID().UnsafeBytes(), r.ID(),
 		)
+		if err != nil {
+			return errors.Wrap(err, "could not query jobs table")
+		}
+		// Note that we have to buffer all rows first - before processing each
+		// job - because we have to make sure that the query executes without an
+		// error (otherwise, the system.jobs table might diverge from the jobs
+		// registry).
+		// TODO(yuzefovich): use QueryBufferedEx method once it is added to
+		// sqlutil.InternalExecutor interface.
+		var rows []tree.Datums
+		var ok bool
+		for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
+			rows = append(rows, it.Cur())
+		}
 		if err != nil {
 			return errors.Wrap(err, "could not query jobs table")
 		}

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
@@ -653,23 +653,12 @@ func (ie *wrappedInternalExecutor) ExecEx(
 	stmt string,
 	qargs ...interface{},
 ) (int, error) {
-	panic("unimplemented")
-}
-
-func (ie *wrappedInternalExecutor) QueryEx(
-	ctx context.Context,
-	opName string,
-	txn *kv.Txn,
-	session sessiondata.InternalExecutorOverride,
-	stmt string,
-	qargs ...interface{},
-) ([]tree.Datums, error) {
 	if f := ie.getErrFunc(); f != nil {
 		if err := f(stmt); err != nil {
-			return nil, err
+			return 0, err
 		}
 	}
-	return ie.wrapped.QueryEx(ctx, opName, txn, session, stmt, qargs...)
+	return ie.wrapped.ExecEx(ctx, opName, txn, o, stmt, qargs...)
 }
 
 func (ie *wrappedInternalExecutor) QueryWithCols(
@@ -699,12 +688,6 @@ func (ie *wrappedInternalExecutor) QueryRowEx(
 	return ie.wrapped.QueryRowEx(ctx, opName, txn, session, stmt, qargs...)
 }
 
-func (ie *wrappedInternalExecutor) Query(
-	ctx context.Context, opName string, txn *kv.Txn, statement string, params ...interface{},
-) ([]tree.Datums, error) {
-	panic("not implemented")
-}
-
 func (ie *wrappedInternalExecutor) QueryRow(
 	ctx context.Context, opName string, txn *kv.Txn, statement string, qargs ...interface{},
 ) (tree.Datums, error) {
@@ -725,7 +708,12 @@ func (ie *wrappedInternalExecutor) QueryIteratorEx(
 	stmt string,
 	qargs ...interface{},
 ) (sqlutil.InternalRows, error) {
-	panic("not implemented")
+	if f := ie.getErrFunc(); f != nil {
+		if err := f(stmt); err != nil {
+			return nil, err
+		}
+	}
+	return ie.wrapped.QueryIteratorEx(ctx, opName, txn, session, stmt, qargs...)
 }
 
 func (ie *wrappedInternalExecutor) getErrFunc() func(statement string) error {

--- a/pkg/migration/migrationmanager/manager.go
+++ b/pkg/migration/migrationmanager/manager.go
@@ -312,7 +312,17 @@ SELECT id, status
 	if err != nil {
 		return false, 0, errors.Wrap(err, "failed to marshal version to JSON")
 	}
-	rows, err := m.ie.Query(ctx, "migration-manager-find-jobs", txn, query, jsonMsg.String())
+	// TODO(yuzefovich): use QueryBuffered method once it is added to
+	// sqlutil.InternalExecutor interface.
+	it, err := m.ie.QueryIterator(ctx, "migration-manager-find-jobs", txn, query, jsonMsg.String())
+	if err != nil {
+		return false, 0, err
+	}
+	var rows []tree.Datums
+	var ok bool
+	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
+		rows = append(rows, it.Cur())
+	}
 	if err != nil {
 		return false, 0, err
 	}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3136,12 +3136,6 @@ type ClientNoticeSender interface {
 // this to sqlutil.InternalExecutor or sql.InternalExecutor, and use the
 // alternatives.
 type InternalExecutor interface {
-	// Query is part of the sqlutil.InternalExecutor interface.
-	Query(
-		ctx context.Context, opName string, txn *kv.Txn,
-		stmt string, qargs ...interface{},
-	) ([]Datums, error)
-
 	// QueryRow is part of the sqlutil.InternalExecutor interface.
 	QueryRow(
 		ctx context.Context, opName string, txn *kv.Txn, stmt string, qargs ...interface{},

--- a/pkg/sql/sqlutil/internal_executor.go
+++ b/pkg/sql/sqlutil/internal_executor.go
@@ -50,34 +50,10 @@ type InternalExecutor interface {
 		qargs ...interface{},
 	) (int, error)
 
-	// Query executes the supplied SQL statement and returns the resulting rows.
-	// If no user has been previously set through SetSessionData, the statement is
-	// executed as the root user.
+	// QueryWithCols executes the supplied SQL statement and returns the
+	// resulting rows as well as the computed ResultColumns of the input query.
 	//
 	// If txn is not nil, the statement will be executed in the respective txn.
-	//
-	// Query is deprecated because it may transparently execute a query as root. Use
-	// QueryEx instead.
-	Query(
-		ctx context.Context, opName string, txn *kv.Txn, statement string, qargs ...interface{},
-	) ([]tree.Datums, error)
-
-	// QueryEx is like Query, but allows the caller to override some session data
-	// fields.
-	//
-	// The fields set in session that are set override the respective fields if
-	// they have previously been set through SetSessionData().
-	QueryEx(
-		ctx context.Context,
-		opName string,
-		txn *kv.Txn,
-		session sessiondata.InternalExecutorOverride,
-		stmt string,
-		qargs ...interface{},
-	) ([]tree.Datums, error)
-
-	// QueryWithCols is like QueryEx, but it also returns the computed ResultColumns
-	// of the input query.
 	QueryWithCols(
 		ctx context.Context, opName string, txn *kv.Txn,
 		o sessiondata.InternalExecutorOverride, statement string, qargs ...interface{},


### PR DESCRIPTION
All usages of `sqlutil.InternalExecutor.Query` and
`sqlutil.InternalExecutor.QueryEx` have been refactored: most of
the changes are taking advantage of the iterator API, in a couple
of places we now use `Exec` and `ExecEx` methods since in those
places we only need the number of affected rows.

In a few places where we still need to buffer all rows, the caller
currently performs the buffering. In the follow-up commit
`QueryBuffered` and `QueryBufferedEx` will be added into the interface
(essentially renaming `Query` and `QueryEx` to make it explicit that the
buffering occurs), and the custom logic will be removed.

Addresses: #48595.

Release note: None