### PR TITLE
bazel: quash unnecessary dependency on `pkg/util/uuid` from protos

### DIFF
--- a/pkg/ccl/utilccl/licenseccl/BUILD.bazel
+++ b/pkg/ccl/utilccl/licenseccl/BUILD.bazel
@@ -28,5 +28,8 @@ go_proto_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/utilccl/licenseccl",
     proto = ":licenseccl_proto",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_gogo_protobuf//gogoproto"],
+    deps = [
+        "//pkg/util/uuid",  # keep
+        "@com_github_gogo_protobuf//gogoproto",
+    ],
 )

--- a/pkg/cmd/protoc-gen-gogoroach/BUILD.bazel
+++ b/pkg/cmd/protoc-gen-gogoroach/BUILD.bazel
@@ -40,7 +40,6 @@ go_proto_compiler(
     valid_archive = True,
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/util/uuid",
         "@com_github_gogo_protobuf//proto",
         "@com_github_gogo_protobuf//sortkeys",
         "@com_github_gogo_protobuf//types",
@@ -61,7 +60,6 @@ go_proto_compiler(
     valid_archive = True,
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/util/uuid",
         "@com_github_gogo_protobuf//proto",
         "@com_github_gogo_protobuf//sortkeys",
         "@com_github_gogo_protobuf//types",

--- a/pkg/jobs/jobspb/BUILD.bazel
+++ b/pkg/jobs/jobspb/BUILD.bazel
@@ -50,6 +50,7 @@ go_proto_library(
         "//pkg/sql/schemachanger/scpb",
         "//pkg/sql/sem/tree",  # keep
         "//pkg/util/hlc",
+        "//pkg/util/uuid",  # keep
         "@com_github_cockroachdb_errors//errorspb",
         "@com_github_gogo_protobuf//gogoproto",
     ],

--- a/pkg/kv/kvserver/kvserverpb/BUILD.bazel
+++ b/pkg/kv/kvserver/kvserverpb/BUILD.bazel
@@ -46,6 +46,7 @@ go_proto_library(
         "//pkg/roachpb",
         "//pkg/storage/enginepb",
         "//pkg/util/hlc",
+        "//pkg/util/uuid",  # keep
         "@com_github_gogo_protobuf//gogoproto",
     ],
 )

--- a/pkg/kv/kvserver/protectedts/ptpb/BUILD.bazel
+++ b/pkg/kv/kvserver/protectedts/ptpb/BUILD.bazel
@@ -23,6 +23,7 @@ go_proto_library(
     deps = [
         "//pkg/roachpb",
         "//pkg/util/hlc",
+        "//pkg/util/uuid",  # keep
         "@com_github_gogo_protobuf//gogoproto",
         "@org_golang_google_genproto//googleapis/api/annotations:go_default_library",
     ],

--- a/pkg/server/serverpb/BUILD.bazel
+++ b/pkg/server/serverpb/BUILD.bazel
@@ -64,6 +64,7 @@ go_proto_library(
         "//pkg/util",
         "//pkg/util/log/logpb",
         "//pkg/util/metric",
+        "//pkg/util/uuid",  # keep
         "@com_github_gogo_protobuf//gogoproto",
         # NB: The grpc-gateway compiler injects a dependency on the descriptor
         # package that Gazelle isn't prepared to deal with.

--- a/pkg/storage/enginepb/BUILD.bazel
+++ b/pkg/storage/enginepb/BUILD.bazel
@@ -27,6 +27,7 @@ go_proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/util/hlc",
+        "//pkg/util/uuid",  # keep
         "@com_github_gogo_protobuf//gogoproto",
     ],
 )

--- a/pkg/util/protoutil/BUILD.bazel
+++ b/pkg/util/protoutil/BUILD.bazel
@@ -51,5 +51,8 @@ go_proto_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/util/protoutil",
     proto = ":protoutil_proto",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_gogo_protobuf//gogoproto"],
+    deps = [
+        "//pkg/util/uuid",  # keep
+        "@com_github_gogo_protobuf//gogoproto",
+    ],
 )


### PR DESCRIPTION
This dependency can be replaced with a few `# keep` deps in a few choice
proto targets, which is what we should have done the whole time anyway.
This fixes build failures elsewhere in tree -- for example,
`pkg/util/uuid:uuid_test`, which doesn't play nicely with `rules_go` in
the presence of this dependency.

Fixes #59778.

Release note: None