### PR TITLE
kv/kvserver: allow the merge transaction to be pushed

### DIFF
--- a/pkg/kv/mock_transactional_sender.go
+++ b/pkg/kv/mock_transactional_sender.go
@@ -198,6 +198,11 @@ func (m *MockTransactionalSender) GetSteppingMode(context.Context) SteppingMode 
 	return SteppingDisabled
 }
 
+// ManualRefresh is part of the TxnSender interface.
+func (m *MockTransactionalSender) ManualRefresh(ctx context.Context) error {
+	panic("unimplemented")
+}
+
 // MockTxnSenderFactory is a TxnSenderFactory producing MockTxnSenders.
 type MockTxnSenderFactory struct {
 	senderFunc func(context.Context, *roachpb.Transaction, roachpb.BatchRequest) (

--- a/pkg/kv/sender.go
+++ b/pkg/kv/sender.go
@@ -290,6 +290,20 @@ type TxnSender interface {
 	// GetSteppingMode accompanies ConfigureStepping. It is provided
 	// for use in tests and assertion checks.
 	GetSteppingMode(ctx context.Context) (curMode SteppingMode)
+
+	// ManualRefresh attempts to refresh a transactions read timestamp up to its
+	// provisional commit timestamp. In the case that the two are already the
+	// same, it is a no-op. The reason one might want to do that is to ensure
+	// that a transaction can commit without experiencing another push.
+	//
+	// A transaction which has proven all of its intents and has been fully
+	// refreshed and does not perform any additional reads or writes that does not
+	// contend with any other transactions will not be pushed further. This
+	// method's reason for existence is to ensure that range merge requests can
+	// be pushed but then can later commit without the possibility of needing to
+	// refresh reads performed on the RHS after the RHS has been subsumed but
+	// before the merge transaction completed.
+	ManualRefresh(ctx context.Context) error
 }
 
 // SteppingMode is the argument type to ConfigureStepping.


### PR DESCRIPTION
Historically we have not allowed the merge transaction to be pushed. The
reason we disabled this was because of the hazard due to attempting to
refresh reads on the RHS of the merge after the SubsumeRequest has been
sent. The `SubsumeRequest` effectively freezes the RHS until the merge
commits or aborts. In order to side-step this hazard, this change ensures
that nothing should prevent the merge transaction from either committing
or aborting.

### kv/kvclient: add ManualRefresh support for transactions

This commit adds support for client-initiated refreshes of transactions.
The implementation is somewhat simplistic in that it hijacks existing
logic that occurs during the sending of a request. This makes the
implementation more uniform with the rest of the client library at
the cost of being somewhat awkward and implicit from a code-reading
perspective.

The motivation for this change is to provide the necessary tools to allow
the merge transaction to get pushed. The adoption follows in the next
commit.

Fixes #59308.

Release note: None
