### PR TITLE
cloudimpl: deprecation notice to GCS `default` cluster setting

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -1,6 +1,6 @@
 Setting	Type	Default	Description
 bulkio.stream_ingestion.minimum_flush_interval	duration	5s	the minimum timestamp between flushes; flushes may still occur if internal buffers fill up
-cloudstorage.gs.default.key	string		if set, JSON key to use during Google Cloud Storage operations
+cloudstorage.gs.default.key	string		[deprecated] if set, JSON key to use during Google Cloud Storage operations. This setting will be removed in 21.2, as we will no longer support the `default` AUTH mode for GCS operations.
 cloudstorage.http.custom_ca	string		custom root CA (appended to system's default CAs) for verifying certificates when interacting with HTTPS storage
 cloudstorage.timeout	duration	10m0s	the timeout for import/export storage operations
 cluster.organization	string		organization name

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -2,7 +2,7 @@
 <thead><tr><th>Setting</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>bulkio.stream_ingestion.minimum_flush_interval</code></td><td>duration</td><td><code>5s</code></td><td>the minimum timestamp between flushes; flushes may still occur if internal buffers fill up</td></tr>
-<tr><td><code>cloudstorage.gs.default.key</code></td><td>string</td><td><code></code></td><td>if set, JSON key to use during Google Cloud Storage operations</td></tr>
+<tr><td><code>cloudstorage.gs.default.key</code></td><td>string</td><td><code></code></td><td>[deprecated] if set, JSON key to use during Google Cloud Storage operations. This setting will be removed in 21.2, as we will no longer support the `default` AUTH mode for GCS operations.</td></tr>
 <tr><td><code>cloudstorage.http.custom_ca</code></td><td>string</td><td><code></code></td><td>custom root CA (appended to system's default CAs) for verifying certificates when interacting with HTTPS storage</td></tr>
 <tr><td><code>cloudstorage.timeout</code></td><td>duration</td><td><code>10m0s</code></td><td>the timeout for import/export storage operations</td></tr>
 <tr><td><code>cluster.organization</code></td><td>string</td><td><code></code></td><td>organization name</td></tr>

--- a/pkg/storage/cloudimpl/external_storage.go
+++ b/pkg/storage/cloudimpl/external_storage.go
@@ -408,7 +408,9 @@ var (
 	// operations.
 	GcsDefault = settings.RegisterStringSetting(
 		CloudstorageGSDefaultKey,
-		"if set, JSON key to use during Google Cloud Storage operations",
+		"[deprecated] if set, JSON key to use during Google Cloud Storage operations. "+
+			"This setting will be removed in "+
+			"21.2, as we will no longer support the `default` AUTH mode for GCS operations.",
 		"",
 	).WithPublic()
 	httpCustomCA = settings.RegisterStringSetting(


### PR DESCRIPTION
We want to get rid of the `default` mode of AUTH for GCS in 21.2. This
mode relies on a cluster setting being set with a JSON key. This change
adds a deprecation warning to the description of that cluster settings.
There will be a docs callout to accompany this change.

Fixes: #60433

Release note: None