### PR TITLE
cli: Add connect command stub

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -167,6 +167,10 @@ type Config struct {
 	// SSLCertsDir is the path to the certificate/key directory.
 	SSLCertsDir string
 
+	// InitToken is a shared initialization token for generating TLS certificates
+	// across multiple nodes.
+	InitToken string
+
 	// User running this process. It could be the user under which
 	// the server is running or the user passed in client calls.
 	User security.SQLUsername

--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "cert.go",
         "cli.go",
         "client_url.go",
+        "connect.go",
         "context.go",
         "cpuprofile.go",
         "debug.go",

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -237,6 +237,8 @@ func init() {
 		startSingleNodeCmd,
 		initCmd,
 		certCmd,
+		// TODO(bilal): Uncomment this when the connect command does something useful.
+		// connectCmd,
 		quitCmd,
 
 		sqlShellCmd,

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -711,6 +711,11 @@ Instead, require the user to always specify access keys.`,
 		Description: `Prompt for the new user's password.`,
 	}
 
+	InitToken = FlagInfo{
+		Name:        "init-token",
+		Description: `Shared token for initialization of node TLS certificates`,
+	}
+
 	CertsDir = FlagInfo{
 		Name:        "certs-dir",
 		EnvVar:      "COCKROACH_CERTS_DIR",

--- a/pkg/cli/connect.go
+++ b/pkg/cli/connect.go
@@ -1,0 +1,34 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import "github.com/spf13/cobra"
+
+// connectCmd triggers a TLS initialization handshake and writes
+// certificates in the specified certs-dir for use with start.
+var connectCmd = &cobra.Command{
+	Use:   "connect --certs-dir=<path to cockroach certs dir> --init-token=<shared secret> --join=<host 1>,<host 2>,...,<host N>",
+	Short: "build TLS certificates for use with the start command",
+	Long: `
+Connects to other nodes and negotiates an initialization bundle for use with
+secure inter-node connections.
+`,
+	Args: cobra.NoArgs,
+	RunE: MaybeDecorateGRPCError(runConnect),
+}
+
+// runConnect connects to other nodes and negotiates an initialization bundle
+// for use with secure inter-node connections.
+func runConnect(cmd *cobra.Command, args []string) error {
+	// TODO(bilal): Implement TLS init handshake.
+	// https://github.com/cockroachdb/cockroach/issues/60632
+	return nil
+}

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -472,6 +472,15 @@ func init() {
 		stringSliceFlag(f, &cliCtx.certPrincipalMap, cliflags.CertPrincipalMap)
 	}
 
+	// Flags for the connect command.
+	{
+		f := connectCmd.Flags()
+		stringFlag(f, &baseCfg.SSLCertsDir, cliflags.CertsDir)
+		stringFlag(f, &baseCfg.InitToken, cliflags.InitToken)
+		varFlag(f, addrSetter{&startCtx.serverListenAddr, &serverListenPort}, cliflags.ListenAddr)
+		varFlag(f, &serverCfg.JoinList, cliflags.Join)
+	}
+
 	for _, cmd := range []*cobra.Command{
 		createCACertCmd,
 		createClientCACertCmd,


### PR DESCRIPTION
Adds a new command stub, `connect`, with relevant args of
`--certs-dir`, `--init-token`, and list of peers. Implementation
code for this command is yet to come, and the command is not hooked
up to the outer `cockroach` command yet.

Very first part of #60632.

Release note: None.
Epic: CRDB-6663