### PR TITLE
tree: correctly redact value of into_db

### DIFF
--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -294,7 +294,7 @@ func (o *RestoreOptions) Format(ctx *FmtCtx) {
 	if o.IntoDB != nil {
 		maybeAddSep()
 		ctx.WriteString("into_db=")
-		o.IntoDB.Format(ctx)
+		ctx.formatNodeOrHideConstants(o.IntoDB)
 	}
 
 	if o.SkipMissingFKs {

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -127,6 +127,13 @@ func TestFormatStatement(t *testing.T) {
 			`ALTER TYPE _ DROP VALUE _`},
 		{`ALTER TYPE a RENAME VALUE 'value1' TO 'value2'`, tree.FmtAnonymize,
 			`ALTER TYPE _ RENAME VALUE _ TO _`},
+
+		{`RESTORE abc.xzy FROM 'a' WITH into_db='foo', skip_missing_foreign_keys`,
+			tree.FmtHideConstants | tree.FmtAnonymize,
+			`RESTORE TABLE _._ FROM _ WITH into_db=_, skip_missing_foreign_keys`},
+		{`RESTORE FROM 'a' WITH into_db='foo', skip_missing_foreign_keys`,
+			tree.FmtHideConstants | tree.FmtAnonymize,
+			`RESTORE FROM _ WITH into_db=_, skip_missing_foreign_keys`},
 	}
 
 	for i, test := range testData {


### PR DESCRIPTION
Release note (bug fix): fix a bug that would cause the value of the optional into_db parameter to RESTORE to be included in anonymizeds crash reports.