### PR TITLE
logic: fix flakey logic test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -354,7 +354,7 @@ node_id  network  address           attrs  locality            server_version
 1        tcp      127.0.0.1:<port>  []     region=test,dc=dc1  <server_version>
 
 query ITTBBT colnames
-SELECT node_id, regexp_replace(epoch::string, '^\d+$', '<epoch>') as epoch, regexp_replace(expiration, '^\d+\.\d+,\d+$', '<timestamp>') as expiration, draining, decommissioning, membership FROM crdb_internal.gossip_liveness WHERE node_id = 1
+SELECT node_id, regexp_replace(epoch::string, '^\d+$', '<epoch>') as epoch, regexp_replace(expiration, '^\d+(\.\d+)?,\d+$', '<timestamp>') as expiration, draining, decommissioning, membership FROM crdb_internal.gossip_liveness WHERE node_id = 1
 ----
 node_id  epoch  expiration    draining  decommissioning     membership
 1        <epoch>      <timestamp>   false     false               active


### PR DESCRIPTION
Since #53842 we write an initial liveness record with a zero timestamp.
This sometimes shows up as the following flake.

```
    logic.go:2283:

        testdata/logic_test/crdb_internal:356: SELECT node_id, regexp_replace(epoch::string, '^\d+$', '<epoch>') as epoch, regexp_replace(expiration, '^\d+\.\d+,\d+$', '<timestamp>') as expiration, draining, decommissioning, membership FROM crdb_internal.gossip_liveness WHERE node_id = 1
        expected:
            node_id  epoch  expiration    draining  decommissioning     membership
            1        <epoch>      <timestamp>   false     false               active

        but found (query options: "colnames") :
            node_id  epoch    expiration  draining  decommissioning  membership
            1        <epoch>  0,0         false     false            active
```

Release note: None