### PR TITLE
kvserver: small improvement to propBuf tests

### DIFF
--- a/pkg/kv/kvserver/replica_proposal_buf_test.go
+++ b/pkg/kv/kvserver/replica_proposal_buf_test.go
@@ -158,6 +158,7 @@ func newPropData(leaseReq bool) (*ProposalData, []byte) {
 		ba.Add(&roachpb.PutRequest{})
 	}
 	return &ProposalData{
+		ctx:     context.Background(),
 		command: &kvserverpb.RaftCommand{},
 		Request: &ba,
 	}, make([]byte, 0, kvserverpb.MaxRaftCommandFooterSize())


### PR DESCRIPTION
Assign a context to test proposals. High-verbosity logs freak out if
this field is nil.

Release note: None