### PR TITLE
kvserver: improve some test failures

### DIFF
--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -1088,6 +1088,7 @@ func getTargetStoreOrFatal(
 func verifyNotLeaseHolderErrors(
 	t *testing.T, ba roachpb.BatchRequest, repls []*kvserver.Replica, expectedNLEs int,
 ) {
+	t.Helper()
 	notLeaseholderErrs, err := countNotLeaseHolderErrors(ba, repls)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Mark a function as a test helper to get better failure line numbers.

Release note: None