### PR TITLE
release-20.2: colmem: limit batches of dynamic size by workmem in memory footprint

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -809,9 +809,13 @@ func NewColOperator(
 				return r, err
 			}
 
+			memoryLimit := execinfra.GetWorkMemLimit(flowCtx.Cfg)
+			if flowCtx.Cfg.TestingKnobs.ForceDiskSpill {
+				memoryLimit = 1
+			}
 			inMemoryHashJoiner := colexec.NewHashJoiner(
 				colmem.NewAllocator(ctx, hashJoinerMemAccount, factory),
-				hashJoinerUnlimitedAllocator, hjSpec, inputs[0], inputs[1],
+				hashJoinerUnlimitedAllocator, hjSpec, inputs[0], inputs[1], memoryLimit,
 			)
 			if args.TestingKnobs.DiskSpillingDisabled {
 				// We will not be creating a disk-backed hash joiner because we're

--- a/pkg/sql/colexec/columnarizer_test.go
+++ b/pkg/sql/colexec/columnarizer_test.go
@@ -81,7 +81,10 @@ func TestColumnarizerDrainsAndClosesInput(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 
 	rb := distsqlutils.NewRowBuffer([]*types.T{types.Int}, nil /* rows */, distsqlutils.RowBufferArgs{})
-	flowCtx := &execinfra.FlowCtx{EvalCtx: &evalCtx}
+	flowCtx := &execinfra.FlowCtx{
+		Cfg:     &execinfra.ServerConfig{Settings: st},
+		EvalCtx: &evalCtx,
+	}
 
 	const errMsg = "artificial error"
 	rb.Push(nil, &execinfrapb.ProducerMetadata{Err: errors.New(errMsg)})

--- a/pkg/sql/colexec/external_hash_joiner.go
+++ b/pkg/sql/colexec/external_hash_joiner.go
@@ -375,7 +375,7 @@ func NewExternalHashJoiner(
 		// limit, so we use the same unlimited allocator for both
 		// buildSideAllocator and outputUnlimitedAllocator arguments.
 		inMemHashJoiner: NewHashJoiner(
-			unlimitedAllocator, unlimitedAllocator, spec, leftJoinerInput, rightJoinerInput,
+			unlimitedAllocator, unlimitedAllocator, spec, leftJoinerInput, rightJoinerInput, memoryLimit,
 		).(*hashJoiner),
 		diskBackedSortMerge: diskBackedSortMerge,
 	}

--- a/pkg/sql/colexec/hashjoiner_test.go
+++ b/pkg/sql/colexec/hashjoiner_test.go
@@ -1077,7 +1077,7 @@ func BenchmarkHashJoiner(b *testing.B) {
 										require.NoError(b, err)
 										hj := NewHashJoiner(
 											testAllocator, testAllocator, hjSpec,
-											leftSource, rightSource,
+											leftSource, rightSource, defaultMemoryLimit,
 										)
 										hj.Init()
 

--- a/pkg/sql/colexec/mergejoiner_exceptall.eg.go
+++ b/pkg/sql/colexec/mergejoiner_exceptall.eg.go
@@ -41976,7 +41976,9 @@ func (o *mergeJoinExceptAllOp) build(ctx context.Context) {
 }
 
 func (o *mergeJoinExceptAllOp) Next(ctx context.Context) coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(o.outputTypes, o.output, 1 /* minCapacity */)
+	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
+		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+	)
 	for {
 		switch o.state {
 		case mjEntry:

--- a/pkg/sql/colexec/mergejoiner_fullouter.eg.go
+++ b/pkg/sql/colexec/mergejoiner_fullouter.eg.go
@@ -48111,7 +48111,9 @@ func (o *mergeJoinFullOuterOp) build(ctx context.Context) {
 }
 
 func (o *mergeJoinFullOuterOp) Next(ctx context.Context) coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(o.outputTypes, o.output, 1 /* minCapacity */)
+	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
+		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+	)
 	for {
 		switch o.state {
 		case mjEntry:

--- a/pkg/sql/colexec/mergejoiner_inner.eg.go
+++ b/pkg/sql/colexec/mergejoiner_inner.eg.go
@@ -32225,7 +32225,9 @@ func (o *mergeJoinInnerOp) build(ctx context.Context) {
 }
 
 func (o *mergeJoinInnerOp) Next(ctx context.Context) coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(o.outputTypes, o.output, 1 /* minCapacity */)
+	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
+		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+	)
 	for {
 		switch o.state {
 		case mjEntry:

--- a/pkg/sql/colexec/mergejoiner_intersectall.eg.go
+++ b/pkg/sql/colexec/mergejoiner_intersectall.eg.go
@@ -33373,7 +33373,9 @@ func (o *mergeJoinIntersectAllOp) build(ctx context.Context) {
 }
 
 func (o *mergeJoinIntersectAllOp) Next(ctx context.Context) coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(o.outputTypes, o.output, 1 /* minCapacity */)
+	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
+		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+	)
 	for {
 		switch o.state {
 		case mjEntry:

--- a/pkg/sql/colexec/mergejoiner_leftanti.eg.go
+++ b/pkg/sql/colexec/mergejoiner_leftanti.eg.go
@@ -40170,7 +40170,9 @@ func (o *mergeJoinLeftAntiOp) build(ctx context.Context) {
 }
 
 func (o *mergeJoinLeftAntiOp) Next(ctx context.Context) coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(o.outputTypes, o.output, 1 /* minCapacity */)
+	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
+		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+	)
 	for {
 		switch o.state {
 		case mjEntry:

--- a/pkg/sql/colexec/mergejoiner_leftouter.eg.go
+++ b/pkg/sql/colexec/mergejoiner_leftouter.eg.go
@@ -40309,7 +40309,9 @@ func (o *mergeJoinLeftOuterOp) build(ctx context.Context) {
 }
 
 func (o *mergeJoinLeftOuterOp) Next(ctx context.Context) coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(o.outputTypes, o.output, 1 /* minCapacity */)
+	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
+		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+	)
 	for {
 		switch o.state {
 		case mjEntry:

--- a/pkg/sql/colexec/mergejoiner_leftsemi.eg.go
+++ b/pkg/sql/colexec/mergejoiner_leftsemi.eg.go
@@ -32060,7 +32060,9 @@ func (o *mergeJoinLeftSemiOp) build(ctx context.Context) {
 }
 
 func (o *mergeJoinLeftSemiOp) Next(ctx context.Context) coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(o.outputTypes, o.output, 1 /* minCapacity */)
+	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
+		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+	)
 	for {
 		switch o.state {
 		case mjEntry:

--- a/pkg/sql/colexec/mergejoiner_rightouter.eg.go
+++ b/pkg/sql/colexec/mergejoiner_rightouter.eg.go
@@ -40027,7 +40027,9 @@ func (o *mergeJoinRightOuterOp) build(ctx context.Context) {
 }
 
 func (o *mergeJoinRightOuterOp) Next(ctx context.Context) coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(o.outputTypes, o.output, 1 /* minCapacity */)
+	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
+		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+	)
 	for {
 		switch o.state {
 		case mjEntry:

--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -1791,7 +1791,7 @@ func TestMergeJoinCrossProduct(t *testing.T) {
 			right: hashJoinerSourceSpec{
 				eqCols: []uint32{0}, sourceTypes: typs,
 			},
-		}, leftHJSource, rightHJSource)
+		}, leftHJSource, rightHJSource, defaultMemoryLimit)
 	hj.Init()
 
 	var mjOutputTuples, hjOutputTuples tuples

--- a/pkg/sql/colexec/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/mergejoiner_tmpl.go
@@ -1594,7 +1594,9 @@ func _SOURCE_FINISHED_SWITCH(_JOIN_TYPE joinTypeInfo) { // */}}
 // */}}
 
 func (o *mergeJoin_JOIN_TYPE_STRINGOp) Next(ctx context.Context) coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(o.outputTypes, o.output, 1 /* minCapacity */)
+	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
+		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
+	)
 	for {
 		switch o.state {
 		case mjEntry:

--- a/pkg/sql/colexec/ordered_synchronizer.eg.go
+++ b/pkg/sql/colexec/ordered_synchronizer.eg.go
@@ -31,6 +31,7 @@ import (
 // stream are assumed to be ordered according to the same set of columns.
 type OrderedSynchronizer struct {
 	allocator             *colmem.Allocator
+	memoryLimit           int64
 	inputs                []SynchronizerInput
 	ordering              colinfo.ColumnOrdering
 	typs                  []*types.T
@@ -92,14 +93,17 @@ func (o *OrderedSynchronizer) Child(nth int, verbose bool) execinfra.OpNode {
 }
 
 // NewOrderedSynchronizer creates a new OrderedSynchronizer.
+// - memoryLimit will limit the size of batches produced by the synchronizer.
 func NewOrderedSynchronizer(
 	allocator *colmem.Allocator,
+	memoryLimit int64,
 	inputs []SynchronizerInput,
 	typs []*types.T,
 	ordering colinfo.ColumnOrdering,
 ) (*OrderedSynchronizer, error) {
 	return &OrderedSynchronizer{
 		allocator:             allocator,
+		memoryLimit:           memoryLimit,
 		inputs:                inputs,
 		ordering:              ordering,
 		typs:                  typs,
@@ -255,7 +259,9 @@ func (o *OrderedSynchronizer) Next(ctx context.Context) coldata.Batch {
 
 func (o *OrderedSynchronizer) resetOutput() {
 	var reallocated bool
-	o.output, reallocated = o.allocator.ResetMaybeReallocate(o.typs, o.output, 1 /* minCapacity */)
+	o.output, reallocated = o.allocator.ResetMaybeReallocate(
+		o.typs, o.output, 1 /* minCapacity */, o.memoryLimit,
+	)
 	if reallocated {
 		o.outBoolCols = o.outBoolCols[:0]
 		o.outBytesCols = o.outBytesCols[:0]

--- a/pkg/sql/colexec/ordered_synchronizer_test.go
+++ b/pkg/sql/colexec/ordered_synchronizer_test.go
@@ -146,7 +146,7 @@ func TestOrderedSync(t *testing.T) {
 			typs[i] = types.Int
 		}
 		runTests(t, tc.sources, tc.expected, orderedVerifier, func(inputs []colexecbase.Operator) (colexecbase.Operator, error) {
-			return NewOrderedSynchronizer(testAllocator, operatorsToSynchronizerInputs(inputs), typs, tc.ordering)
+			return NewOrderedSynchronizer(testAllocator, defaultMemoryLimit, operatorsToSynchronizerInputs(inputs), typs, tc.ordering)
 		})
 	}
 }
@@ -187,7 +187,7 @@ func TestOrderedSyncRandomInput(t *testing.T) {
 		inputs[i].Op = newOpTestInput(batchSize, sources[i], typs)
 	}
 	ordering := colinfo.ColumnOrdering{{ColIdx: 0, Direction: encoding.Ascending}}
-	op, err := NewOrderedSynchronizer(testAllocator, inputs, typs, ordering)
+	op, err := NewOrderedSynchronizer(testAllocator, defaultMemoryLimit, inputs, typs, ordering)
 	require.NoError(t, err)
 	op.Init()
 	out := newOpTestOutput(op, expected)
@@ -217,7 +217,7 @@ func BenchmarkOrderedSynchronizer(b *testing.B) {
 	}
 
 	ordering := colinfo.ColumnOrdering{{ColIdx: 0, Direction: encoding.Ascending}}
-	op, err := NewOrderedSynchronizer(testAllocator, inputs, typs, ordering)
+	op, err := NewOrderedSynchronizer(testAllocator, defaultMemoryLimit, inputs, typs, ordering)
 	require.NoError(b, err)
 	op.Init()
 

--- a/pkg/sql/colexec/sort.go
+++ b/pkg/sql/colexec/sort.go
@@ -12,6 +12,7 @@ package colexec
 
 import (
 	"context"
+	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
@@ -271,7 +272,10 @@ func (p *sortOp) Next(ctx context.Context) coldata.Batch {
 			if toEmit > coldata.BatchSize() {
 				toEmit = coldata.BatchSize()
 			}
-			p.output, _ = p.allocator.ResetMaybeReallocate(p.inputTypes, p.output, toEmit)
+			// For now, we don't enforce any footprint-based memory limit.
+			// TODO(yuzefovich): refactor this.
+			const maxBatchMemSize = math.MaxInt64
+			p.output, _ = p.allocator.ResetMaybeReallocate(p.inputTypes, p.output, toEmit, maxBatchMemSize)
 			newEmitted := p.emitted + toEmit
 			for j := 0; j < len(p.inputTypes); j++ {
 				// At this point, we have already fully sorted the input. It is ok to do

--- a/pkg/sql/colexec/sorttopk.go
+++ b/pkg/sql/colexec/sorttopk.go
@@ -13,6 +13,7 @@ package colexec
 import (
 	"container/heap"
 	"context"
+	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
@@ -216,7 +217,10 @@ func (t *topKSorter) emit() coldata.Batch {
 	if toEmit > coldata.BatchSize() {
 		toEmit = coldata.BatchSize()
 	}
-	t.output, _ = t.allocator.ResetMaybeReallocate(t.inputTypes, t.output, toEmit)
+	// For now, we don't enforce any footprint-based memory limit.
+	// TODO(yuzefovich): refactor this.
+	const maxBatchMemSize = math.MaxInt64
+	t.output, _ = t.allocator.ResetMaybeReallocate(t.inputTypes, t.output, toEmit, maxBatchMemSize)
 	for i := range t.inputTypes {
 		vec := t.output.ColVec(i)
 		// At this point, we have already fully sorted the input. It is ok to do

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -260,8 +260,9 @@ type cFetcher struct {
 		tableoidCol []int64
 	}
 
-	typs      []*types.T
-	allocator *colmem.Allocator
+	typs        []*types.T
+	allocator   *colmem.Allocator
+	memoryLimit int64
 
 	// adapter is a utility struct that helps with memory accounting.
 	adapter struct {
@@ -276,7 +277,7 @@ const cFetcherBatchMinCapacity = 1
 func (rf *cFetcher) resetBatch(timestampOutputIdx, tableOidOutputIdx int) {
 	var reallocated bool
 	rf.machine.batch, reallocated = rf.allocator.ResetMaybeReallocate(
-		rf.typs, rf.machine.batch, cFetcherBatchMinCapacity,
+		rf.typs, rf.machine.batch, cFetcherBatchMinCapacity, rf.memoryLimit,
 	)
 	if reallocated {
 		rf.machine.colvecs = rf.machine.batch.ColVecs()
@@ -296,12 +297,14 @@ func (rf *cFetcher) resetBatch(timestampOutputIdx, tableOidOutputIdx int) {
 func (rf *cFetcher) Init(
 	codec keys.SQLCodec,
 	allocator *colmem.Allocator,
+	memoryLimit int64,
 	reverse bool,
 	lockStrength descpb.ScanLockingStrength,
 	lockWaitPolicy descpb.ScanLockingWaitPolicy,
 	tables ...row.FetcherTableArgs,
 ) error {
 	rf.allocator = allocator
+	rf.memoryLimit = memoryLimit
 	if len(tables) == 0 {
 		return errors.AssertionFailedf("no tables to fetch from")
 	}

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -190,9 +190,9 @@ func NewColBatchScan(
 		return nil, errors.AssertionFailedf("attempting to create a cFetcher with the IsCheck flag set")
 	}
 	if _, _, err := initCRowFetcher(
-		flowCtx.Codec(), allocator, &fetcher, table, int(spec.IndexIdx), columnIdxMap,
-		spec.Reverse, neededColumns, spec.Visibility, spec.LockingStrength, spec.LockingWaitPolicy,
-		sysColDescs,
+		flowCtx.Codec(), allocator, execinfra.GetWorkMemLimit(flowCtx.Cfg), &fetcher,
+		table, int(spec.IndexIdx), columnIdxMap, spec.Reverse, neededColumns,
+		spec.Visibility, spec.LockingStrength, spec.LockingWaitPolicy, sysColDescs,
 	); err != nil {
 		return nil, err
 	}
@@ -219,6 +219,7 @@ func NewColBatchScan(
 func initCRowFetcher(
 	codec keys.SQLCodec,
 	allocator *colmem.Allocator,
+	memoryLimit int64,
 	fetcher *cFetcher,
 	desc *tabledesc.Immutable,
 	indexIdx int,
@@ -251,7 +252,7 @@ func initCRowFetcher(
 		ValNeededForCol:  valNeededForCol,
 	}
 	if err := fetcher.Init(
-		codec, allocator, reverseScan, lockStrength, lockWaitPolicy, tableArgs,
+		codec, allocator, memoryLimit, reverseScan, lockStrength, lockWaitPolicy, tableArgs,
 	); err != nil {
 		return nil, false, err
 	}

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -782,7 +782,8 @@ func (s *vectorizedFlowCreator) setupInput(
 		if input.Type == execinfrapb.InputSyncSpec_ORDERED {
 			os, err := colexec.NewOrderedSynchronizer(
 				colmem.NewAllocator(ctx, s.newStreamingMemAccount(flowCtx), factory),
-				inputStreamOps, input.ColumnTypes, execinfrapb.ConvertToColumnOrdering(input.Ordering),
+				execinfra.GetWorkMemLimit(flowCtx.Cfg), inputStreamOps,
+				input.ColumnTypes, execinfrapb.ConvertToColumnOrdering(input.Ordering),
 			)
 			if err != nil {
 				return nil, nil, nil, err

--- a/pkg/sql/colmem/allocator_test.go
+++ b/pkg/sql/colmem/allocator_test.go
@@ -1,0 +1,110 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colmem_test
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResetMaybeReallocate(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	testMemMonitor := execinfra.NewTestMemMonitor(ctx, st)
+	defer testMemMonitor.Stop(ctx)
+	memAcc := testMemMonitor.MakeBoundAccount()
+	defer memAcc.Close(ctx)
+	evalCtx := tree.MakeTestingEvalContext(st)
+	testColumnFactory := coldataext.NewExtendedColumnFactory(&evalCtx)
+	testAllocator := colmem.NewAllocator(ctx, &memAcc, testColumnFactory)
+
+	t.Run("ResettingBehavior", func(t *testing.T) {
+		if coldata.BatchSize() == 1 {
+			skip.IgnoreLint(t, "the test assumes coldata.BatchSize() is at least 2")
+		}
+
+		var b coldata.Batch
+		typs := []*types.T{types.Bytes}
+
+		// Allocate a new batch and modify it.
+		b, _ = testAllocator.ResetMaybeReallocate(typs, b, coldata.BatchSize(), math.MaxInt64)
+		b.SetSelection(true)
+		b.Selection()[0] = 1
+		b.ColVec(0).Bytes().Set(1, []byte("foo"))
+
+		oldBatch := b
+		b, _ = testAllocator.ResetMaybeReallocate(typs, b, coldata.BatchSize(), math.MaxInt64)
+		// We should have used the same batch, and now it should be in a "reset"
+		// state.
+		require.Equal(t, oldBatch, b)
+		require.Nil(t, b.Selection())
+		// We should be able to set in the Bytes vector using an arbitrary
+		// position since the vector should have been reset.
+		require.NotPanics(t, func() { b.ColVec(0).Bytes().Set(0, []byte("bar")) })
+	})
+
+	t.Run("LimitingByMemSize", func(t *testing.T) {
+		if coldata.BatchSize() == 1 {
+			skip.IgnoreLint(t, "the test assumes coldata.BatchSize() is at least 2")
+		}
+
+		var b coldata.Batch
+		typs := []*types.T{types.Int}
+		const minCapacity = 2
+		const maxBatchMemSize = 0
+
+		// Allocate a batch with smaller capacity.
+		smallBatch := testAllocator.NewMemBatchWithFixedCapacity(typs, minCapacity/2)
+
+		// Allocate a new batch attempting to use the batch with too small of a
+		// capacity - new batch should be allocated.
+		b, _ = testAllocator.ResetMaybeReallocate(typs, smallBatch, minCapacity, maxBatchMemSize)
+		require.NotEqual(t, smallBatch, b)
+		require.Equal(t, minCapacity, b.Capacity())
+
+		oldBatch := b
+
+		// Reset the batch and confirm that a new batch is not allocated because
+		// the old batch has enough capacity and it has reached the memory
+		// limit.
+		b, _ = testAllocator.ResetMaybeReallocate(typs, b, minCapacity, maxBatchMemSize)
+		require.Equal(t, oldBatch, b)
+		require.Equal(t, minCapacity, b.Capacity())
+
+		if coldata.BatchSize() >= minCapacity*2 {
+			// Now reset the batch with large memory limit - we should get a new
+			// batch with the double capacity.
+			//
+			// ResetMaybeReallocate truncates the capacity at
+			// coldata.BatchSize(), so we run this part of the test only when
+			// doubled capacity will not be truncated.
+			b, _ = testAllocator.ResetMaybeReallocate(typs, b, minCapacity, math.MaxInt64)
+			require.NotEqual(t, oldBatch, b)
+			require.Equal(t, 2*minCapacity, b.Capacity())
+		}
+	})
+}

--- a/pkg/sql/sem/tree/eval_test/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test/eval_test.go
@@ -128,10 +128,12 @@ func TestEval(t *testing.T) {
 
 	t.Run("vectorized", func(t *testing.T) {
 		walk(t, func(t *testing.T, d *datadriven.TestData) string {
+			st := cluster.MakeTestingClusterSettings()
 			flowCtx := &execinfra.FlowCtx{
+				Cfg:     &execinfra.ServerConfig{Settings: st},
 				EvalCtx: evalCtx,
 			}
-			memMonitor := execinfra.NewTestMemMonitor(ctx, cluster.MakeTestingClusterSettings())
+			memMonitor := execinfra.NewTestMemMonitor(ctx, st)
 			defer memMonitor.Stop(ctx)
 			acc := memMonitor.MakeBoundAccount()
 			defer acc.Close(ctx)


### PR DESCRIPTION
Backport 1/1 commits from #59851.

/cc @cockroachdb/release

---

This commit adds a minor improvement to `ResetMaybeReallocate` method so
that it reuses the old batch (without doubling the capacity and
allocating a new batch) when the old batch has enough capacity and
reached the provided limit in size. This change effectively allows us to
limit all batches flowing through the vectorized engine by `workmem`
setting in size since the main batch-producers (cfetcher and
columnarizer) use this method.

Addresses: https://github.com/cockroachlabs/support/issues/808.

Release note (sql change): Most batches of data flowing through the
vectorized execution engine will now be limited in size by
`sql.distsql.temp_storage.workmem` (64MiB by default) which should
improve the stability of CockroachDB clusters.
