### PR TITLE
sql/sem/tree: parse ISO8601 format with decimal places for interval types

### DIFF
--- a/pkg/sql/sem/tree/interval.go
+++ b/pkg/sql/sem/tree/interval.go
@@ -429,7 +429,7 @@ func iso8601ToDuration(s string) (duration.Duration, error) {
 			l.offset++
 		}
 
-		v := l.consumeInt()
+		v, hasDecimal, vp := l.consumeNum()
 		u := l.consumeUnit('T')
 		if l.err != nil {
 			return d, l.err
@@ -437,6 +437,13 @@ func iso8601ToDuration(s string) (duration.Duration, error) {
 
 		if unit, ok := unitMap[u]; ok {
 			d = d.Add(unit.Mul(v))
+			if hasDecimal {
+				var err error
+				d, err = addFrac(d, unit, vp)
+				if err != nil {
+					return d, err
+				}
+			}
 		} else {
 			return d, pgerror.Newf(
 				pgcode.InvalidDatetimeFormat,


### PR DESCRIPTION
Previously, CockroachDB can not parse ISO8601 format interval type with
decimals, but Postgres can parse successfully. For example, running
"SELECT INTERVAL 'P1Y2M3DT4H5M6.235S'" in CockroachDB will cause an error
like:
ERROR: could not parse "P1Y2M3DT4H5M6.235S" as type interval: interval:
unknown unit . in ISO-8601 duration P1Y2M3DT4H5M6.235S

This patch fixes this issue. Now cockroachDB can parse ISO8601 format
using decimals correctly and return the same result as Postgres.

Fixes: #59720

Release note: none