### PR TITLE
sql: Forbid setting  of zone config for non physical tables

### DIFF
--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -1422,9 +1422,11 @@ func TestDropPhysicalTableGC(t *testing.T) {
 		tableDescriptor := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "test", table.name)
 		require.NotNil(t, tableDescriptor)
 		tableDescriptorId := tableDescriptor.GetID()
-		// Create a new zone config for the table to test its proper deletion.
-		_, err = sqlDB.Exec(fmt.Sprintf(`ALTER TABLE test.%s CONFIGURE ZONE USING gc.ttlseconds = 123456;`, table.name))
-		require.NoError(t, err)
+		if table.sqlType != "VIEW" {
+			// Create a new zone config for the table to test its proper deletion.
+			_, err = sqlDB.Exec(fmt.Sprintf(`ALTER TABLE test.%s CONFIGURE ZONE USING gc.ttlseconds = 123456;`, table.name))
+			require.NoError(t, err)
+		}
 		// Drop table.
 		_, err = sqlDB.Exec(fmt.Sprintf(`DROP %s test.%s;`, table.sqlType, table.name))
 		require.NoError(t, err)

--- a/pkg/sql/logictest/testdata/logic_test/zone_config
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config
@@ -265,3 +265,29 @@ SELECT zone_id, raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR TABLE a]
     constraints = '[]',
     voter_constraints = '{+region=test: 1}',
     lease_preferences = '[]'
+
+# Check entities for which we can set zone configs.
+subtest test_entity_validity
+
+statement ok
+CREATE TABLE zc (
+  a INT PRIMARY KEY,
+  b INT
+)
+
+statement ok
+ALTER TABLE zc CONFIGURE ZONE USING gc.ttlseconds = 100000
+
+statement ok
+CREATE MATERIALIZED VIEW vm (x, y) AS SELECT a,b FROM zc; ALTER TABLE vm CONFIGURE ZONE USING gc.ttlseconds = 100000
+
+statement error pgcode 42809 cannot set a zone configuration on non-physical object v
+CREATE VIEW v (x, y) AS SELECT a, b FROM zc; ALTER TABLE v CONFIGURE ZONE USING gc.ttlseconds = 100000
+
+user root
+
+statement error pq: user root does not have ZONECONFIG or CREATE privilege on relation pg_type
+ALTER TABLE pg_catalog.pg_type CONFIGURE ZONE USING gc.ttlseconds = 100000
+
+statement error pq: user root does not have ZONECONFIG or CREATE privilege on relation columns
+ALTER TABLE information_schema.columns CONFIGURE ZONE USING gc.ttlseconds = 100000

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -342,6 +342,12 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 		return err
 	}
 
+	// If the table descriptor is resolved but is not a
+	// physical table then return an error.
+	if table != nil && !table.IsPhysicalTable() {
+		return pgerror.Newf(pgcode.WrongObjectType, "cannot set a zone configuration on non-physical object %s", table.GetName())
+	}
+
 	if n.zoneSpecifier.TargetsPartition() && len(n.zoneSpecifier.TableOrIndex.Index) == 0 && !n.allIndexes {
 		// Backward compatibility for ALTER PARTITION ... OF TABLE. Determine which
 		// index has the specified partition.


### PR DESCRIPTION
Fixes #57478
Release note (sql change): Setting of zone configs for non physical tables is
now forbidden .