### PR TITLE
sqlutil: remove QueryWithCols in favor of QueryRowExWithCols

### DIFF
--- a/pkg/ccl/backupccl/create_scheduled_backup_test.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup_test.go
@@ -140,17 +140,17 @@ func (h *testHelper) createBackupSchedule(
 		var id int64
 		require.NoError(t, rows.Scan(&id, &unusedStr, &unusedStr, &unusedTS, &unusedStr, &unusedStr))
 		// Query system.scheduled_job table and load those schedules.
-		datums, cols, err := h.cfg.InternalExecutor.QueryWithCols(
+		datums, cols, err := h.cfg.InternalExecutor.QueryRowExWithCols(
 			context.Background(), "sched-load", nil,
 			sessiondata.InternalExecutorOverride{User: security.RootUserName()},
 			"SELECT * FROM system.scheduled_jobs WHERE schedule_id = $1",
 			id,
 		)
 		require.NoError(t, err)
-		require.Equal(t, 1, len(datums))
+		require.NotNil(t, datums)
 
 		s := jobs.NewScheduledJob(h.env)
-		require.NoError(t, s.InitFromDatums(datums[0], cols))
+		require.NoError(t, s.InitFromDatums(datums, cols))
 		schedules = append(schedules, s)
 	}
 

--- a/pkg/jobs/testutils_test.go
+++ b/pkg/jobs/testutils_test.go
@@ -127,7 +127,7 @@ func (h *testHelper) newScheduledJobForExecutor(
 // loadSchedule loads  all columns for the specified scheduled job.
 func (h *testHelper) loadSchedule(t *testing.T, id int64) *ScheduledJob {
 	j := NewScheduledJob(h.env)
-	rows, cols, err := h.cfg.InternalExecutor.QueryWithCols(
+	row, cols, err := h.cfg.InternalExecutor.QueryRowExWithCols(
 		context.Background(), "sched-load", nil,
 		sessiondata.InternalExecutorOverride{User: security.RootUserName()},
 		fmt.Sprintf(
@@ -135,9 +135,8 @@ func (h *testHelper) loadSchedule(t *testing.T, id int64) *ScheduledJob {
 			h.env.ScheduledJobsTableName(), id),
 	)
 	require.NoError(t, err)
-
-	require.Equal(t, 1, len(rows))
-	require.NoError(t, j.InitFromDatums(rows[0], cols))
+	require.NotNil(t, row)
+	require.NoError(t, j.InitFromDatums(row, cols))
 	return j
 }
 

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
@@ -661,17 +661,6 @@ func (ie *wrappedInternalExecutor) ExecEx(
 	return ie.wrapped.ExecEx(ctx, opName, txn, o, stmt, qargs...)
 }
 
-func (ie *wrappedInternalExecutor) QueryWithCols(
-	ctx context.Context,
-	opName string,
-	txn *kv.Txn,
-	o sessiondata.InternalExecutorOverride,
-	statement string,
-	qargs ...interface{},
-) ([]tree.Datums, colinfo.ResultColumns, error) {
-	panic("unimplemented")
-}
-
 func (ie *wrappedInternalExecutor) QueryRowEx(
 	ctx context.Context,
 	opName string,
@@ -691,6 +680,17 @@ func (ie *wrappedInternalExecutor) QueryRowEx(
 func (ie *wrappedInternalExecutor) QueryRow(
 	ctx context.Context, opName string, txn *kv.Txn, statement string, qargs ...interface{},
 ) (tree.Datums, error) {
+	panic("not implemented")
+}
+
+func (ie *wrappedInternalExecutor) QueryRowExWithCols(
+	ctx context.Context,
+	opName string,
+	txn *kv.Txn,
+	session sessiondata.InternalExecutorOverride,
+	stmt string,
+	qargs ...interface{},
+) (tree.Datums, colinfo.ResultColumns, error) {
 	panic("not implemented")
 }
 


### PR DESCRIPTION
This commit refactors all usages of
`sqlutil.InternalExecutor.QueryWithCols` method in favor of newly added
`QueryRowExWithCols` since in almost all places where the former was
used, we expected exactly one row. The only noticeable change is the
refactor of `jobScheduler.executeSchedules` where we now use the
iterator pattern. The difference there is that now it is possible to
execute some schedules before encountering an error on the iterator
(previously, we would buffer up all rows first), but this change is
acceptable because each schedule is executed under savepoint to guard
against errors in schedule planning/execution.

Addresses: #48595.

Release note: None