### PR TITLE
release-20.2: colexecerror: improve the panic-catcher

### DIFF
--- a/pkg/sql/colexecbase/colexecerror/error_test.go
+++ b/pkg/sql/colexecbase/colexecerror/error_test.go
@@ -1,0 +1,76 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colexecerror_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCatchVectorizedRuntimeError verifies that the panic-catcher doesn't catch
+// panics that originate outside of the vectorized engine and correctly
+// annotates errors that are propagated via
+// colexecerror.(Internal|Expected)Error methods.
+func TestCatchVectorizedRuntimeError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Setup multiple levels of catchers to ensure that the panic-catcher
+	// doesn't fool itself into catching panics that the inner catcher emitted.
+	require.Panics(t, func() {
+		require.NoError(t, colexecerror.CatchVectorizedRuntimeError(func() {
+			require.NoError(t, colexecerror.CatchVectorizedRuntimeError(func() {
+				colexecerror.NonVectorizedTestPanic(errors.New("should not be caught"))
+			}))
+		}))
+	})
+
+	const shouldBeCaughtText = "should be caught"
+	shouldBeCaughtErr := errors.New(shouldBeCaughtText)
+	const annotationText = "unexpected error from the vectorized engine"
+
+	// Propagate an error as an internal one (this should add annotations to the
+	// returned error).
+	annotatedErr := colexecerror.CatchVectorizedRuntimeError(func() {
+		colexecerror.InternalError(shouldBeCaughtErr)
+	})
+	require.NotNil(t, annotatedErr)
+	require.True(t, strings.Contains(annotatedErr.Error(), shouldBeCaughtText))
+	require.True(t, strings.Contains(annotatedErr.Error(), annotationText))
+
+	// Propagate an error as an expected one (this should *not* add annotations
+	// to the returned error).
+	notAnnotatedErr := colexecerror.CatchVectorizedRuntimeError(func() {
+		colexecerror.ExpectedError(shouldBeCaughtErr)
+	})
+	require.NotNil(t, notAnnotatedErr)
+	require.True(t, strings.Contains(notAnnotatedErr.Error(), shouldBeCaughtText))
+	require.False(t, strings.Contains(notAnnotatedErr.Error(), annotationText))
+}
+
+// TestNonVectorizedTestPanicIsNotCaught verifies that panics emitted via
+// NonVectorizedTestPanic() method are not caught by the catcher.
+func TestNonVectorizedTestPanicIsNotCaught(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	require.Panics(t, func() {
+		require.NoError(t, colexecerror.CatchVectorizedRuntimeError(func() {
+			colexecerror.NonVectorizedTestPanic("should panic")
+		}))
+	})
+}

--- a/pkg/sql/colflow/vectorized_panic_propagation_test.go
+++ b/pkg/sql/colflow/vectorized_panic_propagation_test.go
@@ -179,7 +179,7 @@ func (e *testNonVectorizedPanicEmitter) Init() {
 func (e *testNonVectorizedPanicEmitter) Next(ctx context.Context) coldata.Batch {
 	if !e.emitBatch {
 		e.emitBatch = true
-		panic("")
+		colexecerror.NonVectorizedTestPanic("")
 	}
 
 	e.emitBatch = false

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1575,7 +1575,6 @@ func TestLint(t *testing.T) {
 			"sql/col*",
 			":!sql/colexecbase/colexecerror/error.go",
 			":!sql/colexec/execpb/stats.pb.go",
-			":!sql/colflow/vectorized_panic_propagation_test.go",
 			// This exception is because execgen itself uses panics during code
 			// generation - not at execution time. The (glob,exclude) directive
 			// (see git help gitglossary) makes * behave like a normal, single dir


### PR DESCRIPTION
Backport 1/1 commits from #59866.

/cc @cockroachdb/release

---

This commit updates the vectorized panic-catcher to not catch panics if
they came from the catcher itself. Previously, this would occur when we
have several levels of catchers with the inner-most determining that the
panic is not from the vectorized engine. This would result in
`panic(panicObj)` call, however, the catcher one level up would see that
the panic came from `CatchVectorizedRuntimeError` which is "within" the
vectorized engine, thus, the higher level catcher could do something
with it while it shouldn't.

This commit also starts treating packages with `pkg/sql/row` in the path
prefix (e.g. `rowexec`, `row`, `rowenc`) as part of the vectorized
engine too (previously, only `rowexec` was treated as such).

Additionally, this commit adds a utility method `NonVectorizedTestPanic`
that can be used by the testing code to simulate panics that occur
outside of the vectorized engine.

Fixes: #58405
Fixes: #58644

Release note: None
