### PR TITLE
*: fix uses of leaktest.AfterTest

### DIFF
--- a/pkg/kv/kvserver/closedts/tracker/tracker_test.go
+++ b/pkg/kv/kvserver/closedts/tracker/tracker_test.go
@@ -33,14 +33,14 @@ import (
 )
 
 func TestLockfreeTracker(t *testing.T) {
-	defer leaktest.AfterTest(t)
+	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 	tr := NewLockfreeTracker()
 	testTracker(ctx, t, tr)
 }
 
 func TestHeapTracker(t *testing.T) {
-	defer leaktest.AfterTest(t)
+	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 	tr := newHeapTracker()
 	testTracker(ctx, t, tr)
@@ -99,7 +99,7 @@ func testTracker(ctx context.Context, t *testing.T, tr Tracker) {
 // much lower than the lowest timestamp at which a request is currently
 // evaluating).
 func TestLockfreeTrackerRandomStress(t *testing.T) {
-	defer leaktest.AfterTest(t)
+	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 	tr := NewLockfreeTracker().(*lockfreeTracker)
 

--- a/pkg/migration/migrationcluster/client_test.go
+++ b/pkg/migration/migrationcluster/client_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestCluster_IterateRangeDescriptors(t *testing.T) {
-	defer leaktest.AfterTest(t)
+	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
 	const numNodes = 1

--- a/pkg/migration/migrationcluster/helper_test.go
+++ b/pkg/migration/migrationcluster/helper_test.go
@@ -36,7 +36,7 @@ func (n NoopDialer) Dial(
 var _ NodeDialer = NoopDialer{}
 
 func TestHelperEveryNode(t *testing.T) {
-	defer leaktest.AfterTest(t)
+	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
 	var mu syncutil.Mutex
@@ -150,7 +150,7 @@ func TestHelperEveryNode(t *testing.T) {
 }
 
 func TestClusterNodes(t *testing.T) {
-	defer leaktest.AfterTest(t)
+	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
 	const numNodes = 3

--- a/pkg/migration/migrationcluster/nodes_test.go
+++ b/pkg/migration/migrationcluster/nodes_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestNodesString(t *testing.T) {
-	defer leaktest.AfterTest(t)
+	defer leaktest.AfterTest(t)()
 
 	ns := func(ids ...int) Nodes {
 		var nodes []Node
@@ -49,7 +49,7 @@ func TestNodesString(t *testing.T) {
 }
 
 func TestNodesIdentical(t *testing.T) {
-	defer leaktest.AfterTest(t)
+	defer leaktest.AfterTest(t)()
 
 	list := func(nodes ...string) Nodes { // takes in strings of the form "ID@Epoch"
 		var ns []Node

--- a/pkg/migration/migrations/truncated_state_external_test.go
+++ b/pkg/migration/migrations/truncated_state_external_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestTruncatedStateMigration(t *testing.T) {
-	defer leaktest.AfterTest(t)
+	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
 	for _, testCase := range []struct {

--- a/pkg/server/diagnostics/reporter_test.go
+++ b/pkg/server/diagnostics/reporter_test.go
@@ -48,7 +48,7 @@ var _ = kvtenantccl.Connector{}
 const elemName = "somestring"
 
 func TestTenantReport(t *testing.T) {
-	defer leaktest.AfterTest(t)
+	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
 	rt := startReporterTest(t)
@@ -100,7 +100,7 @@ func TestTenantReport(t *testing.T) {
 // TestServerReport checks nodes, stores, localities, and zone configs.
 // Telemetry metrics are checked in datadriven tests (see sql.TestTelemetry).
 func TestServerReport(t *testing.T) {
-	defer leaktest.AfterTest(t)
+	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
 	rt := startReporterTest(t)

--- a/pkg/util/log/fluent_client_test.go
+++ b/pkg/util/log/fluent_client_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestFluentClient(t *testing.T) {
-	defer leaktest.AfterTest(t)
+	defer leaktest.AfterTest(t)()
 	sc := Scope(t)
 	defer sc.Close(t)
 

--- a/pkg/util/stop/stopper_test.go
+++ b/pkg/util/stop/stopper_test.go
@@ -592,7 +592,7 @@ func maybePrint(context.Context) {
 }
 
 func BenchmarkDirectCall(b *testing.B) {
-	defer leaktest.AfterTest(b)
+	defer leaktest.AfterTest(b)()
 	s := stop.NewStopper()
 	ctx := context.Background()
 	defer s.Stop(ctx)
@@ -602,7 +602,7 @@ func BenchmarkDirectCall(b *testing.B) {
 }
 
 func BenchmarkStopper(b *testing.B) {
-	defer leaktest.AfterTest(b)
+	defer leaktest.AfterTest(b)()
 	ctx := context.Background()
 	s := stop.NewStopper()
 	defer s.Stop(ctx)
@@ -613,7 +613,7 @@ func BenchmarkStopper(b *testing.B) {
 	}
 }
 func BenchmarkDirectCallPar(b *testing.B) {
-	defer leaktest.AfterTest(b)
+	defer leaktest.AfterTest(b)()
 	s := stop.NewStopper()
 	ctx := context.Background()
 	defer s.Stop(ctx)
@@ -625,7 +625,7 @@ func BenchmarkDirectCallPar(b *testing.B) {
 }
 
 func BenchmarkStopperPar(b *testing.B) {
-	defer leaktest.AfterTest(b)
+	defer leaktest.AfterTest(b)()
 	ctx := context.Background()
 	s := stop.NewStopper()
 	defer s.Stop(ctx)


### PR DESCRIPTION
These places did not invoke the returned closure. Probably something to be done in the linter still. 

Release note: None