### PR TITLE
streamingclient: add support for streaming clients to return errors

### DIFF
--- a/pkg/ccl/streamingccl/streamclient/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamclient/BUILD.bazel
@@ -36,6 +36,5 @@ go_test(
         "//pkg/roachpb",
         "//pkg/util/hlc",
         "//pkg/util/timeutil",
-        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/ccl/streamingccl/streamclient/client.go
+++ b/pkg/ccl/streamingccl/streamclient/client.go
@@ -28,9 +28,7 @@ type Client interface {
 	//
 	// Canceling the context will stop reading the partition and close the event
 	// channel.
-	// TODO: Add an error channel so that the client can report any errors
-	// encountered while reading the stream.
-	ConsumePartition(ctx context.Context, address streamingccl.PartitionAddress, startTime time.Time) (chan streamingccl.Event, error)
+	ConsumePartition(ctx context.Context, address streamingccl.PartitionAddress, startTime time.Time) (chan streamingccl.Event, chan error, error)
 }
 
 // NewStreamClient creates a new stream client based on the stream

--- a/pkg/ccl/streamingccl/streamclient/random_stream_client.go
+++ b/pkg/ccl/streamingccl/streamclient/random_stream_client.go
@@ -260,7 +260,7 @@ func (m *randomStreamClient) getDescriptorAndNamespaceKVForTableID(
 // ConsumePartition implements the Client interface.
 func (m *randomStreamClient) ConsumePartition(
 	ctx context.Context, partitionAddress streamingccl.PartitionAddress, startTime time.Time,
-) (chan streamingccl.Event, error) {
+) (chan streamingccl.Event, chan error, error) {
 	eventCh := make(chan streamingccl.Event)
 	now := timeutil.Now()
 	if startTime.After(now) {
@@ -269,17 +269,17 @@ func (m *randomStreamClient) ConsumePartition(
 
 	partitionURL, err := partitionAddress.URL()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	var partitionTableID int
 	partitionTableID, err = strconv.Atoi(partitionURL.Host)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	tableDesc, systemKVs, err := m.getDescriptorAndNamespaceKVForTableID(descpb.ID(partitionTableID))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	go func() {
 		defer close(eventCh)
@@ -346,7 +346,7 @@ func (m *randomStreamClient) ConsumePartition(
 		}
 	}()
 
-	return eventCh, nil
+	return eventCh, nil, nil
 }
 
 func rekey(tenantID roachpb.TenantID, k roachpb.Key) roachpb.Key {
@@ -394,7 +394,7 @@ func (m *randomStreamClient) makeRandomKey(
 	}
 }
 
-// RegisterInterception implements streamingest.interceptableStreamClient.
+// RegisterInterception implements the InterceptableStreamClient interface.
 func (m *randomStreamClient) RegisterInterception(fn interceptFn) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/pkg/ccl/streamingccl/streamclient/stream_client.go
+++ b/pkg/ccl/streamingccl/streamclient/stream_client.go
@@ -30,11 +30,11 @@ func (m *mockClient) GetTopology(_ streamingccl.StreamAddress) (streamingccl.Top
 // ConsumePartition implements the Client interface.
 func (m *mockClient) ConsumePartition(
 	ctx context.Context, _ streamingccl.PartitionAddress, _ time.Time,
-) (chan streamingccl.Event, error) {
+) (chan streamingccl.Event, chan error, error) {
 	eventCh := make(chan streamingccl.Event)
 	go func() {
 		<-ctx.Done()
 		close(eventCh)
 	}()
-	return eventCh, nil
+	return eventCh, nil, nil
 }


### PR DESCRIPTION
This commit adds support for streamingclient.Clients to return errors as
they consume the stream. This change also updates the ingestion
processor to handle these errors.

Release note: None