### PR TITLE
kvserver: improve handling for removal of a replica, when multiple replicas already exist on the same node

### DIFF
--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -1158,6 +1158,27 @@ func maybeLeaveAtomicChangeReplicasAndRemoveLearners(
 	return desc, nil
 }
 
+func validateReplicationChangesMultipleReplicasOnTheSameNode(
+	byStoreID map[roachpb.StoreID]roachpb.ReplicationChange,
+	rDescsForNode []roachpb.ReplicaDescriptor,
+) error {
+	if len(byStoreID) != 1 {
+		return errors.Errorf(
+			"An unexpected number of changes %s for range %s, the only valid operation when there are already multiple replicas on the same node is removal", byStoreID, rDescsForNode)
+	}
+	for _, rDesc := range rDescsForNode {
+		chg, ok := byStoreID[rDesc.StoreID]
+		if ok {
+			if !chg.ChangeType.IsRemoval() {
+				return errors.Errorf(
+					"Expected replica to be removed from %v instead got %v.", rDesc, chg)
+			}
+			return nil
+		}
+	}
+	return errors.Errorf("Expected a removal of one of the replicas in %s, instead got %s", rDescsForNode, byStoreID)
+}
+
 func validateReplicationChanges(
 	desc *roachpb.RangeDescriptor, chgs roachpb.ReplicationChanges,
 ) error {
@@ -1188,15 +1209,29 @@ func validateReplicationChanges(
 		byStoreID[chg.Target.StoreID] = chg
 	}
 
+	descriptorsByNodeID := make(map[roachpb.NodeID][]roachpb.ReplicaDescriptor, len(desc.Replicas().Descriptors()))
+	for _, rDesc := range desc.Replicas().Descriptors() {
+		descriptorsByNodeID[rDesc.NodeID] = append(descriptorsByNodeID[rDesc.NodeID], rDesc)
+	}
+
 	// Then, check that we're not adding a second replica on nodes that already
 	// have one, or "re-add" an existing replica. We delete from byNodeAndStoreID so that
 	// after this loop, it contains only Nodes that we haven't seen in desc.
-	for _, rDesc := range desc.Replicas().Descriptors() {
-		byStoreID, ok := byNodeAndStoreID[rDesc.NodeID]
+	for nodeID, rDescsForNode := range descriptorsByNodeID {
+		byStoreID, ok := byNodeAndStoreID[nodeID]
 		if !ok {
 			continue
 		}
-		delete(byNodeAndStoreID, rDesc.NodeID)
+		delete(byNodeAndStoreID, nodeID)
+		// The only valid thing to do when we already have multiple replicas on the
+		// same node is to remove a replica.
+		if len(rDescsForNode) > 1 {
+			if err := validateReplicationChangesMultipleReplicasOnTheSameNode(byStoreID, rDescsForNode); err != nil {
+				return err
+			}
+			continue
+		}
+		rDesc := rDescsForNode[0]
 		if len(byStoreID) == 2 {
 			chg, k := byStoreID[rDesc.StoreID]
 			// We should be removing the replica from the existing store during a


### PR DESCRIPTION
Fixes #60545

The allocator in some cases allows for a range to have a replica
on multiple stores of the same node. If that happens, it should allow
itself to fix the situation by removing one of the offending replicas.
This was only half working due to an ordering problem in how the replicas
appeared in the descriptor. It could remove the first replica, but not the second one.

.

Release note: None