### PR TITLE
opt: cast to identical types for set operations

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -348,3 +348,21 @@ NULL
 statement ok
 CREATE TABLE ab (a INT, b INT);
 SELECT a, b, rowid FROM ab UNION VALUES (1, 2, 3);
+DROP TABLE ab;
+
+# Regression test for #59148.
+statement ok
+CREATE TABLE ab (a INT4, b INT8);
+INSERT INTO ab VALUES (1, 1), (1, 2), (2, 1), (2, 2);
+
+query I rowsort
+SELECT a FROM ab UNION SELECT b FROM ab
+----
+1
+2
+
+query I rowsort
+SELECT b FROM ab UNION SELECT a FROM ab
+----
+1
+2

--- a/pkg/sql/opt/optbuilder/BUILD.bazel
+++ b/pkg/sql/opt/optbuilder/BUILD.bazel
@@ -81,6 +81,7 @@ go_test(
     srcs = [
         "builder_test.go",
         "name_resolution_test.go",
+        "union_test.go",
     ],
     data = glob(["testdata/**"]),
     embed = [":optbuilder"],
@@ -95,6 +96,7 @@ go_test(
         "//pkg/sql/parser",
         "//pkg/sql/sem/builtins",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/types",
         "//pkg/testutils/sqlutils",
         "//pkg/util/leaktest",
         "@com_github_cockroachdb_datadriven//:datadriven",

--- a/pkg/sql/opt/optbuilder/testdata/union
+++ b/pkg/sql/opt/optbuilder/testdata/union
@@ -874,3 +874,128 @@ except
       │                   │         └── 1 [as="?column?":6]
       │                   └── 1
       └── (1,)
+
+# Verify that we add casts for equivalent, but not identical types.
+exec-ddl
+CREATE TABLE ab (i8 INT8, i4 INT4, f8 FLOAT, f4 FLOAT4, d DECIMAL)
+----
+
+build
+SELECT i4 FROM ab UNION SELECT i8 FROM ab
+----
+union
+ ├── columns: i4:16
+ ├── left columns: i4:15
+ ├── right columns: i8:8
+ ├── project
+ │    ├── columns: i4:15
+ │    ├── project
+ │    │    ├── columns: ab.i4:2
+ │    │    └── scan ab
+ │    │         └── columns: i8:1 ab.i4:2 f8:3 f4:4 d:5 rowid:6!null crdb_internal_mvcc_timestamp:7
+ │    └── projections
+ │         └── ab.i4:2::INT8 [as=i4:15]
+ └── project
+      ├── columns: i8:8
+      └── scan ab
+           └── columns: i8:8 ab.i4:9 f8:10 f4:11 d:12 rowid:13!null crdb_internal_mvcc_timestamp:14
+
+build
+SELECT i8 FROM ab UNION SELECT i4 FROM ab
+----
+union
+ ├── columns: i8:16
+ ├── left columns: ab.i8:1
+ ├── right columns: i4:15
+ ├── project
+ │    ├── columns: ab.i8:1
+ │    └── scan ab
+ │         └── columns: ab.i8:1 ab.i4:2 f8:3 f4:4 d:5 rowid:6!null crdb_internal_mvcc_timestamp:7
+ └── project
+      ├── columns: i4:15
+      ├── project
+      │    ├── columns: ab.i4:9
+      │    └── scan ab
+      │         └── columns: ab.i8:8 ab.i4:9 f8:10 f4:11 d:12 rowid:13!null crdb_internal_mvcc_timestamp:14
+      └── projections
+           └── ab.i4:9::INT8 [as=i4:15]
+
+build
+SELECT f4 FROM ab UNION SELECT f8 FROM ab
+----
+union
+ ├── columns: f4:16
+ ├── left columns: f4:15
+ ├── right columns: f8:10
+ ├── project
+ │    ├── columns: f4:15
+ │    ├── project
+ │    │    ├── columns: ab.f4:4
+ │    │    └── scan ab
+ │    │         └── columns: i8:1 i4:2 f8:3 ab.f4:4 d:5 rowid:6!null crdb_internal_mvcc_timestamp:7
+ │    └── projections
+ │         └── ab.f4:4::FLOAT8 [as=f4:15]
+ └── project
+      ├── columns: f8:10
+      └── scan ab
+           └── columns: i8:8 i4:9 f8:10 ab.f4:11 d:12 rowid:13!null crdb_internal_mvcc_timestamp:14
+
+build
+SELECT i8 FROM ab UNION SELECT f4 FROM ab
+----
+union
+ ├── columns: i8:16
+ ├── left columns: i8:15
+ ├── right columns: f4:11
+ ├── project
+ │    ├── columns: i8:15
+ │    ├── project
+ │    │    ├── columns: ab.i8:1
+ │    │    └── scan ab
+ │    │         └── columns: ab.i8:1 i4:2 f8:3 f4:4 d:5 rowid:6!null crdb_internal_mvcc_timestamp:7
+ │    └── projections
+ │         └── ab.i8:1::FLOAT4 [as=i8:15]
+ └── project
+      ├── columns: f4:11
+      └── scan ab
+           └── columns: ab.i8:8 i4:9 f8:10 f4:11 d:12 rowid:13!null crdb_internal_mvcc_timestamp:14
+
+build
+SELECT i8 FROM ab UNION SELECT d FROM ab
+----
+union
+ ├── columns: i8:16
+ ├── left columns: i8:15
+ ├── right columns: d:12
+ ├── project
+ │    ├── columns: i8:15
+ │    ├── project
+ │    │    ├── columns: ab.i8:1
+ │    │    └── scan ab
+ │    │         └── columns: ab.i8:1 i4:2 f8:3 f4:4 d:5 rowid:6!null crdb_internal_mvcc_timestamp:7
+ │    └── projections
+ │         └── ab.i8:1::DECIMAL [as=i8:15]
+ └── project
+      ├── columns: d:12
+      └── scan ab
+           └── columns: ab.i8:8 i4:9 f8:10 f4:11 d:12 rowid:13!null crdb_internal_mvcc_timestamp:14
+
+build
+SELECT d FROM ab UNION SELECT f8 FROM ab
+----
+union
+ ├── columns: d:16
+ ├── left columns: ab.d:5
+ ├── right columns: f8:15
+ ├── project
+ │    ├── columns: ab.d:5
+ │    └── scan ab
+ │         └── columns: i8:1 i4:2 ab.f8:3 f4:4 ab.d:5 rowid:6!null crdb_internal_mvcc_timestamp:7
+ └── project
+      ├── columns: f8:15
+      ├── project
+      │    ├── columns: ab.f8:10
+      │    └── scan ab
+      │         └── columns: i8:8 i4:9 ab.f8:10 f4:11 ab.d:12 rowid:13!null crdb_internal_mvcc_timestamp:14
+      └── projections
+           └── ab.f8:10::DECIMAL [as=f8:15]

--- a/pkg/sql/opt/optbuilder/testdata/with
+++ b/pkg/sql/opt/optbuilder/testdata/with
@@ -1327,6 +1327,12 @@ with &3 (cte)
       └── mapping:
            └──  a:5 => a:8
 
+# We don't support upcasting the "initial" query.
+build
+WITH RECURSIVE cte(x) AS (SELECT a FROM x UNION ALL SELECT x::FLOAT FROM cte WHERE x < 10) SELECT * FROM cte;
+----
+error (42804): UNION types int and float cannot be matched for WITH RECURSIVE
+
 # Mutating WITHs not allowed at non-root positions.
 build
 SELECT * FROM (WITH foo AS (INSERT INTO y VALUES (1) RETURNING *) SELECT * FROM foo)

--- a/pkg/sql/opt/optbuilder/union_test.go
+++ b/pkg/sql/opt/optbuilder/union_test.go
@@ -1,0 +1,98 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package optbuilder
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+)
+
+func TestUnionType(t *testing.T) {
+	testCases := []struct {
+		left, right, expected *types.T
+	}{
+		{
+			left:     types.Unknown,
+			right:    types.Int,
+			expected: types.Int,
+		},
+		{
+			left:     types.Int,
+			right:    types.Unknown,
+			expected: types.Int,
+		},
+		{
+			left:     types.Int4,
+			right:    types.Int,
+			expected: types.Int,
+		},
+		{
+			left:     types.Int4,
+			right:    types.Int2,
+			expected: types.Int4,
+		},
+		{
+			left:     types.Float4,
+			right:    types.Float,
+			expected: types.Float,
+		},
+		{
+			left:     types.MakeDecimal(12 /* precision */, 5 /* scale */),
+			right:    types.MakeDecimal(10 /* precision */, 7 /* scale */),
+			expected: types.MakeDecimal(10 /* precision */, 7 /* scale */),
+		},
+		{
+			// At the same scale, we use the left type.
+			left:     types.MakeDecimal(10 /* precision */, 1 /* scale */),
+			right:    types.MakeDecimal(12 /* precision */, 1 /* scale */),
+			expected: types.MakeDecimal(10 /* precision */, 1 /* scale */),
+		},
+		{
+			left:     types.Int4,
+			right:    types.Decimal,
+			expected: types.Decimal,
+		},
+		{
+			left:     types.Decimal,
+			right:    types.Float,
+			expected: types.Decimal,
+		},
+		{
+			// Error.
+			left:     types.Float,
+			right:    types.String,
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		result := func() *types.T {
+			defer func() {
+				// Swallow any error and return nil.
+				_ = recover()
+			}()
+			return determineUnionType(tc.left, tc.right, "test")
+		}()
+		toStr := func(t *types.T) string {
+			if t == nil {
+				return "<nil>"
+			}
+			return t.SQLString()
+		}
+		if toStr(result) != toStr(tc.expected) {
+			t.Errorf(
+				"left: %s  right: %s  expected: %s  got: %s",
+				toStr(tc.left), toStr(tc.right), toStr(tc.expected), toStr(result),
+			)
+		}
+	}
+}


### PR DESCRIPTION
This change makes the optbuilder more strict when building set
operations. Previously, it could build expressions which have
corresponding left/right types which are `Equivalent()`, but not
`Identical()`. This leads to errors in vectorized execution, when we
e.g. try to union a INT8 with an INT4.

We now make the types on both sides `Identical()`, adding casts as
necessary. We try to do a best-effort attempt to use the larger
numeric type when possible (e.g. int4->int8, int->float, float->decimal).

Fixes #59148.

Release note (bug fix): fixed execution errors for some queries that
use set operations (UNION / EXCEPT / INTERSECT) where a column has
types of different widths on the two sides (e.g. INT4 vs INT8).