### PR TITLE
opt: add test constraining partial index on virtual column

### DIFF
--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -127,7 +127,8 @@ CREATE TABLE virtual (
     upper_s STRING AS (upper(s)) VIRTUAL,
     INDEX (a) WHERE c IN (10, 20, 30),
     INDEX (lower_s),
-    INDEX (a) WHERE upper_s = 'FOO'
+    INDEX (a) WHERE upper_s = 'FOO',
+    INDEX (c) WHERE c > 100
 )
 ----
 
@@ -376,8 +377,10 @@ project
       │    ├── partial index predicates
       │    │    ├── secondary: filters
       │    │    │    └── (b:3 + 10) IN (10, 20, 30) [outer=(3), immutable]
+      │    │    ├── secondary: filters
+      │    │    │    └── upper(s:5) = 'FOO' [outer=(5), immutable]
       │    │    └── secondary: filters
-      │    │         └── upper(s:5) = 'FOO' [outer=(5), immutable]
+      │    │         └── b:3 > 90 [outer=(3), constraints=(/3: [/91 - ]; tight)]
       │    ├── key: (1)
       │    └── fd: (1)-->(3)
       └── filters
@@ -1724,8 +1727,10 @@ project
       │    ├── partial index predicates
       │    │    ├── secondary: filters
       │    │    │    └── (b:3 + 10) IN (10, 20, 30) [outer=(3), immutable]
+      │    │    ├── secondary: filters
+      │    │    │    └── upper(s:5) = 'FOO' [outer=(5), immutable]
       │    │    └── secondary: filters
-      │    │         └── upper(s:5) = 'FOO' [outer=(5), immutable]
+      │    │         └── b:3 > 90 [outer=(3), constraints=(/3: [/91 - ]; tight)]
       │    ├── key: (1)
       │    └── fd: (1)-->(2,3)
       └── filters
@@ -1747,9 +1752,60 @@ project
       ├── key: (1)
       └── fd: (1)-->(2)
 
+# Constrained partial index scan with an indexed virtual computed column also in
+# the predicate.
+# TODO(mgartner): Teach indexConstraintCtx.simplifyFilter to remove b=140 from
+# the remaining filters after the index constraint is built. This will eliminate
+# the unnecessary index-join and select expressions.
+opt
+SELECT k FROM virtual WHERE c = 150
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null b:3!null
+      ├── key: (1)
+      ├── fd: ()-->(3)
+      ├── index-join virtual
+      │    ├── columns: k:1!null b:3
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(3)
+      │    └── scan virtual@secondary,partial
+      │         ├── columns: k:1!null
+      │         ├── constraint: /4/1: [/150 - /150]
+      │         └── key: (1)
+      └── filters
+           └── b:3 = 140 [outer=(3), constraints=(/3: [/140 - /140]; tight), fd=()-->(3)]
+
+# Constrain a scan on a partial index on virtual column c constraining the
+# dependent column b.
+# TODO(mgartner): Teach indexConstraintCtx.simplifyFilter to remove b=140 from
+# the remaining filters after the index constraint is built. This will eliminate
+# the unnecessary index-join and select expressions.
+opt
+SELECT k FROM virtual WHERE b = 140
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null b:3!null
+      ├── key: (1)
+      ├── fd: ()-->(3)
+      ├── index-join virtual
+      │    ├── columns: k:1!null b:3
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(3)
+      │    └── scan virtual@secondary,partial
+      │         ├── columns: k:1!null
+      │         ├── constraint: /4/1: [/150 - /150]
+      │         └── key: (1)
+      └── filters
+           └── b:3 = 140 [outer=(3), constraints=(/3: [/140 - /140]; tight), fd=()-->(3)]
+
 # Regression test for #55387. GenerateConstrainedScans should not reduce the
 # input filters when proving partial index implication.
-
 exec-ddl
 CREATE TABLE t55387 (
     k INT PRIMARY KEY,


### PR DESCRIPTION
No code changes were necessary in order to generate a constrained scan
for a partial index on a virtual column.

Release note: None