### PR TITLE
sql: remove dead code in span Builder.encodeConstraintKey

### DIFF
--- a/pkg/sql/span/span_builder.go
+++ b/pkg/sql/span/span_builder.go
@@ -316,25 +316,9 @@ func (s *Builder) encodeConstraintKey(
 			}
 		}
 
-		if s.index.Type == descpb.IndexDescriptor_INVERTED {
-			keys, err := rowenc.EncodeInvertedIndexTableKeys(val, key, s.index.Version)
-			if err != nil {
-				return nil, false, err
-			}
-			if len(keys) == 0 {
-				err := errors.AssertionFailedf("trying to use null key in index lookup")
-				return nil, false, err
-			}
-			if len(keys) > 1 {
-				err := errors.AssertionFailedf("trying to use multiple keys in index lookup")
-				return nil, false, err
-			}
-			key = keys[0]
-		} else {
-			key, err = rowenc.EncodeTableKey(key, val, dir)
-			if err != nil {
-				return nil, false, err
-			}
+		key, err = rowenc.EncodeTableKey(key, val, dir)
+		if err != nil {
+			return nil, false, err
 		}
 	}
 	return key, containsNull, nil


### PR DESCRIPTION
This commit removes code that builds a `roachpb.Key` from a
`constraint.Constraint` for scanning an inverted index. We no longer use
constraints to constrain inverted indexes, so this code path would never
be reached.

Release note: None