### PR TITLE
sql: refactor fk backreference removal

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -405,7 +405,7 @@ func (sc *SchemaChanger) dropConstraints(
 						return err
 					}
 					if err := removeFKBackReferenceFromTable(
-						backrefTable, def.Name, scTable,
+						backrefTable, def, scTable,
 					); err != nil {
 						return err
 					}
@@ -1923,13 +1923,11 @@ func runSchemaChangesInTxn(
 						}
 					}
 				case descpb.ConstraintToUpdate_FOREIGN_KEY:
-					for i := range tableDesc.OutboundFKs {
-						fk := &tableDesc.OutboundFKs[i]
+					for _, fk := range tableDesc.OutboundFKs {
 						if fk.Name == t.Constraint.Name {
-							if err := planner.removeFKBackReference(ctx, tableDesc, fk); err != nil {
+							if err := planner.removeFKBackReference(ctx, tableDesc, &fk); err != nil {
 								return err
 							}
-							tableDesc.OutboundFKs = append(tableDesc.OutboundFKs[:i], tableDesc.OutboundFKs[i+1:]...)
 							break
 						}
 					}

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -1696,7 +1696,6 @@ func (desc *Mutable) DropConstraint(
 					if err := removeFK(desc, detail.FK); err != nil {
 						return err
 					}
-					desc.OutboundFKs = append(desc.OutboundFKs[:i], desc.OutboundFKs[i+1:]...)
 					return nil
 				}
 				ref.Validity = descpb.ConstraintValidity_Dropping

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -55,7 +55,7 @@ Query {"String": "DROP INDEX t_x_idx"}
 until crdb_only
 CommandComplete
 ----
-{"Severity":"NOTICE","SeverityUnlocalized":"","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":519,"Routine":"dropIndexByName","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":516,"Routine":"dropIndexByName","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 
 until noncrdb_only

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1599,7 +1599,7 @@ func (sc *SchemaChanger) maybeReverseMutations(ctx context.Context, causingError
 					if err != nil {
 						return err
 					}
-					if err := removeFKBackReferenceFromTable(backrefTable, fk.Name, scTable); err != nil {
+					if err := removeFKBackReferenceFromTable(backrefTable, fk, scTable); err != nil {
 						// The function being called will return an assertion error if the
 						// backreference was not found, but it may not have been installed
 						// during the incomplete schema change, so we swallow the error.


### PR DESCRIPTION
Previously, from the point of view of the outbound and inbound table
descriptors, the removal of a foreign key would be performed separately.
Ideally we'd want the OutboundFKs slice of one table descriptor and the
InboundFKs slice of the other to always be consistent, both in storage
(which is already the case) as well as in memory. This refactor commit
addresses this by making these changes closer together for the mutable
table descriptors.

Release note: None