### PR TITLE
sql: add percentage to the estimated row count for scans

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vectorize_local
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_local
@@ -74,7 +74,7 @@ vectorized: <hidden>
       actual row count: 2
       KV rows read: 2
       KV bytes read: 16 B
-      estimated row count: 1
+      estimated row count: 1 (100% of the table)
       table: c@sec
       spans: FULL SCAN
 ·
@@ -98,7 +98,7 @@ vectorized: <hidden>
 │     actual row count: 2
 │     KV rows read: 2
 │     KV bytes read: 16 B
-│     estimated row count: 1
+│     estimated row count: 1 (100% of the table)
 │     table: c@primary
 │     spans: FULL SCAN
 │

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_threshold
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_threshold
@@ -68,7 +68,7 @@ vectorized: false
 • group (scalar)
 │
 └── • scan
-      estimated row count: 100
+      estimated row count: 100 (100% of the table)
       table: small@primary
       spans: FULL SCAN
 
@@ -86,7 +86,7 @@ vectorized: true
 • group (scalar)
 │
 └── • scan
-      estimated row count: 100
+      estimated row count: 100 (100% of the table)
       table: small@primary
       spans: FULL SCAN
 
@@ -116,7 +116,7 @@ vectorized: true
 • group (scalar)
 │
 └── • scan
-      estimated row count: 100,000
+      estimated row count: 100,000 (100% of the table)
       table: large@primary
       spans: FULL SCAN
 
@@ -134,7 +134,7 @@ vectorized: false
 • group (scalar)
 │
 └── • scan
-      estimated row count: 100,000
+      estimated row count: 100,000 (100% of the table)
       table: large@primary
       spans: FULL SCAN
 
@@ -155,11 +155,11 @@ vectorized: true
 │ right cols are key
 │
 ├── • scan
-│     estimated row count: 100
+│     estimated row count: 100 (100% of the table)
 │     table: small@primary
 │     spans: FULL SCAN
 │
 └── • scan
-      estimated row count: 100,000
+      estimated row count: 100,000 (100% of the table)
       table: large@primary
       spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_misc
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_misc
@@ -119,7 +119,7 @@ vectorized: true
 ·
 • scan
   columns: (a int, b int, c float, d decimal)
-  estimated row count: 1,000
+  estimated row count: 1,000 (100% of the table)
   table: data@primary
   spans: FULL SCAN
 ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -1451,3 +1451,107 @@ vectorized: true
           estimated row count: 10 (missing stats)
           table: pg_attribute@pg_attribute_attrelid_idx
           spans: [/ab - /ab]
+
+
+# Verify the output for the percentage of table that is scanned.
+statement ok
+CREATE TABLE percent (a INT PRIMARY KEY, b INT)
+
+statement ok
+ALTER TABLE percent INJECT STATISTICS '[
+  {
+    "columns": ["a"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000,
+    "distinct_count": 1000000,
+    "histo_buckets": []
+  }
+]'
+
+query T
+EXPLAIN SELECT * FROM percent
+----
+distribution: local
+vectorized: true
+·
+• scan
+  estimated row count: 1,000,000 (100% of the table)
+  table: percent@primary
+  spans: FULL SCAN
+
+query T
+EXPLAIN SELECT * FROM percent WHERE a BETWEEN 1 AND 150000
+----
+distribution: local
+vectorized: true
+·
+• scan
+  estimated row count: 150,000 (15% of the table)
+  table: percent@primary
+  spans: [/1 - /150000]
+
+query T
+EXPLAIN SELECT * FROM percent WHERE a BETWEEN 1 AND 20000
+----
+distribution: local
+vectorized: true
+·
+• scan
+  estimated row count: 20,000 (2.0% of the table)
+  table: percent@primary
+  spans: [/1 - /20000]
+
+query T
+EXPLAIN SELECT * FROM percent WHERE a BETWEEN 1 AND 1234
+----
+distribution: local
+vectorized: true
+·
+• scan
+  estimated row count: 1,234 (0.12% of the table)
+  table: percent@primary
+  spans: [/1 - /1234]
+
+query T
+EXPLAIN SELECT * FROM percent WHERE a BETWEEN 1 AND 980
+----
+distribution: local
+vectorized: true
+·
+• scan
+  estimated row count: 980 (0.10% of the table)
+  table: percent@primary
+  spans: [/1 - /980]
+
+query T
+EXPLAIN SELECT * FROM percent WHERE a BETWEEN 1 and 100
+----
+distribution: local
+vectorized: true
+·
+• scan
+  estimated row count: 100 (0.01% of the table)
+  table: percent@primary
+  spans: [/1 - /100]
+
+query T
+EXPLAIN SELECT * FROM percent WHERE a BETWEEN 1 and 99
+----
+distribution: local
+vectorized: true
+·
+• scan
+  estimated row count: 99 (<0.01% of the table)
+  table: percent@primary
+  spans: [/1 - /99]
+
+query T
+EXPLAIN SELECT * FROM percent WHERE a = 1
+----
+distribution: local
+vectorized: true
+·
+• scan
+  estimated row count: 1 (<0.01% of the table)
+  table: percent@primary
+  spans: [/1 - /1]

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -1217,7 +1217,7 @@ vectorized: true
             │     label: buffer 1
             │
             └── • scan
-                  estimated row count: 1
+                  estimated row count: 1 (100% of the table)
                   table: p@primary
                   spans: FULL SCAN
 
@@ -1239,7 +1239,7 @@ vectorized: true
 │       └── • render
 │           │
 │           └── • scan
-│                 estimated row count: 1
+│                 estimated row count: 1 (100% of the table)
 │                 table: c@primary
 │                 spans: [/1 - ]
 │                 locking strength: for update
@@ -1259,7 +1259,7 @@ vectorized: true
             │         label: buffer 1
             │
             └── • scan
-                  estimated row count: 1
+                  estimated row count: 1 (100% of the table)
                   table: p@primary
                   spans: FULL SCAN
 
@@ -1281,7 +1281,7 @@ vectorized: true
 │       └── • render
 │           │
 │           └── • scan
-│                 estimated row count: 1
+│                 estimated row count: 1 (100% of the table)
 │                 table: p@primary
 │                 spans: [/1 - ]
 │                 locking strength: for update
@@ -1303,7 +1303,7 @@ vectorized: true
             │         label: buffer 1
             │
             └── • scan
-                  estimated row count: 1
+                  estimated row count: 1 (100% of the table)
                   table: c@primary
                   spans: FULL SCAN
 
@@ -1322,7 +1322,7 @@ vectorized: true
 │       │ label: buffer 1
 │       │
 │       └── • scan
-│             estimated row count: 1
+│             estimated row count: 1 (100% of the table)
 │             table: p@primary
 │             spans: [/1 - ]
 │
@@ -1338,7 +1338,7 @@ vectorized: true
             │     label: buffer 1
             │
             └── • scan
-                  estimated row count: 1
+                  estimated row count: 1 (100% of the table)
                   table: c@primary
                   spans: FULL SCAN
 
@@ -1376,7 +1376,7 @@ vectorized: true
 │       └── • render
 │           │
 │           └── • scan
-│                 estimated row count: 1
+│                 estimated row count: 1 (100% of the table)
 │                 table: c@primary
 │                 spans: [/1 - ]
 │                 locking strength: for update
@@ -1414,7 +1414,7 @@ vectorized: true
 │       └── • render
 │           │
 │           └── • scan
-│                 estimated row count: 1
+│                 estimated row count: 1 (100% of the table)
 │                 table: p@primary
 │                 spans: [/1 - ]
 │                 locking strength: for update
@@ -1450,7 +1450,7 @@ vectorized: true
 │       │ label: buffer 1
 │       │
 │       └── • scan
-│             estimated row count: 1
+│             estimated row count: 1 (100% of the table)
 │             table: p@primary
 │             spans: [/1 - ]
 │
@@ -1517,7 +1517,7 @@ vectorized: true
             │     label: buffer 1
             │
             └── • scan
-                  estimated row count: 10
+                  estimated row count: 10 (100% of the table)
                   table: small_parent@primary
                   spans: FULL SCAN
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -428,49 +428,49 @@ vectorized: true
         │   │   │   │   │   ├── • union
         │   │   │   │   │   │   │
         │   │   │   │   │   │   ├── • scan
-        │   │   │   │   │   │   │     estimated row count: 5
+        │   │   │   │   │   │   │     estimated row count: 5 (0.05% of the table)
         │   │   │   │   │   │   │     table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
         │   │   │   │   │   │   │     spans: [/0/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /0/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
         │   │   │   │   │   │   │     limit: 5
         │   │   │   │   │   │   │
         │   │   │   │   │   │   └── • scan
-        │   │   │   │   │   │         estimated row count: 5
+        │   │   │   │   │   │         estimated row count: 5 (0.05% of the table)
         │   │   │   │   │   │         table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
         │   │   │   │   │   │         spans: [/1/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /1/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
         │   │   │   │   │   │         limit: 5
         │   │   │   │   │   │
         │   │   │   │   │   └── • scan
-        │   │   │   │   │         estimated row count: 5
+        │   │   │   │   │         estimated row count: 5 (0.05% of the table)
         │   │   │   │   │         table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
         │   │   │   │   │         spans: [/2/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /2/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
         │   │   │   │   │         limit: 5
         │   │   │   │   │
         │   │   │   │   └── • scan
-        │   │   │   │         estimated row count: 5
+        │   │   │   │         estimated row count: 5 (0.05% of the table)
         │   │   │   │         table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
         │   │   │   │         spans: [/3/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /3/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
         │   │   │   │         limit: 5
         │   │   │   │
         │   │   │   └── • scan
-        │   │   │         estimated row count: 5
+        │   │   │         estimated row count: 5 (0.05% of the table)
         │   │   │         table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
         │   │   │         spans: [/4/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /4/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
         │   │   │         limit: 5
         │   │   │
         │   │   └── • scan
-        │   │         estimated row count: 5
+        │   │         estimated row count: 5 (0.05% of the table)
         │   │         table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
         │   │         spans: [/5/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /5/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
         │   │         limit: 5
         │   │
         │   └── • scan
-        │         estimated row count: 5
+        │         estimated row count: 5 (0.05% of the table)
         │         table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
         │         spans: [/6/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /6/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
         │         limit: 5
         │
         └── • scan
-              estimated row count: 5
+              estimated row count: 5 (0.05% of the table)
               table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
               spans: [/7/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /7/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
               limit: 5

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -42,7 +42,7 @@ vectorized: true
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 100
+      estimated row count: 100 (100% of the table)
       table: abc@primary
       spans: FULL SCAN
 
@@ -61,7 +61,7 @@ vectorized: true
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 100
+      estimated row count: 100 (100% of the table)
       table: abc@primary
       spans: FULL SCAN
 
@@ -80,7 +80,7 @@ vectorized: true
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 33
+      estimated row count: 33 (33% of the table)
       table: abc@primary
       spans: /2-
 
@@ -99,7 +99,7 @@ vectorized: true
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 33
+      estimated row count: 33 (33% of the table)
       table: abc@primary
       spans: /2-
 
@@ -118,7 +118,7 @@ vectorized: true
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 100
+      estimated row count: 100 (100% of the table)
       table: abc@primary
       spans: FULL SCAN
 
@@ -137,7 +137,7 @@ vectorized: true
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 100
+      estimated row count: 100 (100% of the table)
       table: abc@primary
       spans: FULL SCAN
 
@@ -208,7 +208,7 @@ vectorized: true
         │
         └── • scan
               columns: (a, b, c, d)
-              estimated row count: 100,000
+              estimated row count: 100,000 (100% of the table)
               table: data@primary
               spans: FULL SCAN
 
@@ -231,7 +231,7 @@ vectorized: true
     │ filter: c = 1
     │
     └── • scan
-          estimated row count: 100,000
+          estimated row count: 100,000 (100% of the table)
           table: data@primary
           spans: FULL SCAN
 ·
@@ -290,7 +290,7 @@ vectorized: true
         └── • scan
               columns: (title, shelf)
               ordering: +title
-              estimated row count: 100
+              estimated row count: 100 (100% of the table)
               table: books@primary
               spans: FULL SCAN
 
@@ -335,13 +335,13 @@ vectorized: true
             │
             ├── • scan
             │     columns: (title, shelf)
-            │     estimated row count: 100
+            │     estimated row count: 100 (100% of the table)
             │     table: books@primary
             │     spans: FULL SCAN
             │
             └── • scan
                   columns: (name, book)
-                  estimated row count: 100
+                  estimated row count: 100 (100% of the table)
                   table: authors@primary
                   spans: FULL SCAN
 
@@ -370,12 +370,12 @@ vectorized: true
         │ equality: (title) = (book)
         │
         ├── • scan
-        │     estimated row count: 100
+        │     estimated row count: 100 (100% of the table)
         │     table: books@primary
         │     spans: FULL SCAN
         │
         └── • scan
-              estimated row count: 100
+              estimated row count: 100 (100% of the table)
               table: authors@primary
               spans: FULL SCAN
 ·
@@ -407,7 +407,7 @@ vectorized: true
         │
         └── • scan
               columns: (name, book)
-              estimated row count: 100
+              estimated row count: 100 (100% of the table)
               table: authors@primary
               spans: FULL SCAN
 
@@ -424,13 +424,13 @@ vectorized: true
 │
 ├── • scan
 │     columns: (title, edition, shelf)
-│     estimated row count: 10,000
+│     estimated row count: 10,000 (100% of the table)
 │     table: books2@primary
 │     spans: FULL SCAN
 │
 └── • scan
       columns: (title, edition, shelf)
-      estimated row count: 100
+      estimated row count: 100 (100% of the table)
       table: books@primary
       spans: FULL SCAN
 
@@ -448,7 +448,7 @@ vectorized: true
 └── • render
     │
     └── • scan
-          estimated row count: 100
+          estimated row count: 100 (100% of the table)
           table: authors@primary
           spans: FULL SCAN
 ·
@@ -514,7 +514,7 @@ vectorized: true
     │
     └── • scan
           columns: (a)
-          estimated row count: 100
+          estimated row count: 100 (100% of the table)
           table: small@primary
           spans: FULL SCAN
 
@@ -547,7 +547,7 @@ vectorized: true
             │
             └── • scan
                   columns: (a)
-                  estimated row count: 100
+                  estimated row count: 100 (100% of the table)
                   table: small@primary
                   spans: FULL SCAN
 
@@ -570,7 +570,7 @@ vectorized: true
 │
 └── • scan
       columns: (b)
-      estimated row count: 100
+      estimated row count: 100 (100% of the table)
       table: small@primary
       spans: FULL SCAN
 
@@ -597,7 +597,7 @@ vectorized: true
     └── • scan
           columns: (a)
           ordering: +a
-          estimated row count: 100
+          estimated row count: 100 (100% of the table)
           table: small@primary
           spans: FULL SCAN
 
@@ -613,7 +613,7 @@ vectorized: true
 │ pred: (b % 6) = 0
 │
 └── • scan
-      estimated row count: 100
+      estimated row count: 100 (100% of the table)
       table: small@primary
       spans: FULL SCAN
 ·
@@ -638,7 +638,7 @@ vectorized: true
     │
     └── • scan
           columns: (c)
-          estimated row count: 100
+          estimated row count: 100 (100% of the table)
           table: small@primary
           spans: FULL SCAN
 
@@ -671,7 +671,7 @@ vectorized: true
             │
             └── • scan
                   columns: (c)
-                  estimated row count: 100
+                  estimated row count: 100 (100% of the table)
                   table: small@primary
                   spans: FULL SCAN
 
@@ -695,7 +695,7 @@ vectorized: true
     │
     └── • scan
           columns: (c)
-          estimated row count: 100
+          estimated row count: 100 (100% of the table)
           table: small@primary
           spans: FULL SCAN
 
@@ -724,13 +724,13 @@ vectorized: true
     │   │
     │   └── • scan
     │         columns: (b, d)
-    │         estimated row count: 10,000
+    │         estimated row count: 10,000 (100% of the table)
     │         table: large@primary
     │         spans: FULL SCAN
     │
     └── • scan
           columns: (c)
-          estimated row count: 100
+          estimated row count: 100 (100% of the table)
           table: small@primary
           spans: FULL SCAN
 
@@ -930,7 +930,7 @@ vectorized: true
 └── • scan
       columns: (a, b, c)
       ordering: +a
-      estimated row count: 100
+      estimated row count: 100 (100% of the table)
       table: abc@primary
       spans: FULL SCAN
 
@@ -951,14 +951,14 @@ vectorized: true
 ├── • scan
 │     columns: (d, e, f)
 │     ordering: +f
-│     estimated row count: 10,000
+│     estimated row count: 10,000 (100% of the table)
 │     table: def@primary
 │     spans: FULL SCAN
 │
 └── • scan
       columns: (a, b, c)
       ordering: +a
-      estimated row count: 100
+      estimated row count: 100 (100% of the table)
       table: abc@primary
       spans: FULL SCAN
 
@@ -982,13 +982,13 @@ vectorized: true
     │
     ├── • scan
     │     columns: (d, e, f)
-    │     estimated row count: 10,000
+    │     estimated row count: 10,000 (100% of the table)
     │     table: def@primary
     │     spans: FULL SCAN
     │
     └── • scan
           columns: (a, b, c)
-          estimated row count: 100
+          estimated row count: 100 (100% of the table)
           table: abc@primary
           spans: FULL SCAN
 
@@ -1007,7 +1007,7 @@ vectorized: true
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 100
+      estimated row count: 100 (100% of the table)
       table: abc@primary
       spans: FULL SCAN
 
@@ -1025,7 +1025,7 @@ vectorized: true
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 100
+      estimated row count: 100 (100% of the table)
       table: abc@primary
       spans: FULL SCAN
 
@@ -1044,7 +1044,7 @@ vectorized: true
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 100
+      estimated row count: 100 (100% of the table)
       table: abc@primary
       spans: FULL SCAN
 
@@ -1063,7 +1063,7 @@ vectorized: true
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 100
+      estimated row count: 100 (100% of the table)
       table: abc@primary
       spans: FULL SCAN
 
@@ -1082,7 +1082,7 @@ vectorized: true
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 100
+      estimated row count: 100 (100% of the table)
       table: abc@primary
       spans: FULL SCAN
 
@@ -1101,7 +1101,7 @@ vectorized: true
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 100
+      estimated row count: 100 (100% of the table)
       table: abc@primary
       spans: FULL SCAN
 
@@ -1117,7 +1117,7 @@ vectorized: true
 │ equality: (a) = (a)
 │
 └── • scan
-      estimated row count: 100
+      estimated row count: 100 (100% of the table)
       table: small@primary
       spans: FULL SCAN
 ·
@@ -1139,7 +1139,7 @@ vectorized: true
     │ filter: (a + b) < 20
     │
     └── • scan
-          estimated row count: 100
+          estimated row count: 100 (100% of the table)
           table: small@primary
           spans: FULL SCAN
 ·
@@ -1747,7 +1747,7 @@ vectorized: true
                                         │ filter: n_name = 'SAUDI ARABIA'
                                         │
                                         └── • scan
-                                              estimated row count: 25
+                                              estimated row count: 25 (100% of the table)
                                               table: nation@primary
                                               spans: FULL SCAN
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare
@@ -99,6 +99,6 @@ vectorized: true
 │ equality cols are key
 │
 └── • scan
-      estimated row count: 1
+      estimated row count: 1 (100% of the table)
       table: ab@primary
       spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -1576,7 +1576,7 @@ vectorized: true
     │
     └── • scan
           columns: (a, b, c)
-          estimated row count: 3
+          estimated row count: 3 (3.3% of the table)
           table: t2@bc
           spans: /2-/3
 
@@ -1612,7 +1612,7 @@ vectorized: true
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 3
+      estimated row count: 3 (3.1% of the table)
       table: t2@bc
       spans: /2/!NULL-/2/2 /2/3-/3
 
@@ -1723,7 +1723,7 @@ vectorized: true
 │
 └── • scan
       columns: (a, b)
-      estimated row count: 3
+      estimated row count: 3 (3.3% of the table)
       table: t2@bc
       spans: /2-/3
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/stats
@@ -47,7 +47,7 @@ vectorized: true
 │
 └── • scan
       columns: (u, v)
-      estimated row count: 1
+      estimated row count: 1 (12% of the table)
       table: uv@uv_v_idx
       spans: /1-/2
 
@@ -81,7 +81,7 @@ vectorized: true
 │
 └── • scan
       columns: (u, v)
-      estimated row count: 1
+      estimated row count: 1 (1.0% of the table)
       table: uv@uv_u_idx
       spans: /1-/2
 
@@ -118,7 +118,7 @@ vectorized: true
 │
 └── • scan
       columns: (u, v)
-      estimated row count: 5
+      estimated row count: 5 (5.0% of the table)
       table: uv@uv_u_idx
       spans: /1-/2
 
@@ -153,7 +153,7 @@ vectorized: true
 │
 └── • scan
       columns: (u, v)
-      estimated row count: 1
+      estimated row count: 1 (1.1% of the table)
       table: uv@uv_v_idx
       spans: /1-/2
 

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -286,6 +286,9 @@ type EstimatedStats struct {
 	TableStatsAvailable bool
 	// RowCount is the estimated number of rows produced by the operator.
 	RowCount float64
+	// TableRowCount is set only for scans; it is the estimated total number of
+	// rows in the table we are scanning.
+	TableRowCount float64
 	// Cost is the estimated cost of the operator. This cost includes the costs of
 	// the child operators.
 	Cost float64

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -611,6 +611,13 @@ func (sb *statisticsBuilder) colStatTable(
 	return sb.colStatLeaf(colSet, tableStats, tableFD, tableNotNullCols)
 }
 
+// GetCachedTableStatistics returns the statistics for the given table, if they
+// were calculated already.
+func (m *Memo) GetCachedTableStatistics(tabID opt.TableID) (_ *props.Statistics, ok bool) {
+	stats, ok := m.metadata.TableAnnotation(tabID, statsAnnID).(*props.Statistics)
+	return stats, ok
+}
+
 // +------+
 // | Scan |
 // +------+


### PR DESCRIPTION
This change improves the estimated row count in EXPLAIN by showing
what percentage of the table is scanned. This value only shows up when
stats are available.

Example: `estimated row count: 25 (1% of the table)`

Fixes #48420.

Release note (sql change): EXPLAIN now shows the estimated percentage
of the table that is scanned.