### PR TITLE
sql: Added telemetry for pg_catalog and information_schema tables access

### DIFF
--- a/pkg/sql/sqltelemetry/BUILD.bazel
+++ b/pkg/sql/sqltelemetry/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "session.go",
         "show.go",
         "user_defined_schema.go",
+        "virtual_schema.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry",
     visibility = ["//visibility:public"],

--- a/pkg/sql/sqltelemetry/virtual_schema.go
+++ b/pkg/sql/sqltelemetry/virtual_schema.go
@@ -1,0 +1,33 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sqltelemetry
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+)
+
+const getVirtualSchemaEntry = "sql.schema.get_virtual_table.%s.%s"
+
+// trackedSchemas have the schemas that we track by telemetry.
+var trackedSchemas = map[string]struct{}{
+	"pg_catalog":         {},
+	"information_schema": {},
+}
+
+// IncrementGetVirtualTableEntry is used to increment telemetry counter for any
+// use of tracked schemas tables.
+func IncrementGetVirtualTableEntry(schema, tableName string) {
+	if _, ok := trackedSchemas[schema]; ok {
+		telemetry.Inc(telemetry.GetCounter(fmt.Sprintf(getVirtualSchemaEntry, schema, tableName)))
+	}
+}

--- a/pkg/sql/testdata/telemetry/virtual_schema
+++ b/pkg/sql/testdata/telemetry/virtual_schema
@@ -1,0 +1,22 @@
+feature-allowlist
+sql.schema.get_virtual_table.*
+----
+
+feature-usage
+SELECT * FROM pg_catalog.pg_cast
+----
+sql.schema.get_virtual_table.pg_catalog.pg_cast
+
+feature-usage
+SELECT * FROM information_schema.schema_privileges LIMIT 1
+----
+sql.schema.get_virtual_table.information_schema.schema_privileges
+
+feature-usage
+SELECT * FROM crdb_internal.databases LIMIT 1
+----
+
+feature-usage
+SELECT * FROM pg_catalog.pg_xxx
+----
+error: pq: relation "pg_catalog.pg_xxx" does not exist

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/errors"
@@ -714,6 +715,7 @@ func (vs *VirtualSchemaHolder) getVirtualTableEntry(tn *tree.TableName) (*virtua
 	if db, ok := vs.getVirtualSchemaEntry(tn.Schema()); ok {
 		tableName := tn.Table()
 		if t, ok := db.defs[tableName]; ok {
+			sqltelemetry.IncrementGetVirtualTableEntry(tn.Schema(), tableName)
 			return t, nil
 		}
 		if _, ok := db.allTableNames[tableName]; ok {


### PR DESCRIPTION
Previously, when querying a not implemented table it was tracket by telemetry
This was inadequate because when adding these tables as empty tables we no longer capture the access of these tables that are empty and unsupported
To address this, this patch adds telemetry to track queries at pg_catalog and
information_schema existing tables

Release note (sql change): Added telemetry to track usage of pg_catalog and
information_schema tables

Fixes #58732