### PR TITLE
sql: allow REGIONAL BY ROW without experimental flag

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
+++ b/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
@@ -19,11 +19,6 @@ ALTER TABLE IF EXISTS table_does_not_exist SET LOCALITY REGIONAL BY TABLE
 statement ok
 use alter_locality_test
 
-# Turn on experimental flag to allow REGIONAL BY ROW table creation
-# TODO(#59629): remove this once flag is no longer needed for REGIONAL BY ROW tables
-statement ok
-SET experimental_enable_implicit_column_partitioning = true
-
 statement ok
 CREATE TABLE regional_by_row (
   pk INT PRIMARY KEY,

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -3,12 +3,6 @@
 statement ok
 CREATE DATABASE multi_region_test_db PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1" SURVIVE REGION FAILURE
 
-statement error REGIONAL BY ROW is currently experimental
-CREATE TABLE regional_by_row_table (pk int) LOCALITY REGIONAL BY ROW
-
-statement ok
-SET experimental_enable_implicit_column_partitioning = true
-
 statement error cannot set LOCALITY on a database that is not multi-region enabled
 CREATE TABLE regional_by_row_table (pk int) LOCALITY REGIONAL BY ROW
 

--- a/pkg/ccl/partitionccl/regional_by_row_test.go
+++ b/pkg/ccl/partitionccl/regional_by_row_test.go
@@ -220,7 +220,6 @@ func TestAlterTableLocalityRegionalByRowError(t *testing.T) {
 							defer sqltestutils.DisableGCTTLStrictEnforcement(t, sqlDB)()
 
 							if _, err := sqlDB.Exec(fmt.Sprintf(`
-SET experimental_enable_implicit_column_partitioning = true;
 CREATE DATABASE t PRIMARY REGION "ajstorm-1";
 USE t;
 %s;

--- a/pkg/sql/alter_index.go
+++ b/pkg/sql/alter_index.go
@@ -78,6 +78,8 @@ func (n *alterIndexNode) startExec(params runParams) error {
 					"cannot ALTER INDEX PARTITION BY on index which already has implicit column partitioning",
 				)
 			}
+			allowImplicitPartitioning := params.p.EvalContext().SessionData.ImplicitColumnPartitioningEnabled ||
+				n.tableDesc.IsLocalityRegionalByRow()
 			newIndexDesc, err := CreatePartitioning(
 				params.ctx,
 				params.extendedEvalCtx.Settings,
@@ -86,6 +88,7 @@ func (n *alterIndexNode) startExec(params runParams) error {
 				*n.indexDesc,
 				t.PartitionBy,
 				nil, /* allowedNewColumnNames */
+				allowImplicitPartitioning,
 			)
 			if err != nil {
 				return err

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -809,6 +809,8 @@ func (n *alterTableNode) startExec(params runParams) error {
 				*n.tableDesc.GetPrimaryIndex().IndexDesc(),
 				t.PartitionBy,
 				nil, /* allowedNewColumnNames */
+				params.p.EvalContext().SessionData.ImplicitColumnPartitioningEnabled ||
+					n.tableDesc.IsLocalityRegionalByRow(),
 			)
 			if err != nil {
 				return err

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -539,7 +539,8 @@ func (p *planner) configureIndexDescForNewIndexPartitioning(
 				return indexDesc, err
 			}
 		}
-
+		allowImplicitPartitioning := p.EvalContext().SessionData.ImplicitColumnPartitioningEnabled ||
+			tableDesc.IsLocalityRegionalByRow()
 		if partitionBy != nil {
 			if indexDesc, err = CreatePartitioning(
 				ctx,
@@ -549,6 +550,7 @@ func (p *planner) configureIndexDescForNewIndexPartitioning(
 				indexDesc,
 				partitionBy,
 				nil, /* allowedNewColumnNames */
+				allowImplicitPartitioning,
 			); err != nil {
 				return indexDesc, err
 			}


### PR DESCRIPTION
No longer require experimental_enable_implicit_column_partitioning when
creating REGIONAL BY ROW tables.

Resolves https://github.com/cockroachdb/cockroach/issues/59629

Release note: None