### PR TITLE
release-20.2: opt: fix panic in GenerateInvertedIndexScans

### DIFF
--- a/pkg/sql/opt/invertedidx/geo.go
+++ b/pkg/sql/opt/invertedidx/geo.go
@@ -153,7 +153,7 @@ func TryConstrainGeoIndex(
 	}
 
 	spanExpr, ok := invertedExpr.(*invertedexpr.SpanExpression)
-	if !ok {
+	if !ok || spanExpr == nil {
 		return nil, false
 	}
 

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -2377,6 +2377,31 @@ project
       └── filters
            └── geom:3 ~ '01040000000200000001010000009A999999999901409A99999999990140010100000000000000000008400000000000000840' [outer=(3), immutable, constraints=(/3: (/NULL - ])]
 
+# Regression test for #59702. Do not panic when empty index spans are generated
+# from a filter on an inverted column.
+exec-ddl
+CREATE TABLE t59702 (
+  k INT PRIMARY KEY,
+  g GEOGRAPHY,
+  INVERTED INDEX (g)
+)
+----
+
+opt
+SELECT * FROM t59702 WHERE st_intersects(g, st_buffer(st_makepoint(1, 1)::GEOGRAPHY, 0))
+----
+select
+ ├── columns: k:1!null g:2
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── scan t59702
+ │    ├── columns: k:1!null g:2
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ └── filters
+      └── st_intersects(g:2, '0103000020E610000000000000') [outer=(2), immutable]
+
 # --------------------------------------------------
 # SplitDisjunction
 # --------------------------------------------------


### PR DESCRIPTION
Backport 1/1 commits from #60598.

/cc @cockroachdb/release

---

This commit fixes a nil-pointer exception caused when empty index spans
were generated from a filter on an inverted column.

Fixes #59702

Release note (bug fix): A bug has been fixed that caused errors for some
queries on tables with GEOMETRY or GEOGRAPHY inverted indexes with
filters containing shapes with zero area.
