### PR TITLE
execstats: include local streams in the physical plan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -910,7 +910,8 @@ OPTGEN_TARGETS = \
 test-targets := \
 	check test testshort testslow testrace testraceslow testbuild \
 	stress stressrace \
-	roachprod-stress roachprod-stressrace
+	roachprod-stress roachprod-stressrace \
+	testlogic testbaselogic testccllogic testoptlogic
 
 go-targets-ccl := \
 	$(COCKROACH) \

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/stmtdiagnostics"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
@@ -80,6 +81,9 @@ type instrumentationHelper struct {
 	// collectExecStats is set when we are collecting execution statistics for a
 	// statement.
 	collectExecStats bool
+	// startedExplicitTrace is set to true when the instrumentation helper started
+	// an explicit trace to collect execution stats.
+	startedExplicitTrace bool
 
 	// discardRows is set if we want to discard any results rather than sending
 	// them back to the client. Used for testing/benchmarking. Note that the
@@ -178,6 +182,7 @@ func (ih *instrumentationHelper) Setup(
 			// If we need to collect stats, create a non-verbose child span. Stats
 			// will be added as structured metadata and processed in Finish.
 			ih.origCtx = ctx
+			ih.startedExplicitTrace = true
 			newCtx, ih.sp = tracing.EnsureChildSpan(ctx, cfg.AmbientCtx.Tracer, "traced statement")
 			return newCtx, true
 		}
@@ -231,7 +236,13 @@ func (ih *instrumentationHelper) Finish(
 		}
 		queryLevelStats, err := execstats.GetQueryLevelStats(trace, cfg.TestingKnobs.DeterministicExplainAnalyze, flowsMetadata)
 		if err != nil {
-			log.VInfof(ctx, 1, "error getting query level stats for statement %s: %+v", ast, err)
+			const msg = "error getting query level stats for statement: %s: %+v"
+			if util.CrdbTestBuild && ih.startedExplicitTrace {
+				// A panic is much more visible in tests than an error.
+				// TODO(asubiotto): Remove ih.startedExplicitTrace. See #60609.
+				panic(fmt.Sprintf(msg, ih.fingerprint, err))
+			}
+			log.VInfof(ctx, 1, msg, ih.fingerprint, err)
 		} else {
 			stmtStats.mu.Lock()
 			stmtStats.mu.data.ExecStatCollectionCount++


### PR DESCRIPTION
Fixes #60463 

Look at commits for individual details. Ignored errors caused this bug to go unnoticed, so the first commit adds a panic when the crdb test flag is specified. This would've caught the issue easily.

Release note: None