### PR TITLE
sql: fix connect_privilege logic test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/connect_privilege
+++ b/pkg/sql/logictest/testdata/logic_test/connect_privilege
@@ -8,11 +8,8 @@ public  a  root
 
 user testuser
 
-query T noticetrace
+statement notice NOTICE: CONNECT privilege will be required to connect to databases in a future release\nHINT: .*59875.*
 use test
-----
-NOTICE: CONNECT privilege will be required to connect to databases in a future release
-HINT: See: https://go.crdb.dev/issue-v/59875/v21.1
 
 query TTT
 SELECT schemaname, tablename, tableowner FROM pg_catalog.pg_tables WHERE tablename = 'a'


### PR DESCRIPTION
Previously, this logic test performed an assertion on a notice output
which contained an issue link, which isn't stable across versions.

This patch replaces the `query T noticetrace` matching rule with the
`statement notice` rule which allows for partial matching.

Release note: None