### PR TITLE
cli,kvserver: fixes for separated intents printing

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1200,7 +1200,7 @@ process that has failed and cannot restart.
 	RunE: usageAndErr,
 }
 
-// mvccValueFormatter is an fmt.Formatter for MVCC values.
+// mvccValueFormatter is a fmt.Formatter for MVCC values.
 type mvccValueFormatter struct {
 	kv  storage.MVCCKeyValue
 	err error
@@ -1215,18 +1215,34 @@ func (m mvccValueFormatter) Format(f fmt.State, c rune) {
 	fmt.Fprint(f, kvserver.SprintKeyValue(m.kv, false /* printKey */))
 }
 
+// lockValueFormatter is a fmt.Formatter for lock values.
+type lockValueFormatter struct {
+	value []byte
+}
+
+// Format implements the fmt.Formatter interface.
+func (m lockValueFormatter) Format(f fmt.State, c rune) {
+	fmt.Fprint(f, kvserver.SprintIntent(m.value))
+}
+
 func init() {
 	DebugCmd.AddCommand(debugCmds...)
 
 	// Note: we hook up FormatValue here in order to avoid a circular dependency
 	// between kvserver and storage.
-	// TODO(sumeer): fix this to also format EngineKey KVs.
 	storage.EngineComparer.FormatValue = func(key, value []byte) fmt.Formatter {
-		decoded, err := storage.DecodeMVCCKey(key)
-		if err != nil {
-			return mvccValueFormatter{err: err}
+		decoded, ok := storage.DecodeEngineKey(key)
+		if !ok {
+			return mvccValueFormatter{err: errors.Errorf("invalid encoded engine key: %x", key)}
 		}
-		return mvccValueFormatter{kv: storage.MVCCKeyValue{Key: decoded, Value: value}}
+		if decoded.IsMVCCKey() {
+			mvccKey, err := decoded.ToMVCCKey()
+			if err != nil {
+				return mvccValueFormatter{err: err}
+			}
+			return mvccValueFormatter{kv: storage.MVCCKeyValue{Key: mvccKey, Value: value}}
+		}
+		return lockValueFormatter{value: value}
 	}
 
 	// To be able to read Cockroach-written RocksDB manifests/SSTables, comparator

--- a/pkg/kv/kvserver/debug_print.go
+++ b/pkg/kv/kvserver/debug_print.go
@@ -33,7 +33,7 @@ func PrintKeyValue(kv storage.MVCCKeyValue) {
 	fmt.Println(SprintKeyValue(kv, true /* printKey */))
 }
 
-// SprintKey pretty-prings the specified MVCCKey.
+// SprintKey pretty-prints the specified MVCCKey.
 func SprintKey(key storage.MVCCKey) string {
 	return fmt.Sprintf("%s %s (%#x): ", key.Timestamp, key.Key, storage.EncodeKey(key))
 }
@@ -73,6 +73,14 @@ func SprintKeyValue(kv storage.MVCCKeyValue, printKey bool) string {
 		return sb.String()
 	}
 	panic("unreachable")
+}
+
+// SprintIntent pretty-prints the specified intent value.
+func SprintIntent(value []byte) string {
+	if out, err := tryIntent(storage.MVCCKeyValue{Value: value}); err == nil {
+		return out
+	}
+	return fmt.Sprintf("%x", value)
 }
 
 func tryRangeDescriptor(kv storage.MVCCKeyValue) (string, error) {
@@ -394,4 +402,5 @@ func PrintEngineKeyValue(k storage.EngineKey, v []byte) {
 	} else {
 		fmt.Fprintf(&sb, "%x", v)
 	}
+	fmt.Println(sb.String())
 }


### PR DESCRIPTION
- fix EngineComparer.FormatValue to format separated intents
- fix PrintEngineKeyValue to actually print

Informs #41720

Release note: None