### PR TITLE
release-20.2: kvserver: improve handling for removal of a replica, when multiple replicas already exist on the same node

### DIFF
--- a/pkg/kv/kvserver/replica_command_test.go
+++ b/pkg/kv/kvserver/replica_command_test.go
@@ -198,7 +198,7 @@ func TestValidateReplicationChanges(t *testing.T) {
 		InternalReplicas: []roachpb.ReplicaDescriptor{
 			{NodeID: 1, StoreID: 1},
 			{NodeID: 2, StoreID: 2},
-			{NodeID: 1, StoreID: 2, Type: &learnerType},
+			{NodeID: 1, StoreID: 3, Type: &learnerType},
 		},
 	}
 	err = validateReplicationChanges(descRebalancing, roachpb.ReplicationChanges{
@@ -206,20 +206,26 @@ func TestValidateReplicationChanges(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Test Case 15: Do an add while rebalancing within a node
+	// Test Case 15: same as 14 but remove the second node
+	err = validateReplicationChanges(descRebalancing, roachpb.ReplicationChanges{
+		{ChangeType: roachpb.REMOVE_REPLICA, Target: roachpb.ReplicationTarget{NodeID: 1, StoreID: 3}},
+	})
+	require.NoError(t, err)
+
+	// Test Case 16: Do an add while rebalancing within a node
 	err = validateReplicationChanges(descRebalancing, roachpb.ReplicationChanges{
 		{ChangeType: roachpb.ADD_REPLICA, Target: roachpb.ReplicationTarget{NodeID: 3, StoreID: 3}},
 	})
 	require.NoError(t, err)
 
-	// Test Case 16: Remove/Add within a node is not allowed, since we expect Add/Remove
+	// Test Case 17: Remove/Add within a node is not allowed, since we expect Add/Remove
 	err = validateReplicationChanges(desc, roachpb.ReplicationChanges{
 		{ChangeType: roachpb.REMOVE_REPLICA, Target: roachpb.ReplicationTarget{NodeID: 1, StoreID: 1}},
 		{ChangeType: roachpb.ADD_REPLICA, Target: roachpb.ReplicationTarget{NodeID: 1, StoreID: 2}},
 	})
 	require.Regexp(t, "can only add-remove a replica within a node, but got ", err)
 
-	// Test Case 17: We are rebalancing within a node and have only one replica
+	// Test Case 18: We are rebalancing within a node and have only one replica
 	descSingle := &roachpb.RangeDescriptor{
 		InternalReplicas: []roachpb.ReplicaDescriptor{
 			{NodeID: 1, StoreID: 1},


### PR DESCRIPTION
Backport 1/1 commits from #60546.

/cc @cockroachdb/release

---

Fixes #60545

The allocator in some cases allows for a range to have a replica
on multiple stores of the same node. If that happens, it should allow
itself to fix the situation by removing one of the offending replicas.
This was only half working due to an ordering problem in how the replicas
appeared in the descriptor. It could remove the first replica, but not the second one.

.

Release note: None
