### PR TITLE
colserde: fix null handling in arrowbatchconverter

### DIFF
--- a/pkg/sql/colcontainer/diskqueue_test.go
+++ b/pkg/sql/colcontainer/diskqueue_test.go
@@ -178,7 +178,7 @@ func TestDiskQueueCloseOnErr(t *testing.T) {
 	defer cleanup()
 
 	serverCfg := &execinfra.ServerConfig{}
-	serverCfg.TestingKnobs.MemoryLimitBytes = 1
+	serverCfg.TestingKnobs.ForceDiskSpill = true
 	diskMon := execinfra.NewLimitedMonitor(ctx, testDiskMonitor, serverCfg, t.Name())
 	defer diskMon.Stop(ctx)
 	diskAcc := diskMon.MakeBoundAccount()

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -963,13 +963,7 @@ func NewColOperator(
 			rightTypes := make([]*types.T, len(spec.Input[1].ColumnTypes))
 			copy(rightTypes, spec.Input[1].ColumnTypes)
 
-			// TODO(yuzefovich): audit all usages of GetWorkMemLimit to see
-			// whether we should be paying attention to ForceDiskSpill knob
-			// there too.
 			memoryLimit := execinfra.GetWorkMemLimit(flowCtx.Cfg)
-			if flowCtx.Cfg.TestingKnobs.ForceDiskSpill {
-				memoryLimit = 1
-			}
 			if len(core.HashJoiner.LeftEqColumns) == 0 {
 				// We are performing a cross-join, so we need to plan a
 				// specialized operator.

--- a/pkg/sql/colexec/external_hash_joiner_test.go
+++ b/pkg/sql/colexec/external_hash_joiner_test.go
@@ -130,8 +130,7 @@ func TestExternalHashJoinerFallbackToSortMergeJoin(t *testing.T) {
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 			TestingKnobs: execinfra.TestingKnobs{
-				ForceDiskSpill:   true,
-				MemoryLimitBytes: 1,
+				ForceDiskSpill: true,
 			},
 			DiskMonitor: testDiskMonitor,
 		},

--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -62,12 +62,12 @@ func TestExternalSort(t *testing.T) {
 	// Test the case in which the default memory is used as well as the case in
 	// which the joiner spills to disk.
 	for _, spillForced := range []bool{false, true} {
-		flowCtx.Cfg.TestingKnobs.ForceDiskSpill = spillForced
 		if spillForced {
-			// In order to increase test coverage of recursive merging, we have the
-			// lowest possible memory limit - this will force creating partitions
+			// In order to increase test coverage of recursive merging, we have
+			// the lowest possible memory limit (that will not be overridden by
+			// the external sorter) - this will force creating partitions
 			// consisting of a single batch.
-			flowCtx.Cfg.TestingKnobs.MemoryLimitBytes = 1
+			flowCtx.Cfg.TestingKnobs.MemoryLimitBytes = 2
 		} else {
 			flowCtx.Cfg.TestingKnobs.MemoryLimitBytes = 0
 		}

--- a/pkg/sql/colexec/relative_rank.eg.go
+++ b/pkg/sql/colexec/relative_rank.eg.go
@@ -90,6 +90,14 @@ func NewRelativeRankOperator(
 	}
 }
 
+// relativeRankNumRequiredFDs is the minimum number of file descriptors that
+// might be needed for the machinery of the relative rank operators: the maximum
+// number is needed when CUME_DIST function with either PARTITION BY or ORDER BY
+// clause (or both) is used - we need 3 FDs for each of the spilling queues used
+// by the operator directly plus we use an external sort to handle PARTITION BY
+// and/or ORDER BY clauses.
+const relativeRankNumRequiredFDs = 3 + ExternalSorterMinPartitions
+
 // NOTE: in the context of window functions "partitions" mean a different thing
 // from "partition" in the context of external algorithms and some disk
 // infrastructure: here, "partitions" are sets of tuples that are not distinct

--- a/pkg/sql/colexec/relative_rank_tmpl.go
+++ b/pkg/sql/colexec/relative_rank_tmpl.go
@@ -100,6 +100,14 @@ func NewRelativeRankOperator(
 	}
 }
 
+// relativeRankNumRequiredFDs is the minimum number of file descriptors that
+// might be needed for the machinery of the relative rank operators: the maximum
+// number is needed when CUME_DIST function with either PARTITION BY or ORDER BY
+// clause (or both) is used - we need 3 FDs for each of the spilling queues used
+// by the operator directly plus we use an external sort to handle PARTITION BY
+// and/or ORDER BY clauses.
+const relativeRankNumRequiredFDs = 3 + ExternalSorterMinPartitions
+
 // NOTE: in the context of window functions "partitions" mean a different thing
 // from "partition" in the context of external algorithms and some disk
 // infrastructure: here, "partitions" are sets of tuples that are not distinct

--- a/pkg/sql/colexec/window_functions_test.go
+++ b/pkg/sql/colexec/window_functions_test.go
@@ -54,12 +54,6 @@ func TestWindowFunctions(t *testing.T) {
 			DiskMonitor: testDiskMonitor,
 		},
 	}
-	// All supported window function operators will use from 0 to 3 disk queues
-	// with each using a single FD at any point in time. Additionally, the
-	// disk-backed sorter (that will be planned depending on PARTITION BY and
-	// ORDER BY combinations) will be limited to this number using a testing
-	// knob, so 3 is necessary and sufficient.
-	const maxNumberFDs = 3
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
 
@@ -299,7 +293,9 @@ func TestWindowFunctions(t *testing.T) {
 					},
 					ResultTypes: append(ct, resultType),
 				}
-				sem := colexecbase.NewTestingSemaphore(maxNumberFDs)
+				// Relative rank operators currently require the most number of
+				// FDs.
+				sem := colexecbase.NewTestingSemaphore(relativeRankNumRequiredFDs)
 				args := &NewColOperatorArgs{
 					Spec:                spec,
 					Inputs:              inputs,
@@ -309,7 +305,6 @@ func TestWindowFunctions(t *testing.T) {
 				}
 				semsToCheck = append(semsToCheck, sem)
 				args.TestingKnobs.UseStreamingMemAccountForBuffering = true
-				args.TestingKnobs.NumForcedRepartitions = maxNumberFDs
 				result, err := TestNewColOperator(ctx, flowCtx, args)
 				accounts = append(accounts, result.OpAccounts...)
 				monitors = append(monitors, result.OpMonitors...)

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -714,12 +714,12 @@ func (s *vectorizedFlowCreator) setupRouter(
 		allocators[i] = colmem.NewAllocator(ctx, &acc, factory)
 		s.accounts = append(s.accounts, &acc)
 	}
-	limit := execinfra.GetWorkMemLimit(flowCtx.Cfg)
-	if flowCtx.Cfg.TestingKnobs.ForceDiskSpill {
-		limit = 1
-	}
 	diskMon, diskAccounts := s.createDiskAccounts(ctx, flowCtx, mmName, len(output.Streams))
-	router, outputs := colexec.NewHashRouter(allocators, input, outputTyps, output.HashColumns, limit, s.diskQueueCfg, s.fdSemaphore, diskAccounts, metadataSourcesQueue, toClose)
+	router, outputs := colexec.NewHashRouter(
+		allocators, input, outputTyps, output.HashColumns,
+		execinfra.GetWorkMemLimit(flowCtx.Cfg), s.diskQueueCfg, s.fdSemaphore,
+		diskAccounts, metadataSourcesQueue, toClose,
+	)
 	runRouter := func(ctx context.Context, _ context.CancelFunc) {
 		router.Run(logtags.AddTag(ctx, "hashRouterID", strings.Join(streamIDs, ",")))
 	}

--- a/pkg/sql/colflow/vectorized_flow_space_test.go
+++ b/pkg/sql/colflow/vectorized_flow_space_test.go
@@ -211,7 +211,7 @@ func TestVectorizeAllocatorSpaceError(t *testing.T) {
 					}
 				} else {
 					memMon.Start(ctx, nil, mon.MakeStandaloneBudget(1))
-					flowCtx.Cfg.TestingKnobs.MemoryLimitBytes = 1
+					flowCtx.Cfg.TestingKnobs.ForceDiskSpill = true
 				}
 				defer memMon.Stop(ctx)
 				acc := memMon.MakeBoundAccount()

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -923,11 +923,7 @@ func NewMonitor(ctx context.Context, parent *mon.BytesMonitor, name string) *mon
 func NewLimitedMonitor(
 	ctx context.Context, parent *mon.BytesMonitor, config *ServerConfig, name string,
 ) *mon.BytesMonitor {
-	limit := GetWorkMemLimit(config)
-	if config.TestingKnobs.ForceDiskSpill {
-		limit = 1
-	}
-	limitedMon := mon.NewMonitorInheritWithLimit(name, limit, parent)
+	limitedMon := mon.NewMonitorInheritWithLimit(name, GetWorkMemLimit(config), parent)
 	limitedMon.Start(ctx, parent, mon.BoundAccount{})
 	return limitedMon
 }

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -411,9 +411,6 @@ func (jr *joinReader) initJoinReaderStrategy(
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// joinReader will overflow to disk if this limit is not enough.
 	limit := execinfra.GetWorkMemLimit(flowCtx.Cfg)
-	if flowCtx.Cfg.TestingKnobs.ForceDiskSpill {
-		limit = 1
-	}
 	// Initialize memory monitors and row container for looked up rows.
 	jr.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx.Cfg, "joinreader-limited")
 	jr.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.Cfg.DiskMonitor, "joinreader-disk")


### PR DESCRIPTION
**colserde: fix null handling in arrowbatchconverter**

This commit fixes the null handling in the ArrowBatchConverter.
Previously, we would always marshal/unmarshal values without paying
attention to the nulls bitmaps. Those operations could result in errors
which would stop the execution whereas it shouldn't. Now we are paying
attention to the nulls bitmaps and we enhance the testing harness to
insert garbage values when setting random nulls.

In theory, this bug could occur in production, but it seems unlikely in
practice.

Release note: None

**colexec: override testing mem limit in external operators**

This commit overrides the testing memory limit of 1 byte in the external
operators to the default value of 64MiB. Such behavior is acceptable
because this limit will matter only once the operators spill to disk
(which is the goal of setting such low limit in the first place). This
allows for faster test runs and more realistic benchmarks.

Release note: None

**execinfra: check ForceDiskSpill in GetWorkMemLimit**

This commit cleans up the logic around `ForceDiskSpill` and
`MemoryLimitBytes` testing knobs. Now we require that only one of the
two knobs is used, and we also check the former knob in
`GetWorkMemLimit` utility function since we have already been doing it
in all callsites.

Additionally, several callsites that have `MemoryLimitBytes = 1` are
replaced with more explicit `ForceDiskSpill = true`.

Release note: None