### PR TITLE
colexec: make external sorter respect memory limit better

### DIFF
--- a/pkg/sql/colexec/BUILD.bazel
+++ b/pkg/sql/colexec/BUILD.bazel
@@ -87,6 +87,7 @@ go_library(
         "//pkg/util/cancelchecker",
         "//pkg/util/duration",  # keep
         "//pkg/util/encoding",  # keep
+        "//pkg/util/humanizeutil",
         "//pkg/util/log",
         "//pkg/util/mon",
         "//pkg/util/randutil",

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -448,16 +448,26 @@ func (r opResult) createDiskBackedSort(
 		sorterMemMonitorName,
 		func(input colexecbase.Operator) colexecbase.Operator {
 			monitorNamePrefix := fmt.Sprintf("%sexternal-sorter", memMonitorNamePrefix)
-			// We are using an unlimited memory monitor here because external
+			// We are using unlimited memory monitors here because external
 			// sort itself is responsible for making sure that we stay within
 			// the memory limit.
-			unlimitedAllocator := colmem.NewAllocator(
+			sortUnlimitedAllocator := colmem.NewAllocator(
 				ctx, r.createBufferingUnlimitedMemAccount(
-					ctx, flowCtx, monitorNamePrefix,
+					ctx, flowCtx, monitorNamePrefix+"-sort",
+				), factory)
+			mergeUnlimitedAllocator := colmem.NewAllocator(
+				ctx, r.createBufferingUnlimitedMemAccount(
+					ctx, flowCtx, monitorNamePrefix+"-merge",
+				), factory)
+			outputUnlimitedAllocator := colmem.NewAllocator(
+				ctx, r.createBufferingUnlimitedMemAccount(
+					ctx, flowCtx, monitorNamePrefix+"-output",
 				), factory)
 			diskAccount := r.createDiskAccount(ctx, flowCtx, monitorNamePrefix)
 			es := colexec.NewExternalSorter(
-				unlimitedAllocator,
+				sortUnlimitedAllocator,
+				mergeUnlimitedAllocator,
+				outputUnlimitedAllocator,
 				input, inputTypes, ordering,
 				execinfra.GetWorkMemLimit(flowCtx.Cfg),
 				maxNumberPartitions,

--- a/pkg/sql/colexec/disk_spiller.go
+++ b/pkg/sql/colexec/disk_spiller.go
@@ -207,8 +207,13 @@ func (d *diskSpillerBase) Next(ctx context.Context) coldata.Batch {
 			if d.spillingCallbackFn != nil {
 				d.spillingCallbackFn()
 			}
-			d.diskBackedOp.Init()
-			d.distBackedOpInitStatus = OperatorInitialized
+			if d.distBackedOpInitStatus == OperatorNotInitialized {
+				// The disk spiller might be reset for reuse in which case the
+				// the disk-backed operator has already been initialized and we
+				// don't want to perform the initialization again.
+				d.diskBackedOp.Init()
+				d.distBackedOpInitStatus = OperatorInitialized
+			}
 			return d.diskBackedOp.Next(ctx)
 		}
 		// Either not an out of memory error or an OOM error coming from a

--- a/pkg/sql/colexec/external_sort.go
+++ b/pkg/sql/colexec/external_sort.go
@@ -12,6 +12,7 @@ package colexec
 
 import (
 	"context"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
@@ -21,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/errors"
@@ -121,11 +123,14 @@ type externalSorter struct {
 	// outputUnlimitedAllocator is used to track the memory under the output
 	// batch in the merge operation.
 	outputUnlimitedAllocator *colmem.Allocator
+	// mergeMemoryLimit determines the amount of RAM available during the merge
+	// operation. This will be roughly a half of the total limit and is used by
+	// the dequeued batches and the output batch.
+	mergeMemoryLimit int64
 
-	totalMemoryLimit int64
-	state            externalSorterState
-	inputTypes       []*types.T
-	ordering         execinfrapb.Ordering
+	state      externalSorterState
+	inputTypes []*types.T
+	ordering   execinfrapb.Ordering
 	// columnOrdering is the same as ordering used when creating mergers.
 	columnOrdering     colinfo.ColumnOrdering
 	inMemSorter        ResettableOperator
@@ -140,9 +145,27 @@ type externalSorter struct {
 	// numPartitions is the current number of partitions.
 	numPartitions int
 	// firstPartitionIdx is the index of the first partition to merge next.
-	firstPartitionIdx   int
+	firstPartitionIdx int
+	// maxNumberPartitions determines the maximum number of active partitions
+	// we can have at once. This number can be limited by the number of FDs
+	// available as well as by dynamically computed limit when the memory usage
+	// of the merge operation exceeds its allowance.
 	maxNumberPartitions int
-	numForcedMerges     int
+	// maxNumberPartitionsDynamicallyReduced is true when maxNumberPartitions
+	// has been reduced based on the memory usage of the merge operation. Once
+	// it is true, we won't reduce maxNumberPartitions any further.
+	maxNumberPartitionsDynamicallyReduced bool
+	numForcedMerges                       int
+
+	// partitionsInfo tracks some information about all current partitions
+	// (those in [firstPartitionIdx, firstPartitionIdx+numPartitions) range).
+	partitionsInfo struct {
+		// TODO(yuzefovich): use this information to change the order of merging
+		// the partitions (currently, the first partition can become very large
+		// and is constantly being merged).
+		totalSize       []int64
+		maxBatchMemSize []int64
+	}
 
 	// fdState is used to acquire file descriptors up front.
 	fdState struct {
@@ -212,18 +235,22 @@ func NewExternalSorter(
 		// have already spilled, so we'll use a larger limit.
 		memoryLimit = defaultMemoryLimit
 	}
-	estimatedOutputBatchMemSize := colmem.EstimateBatchSizeBytes(inputTypes, coldata.BatchSize())
 	// Each disk queue will use up to BufferSizeBytes of RAM, so we reduce the
-	// memoryLimit of the partitions to sort in memory by those cache sizes. To
-	// be safe, we also estimate the size of the output batch and subtract that
-	// as well.
-	singlePartitionSize := memoryLimit - int64(maxNumberPartitions*diskQueueCfg.BufferSizeBytes+estimatedOutputBatchMemSize)
-	if singlePartitionSize < 1 {
+	// memoryLimit of the partitions to sort in memory by those cache sizes.
+	memoryLimit -= int64(maxNumberPartitions * diskQueueCfg.BufferSizeBytes)
+	// We give half of the available RAM to the in-memory sorter. Note that we
+	// will reuse that memory for each partition and will be holding onto it all
+	// the time, so we cannot "return" this usage after spilling each partition.
+	inMemSortMemoryLimit := memoryLimit / 2
+	// We give another half of the available RAM to the merge operation.
+	mergeMemoryLimit := memoryLimit / 2
+	if inMemSortMemoryLimit < 1 {
 		// If the memory limit is 0, the input partitioning operator will return
 		// a zero-length batch, so make it at least 1.
-		singlePartitionSize = 1
+		inMemSortMemoryLimit = 1
+		mergeMemoryLimit = 1
 	}
-	inputPartitioner := newInputPartitioningOperator(input, singlePartitionSize)
+	inputPartitioner := newInputPartitioningOperator(input, inMemSortMemoryLimit)
 	inMemSorter, err := newSorter(
 		sortUnlimitedAllocator, newAllSpooler(sortUnlimitedAllocator, inputPartitioner, inputTypes),
 		inputTypes, ordering.Columns,
@@ -243,23 +270,20 @@ func NewExternalSorter(
 		OneInputNode:             NewOneInputNode(inMemSorter),
 		mergeUnlimitedAllocator:  mergeUnlimitedAllocator,
 		outputUnlimitedAllocator: outputUnlimitedAllocator,
-		totalMemoryLimit:         memoryLimit,
+		mergeMemoryLimit:         mergeMemoryLimit,
 		inMemSorter:              inMemSorter,
 		inMemSorterInput:         inputPartitioner.(*inputPartitioningOperator),
 		partitionerCreator: func() colcontainer.PartitionedQueue {
 			return colcontainer.NewPartitionedDiskQueue(inputTypes, diskQueueCfg, partitionedDiskQueueSemaphore, colcontainer.PartitionerStrategyCloseOnNewPartition, diskAcc)
 		},
-		inputTypes:     inputTypes,
-		ordering:       ordering,
-		columnOrdering: execinfrapb.ConvertToColumnOrdering(ordering),
-		// TODO(yuzefovich): maxNumberPartitions should also be semi-dynamically
-		// limited based on the sizes of batches. Consider a scenario when each
-		// input batch is 1 GB in size - if we don't put any limiting in place,
-		// we might try to use 16 partitions at once, which means that during
-		// merging we will be keeping 16 batches (i.e. 16GB of data) in memory.
+		inputTypes:          inputTypes,
+		ordering:            ordering,
+		columnOrdering:      execinfrapb.ConvertToColumnOrdering(ordering),
 		maxNumberPartitions: maxNumberPartitions,
 		numForcedMerges:     numForcedMerges,
 	}
+	es.partitionsInfo.totalSize = make([]int64, maxNumberPartitions)
+	es.partitionsInfo.maxBatchMemSize = make([]int64, maxNumberPartitions)
 	es.fdState.fdSemaphore = fdSemaphore
 	es.testingKnobs.delegateFDAcquisitions = delegateFDAcquisitions
 	return es
@@ -283,7 +307,6 @@ func (s *externalSorter) Next(ctx context.Context) coldata.Batch {
 				s.state = externalSorterFinalMerging
 				continue
 			}
-			newPartitionIdx := s.firstPartitionIdx + s.numPartitions
 			if s.partitioner == nil {
 				s.partitioner = s.partitionerCreator()
 				if !s.testingKnobs.delegateFDAcquisitions && s.fdState.fdSemaphore != nil {
@@ -294,20 +317,14 @@ func (s *externalSorter) Next(ctx context.Context) coldata.Batch {
 					s.fdState.acquiredFDs = toAcquire
 				}
 			}
-			// Note that b will never have a selection vector set because the
-			// allSpooler performs a deselection when buffering up the tuples,
-			// and the in-memory sorter has allSpooler as its input.
-			if err := s.partitioner.Enqueue(ctx, newPartitionIdx, b); err != nil {
-				colexecerror.InternalError(err)
-			}
+			s.partitionsInfo.totalSize[s.numPartitions] = 0
+			s.partitionsInfo.maxBatchMemSize[s.numPartitions] = 0
+			s.enqueue(ctx, b)
 			s.state = externalSorterSpillPartition
 
 		case externalSorterSpillPartition:
-			curPartitionIdx := s.firstPartitionIdx + s.numPartitions
 			b := s.input.Next(ctx)
-			if err := s.partitioner.Enqueue(ctx, curPartitionIdx, b); err != nil {
-				colexecerror.InternalError(err)
-			}
+			s.enqueue(ctx, b)
 			if b.Length() == 0 {
 				// The partition has been fully spilled, so we reset the
 				// in-memory sorter (which will do the "shallow" reset of
@@ -315,17 +332,7 @@ func (s *externalSorter) Next(ctx context.Context) coldata.Batch {
 				s.inMemSorterInput.interceptReset = true
 				s.inMemSorter.reset(ctx)
 				s.numPartitions++
-				forceRepeatedMerging := s.numForcedMerges > 0 && s.numPartitions == 2
-				if s.numPartitions == s.maxNumberPartitions-1 || forceRepeatedMerging {
-					// We either have reached the maximum number of active
-					// partitions that we know that we'll be able to merge
-					// without exceeding the limit or we're forced to merge the
-					// partitions in tests, so we need to merge all of them and
-					// spill the new partition to disk before we can proceed on
-					// consuming the input.
-					if forceRepeatedMerging {
-						s.numForcedMerges--
-					}
+				if s.shouldMergeAllPartitions() {
 					s.state = externalSorterRepeatedMerging
 					continue
 				}
@@ -352,15 +359,17 @@ func (s *externalSorter) Next(ctx context.Context) coldata.Batch {
 				colexecerror.InternalError(err)
 			}
 			merger.Init()
-			newPartitionIdx := s.firstPartitionIdx + s.numPartitions
+			s.firstPartitionIdx += s.numPartitions
+			s.numPartitions = 0
+			s.partitionsInfo.totalSize[s.numPartitions] = 0
+			s.partitionsInfo.maxBatchMemSize[s.numPartitions] = 0
 			for b := merger.Next(ctx); ; b = merger.Next(ctx) {
-				if err := s.partitioner.Enqueue(ctx, newPartitionIdx, b); err != nil {
-					colexecerror.InternalError(err)
-				}
+				s.enqueue(ctx, b)
 				if b.Length() == 0 {
 					break
 				}
 			}
+			s.numPartitions = 1
 			// We are now done with the merger, so we can release the memory
 			// used for the output batches (all of which have been enqueued into
 			// the new partition).
@@ -371,8 +380,6 @@ func (s *externalSorter) Next(ctx context.Context) coldata.Batch {
 			if err := s.partitioner.CloseInactiveReadPartitions(ctx); err != nil {
 				colexecerror.InternalError(err)
 			}
-			s.firstPartitionIdx += s.numPartitions
-			s.numPartitions = 1
 			s.state = externalSorterNewPartition
 
 		case externalSorterFinalMerging:
@@ -412,6 +419,83 @@ func (s *externalSorter) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
+// enqueue enqueues b to the current partition (which has index
+// firstPartitionIdx + numPartitions) as well as updates the information about
+// the partition.
+func (s *externalSorter) enqueue(ctx context.Context, b coldata.Batch) {
+	if b.Length() > 0 {
+		batchMemSize := colmem.GetBatchMemSize(b)
+		s.partitionsInfo.totalSize[s.numPartitions] += batchMemSize
+		if batchMemSize > s.partitionsInfo.maxBatchMemSize[s.numPartitions] {
+			s.partitionsInfo.maxBatchMemSize[s.numPartitions] = batchMemSize
+		}
+	}
+	curPartitionIdx := s.firstPartitionIdx + s.numPartitions
+	// Note that b will never have a selection vector set because the allSpooler
+	// performs a deselection when buffering up the tuples, and the in-memory
+	// sorter has allSpooler as its input.
+	if err := s.partitioner.Enqueue(ctx, curPartitionIdx, b); err != nil {
+		colexecerror.InternalError(err)
+	}
+}
+
+// shouldMergeAllPartitions returns true if we need to merge all current
+// partitions into one before proceeding to spilling a new partition.
+func (s *externalSorter) shouldMergeAllPartitions() bool {
+	if s.numPartitions <= 1 {
+		return false
+	}
+	forceRepeatedMerging := s.numForcedMerges > 0 && s.numPartitions == 2
+	if s.numPartitions == s.maxNumberPartitions-1 || forceRepeatedMerging {
+		// We either have reached the maximum number of active partitions that
+		// we know that we'll be able to merge without exceeding the limit of
+		// FDs or we're forced to merge the partitions in tests, so we need to
+		// merge all of them and spill the new partition to disk before we can
+		// proceed on consuming the input.
+		if forceRepeatedMerging {
+			s.numForcedMerges--
+		}
+		return true
+	}
+	if s.maxNumberPartitionsDynamicallyReduced {
+		// We haven't reached the dynamically computed maximum number of
+		// partitions yet, so we will wait before performing the merge
+		// operation.
+		return false
+	}
+	// Now we check whether already we're likely to exceed the memory limit for
+	// the merge operation.
+	//
+	// Each of the partitions will need to use a single batch at a time, so we
+	// count that usage based on the maximum batch mem size of each partition.
+	var expectedMergeMemUsage int64
+	for i := 0; i < s.numPartitions; i++ {
+		expectedMergeMemUsage += s.partitionsInfo.maxBatchMemSize[i]
+	}
+	// We also need to account for the output batch of the merge operation. We
+	// will estimate that it will use the average of max batch mem sizes from
+	// each of the partition.
+	expectedMergeMemUsage = expectedMergeMemUsage / int64(s.numPartitions) * int64(s.numPartitions+1)
+	if expectedMergeMemUsage < s.mergeMemoryLimit {
+		return false
+	}
+	// From now on, we will never be able to create more partitions than we
+	// currently have due to the fact that we're keeping the memory used for
+	// dequeued batches, so we'll override the maximum number of partitions and
+	// release the unused FDs.
+	//
+	// Note that we need an extra partition to write into.
+	newMaxNumberPartitions := s.numPartitions + 1
+	if !s.testingKnobs.delegateFDAcquisitions && s.fdState.fdSemaphore != nil {
+		toRelease := s.maxNumberPartitions - newMaxNumberPartitions
+		s.fdState.fdSemaphore.Release(toRelease)
+		s.fdState.acquiredFDs -= toRelease
+	}
+	s.maxNumberPartitions = newMaxNumberPartitions
+	s.maxNumberPartitionsDynamicallyReduced = true
+	return true
+}
+
 func (s *externalSorter) reset(ctx context.Context) {
 	if r, ok := s.input.(resetter); ok {
 		r.reset(ctx)
@@ -424,6 +508,9 @@ func (s *externalSorter) reset(ctx context.Context) {
 	s.closed = false
 	s.firstPartitionIdx = 0
 	s.numPartitions = 0
+	// Note that we consciously do not reset maxNumberPartitions and
+	// maxNumberPartitionsDynamicallyReduced (when the latter is true) since we
+	// are keeping the memory used for dequeueing batches.
 }
 
 func (s *externalSorter) Close(ctx context.Context) error {
@@ -477,17 +564,35 @@ func (s *externalSorter) createMergerForPartitions(
 		syncInputs[i].Op = s.partitionerToOperators[i]
 	}
 	if log.V(2) {
+		var b strings.Builder
+		for i := 0; i < s.numPartitions; i++ {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString(humanizeutil.IBytes(s.partitionsInfo.totalSize[i]))
+		}
 		log.Infof(ctx,
-			"external sorter is merging partitions in range [%d, %d)",
-			s.firstPartitionIdx, s.firstPartitionIdx+s.numPartitions,
+			"external sorter is merging partitions in range [%d, %d) with sizes [%s]",
+			s.firstPartitionIdx, s.firstPartitionIdx+s.numPartitions, b.String(),
 		)
 	}
 
-	// TODO(yuzefovich): we should calculate a more precise memory limit taking
-	// into account how many partitions are currently being merged and the
-	// average batch size in each one of them.
+	// Calculate the limit on the output batch mem size.
+	outputBatchMemSize := s.mergeMemoryLimit
+	for i := 0; i < s.numPartitions; i++ {
+		outputBatchMemSize -= s.partitionsInfo.maxBatchMemSize[i]
+	}
+	// It is possible that the expected usage of the dequeued batches already
+	// exceeds the memory limit (this is likely when the tuples are wide). In
+	// such a scenario we want to produce output batches of relatively large
+	// memory size too, so we give the output batch at least its fair share of
+	// the memory limit.
+	minOutputBatchMemSize := s.mergeMemoryLimit / int64(s.numPartitions+1)
+	if outputBatchMemSize < minOutputBatchMemSize {
+		outputBatchMemSize = minOutputBatchMemSize
+	}
 	return NewOrderedSynchronizer(
-		s.outputUnlimitedAllocator, s.totalMemoryLimit, syncInputs, s.inputTypes, s.columnOrdering,
+		s.outputUnlimitedAllocator, outputBatchMemSize, syncInputs, s.inputTypes, s.columnOrdering,
 	)
 }
 

--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -340,15 +340,14 @@ func TestExternalSortMemoryAccounting(t *testing.T) {
 	// We cannot guarantee a fixed value, so we use an allowed range.
 	//
 	// In an ideal world:
-	// - all of the memory would be accounted for (this is not done at the
-	//   moment)
+	// - all of the memory would be accounted for
 	// - no memory is double-counted
 	// - the reported usage is very close to 2 x memoryLimit (the monitor for
 	//   the in-memory sorter reports slightly below and the monitor for the
 	//   external sorter reports slightly above memoryLimit usage).
 	// TODO(yuzefovich): fix known deficiencies of the memory accounting and
 	// tighten the bounds.
-	expMin := memoryLimit * 3 / 2
+	expMin := memoryLimit * 2
 	expMax := memoryLimit * 3
 	require.GreaterOrEqualf(t, totalMaxMemUsage, expMin, "minimum memory bound not satisfied: "+
 		"actual %d, expected min %d", totalMaxMemUsage, expMin)

--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -252,6 +252,7 @@ func TestExternalSortMemoryAccounting(t *testing.T) {
 			DiskMonitor: testDiskMonitor,
 		},
 	}
+	rng, _ := randutil.NewPseudoRand()
 
 	// Use the Bytes type because we can control the size of values with it
 	// easily.
@@ -260,14 +261,14 @@ func TestExternalSortMemoryAccounting(t *testing.T) {
 
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
+	queueCfg.CacheMode = colcontainer.DiskQueueCacheModeReuseCache
+	queueCfg.SetDefaultBufferSizeBytesForCacheMode()
 
-	// TODO(yuzefovich): randomize some of these values once the memory
-	// accounting is as expected.
-	numInMemoryBufferedBatches := 8
+	numInMemoryBufferedBatches := 8 + rng.Intn(4)
 	// numNewPartitions determines the expected number of partitions created as
 	// a result of consuming the input (i.e. not as a result of the repeated
 	// merging).
-	numNewPartitions := 4
+	numNewPartitions := 4 + rng.Intn(3)
 	numTotalBatches := numInMemoryBufferedBatches * numNewPartitions
 	batchLength := coldata.BatchSize()
 	batch := testAllocator.NewMemBatchWithFixedCapacity(typs, batchLength)
@@ -279,13 +280,16 @@ func TestExternalSortMemoryAccounting(t *testing.T) {
 		batch.ColVec(0).Bytes().Set(i, singleTupleValue)
 	}
 	batch.SetLength(batchLength)
-	memoryLimit := colmem.GetBatchMemSize(batch) * int64(numInMemoryBufferedBatches)
+	numFDs := ExternalSorterMinPartitions + rng.Intn(3)
+	// The memory limit in the external sorter is divided as follows:
+	// - BufferSizeBytes for each of the disk queues is subtracted right away
+	// - the remaining part is divided evenly between the sorter and the merger.
+	memoryLimit := 2*colmem.GetBatchMemSize(batch)*int64(numInMemoryBufferedBatches) + int64(queueCfg.BufferSizeBytes*numFDs)
 	flowCtx.Cfg.TestingKnobs.MemoryLimitBytes = memoryLimit
 	input := newFiniteBatchSource(batch, typs, numTotalBatches)
 
 	var spilled bool
-	// TODO(yuzefovich): randomize number of available FDs.
-	sem := colexecbase.NewTestingSemaphore(ExternalSorterMinPartitions)
+	sem := colexecbase.NewTestingSemaphore(numFDs)
 	sorter, accounts, monitors, closers, err := createDiskBackedSorter(
 		ctx, flowCtx, []colexecbase.Operator{input}, typs, ordCols,
 		0 /* matchLen */, 0 /* k */, func() { spilled = true },
@@ -298,25 +302,26 @@ func TestExternalSortMemoryAccounting(t *testing.T) {
 	sorter.Init()
 	for b := sorter.Next(ctx); b.Length() > 0; b = sorter.Next(ctx) {
 	}
-	require.NoError(t, closers[0].Close(ctx))
+	for _, c := range closers {
+		require.NoError(t, c.Close(ctx))
+	}
 
 	require.True(t, spilled)
 	require.Zero(t, sem.GetCount(), "sem still reports open FDs")
 
-	// In the ideal world, given the limit in the semaphore, we expect that each
-	// newly created partition contains about numInMemoryBufferedBatches number
-	// of batches with only the partition that is the result of the repeated
-	// merge growing with count as a multiple of numInMemoryBufferedBatches
-	// (first merge = 2x, second merge = 3x, third merge 4x, etc, so we expect
-	// 2*numNewPartitions-1 partitions).
 	externalSorter := sorter.(*diskSpillerBase).diskBackedOp.(*externalSorter)
 	numPartitionsCreated := externalSorter.firstPartitionIdx + externalSorter.numPartitions
-	expMinTotalPartitionsCreated := 2*numNewPartitions - 1
-	// Because of some issues we might create more partitions than we would
-	// expect (depending on the batch size if numNewPartitions is 4, then we
-	// will create from 7 (large batch size) to 15 (batch size of 4)).
-	// The formula below might not apply if we change numNewPartitions.
-	expMaxTotalPartitionsCreated := 4*numNewPartitions - 1
+	// This maximum can be achieved when we have minimum required number of FDs
+	// as follows: we expect that each newly created partition contains about
+	// numInMemoryBufferedBatches number of batches with only the partition that
+	// is the result of the repeated merge growing with count as a multiple of
+	// numInMemoryBufferedBatches (first merge = 2x, second merge = 3x, third
+	// merge 4x, etc, so we expect 2*numNewPartitions-1 partitions).
+	expMaxTotalPartitionsCreated := 2*numNewPartitions - 1
+	// Because of our "after the fact" memory accounting, we might create less
+	// partitions than maximum defined above (e.g., if numNewPartitions is 5,
+	// then we will create 5 partitions when batch size is 3).
+	expMinTotalPartitionsCreated := numNewPartitions
 	require.GreaterOrEqualf(t, numPartitionsCreated, expMinTotalPartitionsCreated,
 		"didn't create enough partitions: actual %d, min expected %d",
 		numPartitionsCreated, expMinTotalPartitionsCreated,
@@ -339,16 +344,12 @@ func TestExternalSortMemoryAccounting(t *testing.T) {
 	}
 	// We cannot guarantee a fixed value, so we use an allowed range.
 	//
-	// In an ideal world:
-	// - all of the memory would be accounted for
-	// - no memory is double-counted
-	// - the reported usage is very close to 2 x memoryLimit (the monitor for
-	//   the in-memory sorter reports slightly below and the monitor for the
-	//   external sorter reports slightly above memoryLimit usage).
-	// TODO(yuzefovich): fix known deficiencies of the memory accounting and
-	// tighten the bounds.
-	expMin := memoryLimit * 2
-	expMax := memoryLimit * 3
+	// In an ideal world the reported usage is very close to 2 x memoryLimit
+	// (the monitor for the in-memory sorter reports slightly below and the
+	// monitors for the external sorter report slightly above memoryLimit
+	// usage).
+	expMin := memoryLimit * 3 / 2
+	expMax := memoryLimit * 5 / 2
 	require.GreaterOrEqualf(t, totalMaxMemUsage, expMin, "minimum memory bound not satisfied: "+
 		"actual %d, expected min %d", totalMaxMemUsage, expMin)
 	require.GreaterOrEqualf(t, expMax, totalMaxMemUsage, "maximum memory bound not satisfied: "+

--- a/pkg/sql/colexec/utils.go
+++ b/pkg/sql/colexec/utils.go
@@ -65,16 +65,12 @@ func makeWindowIntoBatch(
 }
 
 func newPartitionerToOperator(
-	allocator *colmem.Allocator,
-	types []*types.T,
-	partitioner colcontainer.PartitionedQueue,
-	partitionIdx int,
+	allocator *colmem.Allocator, types []*types.T, partitioner colcontainer.PartitionedQueue,
 ) *partitionerToOperator {
 	return &partitionerToOperator{
-		allocator:    allocator,
-		types:        types,
-		partitioner:  partitioner,
-		partitionIdx: partitionIdx,
+		allocator:   allocator,
+		types:       types,
+		partitioner: partitioner,
 	}
 }
 
@@ -95,13 +91,22 @@ type partitionerToOperator struct {
 var _ colexecbase.Operator = &partitionerToOperator{}
 
 func (p *partitionerToOperator) Init() {
-	// We will be dequeuing the batches from disk into this batch, so we need to
-	// have enough capacity to support the batches of any size.
-	p.batch = p.allocator.NewMemBatchWithFixedCapacity(p.types, coldata.BatchSize())
+	if p.batch == nil {
+		// We will be dequeueing the batches from disk into this batch, so we
+		// need to have enough capacity to support the batches of any size.
+		p.batch = p.allocator.NewMemBatchWithFixedCapacity(p.types, coldata.BatchSize())
+	}
 }
 
 func (p *partitionerToOperator) Next(ctx context.Context) coldata.Batch {
-	if err := p.partitioner.Dequeue(ctx, p.partitionIdx, p.batch); err != nil {
+	var err error
+	// We need to perform the memory accounting on the dequeued batch. Note that
+	// such setup allows us to release the memory under the old p.batch (which
+	// is no longer valid) and to retain the memory under the just dequeued one.
+	p.allocator.PerformOperation(p.batch.ColVecs(), func() {
+		err = p.partitioner.Dequeue(ctx, p.partitionIdx, p.batch)
+	})
+	if err != nil {
 		colexecerror.InternalError(err)
 	}
 	return p.batch


### PR DESCRIPTION
**colexec: register memory used by dequeued batches from partitioned queue**

Previously, we forgot to perform the memory accounting of the batches
that are dequeued from the partitions in the external sort (which could
be substantial when we're merging multiple partitions at once and the
tuples are wide) and in the hash based partitioner. This is now fixed.

Additionally, this commit retains references to some internal operators
in the external sort in order to reuse the memory under the dequeued
batches (this will be beneficial if we perform repeated merging).

Also, this commit fixes an issue with repeated re-initializing of the
disk-backed operators in the disk spiller if the latter has been reset
(the problem would lead to redundant allocations and not reusing of the
available memory).

Slight complication with accounting was because of the fact that we were
using the same allocator for all usages. This would be quite wrong
because in the merge phase we have two distinct memory usage with
different lifecycles - the memory under the dequeued batches is kept
(and reused later) whereas the memory under the output batch of the
ordered synchronizer is released. We now correctly handle these
lifecycles by using separate allocators.

Release note (bug fix): CockroachDB previously didn't account for some
RAM used when disk-spilling operations (like sorts and hash joins) were
using the temporary storage in the vectorized execution engine. This
could result in OOM crashes, especially when the rows are large in size.

**colexec: make external sorter respect memory limit better**

This commit improves in how the external sorter manages its available
RAM. There are two different main usages that overlap because we are
keeping the references to both at all times:
1. during the spilling/sorting phase, we use a single in-memory sorter
2. during the merging phase, we use the ordered synchronizer that reads
one batch from each of the partitions and also allocates an output
batch.

Previously, we would give the whole memory limit to the in-memory sorter
in 1. which resulted in the external sorter using at least 2x of its
memory limit. This is now fixed by giving only a half to the in-memory
sorter.

The handling of 2. was even worse - we didn't have any logic that would
limit the number of active partitions based on the memory footprint. If
the batches are large (say 1GB in size), during the merge phase we would
be using on the order of 16GB of RAM (number 16 would be determined
based on the number of file descriptors). Additionally, we would give
the whole memory limit to the output batch too.

This misbehavior is also now fixed by tracking the maximum size of
a single batch in each active partition and computing the actual maximum
number of partitions to have using those sizes.

Fixes: #60017.

Release note: None