### PR TITLE
go.mod: bump etcd/raft to pick up probing improvements

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -2891,8 +2891,8 @@ def go_deps():
         patches = [
             "@cockroach//build/patches:io_etcd_go_etcd_raft_v3.patch",
         ],
-        sum = "h1:+9CYw4wP53Ryj4CtTy4VJv1fzA6SgyVZkCUEubdsISg=",
-        version = "v3.0.0-20201109164711-01844fd28560",
+        sum = "h1:W9sYVQfb5q8/WMnlTkjpYK8CwMfGCU6Tp9mR+Qm6NFU=",
+        version = "v3.0.0-20210215124703-719f6ce06fbc",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -145,7 +145,7 @@ require (
 	github.com/twpayne/go-geom v1.3.6
 	github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad
 	github.com/zabawaba99/go-gitignore v0.0.0-20200117185801-39e6bddfb292
-	go.etcd.io/etcd/raft/v3 v3.0.0-20201109164711-01844fd28560
+	go.etcd.io/etcd/raft/v3 v3.0.0-20210215124703-719f6ce06fbc
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 	golang.org/x/exp v0.0.0-20210201131500-d352d2db2ceb
 	golang.org/x/lint v0.0.0-20200130185559-910be7a94367

--- a/go.sum
+++ b/go.sum
@@ -758,8 +758,8 @@ github.com/zabawaba99/go-gitignore v0.0.0-20200117185801-39e6bddfb292/go.mod h1:
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 go.etcd.io/etcd/pkg/v3 v3.0.0-20201109164711-01844fd28560 h1:U/PIBuOTa8JXLPKF81Xh7xhIjA0jbpyqFWUPIiT4Ilc=
 go.etcd.io/etcd/pkg/v3 v3.0.0-20201109164711-01844fd28560/go.mod h1:0HiXlybqS+XtfgnNkiEZWwGXYYEhWsWL8fDVdZzb7is=
-go.etcd.io/etcd/raft/v3 v3.0.0-20201109164711-01844fd28560 h1:+9CYw4wP53Ryj4CtTy4VJv1fzA6SgyVZkCUEubdsISg=
-go.etcd.io/etcd/raft/v3 v3.0.0-20201109164711-01844fd28560/go.mod h1:k4YNiZ1JOTtvGkRi4GMQRKOAU/ZvuDEQ4h+/Fb7hYEA=
+go.etcd.io/etcd/raft/v3 v3.0.0-20210215124703-719f6ce06fbc h1:W9sYVQfb5q8/WMnlTkjpYK8CwMfGCU6Tp9mR+Qm6NFU=
+go.etcd.io/etcd/raft/v3 v3.0.0-20210215124703-719f6ce06fbc/go.mod h1:lOAojD+joNvQ+1WBvyjLbjEwCDgymdjYYZdkI6uddZ4=
 go.opencensus.io v0.18.0 h1:Mk5rgZcggtbvtAun5aJzAtjKKN/t0R3jJPlWILlv938=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=


### PR DESCRIPTION
This picks up this PR:

https://github.com/etcd-io/etcd/pull/11964

There were no other code changes affecting raft.

Release note (bug fix): fixed a deficiency in the replication layer
that could result in ranges becoming unavailable for prolonged periods
of time (hours) when a write burst occurred under system overload.
While unavailable, the range status page for the affected range would
show a last index much larger than the committed index and no movement
in these indexes on a quorum of the replicas. Note that this should
be distinguished from the case in which enough replicas are offline
to constitute a loss of quorum, where the replication layer can not
make progress due to the loss of quorum itself.
