### PR TITLE
bazel: fix up name of `forbiddenmethod` library target

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -241,7 +241,6 @@ ALL_TESTS = [
     "//pkg/storage:storage_test",
     "//pkg/testutils/keysutils:keysutils_test",
     "//pkg/testutils/lint/passes/fmtsafe:fmtsafe_test",
-    "//pkg/testutils/lint/passes/forbiddenmethod:descriptormarshal_test",
     "//pkg/testutils/lint/passes/forbiddenmethod:forbiddenmethod_test",
     "//pkg/testutils/lint/passes/hash:hash_test",
     "//pkg/testutils/lint/passes/nocopy:nocopy_test",

--- a/pkg/cmd/roachvet/BUILD.bazel
+++ b/pkg/cmd/roachvet/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
     deps = [
         "//pkg/testutils/lint/passes/errcmp",
         "//pkg/testutils/lint/passes/fmtsafe",
-        "//pkg/testutils/lint/passes/forbiddenmethod:descriptormarshal",
+        "//pkg/testutils/lint/passes/forbiddenmethod",
         "//pkg/testutils/lint/passes/hash",
         "//pkg/testutils/lint/passes/nocopy",
         "//pkg/testutils/lint/passes/returnerrcheck",

--- a/pkg/testutils/lint/passes/forbiddenmethod/BUILD.bazel
+++ b/pkg/testutils/lint/passes/forbiddenmethod/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "descriptormarshal",
+    name = "forbiddenmethod",
     srcs = [
         "analyzers.go",
         "forbiddenmethod.go",
@@ -17,24 +17,13 @@ go_library(
 )
 
 go_test(
-    name = "descriptormarshal_test",
+    name = "forbiddenmethod_test",
     size = "small",
     srcs = ["descriptormarshal_test.go"],
     data = glob(["testdata/**"]),
     tags = ["broken_in_bazel"],
     deps = [
-        ":descriptormarshal",
-        "//pkg/testutils/skip",
-        "@org_golang_x_tools//go/analysis/analysistest",
-    ],
-)
-
-go_test(
-    name = "forbiddenmethod_test",
-    srcs = ["descriptormarshal_test.go"],
-    data = glob(["testdata/**"]),
-    deps = [
-        ":descriptormarshal",
+        ":forbiddenmethod",
         "//pkg/testutils/skip",
         "@org_golang_x_tools//go/analysis/analysistest",
     ],

--- a/pkg/testutils/lint/passes/passesutil/BUILD.bazel
+++ b/pkg/testutils/lint/passes/passesutil/BUILD.bazel
@@ -17,7 +17,7 @@ go_test(
     srcs = ["passes_util_test.go"],
     tags = ["broken_in_bazel"],
     deps = [
-        "//pkg/testutils/lint/passes/forbiddenmethod:descriptormarshal",
+        "//pkg/testutils/lint/passes/forbiddenmethod",
         "//pkg/testutils/lint/passes/unconvert",
         "//pkg/testutils/skip",
         "@com_github_stretchr_testify//require",


### PR DESCRIPTION
This was moved wholesale from a directory called `descriptormarshal`,
so it retained its old library name. This isn't the normal style we're
using and I'm concerned about how Gazelle will handle this going
forward, so change it to the expected style. Also delete an accidentally
duplicated test.

Release note: None