### PR TITLE
cli: add userfile get command

### DIFF
--- a/pkg/storage/cloudimpl/filetable/file_table_read_writer.go
+++ b/pkg/storage/cloudimpl/filetable/file_table_read_writer.go
@@ -702,7 +702,7 @@ func newFileTableReader(
 			ORDER BY byte_offset DESC
 			LIMIT 1`, payloadTableName)
 		rows, err := ie.Query(
-			ctx, "userfile-reader-payload", query, username, fileID, pos, bufSize,
+			ctx, "userfile-reader-payload", query, username, fileID, pos, int64(bufSize),
 		)
 		if err != nil {
 			return 0, errors.Wrap(err, "reading file content")


### PR DESCRIPTION
`userfile get` fetches the file or files that match the supplied path,
path prefix or glob-style path pattern to the current working directory.

Release note (cli change): `userfile get` can be used to fetch files from a cluster.