### PR TITLE
sql: ensure type schema change cleanup job is resilient to retries

### DIFF
--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -162,6 +162,9 @@ type TypeSchemaChangerTestingKnobs struct {
 	// RunBeforeEnumMemberPromotion runs before enum members are promoted from
 	// readable to all permissions in the typeSchemaChanger.
 	RunBeforeEnumMemberPromotion func()
+	// RunAfterOnFailOrCancel runs after OnFailOrCancel completes, if
+	// OnFailOrCancel is triggered.
+	RunAfterOnFailOrCancel func() error
 }
 
 // ModuleTestingKnobs implements the ModuleTestingKnobs interface.
@@ -612,14 +615,41 @@ func (t *typeChangeResumer) OnFailOrCancel(ctx context.Context, execCtx interfac
 		execCfg:              execCtx.(JobExecContext).ExecCfg(),
 	}
 
-	if err := tc.cleanupEnumValues(ctx); err != nil {
-		return err
+	if rollbackErr := func() error {
+		if err := tc.cleanupEnumValues(ctx); err != nil {
+			return err
+		}
+
+		if err := drainNamesForDescriptor(
+			ctx, tc.execCfg.Settings, tc.typeID, tc.execCfg.DB,
+			tc.execCfg.InternalExecutor, tc.execCfg.LeaseManager, tc.execCfg.Codec, nil,
+		); err != nil {
+			return err
+		}
+
+		if fn := tc.execCfg.TypeSchemaChangerTestingKnobs.RunAfterOnFailOrCancel; fn != nil {
+			return fn()
+		}
+
+		return nil
+	}(); rollbackErr != nil {
+		switch {
+		case errors.Is(rollbackErr, catalog.ErrDescriptorNotFound):
+			// If the descriptor for the ID can't be found, we assume that another
+			// job executed already and dropped the type.
+			log.Infof(
+				ctx,
+				"descriptor %d not found for type change job; assuming it was dropped, and exiting",
+				tc.typeID,
+			)
+		case !isPermanentSchemaChangeError(rollbackErr):
+			return jobs.NewRetryJobError(rollbackErr.Error())
+		default:
+			return rollbackErr
+		}
 	}
 
-	return drainNamesForDescriptor(
-		ctx, tc.execCfg.Settings, tc.typeID, tc.execCfg.DB,
-		tc.execCfg.InternalExecutor, tc.execCfg.LeaseManager, tc.execCfg.Codec, nil,
-	)
+	return nil
 }
 
 func init() {

--- a/pkg/sql/type_change_test.go
+++ b/pkg/sql/type_change_test.go
@@ -12,6 +12,7 @@ package sql_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -26,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
 )
 
 // TestDrainingNamesAreCleanedTypeChangeOnFailure ensures that draining names
@@ -155,6 +157,70 @@ CREATE TYPE d.t AS ENUM();
 	// The retry should happen within the job and succeed.
 	if _, err := sqlDB.Exec(`ALTER TYPE d.t RENAME TO t2`); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestFailedTypeSchemaChangeRetriesTransparently fails the initial type schema
+// change operation and then tests that if the cleanup job runs into a
+// non-permanent error, it is retried transparently.
+func TestFailedTypeSchemaChangeRetriesTransparently(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Decrease the adopt loop interval so that retries happen quickly.
+	defer sqltestutils.SetTestJobsAdoptInterval()()
+
+	ctx := context.Background()
+	// Protects errReturned.
+	var mu syncutil.Mutex
+	// Ensures just the first try to cleanup returns a retryable error.
+	errReturned := false
+	params, _ := tests.CreateTestServerParams()
+	cleanupSuccessfullyFinished := make(chan struct{})
+	params.Knobs.SQLTypeSchemaChanger = &sql.TypeSchemaChangerTestingKnobs{
+		RunBeforeExec: func() error {
+			return errors.New("yikes")
+		},
+		RunAfterOnFailOrCancel: func() error {
+			mu.Lock()
+			defer mu.Unlock()
+			if errReturned {
+				return nil
+			}
+			errReturned = true
+			close(cleanupSuccessfullyFinished)
+			return context.DeadlineExceeded
+		},
+	}
+
+	s, sqlDB, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	// Create a type.
+	_, err := sqlDB.Exec(`
+CREATE DATABASE d;
+CREATE TYPE d.t AS ENUM();
+`)
+	require.NoError(t, err)
+
+	// The initial drop should fail.
+	_, err = sqlDB.Exec(`DROP TYPE d.t`)
+	testutils.IsError(err, "yikes")
+
+	// The cleanup job, which is expected to drain names, should retry
+	// transparently.
+	<-cleanupSuccessfullyFinished
+
+	// type descriptor name + array alias name.
+	namespaceEntries := []string{"t", "_t"}
+	for _, name := range namespaceEntries {
+		rows := sqlDB.QueryRow(fmt.Sprintf(`SELECT count(*) FROM system.namespace WHERE name= '%s'`, name))
+		var count int
+		err = rows.Scan(&count)
+		require.NoError(t, err)
+		if count != 0 {
+			t.Fatalf("expected namespace entries to be cleaned up for type desc %q", name)
+		}
 	}
 }
 


### PR DESCRIPTION
Previously if the type schema changer ran into a non-permanent error,
it wouldn't retry transparently. Instead, manual cleanup would be
required. This patch fixes this behavior.

This patch also adds a testing knob, `RunAfterOnFailOrCancel` to test
the afformentioned bug.

Fixes #60489

Release note (bug fix): Previosly, retryable errors in the cleanup
phase of the type schema changer wouldn't be retried automatically
in the background. This is now fixed.