### PR TITLE
rfcs: Task groups in Go: per-session resource usage tracking

### DIFF
--- a/docs/RFCS/20210215_task_group_resource_tracking_cpu.md
+++ b/docs/RFCS/20210215_task_group_resource_tracking_cpu.md
@@ -1,0 +1,579 @@
+- Feature Name: Task groups in Go: per-session resource usage tracking (CPU)
+- Status: draft
+- Start Date: 2021-02-08
+- Authors: knz, tbg, peter
+- RFC PR: [#60589](https://github.com/cockroachdb/cockroach/pull/60589)
+- Cockroach Issue: [#59998](https://github.com/cockroachdb/cockroach/issues/59998)
+
+
+# Summary
+
+This RFC proposes to use custom extensions to the Go runtime to track
+CPU usage, as well as other CPU-related metrics, per SQL session --
+including all goroutines that do work on behalf of a SQL session, and
+without instrumenting the code manually inside CockroachDB.
+
+In a later stage, this work will also enable constraining
+CPU usage per SQL session or query according to configurable quota.
+
+Note: there is a [separate
+RFC](20210215_task_group_resource_tracking_ram.md) for observing and
+restricting RAM usage.
+
+Note: this work is valuable even if we consider splitting the SQL
+processing into different processes (e.g. one process for SQL, one for
+KV; or one process per SQL tenant; or separate process for SQL
+gateways and distSQL processors). Even in a multi-process
+architecture, we are unlikely to create one separate process per SQL
+session. The proposal in this RFC provides fine-grained resource
+consumption separation between SQL sessions, including separate
+sessions for the same SQL tenant.
+
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
+**Table of Contents**
+
+- [Summary](#summary)
+- [Motivation](#motivation)
+- [Technical design](#technical-design)
+    - [Proof of concept: CPU scheduler ticks](#proof-of-concept-cpu-scheduler-ticks)
+        - [Precise CPU time / utilization](#precise-cpu-time--utilization)
+    - [Later benefit: resource control (not just measurement)](#later-benefit-resource-control-not-just-measurement)
+    - [Related work](#related-work)
+        - [Tailscale's custom Go patches](#tailscales-custom-go-patches)
+        - [Related work in the Go project](#related-work-in-the-go-project)
+    - [Rationale and Alternatives](#rationale-and-alternatives)
+        - [Manual instrumentation](#manual-instrumentation)
+        - [PProf-based CPU reporting](#pprof-based-cpu-reporting)
+        - [Taskgroup-based CPU usage sampling](#taskgroup-based-cpu-usage-sampling)
+- [Explain it to someone else](#explain-it-to-someone-else)
+- [Unresolved questions](#unresolved-questions)
+
+<!-- markdown-toc end -->
+
+
+# Motivation
+
+Today there is an issue when CPU usage is high, it is difficult
+to track down which SQL session or query is responsible for that load.
+
+In turn the difficulty comes from the Go runtime which does not provide
+an abstraction to extract metrics per group of goroutines performing
+related work on behalf of a common client-defined query or session.
+
+Even though we are also considering process-level separation (e.g. one
+separate SQL process per tenant), users still wish to know which
+queries use the most CPU within the same CockroachDB process.
+
+# Technical design
+
+In a nutshell, the proposed change adds new APIs to Go's `runtime` package to
+create a new “task group” abstraction, which captures counters and other
+control mechanisms shared by a collection of goroutines and is inherited
+automatically by all new goroutines indirectly spawned.
+
+See the [companion mini-RFC](20210215_task_groups.md) for details
+about the new abstraction.
+
+Once this API is in place inside Go, we can extend CockroachDB as follows:
+
+- whenever a SQL session is created, a new task group is created for its
+  goroutine and its children goroutines
+- distsql execution on other nodes also sets up a task group whenever
+  one or more flows are set up on behalf of a query started on a different node,
+  to connect all the flows for that queries “under” a common, separate task group.
+- as the distsql processors advance or complete work, the current metrics
+  of the task group are pushed back to the gateway to update common counters
+  for the session.
+- on the gateway, the vtable `crdb_internal.node_sessions` and other related
+  facilities report, for each session/query, the additional metrics from the task group.
+- SQL job execution also creates task groups, one per job, in a way
+  that can be inspected separately (e.g. via `crdb_internal.jobs`? TBD)
+
+And an example application inside CockroachDB, to measure CPU
+scheduling ticks and absolute run time in nanoseconds, separately for
+each SQL session, is available here:
+
+https://github.com/cockroachdb/cockroach/pull/60588
+
+## Proof of concept: CPU scheduler ticks
+
+**NB: this section is just proof of concept. See section immediately below
+for a better production-level approach.**
+
+Context: The Go scheduler is preemptive and runs goroutines in
+segments of time called "ticks" (at most 10ms per tick).
+
+In order to estimate CPU usage for different SQL queries/sessions, and
+generally identify which SQL session(s)/query(ies) is/are responsible
+for peaks in CPU usage, we can collect stats about scheduler
+ticks.
+
+However we cannot / do not want to do so separately per goroutine,
+since a single SQL session/query may be served by many goroutines over
+time. Instead, we wish to collect this metric across all goroutines
+that participate in a SQL query/session.
+
+For this we can use the new task group abstraction.
+
+The RFC proposes to extend the internal task group struct with a new
+`schedticks` field, incremented upon every scheduler tick for the
+current task group.
+
+Example diff to add this increment, in `runtime/proc.go`:
+
+```go
+func execute(gp *g, inheritTime bool) {
+   ...
+    if gp.taskGroupCtx != nil {
+        atomic.Xadd64(&gp.taskGroupCtx.schedtick, 1)
+    }
+```
+
+Then we can retrieve the scheduling ticks for a given task group, in
+`runtime/task_group.go`:
+
+```go
+func initTaskGroupMetrics() {
+  ...
+  taskGroupMetrics.metrics = map[string]func(tg *t, out *metricValue){
+		"/taskgroup/sched/ticks:ticks": func(tg *t, out *metricValue) {
+			out.kind = metricKindUint64
+			out.scalar = atomic.Load64(&tg.schedtick)
+		},
+        ...
+}
+
+//go:linkname readTaskGroupMetrics runtime/metrics.runtime_readTaskGroupMetrics
+func readTaskGroupMetrics(taskGroup InternalTaskGroup, samplesp unsafe.Pointer, len int, cap int) {
+	sl := slice{samplesp, len, cap}
+	samples := *(*[]metricSample)(unsafe.Pointer(&sl))
+	...
+ 	for i := range samples {
+		sample := &samples[i]
+		compute, ok := taskGroupMetrics.metrics[sample.name]
+		compute((*t)(taskGroup), &sample.value)
+    }
+}
+```
+
+Then we expose the metrics via the new `metrics` package, in
+`runtime/metrics/task_group.go`:
+
+
+```go
+// Implemented in the runtime.
+func runtime_readTaskGroupMetrics(runtime.InternalTaskGroup, unsafe.Pointer, int, int)
+
+// ReadTaskGroup populates each Value field in the given slice of metric samples.
+// The metrics are read for the specified task group only.
+//
+// See the documentation of Read() for details.
+func ReadTaskGroup(taskGroup runtime.InternalTaskGroup, m []Sample) {
+	runtime_readTaskGroupMetrics(taskGroup, unsafe.Pointer(&m[0]), len(m), cap(m))
+}
+```
+
+(NB: This is the API pattern promoted by [Go 1.16's new `metrics` package](https://tip.golang.org/pkg/runtime/metrics/).)
+
+
+
+
+And then we can connect this inside SQL via the [`go-plus`
+library](https://github.com/cockroachdb/go-plus), in
+`sql/conn_executor.go`:
+
+```go
+func (ex *connExecutor) run(...) {
+    ...
+    ex.taskGroup = taskgroup.SetTaskGroup()
+}
+
+...
+
+func (ex *connExecutor) serialize() serverpb.Session {
+    ...
+	taskGroupMetrics := []metrics.Sample{
+		{Name: "/taskgroup/sched/ticks:ticks"}, ...}
+	metrics.ReadTaskGroup(ex.taskGroup, taskGroupMetrics)
+	var schedTicks uint64
+	if taskGroupMetrics[0].Value.Kind() != metrics.KindBad {
+		schedTicks = taskGroupMetrics[0].Value.Uint64()
+	}
+
+    return serverpb.Session{
+         ...
+        // Experimental
+        SchedTicks: schedTicks,
+    }
+}
+```
+
+And then, to make it observable for SQL DBAs, in `sql/crdb_internal.go`:
+
+```go
+func populateSessionsTable(...) {
+   ...
+   ... addRow(
+            ...
+            tree.NewDInt(tree.DInt(session.SchedTicks)),
+   )
+   ...
+}
+```
+
+Example usage:
+
+```
+root@:26257/defaultdb> select node_id, client_address, last_active_Query, sched_ticks 
+                       from crdb_internal.node_sessions;
+
+  node_id | client_address | last_active_query | sched_ticks
+----------+----------------+-------------------+--------------
+        1 | [::1]:27580    | SHOW database     |         972
+        1 | [::1]:27577    | SHOW database     |        6675
+(2 rows)
+```
+
+This shows 2 distinct SQL sessions (there are two interactive terminals
+running a SQL shell connected to this node). The `sched_ticks` column
+reports that one session has used 972 ticks and the other has used 6675 ticks.
+
+The value of sched ticks can be confirmed to increase in relation to
+actual CPU usage. We can compare how the ticks are incremented for several operations:
+
+| Operation                                           | Tick increment                              |
+|-----------------------------------------------------|---------------------------------------------|
+| `pg_sleep(0)`                                       | 20                                          |
+| `pg_sleep(1)`                                       | 20 (sleeping time does not incur CPU usage) |
+| `select count(*) from generate_series(1,10000000)`  | 280                                         |
+| `select count(*) from generate_series(1,100000000)` | 2800  (ten times more than previous)        |
+
+As this confirms, idle sessions don't increase their `sched_ticks`, whereas busy sessions increment
+it in proportion to the work actually done.
+
+(NB: the Go changes outlined above do not include the aggregation of
+sched ticks across multiple nodes when queries are distributed. We'd
+need to think further about how to reason about CPU usage on multiple
+nodes, and whether we even want this to be aggregated, or whether we
+want the CPU ticks to be presented side-by-side for separate nodes.)
+
+PR where this change has been prototyped: https://github.com/cockroachdb/cockroach/pull/60589
+
+**Why this approach is unsuitable to measure CPU time:**
+
+It is possible for ticks to be shorter than the preemption interval,
+for example when a Goroutine yields CPU to grab a lock currently held
+elswehere. So a goroutine that often swaps in and out of CPU usage
+because its progress is blocked by another goroutine will appear as if
+it is using a lot of CPU time, even though it is merely yielding CPU
+more often.
+
+Generally, *ticks* are not a very precise measurement of CPU time.
+
+### Precise CPU time / utilization
+
+We reuse the same approach as the previous section; however instead of
+ticks we measure actual CPU time, not ticks.
+
+We achieve this using the internal (non-exported) runtime function
+`nanotime()` or `walltime()`.  These functions report the current time
+at nanosecond-precision. They have negligible cost, because they
+merely read a value from RAM via the [process's vDSO
+interface](https://man7.org/linux/man-pages/man7/vdso.7.html).
+
+This works as follows:
+
+- we add a new field `lastSchedTime` in the `g` struct.
+- we add a new field `nanos` in the `taskGroupCtx`
+
+- upon leaving the processor (in the `dropg()` function):
+  - we take `lastSchedtime` from the current/past `g` (indicates the start time of the goroutine we're scheduling away from)
+  - we measure the current time with `nanotime()` or `walltime()`.
+  - we add the delta between current time and `lastSchedTime` to `taskGroupCtx.nanos`
+
+- upon entering the processor (in the `execute()` function):
+  - we store the current time in `lastSchedTime` of the new `g`.
+
+On CPU architectures that provide a hardware timestamp counter (TSC)
+that is synchronized across all CPU cores, where the TSC is available
+without special system privileges, and where the TSC unit has a clear
+relationship to real time, we can also build a custom assembly-level
+function that retrieves the TSC and uses that instead. This may yield
+even better performance since it does not need to synchronize the vDSO
+timestamp across all core caches.
+
+Example usage:
+
+```
+root@:26257/defaultdb> select node_id, client_address, last_active_Query, cpu_time
+                       from crdb_internal.node_sessions;
+  node_id | client_address | last_active_query |    cpu_time
+----------+----------------+-------------------+------------------
+        1 | [::1]:58417    | SHOW database     | 00:00:00.003878
+        1 | [::1]:58420    | SHOW database     | 00:00:00.00287
+(2 rows)
+```
+
+This shows 2 distinct SQL sessions (there are two interactive terminals
+running a SQL shell connected to this node). The `cpu_time` column
+reports that one session has used 388ms of CPU time and the other has used 892ms.
+
+The CPU time column can be confirmed to increase in relation to
+actual CPU usage. For example:
+
+| Operation                                           | CPU time increment                              |
+|-----------------------------------------------------|-------------------------------------------------|
+| `pg_sleep(0)`                                       | ~900µs                                          |
+| `pg_sleep(1)`                                       | ~900µs (sleeping time does not incur CPU usage) |
+| `select count(*) from generate_series(1,10000000)`  | ~1.24s                                          |
+| `select count(*) from generate_series(1,100000000)` | ~12.4s  (ten times more than previous)          |
+
+As this confirms, idle sessions don't increase their CPU time, whereas busy sessions increment it.
+
+(NB: Again, the Go changes outlined above do not include the aggregation of
+CPU time across multiple nodes when queries are distributed.)
+
+PR where this change has been prototyped: https://github.com/cockroachdb/cockroach/pull/60588
+
+
+## Later benefit: resource control (not just measurement)
+
+Once these facilites are in place, we can then extend the task group
+abstraction inside the go runtime, with a per-group configurable
+maximum value, such that an exception or other control mechanism is
+issued whenever the go runtime notices the metric is exceeding the
+configured budget.
+
+## Related work
+
+### Related work in the Go project
+
+- [runtime: GC pacer problems meta-issue](https://github.com/golang/go/issues/42430)
+
+  An inventory of the following known problems:
+
+  - Idle GC interferes with auto-scaling systems - the idle GC
+    utilizes idle CPU cycles, which prevents orchestration tools from
+    reducing hardware CPU allocation to an idle server.
+
+  - Assist credit system issues - certain goroutines are forcefully
+    slowed down when memory pressure is high, even if they do not
+    participate in memory usage.
+
+  - High GOGC values have some phase change issues - if a server's
+    behavior changes suddenly, e.g. a single query comes in with more
+    memory usage than usual, the GC will not notice this on time.
+
+  - Support for minimum and maximum heaps - it is not possible to
+    configure soft minimum and maximum limits for heap usage or to use
+    a ballast allocation to recover from memory exhaustion.
+
+  - Failure to amortize GC costs for small heaps - a program which has
+    a majority of its allocations in global variables will confuse the
+    GC and cause it to consume too much CPU.
+
+- [proposal: runtime: add per-goroutine CPU stats](https://github.com/golang/go/issues/41554)
+
+  This is an issue filed by a member of our team (Alfonso).
+  It proposes to accumulate CPU time per goroutine.
+
+  Recent discussion on the issue cross-referenced this PR.
+
+  Main problem with the proposal: measuring at the level of individual
+  goroutines is too fine, there may be multiple goroutines for a
+  single query. Also it makes it impossible to collect cumulative
+  stats when sub-goroutines terminate.
+
+## Rationale and Alternatives
+
+There are two main alternatives to the work considered here:
+
+- manual instrumentation everywhere.
+- separate processes.
+- pprof-based CPU reporting.
+- another taskgroup-based approach to CPU reporting, using a sampling approach.
+
+They are outlined below.
+
+### Manual instrumentation
+
+The idea is to manually instrument every single entry point in Go
+where "CPU time"  can be incurred.
+
+For CPU usage, we can add an "increment CPU time" call into every function
+that performs work on behalf of a SQL query or session. This also needs
+to be called inside every loop, once per iteration.
+
+Problems with this approach:
+
+- engineers will forget to add the CPU accounting.
+- the accounting will make the code harder to read and to maintain.
+- the tracking will be imprecise and it will be impossible to distinguish
+  a function that performs a lot of work without a loop, from one
+  that is simply waiting.
+
+### Separate processes
+
+We could spawn more CockroachDB processes, with fewer work done per
+process.
+
+We already do this for multi-tenant, with one process per SQL tenant.
+One known drawback is that a process crash kills all that tenant's
+connections to the server.
+
+We can further refine by creating more processes. There are two approaches:
+
+- Create one sub-process per session. That is more or less what pg does.
+
+  - One drawback is that we must be very aggressive with connection
+    pooling, to avoid keeping/starting processes
+    for idle sessions.
+
+- Create sub-processes for the distSQL execution. That would be a new idea.
+
+  - One drawback is that we would need cross-process IPCs to flow data
+    back and forth, as well as table descriptors and other metadata
+    used for exec processors. This may have a performance overhead.
+
+  - Another drawback is that we have many queries that operate on the
+    gateway node directly. This makes the CPU usage for multiple
+    sessions confusing to monitor on the gateway node.
+
+Finally, something not discussed so far but must be mentioned for any
+process-based solutions: we still also need to think about CPU
+accounting and budgeting:
+
+- separate processes give us CPU accounting "for free" thanks to OS metrics.
+
+- CPU budgeting would then come in either of three variants:
+
+  - no specific budgets: the OS scheduler is responsible for
+    fairness. This might be OK but we'd need a lot of benchmarking to
+    know for sure.
+  - fixed CPU limits: like above, we'd need to find out what is a good limit.
+  - relative CPU limits: we can group processes on Linux, and assign
+    scheduling priorities to groups. Within a group processes are
+    scheduled fairly. This would enable us to give priority to certain
+    SQL sessions, e.g. admin or internal sessions.
+
+### PProf-based CPU reporting
+
+The Go [`pprof`](https://golang.org/pkg/runtime/pprof/) package is
+integrated with the Go runtime system to provide a breakdown of CPU
+and RAM usage when *profiling* a process.
+
+Here is how this works:
+
+1. the program sets “profiling labels” at the top of a goroutine spawn
+   tree using `pprof.SetGoroutineLabels()`. The Go runtime system
+   has special support for labels and ensures they are inherited by any
+   goroutine spawned from this root.
+   (This is the `labels` field in the `g` struct, see `src/runtime/runtime2.go`)
+
+   Also, gRPC propagates profiling labels along RPC calls so they are
+   also inherited on remote nodes automatically.
+
+2. to start a CPU usage report, the program requests `StartCPUProfile`
+   on every server process simultaneously. An output file / buffer
+   must be passed as argument. This instructs the Go runtime to start
+   collecting stats.
+
+   The Go runtime profiles CPU execution by interrupting execution at
+   a configurable frequency (configurable via `SetCPUProfileRate`, for
+   example 100 times per second). Every time execution is interrupted,
+   it inspects which goroutines are currently running, and
+   tallies them as "active" as per their profiling labels.
+
+   The profiling reports are written to the output buffer specified at
+   the beginning.
+
+3. to end the profiling report, the program requests `StopCPUProfile`.
+
+An example implementation of this approach was prototyped here:
+https://github.com/cockroachdb/cockroach/pull/60508
+
+**Considerations**
+
+- CPU Profiling operates by suspending execution of, and taking snapshots
+  of goroutines' stacks at a defined frequency, which comes at a
+  performance cost. The lower the frequency, the smaller the cost, but
+  there is a corresponding loss of fidelity. There is skepticism
+  whether the approach can achieve a useful trade-off between the two
+  dimensions that would ultimately be preferable to modifying the
+  runtime directly.
+
+  For reference a (non-scientific) experiment observed a 6% perf hit
+  on the kv100 workload.
+
+- DataDog built an entire product around regular CPU profiles
+  collected for [15s every
+  minute](https://github.com/DataDog/dd-trace-go/blob/8026b33c428aea01d992707b1951d5e5559f4ed3/profiler/options.go#L40-L44)
+  at 100hz (the default frequency). They don't provide performance
+  numbers though, so the above question remains.
+
+- Profiler labels are not yet implemented for use in heap profiles,
+  though this is something the Go community
+  [wants](https://github.com/golang/go/issues/23458#issuecomment-377973247)
+  (i.e. it will either happen or they will be open to us making it
+  happen without a need to fork)
+
+- the pprof *label* abstraction is too heavyweight for use for heap usage
+  and there is mounting consensus in the go team that the API needs to change
+  before we can do something about heap usage. [This issue comment](https://github.com/golang/go/issues/23458#issuecomment-377973247)
+  and [this one](https://github.com/golang/go/issues/23458#issuecomment-620237813) discuss this further.
+  This uncertainty about API definitions may delay the work further
+  on the Go team's side.
+
+- relying on profiling can only make resource consumption
+  *observable*, not *controllable*. Reigning in resource usage is only
+  possible in a reactive way (i.e. eg. by terminating queries that are
+  above budget) while modifying the runtime directly could in
+  principle allow us to establish hard bounds.
+
+- a pprof-based approach avoids maintaining a permanent fork of the Go runtime.
+
+
+### Taskgroup-based CPU usage sampling
+
+Let's assume we annotate goroutines with a task group ID, as outlined
+in the main proposal.
+
+An alternative approach to CPU accounting is to not track CPU time at
+every scheduling event. Instead, we can use a *sampling* approach as
+follows:
+
+- at a periodic interval (e.g. 10 times per second), iterate over all
+  Ps, for each P look at the associated M, what goroutine it is
+  running (`curg`) and then peek at which task group the goroutine is associated.
+- increment a counter in the task group.
+
+This is conceptually similar to the pprof-based approach, except that
+we are not interested in a full stack trace per goroutine. So we do
+not need to interrupt the goroutine execution to observe the goroutine
+state.
+
+This sampling approach is likely lighterweight than the precise
+counters proposed in the main text of the RFC above.
+
+However, sampling in general does not offer us a path to *control* CPU
+usage, for example via a conditional against a configurable budget in
+the scheduling code.
+
+# Explain it to someone else
+
+We enhanced CockroachDB's ability to track CPU resource usage at
+the level of SQL queries and session.
+
+We achieved this by implementing custom changes to the runtime system
+of the Go language. This means that a custom Go runtime is now needed
+to build CockroachDB.
+
+It is still possible to build CockroachDB without these custom
+patches, however that will prevent CockroachDB from performing precise
+resource tracking and cause certain features to become disabled.
+
+
+# Unresolved questions
+
+- Do we want to extend the approach here to also measure resource
+  usage incurred by KV-level goroutines? How would that work?

--- a/docs/RFCS/20210215_task_group_resource_tracking_ram.md
+++ b/docs/RFCS/20210215_task_group_resource_tracking_ram.md
@@ -1,0 +1,449 @@
+- Feature Name: Task groups in Go: per-session resource usage tracking (RAM)
+- Status: draft
+- Start Date: 2021-02-08
+- Authors: knz, tbg, peter
+- RFC PR: [#60589](https://github.com/cockroachdb/cockroach/pull/60589)
+- Cockroach Issue: [#59998](https://github.com/cockroachdb/cockroach/issues/59998)
+
+
+# Summary
+
+This RFC proposes to use custom extensions to the Go runtime to track
+RAM usage, as well as other RAM-related metrics, per SQL session -- including all
+goroutines that do work on behalf of a SQL session, and without
+instrumenting the code manually inside CockroachDB.
+
+In a later stage, this work will also enable constraining
+CPU usage and other resources according to configurable quota.
+
+Note: there is a [separate
+RFC](20210215_task_group_resource_tracking_cpu.md) for observing and
+restricting CPU usage.
+
+Note: this work is valuable even if we consider splitting the SQL
+processing into different processes (e.g. one process for SQL, one for
+KV; or one process per SQL tenant; or separate process for SQL
+gateways and distSQL processors). Even in a multi-process
+architecture, we are unlikely to create one separate process per SQL
+session. The proposal in this RFC provides fine-grained resource
+consumption separation between SQL sessions, including separate
+sessions for the same SQL tenant.
+
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
+**Table of Contents**
+
+- [Summary](#summary)
+- [Motivation](#motivation)
+- [Technical design](#technical-design)
+    - [Context: how the Go heap allocator works](#context-how-the-go-heap-allocator-works)
+    - [Tweaking the Go heap allocator for precise measurement](#tweaking-the-go-heap-allocator-for-precise-measurement)
+    - [Proof of concept: tracking large heap allocs precisely](#proof-of-concept-tracking-large-heap-allocs-precisely)
+    - [How to account for shared data structures (e.g. caches)](#how-to-account-for-shared-data-structures-eg-caches)
+    - [Possible future enhancement: custom allocators](#possible-future-enhancement-custom-allocators)
+    - [Later benefit: resource control (not just measurement)](#later-benefit-resource-control-not-just-measurement)
+    - [Related work](#related-work)
+        - [The `gotcha` package](#the-gotcha-package)
+        - [Related work in the Go project](#related-work-in-the-go-project)
+    - [Rationale and Alternatives](#rationale-and-alternatives)
+        - [Manual instrumentation](#manual-instrumentation)
+        - [Separate processes](#separate-processes)
+- [Explain it to someone else](#explain-it-to-someone-else)
+- [Unresolved questions](#unresolved-questions)
+
+<!-- markdown-toc end -->
+
+
+# Motivation
+
+Today there is an issue when RAM usage is high, it is  difficult
+to track down which SQL session or query is responsible for that load.
+
+In turn the difficulty comes from the Go runtime which does not provide
+an abstraction to extract metrics per group of goroutines performing
+related work on behalf of a common client-defined query or session.
+
+Even though we are also considering process-level separation (e.g. one
+separate SQL process per tenant), users still wish to know which
+queries use the most RAM within the same CockroachDB process.
+
+# Technical design
+
+In a nutshell, the proposed change adds new APIs to Go's `runtime` package to
+create a new “task group” abstraction, which captures counters and other
+control mechanisms shared by a collection of goroutines and is inherited
+automatically by all new goroutines indirectly spawned.
+
+See the [companion mini-RFC](20210215_task_groups.md) for details
+about the new abstraction.
+
+Once this API is in place inside Go, we can extend CockroachDB as follows:
+
+- whenever a SQL session is created, a new task group is created for its
+  goroutine and its children goroutines
+- distsql execution on other nodes also sets up a task group whenever
+  one or more flows are set up on behalf of a query started on a different node,
+  to connect all the flows for that queries “under” a common, separate task group.
+- as the distsql processors advance or complete work, the current metrics
+  of the task group are pushed back to the gateway to update common counters
+  for the session.
+- on the gateway, the vtable `crdb_internal.node_sessions` and other related
+  facilities report, for each session/query, the additional metrics from the task group.
+- SQL job execution also creates task groups, one per job, in a way
+  that can be inspected separately (e.g. via `crdb_internal.jobs`? TBD)
+
+And an example application inside CockroachDB, to measure large heap
+allocations (>32KB) separately for each SQL session, is available
+here:
+
+https://github.com/cockroachdb/cockroach/pull/60588
+
+## Context: how the Go heap allocator works
+
+The Go heap allocator is explained in a comment at the top of
+the file `src/runtime/malloc.go` and `mcache.go`.
+
+In a nutshell, the allocator works differently for small and large
+objects.
+
+For small objects it tries to allocate locally to the current thread
+(one `mcache` per P) and if that fails grab memory globally.
+
+Of note, small allocations in the `mcache` are grouped together
+(including from separate goroutines running on the same P) so that
+multiple allocated objects appear as one from the GC's perspective.
+
+Large objects are allocated globally in any case.
+
+The allocation unit is the page (8KB), however pages are allocated
+from the OS in batches of 64MB called “arenas”. Each arena has
+metadata that indicates which parts of it contain pointers and which
+do not; this metadata is needed during GC to decide whether to
+interpret data as reference or an integer.
+
+All the arena metadata is linked together in a single “arena map” so
+that the GC can find metadata for every location in the process'
+address space.
+
+The GC is asynchronous and runs in a different goroutine than where
+allocations were made.
+
+## Tweaking the Go heap allocator for precise measurement
+
+We can tweak the allocator as follows:
+
+- the `mspan` for large allocations are tagged with a pointer to their
+  `taskGroupCtx`. We increment the allocation tally in `taskGroupCtx`
+  when the allocation occurs. When the GC releases the object, its
+  size is subtracted from the tally in the linked `taskGroupCtx`.
+
+  This is the simple case. See proof of concept below.
+
+- for small allocations, we do as follows:
+
+  - we change the mapping of P to `mcache`.  Instead of one
+    `mcache` per P, we use one `mcache` per P per `taskGroupCtx` --
+    i.e. we implement a separate small heap per task group.
+
+  - when an allocation elects to use a small heap, instead of
+    retrieving the mcache via `getg().p.mcache`, we use
+    `getg().taskGroupCtx.mcache[getg().p.id]`.
+
+    (This is simple+safe because the P IDs are allocated from 0
+    to GOMAXPROCS-1, and we can reallocate the mcache arrays
+    everytime GOMAXPROCS is overridden.)
+
+  - every page allocated by a `mcache` is tagged with a pointer
+    to its owner `taskGroupCtx`. This tells the GC that
+    every object “under” this page “belongs” to that
+    task group. This is correct because the mapping established
+    above forces this ownership.
+
+  - we increment the allocation tally each time a small allocation
+    occurs.
+
+  - like for large allocations above, everytime the GC deallocates
+    a full page of small objects it decreases the tally in the
+    linked `taskGroupCtx`.
+
+**Concern with the proposal above**
+
+The small heap is defined as an array of `numSpanClasses` *size
+classes* (default 134), with each span defined as a linked list of
+pages to serve allocations of that size.
+
+Creating P times `numSpanClasses` a linked list of 8KB pages, *per
+task group*, would incur a potential cost of 1MB per core per task
+group, e.g. 16MB per task group on a 16-core machine. If we have one
+task group per SQL session, that may be too expensive. For reference,
+today an idle SQL session costs less than 100KB.
+
+**Other alternate approaches**
+
+- have small heaps (mcaches) shared more, for example across multiple
+  SQL sessions. Only keep the larger allocs separate and billed to
+  individual task groups. This would make sense if we assume that the
+  bulk of allocations comes from larger objects.
+
+  Implementation-wise that would need a separate abstraction from the
+  task group identified here, something like "bags of goroutines that
+  share a small cache".
+
+- we could have a separate implementation of small heap dedicated to
+  individual SQL queries, that would do stack allocation
+  (i.e. everything goes to a single linked list of pages, all tagged
+  by the task group). This is OK-ish because we know everything gets
+  deallocated in bulk at the end.
+
+In any case this section needs further experiments to narrow down the
+most promising approach.
+
+## Proof of concept: tracking large heap allocs precisely
+
+For large allocations, the go heap allocator dedicates entires
+`mspans` (the internal unit of accounting) to each allocation.
+Because the `mspans` are dedicated, we can do precise accounting as
+described below.
+
+NB: An allocation is considered “large” when it is 32KiB or larger
+(see `_MaxSmallSize` in `sizeclasses.go`).
+
+How to achieve this:
+
+1. add a new `largeHeapUse` counter in the task group struct.
+2. in `(*mcache).allocLarge()`, increment the task group counter
+   by the size of the allocation if a task group is defined.
+   Also, store a pointer to the *counter* (not the task group - this is not needed)
+   inside the `mspan`.
+3. in `(*mheap).freeSpanLocked()`, if a counter pointer is present in the
+   `mspan`, decrease it by the size of the allocation.
+
+We place the increase in `allocLarge()` and not `allocSpan()` because the latter
+is also used for prepopulating mspans in the small heap and this proof of
+concept should be limited to large allocations (see discussion above about
+the complexities of the small heap).
+
+When this is achieved, we can expose the new counter via the `metrics` API,
+for example in crdb's `conn_executor.go`:
+
+```go
+	taskGroupMetrics := []metrics.Sample{
+	    // ...
+		{Name: "/taskgroup/heap/largeHeapUsage:bytes"},
+	}
+	metrics.ReadTaskGroup(ex.taskGroup, taskGroupMetrics)
+```
+
+This is demonstrated in the custom go runtime at https://github.com/cockroachdb/go/commits/crdb-fixes
+and the PR at https://github.com/cockroachdb/cockroach/pull/60588
+
+## How to account for shared data structures (e.g. caches)
+
+Some data structures in RAM are populated by one SQL session but the
+data remains for use by other SQL sessions. For example the SQL role
+membership cache, the descriptor collection, etc. all are "shared resources".
+
+If we account for these allocations as "belonging" to one task group,
+that will creates the illusion of imbalance and possibly trigger
+assertions that no data leaks from a SQL session when it terminates.
+
+How to deal with this?
+
+We can use a task group for the cache itself. Then we can have the
+goroutine temporarily swap in the cache task group for that
+allocation, then swap it out (and restore the original goroutine's
+task group) after the allocation completes.
+
+This can be done in the crdb code, there is no extra Go runtime
+customization needed.
+
+## Possible future enhancement: custom allocators
+
+(NB: this section is out of scope for this RFC but is included
+as a teaser for later opportunities.)
+
+This is an idea proposed by Andrei M: instead of a fixed
+mapping from task group to P to `mcache`, we could even customize
+the allocation algorithm(s) per task group.
+
+That is, we can define a custom `malloc` function pointer per task
+group, and have the runtime-level `mallogc` function call the current
+task group's `malloc` function if defined.
+
+This would make it possible for applications to implement custom
+allocation policies for different objects, including slab allocations,
+separate accounting for different types, etc.
+
+## Later benefit: resource control (not just measurement)
+
+Once these facilites are in place, we can then extend the task group
+abstraction inside the go runtime, with a per-group configurable
+maximum value, such that an exception or other control mechanism is
+issued whenever the go runtime notices the metric is exceeding the
+configured budget.
+
+## Related work
+
+### The `gotcha` package
+
+Kostiantyn Masliuk created the
+[`gotcha`](https://github.com/1pkg/gotcha) package which overrides the
+Go heap allocator function `mallocgc` at runtime (i.e. does not need a
+custom Go build), to provide statistics at the level of individual
+goroutines.
+
+Explanatory article: [Let's trace goroutine allocated
+memory](https://1pkg.github.io/posts/lets_trace_goroutine_allocated_memory/)
+
+The way this works is that it catches all calls to `mallocgc`, then
+retrieves a struct from the goroutine's local storage (provided by
+separate packages [`golocal`](github.com/1pkg/golocal) and
+[`gls`](github.com/modern-go/gls)), then increments counters in that
+struct with the requested object size.
+
+Deallocations are not tracked, so this only provides **total
+cumulative allocated size**, not *current* allocated size.
+
+Also the data is hard to retrieve/interpret once the goroutines have
+terminated.
+
+Also the way `mallocgc` is overridden is extremely unsafe,
+platform-specific and version-specific (to one version of Go).
+
+### Related work in the Go project
+
+- [Proposal: add a way for applications to respond to GC
+  backpressure](https://github.com/golang/go/issues/29696).
+
+  The person who posted the issue remarked that without GC
+  backpressure, applications cannot respond to memory exhaustion.
+
+  The discussion then went on and focused on a solution that posts GC
+  events on a Go channel. The assumption is that a single listener in
+  the application code would be able to respond to GC pressure events.
+
+  **This approach is flawed** for CockroachDB's needed because it does
+  not make it possible to stop or suspend individual SQL queries when
+  memory exhaustion is reached.
+
+  It also does not make it possible to set different memory budgets
+  for different SQL sessions or applications.
+
+- [runtime: GC pacer problems meta-issue](https://github.com/golang/go/issues/42430)
+
+  An inventory of the following known problems:
+
+  - Idle GC interferes with auto-scaling systems - the idle GC
+    utilizes idle CPU cycles, which prevents orchestration tools from
+    reducing hardware CPU allocation to an idle server.
+
+  - Assist credit system issues - certain goroutines are forcefully
+    slowed down when memory pressure is high, even if they do not
+    participate in memory usage.
+
+  - High GOGC values have some phase change issues - if a server's
+    behavior changes suddenly, e.g. a single query comes in with more
+    memory usage than usual, the GC will not notice this on time.
+
+  - Support for minimum and maximum heaps - it is not possible to
+    configure soft minimum and maximum limits for heap usage or to use
+    a ballast allocation to recover from memory exhaustion.
+
+  - Failure to amortize GC costs for small heaps - a program which has
+    a majority of its allocations in global variables will confuse the
+    GC and cause it to consume too much CPU.
+
+- [proposal: runtime: add per-goroutine CPU stats](https://github.com/golang/go/issues/41554)
+
+  This is an issue filed by a member of our team (Alfonso).
+  It proposes to accumulate CPU time per goroutine.
+
+  Recent discussion on the issue cross-referenced this PR.
+
+  Main problem with the proposal: measuring at the level of individual
+  goroutines is too fine, there may be multiple goroutines for a
+  single query. Also it makes it impossible to collect cumulative
+  stats when sub-goroutines terminate.
+
+## Rationale and Alternatives
+
+There are two main alternatives to the work considered here:
+
+- manual instrumentation everywhere.
+
+They are outlined below.
+
+### Manual instrumentation
+
+The idea is to manually instrument every single entry point in Go
+where  "memory usage" can be incurred.
+
+For memory, extend use of the existing `mon.BytesMonitor` to every
+heap allocation performed on behalf of a SQL query or session. Track
+down the end of the lifetime for every allocated object, to perform
+the corresponding `Close` / `Shrink` calls.
+
+Problems with this approach:
+
+- a `Shrink` call does not guarantee the memory is free for another
+  task to take, as described in the problem statement at the top:
+  until the GC runs, it is still possible for the process to crash
+  even though the bytes monitor count memory as “available.”
+- engineers will forget to add the memory accounting.
+- tracking the exact lifetimes will add complexity to the programming process.
+- the accounting will make the code harder to read and to maintain.
+
+### Separate processes
+
+We could spawn more CockroachDB processes, with fewer work done per
+process.
+
+We already do this for multi-tenant, with one process per SQL tenant.
+One known drawback is that a process crash kills all that tenant's
+connections to the server.
+
+We can further refine by creating more processes. There are two approaches:
+
+- Create one sub-process per session. That is more or less what pg does.
+
+  - One drawback is that we must be very aggressive with connection
+    pooling, to avoid keeping/starting processes
+    for idle sessions.
+
+- Create sub-processes for the distSQL execution. That would be a new idea.
+
+  - One drawback is that we would need cross-process IPCs to flow data
+    back and forth, as well as table descriptors and other metadata
+    used for exec processors. This may have a performance overhead.
+
+  - Another drawback is that we have many queries that operate on the
+    gateway node directly. These can also cause OOM problems, and
+    would not be protected by distsql-specific forks.
+
+Meanwhile, regardless of the approach considered, we have a discussion
+about memory budgets. When using multiple processes, do we set limits
+and how?
+
+- fixed limits will cause fragmentation.
+- fixed limits raise the question: what is a good limit? We do not have a model for that.
+- we could also operate without limits. In that case we rely on the
+  system OOM killer to only select "offending" processes, and we will
+  need to be careful to "protect" the gateway/master processes.
+
+# Explain it to someone else
+
+We enhanced CockroachDB's ability to track RAM resource usage at
+the level of SQL queries and session.
+
+We achieved this by implementing custom changes to the runtime system
+of the Go language. This means that a custom Go runtime is now needed
+to build CockroachDB.
+
+It is still possible to build CockroachDB without these custom
+patches, however that will prevent CockroachDB from performing precise
+resource tracking and cause certain features to become disabled.
+
+
+# Unresolved questions
+
+- Do we want to extend the approach here to also measure resource
+  usage incurred by KV-level goroutines? How would that work?

--- a/docs/RFCS/20210215_task_groups.md
+++ b/docs/RFCS/20210215_task_groups.md
@@ -1,0 +1,441 @@
+- Feature Name: Task groups in Go
+- Status: draft
+- Start Date: 2021-02-08
+- Authors: knz, tbg, peter
+- RFC PR: [#60589](https://github.com/cockroachdb/cockroach/pull/60589)
+- Cockroach Issue: [#59998](https://github.com/cockroachdb/cockroach/issues/59998)
+
+# Summary
+
+This mini-RFC introduces several extensions to the low-level
+concepts inside the Go language, including a notion of “task group”,
+by means of a customization to the Go runtime system.
+
+The proposal creates an API which is going to be available for both
+customized and non-customized (“vanilla”) Go runtimes. With a vanilla
+runtime, the API will provide  no-op behavior. This retains the ability
+for community members to produce custom CockroachDB builds without
+the hassle of setting up a custom Go installation.
+
+
+This mini-RFC is a companion to the two other RFCs that propose to
+expose (and later control) CPU and RAM usage per SQL session.
+Refer to these two other texts for a wider context.
+
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
+**Table of Contents**
+
+- [Summary](#summary)
+- [Motivation](#motivation)
+- [Technical design](#technical-design)
+    - [Overview](#overview)
+    - [Proof of concept](#proof-of-concept)
+    - [Inheritable Goroutine IDs](#inheritable-goroutine-ids)
+    - [Task group abstraction](#task-group-abstraction)
+        - [API](#api)
+        - [State associated with task groups](#state-associated-with-task-groups)
+    - [Implementation of the IGID and task group abstractions](#implementation-of-the-igid-and-task-group-abstractions)
+    - [Other runtime customizations](#other-runtime-customizations)
+        - [Goroutine observability](#goroutine-observability)
+        - [Manual control over the Go scheduler](#manual-control-over-the-go-scheduler)
+        - [Choose panic behavior on fault](#choose-panic-behavior-on-fault)
+        - [Choose output for runtime errors](#choose-output-for-runtime-errors)
+- [Related work](#related-work)
+
+<!-- markdown-toc end -->
+
+
+# Motivation
+
+There are several objectives wrt resource usage observability and
+control which cannot be achieved using the standard APIs from the Go
+runtime. We wish to enhance CockroachDB in that direction.
+
+In the past, we were reluctant to mandate custom Go runtimes because
+Cockroach Labs was heavily reliant on bottom-up adopters using the
+source repository directly. Since the start of CockroachdB's history
+however, we now know that the majority of users download pre-built
+binaries (either standalone or via Docker container images). It has
+thus become reasonable for Cockroach Labs to standardize a set of Go
+patches that would be automatically applied in the release process to
+produce “official” binaries.
+
+# Technical design
+
+In a nutshell, the proposed change adds new APIs to Go's `runtime` package to
+create new abstractions, including new APIs inside the `runtime` package.
+
+When doing so however, we need to be careful to ensure that Go programs
+like CockroachDB can continue to build using non-customized rutime systems.
+
+To achieve this, we also provide a Go library shim called `go-plus`, which
+exposes the same API to Go programs regardless of whether the Go runtime
+is customized or not.
+
+Internally, the `go-plus` library switches behavior based on a (new) build
+tag `goplus`. The customized go compiler/runtime defines this tag implicitly
+and automatically, whereas a vanilla compiler would not.
+
+## Overview
+
+
+At the time of this writing, we envision two API layers:
+
+- **proc** provides Go programs with finer grain control over the Go
+  runtime system. This makes it possible to build more "advanced"
+  concurrency data structures such as a custom sync.Pool
+  implementation.
+
+  It also provides a new runtime feature called "Inheritable Goroutine ID" (IGID),
+  further described below.
+
+  API doc link: pkg.go.dev/github.com/cockroachdb/go-plus/proc
+
+- **taskgroup** provides Go programs with a new runtime abstraction
+  called “task group”, to provide aggregate accounting of resource
+  usage to fleets of related goroutines. This is also further detailed below.
+
+  API doc link: pkg.go.dev/github.com/cockroachdb/go-plus/taskgroup
+
+## Proof of concept
+
+The proposed Go runtime extensions are available on a branch `crdb-fixes`
+on a fork of the Go runtime at
+https://github.com/cockroachdb/go/commits/crdb-fixes
+
+The shim adapter library `go-plus` is available at
+https://github.com/cockroachdb/go-plus
+
+The auto-generated Go documentation for the extension is available here:
+
+https://pkg.go.dev/github.com/cockroachdb/go-plus/proc
+
+https://pkg.go.dev/github.com/cockroachdb/go-plus/taskgroup
+
+## Inheritable Goroutine IDs
+
+One of the proposed abstractions is the Inheritable Goroutine ID, a
+64-bit integer which, once set on a goroutine, is automatically
+inherited by all goroutines spawned from it.
+
+This makes it possible to associate e.g. a group of goroutines
+to a SQL query or session ID and report it in logs and traces.
+
+This clarifies when looking at goroutine dumps how the goroutines are
+related to each other.
+
+Relevant APIs in the `proc` sub-package of `go-plus`:
+
+```go
+package proc
+
+// GetIGID retrieves the inheritable goroutine ID (IGID).
+// This is inherited from the goroutine's parent.
+// Top-level goroutines are assigned their own ID as group ID.
+//
+// Returns 0 if the extension is not supported.
+func GetIGID() int64
+
+
+// SetIGID sets the current goroutine's inheritable
+// goroutine ID.
+// This value is inherited to children goroutines.
+//
+// A possible good value to use is the value of GetGID(),
+// to obtain a behavior similar to process group IDs on unix.
+//
+// No-op if the extension is not supported.
+func SetIGID(igid int64)
+```
+
+## Task group abstraction
+
+This proposes a new “task group” abstraction inside the Go runtime /
+scheduler, in addition to the existing G / M / P abstractions.
+
+(The reader of this RFC is expected to have some familiarity with the
+G / M / P abstractions already. Refer to the Go team's own
+documentation and the top comment inside the `runtime/proc.go` file in
+the Go distribution.)
+
+A task group is a collection of zero or more goroutines.
+
+Each goroutine is associated to exactly one task group.
+
+There is a “default” task group defined initially for all goroutines
+spawned from the main/initial goroutine.
+
+Each new goroutine (started with the `go` keyword) inherits the task
+group of its parent.
+
+A `taskgroup.SetTaskGroup()` API enables Go applications to override the
+task group of the current goroutine. After this has been overridden,
+all further goroutines spawned from that point inherit the new task
+group. (But all previously spawned goroutines retain their previously
+defined task group.)
+
+The Go runtime scheduler is aware of the task groups and is able to
+update / maintain runtime counters and other metrics at the level
+of the task group, not just the goroutine.
+
+### API
+
+```
+package taskgroup
+// T represents a task group inside the Go runtime.
+//
+// T values are reference-like, are comparable and can be nil, however
+// no guarantee is provided about their concrete type.
+type T
+
+// SetTaskGroup creates a new task group and attaches it to the
+// current goroutine. It is inherited by future children goroutines.
+// Top-level goroutines that have not been set a task group
+// share a global (default) task group.
+//
+// If the extension is not supported, the operation is a no-op
+// and returns a nil value.
+func SetTaskGroup() T
+
+// ReadTaskGroupMetrics reads the runtime metrics for the specified
+// task group. This is similar to the Go standard metrics.Read() but
+// reads metrics scoped to just one task group.
+//
+// The following metric names are supported:
+//
+//   /taskgroup/sched/ticks:ticks
+//   /taskgroup/sched/cputime:nanoseconds
+//   /taskgroup/heap/largeHeapUsage:bytes
+//
+// If the extension is not supported, the metric value will be
+// initialized with metric.KindBad.
+//
+// The reason why tg metrics are served by a dedicated function is
+// that this function only locks the data structures for the specified
+// task group, not the entire runtime. This makes it generally cheaper
+// to use in a concurrent environment than metrics.Read().
+func ReadTaskGroupMetrics(taskGroup T, m []metrics.Sample)
+```
+
+### State associated with task groups
+
+There is an (opaque) type `taskgroup.T`.  It is also the state
+produced via the main new API `taskgroup.SetTaskGroup()` outlined
+above.
+
+This is the struct used inside the Go scheduler and other runtime
+subsystems (e.g. the heap GC in the future).
+
+This struct is associated with various counters and other metrics
+that are updated by the Go scheduler.
+
+At this time, the following are maintained separately per task group:
+
+- CPU scheduling ticks.
+- CPU effective runtime nanoseconds.
+- number of discrete heap allocations (cumulative).
+- currently allocated size of large (>32KB) heap allocations.
+
+The metrics per task group can be extracted using the
+new `taskgroup.GetTaskGroupMetrics()` API.
+
+## Implementation of the IGID and task group abstractions
+
+Implementation-wise, we extend the `g` struct inside the go runtime
+with two fields `taskGroupCtx` (for the internal task group)
+and `groupId` (for the IGID).
+
+Both are inherited when creating a new goroutine. When a goroutine is
+created without a parent, they are initialized as follows:
+
+- `taskGroupCtx` is set to `defaultTaskGroupCtx`, the default/common
+  task group.
+- `groupId` is set to the goroutine's ID (this default may change, unsure).
+
+These defaults are not too important/interesting since we will ensure
+that the task group is overridden every time we create a new SQL
+session or job.
+
+## Other runtime customizations
+
+### Goroutine observability
+
+```go
+package proc
+
+// GetGID retrieves the goroutine (G's) ID.
+//
+// This works even when the extension is not supported,
+// by relying on github.com/petermattis/goid.
+func GetGID() int64
+
+// GetGoroutineStackSize retrieves an approximation of the current goroutine (G)'s
+// stack size.
+//
+// Returns 0 if the extension is not supported.
+func GetGoroutineStackSize() uintptr
+```
+
+### Manual control over the Go scheduler
+
+```go
+package proc
+
+// GetPID retrieves the P (virtual CPU) ID of the current goroutine.
+// These are by design set between 0 and gomaxprocs - 1.
+// This can be used to create data structures with CPU affinity.
+//
+// Note: because of preemption, there is no guarantee that the
+// goroutine remains on the same P after the call to GetPID()
+// completes. See Pin/UnpinGoroutine().
+//
+// Returns 0 if the extension is not supported.
+func GetPID()
+
+// GetOSThreadID retrieves the OS-level thread ID, which can be used to e.g.
+// set scheduling policies or retrieve CPU usage statistics.
+//
+// Note: because of preemption, there is no guarantee that the current
+// goroutine remains on the same OS thread after a call to this
+// function completes. See Pin/UnpinGoroutine.
+//
+// Returns 0 if the extension is not supported.
+func GetOSThreadID() uint64
+
+// PinGoroutine pins the current G to its P and disables preemption.
+// The caller is responsible for calling Unpin. The GC is not running
+// between Pin and Unpin.
+// Returns the ID of the P that the G has been pinned to.
+//
+// Returns -1 if the extension is not supported.
+func PinGoroutine()
+
+// UnpinGoroutine unpints the current G from its P.
+// The caller is responsible for ensuring that PinGoroutine()
+// has been called first. The behavior is undefined
+// otherwise.
+//
+// No-op if the extension is not supported.
+func UnpinGoroutine()
+```
+
+### Choose panic behavior on fault
+
+This enables telling the goroutine to throw panic objects instead of
+stopping the entire program:
+
+```go
+package proc
+
+// SetDefaultPanicOnFault sets the default value of the "panic on
+// fault" that is otherwise customizable with debug.SetPanicOnFault.
+//
+// The default value is used for "top level" goroutines that are
+// started during the init process / runtime. The flag is inherited to
+// children goroutines.
+// When not customized, the go runtime uses "false" as default.
+//
+// Returns false if the extension is not supported.
+func SetDefaultPanicOnFault(enabled bool)
+
+// GetDefaultPanicOnFault retrieves the default value of the "panic on
+// fault" flag.
+//
+// Returns false if the extension is not supported.
+func GetDefaultPanicOnFault()
+```
+
+### Choose output for runtime errors
+
+```go
+package proc
+
+// GetExternalErrorFd retrieves the file descriptor used to emit
+// panic messages and other internal errors by the go runtime.
+//
+// Returns -1 if the extension is not supported.
+func GetExternalErrorFd()
+
+// SetExternalErrorFd changes the file descriptor used to emit panic
+// messages and other internal errors by the go runtime.
+//
+// No-op if the extension is not supported.
+func SetExternalErrorFd(fd int)
+```
+
+## Drawbacks
+
+Maintaining a custom runtime extension in the Go project really means
+creating a new project maintained by Cockroach Labs, which will
+responsible for importing all the changes made upstream by the Go
+team. This is additional effort, also requiring a skill set that we
+have not yet been hiring for inside the CockroachDB and Cockroach
+Cloud projets.
+
+That will in turn incur working hours for the unforeseeable future.
+
+We can mitigate that risk either:
+
+- by setting up a communication forum
+  with the Go team to demonstrate the runtime extensions we are
+  working with and advocate for their inclusion in the mainstream
+  Go distribution.
+
+- by developing the runtime extensions not as a repository fork, but
+  instead as a patchset, and create automation which will
+  automatically detect changes to upstream Go and apply the patches
+  automatically every time a new Go release is made.  (This is the
+  approach taken by the `redact` package to override the `fmt`
+  behavior, see
+  [here](https://github.com/cockroachdb/redact/blob/master/internal/README.md#refreshing-the-sources).)
+
+Additionally, we can also consider that other companies even smaller
+than Cockroach Labs have invested in a custom Go fork before us.
+
+# Related work
+
+Some related work is described below, as well as in the two companion
+RFCs on CPU and RAM usage.
+
+However, all this related work suffers from the same limitation: **they
+assume that the desired observability granularity is one goroutine**.
+
+In CockroachDB, the unit of processing is a group of goroutines
+performing work on behalf of a SQL query (or, inside KV, on behalf of
+a range queue, or on behalf of a KV client).
+
+Hence the need for an abtraction that groups goroutines together.
+
+### Tailscale's custom Go patches
+
+As per [this Twitter
+message](https://twitter.com/bradfitz/status/1360293997038637058) from
+Brad Fitzpatrick, Tailscale is using a custom Go fork to fix issues
+with the networking code and perhaps other patches.
+
+That tweet in turn refers to example use [here](https://github.com/tailscale/tailscale/commit/88586ec4a43542b758d6f4e15990573970fb4e8a).
+
+These patches do not relate to resource consumption, however it is
+interesting to see that Tailscale found it a worthwhile investment
+manage a custom fork of Go.
+
+For reference, Tailscale was founded in 2019 and has a smaller
+engineering team than Cockroach Labs at the time of this writing.
+
+Some additional points:
+
+1. the Tailscale team attempts to upstream everything. Most of their
+    fork is "this will be in the next Go version but I wanted it now",
+    so their fork is correspondingly small.
+2. It is unlikely that what we are proposing in the RFC will ever be
+   upstreamed. Our fork will possibly be much larger than theirs.
+
+Also, Tailscale has a smaller engineering team, but they have more Go core expertise.
+
+# Rationale and Alternatives
+
+See discussion in related RFCs on CPU and RAM usage tracking.
+
+# Unresolved questions
+
+None known.


### PR DESCRIPTION
RFC text here: 

- Shared mini-RFC on task groups: https://github.com/knz/cockroach/blob/20210215-task-group-rfc/docs/RFCS/20210215_task_groups.md

- RFC on CPU usage: https://github.com/knz/cockroach/blob/20210215-task-group-rfc/docs/RFCS/20210215_task_group_resource_tracking_cpu.md

- RFC on RAM usage: https://github.com/knz/cockroach/blob/20210215-task-group-rfc/docs/RFCS/20210215_task_group_resource_tracking_ram.md

Release note: None