### PR TITLE
jobs: remove WithTxn

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1227,7 +1227,7 @@ func createImportingDescriptors(
 				}
 
 				// Update the job once all descs have been prepared for ingestion.
-				err := r.job.WithTxn(txn).SetDetails(ctx, details)
+				err := r.job.SetDetails(ctx, txn, details)
 
 				return err
 			})
@@ -1464,7 +1464,7 @@ func insertStats(
 			return errors.Wrapf(err, "inserting stats from backup")
 		}
 		details.StatsInserted = true
-		if err := job.WithTxn(txn).SetDetails(ctx, details); err != nil {
+		if err := job.SetDetails(ctx, txn, details); err != nil {
 			return errors.Wrapf(err, "updating job marking stats insertion complete")
 		}
 		return nil
@@ -1626,11 +1626,10 @@ func (r *restoreResumer) publishDescriptors(
 	details.TypeDescs = newTypes
 	details.SchemaDescs = newSchemas
 	details.DatabaseDescs = newDBs
-	if err := r.job.WithTxn(txn).SetDetails(ctx, details); err != nil {
+	if err := r.job.SetDetails(ctx, txn, details); err != nil {
 		return newDescriptorChangeJobs, errors.Wrap(err,
 			"updating job details after publishing tables")
 	}
-	r.job.WithTxn(nil)
 
 	return newDescriptorChangeJobs, nil
 }

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -891,7 +891,9 @@ func (cf *changeFrontier) Start(ctx context.Context) context.Context {
 			cf.MoveToDraining(err)
 			return ctx
 		}
-		cf.jobProgressedFn = job.HighWaterProgressed
+		cf.jobProgressedFn = func(ctx context.Context, fn jobs.HighWaterProgressedFn) error {
+			return job.HighWaterProgressed(ctx, nil /* txn */, fn)
+		}
 
 		p := job.Progress()
 		if ts := p.GetHighWater(); ts != nil {

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
@@ -168,7 +168,7 @@ func (s *streamIngestionResultWriter) AddRow(ctx context.Context, row tree.Datum
 	if err != nil {
 		return err
 	}
-	return job.HighWaterProgressed(s.ctx, func(ctx context.Context, txn *kv.Txn,
+	return job.HighWaterProgressed(s.ctx, nil /* txn */, func(ctx context.Context, txn *kv.Txn,
 		details jobspb.ProgressDetails) (hlc.Timestamp, error) {
 		// Decode the row and write the ts.
 		var ingestedHighWatermark hlc.Timestamp

--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -301,7 +301,7 @@ RETURNING id, status`,
 				r.unregister(id)
 				log.Infof(ctx, "job %d, session %s: paused", id, s.ID())
 			case StatusReverting:
-				if err := job.WithTxn(txn).Update(ctx, func(txn *kv.Txn, md JobMetadata, ju *JobUpdater) error {
+				if err := job.Update(ctx, txn, func(txn *kv.Txn, md JobMetadata, ju *JobUpdater) error {
 					r.unregister(id)
 					md.Payload.Error = errJobCanceled.Error()
 					encodedErr := errors.EncodeError(ctx, errJobCanceled)

--- a/pkg/jobs/helpers_test.go
+++ b/pkg/jobs/helpers_test.go
@@ -64,7 +64,7 @@ func (d FakeResumer) OnPauseRequest(
 // Started is a wrapper around the internal function that moves a job to the
 // started state.
 func (j *Job) Started(ctx context.Context) error {
-	return j.started(ctx)
+	return j.started(ctx, nil /* txn */)
 }
 
 // Created is a test only function that inserts a new jobs table row.
@@ -72,23 +72,23 @@ func (j *Job) Created(ctx context.Context) error {
 	if j.ID() != nil {
 		return errors.Errorf("job already created with ID %v", *j.ID())
 	}
-	return j.deprecatedInsert(ctx, j.registry.makeJobID(), nil /* lease */, nil /* session */)
+	return j.deprecatedInsert(ctx, nil /* txn */, j.registry.makeJobID(), nil /* lease */, nil /* session */)
 }
 
 // Paused is a wrapper around the internal function that moves a job to the
 // paused state.
 func (j *Job) Paused(ctx context.Context) error {
-	return j.paused(ctx, nil /* fn */)
+	return j.paused(ctx, nil /* txn */, nil /* fn */)
 }
 
 // Failed is a wrapper around the internal function that moves a job to the
 // failed state.
 func (j *Job) Failed(ctx context.Context, causingErr error) error {
-	return j.failed(ctx, causingErr, nil /* fn */)
+	return j.failed(ctx, nil /* txn */, causingErr, nil /* fn */)
 }
 
 // Succeeded is a wrapper around the internal function that moves a job to the
 // succeeded state.
 func (j *Job) Succeeded(ctx context.Context) error {
-	return j.succeeded(ctx, nil /* fn */)
+	return j.succeeded(ctx, nil /* txn */, nil /* fn */)
 }

--- a/pkg/jobs/jobsprotectedts/jobs_protected_ts.go
+++ b/pkg/jobs/jobsprotectedts/jobs_protected_ts.go
@@ -45,7 +45,8 @@ func MakeStatusFunc(jr *jobs.Registry) ptreconcile.StatusFunc {
 		if err != nil {
 			return false, err
 		}
-		isTerminal := j.CheckTerminalStatus(ctx)
+		// TODO: This job update should possibly use the txn (#60690).
+		isTerminal := j.CheckTerminalStatus(ctx, nil /* txn */)
 		return isTerminal, nil
 	}
 }

--- a/pkg/jobs/progress.go
+++ b/pkg/jobs/progress.go
@@ -76,7 +76,7 @@ func NewChunkProgressLogger(
 			completed: startFraction,
 			reported:  startFraction,
 			Report: func(ctx context.Context, pct float32) error {
-				return j.FractionProgressed(ctx, func(ctx context.Context, details jobspb.ProgressDetails) float32 {
+				return j.FractionProgressed(ctx, nil /* txn */, func(ctx context.Context, details jobspb.ProgressDetails) float32 {
 					if progressedFn != nil {
 						progressedFn(ctx, details)
 					}

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -431,8 +431,8 @@ func (r *Registry) CreateJobWithTxn(ctx context.Context, record Record, txn *kv.
 	if !r.startUsingSQLLivenessAdoption(ctx) {
 		// TODO(spaskob): remove in 20.2 as this code path is only needed while
 		// migrating to 20.2 cluster.
-		if err := j.WithTxn(txn).deprecatedInsert(
-			ctx, r.makeJobID(), r.deprecatedNewLease(), s,
+		if err := j.deprecatedInsert(
+			ctx, txn, r.makeJobID(), r.deprecatedNewLease(), s,
 		); err != nil {
 			return nil, err
 		}
@@ -477,8 +477,8 @@ func (r *Registry) CreateAdoptableJobWithTxn(
 	// in the cluster) to adopt this job at a later time.
 	lease := &jobspb.Lease{NodeID: invalidNodeID}
 
-	if err := j.WithTxn(txn).deprecatedInsert(
-		ctx, r.makeJobID(), lease, nil,
+	if err := j.deprecatedInsert(
+		ctx, txn, r.makeJobID(), lease, nil,
 	); err != nil {
 		return nil, err
 	}
@@ -505,11 +505,6 @@ func (r *Registry) CreateStartableJobWithTxn(
 	if err != nil {
 		return nil, err
 	}
-	// The job itself must not hold on to this transaction. We ensure in Start()
-	// that the transaction used to create the job is committed. When jobs hold
-	// onto transactions they use the transaction in methods which modify the job.
-	// On the whole this pattern is bug-prone and hard to reason about.
-	j.WithTxn(nil)
 	resumer, err := r.createResumer(j, r.settings)
 	if err != nil {
 		return nil, err
@@ -564,7 +559,7 @@ func (r *Registry) LoadJobWithTxn(ctx context.Context, jobID int64, txn *kv.Txn)
 		id:       &jobID,
 		registry: r,
 	}
-	if err := j.WithTxn(txn).load(ctx); err != nil {
+	if err := j.load(ctx, txn); err != nil {
 		return nil, err
 	}
 	return j, nil
@@ -580,7 +575,7 @@ func (r *Registry) UpdateJobWithTxn(
 		id:       &jobID,
 		registry: r,
 	}
-	return j.WithTxn(txn).Update(ctx, updateFunc)
+	return j.Update(ctx, txn, updateFunc)
 }
 
 // DefaultCancelInterval is a reasonable interval at which to poll this node
@@ -1004,12 +999,12 @@ func (r *Registry) CancelRequested(ctx context.Context, txn *kv.Txn, id int64) e
 			// safest way for now (i.e., without a larger jobs/schema change refactor)
 			// is to hack this up with a string comparison.
 			if payload.Type() == jobspb.TypeSchemaChange && !strings.HasPrefix(payload.Description, "ROLL BACK") {
-				return job.WithTxn(txn).cancelRequested(ctx, nil)
+				return job.cancelRequested(ctx, txn, nil)
 			}
 		}
 		return err
 	}
-	return job.WithTxn(txn).cancelRequested(ctx, nil)
+	return job.cancelRequested(ctx, txn, nil)
 }
 
 // PauseRequested marks the job with id as paused-requested using the specified txn (may be nil).
@@ -1022,7 +1017,7 @@ func (r *Registry) PauseRequested(ctx context.Context, txn *kv.Txn, id int64) er
 	if pr, ok := resumer.(PauseRequester); ok {
 		onPauseRequested = pr.OnPauseRequest
 	}
-	return job.WithTxn(txn).pauseRequested(ctx, onPauseRequested)
+	return job.pauseRequested(ctx, txn, onPauseRequested)
 }
 
 // Succeeded marks the job with id as succeeded.
@@ -1031,7 +1026,7 @@ func (r *Registry) Succeeded(ctx context.Context, txn *kv.Txn, id int64) error {
 	if err != nil {
 		return err
 	}
-	return job.WithTxn(txn).succeeded(ctx, nil)
+	return job.succeeded(ctx, txn, nil)
 }
 
 // Failed marks the job with id as failed.
@@ -1040,7 +1035,7 @@ func (r *Registry) Failed(ctx context.Context, txn *kv.Txn, id int64, causingErr
 	if err != nil {
 		return err
 	}
-	return job.WithTxn(txn).failed(ctx, causingError, nil)
+	return job.failed(ctx, txn, causingError, nil)
 }
 
 // Unpause changes the paused job with id to running or reverting using the
@@ -1050,7 +1045,7 @@ func (r *Registry) Unpause(ctx context.Context, txn *kv.Txn, id int64) error {
 	if err != nil {
 		return err
 	}
-	return job.WithTxn(txn).unpaused(ctx)
+	return job.unpaused(ctx, txn)
 }
 
 // Resumer is a resumable job, and is associated with a Job object. Jobs can be
@@ -1157,7 +1152,7 @@ func (r *Registry) stepThroughStateMachine(
 		}
 		resumeCtx := logtags.AddTag(ctx, "job", *job.ID())
 		if payload.StartedMicros == 0 {
-			if err := job.started(ctx); err != nil {
+			if err := job.started(ctx, nil /* txn */); err != nil {
 				return err
 			}
 		}
@@ -1204,7 +1199,7 @@ func (r *Registry) stepThroughStateMachine(
 		return errors.NewAssertionErrorWithWrappedErrf(jobErr,
 			"job %d: unexpected status %s provided to state machine", *job.ID(), status)
 	case StatusCanceled:
-		if err := job.canceled(ctx, nil); err != nil {
+		if err := job.canceled(ctx, nil /* txn */, nil /* fn */); err != nil {
 			// If we can't transactionally mark the job as canceled then it will be
 			// restarted during the next adopt loop and reverting will be retried.
 			return errors.Wrapf(err, "job %d: could not mark as canceled: %v", *job.ID(), jobErr)
@@ -1215,7 +1210,7 @@ func (r *Registry) stepThroughStateMachine(
 			return errors.NewAssertionErrorWithWrappedErrf(jobErr,
 				"job %d: successful bu unexpected error provided", *job.ID())
 		}
-		if err := job.succeeded(ctx, nil); err != nil {
+		if err := job.succeeded(ctx, nil /* txn */, nil /* fn */); err != nil {
 			// If it didn't succeed, we consider the job as failed and need to go
 			// through reverting state first.
 			// TODO(spaskob): this is silly, we should remove the OnSuccess hooks and
@@ -1225,7 +1220,7 @@ func (r *Registry) stepThroughStateMachine(
 		}
 		return nil
 	case StatusReverting:
-		if err := job.reverted(ctx, jobErr, nil); err != nil {
+		if err := job.reverted(ctx, nil /* txn */, jobErr, nil /* fn */); err != nil {
 			// If we can't transactionally mark the job as reverting then it will be
 			// restarted during the next adopt loop and it will be retried.
 			return errors.Wrapf(err, "job %d: could not mark as reverting: %s", *job.ID(), jobErr)
@@ -1272,7 +1267,7 @@ func (r *Registry) stepThroughStateMachine(
 			return errors.NewAssertionErrorWithWrappedErrf(jobErr,
 				"job %d: has StatusFailed but no error was provided", *job.ID())
 		}
-		if err := job.failed(ctx, jobErr, nil); err != nil {
+		if err := job.failed(ctx, nil /* txn */, jobErr, nil /* fn */); err != nil {
 			// If we can't transactionally mark the job as failed then it will be
 			// restarted during the next adopt loop and reverting will be retried.
 			return errors.Wrapf(err, "job %d: could not mark as failed: %s", *job.ID(), jobErr)

--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -98,14 +98,14 @@ func (ju *JobUpdater) hasUpdates() bool {
 //
 // Note that there are various convenience wrappers (like FractionProgressed)
 // defined in jobs.go.
-func (j *Job) Update(ctx context.Context, updateFn UpdateFn) error {
+func (j *Job) Update(ctx context.Context, txn *kv.Txn, updateFn UpdateFn) error {
 	if j.id == nil {
 		return errors.New("job: cannot update: job not created")
 	}
 
 	var payload *jobspb.Payload
 	var progress *jobspb.Progress
-	if err := j.runInTxn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+	if err := j.runInTxn(ctx, txn, func(ctx context.Context, txn *kv.Txn) error {
 		stmt := "SELECT status, payload, progress FROM system.jobs WHERE id = $1 FOR UPDATE"
 		if j.sessionID != "" {
 			stmt = "SELECT status, payload, progress, claim_session_id FROM system." +

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -531,8 +531,9 @@ func (r *createStatsResumer) Resume(ctx context.Context, execCtx interface{}) er
 			// job progress to coerce out the correct error type. If the update succeeds
 			// then return the original error, otherwise return this error instead so
 			// it can be cleaned up at a higher level.
+			// TODO: This job update should possibly use the txn (#60690).
 			if jobErr := r.job.FractionProgressed(
-				ctx,
+				ctx, nil, /* txn */
 				func(ctx context.Context, _ jobspb.ProgressDetails) float32 {
 					// The job failed so the progress value here doesn't really matter.
 					return 0

--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -222,7 +222,7 @@ func DistIngest(
 
 	dsp.FinalizePlan(planCtx, p)
 
-	if err := job.FractionProgressed(ctx,
+	if err := job.FractionProgressed(ctx, nil, /* txn */
 		func(ctx context.Context, details jobspb.ProgressDetails) float32 {
 			prog := details.(*jobspb.Progress_Import).Import
 			prog.ReadProgress = make([]float32, len(from))
@@ -244,7 +244,7 @@ func DistIngest(
 	fractionProgress := make([]uint32, len(from))
 
 	updateJobProgress := func() error {
-		return job.FractionProgressed(ctx,
+		return job.FractionProgressed(ctx, nil, /* txn */
 			func(ctx context.Context, details jobspb.ProgressDetails) float32 {
 				var overall float32
 				prog := details.(*jobspb.Progress_Import).Import

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -491,8 +491,8 @@ func (p *planner) initiateDropTable(
 			}
 			return err
 		}
-		if err := mutationJob.WithTxn(p.txn).Update(
-			ctx, func(txn *kv.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+		if err := mutationJob.Update(
+			ctx, p.txn, func(txn *kv.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
 				status := md.Status
 				switch status {
 				case jobs.StatusSucceeded, jobs.StatusCanceled, jobs.StatusFailed:

--- a/pkg/sql/gcjob/gc_job_utils.go
+++ b/pkg/sql/gcjob/gc_job_utils.go
@@ -117,7 +117,8 @@ func initializeProgress(
 			if err != nil {
 				return err
 			}
-			return job.SetProgress(ctx, *progress)
+			// TODO: This job update should possibly use the txn (#60690).
+			return job.SetProgress(ctx, nil /* txn */, *progress)
 		}); err != nil {
 			return err
 		}
@@ -260,11 +261,12 @@ func persistProgress(
 		if err != nil {
 			return err
 		}
-		if err := job.SetProgress(ctx, *progress); err != nil {
+		// TODO: This job update should possibly use the txn (#60690).
+		if err := job.SetProgress(ctx, nil /* txn */, *progress); err != nil {
 			return err
 		}
 		log.Infof(ctx, "updated progress payload: %+v", progress)
-		err = job.RunningStatus(ctx, func(_ context.Context, _ jobspb.Details) (jobs.RunningStatus, error) {
+		err = job.RunningStatus(ctx, nil /* txn */, func(_ context.Context, _ jobspb.Details) (jobs.RunningStatus, error) {
 			return runningStatus, nil
 		})
 		if err != nil {

--- a/pkg/sql/gcjob_test/gc_job_test.go
+++ b/pkg/sql/gcjob_test/gc_job_test.go
@@ -370,7 +370,7 @@ func TestGCResumer(t *testing.T) {
 		require.NoError(t, sj.AwaitCompletion(ctx))
 		job, err := jobRegistry.LoadJob(ctx, *sj.ID())
 		require.NoError(t, err)
-		st, err := job.CurrentStatus(ctx)
+		st, err := job.CurrentStatus(ctx, nil /* txn */)
 		require.NoError(t, err)
 		require.Equal(t, jobs.StatusSucceeded, st)
 		_, err = sql.GetTenantRecord(ctx, &execCfg, nil /* txn */, tenID)
@@ -401,7 +401,7 @@ func TestGCResumer(t *testing.T) {
 
 		job, err := jobRegistry.LoadJob(ctx, *sj.ID())
 		require.NoError(t, err)
-		st, err := job.CurrentStatus(ctx)
+		st, err := job.CurrentStatus(ctx, nil /* txn */)
 		require.NoError(t, err)
 		require.Equal(t, jobs.StatusSucceeded, st)
 		_, err = sql.GetTenantRecord(ctx, &execCfg, nil /* txn */, tenID)

--- a/pkg/sql/rowexec/backfiller.go
+++ b/pkg/sql/rowexec/backfiller.go
@@ -256,5 +256,5 @@ func SetResumeSpansInJob(
 		return errors.Errorf("expected SchemaChangeDetails job type, got %T", job.Details())
 	}
 	details.ResumeSpanList[mutationIdx].ResumeSpans = spans
-	return job.WithTxn(txn).SetDetails(ctx, details)
+	return job.SetDetails(ctx, txn, details)
 }

--- a/pkg/sql/rowexec/backfiller_test.go
+++ b/pkg/sql/rowexec/backfiller_test.go
@@ -136,13 +136,13 @@ func TestWriteResumeSpan(t *testing.T) {
 		t.Fatal(errors.Wrapf(err, "can't find job %d", jobID))
 	}
 
-	require.NoError(t, job.Update(ctx,
+	require.NoError(t, job.Update(ctx, nil, /* txn */
 		func(_ *kv.Txn, _ jobs.JobMetadata, ju *jobs.JobUpdater) error {
 			ju.UpdateStatus(jobs.StatusRunning)
 			return nil
 		}))
 
-	err = job.SetDetails(ctx, details)
+	err = job.SetDetails(ctx, nil /* txn */, details)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -223,10 +223,10 @@ func (s *sampleAggregator) mainLoop(ctx context.Context) (earlyExit bool, err er
 		// If it changed by less than 1%, just check for cancellation (which is more
 		// efficient).
 		if fractionCompleted < 1.0 && fractionCompleted < lastReportedFractionCompleted+0.01 {
-			return job.CheckStatus(ctx)
+			return job.CheckStatus(ctx, nil /* txn */)
 		}
 		lastReportedFractionCompleted = fractionCompleted
-		return job.FractionProgressed(ctx, jobs.FractionUpdater(fractionCompleted))
+		return job.FractionProgressed(ctx, nil /* txn */, jobs.FractionUpdater(fractionCompleted))
 	}
 
 	var rowsProcessed uint64

--- a/pkg/sql/schema.go
+++ b/pkg/sql/schema.go
@@ -59,7 +59,7 @@ func (p *planner) writeSchemaDescChange(
 	job, jobExists := p.extendedEvalCtx.SchemaChangeJobCache[desc.ID]
 	if jobExists {
 		// Update it.
-		if err := job.WithTxn(p.txn).SetDescription(ctx,
+		if err := job.SetDescription(ctx, p.txn,
 			func(ctx context.Context, desc string) (string, error) {
 				return desc + "; " + jobDesc, nil
 			},

--- a/pkg/sql/schemachanger/scjob/job.go
+++ b/pkg/sql/schemachanger/scjob/job.go
@@ -79,7 +79,7 @@ var _ scexec.JobProgressTracker = (*badJobTracker)(nil)
 
 func (n *newSchemaChangeResumer) Resume(ctx context.Context, execCtxI interface{}) (err error) {
 	execCtx := execCtxI.(sql.JobExecContext)
-	if err := n.job.WithTxn(nil).Update(ctx, func(txn *kv.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+	if err := n.job.Update(ctx, nil /* txn */, func(txn *kv.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
 		return nil
 	}); err != nil {
 		// TODO(ajwerner): Detect transient errors and classify as retriable here or
@@ -115,8 +115,7 @@ func (n *newSchemaChangeResumer) Resume(ctx context.Context, execCtxI interface{
 				return err
 			}
 			descriptorsWithUpdatedVersions = descriptors.GetDescriptorsWithNewVersion()
-			defer n.job.WithTxn(nil)
-			return n.job.WithTxn(txn).Update(ctx, func(txn *kv.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+			return n.job.Update(ctx, txn, func(txn *kv.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
 				pg := md.Progress.GetNewSchemaChange()
 				pg.States = makeStates(s.After)
 				ju.UpdateProgress(md.Progress)

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -183,12 +183,12 @@ func (p *planner) createOrUpdateSchemaChangeJob(
 					MutationID: mutationID, JobID: *job.ID()})
 			}
 		}
-		if err := job.WithTxn(p.txn).SetDetails(ctx, newDetails); err != nil {
+		if err := job.SetDetails(ctx, p.txn, newDetails); err != nil {
 			return err
 		}
 		if jobDesc != "" {
-			if err := job.WithTxn(p.txn).SetDescription(
-				ctx,
+			if err := job.SetDescription(
+				ctx, p.txn,
 				func(ctx context.Context, description string) (string, error) {
 					return strings.Join([]string{description, jobDesc}, ";"), nil
 				},

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -95,10 +95,10 @@ func (p *planner) writeTypeSchemaChange(
 			TypeID:               typeDesc.ID,
 			TransitioningMembers: transitioningMembers,
 		}
-		if err := job.WithTxn(p.txn).SetDetails(ctx, newDetails); err != nil {
+		if err := job.SetDetails(ctx, p.txn, newDetails); err != nil {
 			return err
 		}
-		if err := job.WithTxn(p.txn).SetDescription(ctx,
+		if err := job.SetDescription(ctx, p.txn,
 			func(ctx context.Context, description string) (string, error) {
 				return description + "; " + jobDesc, nil
 			},


### PR DESCRIPTION
This commit removes the `Job`'s `WithTxn` method and its `txn` field,
which were used to set the next transaction used by a job, and have been
a source of many bugs due to setting an incorrect or nil transaction.
Now there is an explicit `*kv.Txn` argument on all the `Job` methods
that read from the store, where a nil argument still indicates that a
new txn should be created.

Closes #57534.

Release note: None