### PR TITLE
kvserver: initialize propBuf LAI tracking

### DIFF
--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -208,6 +208,7 @@ type proposerRaft interface {
 func (b *propBuf) Init(p proposer) {
 	b.p = p
 	b.full.L = p.rlocker()
+	b.liBase = p.leaseAppliedIndex()
 }
 
 // Len returns the number of proposals currently in the buffer.


### PR DESCRIPTION
The initialization of the LAI tracking in the proposal buffer seems
pretty lacking (see #60625). This patch adds initialization of
propBuf.liBase at propBuf.Init() time, which is irrelevant for
production, but will help future tests which will surely want the
a propBuf's first assigned LAIs to have some relationship to the replica
state.

Release note: None