### PR TITLE
sql: prohibit DROP COLUMN on REGIONAL BY ROW column reference

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -261,6 +261,10 @@ pk  pk2  a   b   j
 20  20   21  22  NULL
 23  23   24  25  NULL
 
+# Tests dropping a referenced column in REGIONAL BY ROW does not succeed.
+statement error cannot drop column crdb_region as it is used to store the region in a REGIONAL BY ROW table\nHINT: You must change the table locality before dropping this table
+ALTER TABLE regional_by_row_table DROP COLUMN crdb_region
+
 # Tests creating a index and a unique constraint on a REGIONAL BY ROW table.
 statement ok
 CREATE INDEX new_idx ON regional_by_row_table(a, b)
@@ -714,6 +718,10 @@ pk  a     b     crdb_region_col
 1   NULL  NULL  us-east-1
 10  NULL  NULL  us-east-1
 20  NULL  NULL  ap-southeast-2
+
+# Tests dropping a referenced column in REGIONAL BY ROW does not succeed.
+statement error cannot drop column crdb_region_col as it is used to store the region in a REGIONAL BY ROW table\nHINT: You must change the table locality before dropping this table
+ALTER TABLE regional_by_row_table_as DROP COLUMN crdb_region_col
 
 # Tests for altering the survivability of a REGIONAL BY ROW table.
 statement ok

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -4013,13 +4013,26 @@ func (desc *wrapper) IsLocalityGlobal() bool {
 // homed in.
 func (desc *wrapper) GetRegionalByTableRegion() (descpb.RegionName, error) {
 	if !desc.IsLocalityRegionalByTable() {
-		return "", errors.New("is not REGIONAL BY TABLE")
+		return "", errors.AssertionFailedf("%s is not REGIONAL BY TABLE", desc.Name)
 	}
 	region := desc.LocalityConfig.GetRegionalByTable().Region
 	if region == nil {
 		return descpb.RegionName(tree.PrimaryRegionLocalityName), nil
 	}
 	return *region, nil
+}
+
+// GetRegionalByRowTableRegionColumnName returns the region column name of a
+// REGIONAL BY ROW table.
+func (desc *wrapper) GetRegionalByRowTableRegionColumnName() (tree.Name, error) {
+	if !desc.IsLocalityRegionalByRow() {
+		return "", errors.AssertionFailedf("%s is not REGIONAL BY ROW", desc.Name)
+	}
+	colName := desc.LocalityConfig.GetRegionalByRow().As
+	if colName == nil {
+		return tree.RegionalByRowRegionDefaultColName, nil
+	}
+	return tree.Name(*colName), nil
 }
 
 // GetMultiRegionEnumDependency returns true if the given table has an "implicit"


### PR DESCRIPTION
The foundation of REGIONAL BY ROW is to use a column which dictates the
location to which the row is stored. As such, we should prevent the
column from being used as a DROP COLUMN reference.

Resolves #59117 

Release note: None