### PR TITLE
release-20.2: opt: fix stats bug causing unconstrained partial index scan

### DIFF
--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -643,7 +643,7 @@ func (sb *statisticsBuilder) buildScan(scan *ScanExpr, relProps *props.Relationa
 				notNullCols.UnionWith(c.ExtractNotNullCols(sb.evalCtx))
 			}
 		}
-		sb.filterRelExpr(pred, scan, notNullCols, relProps, s, &scan.Relational().FuncDeps)
+		sb.filterRelExpr(pred, scan, notNullCols, relProps, s, MakeTableFuncDep(sb.md, scan.Table))
 		sb.finalizeFromCardinality(relProps)
 		return
 	}
@@ -751,7 +751,7 @@ func (sb *statisticsBuilder) constrainScan(
 		predUnappliedConjucts, predConstrainedCols, predHistCols := sb.applyFilter(pred, scan, relProps)
 		numUnappliedConjuncts += predUnappliedConjucts
 		constrainedCols.UnionWith(predConstrainedCols)
-		constrainedCols = sb.tryReduceCols(constrainedCols, s, &scan.Relational().FuncDeps)
+		constrainedCols = sb.tryReduceCols(constrainedCols, s, MakeTableFuncDep(sb.md, scan.Table))
 		histCols.UnionWith(predHistCols)
 	}
 

--- a/pkg/sql/opt/memo/testdata/stats/partial-index-scan
+++ b/pkg/sql/opt/memo/testdata/stats/partial-index-scan
@@ -414,6 +414,35 @@ exec-ddl
 DROP INDEX idx
 ----
 
+# Regression test for #60502. Ensure that a constrained scan is preferred over
+# an unconstrained scan.
+exec-ddl
+CREATE TABLE t (
+   pk1 INT NOT NULL,
+   pk2 INT NOT NULL,
+   b1 BOOL,
+   b2 BOOL,
+   PRIMARY KEY (pk1, pk2),
+   INDEX (pk2) WHERE (b1 = false) AND (b2 = false)
+)
+----
+
+opt
+SELECT * FROM t WHERE pk2 = 1 AND b1 = false AND b2 = false
+----
+index-join t
+ ├── columns: pk1:1(int!null) pk2:2(int!null) b1:3(bool!null) b2:4(bool!null)
+ ├── stats: [rows=1.245025, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(4)=1, null(4)=0, distinct(2-4)=1, null(2-4)=0]
+ ├── key: (1)
+ ├── fd: ()-->(2-4)
+ └── scan t@secondary,partial
+      ├── columns: pk1:1(int!null) pk2:2(int!null)
+      ├── constraint: /2/1: [/1 - /1]
+      ├── stats: [rows=1.245025, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(4)=1, null(4)=0, distinct(2-4)=1, null(2-4)=0]
+      ├── key: (1)
+      └── fd: ()-->(2)
+
+
 # ---------------------
 # Tests with Histograms
 # ---------------------

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -1105,11 +1105,11 @@ memo (optimized, ~17KB, required=[presentation: i:1])
  ├── G1: (project G2 G3 i) (project G4 G3 i) (project G5 G3 i)
  │    └── [presentation: i:1]
  │         ├── best: (project G5 G3 i)
- │         └── cost: 14.33
+ │         └── cost: 4.98
  ├── G2: (select G6 G7) (select G8 G9) (index-join G4 p,cols=(1,3)) (select G10 G9) (index-join G5 p,cols=(1,3))
  │    └── []
- │         ├── best: (index-join G4 p,cols=(1,3))
- │         └── cost: 19.26
+ │         ├── best: (index-join G5 p,cols=(1,3))
+ │         └── cost: 8.68
  ├── G3: (projections)
  ├── G4: (select G11 G9)
  │    └── []
@@ -1118,7 +1118,7 @@ memo (optimized, ~17KB, required=[presentation: i:1])
  ├── G5: (scan p@idx2,partial,cols=(1,5),constrained)
  │    └── []
  │         ├── best: (scan p@idx2,partial,cols=(1,5),constrained)
- │         └── cost: 14.31
+ │         └── cost: 4.96
  ├── G6: (scan p,cols=(1,3))
  │    └── []
  │         ├── best: (scan p,cols=(1,3))


### PR DESCRIPTION
Backport 1/1 commits from #60516.

/cc @cockroachdb/release

---

This commit fixes a bug where an unconstrained partial index scan
was sometimes preferred over a constrained scan of the same index.
The bug was due to an error in the statistics code, which was incorrectly
reducing the set of columns used for calculating filter selectivity due
to using an incorrect set of functional dependencies (FDs).

Prior to this commit, the stats code was using the FDs from the constrained
scan to reduce the columns, when it should have been using the input FDs
from the unconstrained scan. This commit fixes the code to use the FDs
from the underlying table.

Fixes #60502

Release note (bug fix): Fixed a bug in the optimizer statistics code that
could cause an unconstrained partial index scan to be preferred over a
constrained scan of the same index.
