### PR TITLE
migrations: add migration to remove pre-19.2 FK representation

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -99,4 +99,4 @@ timeseries.storage.resolution_30m.ttl	duration	2160h0m0s	the maximum age of time
 trace.debug.enable	boolean	false	if set, traces for recent requests can be seen at https://<ui>/debug/requests
 trace.lightstep.token	string		if set, traces go to Lightstep using this token
 trace.zipkin.collector	string		if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set
-version	version	20.2-40	set the active cluster version in the format '<major>.<minor>'
+version	version	20.2-42	set the active cluster version in the format '<major>.<minor>'

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -101,6 +101,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen at https://<ui>/debug/requests</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set</td></tr>
-<tr><td><code>version</code></td><td>version</td><td><code>20.2-40</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>version</td><td><code>20.2-42</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -263,6 +263,9 @@ const (
 	// Previously this was implemented as an async task with no guarantees about
 	// completion.
 	NamespaceTableWithSchemasMigration
+	// ForeignKeyRepresentationMigration is used to ensure that all no table
+	// descriptors use the pre-19.2 foreign key migration.
+	ForeignKeyRepresentationMigration
 
 	// Step (1): Add new versions here.
 )
@@ -448,6 +451,11 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 	{
 		Key:     NamespaceTableWithSchemasMigration,
 		Version: roachpb.Version{Major: 20, Minor: 2, Internal: 40},
+	},
+
+	{
+		Key:     ForeignKeyRepresentationMigration,
+		Version: roachpb.Version{Major: 20, Minor: 2, Internal: 42},
 	},
 	// Step (2): Add new versions here.
 })

--- a/pkg/clusterversion/key_string.go
+++ b/pkg/clusterversion/key_string.go
@@ -48,11 +48,12 @@ func _() {
 	_ = x[ClosedTimestampsRaftTransport-37]
 	_ = x[ChangefeedsSupportPrimaryIndexChanges-38]
 	_ = x[NamespaceTableWithSchemasMigration-39]
+	_ = x[ForeignKeyRepresentationMigration-40]
 }
 
-const _Key_name = "NamespaceTableWithSchemasStart20_2GeospatialTypeEnumsRangefeedLeasesAlterColumnTypeGeneralAlterSystemJobsAddCreatedByColumnsAddScheduledJobsTableUserDefinedSchemasNoOriginFKIndexesNodeMembershipStatusMinPasswordLengthAbortSpanBytesAlterSystemJobsAddSqllivenessColumnsAddNewSystemSqllivenessTableMaterializedViewsBox2DTypeUpdateScheduledJobsSchemaCreateLoginPrivilegeHBAForNonTLSV20_2Start21_1EmptyArraysInInvertedIndexesUniqueWithoutIndexConstraintsVirtualComputedColumnsCPutInlineReplicaVersionsreplacedTruncatedAndRangeAppliedStateMigrationreplacedPostTruncatedAndRangeAppliedStateMigrationNewSchemaChangerLongRunningMigrationsTruncatedAndRangeAppliedStateMigrationPostTruncatedAndRangeAppliedStateMigrationSeparatedIntentsTracingVerbosityIndependentSemanticsSequencesRegclassImplicitColumnPartitioningMultiRegionFeaturesClosedTimestampsRaftTransportChangefeedsSupportPrimaryIndexChangesNamespaceTableWithSchemasMigration"
+const _Key_name = "NamespaceTableWithSchemasStart20_2GeospatialTypeEnumsRangefeedLeasesAlterColumnTypeGeneralAlterSystemJobsAddCreatedByColumnsAddScheduledJobsTableUserDefinedSchemasNoOriginFKIndexesNodeMembershipStatusMinPasswordLengthAbortSpanBytesAlterSystemJobsAddSqllivenessColumnsAddNewSystemSqllivenessTableMaterializedViewsBox2DTypeUpdateScheduledJobsSchemaCreateLoginPrivilegeHBAForNonTLSV20_2Start21_1EmptyArraysInInvertedIndexesUniqueWithoutIndexConstraintsVirtualComputedColumnsCPutInlineReplicaVersionsreplacedTruncatedAndRangeAppliedStateMigrationreplacedPostTruncatedAndRangeAppliedStateMigrationNewSchemaChangerLongRunningMigrationsTruncatedAndRangeAppliedStateMigrationPostTruncatedAndRangeAppliedStateMigrationSeparatedIntentsTracingVerbosityIndependentSemanticsSequencesRegclassImplicitColumnPartitioningMultiRegionFeaturesClosedTimestampsRaftTransportChangefeedsSupportPrimaryIndexChangesNamespaceTableWithSchemasMigrationForeignKeyRepresentationMigration"
 
-var _Key_index = [...]uint16{0, 25, 34, 48, 53, 68, 90, 124, 145, 163, 180, 200, 217, 231, 295, 312, 321, 346, 366, 378, 383, 392, 420, 449, 471, 481, 496, 542, 592, 608, 629, 667, 709, 725, 761, 778, 804, 823, 852, 889, 923}
+var _Key_index = [...]uint16{0, 25, 34, 48, 53, 68, 90, 124, 145, 163, 180, 200, 217, 231, 295, 312, 321, 346, 366, 378, 383, 392, 420, 449, 471, 481, 496, 542, 592, 608, 629, 667, 709, 725, 761, 778, 804, 823, 852, 889, 923, 956}
 
 func (i Key) String() string {
 	if i < 0 || i >= Key(len(_Key_index)-1) {

--- a/pkg/migration/migrations/BUILD.bazel
+++ b/pkg/migration/migrations/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "migrations",
     srcs = [
+        "foreign_key_representation_upgrade.go",
         "migrations.go",
         "migrations_table.go",
         "namespace_migration.go",
@@ -20,11 +21,15 @@ go_library(
         "//pkg/server/serverpb",
         "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/systemschema",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
+        "//pkg/sql/sqlutil",
         "//pkg/sqlmigrations",
         "//pkg/util/log",
+        "//pkg/util/protoutil",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 
@@ -32,6 +37,7 @@ go_test(
     name = "migrations_test",
     size = "medium",
     srcs = [
+        "foreign_key_representation_upgrade_external_test.go",
         "main_test.go",
         "namespace_migration_external_test.go",
         "truncated_state_external_test.go",
@@ -53,6 +59,7 @@ go_test(
         "//pkg/testutils/testcluster",
         "//pkg/util",
         "//pkg/util/leaktest",
+        "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/migration/migrations/foreign_key_representation_upgrade.go
+++ b/pkg/migration/migrations/foreign_key_representation_upgrade.go
@@ -1,0 +1,115 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/migration"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/errors"
+)
+
+// TODO(ajwerner): Add assertions in descriptor validation that is active once
+// the migration has completed. Consider how this interacts with unsafe
+// descriptor injection.
+
+func foreignKeyRepresentationUpgrade(
+	ctx context.Context, _ clusterversion.ClusterVersion, d migration.SQLDeps,
+) error {
+	var lastUpgradedID descpb.ID
+	for {
+		done, idToUpgrade, err := findNextDescriptorToUpdate(ctx, d.InternalExecutor, lastUpgradedID)
+		if err != nil || done {
+			return err
+		}
+		if err := upgradeFKRepresentation(ctx, idToUpgrade, d); err != nil {
+			return err
+		}
+		lastUpgradedID = idToUpgrade
+	}
+}
+
+func upgradeFKRepresentation(ctx context.Context, upgrade descpb.ID, d migration.SQLDeps) error {
+	return descs.Txn(ctx, d.Settings, d.LeaseManager, d.InternalExecutor, d.DB, func(
+		ctx context.Context, txn *kv.Txn, descriptors *descs.Collection,
+	) error {
+		t, err := descriptors.GetMutableTableByID(ctx, txn, upgrade, tree.ObjectLookupFlagsWithRequired())
+		if err != nil {
+			return err
+		}
+		// Must have already happened, so no-op.
+		if !t.GetPostDeserializationChanges().UpgradedForeignKeyRepresentation {
+			log.Infof(ctx, "discovered fk representation already occurred for %d, skipping", upgrade)
+			return nil
+		}
+		t.MaybeIncrementVersion()
+		return descriptors.WriteDesc(ctx, false /* kvTrace */, t, txn)
+	})
+}
+
+func findNextDescriptorToUpdate(
+	ctx context.Context, ie sqlutil.InternalExecutor, lastScannedID descpb.ID,
+) (done bool, idToUpgrade descpb.ID, _ error) {
+	rows, err := ie.QueryIterator(ctx, "upgrade-fk-find-desc", nil, /* txn */
+		`
+SELECT id, descriptor, crdb_internal_mvcc_timestamp FROM system.descriptor WHERE id > $1 ORDER BY ID ASC
+`, lastScannedID)
+	if err != nil {
+		return false, 0, err
+	}
+	defer func() { _ = rows.Close() }()
+	ok, err := rows.Next(ctx)
+	for ; ok; ok, err = rows.Next(ctx) {
+		row := rows.Cur()
+		id := descpb.ID(*row[0].(*tree.DInt))
+		ts, err := tree.DecimalToHLC(&row[2].(*tree.DDecimal).Decimal)
+		if err != nil {
+			return false, 0, errors.Wrapf(err,
+				"failed to convert MVCC timestamp decimal to HLC for ID %d", id)
+		}
+		var desc descpb.Descriptor
+		if err := protoutil.Unmarshal(([]byte)(*row[1].(*tree.DBytes)), &desc); err != nil {
+			return false, 0, errors.Wrapf(err,
+				"failed to unmarshal descriptor with ID %d", id)
+		}
+		t := descpb.TableFromDescriptor(&desc, ts)
+		if t != nil && !t.Dropped() && tableNeedsFKUpgrade(t) {
+			return false, id, nil
+		}
+	}
+	if err != nil {
+		return false, 0, err
+	}
+	return true, 0, nil
+}
+
+func tableNeedsFKUpgrade(t *descpb.TableDescriptor) bool {
+	indexNeedsFKUpgrade := func(idx *descpb.IndexDescriptor) bool {
+		return idx.ForeignKey.IsSet() || len(idx.ReferencedBy) > 0
+	}
+	if indexNeedsFKUpgrade(&t.PrimaryIndex) {
+		return true
+	}
+	for i := range t.Indexes {
+		if indexNeedsFKUpgrade(&t.Indexes[i]) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/migration/migrations/foreign_key_representation_upgrade_external_test.go
+++ b/pkg/migration/migrations/foreign_key_representation_upgrade_external_test.go
@@ -1,0 +1,122 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package migrations_test
+
+import (
+	"context"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestForeignKeyMigration(t *testing.T) {
+	defer leaktest.AfterTest(t)
+
+	/*
+	   These descriptors were crafted in v19.1 with the following SQL:
+
+	   	CREATE DATABASE db;
+	   	SET database = db;
+	   	BEGIN;
+	   		CREATE TABLE parent (i INT8 PRIMARY KEY, j INT8 NOT NULL UNIQUE);
+	   		CREATE TABLE child_pk (i INT8 PRIMARY KEY REFERENCES parent (i));
+	   		CREATE TABLE child_secondary (i INT8 PRIMARY KEY, j INT8 REFERENCES parent (j));
+	   	COMMIT;
+
+	   The descriptors were then extracted using:
+
+	   	SELECT encode(descriptor, 'hex') AS descriptor
+	   		FROM system.descriptor
+	   	 WHERE id
+	   				 IN (
+	   							SELECT id
+	   								FROM system.namespace
+	   							 WHERE "parentID"
+	   										 = (
+	   													SELECT id
+	   														FROM system.namespace
+	   													 WHERE "parentID" = 0 AND name = 'db'
+	   											)
+	   									OR "parentID" = 0 AND name = 'db'
+	   					);
+	*/
+	const descriptorStringsToInject = `
+121d0a02646210341a150a090a0561646d696e10020a080a04726f6f741002
+0aa5020a06706172656e741835203428013a0a08d3d9d1d782e393b31642130a016910011a0808011040180030032000300042130a016a10021a08080110401800300320003000480352410a077072696d61727910011801220169300140004a10080010001a00200028003000380040005210083610011a00200028003000380040005a007a0208008001005a480a0c706172656e745f6a5f6b65791002180122016a3002380140004a10080010001a00200028003000380040005210083710021a00200028003000380040005a007a02080080010060036a150a090a0561646d696e10020a080a04726f6f741002800101880103980100b201170a077072696d61727910001a01691a016a200120022802b80101c20100e80100f2010408001200f80100800200
+0ac0010a086368696c645f706b1836203428013a0a08d3d9d1d782e393b31642130a016910011a080801104018003003200030004802523e0a077072696d61727910011801220169300140004a1f083510011a0f666b5f695f7265665f706172656e74200028013000380040005a007a02080080010060026a150a090a0561646d696e10020a080a04726f6f741002800101880103980100b201120a077072696d61727910001a016920012800b80101c20100e80100f2010408001200f80100800200
+0ab7020a0f6368696c645f7365636f6e646172791837203428013a0a08d3d9d1d782e393b31642130a016910011a0808011040180030032000300042130a016a10021a080801104018003003200130004803522f0a077072696d61727910011801220169300140004a10080010001a00200028003000380040005a007a0208008001005a630a2a6368696c645f7365636f6e646172795f6175746f5f696e6465785f666b5f6a5f7265665f706172656e741002180022016a3002380140004a1f083510021a0f666b5f6a5f7265665f706172656e74200028013000380040005a007a02080080010060036a150a090a0561646d696e10020a080a04726f6f741002800101880103980100b201170a077072696d61727910001a01691a016a200120022802b80101c20100e80100f2010408001200f80100800200
+`
+	var descriptorsToInject []*descpb.Descriptor
+	for _, s := range strings.Split(strings.TrimSpace(descriptorStringsToInject), "\n") {
+		encoded, err := hex.DecodeString(s)
+		require.NoError(t, err)
+		var desc descpb.Descriptor
+		require.NoError(t, protoutil.Unmarshal(encoded, &desc))
+		descriptorsToInject = append(descriptorsToInject, &desc)
+	}
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Server: &server.TestingKnobs{
+					DisableAutomaticVersionUpgrade: 1,
+					BinaryVersionOverride:          clusterversion.ByKey(clusterversion.ForeignKeyRepresentationMigration - 1),
+				},
+			},
+		},
+	})
+
+	defer tc.Stopper().Stop(ctx)
+	db := tc.ServerConn(0)
+	require.NoError(t, sqlutils.InjectDescriptors(ctx, db, descriptorsToInject))
+	tdb := sqlutils.MakeSQLRunner(db)
+	numUnupgradedDescriptors := func() (numUnupgraded int) {
+		tdb.QueryRow(t, `
+WITH dd AS (
+            SELECT id,
+                   crdb_internal.pb_to_json(
+                    'cockroach.sql.sqlbase.Descriptor',
+                    descriptor,
+                    false
+                   ) AS descriptor
+              FROM system.descriptor
+          ),
+       tables AS (
+                SELECT id, descriptor->'table' AS tab
+                  FROM dd
+                 WHERE (descriptor->'table') IS NOT NULL
+              ),
+       indexes AS (
+                 SELECT id, tab->'primaryIndex' AS idx FROM tables
+                 UNION SELECT id, json_array_elements(tab->'indexes') AS idx
+                         FROM tables
+               )
+SELECT count(*)
+  FROM indexes
+ WHERE idx->'foreignKey' != '{}' OR (idx->'referencedBy') IS NOT NULL;`).Scan(&numUnupgraded)
+		return numUnupgraded
+	}
+	require.Equal(t, 4, numUnupgradedDescriptors())
+	tdb.Exec(t, "SET CLUSTER SETTING version = $1",
+		clusterversion.ByKey(clusterversion.ForeignKeyRepresentationMigration).String())
+	require.Equal(t, 0, numUnupgradedDescriptors())
+}

--- a/pkg/migration/migrations/migrations.go
+++ b/pkg/migration/migrations/migrations.go
@@ -52,6 +52,11 @@ var migrations = []migration.Migration{
 		toCV(clusterversion.NamespaceTableWithSchemasMigration),
 		namespaceMigration,
 	),
+	migration.NewSQLMigration(
+		"upgrade old foreign key representation",
+		toCV(clusterversion.ForeignKeyRepresentationMigration),
+		foreignKeyRepresentationUpgrade,
+	),
 }
 
 func init() {

--- a/pkg/sql/repair.go
+++ b/pkg/sql/repair.go
@@ -437,14 +437,14 @@ func (p *planner) UnsafeUpsertNamespaceEntry(
 			return nil
 		}
 		schema, err := p.Descriptors().GetMutableDescriptorByID(
-			ctx, parentID, p.txn,
+			ctx, parentSchemaID, p.txn,
 		)
 		if err != nil {
 			return err
 		}
 		if _, isSchema := schema.(catalog.SchemaDescriptor); !isSchema {
 			return pgerror.Newf(pgcode.InvalidCatalogName,
-				"parentSchemaID %d is a %T, not a schema", parentID, schema)
+				"parentSchemaID %d is a %T, not a schema", parentSchemaID, schema)
 		}
 		return nil
 	}

--- a/pkg/testutils/sqlutils/BUILD.bazel
+++ b/pkg/testutils/sqlutils/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "sqlutils",
     srcs = [
+        "inject.go",
         "name_resolution_testutils.go",
         "pg_url.go",
         "pretty.go",
@@ -16,14 +17,17 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/config/zonepb",
+        "//pkg/keys",
         "//pkg/security",
         "//pkg/security/securitytest",
+        "//pkg/sql/catalog/descpb",
         "//pkg/sql/lex",
         "//pkg/sql/parser",
         "//pkg/sql/sem/tree",
         "//pkg/testutils",
         "//pkg/util/fileutil",
         "//pkg/util/protoutil",
+        "@com_github_cockroachdb_cockroach_go//crdb",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )
@@ -32,6 +36,7 @@ go_test(
     name = "sqlutils_test",
     size = "medium",
     srcs = [
+        "inject_test.go",
         "main_test.go",
         "sql_runner_test.go",
         "table_gen_test.go",
@@ -42,10 +47,13 @@ go_test(
         "//pkg/security",
         "//pkg/security/securitytest",
         "//pkg/server",
+        "//pkg/sql/catalog/descpb",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
+        "//pkg/util/protoutil",
         "//pkg/util/randutil",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/testutils/sqlutils/inject.go
+++ b/pkg/testutils/sqlutils/inject.go
@@ -96,7 +96,7 @@ func InjectDescriptors(ctx context.Context, db *gosql.DB, input []*descpb.Descri
 			parent, schema := getDescriptorParentAndSchema(d)
 			if err := injectNamespaceEntry(tx, parent, schema, name, id); err != nil {
 				return errors.Wrapf(err, "failed to inject namespace entry (%d, %d, %s) %d",
-					parent, schema, name, id, d)
+					parent, schema, name, id)
 			}
 		}
 		return nil

--- a/pkg/testutils/sqlutils/inject.go
+++ b/pkg/testutils/sqlutils/inject.go
@@ -1,0 +1,137 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sqlutils
+
+import (
+	"context"
+	gosql "database/sql"
+
+	"github.com/cockroachdb/cockroach-go/crdb"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/errors"
+)
+
+// InjectDescriptors attempts to inject the provided descriptors into the
+// database.
+func InjectDescriptors(ctx context.Context, db *gosql.DB, input []*descpb.Descriptor) error {
+	cloneInput := func() []*descpb.Descriptor {
+		cloned := make([]*descpb.Descriptor, 0, len(input))
+		for _, d := range input {
+			cloned = append(cloned, protoutil.Clone(d).(*descpb.Descriptor))
+		}
+		return cloned
+	}
+	findDatabases := func(descs []*descpb.Descriptor) (dbs, others []*descpb.Descriptor) {
+		for _, d := range descs {
+			if _, ok := d.Union.(*descpb.Descriptor_Database); ok {
+				dbs = append(dbs, d)
+			} else {
+				others = append(others, d)
+			}
+		}
+		return dbs, others
+	}
+	injectDescriptor := func(tx *gosql.Tx, id descpb.ID, desc *descpb.Descriptor) error {
+		resetVersionAndModificationTime(desc)
+		encoded, err := protoutil.Marshal(desc)
+		if err != nil {
+			return err
+		}
+		_, err = tx.Exec(
+			"SELECT crdb_internal.unsafe_upsert_descriptor($1, $2)",
+			id, encoded,
+		)
+		return err
+	}
+	injectNamespaceEntry := func(
+		tx *gosql.Tx, parent, schema descpb.ID, name string, id descpb.ID,
+	) error {
+		_, err := tx.Exec(
+			"SELECT crdb_internal.unsafe_upsert_namespace_entry($1, $2, $3, $4)",
+			parent, schema, name, id,
+		)
+		return err
+	}
+	return crdb.ExecuteTx(ctx, db, nil, func(tx *gosql.Tx) error {
+		descriptors := cloneInput()
+
+		// Pick out the databases and inject them.
+		databases, others := findDatabases(descriptors)
+		for _, db := range databases {
+			id, _, name, _ := descpb.GetDescriptorMetadata(db)
+			if err := injectDescriptor(tx, id, db); err != nil {
+				return errors.Wrapf(err, "failed to inject database descriptor %d", id)
+			}
+			if err := injectNamespaceEntry(tx, 0, 0, name, id); err != nil {
+				return errors.Wrapf(err, "failed to inject namespace entry for database %d", id)
+			}
+			if err := injectNamespaceEntry(
+				tx, id, 0, tree.PublicSchema, keys.PublicSchemaID,
+			); err != nil {
+				return errors.Wrapf(err, "failed to inject namespace entry for public schema in %d", id)
+			}
+		}
+		// Inject the other descriptors - this won't do much in the way of
+		// validation.
+		for _, d := range others {
+			id, _, _, _ := descpb.GetDescriptorMetadata(d)
+			if err := injectDescriptor(tx, id, d); err != nil {
+				return errors.Wrapf(err, "failed to inject descriptor %d", id)
+			}
+		}
+		// Inject the namespace entries.
+		for _, d := range others {
+			id, _, name, _ := descpb.GetDescriptorMetadata(d)
+			parent, schema := getDescriptorParentAndSchema(d)
+			if err := injectNamespaceEntry(tx, parent, schema, name, id); err != nil {
+				return errors.Wrapf(err, "failed to inject namespace entry (%d, %d, %s) %d",
+					parent, schema, name, id, d)
+			}
+		}
+		return nil
+	})
+}
+
+func getDescriptorParentAndSchema(d *descpb.Descriptor) (parent, schema descpb.ID) {
+	switch d := d.Union.(type) {
+	case *descpb.Descriptor_Database:
+		return 0, 0
+	case *descpb.Descriptor_Schema:
+		return d.Schema.ParentID, 0
+	case *descpb.Descriptor_Type:
+		return d.Type.ParentID, d.Type.ParentSchemaID
+	case *descpb.Descriptor_Table:
+		schema := d.Table.UnexposedParentSchemaID
+		// Descriptors from prior to 20.1 carry a 0 schema ID.
+		if schema == 0 {
+			schema = keys.PublicSchemaID
+		}
+		return d.Table.ParentID, schema
+	default:
+		panic(errors.Errorf("unknown descriptor type %T", d))
+	}
+}
+
+func resetVersionAndModificationTime(d *descpb.Descriptor) {
+	switch d := d.Union.(type) {
+	case *descpb.Descriptor_Database:
+		d.Database.Version = 1
+	case *descpb.Descriptor_Schema:
+		d.Schema.Version = 1
+	case *descpb.Descriptor_Type:
+		d.Type.Version = 1
+	case *descpb.Descriptor_Table:
+		d.Table.Version = 1
+	}
+}

--- a/pkg/testutils/sqlutils/inject_test.go
+++ b/pkg/testutils/sqlutils/inject_test.go
@@ -63,7 +63,7 @@ ORDER BY gen_random_uuid(); -- to mix it up
 `, dbID)
 		for rows.Next() {
 			var encoded []byte
-			rows.Scan(&encoded)
+			require.NoError(t, rows.Scan(&encoded))
 			var decoded descpb.Descriptor
 			require.NoError(t, protoutil.Unmarshal(encoded, &decoded))
 			descriptors = append(descriptors, &decoded)

--- a/pkg/testutils/sqlutils/inject_test.go
+++ b/pkg/testutils/sqlutils/inject_test.go
@@ -1,0 +1,87 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sqlutils_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInjectDescriptors verifies that descriptors can be extracted from a
+// cluster and then injected into another using InjectDescriptors.
+func TestInjectDescriptors(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// A smattering of schema features.
+	setupStmts := []string{
+		`CREATE DATABASE db`,
+		`CREATE TABLE db.foo (i INT PRIMARY KEY)`,
+		`USE db`,
+		`CREATE SCHEMA sc`,
+		`CREATE TABLE sc.foo (i INT PRIMARY KEY, j INT NOT NULL UNIQUE REFERENCES db.foo(i))`,
+		`CREATE TYPE dogs AS ENUM ('jake', 'carl')`,
+		`CREATE TYPE cats AS ENUM ('cake', 'jumbotron')`,
+		`CREATE TABLE sc.cats_and_dogs (dog dogs, cat cats, PRIMARY KEY (dog, cat))`,
+	}
+	afterStmts := []string{
+		`SELECT * FROM db.foo`,
+		`SELECT * FROM db.sc.foo`,
+		`SELECT * FROM db.sc.cats_and_dogs WHERE dog = 'jake' AND cat = 'cake'`,
+	}
+
+	var descriptors []*descpb.Descriptor
+	{
+		s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+		defer s.Stopper().Stop(context.Background())
+		tdb := sqlutils.MakeSQLRunner(db)
+		for _, stmt := range setupStmts {
+			tdb.Exec(t, stmt)
+		}
+		var dbID int
+		tdb.QueryRow(t, `SELECT id FROM system.namespace WHERE "parentID" = 0 AND name = 'db'`).Scan(&dbID)
+		rows := tdb.Query(t, `
+  SELECT descriptor
+    FROM system.descriptor
+   WHERE id >= $1
+ORDER BY gen_random_uuid(); -- to mix it up
+`, dbID)
+		for rows.Next() {
+			var encoded []byte
+			rows.Scan(&encoded)
+			var decoded descpb.Descriptor
+			require.NoError(t, protoutil.Unmarshal(encoded, &decoded))
+			descriptors = append(descriptors, &decoded)
+		}
+		// Sanity check the afterStmts.
+		for _, stmt := range afterStmts {
+			tdb.Exec(t, stmt)
+		}
+	}
+	{
+		s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+		defer s.Stopper().Stop(context.Background())
+
+		require.NoError(t, sqlutils.InjectDescriptors(context.Background(), db, descriptors))
+
+		tdb := sqlutils.MakeSQLRunner(db)
+		for _, stmt := range afterStmts {
+			tdb.Exec(t, stmt)
+		}
+	}
+}


### PR DESCRIPTION
We've been carrying this old representation for a long time. This migration
is written as simply as I can think to do it. It could perhaps be better.

One thing this patch doesn't do is really enforce that it's gone. Probably
we'll want to do that in validation for this cycle. In the next release we'll
stop decoding the fields.

The change should not be user visible so no release note.

Release note: None