### PR TITLE
kvserver: unify two request flags

### DIFF
--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -205,9 +205,9 @@ func (r *Replica) tryReproposeWithNewLeaseIndex(
 
 	minTS, untrack := r.store.cfg.ClosedTimestamp.Tracker.Track(ctx)
 	defer untrack(ctx, 0, 0, 0) // covers all error paths below
-	// The ConsultsTimestampCache condition matches the similar logic for caring
+	// The IsIntentWrite condition matches the similar logic for caring
 	// about the closed timestamp cache in applyTimestampCache().
-	if p.Request.ConsultsTimestampCache() && p.Request.WriteTimestamp().LessEq(minTS) {
+	if p.Request.IsIntentWrite() && p.Request.WriteTimestamp().LessEq(minTS) {
 		// The tracker wants us to forward the request timestamp, but we can't
 		// do that without re-evaluating, so give up. The error returned here
 		// will go to back to DistSender, so send something it can digest.

--- a/pkg/kv/kvserver/replica_tscache.go
+++ b/pkg/kv/kvserver/replica_tscache.go
@@ -270,7 +270,7 @@ func (r *Replica) applyTimestampCache(
 
 	for _, union := range ba.Requests {
 		args := union.GetInner()
-		if roachpb.ConsultsTimestampCache(args) {
+		if roachpb.IsIntentWrite(args) {
 			header := args.Header()
 
 			// Forward the timestamp if there's been a more recent read (by someone else).

--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -169,14 +169,6 @@ func (ba *BatchRequest) IsUnsplittable() bool {
 	return ba.hasFlag(isUnsplittable)
 }
 
-// ConsultsTimestampCache returns whether the request must consult
-// the timestamp cache to determine whether a mutation is safe at
-// a proposed timestamp or needs to move to a higher timestamp to
-// avoid re-writing history.
-func (ba *BatchRequest) ConsultsTimestampCache() bool {
-	return ba.hasFlag(consultsTSCache)
-}
-
 // IsSingleRequest returns true iff the BatchRequest contains a single request.
 func (ba *BatchRequest) IsSingleRequest() bool {
 	return len(ba.Requests) == 1


### PR DESCRIPTION
isIntentWrite and consultsTSCache are always used in conjunction. It
seems that they must always be used in conjunction. Remove
consultsTSCache.

Release note: None