### PR TITLE
opt: inline all filters with virtual columns

### DIFF
--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -675,6 +675,11 @@ func (c *CustomFuncs) IsFilterFalse(filters memo.FiltersExpr) bool {
 	return filters.IsFalse()
 }
 
+// IsFilterEmpty returns true if filters is empty.
+func (c *CustomFuncs) IsFilterEmpty(filters memo.FiltersExpr) bool {
+	return len(filters) == 0
+}
+
 // IsContradiction returns true if the given filter item contains a
 // contradiction constraint.
 func (c *CustomFuncs) IsContradiction(item *memo.FiltersItem) bool {
@@ -690,6 +695,13 @@ func (c *CustomFuncs) ConcatFilters(left, right memo.FiltersExpr) memo.FiltersEx
 	copy(newFilters, left)
 	copy(newFilters[len(left):], right)
 	return newFilters
+}
+
+// DiffFilters creates new Filters that contains all conditions in left that do
+// not exist in right. If right is empty, the original left filters are
+// returned.
+func (c *CustomFuncs) DiffFilters(left, right memo.FiltersExpr) memo.FiltersExpr {
+	return left.Difference(right)
 }
 
 // RemoveFiltersItem returns a new list that is a copy of the given list, except

--- a/pkg/sql/opt/norm/inline_funcs.go
+++ b/pkg/sql/opt/norm/inline_funcs.go
@@ -223,148 +223,32 @@ func (c *CustomFuncs) VirtualColumns(scanPrivate *memo.ScanPrivate) opt.ColSet {
 	return tabMeta.VirtualComputedColumns()
 }
 
-// TryInlineSelectVirtualColumns is used by the InlineSelectVirtualColumns rule
-// to find filters on virtual computed columns that can be pushed below the
-// Project that produces the virtual column. The filter is pushed-down by
-// inlining the virtual column expression. Only the columns in virtualColumns
-// are eligible for inlining. It is useful to inline filters with virtual
-// columns in order to generate expressions that utilize indexes on virtual
-// columns during exploration. See the InlineSelectVirtualColumns rule for more
-// details.
+// InlinableVirtualColumnFilters returns a new filters expression containing any
+// of the given filters that meet the criteria:
 //
-// If successful, a pair of filters is returned; the first containing filters in
-// which virtual columns have been inlined, and the second containing filters
-// that were unaffected by inlining. If unsuccessful, an empty
-// InlinedVirtualColumnFiltersPair is returned, indicating that there is nothing
-// to inline.
+//   1. The filter has references to any of the columns in virtualColumns.
+//   2. The filter is not a correlated subquery.
 //
-// Two separate filters are returned as a pair so that the
-// InlineSelectVirtualColumns rule can push down eligible filters, but not the
-// rest.
-//
-// For example:
-//
-//   CREATE TABLE t (
-//     a INT,
-//     b INT,
-//     v INT AS (abs(a))
-//   )
-//
-//   SELECT v, w FROM (
-//     SELECT v, abs(b) AS w FROM t
-//   ) WHERE v = 5 AND w = 10
-//
-// The (v = 5) and (w = 10) filters are returned in separate filters. In the
-// first v is inlined because it is a virtual column, and the filter is
-// transformed to (abs(a) = 5). This filter is no longer dependent on the
-// projection of v, so it can be pushed below the Project. The w variable is not
-// a virtual column, so the (w = 10) filter is unchanged and remains above the
-// Project.
-func (c *CustomFuncs) TryInlineSelectVirtualColumns(
-	filters memo.FiltersExpr, projections memo.ProjectionsExpr, virtualColumns opt.ColSet,
-) InlinedVirtualColumnFiltersPair {
-	// Collect the projections for the virtual columns.
-	var inlinableCols opt.ColSet
-	var inlinableProjections memo.ProjectionsExpr
-	for i := range projections {
-		col := projections[i].Col
-
-		// If the projected expression is volatile, it cannot be inlined. This
-		// should be impossible (computed column expressions cannot be
-		// volatile), but adds additional safety in case this function is
-		// expanded to inline non-virtual columns in the future.
-		if projections[i].ScalarProps().VolatilitySet.HasVolatile() {
-			continue
-		}
-
-		if virtualColumns.Contains(col) {
-			// Initialize inlinableProjections lazily.
-			if inlinableProjections == nil {
-				inlinableProjections = make(memo.ProjectionsExpr, 0, len(projections)-i)
-			}
-			inlinableCols.Add(col)
-			inlinableProjections = append(inlinableProjections, projections[i])
-		}
-	}
-
-	if len(inlinableProjections) == 0 {
-		// None of the projections are eligible for inlining in filters.
-		return InlinedVirtualColumnFiltersPair{}
-	}
-
-	// For each filter, determine if there are any virtual columns to inline. If
-	// so, inline the virtual column expressions in the filter. We keep track of
-	// which filters have inlined projections in inlinedFilterIdxs so that we
-	// can build a list of non-inlined filters below.
-	var inlined memo.FiltersExpr
-	var inlinedFilterIdxs util.FastIntSet
+func (c *CustomFuncs) InlinableVirtualColumnFilters(
+	filters memo.FiltersExpr, virtualColumns opt.ColSet,
+) (inlinableFilters memo.FiltersExpr) {
 	for i := range filters {
 		item := &filters[i]
 
 		// Do not inline a filter if it has a correlated subquery or it does not
 		// reference a virtual column.
-		if item.ScalarProps().HasCorrelatedSubquery || !item.ScalarProps().OuterCols.Intersects(inlinableCols) {
+		if item.ScalarProps().HasCorrelatedSubquery || !item.ScalarProps().OuterCols.Intersects(virtualColumns) {
 			continue
 		}
 
-		// Initialize inlined lazily.
-		if inlined == nil {
-			inlined = make(memo.FiltersExpr, 0, len(filters)-i)
+		// Initialize inlinableFilters lazily.
+		if inlinableFilters == nil {
+			inlinableFilters = make(memo.FiltersExpr, 0, len(filters)-i)
 		}
 
-		// Inline the virtual column expressions in the filter.
-		filter := c.f.ConstructFiltersItem(
-			c.inlineProjections(item.Condition, inlinableProjections).(opt.ScalarExpr),
-		)
-		inlined = append(inlined, filter)
-		inlinedFilterIdxs.Add(i)
+		inlinableFilters = append(inlinableFilters, *item)
 	}
-
-	if len(inlined) == 0 {
-		// No projections were inlined in filters.
-		return InlinedVirtualColumnFiltersPair{}
-	}
-
-	// Collect the filters which did not have projections inlined.
-	notInlined := make(memo.FiltersExpr, 0, len(filters)-inlinedFilterIdxs.Len())
-	for i := range filters {
-		if !inlinedFilterIdxs.Contains(i) {
-			notInlined = append(notInlined, filters[i])
-		}
-	}
-
-	return InlinedVirtualColumnFiltersPair{
-		inlined:    inlined,
-		notInlined: notInlined,
-	}
-}
-
-// InlinedVirtualColumnFiltersPair is the result of
-// TryInlineSelectVirtualColumns. See that function for more details.
-type InlinedVirtualColumnFiltersPair struct {
-	inlined    memo.FiltersExpr
-	notInlined memo.FiltersExpr
-}
-
-// InlinedFilters returns the filters in the pair where virtual columns were
-// inlined.
-func (c *CustomFuncs) InlinedFilters(pair InlinedVirtualColumnFiltersPair) memo.FiltersExpr {
-	return pair.inlined
-}
-
-// NotInlinedFilters returns the filters in the pair where virtual columns were
-// not inlined.
-func (c *CustomFuncs) NotInlinedFilters(pair InlinedVirtualColumnFiltersPair) memo.FiltersExpr {
-	return pair.notInlined
-}
-
-// InlineSelectVirtualColumnsSucceeded returns true if the inlined filters in
-// the pair are not empty, indicating that InlineSelectVirtualColumns
-// successfully inlined virtual columns into some of the filters.
-func (c *CustomFuncs) InlineSelectVirtualColumnsSucceeded(
-	pair InlinedVirtualColumnFiltersPair,
-) bool {
-	return len(pair.inlined) > 0
+	return inlinableFilters
 }
 
 // InlineSelectProject searches the filter conditions for any variable
@@ -395,6 +279,7 @@ func (c *CustomFuncs) InlineProjectProject(
 	newProjections := make(memo.ProjectionsExpr, len(projections))
 	for i := range projections {
 		item := &projections[i]
+
 		newProjections[i] = c.f.ConstructProjectionsItem(
 			c.inlineProjections(item.Element, innerProjections).(opt.ScalarExpr),
 			item.Col,

--- a/pkg/sql/opt/norm/rules/inline.opt
+++ b/pkg/sql/opt/norm/rules/inline.opt
@@ -246,10 +246,9 @@
         ^(ColsAreEmpty
             $virtualColumns:(VirtualColumns $scanPrivate)
         ) &
-        (InlineSelectVirtualColumnsSucceeded
-            $result:(TryInlineSelectVirtualColumns
+        ^(IsFilterEmpty
+            $inlinableFilters:(InlinableVirtualColumnFilters
                 $filters
-                $projections
                 $virtualColumns
             )
         )
@@ -257,11 +256,14 @@
 =>
 (Select
     (Project
-        (Select $scan (InlinedFilters $result))
+        (Select
+            $scan
+            (InlineSelectProject $inlinableFilters $projections)
+        )
         $projections
         $passthrough
     )
-    (NotInlinedFilters $result)
+    (DiffFilters $filters $inlinableFilters)
 )
 
 # InlineProjectInProject folds an inner Project operator into an outer Project

--- a/pkg/sql/opt/norm/rules/inline.opt
+++ b/pkg/sql/opt/norm/rules/inline.opt
@@ -159,76 +159,76 @@
 
 # InlineSelectVirtualColumns pushes Select filters referencing virtual columns
 # into a Project by inlining the virtual column expressions. This makes the
-# Select independent of the Project. Filters with virtual columns are only
-# pushed below the Project if those virtual columns are indexed by a secondary
-# index. This allows exploration rules to generate plans that use those indexes.
-# Non-indexed virtual column filters are not inlined because the virtual column
+# Select independent of the Project. Because these filters are pushed below the
+# Project, exploration rules that match on the (Select (Scan)) pattern can
+# generate plans that use indexes on virtual columns.
+#
+# Filters on non-virtual projected columns are not inlined because the
 # expression would be executed twice (once in the filter and once in the
-# projection), adding overhead without any chance of a secondary index being
-# used in the optimized plan.
+# projection), adding overhead without any chance of a secondary index on a
+# virtual column being used in the optimized plan.
 #
 # Notice that this rule is similar to PushSelectIntoInlinableProject. The key
 # difference is that PushSelectIntoInlinableProject only inlines simple
 # expressions that will add negligible overhead when computing twice.
 # Conversely, InlineSelectVirtualColumns does not discriminate by the type of
-# expression. It will inline all virtual columns that are indexed in the hopes
-# that inling will lead to a query plan that uses a virtual column index.
+# expression. It will inline all virtual columns in the hopes that inlining will
+# lead to a query plan that uses a virtual column index.
 #
-# Also, PushSelectIntoInlinableProject will inline filters if and only if each
-# filter is inlinable (by its definition), whereas InlineSelectVirtualColumns
-# will split the input filters into two groups: one to inline below the Project,
-# and one to leave above the Project.
+# Also, PushSelectIntoInlinableProject will inline filters if and only if all of
+# the filter items are inlinable (by its definition), whereas
+# InlineSelectVirtualColumns will split the input filters into two groups: one
+# to inline below the Project, and one to leave above the Project. This allows
+# filters on virtual columns to be pushed down in more cases.
 #
 # For example, consider the table and query:
 #
 #   CREATE TABLE t (
 #     a INT,
 #     b INT,
-#     v INT AS (abs(a)),
-#     w INT AS (abs(b)),
+#     v INT AS (abs(a)) VIRTUAL,
 #     INDEX (v)
 #   )
-#   SELECT * FROM t WHERE v = 5 AND w = 10
+#   SELECT v, w FROM (
+#     SELECT v, abs(b) AS w FROM t
+#   ) WHERE v = 5 AND w = 10
 #
 # The partially normalized expression for the SELECT query before
-# InlineSelectVirtualColumns is:
+# InlineSelectVirtualColumns is applied is:
 #
-#   project
-#    ├── columns: a:1 b:2 v:3 w:4
-#    └── select
-#         ├── columns: a:1 b:2 v:3 w:4
-#         ├── project
-#         │    ├── columns: v:3 w:4 a:1 b:2
-#         │    ├── scan t
-#         │    │    └── columns: a:1 b:2
-#         │    └── projections
-#         │         ├── abs(a:1) [as=v:3]
-#         │         └── abs(b:2) [as=w:4]
-#         └── filters
-#              ├── v:3 = 5
-#              └── w:4 = 10
+#   select
+#    ├── columns: v:3 w:6
+#    ├── project
+#    │    ├── columns: w:6 v:3
+#    │    ├── scan t
+#    │    │    └── columns: a:1 b:2
+#    │    └── projections
+#    │         ├── abs(b:2) [as=w:6]
+#    │         └── abs(a:1) [as=v:3]
+#    └── filters
+#         ├── v:3 = 5
+#         └── w:6 = 10
 #
 # InlineSelectVirtualColumns will push only the (v = 5) filter below the Project
-# as (abs(a) = 5) because v is indexed. The (w = 10) filter remains above the
-# Project.
+# as (abs(a) = 5) because v is a virtual column. The (w = 10) filter remains
+# above the Project. Notice the (Select (Scan)) pattern that will allow a
+# constrained scan over the secondary index to be generated.
 #
-#   project
-#    ├── columns: a:1 b:2 v:3 w:4
-#    └── select
-#         ├── columns: a:1 b:2 v:3 w:4!null
-#         ├── project
-#         │    ├── columns: v:3 w:4 a:1 b:2
-#         │    ├── select
-#         │    │    ├── columns: a:1 b:2
-#         │    │    ├── scan t
-#         │    │    │    └── columns: a:1 b:2
-#         │    │    └── filters
-#         │    │         └── abs(a:1) = 5
-#         │    └── projections
-#         │         ├── abs(a:1) [as=v:3]
-#         │         └── abs(b:2) [as=w:4]
-#         └── filters
-#              └── w:4 = 10
+#   select
+#    ├── columns: v:3 w:6
+#    ├── project
+#    │    ├── columns: w:6 v:3
+#    │    ├── select
+#    │    │    ├── columns: a:1 b:2
+#    │    │    ├── scan t
+#    │    │    │    └── columns: a:1 b:2
+#    │    │    └── filters
+#    │    │         └── abs(a:1) = 5
+#    │    └── projections
+#    │         ├── abs(b:2) [as=w:6]
+#    │         └── abs(a:1) [as=v:3]
+#    └── filters
+#         └── w:6 = 10
 #
 # This rule has no explicit priority so that it runs before
 # PushSelectIntoInlinableProject (which is low priority). It must run before
@@ -244,15 +244,13 @@
     )
     $filters:* &
         ^(ColsAreEmpty
-            $indexedVirtualColumns:(IndexedVirtualColumns
-                $scanPrivate
-            )
+            $virtualColumns:(VirtualColumns $scanPrivate)
         ) &
         (InlineSelectVirtualColumnsSucceeded
             $result:(TryInlineSelectVirtualColumns
                 $filters
                 $projections
-                $indexedVirtualColumns
+                $virtualColumns
             )
         )
 )

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -21,7 +21,6 @@ CREATE TABLE virt (
   s STRING,
   j JSON,
   v STRING AS (lower(s)) VIRTUAL,
-  w STRING AS (upper(s)) VIRTUAL,
   x JSON AS (j->'x') VIRTUAL,
   INDEX (v),
   INVERTED INDEX (x)
@@ -723,10 +722,10 @@ norm expect=InlineSelectVirtualColumns
 SELECT * FROM virt WHERE v = 'foo'
 ----
 project
- ├── columns: k:1!null i:2 s:3 j:4 v:5 w:6 x:7
+ ├── columns: k:1!null i:2 s:3 j:4 v:5 x:6
  ├── immutable
  ├── key: (1)
- ├── fd: (1)-->(2-4), (3)-->(5,6), (4)-->(7)
+ ├── fd: (1)-->(2-4), (3)-->(5), (4)-->(6)
  ├── select
  │    ├── columns: k:1!null i:2 s:3 j:4
  │    ├── immutable
@@ -737,9 +736,7 @@ project
  │    │    ├── computed column expressions
  │    │    │    ├── v:5
  │    │    │    │    └── lower(s:3)
- │    │    │    ├── w:6
- │    │    │    │    └── upper(s:3)
- │    │    │    └── x:7
+ │    │    │    └── x:6
  │    │    │         └── j:4->'x'
  │    │    ├── key: (1)
  │    │    └── fd: (1)-->(2-4)
@@ -747,18 +744,17 @@ project
  │         └── lower(s:3) = 'foo' [outer=(3), immutable]
  └── projections
       ├── lower(s:3) [as=v:5, outer=(3), immutable]
-      ├── upper(s:3) [as=w:6, outer=(3), immutable]
-      └── j:4->'x' [as=x:7, outer=(4), immutable]
+      └── j:4->'x' [as=x:6, outer=(4), immutable]
 
 # Inline inverted-indexed virtual columns.
 norm expect=InlineSelectVirtualColumns
 SELECT * FROM virt WHERE x @> '1'
 ----
 project
- ├── columns: k:1!null i:2 s:3 j:4 v:5 w:6 x:7
+ ├── columns: k:1!null i:2 s:3 j:4 v:5 x:6
  ├── immutable
  ├── key: (1)
- ├── fd: (1)-->(2-4), (3)-->(5,6), (4)-->(7)
+ ├── fd: (1)-->(2-4), (3)-->(5), (4)-->(6)
  ├── select
  │    ├── columns: k:1!null i:2 s:3 j:4
  │    ├── immutable
@@ -769,9 +765,7 @@ project
  │    │    ├── computed column expressions
  │    │    │    ├── v:5
  │    │    │    │    └── lower(s:3)
- │    │    │    ├── w:6
- │    │    │    │    └── upper(s:3)
- │    │    │    └── x:7
+ │    │    │    └── x:6
  │    │    │         └── j:4->'x'
  │    │    ├── key: (1)
  │    │    └── fd: (1)-->(2-4)
@@ -779,131 +773,80 @@ project
  │         └── (j:4->'x') @> '1' [outer=(4), immutable]
  └── projections
       ├── lower(s:3) [as=v:5, outer=(3), immutable]
-      ├── upper(s:3) [as=w:6, outer=(3), immutable]
-      └── j:4->'x' [as=x:7, outer=(4), immutable]
+      └── j:4->'x' [as=x:6, outer=(4), immutable]
 
-# Do not inline virtual columns that aren't indexed.
-norm expect-not=InlineSelectVirtualColumns
-SELECT * FROM virt WHERE w = 'FOO'
+# Split the filters and inline only virtual columns.
+norm expect=InlineSelectVirtualColumns
+SELECT * FROM (
+  SELECT i, v, upper(s) AS w FROM virt
+) WHERE v = 'foo' AND w = 'FOO' AND i = 10
 ----
 select
- ├── columns: k:1!null i:2 s:3 j:4 v:5 w:6!null x:7
+ ├── columns: i:2!null v:5 w:9!null
+ ├── immutable
+ ├── fd: ()-->(2,9)
+ ├── project
+ │    ├── columns: w:9 v:5 i:2!null
+ │    ├── immutable
+ │    ├── fd: ()-->(2)
+ │    ├── select
+ │    │    ├── columns: i:2!null s:3
+ │    │    ├── immutable
+ │    │    ├── fd: ()-->(2)
+ │    │    ├── scan virt
+ │    │    │    ├── columns: i:2 s:3
+ │    │    │    └── computed column expressions
+ │    │    │         ├── v:5
+ │    │    │         │    └── lower(s:3)
+ │    │    │         └── x:6
+ │    │    │              └── j:4->'x'
+ │    │    └── filters
+ │    │         ├── lower(s:3) = 'foo' [outer=(3), immutable]
+ │    │         └── i:2 = 10 [outer=(2), constraints=(/2: [/10 - /10]; tight), fd=()-->(2)]
+ │    └── projections
+ │         ├── upper(s:3) [as=w:9, outer=(3), immutable]
+ │         └── lower(s:3) [as=v:5, outer=(3), immutable]
+ └── filters
+      └── w:9 = 'FOO' [outer=(9), constraints=(/9: [/'FOO' - /'FOO']; tight), fd=()-->(9)]
+
+# Do not inline correlated subqueries.
+norm expect-not=InlineSelectVirtualColumns
+SELECT * FROM virt v1
+WHERE EXISTS (
+  SELECT * FROM virt v2 WHERE v1.v = v2.s
+)
+----
+semi-join (hash)
+ ├── columns: k:1!null i:2 s:3 j:4 v:5 x:6
  ├── immutable
  ├── key: (1)
- ├── fd: ()-->(6), (1)-->(2-4), (3)-->(5), (4)-->(7)
+ ├── fd: (1)-->(2-4), (3)-->(5), (4)-->(6)
  ├── project
- │    ├── columns: v:5 w:6 x:7 k:1!null i:2 s:3 j:4
+ │    ├── columns: v:5 x:6 k:1!null i:2 s:3 j:4
  │    ├── immutable
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-4), (3)-->(5,6), (4)-->(7)
+ │    ├── fd: (1)-->(2-4), (3)-->(5), (4)-->(6)
  │    ├── scan virt
  │    │    ├── columns: k:1!null i:2 s:3 j:4
  │    │    ├── computed column expressions
  │    │    │    ├── v:5
  │    │    │    │    └── lower(s:3)
- │    │    │    ├── w:6
- │    │    │    │    └── upper(s:3)
- │    │    │    └── x:7
+ │    │    │    └── x:6
  │    │    │         └── j:4->'x'
  │    │    ├── key: (1)
  │    │    └── fd: (1)-->(2-4)
  │    └── projections
  │         ├── lower(s:3) [as=v:5, outer=(3), immutable]
- │         ├── upper(s:3) [as=w:6, outer=(3), immutable]
- │         └── j:4->'x' [as=x:7, outer=(4), immutable]
- └── filters
-      └── w:6 = 'FOO' [outer=(6), constraints=(/6: [/'FOO' - /'FOO']; tight), fd=()-->(6)]
-
-# Split the filters and inline only the indexed virtual columns.
-norm expect=InlineSelectVirtualColumns
-SELECT * FROM virt WHERE v = 'foo' AND w = 'FOO' AND i = 10
-----
-select
- ├── columns: k:1!null i:2!null s:3 j:4 v:5 w:6!null x:7
- ├── immutable
- ├── key: (1)
- ├── fd: ()-->(2,6), (1)-->(3,4), (3)-->(5), (4)-->(7)
- ├── project
- │    ├── columns: v:5 w:6 x:7 k:1!null i:2!null s:3 j:4
- │    ├── immutable
- │    ├── key: (1)
- │    ├── fd: ()-->(2), (1)-->(3,4), (3)-->(5,6), (4)-->(7)
- │    ├── select
- │    │    ├── columns: k:1!null i:2!null s:3 j:4
- │    │    ├── immutable
- │    │    ├── key: (1)
- │    │    ├── fd: ()-->(2), (1)-->(3,4)
- │    │    ├── scan virt
- │    │    │    ├── columns: k:1!null i:2 s:3 j:4
- │    │    │    ├── computed column expressions
- │    │    │    │    ├── v:5
- │    │    │    │    │    └── lower(s:3)
- │    │    │    │    ├── w:6
- │    │    │    │    │    └── upper(s:3)
- │    │    │    │    └── x:7
- │    │    │    │         └── j:4->'x'
- │    │    │    ├── key: (1)
- │    │    │    └── fd: (1)-->(2-4)
- │    │    └── filters
- │    │         ├── lower(s:3) = 'foo' [outer=(3), immutable]
- │    │         └── i:2 = 10 [outer=(2), constraints=(/2: [/10 - /10]; tight), fd=()-->(2)]
- │    └── projections
- │         ├── lower(s:3) [as=v:5, outer=(3), immutable]
- │         ├── upper(s:3) [as=w:6, outer=(3), immutable]
- │         └── j:4->'x' [as=x:7, outer=(4), immutable]
- └── filters
-      └── w:6 = 'FOO' [outer=(6), constraints=(/6: [/'FOO' - /'FOO']; tight), fd=()-->(6)]
-
-# Do not inline correlated subqueries.
-norm expect-not=InlineSelectVirtualColumns
-SELECT * FROM virt v1
-WHERE w = 'FOO' AND EXISTS (
-  SELECT * FROM virt v2 WHERE v1.v = v2.s
-)
-----
-semi-join (hash)
- ├── columns: k:1!null i:2 s:3 j:4 v:5 w:6!null x:7
- ├── immutable
- ├── key: (1)
- ├── fd: ()-->(6), (1)-->(2-4), (3)-->(5), (4)-->(7)
- ├── select
- │    ├── columns: k:1!null i:2 s:3 j:4 v:5 w:6!null x:7
- │    ├── immutable
- │    ├── key: (1)
- │    ├── fd: ()-->(6), (1)-->(2-4), (3)-->(5), (4)-->(7)
- │    ├── project
- │    │    ├── columns: v:5 w:6 x:7 k:1!null i:2 s:3 j:4
- │    │    ├── immutable
- │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2-4), (3)-->(5,6), (4)-->(7)
- │    │    ├── scan virt
- │    │    │    ├── columns: k:1!null i:2 s:3 j:4
- │    │    │    ├── computed column expressions
- │    │    │    │    ├── v:5
- │    │    │    │    │    └── lower(s:3)
- │    │    │    │    ├── w:6
- │    │    │    │    │    └── upper(s:3)
- │    │    │    │    └── x:7
- │    │    │    │         └── j:4->'x'
- │    │    │    ├── key: (1)
- │    │    │    └── fd: (1)-->(2-4)
- │    │    └── projections
- │    │         ├── lower(s:3) [as=v:5, outer=(3), immutable]
- │    │         ├── upper(s:3) [as=w:6, outer=(3), immutable]
- │    │         └── j:4->'x' [as=x:7, outer=(4), immutable]
- │    └── filters
- │         └── w:6 = 'FOO' [outer=(6), constraints=(/6: [/'FOO' - /'FOO']; tight), fd=()-->(6)]
+ │         └── j:4->'x' [as=x:6, outer=(4), immutable]
  ├── scan virt
- │    ├── columns: s:12
+ │    ├── columns: s:11
  │    └── computed column expressions
- │         ├── v:14
- │         │    └── lower(s:12)
- │         ├── w:15
- │         │    └── upper(s:12)
- │         └── x:16
- │              └── j:13->'x'
+ │         ├── v:13
+ │         │    └── lower(s:11)
+ │         └── x:14
+ │              └── j:12->'x'
  └── filters
-      └── v:5 = s:12 [outer=(5,12), constraints=(/5: (/NULL - ]; /12: (/NULL - ]), fd=(5)==(12), (12)==(5)]
+      └── v:5 = s:11 [outer=(5,11), constraints=(/5: (/NULL - ]; /11: (/NULL - ]), fd=(5)==(11), (11)==(5)]
 
 # --------------------------------------------------
 # InlineProjectInProject

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -124,8 +124,10 @@ CREATE TABLE virtual (
     c INT AS (b + 10) VIRTUAL,
     s STRING,
     lower_s STRING AS (lower(s)) VIRTUAL,
+    upper_s STRING AS (upper(s)) VIRTUAL,
     INDEX (a) WHERE c IN (10, 20, 30),
-    INDEX (lower_s)
+    INDEX (lower_s),
+    INDEX (a) WHERE upper_s = 'FOO'
 )
 ----
 
@@ -367,11 +369,15 @@ project
       │    ├── computed column expressions
       │    │    ├── c:4
       │    │    │    └── b:3 + 10
-      │    │    └── lower_s:6
-      │    │         └── lower(s:5)
+      │    │    ├── lower_s:6
+      │    │    │    └── lower(s:5)
+      │    │    └── upper_s:7
+      │    │         └── upper(s:5)
       │    ├── partial index predicates
+      │    │    ├── secondary: filters
+      │    │    │    └── (b:3 + 10) IN (10, 20, 30) [outer=(3), immutable]
       │    │    └── secondary: filters
-      │    │         └── (b:3 + 10) IN (10, 20, 30) [outer=(3), immutable]
+      │    │         └── upper(s:5) = 'FOO' [outer=(5), immutable]
       │    ├── key: (1)
       │    └── fd: (1)-->(3)
       └── filters
@@ -1711,16 +1717,35 @@ project
       │    ├── computed column expressions
       │    │    ├── c:4
       │    │    │    └── b:3 + 10
-      │    │    └── lower_s:6
-      │    │         └── lower(s:5)
+      │    │    ├── lower_s:6
+      │    │    │    └── lower(s:5)
+      │    │    └── upper_s:7
+      │    │         └── upper(s:5)
       │    ├── partial index predicates
+      │    │    ├── secondary: filters
+      │    │    │    └── (b:3 + 10) IN (10, 20, 30) [outer=(3), immutable]
       │    │    └── secondary: filters
-      │    │         └── (b:3 + 10) IN (10, 20, 30) [outer=(3), immutable]
+      │    │         └── upper(s:5) = 'FOO' [outer=(5), immutable]
       │    ├── key: (1)
       │    └── fd: (1)-->(2,3)
       └── filters
            ├── (a:2 > 10) AND (a:2 < 20) [outer=(2), constraints=(/2: [/11 - /19]; tight)]
            └── b:3 = 10 [outer=(3), constraints=(/3: [/10 - /10]; tight), fd=()-->(3)]
+
+# Test that we can constrain a partial index with a virtual column in the
+# predicate.
+opt expect=GenerateConstrainedScans
+SELECT k FROM virtual WHERE a > 1 AND a < 10 AND upper_s = 'FOO'
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── scan virtual@secondary,partial
+      ├── columns: k:1!null a:2!null
+      ├── constraint: /2/1: [/2 - /9]
+      ├── key: (1)
+      └── fd: (1)-->(2)
 
 # Regression test for #55387. GenerateConstrainedScans should not reduce the
 # input filters when proving partial index implication.


### PR DESCRIPTION
#### opt: inline all filters with virtual columns

Previously, `InlineSelectVirtualColumns` inlined virtual column
expressions in filters and pushed those filters below a Project only if
the virtual columns were indexed. Now, all virtual column expressions
are inlined. This allows exploration rules to generate expressions that
utilize partial indexes with predicates that reference virtual columns.

We considered extending `InlineSelectVirtualColumns` to also inline a
virtual columns if they are referenced in partial index predicates.
This would require addition metadata to keep track of the set of such
virtual columns. Virtual columns have already been inlined in the
predicates in the table metadata, so simply fetching the outer columns
of those predicates would not suffice. Because this rule already is
highly selective (only operating on virtual columns), we opted to
simplify the rule to inline all virtual columns instead.

There is no release note because virtual columns are gated behind an
experimental session setting.

Release note: None

#### opt: fix optsteps panic from InlineSelectVirtualColumns

Previously, running the `optsteps` test command panicked with "could not
find path to expr" for queries when `InlineSelectVirtualColumns` was
matched. This commit fixes the panic by eliminating the anti-pattern of
calling a constructor during the pattern-match phase of a normalization
rule.

The `optsteps` test command displays step `n` of optimization by running
the optimizer twice and halting after `n` and `n - 1` rules have been
applied. The difference in the two resulting expressions represents the
change in step `n`. `InlineSelectVirtualColumns` previously called
`ConstructFiltersItem` during the pattern-match phase of the rule, but
only added the constructed filters item to the memo in the replace
phase of the rule. When some normalization rule applied during the call
to `ConstructFiltersItem` was the last rule applied in a step, the
constructed item was not added to the memo because the limit on the
number of rules prevented the replace phase of
`InlineSelectVirtualColumns`. As a result, `optsteps` panicked when it
could not find the normalized `FiltersItem` in the memo.

Release note: None
