### PR TITLE
sql: fix UNIQUE column not having PARTITION BY on PARTITION BY ALL

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_all_by_nothing
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_all_by_nothing
@@ -20,7 +20,8 @@ CREATE TABLE partition_all_by_nothing (
   UNIQUE(b),
   b INT,
   INDEX(b),
-  FAMILY (pk, a, b)
+  c INT UNIQUE,
+  FAMILY (pk, a, b, c)
 ) PARTITION ALL BY NOTHING
 
 query T
@@ -30,10 +31,12 @@ CREATE TABLE public.partition_all_by_nothing (
                             pk INT8 NOT NULL,
                             a INT8 NULL,
                             b INT8 NULL,
+                            c INT8 NULL,
                             CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                            UNIQUE INDEX partition_all_by_nothing_c_key (c ASC),
                             UNIQUE INDEX partition_all_by_nothing_b_key (b ASC),
                             INDEX partition_all_by_nothing_b_idx (b ASC),
-                            FAMILY fam_0_pk_a_b (pk, a, b)
+                            FAMILY fam_0_pk_a_b_c (pk, a, b, c)
 ) PARTITION ALL BY NOTHING
 
 statement error cannot define PARTITION BY on an index if the table has a PARTITION ALL BY definition
@@ -49,9 +52,11 @@ CREATE TABLE public.partition_all_by_nothing (
                             pk INT8 NOT NULL,
                             a INT8 NULL,
                             b INT8 NULL,
+                            c INT8 NULL,
                             CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                            UNIQUE INDEX partition_all_by_nothing_c_key (c ASC),
                             UNIQUE INDEX partition_all_by_nothing_b_key (b ASC),
                             INDEX partition_all_by_nothing_b_idx (b ASC),
                             INDEX idx (pk ASC),
-                            FAMILY fam_0_pk_a_b (pk, a, b)
+                            FAMILY fam_0_pk_a_b_c (pk, a, b, c)
 ) PARTITION ALL BY NOTHING

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -346,11 +346,12 @@ CREATE TABLE public.t (
   c int NOT NULL,
   d int NOT NULL,
   j JSON,
+  u STRING UNIQUE,
   INDEX (a),
   UNIQUE (b),
   INDEX (partition_by, c),
   INVERTED INDEX (j),
-  FAMILY (pk, pk2, partition_by, a, b, c, d)
+  FAMILY (pk, pk2, partition_by, a, b, c, d, j, u)
 ) PARTITION ALL BY LIST (partition_by) (
   PARTITION one VALUES IN (1),
   PARTITION two VALUES IN (2)
@@ -381,14 +382,16 @@ CREATE TABLE public.t (
   c INT8 NOT NULL,
   d INT8 NOT NULL,
   j JSONB NULL,
+  u STRING NULL,
   CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+  UNIQUE INDEX t_u_key (u ASC),
   INDEX t_a_idx (a ASC),
   UNIQUE INDEX t_b_key (b ASC),
   INDEX t_partition_by_c_idx (partition_by ASC, c ASC),
   INVERTED INDEX t_j_idx (j),
   INDEX created_idx (c ASC),
   UNIQUE INDEX unique_c_d (c ASC, d ASC),
-  FAMILY fam_0_pk_pk2_partition_by_a_b_c_d_j (pk, pk2, partition_by, a, b, c, d, j)
+  FAMILY fam_0_pk_pk2_partition_by_a_b_c_d_j_u (pk, pk2, partition_by, a, b, c, d, j, u)
 ) PARTITION ALL BY LIST (partition_by) (
   PARTITION one VALUES IN ((1)),
   PARTITION two VALUES IN ((2))
@@ -413,6 +416,8 @@ t_j_idx               j             false
 t_j_idx               partition_by  true
 t_partition_by_c_idx  c             false
 t_partition_by_c_idx  partition_by  false
+t_u_key               partition_by  true
+t_u_key               u             false
 unique_c_d            c             false
 unique_c_d            d             false
 unique_c_d            partition_by  true
@@ -432,15 +437,17 @@ CREATE TABLE public.t (
   c INT8 NOT NULL,
   d INT8 NOT NULL,
   j JSONB NULL,
+  u STRING NULL,
   CONSTRAINT "primary" PRIMARY KEY (pk2 ASC),
   UNIQUE INDEX t_pk_key (pk ASC),
+  UNIQUE INDEX t_u_key (u ASC),
   INDEX t_a_idx (a ASC),
   UNIQUE INDEX t_b_key (b ASC),
   INDEX t_partition_by_c_idx (partition_by ASC, c ASC),
   INVERTED INDEX t_j_idx (j),
   INDEX created_idx (c ASC),
   UNIQUE INDEX unique_c_d (c ASC, d ASC),
-  FAMILY fam_0_pk_pk2_partition_by_a_b_c_d_j (pk, pk2, partition_by, a, b, c, d, j)
+  FAMILY fam_0_pk_pk2_partition_by_a_b_c_d_j_u (pk, pk2, partition_by, a, b, c, d, j, u)
 ) PARTITION ALL BY LIST (partition_by) (
   PARTITION one VALUES IN ((1)),
   PARTITION two VALUES IN ((2))
@@ -467,6 +474,8 @@ t_partition_by_c_idx  c             false
 t_partition_by_c_idx  partition_by  false
 t_pk_key              partition_by  true
 t_pk_key              pk            false
+t_u_key               partition_by  true
+t_u_key               u             false
 unique_c_d            c             false
 unique_c_d            d             false
 unique_c_d            partition_by  true

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1706,6 +1706,25 @@ func NewTableDesc(
 
 			if idx != nil {
 				idx.Version = indexEncodingVersion
+
+				// If it a non-primary index that is implicitly created, ensure partitioning
+				// for PARTITION ALL BY.
+				if desc.PartitionAllBy && !d.PrimaryKey.IsPrimaryKey {
+					var err error
+					*idx, err = CreatePartitioning(
+						ctx,
+						st,
+						evalCtx,
+						&desc,
+						*idx,
+						partitionAllBy,
+						nil, /* allowedNewColumnNames */
+					)
+					if err != nil {
+						return nil, err
+					}
+				}
+
 				if err := desc.AddIndex(*idx, d.PrimaryKey.IsPrimaryKey); err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
Turns out there's even more ways indexes can come out of nowhere on
CREATE TABLE, so add that as a spot too.

Resolves https://github.com/cockroachdb/cockroach/issues/60456

Release note: None