### PR TITLE
sql: use catalog.Column for virtual and system columns

### DIFF
--- a/pkg/sql/add_column.go
+++ b/pkg/sql/add_column.go
@@ -154,6 +154,11 @@ func checkColumnDoesNotExist(
 	if col == nil {
 		return false, nil
 	}
+	if col.IsSystemColumn() {
+		return false, pgerror.Newf(pgcode.DuplicateColumn,
+			"column name %q conflicts with a system column name",
+			col.GetName())
+	}
 	if col.Public() {
 		return true, sqlerrors.NewColumnAlreadyExistsError(tree.ErrString(&name), tableDesc.GetName())
 	}

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -667,8 +667,8 @@ func (ib *IndexBackfiller) ShrinkBoundAccount(ctx context.Context, shrinkBy int6
 // initCols is a helper to populate column metadata of an IndexBackfiller. It
 // populates the cols and colIdxMap fields.
 func (ib *IndexBackfiller) initCols(desc catalog.TableDescriptor) {
-	ib.cols = make([]descpb.ColumnDescriptor, 0, len(desc.AllColumns()))
-	for _, column := range desc.AllColumns() {
+	ib.cols = make([]descpb.ColumnDescriptor, 0, len(desc.DeletableColumns()))
+	for _, column := range desc.DeletableColumns() {
 		columnDesc := *column.ColumnDesc()
 		if column.Public() {
 			if column.IsComputed() && column.IsVirtual() {

--- a/pkg/sql/catalog/colinfo/result_columns.go
+++ b/pkg/sql/catalog/colinfo/result_columns.go
@@ -11,6 +11,7 @@
 package colinfo
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -51,6 +52,13 @@ func ResultColumnsFromColDescPtrs(
 ) ResultColumns {
 	return resultColumnsFromColDescs(tableID, len(colDescs), func(i int) *descpb.ColumnDescriptor {
 		return colDescs[i]
+	})
+}
+
+// ResultColumnsFromColumns converts []catalog.Column to []ResultColumn.
+func ResultColumnsFromColumns(tableID descpb.ID, columns []catalog.Column) ResultColumns {
+	return resultColumnsFromColDescs(tableID, len(columns), func(i int) *descpb.ColumnDescriptor {
+		return columns[i].ColumnDesc()
 	})
 }
 

--- a/pkg/sql/catalog/colinfo/system_columns.go
+++ b/pkg/sql/catalog/colinfo/system_columns.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/errors"
 )
 
 // Similar to Postgres, we also expose hidden system columns on tables.
@@ -74,17 +73,6 @@ var TableOIDColumnDesc = descpb.ColumnDescriptor{
 // IsColIDSystemColumn returns whether a column ID refers to a system column.
 func IsColIDSystemColumn(colID descpb.ColumnID) bool {
 	return GetSystemColumnKindFromColumnID(colID) != descpb.SystemColumnKind_NONE
-}
-
-// GetSystemColumnDescriptorFromID returns a column descriptor corresponding
-// to the system column referred to by the input column ID.
-func GetSystemColumnDescriptorFromID(colID descpb.ColumnID) (*descpb.ColumnDescriptor, error) {
-	for i := range AllSystemColumnDescs {
-		if AllSystemColumnDescs[i].ID == colID {
-			return &AllSystemColumnDescs[i], nil
-		}
-	}
-	return nil, errors.AssertionFailedf("unsupported system column ID %d", colID)
 }
 
 // GetSystemColumnKindFromColumnID returns the kind of system column that colID

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -2799,7 +2799,7 @@ func (desc *Mutable) RenameColumnDescriptor(column *descpb.ColumnDescriptor, new
 // same transaction that is currently running.
 func (desc *Mutable) FindActiveOrNewColumnByName(name tree.Name) (catalog.Column, error) {
 	currentMutationID := desc.ClusterVersion.NextMutationID
-	for _, col := range desc.AllColumns() {
+	for _, col := range desc.DeletableColumns() {
 		if (col.Public() && col.ColName() == name) ||
 			(col.Adding() && col.(*column).mutationID == currentMutationID) {
 			return col, nil

--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -507,3 +507,20 @@ func FindPublicColumnWithID(
 	}
 	return col, nil
 }
+
+// FindVirtualColumn returns a catalog.Column matching the virtual column
+// descriptor in `spec` if not nil, nil otherwise.
+func FindVirtualColumn(
+	desc catalog.TableDescriptor, virtualColDesc *descpb.ColumnDescriptor,
+) catalog.Column {
+	if virtualColDesc == nil {
+		return nil
+	}
+	found, err := desc.FindColumnWithID(virtualColDesc.ID)
+	if err != nil {
+		panic(errors.HandleAsAssertionFailure(err))
+	}
+	virtualColumn := found.DeepCopy()
+	*virtualColumn.ColumnDesc() = *virtualColDesc
+	return virtualColumn
+}

--- a/pkg/sql/catalog/tabledesc/table_desc.go
+++ b/pkg/sql/catalog/tabledesc/table_desc.go
@@ -295,6 +295,7 @@ func (desc *wrapper) getExistingOrNewColumnCache() *columnCache {
 //   desc.TableDesc().Columns slice;
 // - all column mutations in the same order as in the underlying
 //   desc.TableDesc().Mutations slice.
+// - all system columns defined in colinfo.AllSystemColumnDescs.
 func (desc *wrapper) AllColumns() []catalog.Column {
 	return desc.getExistingOrNewColumnCache().all
 }
@@ -310,6 +311,12 @@ func (desc *wrapper) PublicColumns() []catalog.Column {
 // order.
 func (desc *wrapper) WritableColumns() []catalog.Column {
 	return desc.getExistingOrNewColumnCache().writable
+}
+
+// DeletableColumns returns a slice of Column interfaces containing the
+// table's public columns and mutations, in the canonical order.
+func (desc *wrapper) DeletableColumns() []catalog.Column {
+	return desc.getExistingOrNewColumnCache().deletable
 }
 
 // NonDropColumns returns a slice of Column interfaces containing the
@@ -337,6 +344,13 @@ func (desc *wrapper) UserDefinedTypeColumns() []catalog.Column {
 // progress, as mutation columns may have NULL values.
 func (desc *wrapper) ReadableColumns() []catalog.Column {
 	return desc.getExistingOrNewColumnCache().readable
+}
+
+// SystemColumns returns a slice of Column interfaces
+// containing the table's system columns, as defined in
+// colinfo.AllSystemColumnDescs.
+func (desc *wrapper) SystemColumns() []catalog.Column {
+	return desc.getExistingOrNewColumnCache().system
 }
 
 // FindColumnWithID returns the first column found whose ID matches the

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -1254,7 +1254,7 @@ func (rf *cFetcher) processValueSingle(
 	if needDecode {
 		if idx, ok := table.colIdxMap.get(colID); ok {
 			if rf.traceKV {
-				prettyKey = fmt.Sprintf("%s/%s", prettyKey, table.desc.AllColumns()[idx].GetName())
+				prettyKey = fmt.Sprintf("%s/%s", prettyKey, table.desc.DeletableColumns()[idx].GetName())
 			}
 			val := rf.machine.nextKV.Value
 			if len(val.RawBytes) == 0 {
@@ -1355,7 +1355,7 @@ func (rf *cFetcher) processValueBytes(
 		}
 
 		if rf.traceKV {
-			prettyKey = fmt.Sprintf("%s/%s", prettyKey, table.desc.AllColumns()[idx].GetName())
+			prettyKey = fmt.Sprintf("%s/%s", prettyKey, table.desc.DeletableColumns()[idx].GetName())
 		}
 
 		vec := rf.machine.colvecs[idx]

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
@@ -202,20 +201,19 @@ func NewColBatchScan(
 	// just setting the ID and Version in the spec or something like that and
 	// retrieving the hydrated immutable from cache.
 	table := tabledesc.NewImmutable(spec.Table)
+	virtualColumn := tabledesc.FindVirtualColumn(table, spec.VirtualColumn)
 	cols := table.PublicColumns()
 	if spec.Visibility == execinfra.ScanVisibilityPublicAndNotPublic {
-		cols = table.AllColumns()
+		cols = table.DeletableColumns()
 	}
 	columnIdxMap := catalog.ColumnIDToOrdinalMap(cols)
-	typs := catalog.ColumnTypesWithVirtualCol(cols, spec.VirtualColumn)
+	typs := catalog.ColumnTypesWithVirtualCol(cols, virtualColumn)
 
 	// Add all requested system columns to the output.
-	var sysColDescs []descpb.ColumnDescriptor
 	if spec.HasSystemColumns {
-		sysColDescs = colinfo.AllSystemColumnDescs
-		for i := range sysColDescs {
-			typs = append(typs, sysColDescs[i].Type)
-			columnIdxMap.Set(sysColDescs[i].ID, columnIdxMap.Len())
+		for _, sysCol := range table.SystemColumns() {
+			typs = append(typs, sysCol.GetType())
+			columnIdxMap.Set(sysCol.GetID(), columnIdxMap.Len())
 		}
 	}
 
@@ -235,7 +233,7 @@ func NewColBatchScan(
 
 	fetcher := cFetcherPool.Get().(*cFetcher)
 	if _, _, err := initCRowFetcher(
-		flowCtx.Codec(), allocator, fetcher, table, columnIdxMap, neededColumns, spec, sysColDescs,
+		flowCtx.Codec(), allocator, fetcher, table, columnIdxMap, neededColumns, spec, spec.HasSystemColumns,
 	); err != nil {
 		return nil, err
 	}
@@ -269,7 +267,7 @@ func initCRowFetcher(
 	colIdxMap catalog.TableColMap,
 	valNeededForCol util.FastIntSet,
 	spec *execinfrapb.TableReaderSpec,
-	systemColumnDescs []descpb.ColumnDescriptor,
+	withSystemColumns bool,
 ) (index *descpb.IndexDescriptor, isSecondaryIndex bool, err error) {
 	indexIdx := int(spec.IndexIdx)
 	if indexIdx >= len(desc.ActiveIndexes()) {
@@ -286,7 +284,9 @@ func initCRowFetcher(
 		IsSecondaryIndex: isSecondaryIndex,
 		ValNeededForCol:  valNeededForCol,
 	}
-	tableArgs.InitCols(desc, spec.Visibility, systemColumnDescs, spec.VirtualColumn)
+
+	virtualColumn := tabledesc.FindVirtualColumn(desc, spec.VirtualColumn)
+	tableArgs.InitCols(desc, spec.Visibility, withSystemColumns, virtualColumn)
 
 	if err := fetcher.Init(
 		codec, allocator, spec.Reverse, spec.LockingStrength, spec.LockingWaitPolicy, tableArgs,

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -992,8 +993,11 @@ func initTableReaderSpec(
 		Spans:            s.Spans[:0],
 		HasSystemColumns: n.containsSystemColumns,
 		NeededColumns:    n.colCfg.wantedColumnsOrdinals,
-		VirtualColumn:    getVirtualColumn(n.colCfg.virtualColumn, n.cols),
 	}
+	if vc := getVirtualColumn(n.colCfg.virtualColumn, n.cols); vc != nil {
+		s.VirtualColumn = vc.ColumnDesc()
+	}
+
 	indexIdx, err := getIndexIdx(n.index, n.desc)
 	if err != nil {
 		return nil, execinfrapb.PostProcessSpec{}, err
@@ -1022,15 +1026,14 @@ func getVirtualColumn(
 	virtualColumn *struct {
 		colID tree.ColumnID
 		typ   *types.T
-	},
-	cols []*descpb.ColumnDescriptor,
-) *descpb.ColumnDescriptor {
+	}, cols []catalog.Column,
+) catalog.Column {
 	if virtualColumn == nil {
 		return nil
 	}
 
 	for i := range cols {
-		if tree.ColumnID(cols[i].ID) == virtualColumn.colID {
+		if tree.ColumnID(cols[i].GetID()) == virtualColumn.colID {
 			return cols[i]
 		}
 	}
@@ -1041,20 +1044,9 @@ func getVirtualColumn(
 func tableOrdinal(
 	desc catalog.TableDescriptor, colID descpb.ColumnID, visibility execinfrapb.ScanVisibility,
 ) int {
-	for _, col := range desc.AllColumns() {
-		if col.Public() || visibility == execinfra.ScanVisibilityPublicAndNotPublic {
-			if col.GetID() == colID {
-				return col.Ordinal()
-			}
-		}
-	}
-
-	// The column is an implicit system column, so give it an ordinal based
-	// on its ID that is larger than physical columns. These ordinals are
-	// different for each system column kind. MVCCTimestampColumnID is the
-	// largest column ID, and all system columns are decreasing from it.
-	if colinfo.IsColIDSystemColumn(colID) {
-		return len(desc.AllColumns()) + int(colinfo.MVCCTimestampColumnID-colID)
+	col, _ := desc.FindColumnWithID(colID)
+	if col != nil && (col.IsSystemColumn() || visibility == execinfra.ScanVisibilityPublicAndNotPublic || col.Public()) {
+		return col.Ordinal()
 	}
 
 	panic(errors.AssertionFailedf("column %d not in desc.Columns", colID))
@@ -1063,7 +1055,7 @@ func tableOrdinal(
 func highestTableOrdinal(desc catalog.TableDescriptor, visibility execinfrapb.ScanVisibility) int {
 	highest := len(desc.PublicColumns()) - 1
 	if visibility == execinfra.ScanVisibilityPublicAndNotPublic {
-		highest = len(desc.AllColumns()) - 1
+		highest = len(desc.DeletableColumns()) - 1
 	}
 	return highest
 }
@@ -1071,13 +1063,11 @@ func highestTableOrdinal(desc catalog.TableDescriptor, visibility execinfrapb.Sc
 // toTableOrdinals returns a mapping from column ordinals in cols to table
 // reader column ordinals.
 func toTableOrdinals(
-	cols []*descpb.ColumnDescriptor,
-	desc catalog.TableDescriptor,
-	visibility execinfrapb.ScanVisibility,
+	cols []catalog.Column, desc catalog.TableDescriptor, visibility execinfrapb.ScanVisibility,
 ) []int {
 	res := make([]int, len(cols))
 	for i := range res {
-		res[i] = tableOrdinal(desc, cols[i].ID, visibility)
+		res[i] = tableOrdinal(desc, cols[i].GetID(), visibility)
 	}
 	return res
 }
@@ -1085,7 +1075,7 @@ func toTableOrdinals(
 // getOutputColumnsFromColsForScan returns the indices of the columns that are
 // returned by a scanNode or a tableReader.
 // If remap is not nil, the column ordinals are remapped accordingly.
-func getOutputColumnsFromColsForScan(cols []*descpb.ColumnDescriptor, remap []int) []uint32 {
+func getOutputColumnsFromColsForScan(cols []catalog.Column, remap []int) []uint32 {
 	outputColumns := make([]uint32, len(cols))
 	// TODO(radu): if we have a scan with a filter, cols will include the
 	// columns needed for the filter, even if they aren't needed for the next
@@ -1236,7 +1226,7 @@ type tableReaderPlanningInfo struct {
 	parallelize           bool
 	estimatedRowCount     uint64
 	reqOrdering           ReqOrdering
-	cols                  []*descpb.ColumnDescriptor
+	cols                  []catalog.Column
 	colsToTableOrdinalMap []int
 	containsSystemColumns bool
 }
@@ -1300,15 +1290,16 @@ func (dsp *DistSQLPlanner) planTableReaders(
 		corePlacement[i].Core.TableReader = tr
 	}
 
+	virtualColumn := tabledesc.FindVirtualColumn(info.desc, info.spec.VirtualColumn)
 	cols := info.desc.PublicColumns()
 	returnMutations := info.scanVisibility == execinfra.ScanVisibilityPublicAndNotPublic
 	if returnMutations {
-		cols = info.desc.AllColumns()
+		cols = info.desc.DeletableColumns()
 	}
-	typs := catalog.ColumnTypesWithVirtualCol(cols, info.spec.VirtualColumn)
+	typs := catalog.ColumnTypesWithVirtualCol(cols, virtualColumn)
 	if info.containsSystemColumns {
-		for i := range colinfo.AllSystemColumnDescs {
-			typs = append(typs, colinfo.AllSystemColumnDescs[i].Type)
+		for _, col := range info.desc.SystemColumns() {
+			typs = append(typs, col.GetType())
 		}
 	}
 
@@ -1321,14 +1312,8 @@ func (dsp *DistSQLPlanner) planTableReaders(
 	var descColumnIDs util.FastIntMap
 	colID := 0
 	for _, col := range info.desc.AllColumns() {
-		if col.Public() || returnMutations {
+		if col.Public() || returnMutations || (col.IsSystemColumn() && info.containsSystemColumns) {
 			descColumnIDs.Set(colID, int(col.GetID()))
-			colID++
-		}
-	}
-	if info.containsSystemColumns {
-		for i := range colinfo.AllSystemColumnDescs {
-			descColumnIDs.Set(colID, int(colinfo.AllSystemColumnDescs[i].ID))
 			colID++
 		}
 	}
@@ -1336,7 +1321,7 @@ func (dsp *DistSQLPlanner) planTableReaders(
 	for i := range planToStreamColMap {
 		planToStreamColMap[i] = -1
 		for j, c := range outCols {
-			if descColumnIDs.GetDefault(int(c)) == int(info.cols[i].ID) {
+			if descColumnIDs.GetDefault(int(c)) == int(info.cols[i].GetID()) {
 				planToStreamColMap[i] = j
 				break
 			}
@@ -2125,8 +2110,8 @@ func mappingHelperForLookupJoins(
 		post.OutputColumns[i] = uint32(i)
 	}
 	for i := range table.cols {
-		outTypes[numLeftCols+i] = table.cols[i].Type
-		ord := tableOrdinal(table.desc, table.cols[i].ID, table.colCfg.visibility)
+		outTypes[numLeftCols+i] = table.cols[i].GetType()
+		ord := tableOrdinal(table.desc, table.cols[i].GetID(), table.colCfg.visibility)
 		post.OutputColumns[numLeftCols+i] = uint32(numLeftCols + ord)
 	}
 	if addContinuationCol {
@@ -2309,10 +2294,10 @@ func (dsp *DistSQLPlanner) createPlanForZigzagJoin(
 		// index that are also in n.columns. This is because we generated
 		// colCfg.wantedColumns for only the necessary columns in
 		// opt/exec/execbuilder/relational_builder.go, similar to lookup joins.
-		for colIdx := range side.scan.cols {
-			ord := tableOrdinal(side.scan.desc, side.scan.cols[colIdx].ID, side.scan.colCfg.visibility)
+		for _, col := range side.scan.cols {
+			ord := tableOrdinal(side.scan.desc, col.GetID(), side.scan.colCfg.visibility)
 			post.OutputColumns[i] = uint32(colOffset + ord)
-			types[i] = side.scan.cols[colIdx].Type
+			types[i] = col.GetType()
 			planToStreamColMap[i] = i
 
 			i++

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -81,7 +81,7 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 	}
 	var colIdxMap catalog.TableColMap
 	for i, c := range scan.cols {
-		colIdxMap.Set(c.ID, i)
+		colIdxMap.Set(c.GetID(), i)
 	}
 	sb := span.MakeBuilder(planCtx.EvalContext(), planCtx.ExtendedEvalCtx.Codec, desc, scan.index)
 	scan.spans, err = sb.UnconstrainedSpans()

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -192,7 +192,7 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 	if err != nil {
 		return nil, err
 	}
-	p.ResultColumns = colinfo.ResultColumnsFromColDescPtrs(tabDesc.GetID(), cols)
+	p.ResultColumns = colinfo.ResultColumnsFromColumns(tabDesc.GetID(), cols)
 
 	if params.IndexConstraint != nil && params.IndexConstraint.IsContradiction() {
 		// Note that empty rows argument is handled by ConstructValues first -
@@ -236,7 +236,9 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 		Spans:            trSpec.Spans[:0],
 		HasSystemColumns: scanContainsSystemColumns(&colCfg),
 		NeededColumns:    colCfg.wantedColumnsOrdinals,
-		VirtualColumn:    getVirtualColumn(colCfg.virtualColumn, cols),
+	}
+	if vc := getVirtualColumn(colCfg.virtualColumn, cols); vc != nil {
+		trSpec.VirtualColumn = vc.ColumnDesc()
 	}
 
 	trSpec.IndexIdx, err = getIndexIdx(indexDesc, tabDesc)

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1955,7 +1955,7 @@ func makeColDescList(table cat.Table, cols exec.TableColumnOrdinalSet) []descpb.
 		if !cols.Contains(i) {
 			continue
 		}
-		colDescs = append(colDescs, *tab.getColDesc(i))
+		colDescs = append(colDescs, *tab.getCol(i).ColumnDesc())
 	}
 	return colDescs
 }

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
@@ -142,12 +143,12 @@ func (p *planner) prepareUsingOptimizer(ctx context.Context) (planFlags, error) 
 			// Convert the metadata opt.ColumnID to its ordinal position in the table.
 			colOrdinal := colMeta.Table.ColumnOrdinal(col.ID)
 			// Use that ordinal position to retrieve the column's stable ID.
-			var desc *descpb.ColumnDescriptor
+			var column catalog.Column
 			if catTable, ok := tab.(optCatalogTableInterface); ok {
-				desc = catTable.getColDesc(colOrdinal)
+				column = catTable.getCol(colOrdinal)
 			}
-			if desc != nil {
-				resultCols[i].PGAttributeNum = desc.GetPGAttributeNum()
+			if column != nil {
+				resultCols[i].PGAttributeNum = column.GetPGAttributeNum()
 			} else {
 				resultCols[i].PGAttributeNum = uint32(tab.Column(colOrdinal).ColID())
 			}

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -253,7 +253,7 @@ func NeededColumnFamilyIDs(
 	}
 
 	// Build some necessary data structures for column metadata.
-	columns := table.AllColumns()
+	columns := table.DeletableColumns()
 	colIdxMap := catalog.ColumnIDToOrdinalMap(columns)
 	var indexedCols util.FastIntSet
 	var compositeCols util.FastIntSet

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -307,7 +307,7 @@ func newInvertedJoiner(
 		flowCtx, &fetcher, ij.desc, int(spec.IndexIdx), ij.colIdxMap, false, /* reverse */
 		allIndexCols, false /* isCheck */, flowCtx.EvalCtx.Mon, &ij.alloc, execinfra.ScanVisibilityPublic,
 		descpb.ScanLockingStrength_FOR_NONE, descpb.ScanLockingWaitPolicy_BLOCK,
-		nil /* systemColumns */, nil, /* virtualColumn */
+		false /* withSystemColumns */, nil, /* virtualColumn */
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/rowexec/rowfetcher.go
+++ b/pkg/sql/rowexec/rowfetcher.go
@@ -74,8 +74,8 @@ func initRowFetcher(
 	scanVisibility execinfrapb.ScanVisibility,
 	lockStrength descpb.ScanLockingStrength,
 	lockWaitPolicy descpb.ScanLockingWaitPolicy,
-	systemColumns []descpb.ColumnDescriptor,
-	virtualColumn *descpb.ColumnDescriptor,
+	withSystemColumns bool,
+	virtualColumn catalog.Column,
 ) (index *descpb.IndexDescriptor, isSecondaryIndex bool, err error) {
 	if indexIdx >= len(desc.ActiveIndexes()) {
 		return nil, false, errors.Errorf("invalid indexIdx %d", indexIdx)
@@ -91,7 +91,7 @@ func initRowFetcher(
 		IsSecondaryIndex: isSecondaryIndex,
 		ValNeededForCol:  valNeededForCol,
 	}
-	tableArgs.InitCols(desc, scanVisibility, systemColumns, virtualColumn)
+	tableArgs.InitCols(desc, scanVisibility, withSystemColumns, virtualColumn)
 
 	if err := fetcher.Init(
 		flowCtx.EvalCtx.Context,

--- a/pkg/sql/rowexec/scrub_tablereader.go
+++ b/pkg/sql/rowexec/scrub_tablereader.go
@@ -128,7 +128,7 @@ func newScrubTableReader(
 		flowCtx, &fetcher, tr.tableDesc, int(spec.IndexIdx), catalog.ColumnIDToOrdinalMap(tr.tableDesc.PublicColumns()),
 		spec.Reverse, neededColumns, true /* isCheck */, flowCtx.EvalCtx.Mon, &tr.alloc,
 		execinfra.ScanVisibilityPublic, spec.LockingStrength, spec.LockingWaitPolicy,
-		nil /* systemColumns */, nil, /* virtualColumn */
+		false /* withSystemColumns */, nil, /* virtualColumn */
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -490,8 +490,8 @@ func (z *zigzagJoiner) setupInfo(
 		// supplied, so there is no locking strength on *ZigzagJoinerSpec.
 		descpb.ScanLockingStrength_FOR_NONE,
 		descpb.ScanLockingWaitPolicy_BLOCK,
-		nil, /* systemColumns */
-		nil, /* virtualColumn */
+		false, /* withSystemColumns */
+		nil,   /* virtualColumn */
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
We recently introduced the catalog.Column interface to encapsulate
column descriptors originating from table descriptors. This did not
include system- and virtual column descriptors. This patch adresses
these cases, a stepping stone in our long-running quest to minimize
usage of descpb.*Descriptor types.

Descriptors for system columns are defined in the colinfo package and
previously their ordinals for a given table were determined in an
ad-hoc manner. This commit extends catalog.TableDescriptor to expose
system columns as catalog.Column interface slices just like all other
table columns, which makes it easy to get their ordinals and avoids
exposing too much colinfo-specific logic.

Descriptors for virtual columns show up in TableReaderSpec messages and
the way they are used is they override the table's column descriptor
with the same ID. This commit refactors that logic using catalog.Column.

Release note: None