### PR TITLE
build: fix shell syntax error in teamcity-testlogicrace.sh

### DIFF
--- a/build/teamcity-testlogicrace.sh
+++ b/build/teamcity-testlogicrace.sh
@@ -48,6 +48,6 @@ for file in $LOGICTESTS; do
           PKG=./pkg/sql/logictest \
           TESTS='^TestLogic/local/'${file}'$$' \
           TESTTIMEOUT="${TESTTIMEOUT}" \
-          TESTFLAGS='-disable-opt-rule-probability=0.5' \
+          TESTFLAGS='-disable-opt-rule-probability=0.5'
     fi
 done


### PR DESCRIPTION
The trailing line `\` meant that the end of the if statement was
actually an argument to run_json_test.

This doesn't impact anything since this test has been disabled for
some time.

Release note: None