### PR TITLE
storage,server: disable separated intents

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"math/rand"
 	"net"
 	"net/http"
 	"net/http/cookiejar"
@@ -132,11 +131,12 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	st := params.Settings
 	if params.Settings == nil {
 		st = cluster.MakeClusterSettings()
-		enabledSeparated := rand.Intn(2) == 0
-		log.Infof(context.Background(),
-			"test Config is randomly setting enabledSeparated: %t",
-			enabledSeparated)
-		storage.SeparatedIntentsEnabled.Override(&st.SV, enabledSeparated)
+		// TODO(sumeer): re-introduce this randomization.
+		// enabledSeparated := rand.Intn(2) == 0
+		// log.Infof(context.Background(),
+		//	"test Config is randomly setting enabledSeparated: %t",
+		//	enabledSeparated)
+		// storage.SeparatedIntentsEnabled.Override(&st.SV, enabledSeparated)
 	}
 	st.ExternalIODir = params.ExternalIODir
 	cfg := makeTestConfig(st)

--- a/pkg/storage/intent_reader_writer.go
+++ b/pkg/storage/intent_reader_writer.go
@@ -45,7 +45,7 @@ var SeparatedIntentsEnabled = settings.RegisterBoolSetting(
 	"storage.transaction.separated_intents.enabled",
 	"if enabled, intents will be written to a separate lock table, instead of being "+
 		"interleaved with MVCC values",
-	true,
+	false,
 )
 
 // This file defines wrappers for Reader and Writer, and functions to do the


### PR DESCRIPTION
They are disabled by default, and the setting is
not randomized on the testing path for testserver.go.

This was causing slowness in TestLogic/*/aggregate
resulting in TestLogic sometimes exceeding the
test timeout.

This is due to an unforseen slowness in intent
resolution caused by the effectively randomized ordering
of the latest and older intents.

Informs #41720

Release note: None