### PR TITLE
opt: create key for UNIQUE WITHOUT INDEX constraints

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -425,7 +425,7 @@ TABLE ok1
  ├── c int
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- └── INDEX primary
+ └── PRIMARY INDEX primary
       ├── a int not null
       ├── b int not null
       └── partition by list prefixes
@@ -469,7 +469,7 @@ TABLE ok2
  ├── c int
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- └── INDEX primary
+ └── PRIMARY INDEX primary
       ├── a int not null
       ├── b int not null
       └── partition by list prefixes
@@ -513,7 +513,7 @@ TABLE ok3
  ├── c int
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- └── INDEX primary
+ └── PRIMARY INDEX primary
       ├── a int not null
       ├── b int not null
       └── partition by list prefixes
@@ -560,7 +560,7 @@ TABLE ok4
  ├── c int
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- └── INDEX primary
+ └── PRIMARY INDEX primary
       ├── a int not null
       ├── b int not null
       └── partition by list prefixes
@@ -600,7 +600,7 @@ TABLE ok5
  ├── c int
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- └── INDEX primary
+ └── PRIMARY INDEX primary
       ├── a int not null
       ├── b int not null
       └── partition by list prefixes
@@ -665,7 +665,7 @@ TABLE ok6
  ├── c int
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- └── INDEX primary
+ └── PRIMARY INDEX primary
       ├── a int not null
       └── b int not null
 scan ok6
@@ -702,7 +702,7 @@ TABLE ok7
  ├── c int
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- └── INDEX primary
+ └── PRIMARY INDEX primary
       ├── a int not null
       └── b int not null
 scan ok7
@@ -745,7 +745,7 @@ TABLE ok8
  ├── c int
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- └── INDEX primary
+ └── PRIMARY INDEX primary
       ├── a int not null
       └── b int not null
 scan ok8
@@ -790,7 +790,7 @@ TABLE ok9
  ├── c int
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- └── INDEX primary
+ └── PRIMARY INDEX primary
       ├── a int not null
       └── b int not null
 scan ok9
@@ -837,7 +837,7 @@ TABLE ok10
  ├── c int
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- └── INDEX primary
+ └── PRIMARY INDEX primary
       ├── a int not null
       └── b int not null
 scan ok10
@@ -893,7 +893,7 @@ TABLE ok11
  ├── c int not null
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- └── INDEX primary
+ └── PRIMARY INDEX primary
       ├── a int not null
       ├── b int not null
       ├── c int not null
@@ -940,7 +940,7 @@ TABLE ok12
  ├── c int
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- └── INDEX primary
+ └── PRIMARY INDEX primary
       ├── a int not null
       ├── b int not null
       └── partition by list prefixes

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -183,6 +183,7 @@ vectorized: true
 │       │
 │       └── • hash join (right anti)
 │           │ equality: (pk) = (column2)
+│           │ left cols are key
 │           │ right cols are key
 │           │
 │           ├── • scan
@@ -631,18 +632,18 @@ vectorized: true
 │       │
 │       └── • render
 │           │
-│           └── • cross join (right outer)
+│           └── • cross join (left outer)
 │               │
-│               ├── • filter
-│               │   │ filter: pk = 3
-│               │   │
-│               │   └── • scan
-│               │         missing stats
-│               │         table: t@primary
-│               │         spans: FULL SCAN
+│               ├── • values
+│               │     size: 7 columns, 1 row
 │               │
-│               └── • values
-│                     size: 7 columns, 1 row
+│               └── • filter
+│                   │ filter: pk = 3
+│                   │
+│                   └── • scan
+│                         missing stats
+│                         table: t@primary
+│                         spans: FULL SCAN
 │
 ├── • constraint-check
 │   │
@@ -650,6 +651,7 @@ vectorized: true
 │       │
 │       └── • hash join (right semi)
 │           │ equality: (pk) = (upsert_pk)
+│           │ right cols are key
 │           │ pred: column3 != partition_by
 │           │
 │           ├── • scan
@@ -666,6 +668,7 @@ vectorized: true
         │
         └── • hash join (right semi)
             │ equality: (b) = (column5)
+            │ right cols are key
             │ pred: (upsert_pk != pk) OR (column3 != partition_by)
             │
             ├── • scan

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -367,15 +367,16 @@ vectorized: true
 │       │
 │       └── • render
 │           │
-│           └── • cross join (right outer)
+│           └── • cross join (left outer)
 │               │
-│               ├── • scan
-│               │     missing stats
-│               │     table: regional_by_row_table@primary
-│               │     spans: [/'ap-southeast-2'/2 - /'ap-southeast-2'/2] [/'ca-central-1'/2 - /'ca-central-1'/2] [/'us-east-1'/2 - /'us-east-1'/2]
+│               ├── • values
+│               │     size: 6 columns, 1 row
 │               │
-│               └── • values
-│                     size: 6 columns, 1 row
+│               └── • scan
+│                     missing stats
+│                     table: regional_by_row_table@primary
+│                     spans: [/'ap-southeast-2'/2 - /'ap-southeast-2'/2] [/'ca-central-1'/2 - /'ca-central-1'/2] [/'us-east-1'/2 - /'us-east-1'/2]
+│                     locking strength: for update
 │
 ├── • constraint-check
 │   │
@@ -389,11 +390,11 @@ vectorized: true
 │           │
 │           └── • cross join
 │               │
-│               ├── • scan buffer
-│               │     label: buffer 1
+│               ├── • values
+│               │     size: 1 column, 3 rows
 │               │
-│               └── • values
-│                     size: 1 column, 3 rows
+│               └── • scan buffer
+│                     label: buffer 1
 │
 ├── • constraint-check
 │   │
@@ -407,11 +408,11 @@ vectorized: true
 │           │
 │           └── • cross join
 │               │
-│               ├── • scan buffer
-│               │     label: buffer 1
+│               ├── • values
+│               │     size: 1 column, 3 rows
 │               │
-│               └── • values
-│                     size: 1 column, 3 rows
+│               └── • scan buffer
+│                     label: buffer 1
 │
 └── • constraint-check
     │
@@ -425,11 +426,11 @@ vectorized: true
             │
             └── • cross join
                 │
-                ├── • scan buffer
-                │     label: buffer 1
+                ├── • values
+                │     size: 1 column, 3 rows
                 │
-                └── • values
-                      size: 1 column, 3 rows
+                └── • scan buffer
+                      label: buffer 1
 
 query T
 EXPLAIN UPSERT INTO regional_by_row_table (crdb_region, pk, pk2, a, b)
@@ -451,6 +452,7 @@ vectorized: true
 │           │
 │           └── • lookup join (left outer)
 │               │ table: regional_by_row_table@primary
+│               │ equality cols are key
 │               │ lookup condition: (column2 = pk) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
 │               │ locking strength: for update
 │               │
@@ -471,11 +473,11 @@ vectorized: true
 │           │
 │           └── • cross join
 │               │
-│               ├── • scan buffer
-│               │     label: buffer 1
+│               ├── • values
+│               │     size: 1 column, 3 rows
 │               │
-│               └── • values
-│                     size: 1 column, 3 rows
+│               └── • scan buffer
+│                     label: buffer 1
 │
 ├── • constraint-check
 │   │
@@ -489,11 +491,11 @@ vectorized: true
 │           │
 │           └── • cross join
 │               │
-│               ├── • scan buffer
-│               │     label: buffer 1
+│               ├── • values
+│               │     size: 1 column, 3 rows
 │               │
-│               └── • values
-│                     size: 1 column, 3 rows
+│               └── • scan buffer
+│                     label: buffer 1
 │
 └── • constraint-check
     │
@@ -507,11 +509,11 @@ vectorized: true
             │
             └── • cross join
                 │
-                ├── • scan buffer
-                │     label: buffer 1
+                ├── • values
+                │     size: 1 column, 3 rows
                 │
-                └── • values
-                      size: 1 column, 3 rows
+                └── • scan buffer
+                      label: buffer 1
 
 query TIIIIIIIIT colnames
 SELECT * FROM (VALUES ('us-east-1', 23, 24, 25, 26), ('ca-central-1', 30, 30, 31, 32)) AS v(crdb_region, pk, pk2, a, b)

--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -44,7 +44,7 @@ TABLE t
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
  ├── FAMILY fam_0_k_v (k, v)
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    ├── k int not null
  │    └── ZONE
  │         └── constraints: [+region=test,+dc=dc2]
@@ -91,7 +91,7 @@ TABLE t
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
  ├── FAMILY fam_0_k_v (k, v)
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    ├── k int not null
  │    └── ZONE
  │         └── constraints: [+region=test,+dc=dc2]
@@ -160,7 +160,7 @@ TABLE t
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
  ├── FAMILY fam_0_k_v (k, v)
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    ├── k int not null
  │    └── ZONE
  │         └── constraints: [+region=test,+dc=dc1]
@@ -272,7 +272,7 @@ TABLE t
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
  ├── FAMILY fam_0_k_v (k, v)
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    ├── k int not null
  │    └── ZONE
  │         ├── constraints: [+region=test]
@@ -329,7 +329,7 @@ TABLE t
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
  ├── FAMILY fam_0_k_v (k, v)
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    ├── k int not null
  │    └── ZONE
  │         ├── constraints: [+region=test]
@@ -440,7 +440,7 @@ TABLE t
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
  ├── FAMILY fam_0_k_v (k, v)
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    ├── k int not null
  │    └── ZONE
  │         ├── constraints: [+region=test]

--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -184,15 +184,19 @@ func FormatTable(cat Catalog, tab Table, tp treeprinter.Node) {
 // debugging and testing.
 func formatCatalogIndex(tab Table, ord int, tp treeprinter.Node) {
 	idx := tab.Index(ord)
-	inverted := ""
-	if idx.IsInverted() {
-		inverted = "INVERTED "
+	idxType := ""
+	if idx.Ordinal() == PrimaryIndex {
+		idxType = "PRIMARY "
+	} else if idx.IsUnique() {
+		idxType = "UNIQUE "
+	} else if idx.IsInverted() {
+		idxType = "INVERTED "
 	}
 	mutation := ""
 	if IsMutationIndex(tab, ord) {
 		mutation = " (mutation)"
 	}
-	child := tp.Childf("%sINDEX %s%s", inverted, idx.Name(), mutation)
+	child := tp.Childf("%sINDEX %s%s", idxType, idx.Name(), mutation)
 
 	var buf bytes.Buffer
 	colCount := idx.ColumnCount()

--- a/pkg/sql/opt/exec/execbuilder/testdata/catalog
+++ b/pkg/sql/opt/exec/execbuilder/testdata/catalog
@@ -18,7 +18,7 @@ TABLE xyz
  ├── z int
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    └── x int not null
  └── INDEX foo
       ├── z int
@@ -53,7 +53,7 @@ TABLE abcdef
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
  ├── CHECK (f > 2:::INT8)
- └── INDEX primary
+ └── PRIMARY INDEX primary
       └── rowid int not null default (unique_rowid()) [hidden]
 scan abcdef
  ├── check constraint expressions
@@ -91,7 +91,7 @@ TABLE uvwxy
  ├── FAMILY fam_0_u_v_w (u, v, w)
  ├── FAMILY fam_1_x (x)
  ├── FAMILY fam_2_y (y)
- └── INDEX primary
+ └── PRIMARY INDEX primary
       ├── u int not null
       └── v int not null
 scan uvwxy
@@ -119,7 +119,7 @@ TABLE child
  ├── r int
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    └── c int not null
  └── CONSTRAINT fk FOREIGN KEY child (p, q, r) REFERENCES parent (p, q, r)
 scan child
@@ -134,7 +134,7 @@ TABLE parent
  ├── other int
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    ├── p int not null
  │    ├── q int not null
  │    └── r int not null
@@ -161,7 +161,7 @@ TABLE child2
  ├── r int
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    └── c int not null
  └── CONSTRAINT fk FOREIGN KEY child2 (p, q, r) REFERENCES parent (p, q, r) MATCH FULL ON DELETE SET NULL
 scan child2
@@ -176,7 +176,7 @@ TABLE parent
  ├── other int
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    ├── p int not null
  │    ├── q int not null
  │    └── r int not null
@@ -213,7 +213,7 @@ TABLE a
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
  ├── FAMILY fam_0_a_other (a, other)
- └── INDEX primary
+ └── PRIMARY INDEX primary
       ├── a int not null
       └── interleaved by
            └── table=60 index=1
@@ -228,7 +228,7 @@ TABLE ab
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
  ├── FAMILY fam_0_a_b (a, b)
- └── INDEX primary
+ └── PRIMARY INDEX primary
       ├── a int not null
       ├── b int not null
       ├── interleave ancestors
@@ -249,7 +249,7 @@ TABLE abc
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
  ├── FAMILY fam_0_a_b_c_k (a, b, c, k)
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    └── k int not null
  └── INDEX abc_idx
       ├── a int
@@ -271,7 +271,7 @@ TABLE abx
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
  ├── FAMILY fam_0_a_b_x (a, b, x)
- └── INDEX primary
+ └── PRIMARY INDEX primary
       ├── a int not null
       ├── b int not null
       ├── x int not null

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -1152,7 +1152,7 @@ TABLE tc
  ├── rowid int not null default (unique_rowid()) [hidden]
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    └── rowid int not null default (unique_rowid()) [hidden]
  └── INDEX c
       ├── a int
@@ -1171,7 +1171,7 @@ TABLE tc
  ├── rowid int not null default (unique_rowid()) [hidden]
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    └── rowid int not null default (unique_rowid()) [hidden]
  └── INDEX c
       ├── a int
@@ -1181,7 +1181,7 @@ TABLE t
  ├── v int
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- └── INDEX primary
+ └── PRIMARY INDEX primary
       └── k int not null
 inner-join (hash)
  ├── columns: a:1 b:2 k:6 v:7

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -27,13 +27,14 @@ CREATE TABLE uniq_overlaps_pk (
   PRIMARY KEY (a, b),
   UNIQUE WITHOUT INDEX (b, c),
   UNIQUE WITHOUT INDEX (a, b, d),
-  UNIQUE WITHOUT INDEX (a),
-  UNIQUE WITHOUT INDEX (c, d),
   FAMILY (a),
   FAMILY (b),
   FAMILY (c),
   FAMILY (d)
-)
+);
+ALTER TABLE uniq_overlaps_pk ADD CONSTRAINT unique_a UNIQUE WITHOUT INDEX (a) NOT VALID;
+ALTER TABLE uniq_overlaps_pk ADD CONSTRAINT unique_c_d UNIQUE WITHOUT INDEX (c, d) NOT VALID
+
 
 statement ok
 CREATE TABLE uniq_hidden_pk (
@@ -881,12 +882,14 @@ vectorized: true
 │               │ columns: (column1, column2, column3, column4)
 │               │ estimated row count: 0 (missing stats)
 │               │ table: uniq_enum@uniq_enum_r_s_j_key
+│               │ equality cols are key
 │               │ lookup condition: ((column2 = s) AND (column4 = j)) AND (r IN ('us-east', 'us-west', 'eu-west'))
 │               │
 │               └── • lookup join (anti)
 │                   │ columns: (column1, column2, column3, column4)
 │                   │ estimated row count: 0 (missing stats)
 │                   │ table: uniq_enum@primary
+│                   │ equality cols are key
 │                   │ lookup condition: (column3 = i) AND (r IN ('us-east', 'us-west', 'eu-west'))
 │                   │
 │                   └── • lookup join (anti)
@@ -1476,6 +1479,80 @@ vectorized: true
             └── • scan buffer
                   label: buffer 1
 
+statement ok
+ALTER TABLE uniq_overlaps_pk VALIDATE CONSTRAINT unique_a
+
+# Same test as the previous, but now that the constraint has been validated, it
+# can be treated as a key. This allows the joins to be more efficient.
+query T
+EXPLAIN UPDATE uniq_overlaps_pk SET a = 1, b = 2, c = 3, d = 4 WHERE a = 5
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • update
+│   │ table: uniq_overlaps_pk
+│   │ set: a, b, c, d
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: uniq_overlaps_pk@primary
+│                 spans: [/5 - /5]
+│                 locking strength: for update
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • hash join (right semi)
+│           │ equality: (b, c) = (b_new, c_new)
+│           │ right cols are key
+│           │ pred: a_new != a
+│           │
+│           ├── • scan
+│           │     missing stats
+│           │     table: uniq_overlaps_pk@primary
+│           │     spans: FULL SCAN
+│           │
+│           └── • scan buffer
+│                 label: buffer 1
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • lookup join (semi)
+│           │ table: uniq_overlaps_pk@primary
+│           │ equality: (a_new) = (a)
+│           │ pred: b_new != b
+│           │
+│           └── • scan buffer
+│                 label: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • hash join (right semi)
+            │ equality: (c, d) = (c_new, d_new)
+            │ right cols are key
+            │ pred: (a_new != a) OR (b_new != b)
+            │
+            ├── • scan
+            │     missing stats
+            │     table: uniq_overlaps_pk@primary
+            │     spans: FULL SCAN
+            │
+            └── • scan buffer
+                  label: buffer 1
+
 # Update with non-constant input.
 # No need to add a check for b,c since those columns weren't updated.
 # Add inequality filters for the hidden primary key column.
@@ -1614,6 +1691,7 @@ vectorized: true
 │       │
 │       └── • hash join (right anti)
 │           │ equality: (b, c) = (b_new, c)
+│           │ right cols are key
 │           │
 │           ├── • scan
 │           │     missing stats
@@ -2688,6 +2766,7 @@ vectorized: true
 │                       │ columns: (column1, column2, column3, column4, r, s, i, j)
 │                       │ estimated row count: 2 (missing stats)
 │                       │ table: uniq_enum@uniq_enum_r_s_j_key
+│                       │ equality cols are key
 │                       │ lookup condition: ((column2 = s) AND (column4 = j)) AND (r IN ('us-east', 'us-west', 'eu-west'))
 │                       │
 │                       └── • values

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
@@ -69,7 +69,7 @@ TABLE t
  ├── tableoid oid [hidden] [system]
  ├── FAMILY fam_0_a (a)
  ├── FAMILY fam_1_b (b)
- └── INDEX primary
+ └── PRIMARY INDEX primary
       └── a int not null
 project
  ├── scan t

--- a/pkg/sql/opt/memo/testdata/logprops/unique
+++ b/pkg/sql/opt/memo/testdata/logprops/unique
@@ -1,0 +1,96 @@
+exec-ddl
+CREATE TABLE t (
+  x INT PRIMARY KEY,
+  y INT UNIQUE WITHOUT INDEX,
+  z INT NOT NULL UNIQUE WITHOUT INDEX,
+  a INT,
+  b INT NOT NULL,
+  c INT NOT NULL,
+  UNIQUE WITHOUT INDEX (a, b),
+  UNIQUE WITHOUT INDEX (b, c),
+  UNIQUE WITHOUT INDEX (c) WHERE a > 5
+)
+----
+
+# Test that we build appropriate strict or lax keys for each of the UNIQUE
+# WITHOUT INDEX constraints depending on whether or not the columns allow
+# NULL values. We should not build a key for the partial constraint.
+build
+SELECT * FROM t
+----
+project
+ ├── columns: x:1(int!null) y:2(int) z:3(int!null) a:4(int) b:5(int!null) c:6(int!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2-6), (2)~~>(1,3-6), (3)-->(1,2,4-6), (4,5)~~>(1-3,6), (5,6)-->(1-4)
+ ├── prune: (1-6)
+ ├── interesting orderings: (+1)
+ └── scan t
+      ├── columns: x:1(int!null) y:2(int) z:3(int!null) a:4(int) b:5(int!null) c:6(int!null) crdb_internal_mvcc_timestamp:7(decimal)
+      ├── key: (1)
+      ├── fd: (1)-->(2-7), (2)~~>(1,3-7), (3)-->(1,2,4-7), (4,5)~~>(1-3,6,7), (5,6)-->(1-4,7)
+      ├── prune: (1-7)
+      └── interesting orderings: (+1)
+
+# Because we're constraining a key to a constant, the resulting FDs should
+# show that all columns are now constant, and cardinality is at most 1.
+build
+SELECT * FROM t WHERE y = 5
+----
+project
+ ├── columns: x:1(int!null) y:2(int!null) z:3(int!null) a:4(int) b:5(int!null) c:6(int!null)
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1-6)
+ ├── prune: (1-6)
+ ├── interesting orderings: (+1)
+ └── select
+      ├── columns: x:1(int!null) y:2(int!null) z:3(int!null) a:4(int) b:5(int!null) c:6(int!null) crdb_internal_mvcc_timestamp:7(decimal)
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(1-7)
+      ├── prune: (1,3-7)
+      ├── interesting orderings: (+1)
+      ├── scan t
+      │    ├── columns: x:1(int!null) y:2(int) z:3(int!null) a:4(int) b:5(int!null) c:6(int!null) crdb_internal_mvcc_timestamp:7(decimal)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-7), (2)~~>(1,3-7), (3)-->(1,2,4-7), (4,5)~~>(1-3,6,7), (5,6)-->(1-4,7)
+      │    ├── prune: (1-7)
+      │    └── interesting orderings: (+1)
+      └── filters
+           └── eq [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
+                ├── variable: y:2 [type=int]
+                └── const: 5 [type=int]
+
+# Because we're constraining a key to a constant, the resulting FDs should
+# show that all columns are now constant, and cardinality is at most 1.
+build
+SELECT * FROM t WHERE a = 1 AND b = 1
+----
+project
+ ├── columns: x:1(int!null) y:2(int) z:3(int!null) a:4(int!null) b:5(int!null) c:6(int!null)
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1-6)
+ ├── prune: (1-6)
+ ├── interesting orderings: (+1)
+ └── select
+      ├── columns: x:1(int!null) y:2(int) z:3(int!null) a:4(int!null) b:5(int!null) c:6(int!null) crdb_internal_mvcc_timestamp:7(decimal)
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(1-7)
+      ├── prune: (1-3,6,7)
+      ├── interesting orderings: (+1)
+      ├── scan t
+      │    ├── columns: x:1(int!null) y:2(int) z:3(int!null) a:4(int) b:5(int!null) c:6(int!null) crdb_internal_mvcc_timestamp:7(decimal)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-7), (2)~~>(1,3-7), (3)-->(1,2,4-7), (4,5)~~>(1-3,6,7), (5,6)-->(1-4,7)
+      │    ├── prune: (1-7)
+      │    └── interesting orderings: (+1)
+      └── filters
+           └── and [type=bool, outer=(4,5), constraints=(/4: [/1 - /1]; /5: [/1 - /1]; tight), fd=()-->(4,5)]
+                ├── eq [type=bool]
+                │    ├── variable: a:4 [type=int]
+                │    └── const: 1 [type=int]
+                └── eq [type=bool]
+                     ├── variable: b:5 [type=int]
+                     └── const: 1 [type=int]

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -3603,7 +3603,7 @@ update uniq
  │    │    ├── scan uniq
  │    │    │    ├── columns: uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 uniq.z:13
  │    │    │    ├── key: (8)
- │    │    │    └── fd: (8)-->(9-13), (13)~~>(8-12)
+ │    │    │    └── fd: (8)-->(9-13), (13)~~>(8-12), (10)~~>(8,9,11-13), (11,12)~~>(8-10,13)
  │    │    └── filters
  │    │         └── uniq.k:8 = 3 [outer=(8), constraints=(/8: [/3 - /3]; tight), fd=()-->(8)]
  │    └── projections
@@ -3709,7 +3709,7 @@ upsert uniq_fk_parent
  │    │    │    ├── scan uniq_fk_parent
  │    │    │    │    ├── columns: uniq_fk_parent.k:10!null uniq_fk_parent.a:11 uniq_fk_parent.b:12 uniq_fk_parent.c:13 uniq_fk_parent.d:14
  │    │    │    │    ├── key: (10)
- │    │    │    │    └── fd: (10)-->(11-14)
+ │    │    │    │    └── fd: (10)-->(11-14), (11)~~>(10,12-14), (12,13)~~>(10,11,14)
  │    │    │    └── filters
  │    │    │         └── uniq_fk_parent.k:10 = 2 [outer=(10), constraints=(/10: [/2 - /2]; tight), fd=()-->(10)]
  │    │    └── filters (true)
@@ -3815,7 +3815,7 @@ upsert uniq_fk_parent
  │    │    │    ├── scan uniq_fk_parent
  │    │    │    │    ├── columns: uniq_fk_parent.k:9!null uniq_fk_parent.a:10 uniq_fk_parent.b:11 uniq_fk_parent.c:12 uniq_fk_parent.d:13
  │    │    │    │    ├── key: (9)
- │    │    │    │    └── fd: (9)-->(10-13)
+ │    │    │    │    └── fd: (9)-->(10-13), (10)~~>(9,11-13), (11,12)~~>(9,10,13)
  │    │    │    └── filters
  │    │    │         └── uniq_fk_parent.k:9 = 1 [outer=(9), constraints=(/9: [/1 - /1]; tight), fd=()-->(9)]
  │    │    └── filters (true)
@@ -3894,7 +3894,7 @@ delete uniq_fk_parent
  │    ├── scan uniq_fk_parent
  │    │    ├── columns: k:7!null uniq_fk_parent.a:8 uniq_fk_parent.b:9 uniq_fk_parent.c:10
  │    │    ├── key: (7)
- │    │    └── fd: (7)-->(8-10)
+ │    │    └── fd: (7)-->(8-10), (8)~~>(7,9,10), (9,10)~~>(7,8)
  │    └── filters
  │         └── k:7 = 1 [outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
  └── f-k-checks
@@ -3913,7 +3913,9 @@ delete uniq_fk_parent
       │         │    ├── key: ()
       │         │    └── fd: ()-->(13,14)
       │         ├── scan uniq_fk_child
-      │         │    └── columns: uniq_fk_child.b:16 uniq_fk_child.c:17
+      │         │    ├── columns: uniq_fk_child.b:16 uniq_fk_child.c:17
+      │         │    ├── lax-key: (16,17)
+      │         │    └── fd: (17)~~>(16)
       │         └── filters
       │              ├── b:13 = uniq_fk_child.b:16 [outer=(13,16), constraints=(/13: (/NULL - ]; /16: (/NULL - ]), fd=(13)==(16), (16)==(13)]
       │              └── c:14 = uniq_fk_child.c:17 [outer=(14,17), constraints=(/14: (/NULL - ]; /17: (/NULL - ]), fd=(14)==(17), (17)==(14)]

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -173,7 +173,8 @@ type mutationBuilder struct {
 	// cascades contains foreign key check cascades; see buildFK* methods.
 	cascades memo.FKCascades
 
-	// withID is nonzero if we need to buffer the input for FK checks.
+	// withID is nonzero if we need to buffer the input for FK or uniqueness
+	// checks.
 	withID opt.WithID
 
 	// extraAccessibleCols stores all the columns that are available to the

--- a/pkg/sql/opt/optbuilder/mutation_builder_unique.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_unique.go
@@ -290,7 +290,9 @@ func (h *uniqueCheckHelper) buildTableScan() (outScope *scope, ordinals []int) {
 	return h.mb.b.buildScan(
 		tabMeta,
 		ordinals,
-		nil, /* indexFlags */
+		// After the update we can't guarantee that the constraints are unique
+		// (which is why we need the uniqueness checks in the first place).
+		&tree.IndexFlags{IgnoreUniqueWithoutIndexKeys: true},
 		noRowLocking,
 		h.mb.b.allocScope(),
 	), ordinals

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -454,8 +454,13 @@ func (b *Builder) buildScan(
 	tab := tabMeta.Table
 	tabID := tabMeta.MetaID
 
-	if indexFlags != nil && indexFlags.IgnoreForeignKeys {
-		tabMeta.IgnoreForeignKeys = true
+	if indexFlags != nil {
+		if indexFlags.IgnoreForeignKeys {
+			tabMeta.IgnoreForeignKeys = true
+		}
+		if indexFlags.IgnoreUniqueWithoutIndexKeys {
+			tabMeta.IgnoreUniqueWithoutIndexKeys = true
+		}
 	}
 
 	outScope = inScope.push()

--- a/pkg/sql/opt/optbuilder/testdata/inverted-indexes
+++ b/pkg/sql/opt/optbuilder/testdata/inverted-indexes
@@ -26,12 +26,11 @@ TABLE kj
  ├── j jsonb
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── j_inverted_key jsonb not null [virtual-inverted]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    └── k int not null
- ├── INVERTED INDEX secondary
- │    ├── j_inverted_key jsonb not null [virtual-inverted]
- │    └── k int not null
- └── UNIQUE (k)
+ └── INVERTED INDEX secondary
+      ├── j_inverted_key jsonb not null [virtual-inverted]
+      └── k int not null
 
 build
 SELECT j_inverted_key FROM kj

--- a/pkg/sql/opt/table_meta.go
+++ b/pkg/sql/opt/table_meta.go
@@ -135,6 +135,10 @@ type TableMeta struct {
 	// the consistency of foreign keys.
 	IgnoreForeignKeys bool
 
+	// IgnoreUniqueWithoutIndexKeys is true if we should disable any rules that
+	// depend on the consistency of unique without index constraints.
+	IgnoreUniqueWithoutIndexKeys bool
+
 	// Constraints stores a *FiltersExpr containing filters that are known to
 	// evaluate to true on the table data. This list is extracted from validated
 	// check constraints; specifically, those check constraints that we can prove

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -487,6 +487,12 @@ func (tc *Catalog) resolveFK(tab *Table, d *tree.ForeignKeyConstraintTableDef) {
 func (tt *Table) addUniqueConstraint(
 	name tree.Name, columns tree.IndexElemList, predicate tree.Expr, withoutIndex bool,
 ) {
+	// We don't currently use unique constraints with an index (those are already
+	// tracked with unique indexes), so don't bother adding them.
+	// NB: This should stay consistent with opt_catalog.go.
+	if !withoutIndex {
+		return
+	}
 	cols := make([]int, len(columns))
 	for i, c := range columns {
 		cols[i] = tt.FindOrdinal(string(c.Column))

--- a/pkg/sql/opt/testutils/testcat/testdata/foreign_keys
+++ b/pkg/sql/opt/testutils/testcat/testdata/foreign_keys
@@ -12,10 +12,9 @@ SHOW CREATE parent
 TABLE parent
  ├── p int not null
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    └── p int not null
- ├── REFERENCED BY CONSTRAINT fk_p_ref_parent FOREIGN KEY child (p) REFERENCES parent (p)
- └── UNIQUE (p)
+ └── REFERENCED BY CONSTRAINT fk_p_ref_parent FOREIGN KEY child (p) REFERENCES parent (p)
 
 exec-ddl
 SHOW CREATE child
@@ -24,10 +23,9 @@ TABLE child
  ├── c int not null
  ├── p int
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    └── c int not null
- ├── CONSTRAINT fk_p_ref_parent FOREIGN KEY child (p) REFERENCES parent (p)
- └── UNIQUE (c)
+ └── CONSTRAINT fk_p_ref_parent FOREIGN KEY child (p) REFERENCES parent (p)
 
 exec-ddl
 CREATE TABLE parent2 (p INT UNIQUE)
@@ -44,14 +42,12 @@ TABLE parent2
  ├── p int
  ├── rowid int not null default (unique_rowid()) [hidden]
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    └── rowid int not null default (unique_rowid()) [hidden]
- ├── INDEX parent2_p_key
+ ├── UNIQUE INDEX parent2_p_key
  │    ├── p int
  │    └── rowid int not null default (unique_rowid()) [hidden] (storing)
- ├── REFERENCED BY CONSTRAINT fk_p_ref_parent2 FOREIGN KEY child2 (p) REFERENCES parent2 (p)
- ├── UNIQUE (rowid)
- └── UNIQUE (p)
+ └── REFERENCED BY CONSTRAINT fk_p_ref_parent2 FOREIGN KEY child2 (p) REFERENCES parent2 (p)
 
 exec-ddl
 SHOW CREATE child2
@@ -60,10 +56,9 @@ TABLE child2
  ├── c int not null
  ├── p int
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    └── c int not null
- ├── CONSTRAINT fk_p_ref_parent2 FOREIGN KEY child2 (p) REFERENCES parent2 (p)
- └── UNIQUE (c)
+ └── CONSTRAINT fk_p_ref_parent2 FOREIGN KEY child2 (p) REFERENCES parent2 (p)
 
 exec-ddl
 CREATE TABLE parent_multicol (p INT, q INT, r INT, PRIMARY KEY (p,q,r))
@@ -97,13 +92,12 @@ TABLE parent_multicol
  ├── q int not null
  ├── r int not null
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    ├── p int not null
  │    ├── q int not null
  │    └── r int not null
  ├── REFERENCED BY CONSTRAINT fk FOREIGN KEY child_multicol (p, q, r) REFERENCES parent_multicol (p, q, r)
- ├── REFERENCED BY CONSTRAINT fk FOREIGN KEY child_multicol_full (p, q, r) REFERENCES parent_multicol (p, q, r) MATCH FULL
- └── UNIQUE (p, q, r)
+ └── REFERENCED BY CONSTRAINT fk FOREIGN KEY child_multicol_full (p, q, r) REFERENCES parent_multicol (p, q, r) MATCH FULL
 
 exec-ddl
 SHOW CREATE child_multicol
@@ -113,12 +107,11 @@ TABLE child_multicol
  ├── q int not null
  ├── r int not null
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    ├── p int not null
  │    ├── q int not null
  │    └── r int not null
- ├── CONSTRAINT fk FOREIGN KEY child_multicol (p, q, r) REFERENCES parent_multicol (p, q, r)
- └── UNIQUE (p, q, r)
+ └── CONSTRAINT fk FOREIGN KEY child_multicol (p, q, r) REFERENCES parent_multicol (p, q, r)
 
 exec-ddl
 SHOW CREATE child_multicol_full
@@ -128,12 +121,11 @@ TABLE child_multicol_full
  ├── q int not null
  ├── r int not null
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    ├── p int not null
  │    ├── q int not null
  │    └── r int not null
- ├── CONSTRAINT fk FOREIGN KEY child_multicol_full (p, q, r) REFERENCES parent_multicol (p, q, r) MATCH FULL
- └── UNIQUE (p, q, r)
+ └── CONSTRAINT fk FOREIGN KEY child_multicol_full (p, q, r) REFERENCES parent_multicol (p, q, r) MATCH FULL
 
 exec-ddl
 DROP TABLE child
@@ -145,9 +137,8 @@ SHOW CREATE parent
 TABLE parent
  ├── p int not null
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── INDEX primary
- │    └── p int not null
- └── UNIQUE (p)
+ └── PRIMARY INDEX primary
+      └── p int not null
 
 exec-ddl
 DROP TABLE child_multicol
@@ -161,12 +152,11 @@ TABLE parent_multicol
  ├── q int not null
  ├── r int not null
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    ├── p int not null
  │    ├── q int not null
  │    └── r int not null
- ├── REFERENCED BY CONSTRAINT fk FOREIGN KEY child_multicol_full (p, q, r) REFERENCES parent_multicol (p, q, r) MATCH FULL
- └── UNIQUE (p, q, r)
+ └── REFERENCED BY CONSTRAINT fk FOREIGN KEY child_multicol_full (p, q, r) REFERENCES parent_multicol (p, q, r) MATCH FULL
 
 exec-ddl
 DROP TABLE child_multicol_full
@@ -180,11 +170,10 @@ TABLE parent_multicol
  ├── q int not null
  ├── r int not null
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── INDEX primary
- │    ├── p int not null
- │    ├── q int not null
- │    └── r int not null
- └── UNIQUE (p, q, r)
+ └── PRIMARY INDEX primary
+      ├── p int not null
+      ├── q int not null
+      └── r int not null
 
 # Verify we can drop a self-referencing table.
 exec-ddl

--- a/pkg/sql/opt/testutils/testcat/testdata/index
+++ b/pkg/sql/opt/testutils/testcat/testdata/index
@@ -16,12 +16,11 @@ TABLE kv
  ├── k int not null
  ├── v int
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    └── k int not null
- ├── INDEX idx
- │    ├── v int
- │    └── k int not null
- └── UNIQUE (k)
+ └── INDEX idx
+      ├── v int
+      └── k int not null
 
 exec-ddl
 CREATE INDEX idx2 ON kv (v)
@@ -54,13 +53,12 @@ TABLE kv
  ├── k int not null
  ├── v int
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    └── k int not null
- ├── INDEX idx
- │    ├── v int
- │    ├── k int not null
- │    └── WHERE v > 1
- └── UNIQUE (k)
+ └── INDEX idx
+      ├── v int
+      ├── k int not null
+      └── WHERE v > 1
 
 exec-ddl
 CREATE TABLE g (
@@ -84,18 +82,17 @@ TABLE g
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── geog_inverted_key geography not null [virtual-inverted]
  ├── geog_inverted_key geography not null [virtual-inverted]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    └── k int not null
  ├── INVERTED INDEX secondary
  │    ├── a int
  │    ├── geog_inverted_key geography not null [virtual-inverted]
  │    └── k int not null
- ├── INVERTED INDEX secondary
- │    ├── a int
- │    ├── b int
- │    ├── geog_inverted_key geography not null [virtual-inverted]
- │    └── k int not null
- └── UNIQUE (k)
+ └── INVERTED INDEX secondary
+      ├── a int
+      ├── b int
+      ├── geog_inverted_key geography not null [virtual-inverted]
+      └── k int not null
 
 # Test for expression-based index columns.
 exec-ddl
@@ -124,7 +121,7 @@ TABLE xyz
  ├── idx_expr_1 string as (lower(z)) virtual [hidden]
  ├── idx_expr_2 int as (y + 1) virtual [hidden]
  ├── idx_expr_3 int as (x + y) virtual [hidden]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    └── x int not null
  ├── INDEX idx1
  │    ├── idx_expr_1 string as (lower(z)) virtual [hidden]
@@ -137,10 +134,9 @@ TABLE xyz
  │    ├── idx_expr_2 int as (y + 1) virtual [hidden]
  │    ├── idx_expr_1 string as (lower(z)) virtual [hidden]
  │    └── x int not null
- ├── INDEX idx4
- │    ├── idx_expr_3 int as (x + y) virtual [hidden]
- │    ├── y int
- │    ├── x int not null
- │    ├── z string (storing)
- │    └── WHERE v > 1
- └── UNIQUE (x)
+ └── INDEX idx4
+      ├── idx_expr_3 int as (x + y) virtual [hidden]
+      ├── y int
+      ├── x int not null
+      ├── z string (storing)
+      └── WHERE v > 1

--- a/pkg/sql/opt/testutils/testcat/testdata/table
+++ b/pkg/sql/opt/testutils/testcat/testdata/table
@@ -12,9 +12,8 @@ TABLE kv
  ├── k int not null
  ├── v int
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── INDEX primary
- │    └── k int not null
- └── UNIQUE (k)
+ └── PRIMARY INDEX primary
+      └── k int not null
 
 exec-ddl
 CREATE TABLE abcdef (
@@ -42,9 +41,8 @@ TABLE abcdef
  ├── rowid int not null default (unique_rowid()) [hidden]
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── CHECK (f > 2)
- ├── INDEX primary
- │    └── rowid int not null default (unique_rowid()) [hidden]
- └── UNIQUE (rowid)
+ └── PRIMARY INDEX primary
+      └── rowid int not null default (unique_rowid()) [hidden]
 
 exec-ddl
 CREATE TABLE uvwxy (
@@ -74,10 +72,9 @@ TABLE uvwxy
  ├── FAMILY family1 (u, v, w, crdb_internal_mvcc_timestamp)
  ├── FAMILY family2 (x)
  ├── FAMILY family3 (y)
- ├── INDEX primary
- │    ├── u int not null
- │    └── v int not null
- └── UNIQUE (u, v)
+ └── PRIMARY INDEX primary
+      ├── u int not null
+      └── v int not null
 
 exec-ddl
 CREATE TABLE a (a INT UNIQUE)
@@ -90,13 +87,11 @@ TABLE a
  ├── a int
  ├── rowid int not null default (unique_rowid()) [hidden]
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    └── rowid int not null default (unique_rowid()) [hidden]
- ├── INDEX a_a_key
- │    ├── a int
- │    └── rowid int not null default (unique_rowid()) [hidden] (storing)
- ├── UNIQUE (rowid)
- └── UNIQUE (a)
+ └── UNIQUE INDEX a_a_key
+      ├── a int
+      └── rowid int not null default (unique_rowid()) [hidden] (storing)
 
 exec-ddl
 CREATE TABLE part1 (a INT PRIMARY KEY, b INT) PARTITION BY LIST (a) (
@@ -113,14 +108,13 @@ TABLE part1
  ├── a int not null
  ├── b int
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── INDEX primary
- │    ├── a int not null
- │    └── partition by list prefixes
- │         ├── (1)
- │         ├── (3)
- │         ├── (4)
- │         └── (5)
- └── UNIQUE (a)
+ └── PRIMARY INDEX primary
+      ├── a int not null
+      └── partition by list prefixes
+           ├── (1)
+           ├── (3)
+           ├── (4)
+           └── (5)
 
 exec-ddl
 CREATE TABLE part2 (
@@ -147,7 +141,7 @@ TABLE part2
  ├── b string not null
  ├── c int not null
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    ├── a string not null
  │    ├── b string not null
  │    ├── c int not null
@@ -156,15 +150,14 @@ TABLE part2
  │         ├── ('foo', 'baz')
  │         ├── ('qux', 'qux')
  │         └── ('waldo')
- ├── INDEX secondary
- │    ├── c int not null
- │    ├── a string not null
- │    ├── b string not null
- │    └── partition by list prefixes
- │         ├── (1)
- │         ├── (3)
- │         └── (4)
- └── UNIQUE (a, b, c)
+ └── INDEX secondary
+      ├── c int not null
+      ├── a string not null
+      ├── b string not null
+      └── partition by list prefixes
+           ├── (1)
+           ├── (3)
+           └── (4)
 
 exec-ddl
 CREATE TABLE inv (
@@ -188,15 +181,14 @@ TABLE inv
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── j_inverted_key jsonb not null [virtual-inverted]
  ├── g_inverted_key geometry not null [virtual-inverted]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    └── k int not null
  ├── INVERTED INDEX secondary
  │    ├── j_inverted_key jsonb not null [virtual-inverted]
  │    └── k int not null
- ├── INVERTED INDEX secondary
- │    ├── g_inverted_key geometry not null [virtual-inverted]
- │    └── k int not null
- └── UNIQUE (k)
+ └── INVERTED INDEX secondary
+      ├── g_inverted_key geometry not null [virtual-inverted]
+      └── k int not null
 
 # Table with inverted indexes and implicit primary index.
 exec-ddl
@@ -220,15 +212,14 @@ TABLE inv2
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── j_inverted_key jsonb not null [virtual-inverted]
  ├── g_inverted_key geometry not null [virtual-inverted]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    └── rowid int not null default (unique_rowid()) [hidden]
  ├── INVERTED INDEX secondary
  │    ├── j_inverted_key jsonb not null [virtual-inverted]
  │    └── rowid int not null default (unique_rowid()) [hidden]
- ├── INVERTED INDEX secondary
- │    ├── g_inverted_key geometry not null [virtual-inverted]
- │    └── rowid int not null default (unique_rowid()) [hidden]
- └── UNIQUE (rowid)
+ └── INVERTED INDEX secondary
+      ├── g_inverted_key geometry not null [virtual-inverted]
+      └── rowid int not null default (unique_rowid()) [hidden]
 
 # Table with unique constraints.
 exec-ddl
@@ -257,19 +248,16 @@ TABLE uniq
  ├── rowid int not null default (unique_rowid()) [hidden]
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── CHECK (k IN ('foo', 'bar', 'baz'))
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    └── rowid int not null default (unique_rowid()) [hidden]
- ├── INDEX uniq_i_key
+ ├── UNIQUE INDEX uniq_i_key
  │    ├── i int
  │    └── rowid int not null default (unique_rowid()) [hidden] (storing)
- ├── INDEX secondary
+ ├── UNIQUE INDEX secondary
  │    ├── k string
  │    ├── j string
  │    └── rowid int not null default (unique_rowid()) [hidden] (storing)
- ├── UNIQUE (rowid)
- ├── UNIQUE (i)
  ├── UNIQUE WITHOUT INDEX (j)
- ├── UNIQUE (j, k)
  ├── UNIQUE WITHOUT INDEX (l, m)
  └── UNIQUE WITHOUT INDEX (l)
       └── WHERE l > 0
@@ -297,12 +285,11 @@ TABLE mutations
  ├── c int [write-only]
  ├── d int [delete-only]
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    └── rowid int not null default (unique_rowid()) [hidden]
  ├── INDEX idxa (mutation)
  │    ├── a int
  │    └── rowid int not null default (unique_rowid()) [hidden]
- ├── INDEX idxb (mutation)
- │    ├── b int [inaccessible]
- │    └── rowid int not null default (unique_rowid()) [hidden]
- └── UNIQUE (rowid)
+ └── INDEX idxb (mutation)
+      ├── b int [inaccessible]
+      └── rowid int not null default (unique_rowid()) [hidden]

--- a/pkg/sql/opt/testutils/testcat/testdata/zone
+++ b/pkg/sql/opt/testutils/testcat/testdata/zone
@@ -20,20 +20,18 @@ TABLE abc
  ├── b int
  ├── c string
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    ├── a int not null
  │    └── ZONE
  │         └── constraints: [+region=central]
- ├── INDEX bc1
+ ├── UNIQUE INDEX bc1
  │    ├── b int
  │    ├── c string
  │    └── a int not null (storing)
- ├── INDEX bc2
- │    ├── b int
- │    ├── c string
- │    └── a int not null (storing)
- ├── UNIQUE (a)
- └── UNIQUE (b, c)
+ └── UNIQUE INDEX bc2
+      ├── b int
+      ├── c string
+      └── a int not null (storing)
 
 exec-ddl
 ALTER INDEX abc@bc1 CONFIGURE ZONE USING constraints='[+region=east]'
@@ -47,22 +45,20 @@ TABLE abc
  ├── b int
  ├── c string
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    ├── a int not null
  │    └── ZONE
  │         └── constraints: [+region=central]
- ├── INDEX bc1
+ ├── UNIQUE INDEX bc1
  │    ├── b int
  │    ├── c string
  │    ├── a int not null (storing)
  │    └── ZONE
  │         └── constraints: [+region=east]
- ├── INDEX bc2
- │    ├── b int
- │    ├── c string
- │    └── a int not null (storing)
- ├── UNIQUE (a)
- └── UNIQUE (b, c)
+ └── UNIQUE INDEX bc2
+      ├── b int
+      ├── c string
+      └── a int not null (storing)
 
 exec-ddl
 ALTER INDEX abc@bc2 CONFIGURE ZONE USING constraints='[+region=west]'
@@ -76,24 +72,22 @@ TABLE abc
  ├── b int
  ├── c string
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    ├── a int not null
  │    └── ZONE
  │         └── constraints: [+region=central]
- ├── INDEX bc1
+ ├── UNIQUE INDEX bc1
  │    ├── b int
  │    ├── c string
  │    ├── a int not null (storing)
  │    └── ZONE
  │         └── constraints: [+region=east]
- ├── INDEX bc2
- │    ├── b int
- │    ├── c string
- │    ├── a int not null (storing)
- │    └── ZONE
- │         └── constraints: [+region=west]
- ├── UNIQUE (a)
- └── UNIQUE (b, c)
+ └── UNIQUE INDEX bc2
+      ├── b int
+      ├── c string
+      ├── a int not null (storing)
+      └── ZONE
+           └── constraints: [+region=west]
 
 exec-ddl
 ALTER TABLE abc CONFIGURE ZONE USING constraints='[+region=us,+dc=central,+rack=1]'
@@ -107,24 +101,22 @@ TABLE abc
  ├── b int
  ├── c string
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    ├── a int not null
  │    └── ZONE
  │         └── constraints: [+region=us,+dc=central,+rack=1]
- ├── INDEX bc1
+ ├── UNIQUE INDEX bc1
  │    ├── b int
  │    ├── c string
  │    ├── a int not null (storing)
  │    └── ZONE
  │         └── constraints: [+region=east]
- ├── INDEX bc2
- │    ├── b int
- │    ├── c string
- │    ├── a int not null (storing)
- │    └── ZONE
- │         └── constraints: [+region=west]
- ├── UNIQUE (a)
- └── UNIQUE (b, c)
+ └── UNIQUE INDEX bc2
+      ├── b int
+      ├── c string
+      ├── a int not null (storing)
+      └── ZONE
+           └── constraints: [+region=west]
 
 exec-ddl
 ALTER INDEX abc@bc1 CONFIGURE ZONE USING constraints='[+region=us,+dc=east,+rack=1]'
@@ -138,24 +130,22 @@ TABLE abc
  ├── b int
  ├── c string
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    ├── a int not null
  │    └── ZONE
  │         └── constraints: [+region=us,+dc=central,+rack=1]
- ├── INDEX bc1
+ ├── UNIQUE INDEX bc1
  │    ├── b int
  │    ├── c string
  │    ├── a int not null (storing)
  │    └── ZONE
  │         └── constraints: [+region=us,+dc=east,+rack=1]
- ├── INDEX bc2
- │    ├── b int
- │    ├── c string
- │    ├── a int not null (storing)
- │    └── ZONE
- │         └── constraints: [+region=west]
- ├── UNIQUE (a)
- └── UNIQUE (b, c)
+ └── UNIQUE INDEX bc2
+      ├── b int
+      ├── c string
+      ├── a int not null (storing)
+      └── ZONE
+           └── constraints: [+region=west]
 
 exec-ddl
 ALTER INDEX abc@bc2 CONFIGURE ZONE USING constraints='[+dc=west]'
@@ -169,21 +159,19 @@ TABLE abc
  ├── b int
  ├── c string
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
- ├── INDEX primary
+ ├── PRIMARY INDEX primary
  │    ├── a int not null
  │    └── ZONE
  │         └── constraints: [+region=us,+dc=central,+rack=1]
- ├── INDEX bc1
+ ├── UNIQUE INDEX bc1
  │    ├── b int
  │    ├── c string
  │    ├── a int not null (storing)
  │    └── ZONE
  │         └── constraints: [+region=us,+dc=east,+rack=1]
- ├── INDEX bc2
- │    ├── b int
- │    ├── c string
- │    ├── a int not null (storing)
- │    └── ZONE
- │         └── constraints: [+dc=west]
- ├── UNIQUE (a)
- └── UNIQUE (b, c)
+ └── UNIQUE INDEX bc2
+      ├── b int
+      ├── c string
+      ├── a int not null (storing)
+      └── ZONE
+           └── constraints: [+dc=west]


### PR DESCRIPTION
**opt: don't add unique constraints with an index to test catalog**

This commit updates the test catalog so that it is consistent with the
real catalog and doesn't add unique constraints with an index to the
catalog table. This also prevents some tests from failing unnecessarily.

Release note: None

**opt: create key for UNIQUE WITHOUT INDEX constraints**

This commit teaches the optimizer that columns with a valid `UNIQUE WITHOUT INDEX`
constraint form a key, and the functional dependencies should reflect that. This will be
necessary to support locality optimized search.

Fixes #58944
Informs #55185

Release note (performance improvement): The optimizer now knows that
the unique columns in an implicitly partitioned unique index form a
key. This can be used to enable certain optimizations and may result
in better plans.