### PR TITLE
importccl: support DETACHED option when running IMPORT

### DIFF
--- a/pkg/ccl/importccl/BUILD.bazel
+++ b/pkg/ccl/importccl/BUILD.bazel
@@ -176,6 +176,7 @@ go_test(
         "//pkg/workload/bank",
         "//pkg/workload/tpcc",
         "//pkg/workload/workloadsql",
+        "@com_github_cockroachdb_cockroach_go//crdb",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_go_sql_driver_mysql//:mysql",

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -80,6 +80,7 @@ const (
 	importOptionSkipFKs          = "skip_foreign_keys"
 	importOptionDisableGlobMatch = "disable_glob_matching"
 	importOptionSaveRejected     = "experimental_save_rejected"
+	importOptionDetached         = "detached"
 
 	pgCopyDelimiter = "delimiter"
 	pgCopyNull      = "nullif"
@@ -124,6 +125,7 @@ var importOptionExpectValues = map[string]sql.KVStringOptValidate{
 
 	importOptionSkipFKs:          sql.KVStringOptRequireNoValue,
 	importOptionDisableGlobMatch: sql.KVStringOptRequireNoValue,
+	importOptionDetached:         sql.KVStringOptRequireNoValue,
 
 	optMaxRowSize: sql.KVStringOptRequireValue,
 
@@ -146,7 +148,7 @@ func makeStringSet(opts ...string) map[string]struct{} {
 // Options common to all formats.
 var allowedCommonOptions = makeStringSet(
 	importOptionSSTSize, importOptionDecompress, importOptionOversample,
-	importOptionSaveRejected, importOptionDisableGlobMatch)
+	importOptionSaveRejected, importOptionDisableGlobMatch, importOptionDetached)
 
 // Format specific allowed options.
 var avroAllowedOptions = makeStringSet(
@@ -296,6 +298,13 @@ func importPlanHook(
 		return nil, nil, nil, false, err
 	}
 
+	opts, optsErr := optsFn()
+
+	var isDetached bool
+	if _, ok := opts[importOptionDetached]; ok {
+		isDetached = true
+	}
+
 	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
 		// TODO(dan): Move this span into sql.
 		ctx, span := tracing.ChildSpan(ctx, importStmt.StatementTag())
@@ -303,13 +312,12 @@ func importPlanHook(
 
 		walltime := p.ExecCfg().Clock.Now().WallTime
 
-		if !p.ExtendedEvalContext().TxnImplicit {
-			return errors.Errorf("IMPORT cannot be used inside a transaction")
+		if !(p.ExtendedEvalContext().TxnImplicit || isDetached) {
+			return errors.Errorf("IMPORT cannot be used inside a transaction without DETACHED option")
 		}
 
-		opts, err := optsFn()
-		if err != nil {
-			return err
+		if optsErr != nil {
+			return optsErr
 		}
 
 		filenamePatterns, err := filesFn()
@@ -882,6 +890,25 @@ func importPlanHook(
 			Progress:    jobspb.ImportProgress{},
 		}
 
+		if isDetached {
+			// When running inside an explicit transaction, we simply create the job
+			// record. We do not wait for the job to finish.
+			aj, err := p.ExecCfg().JobRegistry.CreateAdoptableJobWithTxn(
+				ctx, jr, p.ExtendedEvalContext().Txn)
+			if err != nil {
+				return err
+			}
+
+			if err = protectTimestampForImport(ctx, p, p.ExtendedEvalContext().Txn, *aj.ID(), spansToProtect,
+				walltime, importDetails); err != nil {
+				return err
+			}
+
+			addToFileFormatTelemetry(format.Format.String(), "started")
+			resultsCh <- tree.Datums{tree.NewDInt(tree.DInt(*aj.ID()))}
+			return nil
+		}
+
 		var sj *jobs.StartableJob
 		if err := p.ExecCfg().DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) (err error) {
 			sj, err = p.ExecCfg().JobRegistry.CreateStartableJobWithTxn(ctx, jr, txn)
@@ -889,15 +916,7 @@ func importPlanHook(
 				return err
 			}
 
-			if len(spansToProtect) > 0 {
-				// NB: We protect the timestamp preceding the import statement timestamp
-				// because that's the timestamp to which we want to revert.
-				tsToProtect := hlc.Timestamp{WallTime: walltime}.Prev()
-				rec := jobsprotectedts.MakeRecord(*importDetails.ProtectedTimestampRecord,
-					*sj.ID(), tsToProtect, spansToProtect)
-				return p.ExecCfg().ProtectedTimestampProvider.Protect(ctx, txn, rec)
-			}
-			return nil
+			return protectTimestampForImport(ctx, p, txn, *sj.ID(), spansToProtect, walltime, importDetails)
 		}); err != nil {
 			if sj != nil {
 				if cleanupErr := sj.CleanupOnRollback(ctx); cleanupErr != nil {
@@ -915,6 +934,10 @@ func importPlanHook(
 			return err
 		}
 		return sj.ReportExecutionResults(ctx, resultsCh)
+	}
+
+	if isDetached {
+		return fn, utilccl.DetachedJobExecutionResultHeader, nil, false, nil
 	}
 	return fn, utilccl.BulkJobExecutionResultHeader, nil, false, nil
 }
@@ -1002,6 +1025,29 @@ func parseAvroOptions(
 				return errors.Errorf("%s out of range: %d", override, sz)
 			}
 			format.Avro.MaxRecordSize = int32(sz)
+		}
+	}
+	return nil
+}
+
+func protectTimestampForImport(
+	ctx context.Context,
+	p sql.PlanHookState,
+	txn *kv.Txn,
+	jobID int64,
+	spansToProtect []roachpb.Span,
+	walltime int64,
+	importDetails jobspb.ImportDetails,
+) error {
+	if len(spansToProtect) > 0 {
+		// NB: We protect the timestamp preceding the import statement timestamp
+		// because that's the timestamp to which we want to revert.
+		tsToProtect := hlc.Timestamp{WallTime: walltime}.Prev()
+		rec := jobsprotectedts.MakeRecord(*importDetails.ProtectedTimestampRecord,
+			jobID, tsToProtect, spansToProtect)
+		err := p.ExecCfg().ProtectedTimestampProvider.Protect(ctx, txn, rec)
+		if err != nil {
+			return err
 		}
 	}
 	return nil

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach-go/crdb"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/blobs"
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl"
@@ -6339,4 +6340,79 @@ func putUserfile(
 	}
 
 	return tx.Commit()
+}
+
+func waitForJobResult(t *testing.T, tc *testcluster.TestCluster, id int64, expected jobs.Status) {
+	// Force newly created job to be adopted and verify its result.
+	tc.Server(0).JobRegistry().(*jobs.Registry).TestingNudgeAdoptionQueue()
+	testutils.SucceedsSoon(t, func() error {
+		var unused int64
+		return tc.ServerConn(0).QueryRow(
+			"SELECT job_id FROM [SHOW JOBS] WHERE job_id = $1 AND status = $2",
+			id, expected).Scan(&unused)
+	})
+}
+
+func TestDetachedImport(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const (
+		nodes = 3
+	)
+	ctx := context.Background()
+	baseDir := filepath.Join("testdata", "avro")
+	args := base.TestServerArgs{ExternalIODir: baseDir}
+	tc := testcluster.StartTestCluster(t, nodes, base.TestClusterArgs{ServerArgs: args})
+	defer tc.Stopper().Stop(ctx)
+	connDB := tc.Conns[0]
+	sqlDB := sqlutils.MakeSQLRunner(connDB)
+
+	sqlDB.Exec(t, `CREATE DATABASE foo; SET DATABASE = foo`)
+
+	simpleOcf := fmt.Sprintf("nodelocal://0/%s", "simple.ocf")
+
+	importQuery := `IMPORT TABLE simple (i INT8 PRIMARY KEY, s text, b bytea) AVRO DATA ($1)`
+	importQueryDetached := importQuery + " WITH DETACHED"
+	importIntoQuery := `IMPORT INTO simple AVRO DATA ($1)`
+	importIntoQueryDetached := importIntoQuery + " WITH DETACHED"
+
+	// DETACHED import w/out transaction is okay.
+	var jobID int64
+	sqlDB.QueryRow(t, importQueryDetached, simpleOcf).Scan(&jobID)
+	waitForJobResult(t, tc, jobID, jobs.StatusSucceeded)
+
+	sqlDB.Exec(t, "DROP table simple")
+
+	// Running import under transaction requires DETACHED option.
+	importWithoutDetached := func(txn *gosql.Tx) error {
+		return txn.QueryRow(importQuery, simpleOcf).Scan(&jobID)
+	}
+	err := crdb.ExecuteTx(ctx, connDB, nil, importWithoutDetached)
+	require.True(t,
+		testutils.IsError(err, "IMPORT cannot be used inside a transaction without DETACHED option"))
+
+	// We can execute IMPORT under transaction with detached option.
+	importWithDetached := func(txn *gosql.Tx) error {
+		return txn.QueryRow(importQueryDetached, simpleOcf).Scan(&jobID)
+	}
+	err = crdb.ExecuteTx(ctx, connDB, nil, importWithDetached)
+	require.NoError(t, err)
+	waitForJobResult(t, tc, jobID, jobs.StatusSucceeded)
+
+	sqlDB.Exec(t, "DROP table simple")
+
+	// Detached import should fail when the table already exists.
+	sqlDB.QueryRow(t, importQueryDetached, simpleOcf).Scan(&jobID)
+	waitForJobResult(t, tc, jobID, jobs.StatusSucceeded)
+	sqlDB.QueryRow(t, importQueryDetached, simpleOcf).Scan(&jobID)
+	waitForJobResult(t, tc, jobID, jobs.StatusFailed)
+
+	sqlDB.Exec(t, "DROP table simple")
+
+	// Detached import into should fail when there are key collisions.
+	sqlDB.QueryRow(t, importQueryDetached, simpleOcf).Scan(&jobID)
+	waitForJobResult(t, tc, jobID, jobs.StatusSucceeded)
+	sqlDB.QueryRow(t, importIntoQueryDetached, simpleOcf).Scan(&jobID)
+	waitForJobResult(t, tc, jobID, jobs.StatusFailed)
 }


### PR DESCRIPTION
Previously, IMPORT is not allowed in an explicit transaction.

With this PR, IMPORT is allowed with "DETACHED" specified in an explicit transaction. Then the detached jobID is returned and the job runs asynchronously.

Resolves: #50736

Release notes (sql): Support DETACHED option when running IMPORT. The detached import will return jobID and the user can later use SHOW JOB to check the result of the detached import. This allows users to run IMPORT under explicit transactions with DETACHED option specified.