### PR TITLE
geo/wkt: add support for parsing multipolygons with Z and M dimensions

### DIFF
--- a/pkg/geo/wkt/lex.go
+++ b/pkg/geo/wkt/lex.go
@@ -122,6 +122,14 @@ func getKeywordToken(tokStr string) int {
 		return MULTILINESTRINGZ
 	case "MULTILINESTRINGZM":
 		return MULTILINESTRINGZM
+	case "MULTIPOLYGON":
+		return MULTIPOLYGON
+	case "MULTIPOLYGONM":
+		return MULTIPOLYGONM
+	case "MULTIPOLYGONZ":
+		return MULTIPOLYGONZ
+	case "MULTIPOLYGONZM":
+		return MULTIPOLYGONZM
 	default:
 		return eof
 	}


### PR DESCRIPTION
This patch extends the capabilities of the WKT parser to include
parsing of multipolygons with Z and M dimensions.

Refs: #53091

Release note: None