### PR TITLE
util/tracing: re-key activeSpans map on span ID

### DIFF
--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -228,7 +228,7 @@ func (s *Span) Finish() {
 		s.netTr.Finish()
 	}
 	s.tracer.activeSpans.Lock()
-	delete(s.tracer.activeSpans.m, s)
+	delete(s.tracer.activeSpans.m, s.crdb.spanID)
 	s.tracer.activeSpans.Unlock()
 }
 


### PR DESCRIPTION
Note that the changes in this PR should be used in #60616 to more easily retrieve a span given its span ID, without having to visit all spans and check for a match on span ID. Whichever PR lands later should update the sections of code marked as #TODOs in #60616.

Previously, a tracer's activeSpans map was keyed on the memory
address of the span itself. This commit keys the map on the span ID
(which is deterministically unique) and sets the corresponding
value in the map to be the memory address of the span itself. This
allows us to continue to visit all active spans via the map, but
also easily retrieve a span from its ID using the map.

Release note: None