### PR TITLE
opt: support INSERT ON CONFLICT DO NOTHING with partial unique constraints

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/unique
+++ b/pkg/sql/logictest/testdata/logic_test/unique
@@ -144,6 +144,12 @@ INSERT INTO uniq SELECT k, v, w, x, y FROM other
 statement ok
 INSERT INTO uniq VALUES (100, 10, 1), (200, 20, 2), (400, 40, 4) ON CONFLICT (w) DO NOTHING
 
+# On conflict do nothing with constant input, conflict on UNIQUE WITHOUT INDEX
+# column, conflicting insert rows.
+# Only row (500, 50, 50) is inserted.
+statement ok
+INSERT INTO uniq VALUES (500, 50, 50), (600, 50, 50) ON CONFLICT (w) DO NOTHING
+
 # On conflict do nothing with constant input, no conflict columns.
 # The only row that is successfully inserted here is (20, 20, 20, 20, 20).
 statement ok
@@ -163,6 +169,7 @@ k    v   w     x     y
 7    7   NULL  2     NULL
 20   20  20    20    20
 400  40  4     NULL  5
+500  50  50    NULL  5
 
 
 # Insert into a table in which the primary key overlaps some of the unique
@@ -281,6 +288,30 @@ INSERT INTO uniq_partial VALUES (NULL, 5), (5, 5), (NULL, 5)
 statement error pgcode 23505 pq: duplicate key value violates unique constraint "unique_a"\nDETAIL: Key \(a\)=\(1\) already exists\.
 INSERT INTO uniq_partial SELECT w, x FROM other
 
+statement error there is no unique or exclusion constraint matching the ON CONFLICT specification
+INSERT INTO uniq_partial VALUES (1, 6), (6, 6) ON CONFLICT (a) DO NOTHING
+
+# On conflict do nothing with constant input, conflict on UNIQUE WITHOUT INDEX
+# column. Only the non-conflicting row (6, 6) is inserted.
+statement ok
+INSERT INTO uniq_partial VALUES (1, 6), (6, 6) ON CONFLICT (a) WHERE b > 0 DO NOTHING
+
+# On conflict do nothing with constant input, conflict on UNIQUE WITHOUT INDEX
+# column, conflicting insert rows.
+# Only rows (7, 7) and (7, -7) are inserted.
+statement ok
+INSERT INTO uniq_partial VALUES (7, 7), (7, 8), (7, -7) ON CONFLICT (a) WHERE b > 0 DO NOTHING
+
+# On conflict do nothing with constant input, no conflict columns.
+# Only rows (9, 9) and (9, -9) are inserted.
+statement ok
+INSERT INTO uniq_partial VALUES (1, 9), (9, 9), (9, 10), (9, -9) ON CONFLICT DO NOTHING
+
+# On conflict do nothing with non-constant input.
+# The (1, 10) row is not inserted because of a conflict with (1, 1).
+statement ok
+INSERT INTO uniq_partial SELECT w, k FROM other ON CONFLICT DO NOTHING
+
 query II colnames,rowsort
 SELECT * FROM uniq_partial
 ----
@@ -290,6 +321,11 @@ a     b
 1     -3
 2     2
 5     5
+6     6
+7     7
+7     -7
+9     9
+9     -9
 NULL  5
 NULL  5
 
@@ -335,6 +371,7 @@ k    v   w     x     y
 11   11  10    NULL  2
 20   20  20    20    20
 400  40  4     NULL  5
+500  50  50    NULL  5
 
 
 # Update a table with multiple primary key columns.
@@ -489,6 +526,7 @@ k    v    w     x     y
 20   20   20    20    20
 100  100  1     NULL  5
 400  40   4     NULL  5
+500  50   50    NULL  5
 
 
 # Upsert into a table in which the primary key overlaps some of the unique

--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -268,7 +268,7 @@ type UniqueConstraint interface {
 	// constraint.
 	ColumnOrdinal(tab Table, i int) int
 
-	// Predicate returns the partial index predicate expression and true if the
+	// Predicate returns the partial predicate expression and true if the
 	// constraint is a partial unique constraint. If it is not, the empty string
 	// and false are returned.
 	Predicate() (string, bool)

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -1120,29 +1120,29 @@ vectorized: true
 │           │ estimated row count: 0 (missing stats)
 │           │
 │           └── • distinct
-│               │ columns: (upsert_partial_constraint_distinct1, column1, column2, column3)
+│               │ columns: (arbiter_unique_b_distinct, column1, column2, column3)
 │               │ estimated row count: 0 (missing stats)
-│               │ distinct on: upsert_partial_constraint_distinct1
+│               │ distinct on: arbiter_unique_b_distinct
 │               │ nulls are distinct
 │               │
 │               └── • render
-│                   │ columns: (upsert_partial_constraint_distinct1, column1, column2, column3)
+│                   │ columns: (arbiter_unique_b_distinct, column1, column2, column3)
 │                   │ estimated row count: 0 (missing stats)
-│                   │ render upsert_partial_constraint_distinct1: (column3 > 0) OR CAST(NULL AS BOOL)
+│                   │ render arbiter_unique_b_distinct: (column3 > 0) OR CAST(NULL AS BOOL)
 │                   │ render column1: column1
 │                   │ render column2: column2
 │                   │ render column3: column3
 │                   │
 │                   └── • distinct
-│                       │ columns: (upsert_partial_constraint_distinct0, column1, column2, column3)
+│                       │ columns: (arbiter_unique_a_distinct, column1, column2, column3)
 │                       │ estimated row count: 0 (missing stats)
-│                       │ distinct on: upsert_partial_constraint_distinct0
+│                       │ distinct on: arbiter_unique_a_distinct
 │                       │ nulls are distinct
 │                       │
 │                       └── • render
-│                           │ columns: (upsert_partial_constraint_distinct0, column1, column2, column3)
+│                           │ columns: (arbiter_unique_a_distinct, column1, column2, column3)
 │                           │ estimated row count: 0 (missing stats)
-│                           │ render upsert_partial_constraint_distinct0: (column3 > 0) OR CAST(NULL AS BOOL)
+│                           │ render arbiter_unique_a_distinct: (column3 > 0) OR CAST(NULL AS BOOL)
 │                           │ render column1: column1
 │                           │ render column2: column2
 │                           │ render column3: column3
@@ -1498,15 +1498,15 @@ vectorized: true
 │           │ render column3: column3
 │           │
 │           └── • distinct
-│               │ columns: (upsert_partial_constraint_distinct0, column1, column2, column3)
+│               │ columns: (arbiter_unique_i_distinct, column1, column2, column3)
 │               │ estimated row count: 0 (missing stats)
-│               │ distinct on: upsert_partial_constraint_distinct0, column2
+│               │ distinct on: arbiter_unique_i_distinct, column2
 │               │ nulls are distinct
 │               │
 │               └── • render
-│                   │ columns: (upsert_partial_constraint_distinct0, column1, column2, column3)
+│                   │ columns: (arbiter_unique_i_distinct, column1, column2, column3)
 │                   │ estimated row count: 0 (missing stats)
-│                   │ render upsert_partial_constraint_distinct0: (column3 IN ('bar', 'baz', 'foo')) OR CAST(NULL AS BOOL)
+│                   │ render arbiter_unique_i_distinct: (column3 IN ('bar', 'baz', 'foo')) OR CAST(NULL AS BOOL)
 │                   │ render column1: column1
 │                   │ render column2: column2
 │                   │ render column3: column3

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -847,7 +847,8 @@ vectorized: true
                               columns: (column9, column1, column2, column10, check1)
                               label: buffer 1
 
-# Test that we use the index when available for the ON CONFLICT checks.
+# Test that we use the index when available for de-duplicating INSERT ON
+# CONFLICT DO NOTHING rows before inserting.
 query T
 EXPLAIN (VERBOSE) INSERT INTO uniq_enum VALUES ('us-west', 'foo', 1, 1), ('us-east', 'bar', 2, 2)
 ON CONFLICT DO NOTHING
@@ -1090,6 +1091,180 @@ vectorized: true
                 └── • scan buffer
                       label: buffer 1
 
+# Use all the unique indexes and constraints as arbiters for DO NOTHING with no
+# conflict columns.
+# TODO(mgartner): we should be able to remove the unique checks in this case
+# (see #59119).
+query T
+EXPLAIN (VERBOSE) INSERT INTO uniq_partial VALUES (1, 2, 3) ON CONFLICT DO NOTHING
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • insert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: uniq_partial(k, a, b)
+│   │ arbiter indexes: primary
+│   │ arbiter constraints: unique_a, unique_b
+│   │
+│   └── • buffer
+│       │ columns: (column1, column2, column3)
+│       │ label: buffer 1
+│       │
+│       └── • project
+│           │ columns: (column1, column2, column3)
+│           │ estimated row count: 0 (missing stats)
+│           │
+│           └── • distinct
+│               │ columns: (upsert_partial_constraint_distinct1, column1, column2, column3)
+│               │ estimated row count: 0 (missing stats)
+│               │ distinct on: upsert_partial_constraint_distinct1
+│               │ nulls are distinct
+│               │
+│               └── • render
+│                   │ columns: (upsert_partial_constraint_distinct1, column1, column2, column3)
+│                   │ estimated row count: 0 (missing stats)
+│                   │ render upsert_partial_constraint_distinct1: (column3 > 0) OR CAST(NULL AS BOOL)
+│                   │ render column1: column1
+│                   │ render column2: column2
+│                   │ render column3: column3
+│                   │
+│                   └── • distinct
+│                       │ columns: (upsert_partial_constraint_distinct0, column1, column2, column3)
+│                       │ estimated row count: 0 (missing stats)
+│                       │ distinct on: upsert_partial_constraint_distinct0
+│                       │ nulls are distinct
+│                       │
+│                       └── • render
+│                           │ columns: (upsert_partial_constraint_distinct0, column1, column2, column3)
+│                           │ estimated row count: 0 (missing stats)
+│                           │ render upsert_partial_constraint_distinct0: (column3 > 0) OR CAST(NULL AS BOOL)
+│                           │ render column1: column1
+│                           │ render column2: column2
+│                           │ render column3: column3
+│                           │
+│                           └── • hash join (right anti)
+│                               │ columns: (column1, column2, column3)
+│                               │ estimated row count: 0 (missing stats)
+│                               │ equality: (b) = (column3)
+│                               │ right cols are key
+│                               │
+│                               ├── • filter
+│                               │   │ columns: (b)
+│                               │   │ estimated row count: 333 (missing stats)
+│                               │   │ filter: b > 0
+│                               │   │
+│                               │   └── • scan
+│                               │         columns: (b)
+│                               │         estimated row count: 1,000 (missing stats)
+│                               │         table: uniq_partial@primary
+│                               │         spans: FULL SCAN
+│                               │
+│                               └── • hash join (right anti)
+│                                   │ columns: (column1, column2, column3)
+│                                   │ estimated row count: 0 (missing stats)
+│                                   │ equality: (a) = (column2)
+│                                   │ right cols are key
+│                                   │ pred: column3 > 0
+│                                   │
+│                                   ├── • filter
+│                                   │   │ columns: (a, b)
+│                                   │   │ estimated row count: 333 (missing stats)
+│                                   │   │ filter: b > 0
+│                                   │   │
+│                                   │   └── • scan
+│                                   │         columns: (a, b)
+│                                   │         estimated row count: 1,000 (missing stats)
+│                                   │         table: uniq_partial@primary
+│                                   │         spans: FULL SCAN
+│                                   │
+│                                   └── • cross join (anti)
+│                                       │ columns: (column1, column2, column3)
+│                                       │ estimated row count: 0 (missing stats)
+│                                       │
+│                                       ├── • values
+│                                       │     columns: (column1, column2, column3)
+│                                       │     size: 3 columns, 1 row
+│                                       │     row 0, expr 0: 1
+│                                       │     row 0, expr 1: 2
+│                                       │     row 0, expr 2: 3
+│                                       │
+│                                       └── • scan
+│                                             columns: (k)
+│                                             estimated row count: 1 (missing stats)
+│                                             table: uniq_partial@primary
+│                                             spans: /1/0-/1/1
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │ columns: ()
+│       │
+│       └── • hash join (right semi)
+│           │ columns: (column1, column2, column3)
+│           │ estimated row count: 0 (missing stats)
+│           │ equality: (a) = (column2)
+│           │ right cols are key
+│           │ pred: column1 != k
+│           │
+│           ├── • filter
+│           │   │ columns: (k, a, b)
+│           │   │ estimated row count: 333 (missing stats)
+│           │   │ filter: b > 0
+│           │   │
+│           │   └── • scan
+│           │         columns: (k, a, b)
+│           │         estimated row count: 1,000 (missing stats)
+│           │         table: uniq_partial@primary
+│           │         spans: FULL SCAN
+│           │
+│           └── • filter
+│               │ columns: (column1, column2, column3)
+│               │ estimated row count: 0 (missing stats)
+│               │ filter: column3 > 0
+│               │
+│               └── • scan buffer
+│                     columns: (column1, column2, column3)
+│                     estimated row count: 0 (missing stats)
+│                     label: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • hash join (right semi)
+            │ columns: (column1, column2, column3)
+            │ estimated row count: 0 (missing stats)
+            │ equality: (b) = (column3)
+            │ right cols are key
+            │ pred: column1 != k
+            │
+            ├── • filter
+            │   │ columns: (k, b)
+            │   │ estimated row count: 333 (missing stats)
+            │   │ filter: b > 0
+            │   │
+            │   └── • scan
+            │         columns: (k, b)
+            │         estimated row count: 1,000 (missing stats)
+            │         table: uniq_partial@primary
+            │         spans: FULL SCAN
+            │
+            └── • filter
+                │ columns: (column1, column2, column3)
+                │ estimated row count: 0 (missing stats)
+                │ filter: column3 > 0
+                │
+                └── • scan buffer
+                      columns: (column1, column2, column3)
+                      estimated row count: 0 (missing stats)
+                      label: buffer 1
+
 # Insert with non-constant input.
 query T
 EXPLAIN INSERT INTO uniq_partial SELECT k, v, w FROM other
@@ -1285,6 +1460,116 @@ vectorized: true
                         └── • project
                             │ columns: (column1, column2, column3)
                             │ estimated row count: 2
+                            │
+                            └── • scan buffer
+                                  columns: (column1, column2, column3, check1, partial_index_put1)
+                                  label: buffer 1
+
+# Test that we use the partial index when available for de-duplicating INSERT ON
+# CONFLICT DO NOTHING rows before inserting.
+query T
+EXPLAIN (VERBOSE) INSERT INTO uniq_partial_enum VALUES ('us-west', 1, 'foo'), ('us-east', 2, 'bar')
+ON CONFLICT DO NOTHING
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • insert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: uniq_partial_enum(r, i, s)
+│   │ arbiter indexes: primary
+│   │ arbiter constraints: unique_i
+│   │
+│   └── • buffer
+│       │ columns: (column1, column2, column3, check1, partial_index_put1)
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │ columns: (column1, column2, column3, check1, partial_index_put1)
+│           │ estimated row count: 0 (missing stats)
+│           │ render partial_index_put1: column3 IN ('bar', 'baz', 'foo')
+│           │ render check1: column1 IN ('us-east', 'us-west', 'eu-west')
+│           │ render column1: column1
+│           │ render column2: column2
+│           │ render column3: column3
+│           │
+│           └── • distinct
+│               │ columns: (upsert_partial_constraint_distinct0, column1, column2, column3)
+│               │ estimated row count: 0 (missing stats)
+│               │ distinct on: upsert_partial_constraint_distinct0, column2
+│               │ nulls are distinct
+│               │
+│               └── • render
+│                   │ columns: (upsert_partial_constraint_distinct0, column1, column2, column3)
+│                   │ estimated row count: 0 (missing stats)
+│                   │ render upsert_partial_constraint_distinct0: (column3 IN ('bar', 'baz', 'foo')) OR CAST(NULL AS BOOL)
+│                   │ render column1: column1
+│                   │ render column2: column2
+│                   │ render column3: column3
+│                   │
+│                   └── • lookup join (anti)
+│                       │ columns: (column1, column2, column3)
+│                       │ estimated row count: 0 (missing stats)
+│                       │ table: uniq_partial_enum@uniq_partial_enum_r_i_idx (partial index)
+│                       │ lookup condition: (column2 = i) AND (r IN ('us-east', 'us-west', 'eu-west'))
+│                       │ pred: column3 IN ('bar', 'baz', 'foo')
+│                       │
+│                       └── • lookup join (anti)
+│                           │ columns: (column1, column2, column3)
+│                           │ estimated row count: 0 (missing stats)
+│                           │ table: uniq_partial_enum@primary
+│                           │ equality: (column1, column2) = (r,i)
+│                           │ equality cols are key
+│                           │
+│                           └── • values
+│                                 columns: (column1, column2, column3)
+│                                 size: 3 columns, 2 rows
+│                                 row 0, expr 0: 'us-west'
+│                                 row 0, expr 1: 1
+│                                 row 0, expr 2: 'foo'
+│                                 row 1, expr 0: 'us-east'
+│                                 row 1, expr 1: 2
+│                                 row 1, expr 2: 'bar'
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (column1, column2, column3)
+            │ estimated row count: 0 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: ("lookup_join_const_col_@22", column1, column2, column3)
+                │ table: uniq_partial_enum@uniq_partial_enum_r_i_idx (partial index)
+                │ equality: (lookup_join_const_col_@22, column2) = (r,i)
+                │ equality cols are key
+                │ pred: column1 != r
+                │
+                └── • cross join (inner)
+                    │ columns: ("lookup_join_const_col_@22", column1, column2, column3)
+                    │ estimated row count: 0 (missing stats)
+                    │
+                    ├── • values
+                    │     columns: ("lookup_join_const_col_@22")
+                    │     size: 1 column, 3 rows
+                    │     row 0, expr 0: 'us-east'
+                    │     row 1, expr 0: 'us-west'
+                    │     row 2, expr 0: 'eu-west'
+                    │
+                    └── • filter
+                        │ columns: (column1, column2, column3)
+                        │ estimated row count: 0 (missing stats)
+                        │ filter: column3 IN ('bar', 'baz', 'foo')
+                        │
+                        └── • project
+                            │ columns: (column1, column2, column3)
+                            │ estimated row count: 0 (missing stats)
                             │
                             └── • scan buffer
                                   columns: (column1, column2, column3, check1, partial_index_put1)

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -2135,8 +2135,8 @@ insert a
       │    ├── columns: i:13!null s:15!null
       │    └── key: (13,15)
       └── filters
-           ├── column2:8 = s:15 [outer=(8,15), constraints=(/8: (/NULL - ]; /15: (/NULL - ]), fd=(8)==(15), (15)==(8)]
-           └── column3:9 = i:13 [outer=(9,13), constraints=(/9: (/NULL - ]; /13: (/NULL - ]), fd=(9)==(13), (13)==(9)]
+           ├── column3:9 = i:13 [outer=(9,13), constraints=(/9: (/NULL - ]; /13: (/NULL - ]), fd=(9)==(13), (13)==(9)]
+           └── column2:8 = s:15 [outer=(8,15), constraints=(/8: (/NULL - ]; /15: (/NULL - ]), fd=(8)==(15), (15)==(8)]
 
 # EnsureUpsertDistinctOn treats NULL values as distinct, so it can be eliminated.
 norm expect=EliminateDistinctOnValues
@@ -2306,14 +2306,14 @@ insert a
       │    │    ├── columns: i:19!null s:21!null
       │    │    └── key: (19,21)
       │    └── filters
-      │         ├── column2:8 = s:21 [outer=(8,21), constraints=(/8: (/NULL - ]; /21: (/NULL - ]), fd=(8)==(21), (21)==(8)]
-      │         └── column3:9 = i:19 [outer=(9,19), constraints=(/9: (/NULL - ]; /19: (/NULL - ]), fd=(9)==(19), (19)==(9)]
+      │         ├── column3:9 = i:19 [outer=(9,19), constraints=(/9: (/NULL - ]; /19: (/NULL - ]), fd=(9)==(19), (19)==(9)]
+      │         └── column2:8 = s:21 [outer=(8,21), constraints=(/8: (/NULL - ]; /21: (/NULL - ]), fd=(8)==(21), (21)==(8)]
       ├── scan a
       │    ├── columns: i:25!null f:26
       │    └── lax-key: (25,26)
       └── filters
-           ├── column4:10 = f:26 [outer=(10,26), constraints=(/10: (/NULL - ]; /26: (/NULL - ]), fd=(10)==(26), (26)==(10)]
-           └── column3:9 = i:25 [outer=(9,25), constraints=(/9: (/NULL - ]; /25: (/NULL - ]), fd=(9)==(25), (25)==(9)]
+           ├── column3:9 = i:25 [outer=(9,25), constraints=(/9: (/NULL - ]; /25: (/NULL - ]), fd=(9)==(25), (25)==(9)]
+           └── column4:10 = f:26 [outer=(10,26), constraints=(/10: (/NULL - ]; /26: (/NULL - ]), fd=(10)==(26), (26)==(10)]
 
 # DO NOTHING case where one distinct op can be removed (k), but two others
 # can't: (s, i) and (f, i).
@@ -2378,14 +2378,14 @@ insert a
       │    │    │    │    ├── columns: i:19!null s:21!null
       │    │    │    │    └── key: (19,21)
       │    │    │    └── filters
-      │    │    │         ├── column2:8 = s:21 [outer=(8,21), constraints=(/8: (/NULL - ]; /21: (/NULL - ]), fd=(8)==(21), (21)==(8)]
-      │    │    │         └── column10:10 = i:19 [outer=(10,19), constraints=(/10: (/NULL - ]; /19: (/NULL - ]), fd=(10)==(19), (19)==(10)]
+      │    │    │         ├── column10:10 = i:19 [outer=(10,19), constraints=(/10: (/NULL - ]; /19: (/NULL - ]), fd=(10)==(19), (19)==(10)]
+      │    │    │         └── column2:8 = s:21 [outer=(8,21), constraints=(/8: (/NULL - ]; /21: (/NULL - ]), fd=(8)==(21), (21)==(8)]
       │    │    ├── scan a
       │    │    │    ├── columns: i:25!null f:26
       │    │    │    └── lax-key: (25,26)
       │    │    └── filters
-      │    │         ├── column3:9 = f:26 [outer=(9,26), constraints=(/9: (/NULL - ]; /26: (/NULL - ]), fd=(9)==(26), (26)==(9)]
-      │    │         └── column10:10 = i:25 [outer=(10,25), constraints=(/10: (/NULL - ]; /25: (/NULL - ]), fd=(10)==(25), (25)==(10)]
+      │    │         ├── column10:10 = i:25 [outer=(10,25), constraints=(/10: (/NULL - ]; /25: (/NULL - ]), fd=(10)==(25), (25)==(10)]
+      │    │         └── column3:9 = f:26 [outer=(9,26), constraints=(/9: (/NULL - ]; /26: (/NULL - ]), fd=(9)==(26), (26)==(9)]
       │    └── aggregations
       │         ├── first-agg [as=column1:7, outer=(7)]
       │         │    └── column1:7
@@ -2463,14 +2463,14 @@ insert a
       │    │    │    ├── columns: i:19!null s:21!null
       │    │    │    └── key: (19,21)
       │    │    └── filters
-      │    │         ├── column2:8 = s:21 [outer=(8,21), constraints=(/8: (/NULL - ]; /21: (/NULL - ]), fd=(8)==(21), (21)==(8)]
-      │    │         └── column3:9 = i:19 [outer=(9,19), constraints=(/9: (/NULL - ]; /19: (/NULL - ]), fd=(9)==(19), (19)==(9)]
+      │    │         ├── column3:9 = i:19 [outer=(9,19), constraints=(/9: (/NULL - ]; /19: (/NULL - ]), fd=(9)==(19), (19)==(9)]
+      │    │         └── column2:8 = s:21 [outer=(8,21), constraints=(/8: (/NULL - ]; /21: (/NULL - ]), fd=(8)==(21), (21)==(8)]
       │    ├── scan a
       │    │    ├── columns: i:25!null f:26
       │    │    └── lax-key: (25,26)
       │    └── filters
-      │         ├── column4:10 = f:26 [outer=(10,26), constraints=(/10: (/NULL - ]; /26: (/NULL - ]), fd=(10)==(26), (26)==(10)]
-      │         └── column3:9 = i:25 [outer=(9,25), constraints=(/9: (/NULL - ]; /25: (/NULL - ]), fd=(9)==(25), (25)==(9)]
+      │         ├── column3:9 = i:25 [outer=(9,25), constraints=(/9: (/NULL - ]; /25: (/NULL - ]), fd=(9)==(25), (25)==(9)]
+      │         └── column4:10 = f:26 [outer=(10,26), constraints=(/10: (/NULL - ]; /26: (/NULL - ]), fd=(10)==(26), (26)==(10)]
       └── aggregations
            ├── first-agg [as=column2:8, outer=(8)]
            │    └── column2:8

--- a/pkg/sql/opt/optbuilder/BUILD.bazel
+++ b/pkg/sql/opt/optbuilder/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "locking.go",
         "misc_statements.go",
         "mutation_builder.go",
+        "mutation_builder_arbiter.go",
         "mutation_builder_fk.go",
         "mutation_builder_unique.go",
         "opaque.go",

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -726,9 +726,10 @@ func (mb *mutationBuilder) buildInputForDoNothing(
 		// details.
 		var partialIndexDistinctCol *scopeColumn
 		if _, isPartial := index.Predicate(); isPartial {
-			alias := fmt.Sprintf("upsert_partial_index_distinct%d", idx)
 			pred := mb.parsePartialIndexPredicateExpr(idx)
-			partialIndexDistinctCol = mb.projectPartialArbiterDistinctColumn(insertColScope, pred, alias)
+			partialIndexDistinctCol = mb.projectPartialArbiterDistinctColumn(
+				insertColScope, pred, string(index.Name()),
+			)
 		}
 
 		mb.buildDistinctOnForDoNothingArbiter(
@@ -746,9 +747,10 @@ func (mb *mutationBuilder) buildInputForDoNothing(
 		// details.
 		var partialIndexDistinctCol *scopeColumn
 		if _, isPartial := uniqueConstraint.Predicate(); isPartial {
-			alias := fmt.Sprintf("upsert_partial_constraint_distinct%d", uc)
 			pred := mb.parseUniqueConstraintPredicateExpr(uc)
-			partialIndexDistinctCol = mb.projectPartialArbiterDistinctColumn(insertColScope, pred, alias)
+			partialIndexDistinctCol = mb.projectPartialArbiterDistinctColumn(
+				insertColScope, pred, uniqueConstraint.Name(),
+			)
 		}
 		mb.buildDistinctOnForDoNothingArbiter(
 			insertColScope,
@@ -951,8 +953,9 @@ func (mb *mutationBuilder) buildInputForUpsert(
 		// more details.
 		var partialIndexDistinctCol *scopeColumn
 		if isPartial {
-			alias := fmt.Sprintf("upsert_partial_index_distinct%d", idx)
-			partialIndexDistinctCol = mb.projectPartialArbiterDistinctColumn(insertColScope, pred, alias)
+			partialIndexDistinctCol = mb.projectPartialArbiterDistinctColumn(
+				insertColScope, pred, string(index.Name()),
+			)
 		}
 
 		buildInputForArbiter(func() *scopeColumn {

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/partialidx"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -669,7 +668,7 @@ func (mb *mutationBuilder) buildInsert(returning tree.ReturningExprs) {
 }
 
 // buildInputForDoNothing wraps the input expression in ANTI JOIN expressions,
-// one for each UNIQUE index on the target table. See the comment header for
+// one for each arbiter on the target table. See the comment header for
 // Builder.buildInsert for an example.
 func (mb *mutationBuilder) buildInputForDoNothing(
 	inScope *scope, conflictOrds util.FastIntSet, arbiterPredicate tree.Expr,
@@ -687,122 +686,6 @@ func (mb *mutationBuilder) buildInputForDoNothing(
 	// TODO(andyk): do we need to do more here?
 	mb.outScope.ordering = nil
 
-	// buildInputForArbiter builds the input for a single arbiter index or
-	// constraint.
-	// - colCount is the number of columns in the constraint or lax key columns
-	//   in the index.
-	// - colOrdinal is a function that returns the position of the ith constraint
-	//   or index column in its table.
-	// - predExpr is the partial index predicate. If the arbiter is not a partial
-	//   index, predExpr is nil.
-	buildInputForArbiter := func(
-		colCount int, colOrdinal func(i int) int, predExpr tree.Expr,
-	) {
-		// Build the right side of the anti-join. Use a new metadata instance
-		// of the mutation table so that a different set of column IDs are used for
-		// the two tables in the self-join.
-		fetchScope := mb.b.buildScan(
-			mb.b.addTable(mb.tab, &mb.alias),
-			tableOrdinals(mb.tab, columnKinds{
-				includeMutations:       false,
-				includeSystem:          false,
-				includeVirtualInverted: false,
-				includeVirtualComputed: true,
-			}),
-			nil, /* indexFlags */
-			noRowLocking,
-			inScope,
-		)
-
-		// If the index is a unique partial index, then rows that are not in the
-		// partial index cannot conflict with insert rows. Therefore, a Select
-		// wraps the scan on the right side of the anti-join with the partial
-		// index predicate expression as the filter.
-		if predExpr != nil {
-			texpr := fetchScope.resolveAndRequireType(predExpr, types.Bool)
-			predScalar := mb.b.buildScalar(texpr, fetchScope, nil, nil, nil)
-			fetchScope.expr = mb.b.factory.ConstructSelect(
-				fetchScope.expr,
-				memo.FiltersExpr{mb.b.factory.ConstructFiltersItem(predScalar)},
-			)
-		}
-
-		// Build the join condition by creating a conjunction of equality conditions
-		// that test each conflict column:
-		//
-		//   ON ins.x = scan.a AND ins.y = scan.b
-		//
-		var on memo.FiltersExpr
-		for i := 0; i < colCount; i++ {
-			ord := colOrdinal(i)
-			fetchCol := fetchScope.getColumnForTableOrdinal(ord)
-			if fetchCol == nil {
-				panic(errors.AssertionFailedf("missing column in fetchScope"))
-			}
-
-			condition := mb.b.factory.ConstructEq(
-				mb.b.factory.ConstructVariable(mb.insertColIDs[ord]),
-				mb.b.factory.ConstructVariable(fetchCol.id),
-			)
-			on = append(on, mb.b.factory.ConstructFiltersItem(condition))
-		}
-
-		// If the index is a unique partial index, then insert rows that do not
-		// satisfy the partial index predicate cannot conflict with existing
-		// rows in the unique partial index. Therefore, the partial index
-		// predicate expression is added to the ON filters.
-		if predExpr != nil {
-			texpr := mb.outScope.resolveAndRequireType(predExpr, types.Bool)
-			predScalar := mb.b.buildScalar(texpr, mb.outScope, nil, nil, nil)
-			on = append(on, mb.b.factory.ConstructFiltersItem(predScalar))
-		}
-
-		// Construct the anti-join.
-		mb.outScope.expr = mb.b.factory.ConstructAntiJoin(
-			mb.outScope.expr,
-			fetchScope.expr,
-			on,
-			memo.EmptyJoinPrivate,
-		)
-	}
-
-	// buildDistinctOnForArbiter adds an UpsertDistinctOn operator for a single
-	// arbiter index or constraint.
-	// - colCount is the number of columns in the constraint or lax key columns
-	//   in the index.
-	// - colOrdinal is a function that returns the position of the ith constraint
-	//   or index column in its table.
-	// - partialIndexDistinctCol is a column that allows the UpsertDistinctOn to
-	//   only de-duplicate insert rows that satisfy the partial index predicate.
-	//   If the arbiter is not a partial index, partialIndexDistinctCol is nil.
-	buildDistinctOnForArbiter := func(
-		colCount int, colOrdinal func(int) int, partialIndexDistinctCol *scopeColumn,
-	) {
-		// Add an UpsertDistinctOn operator to ensure there are no duplicate input
-		// rows for this arbiter. Duplicate rows can trigger conflict errors at
-		// runtime, which DO NOTHING is not supposed to do. See issue #37880.
-		var conflictCols opt.ColSet
-		for i := 0; i < colCount; i++ {
-			conflictCols.Add(mb.insertColIDs[colOrdinal(i)])
-		}
-		if partialIndexDistinctCol != nil {
-			conflictCols.Add(partialIndexDistinctCol.id)
-		}
-
-		// Treat NULL values as distinct from one another. And if duplicates are
-		// detected, remove them rather than raising an error.
-		mb.outScope = mb.b.buildDistinctOn(
-			conflictCols, mb.outScope, true /* nullsAreDistinct */, "" /* errorOnDup */)
-
-		// Remove the partialIndexDistinctCol from the output.
-		if partialIndexDistinctCol != nil {
-			projectionScope := mb.outScope.replace()
-			projectionScope.appendColumnsFromScope(insertColScope)
-			mb.b.constructProjectForScope(mb.outScope, projectionScope)
-			mb.outScope = projectionScope
-		}
-	}
-
 	// Loop over each arbiter index and constraint, creating an anti-join for
 	// each one.
 	arbiterIndexes.ForEach(func(idx int) {
@@ -813,13 +696,13 @@ func (mb *mutationBuilder) buildInputForDoNothing(
 			predExpr = mb.parsePartialIndexPredicateExpr(idx)
 		}
 
-		buildInputForArbiter(index.LaxKeyColumnCount(), func(i int) int {
+		mb.buildAntiJoinForDoNothingArbiter(inScope, index.LaxKeyColumnCount(), func(i int) int {
 			return index.Column(i).Ordinal()
 		}, predExpr)
 	})
 	arbiterConstraints.ForEach(func(uc int) {
 		uniqueConstraint := mb.tab.Unique(uc)
-		buildInputForArbiter(uniqueConstraint.ColumnCount(), func(i int) int {
+		mb.buildAntiJoinForDoNothingArbiter(inScope, uniqueConstraint.ColumnCount(), func(i int) int {
 			return uniqueConstraint.ColumnOrdinal(mb.tab, i)
 		}, nil /* predExpr */)
 	})
@@ -839,13 +722,13 @@ func (mb *mutationBuilder) buildInputForDoNothing(
 		if isPartial {
 			partialIndexDistinctCol = mb.projectPartialIndexDistinctColumn(insertColScope, idx)
 		}
-		buildDistinctOnForArbiter(index.LaxKeyColumnCount(), func(i int) int {
+		mb.buildDistinctOnForDoNothingArbiter(insertColScope, index.LaxKeyColumnCount(), func(i int) int {
 			return index.Column(i).Ordinal()
 		}, partialIndexDistinctCol)
 	})
 	arbiterConstraints.ForEach(func(uc int) {
 		uniqueConstraint := mb.tab.Unique(uc)
-		buildDistinctOnForArbiter(uniqueConstraint.ColumnCount(), func(i int) int {
+		mb.buildDistinctOnForDoNothingArbiter(insertColScope, uniqueConstraint.ColumnCount(), func(i int) int {
 			return uniqueConstraint.ColumnOrdinal(mb.tab, i)
 		}, nil /* partialIndexDistinctCol */)
 	})
@@ -1247,235 +1130,6 @@ func (mb *mutationBuilder) projectUpsertColumns() {
 
 	mb.b.constructProjectForScope(mb.outScope, projectionsScope)
 	mb.outScope = projectionsScope
-}
-
-// arbiterIndexesAndConstraints returns sets of index ordinals and unique
-// constraint ordinals to be used as arbiter constraints for an INSERT ON
-// CONFLICT statement. This function panics if no arbiter indexes or constraints
-// are found.
-//
-// Arbiter constraints ensure that the columns designated by conflictOrds
-// reference at most one target row of a UNIQUE index or constraint. Using ANTI
-// JOINs and LEFT OUTER JOINs to detect conflicts relies upon this being true
-// (otherwise result cardinality could increase). This is also a Postgres
-// requirement.
-//
-// An arbiter index:
-//
-//   1. Must have lax key columns that match the columns in conflictOrds.
-//   2. If it is a partial index, its predicate must be implied by the
-//      arbiterPredicate supplied by the user.
-//
-// An arbiter constraint must have columns that match the columns in
-// conflictOrds. Unique constraints without an index cannot be "partial",
-// so they have no predicate to check for implication with arbiterPredicate.
-// TODO(rytaft): revisit this for the case of implicitly partitioned partial
-//  unique indexes (see #59195).
-//
-// If conflictOrds is empty then all unique indexes and unique without index
-// constraints are returned as arbiters. This is required to support a
-// DO NOTHING with no ON CONFLICT columns. In this case, all unique indexes
-// and constraints are used to check for conflicts.
-//
-// If a non-partial or pseudo-partial arbiter index is found, the return set
-// contains only that index. No other arbiter is necessary because a non-partial
-// or pseudo-partial index guarantees uniqueness of its columns across all
-// rows.
-func (mb *mutationBuilder) arbiterIndexesAndConstraints(
-	conflictOrds util.FastIntSet, arbiterPredicate tree.Expr,
-) (indexes util.FastIntSet, uniqueConstraints util.FastIntSet) {
-	// If conflictOrds is empty, then all unique indexes and unique without index
-	// constraints are arbiters.
-	if conflictOrds.Empty() {
-		for idx, idxCount := 0, mb.tab.IndexCount(); idx < idxCount; idx++ {
-			if mb.tab.Index(idx).IsUnique() {
-				indexes.Add(idx)
-			}
-		}
-		for uc, ucCount := 0, mb.tab.UniqueCount(); uc < ucCount; uc++ {
-			if mb.tab.Unique(uc).WithoutIndex() {
-				uniqueConstraints.Add(uc)
-			}
-		}
-		return indexes, uniqueConstraints
-	}
-
-	tabMeta := mb.md.TableMeta(mb.tabID)
-	var tableScope *scope
-	var im *partialidx.Implicator
-	var arbiterFilters memo.FiltersExpr
-	for idx, idxCount := 0, mb.tab.IndexCount(); idx < idxCount; idx++ {
-		index := mb.tab.Index(idx)
-
-		// Skip non-unique indexes. Use lax key columns, which always contain
-		// the minimum columns that ensure uniqueness. Null values are
-		// considered to be *not* equal, but that's OK because the join
-		// condition rejects nulls anyway.
-		if !index.IsUnique() || index.LaxKeyColumnCount() != conflictOrds.Len() {
-			continue
-		}
-
-		// Determine whether the conflict columns match the columns in the lax
-		// key. If not, the index cannot be an arbiter index.
-		indexOrds := getIndexLaxKeyOrdinals(index)
-		if !indexOrds.Equals(conflictOrds) {
-			continue
-		}
-
-		_, isPartial := index.Predicate()
-
-		// If the index is not a partial index, it can always be an arbiter.
-		// Furthermore, it is the only arbiter needed because it guarantees
-		// uniqueness of its columns across all rows.
-		if !isPartial {
-			return util.MakeFastIntSet(idx), util.FastIntSet{}
-		}
-
-		// Initialize tableScope once and only if needed. We need to build a scan
-		// so we can use the logical properties of the scan to fully normalize the
-		// index predicates.
-		if tableScope == nil {
-			tableScope = mb.b.buildScan(
-				tabMeta, tableOrdinals(tabMeta.Table, columnKinds{
-					includeMutations:       false,
-					includeSystem:          false,
-					includeVirtualInverted: false,
-					includeVirtualComputed: true,
-				}),
-				nil, /* indexFlags */
-				noRowLocking,
-				mb.b.allocScope(),
-			)
-		}
-
-		// Fetch the partial index predicate which was added to tabMeta in the
-		// call to buildScan above.
-		p, _ := tabMeta.PartialIndexPredicate(idx)
-		predFilter := *p.(*memo.FiltersExpr)
-
-		// If the index is a pseudo-partial index, it can always be an arbiter.
-		// Furthermore, it is the only arbiter needed because it guarantees
-		// uniqueness of its columns across all rows.
-		if predFilter.IsTrue() {
-			return util.MakeFastIntSet(idx), util.FastIntSet{}
-		}
-
-		// If the index is a partial index, then it can only be an arbiter if
-		// the arbiterPredicate implies it.
-		if arbiterPredicate != nil {
-
-			// Initialize the Implicator once.
-			if im == nil {
-				im = &partialidx.Implicator{}
-				im.Init(mb.b.factory, mb.md, mb.b.evalCtx)
-			}
-
-			// Build the arbiter filters once.
-			if arbiterFilters == nil {
-				var err error
-				arbiterFilters, err = mb.b.buildPartialIndexPredicate(
-					tabMeta, tableScope, arbiterPredicate, "arbiter predicate",
-				)
-				if err != nil {
-					// The error is due to a non-immutable operator in the arbiter
-					// predicate. Continue on to see if a matching non-partial or
-					// pseudo-partial index exists.
-					continue
-				}
-			}
-
-			if _, ok := im.FiltersImplyPredicate(arbiterFilters, predFilter); ok {
-				indexes.Add(idx)
-			}
-		}
-	}
-
-	// Try to find a matching unique constraint. We should always return a full
-	// unique constraint if it exists before returning any partial indexes.
-	for uc, ucCount := 0, mb.tab.UniqueCount(); uc < ucCount; uc++ {
-		uniqueConstraint := mb.tab.Unique(uc)
-		if !uniqueConstraint.WithoutIndex() {
-			// Unique constraints with an index were handled above.
-			continue
-		}
-
-		if uniqueConstraint.ColumnCount() != conflictOrds.Len() {
-			continue
-		}
-
-		// Determine whether the conflict columns match the columns in the unique
-		// constraint. If not, the constraint cannot be an arbiter.
-		var ucOrds util.FastIntSet
-		for i, n := 0, uniqueConstraint.ColumnCount(); i < n; i++ {
-			ucOrds.Add(uniqueConstraint.ColumnOrdinal(mb.tab, i))
-		}
-
-		if ucOrds.Equals(conflictOrds) {
-			return util.FastIntSet{}, util.MakeFastIntSet(uc)
-		}
-	}
-
-	// There are no full indexes or constraints, so return any partial indexes
-	// that were found.
-	if !indexes.Empty() {
-		return indexes, util.FastIntSet{}
-	}
-
-	panic(pgerror.Newf(pgcode.InvalidColumnReference,
-		"there is no unique or exclusion constraint matching the ON CONFLICT specification"))
-}
-
-// projectPartialIndexDistinctColumn projects a column to facilitate
-// de-duplicating insert rows for UPSERT/INSERT ON CONFLICT when the arbiter
-// index is a partial index. Only those insert rows that satisfy the partial
-// index predicate should be de-duplicated. For example:
-//
-//   CREATE TABLE t (a INT, b INT, UNIQUE INDEX (a) WHERE b > 0)
-//   INSERT INTO t VALUES (1, 1), (1, 2), (1, -1), (1, -10) ON CONFLICT DO NOTHING
-//
-// The rows (1, 1), (1, -1), and (1, -10) should be inserted. (1, -1)
-// and (1, -10) should not be removed from the input set. Even though
-// their values for a conflict with the other input rows, their values
-// for b are less than 0, so they will not conflict given the unique
-// partial index predicate.
-//
-// In order to avoid de-duplicating all input rows, we project a new
-// column to group by. This column is true if the predicate is satisfied
-// and NULL otherwise. For the example above, the projected column would
-// be (b > 0) OR NULL. The values of the projected rows would be:
-//
-//   (1, 1)   -> (1, 1, true)
-//   (1, 2)   -> (1, 2, true)
-//   (1, -1)  -> (1, -1, NULL)
-//   (1, -10) -> (1, -10, NULL)
-//
-// The set of conflict columns to be used for de-duplication includes a and the
-// newly projected column. The UpsertDistinctOn considers NULL values as unique,
-// so the rows remaining would be (1, 1, true), (1, -1, NULL), and (1, -10,
-// NULL).
-//
-// The newly project scopeColumn is returned.
-func (mb *mutationBuilder) projectPartialIndexDistinctColumn(
-	insertScope *scope, idx cat.IndexOrdinal,
-) *scopeColumn {
-	projectionScope := mb.outScope.replace()
-	projectionScope.appendColumnsFromScope(insertScope)
-
-	predExpr := mb.parsePartialIndexPredicateExpr(idx)
-	expr := &tree.OrExpr{
-		Left:  predExpr,
-		Right: tree.DNull,
-	}
-	texpr := insertScope.resolveAndRequireType(expr, types.Bool)
-
-	alias := fmt.Sprintf("upsert_partial_index_distinct%d", idx)
-	scopeCol := projectionScope.addColumn(alias, texpr)
-	mb.b.buildScalar(texpr, mb.outScope, projectionScope, scopeCol, nil)
-
-	mb.b.constructProjectForScope(mb.outScope, projectionScope)
-	mb.outScope = projectionScope
-
-	return scopeCol
 }
 
 // mapPublicColumnNamesToOrdinals returns the set of ordinal positions within

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -690,24 +690,27 @@ func (mb *mutationBuilder) buildInputForDoNothing(
 	// each one.
 	arbiterIndexes.ForEach(func(idx int) {
 		index := mb.tab.Index(idx)
-		_, isPartial := index.Predicate()
-		var predExpr tree.Expr
-		if isPartial {
-			predExpr = mb.parsePartialIndexPredicateExpr(idx)
+		var pred tree.Expr
+		if _, isPartial := index.Predicate(); isPartial {
+			pred = mb.parsePartialIndexPredicateExpr(idx)
 		}
 
 		mb.buildAntiJoinForDoNothingArbiter(
 			inScope,
 			getIndexLaxKeyOrdinals(index),
-			predExpr,
+			pred,
 		)
 	})
 	arbiterConstraints.ForEach(func(uc int) {
 		uniqueConstraint := mb.tab.Unique(uc)
+		var pred tree.Expr
+		if _, isPartial := uniqueConstraint.Predicate(); isPartial {
+			pred = mb.parseUniqueConstraintPredicateExpr(uc)
+		}
 		mb.buildAntiJoinForDoNothingArbiter(
 			inScope,
 			getUniqueConstraintOrdinals(mb.tab, uniqueConstraint),
-			nil, /* predExpr */
+			pred,
 		)
 	})
 
@@ -716,15 +719,16 @@ func (mb *mutationBuilder) buildInputForDoNothing(
 	// the anti-joins created above, to avoid removing valid rows (see #59125).
 	arbiterIndexes.ForEach(func(idx int) {
 		index := mb.tab.Index(idx)
-		_, isPartial := index.Predicate()
 
 		// If the index is a partial index, project a new column that allows the
 		// UpsertDistinctOn to only de-duplicate insert rows that satisfy the
-		// partial index predicate. See projectPartialIndexDistinctColumn for more
+		// partial index predicate. See projectPartialArbiterDistinctColumn for more
 		// details.
 		var partialIndexDistinctCol *scopeColumn
-		if isPartial {
-			partialIndexDistinctCol = mb.projectPartialIndexDistinctColumn(insertColScope, idx)
+		if _, isPartial := index.Predicate(); isPartial {
+			alias := fmt.Sprintf("upsert_partial_index_distinct%d", idx)
+			pred := mb.parsePartialIndexPredicateExpr(idx)
+			partialIndexDistinctCol = mb.projectPartialArbiterDistinctColumn(insertColScope, pred, alias)
 		}
 
 		mb.buildDistinctOnForDoNothingArbiter(
@@ -735,10 +739,21 @@ func (mb *mutationBuilder) buildInputForDoNothing(
 	})
 	arbiterConstraints.ForEach(func(uc int) {
 		uniqueConstraint := mb.tab.Unique(uc)
+
+		// If the constraint is partial, project a new column that allows the
+		// UpsertDistinctOn to only de-duplicate insert rows that satisfy the
+		// partial predicate. See projectPartialArbiterDistinctColumn for more
+		// details.
+		var partialIndexDistinctCol *scopeColumn
+		if _, isPartial := uniqueConstraint.Predicate(); isPartial {
+			alias := fmt.Sprintf("upsert_partial_constraint_distinct%d", uc)
+			pred := mb.parseUniqueConstraintPredicateExpr(uc)
+			partialIndexDistinctCol = mb.projectPartialArbiterDistinctColumn(insertColScope, pred, alias)
+		}
 		mb.buildDistinctOnForDoNothingArbiter(
 			insertColScope,
 			getUniqueConstraintOrdinals(mb.tab, uniqueConstraint),
-			nil, /* partialIndexDistinctCol */
+			partialIndexDistinctCol,
 		)
 	})
 
@@ -925,23 +940,24 @@ func (mb *mutationBuilder) buildInputForUpsert(
 		index := mb.tab.Index(idx)
 
 		_, isPartial := index.Predicate()
-		var predExpr tree.Expr
+		var pred tree.Expr
 		if isPartial {
-			predExpr = mb.parsePartialIndexPredicateExpr(idx)
+			pred = mb.parsePartialIndexPredicateExpr(idx)
 		}
 
 		// If the index is a partial index, project a new column that allows the
 		// UpsertDistinctOn to only de-duplicate insert rows that satisfy the
-		// partial index predicate. See projectPartialIndexDistinctColumn for more
-		// details.
+		// partial index predicate. See projectPartialArbiterDistinctColumn for
+		// more details.
 		var partialIndexDistinctCol *scopeColumn
 		if isPartial {
-			partialIndexDistinctCol = mb.projectPartialIndexDistinctColumn(insertColScope, idx)
+			alias := fmt.Sprintf("upsert_partial_index_distinct%d", idx)
+			partialIndexDistinctCol = mb.projectPartialArbiterDistinctColumn(insertColScope, pred, alias)
 		}
 
 		buildInputForArbiter(func() *scopeColumn {
 			return &mb.fetchScope.cols[findNotNullIndexCol(index)]
-		}, predExpr, partialIndexDistinctCol)
+		}, pred, partialIndexDistinctCol)
 	} else if arbiterConstraints.Len() > 0 {
 		buildInputForArbiter(func() *scopeColumn {
 			// Use the primary index, since we don't know at this point whether

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -1239,6 +1239,17 @@ func getIndexLaxKeyOrdinals(index cat.Index) util.FastIntSet {
 	return keyOrds
 }
 
+// getUniqueConstraintOrdinals returns the ordinals of all columns in the given
+// unique constraint. A column's ordinal is the ordered position of that column
+// in the owning table.
+func getUniqueConstraintOrdinals(tab cat.Table, uc cat.UniqueConstraint) util.FastIntSet {
+	var ucOrds util.FastIntSet
+	for i, n := 0, uc.ColumnCount(); i < n; i++ {
+		ucOrds.Add(uc.ColumnOrdinal(tab, i))
+	}
+	return ucOrds
+}
+
 // getExplicitPrimaryKeyOrdinals returns the ordinals of the primary key
 // columns, excluding any implicit partitioning columns in the primary index.
 func getExplicitPrimaryKeyOrdinals(tab cat.Table) util.FastIntSet {

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -188,6 +188,10 @@ type mutationBuilder struct {
 
 	// uniqueCheckHelper is used to prevent allocating the helper separately.
 	uniqueCheckHelper uniqueCheckHelper
+
+	// arbiterPredicateHelper is used to prevent allocating the helper
+	// separately.
+	arbiterPredicateHelper arbiterPredicateHelper
 }
 
 func (mb *mutationBuilder) init(b *Builder, opName string, tab cat.Table, alias tree.TableName) {

--- a/pkg/sql/opt/optbuilder/mutation_builder_arbiter.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_arbiter.go
@@ -1,0 +1,380 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package optbuilder
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/partialidx"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/errors"
+)
+
+// arbiterIndexesAndConstraints returns sets of index ordinals and unique
+// constraint ordinals to be used as arbiter constraints for an INSERT ON
+// CONFLICT statement. This function panics if no arbiter indexes or constraints
+// are found.
+//
+// Arbiter constraints ensure that the columns designated by conflictOrds
+// reference at most one target row of a UNIQUE index or constraint. Using ANTI
+// JOINs and LEFT OUTER JOINs to detect conflicts relies upon this being true
+// (otherwise result cardinality could increase). This is also a Postgres
+// requirement.
+//
+// An arbiter index:
+//
+//   1. Must have lax key columns that match the columns in conflictOrds.
+//   2. If it is a partial index, its predicate must be implied by the
+//      arbiterPredicate supplied by the user.
+//
+// An arbiter constraint must have columns that match the columns in
+// conflictOrds. Unique constraints without an index cannot be "partial",
+// so they have no predicate to check for implication with arbiterPredicate.
+// TODO(rytaft): revisit this for the case of implicitly partitioned partial
+//  unique indexes (see #59195).
+//
+// If conflictOrds is empty then all unique indexes and unique without index
+// constraints are returned as arbiters. This is required to support a
+// DO NOTHING with no ON CONFLICT columns. In this case, all unique indexes
+// and constraints are used to check for conflicts.
+//
+// If a non-partial or pseudo-partial arbiter index is found, the return set
+// contains only that index. No other arbiter is necessary because a non-partial
+// or pseudo-partial index guarantees uniqueness of its columns across all
+// rows.
+func (mb *mutationBuilder) arbiterIndexesAndConstraints(
+	conflictOrds util.FastIntSet, arbiterPredicate tree.Expr,
+) (indexes util.FastIntSet, uniqueConstraints util.FastIntSet) {
+	// If conflictOrds is empty, then all unique indexes and unique without index
+	// constraints are arbiters.
+	if conflictOrds.Empty() {
+		for idx, idxCount := 0, mb.tab.IndexCount(); idx < idxCount; idx++ {
+			if mb.tab.Index(idx).IsUnique() {
+				indexes.Add(idx)
+			}
+		}
+		for uc, ucCount := 0, mb.tab.UniqueCount(); uc < ucCount; uc++ {
+			if mb.tab.Unique(uc).WithoutIndex() {
+				uniqueConstraints.Add(uc)
+			}
+		}
+		return indexes, uniqueConstraints
+	}
+
+	tabMeta := mb.md.TableMeta(mb.tabID)
+	var tableScope *scope
+	var im *partialidx.Implicator
+	var arbiterFilters memo.FiltersExpr
+	for idx, idxCount := 0, mb.tab.IndexCount(); idx < idxCount; idx++ {
+		index := mb.tab.Index(idx)
+
+		// Skip non-unique indexes. Use lax key columns, which always contain
+		// the minimum columns that ensure uniqueness. Null values are
+		// considered to be *not* equal, but that's OK because the join
+		// condition rejects nulls anyway.
+		if !index.IsUnique() || index.LaxKeyColumnCount() != conflictOrds.Len() {
+			continue
+		}
+
+		// Determine whether the conflict columns match the columns in the lax
+		// key. If not, the index cannot be an arbiter index.
+		indexOrds := getIndexLaxKeyOrdinals(index)
+		if !indexOrds.Equals(conflictOrds) {
+			continue
+		}
+
+		_, isPartial := index.Predicate()
+
+		// If the index is not a partial index, it can always be an arbiter.
+		// Furthermore, it is the only arbiter needed because it guarantees
+		// uniqueness of its columns across all rows.
+		if !isPartial {
+			return util.MakeFastIntSet(idx), util.FastIntSet{}
+		}
+
+		// Initialize tableScope once and only if needed. We need to build a scan
+		// so we can use the logical properties of the scan to fully normalize the
+		// index predicates.
+		if tableScope == nil {
+			tableScope = mb.b.buildScan(
+				tabMeta, tableOrdinals(tabMeta.Table, columnKinds{
+					includeMutations:       false,
+					includeSystem:          false,
+					includeVirtualInverted: false,
+					includeVirtualComputed: true,
+				}),
+				nil, /* indexFlags */
+				noRowLocking,
+				mb.b.allocScope(),
+			)
+		}
+
+		// Fetch the partial index predicate which was added to tabMeta in the
+		// call to buildScan above.
+		p, _ := tabMeta.PartialIndexPredicate(idx)
+		predFilter := *p.(*memo.FiltersExpr)
+
+		// If the index is a pseudo-partial index, it can always be an arbiter.
+		// Furthermore, it is the only arbiter needed because it guarantees
+		// uniqueness of its columns across all rows.
+		if predFilter.IsTrue() {
+			return util.MakeFastIntSet(idx), util.FastIntSet{}
+		}
+
+		// If the index is a partial index, then it can only be an arbiter if
+		// the arbiterPredicate implies it.
+		if arbiterPredicate != nil {
+
+			// Initialize the Implicator once.
+			if im == nil {
+				im = &partialidx.Implicator{}
+				im.Init(mb.b.factory, mb.md, mb.b.evalCtx)
+			}
+
+			// Build the arbiter filters once.
+			if arbiterFilters == nil {
+				var err error
+				arbiterFilters, err = mb.b.buildPartialIndexPredicate(
+					tabMeta, tableScope, arbiterPredicate, "arbiter predicate",
+				)
+				if err != nil {
+					// The error is due to a non-immutable operator in the arbiter
+					// predicate. Continue on to see if a matching non-partial or
+					// pseudo-partial index exists.
+					continue
+				}
+			}
+
+			if _, ok := im.FiltersImplyPredicate(arbiterFilters, predFilter); ok {
+				indexes.Add(idx)
+			}
+		}
+	}
+
+	// Try to find a matching unique constraint. We should always return a full
+	// unique constraint if it exists before returning any partial indexes.
+	for uc, ucCount := 0, mb.tab.UniqueCount(); uc < ucCount; uc++ {
+		uniqueConstraint := mb.tab.Unique(uc)
+		if !uniqueConstraint.WithoutIndex() {
+			// Unique constraints with an index were handled above.
+			continue
+		}
+
+		if uniqueConstraint.ColumnCount() != conflictOrds.Len() {
+			continue
+		}
+
+		// Determine whether the conflict columns match the columns in the unique
+		// constraint. If not, the constraint cannot be an arbiter.
+		var ucOrds util.FastIntSet
+		for i, n := 0, uniqueConstraint.ColumnCount(); i < n; i++ {
+			ucOrds.Add(uniqueConstraint.ColumnOrdinal(mb.tab, i))
+		}
+
+		if ucOrds.Equals(conflictOrds) {
+			return util.FastIntSet{}, util.MakeFastIntSet(uc)
+		}
+	}
+
+	// There are no full indexes or constraints, so return any partial indexes
+	// that were found.
+	if !indexes.Empty() {
+		return indexes, util.FastIntSet{}
+	}
+
+	panic(pgerror.Newf(pgcode.InvalidColumnReference,
+		"there is no unique or exclusion constraint matching the ON CONFLICT specification"))
+}
+
+// buildAntiJoinForDoNothingArbiter builds an anti-join for a single arbiter index
+// or constraint for an INSERT ON CONFLICT DO NOTHING mutation. The anti-join
+// wraps the current mb.outScope.expr and removes rows that would conflict with
+// existing rows.
+//
+// 	 - colCount is the number of columns in the constraint or lax key columns
+// 	   in the index.
+// 	 - colOrdinal is a function that returns the position of the ith constraint
+// 	   or index column in its table.
+// 	 - predExpr is the partial index predicate. If the arbiter is not a partial
+//     index, predExpr is nil.
+//
+func (mb *mutationBuilder) buildAntiJoinForDoNothingArbiter(
+	inScope *scope, colCount int, colOrdinal func(i int) int, predExpr tree.Expr,
+) {
+	// Build the right side of the anti-join. Use a new metadata instance
+	// of the mutation table so that a different set of column IDs are used for
+	// the two tables in the self-join.
+	fetchScope := mb.b.buildScan(
+		mb.b.addTable(mb.tab, &mb.alias),
+		tableOrdinals(mb.tab, columnKinds{
+			includeMutations:       false,
+			includeSystem:          false,
+			includeVirtualInverted: false,
+			includeVirtualComputed: true,
+		}),
+		nil, /* indexFlags */
+		noRowLocking,
+		inScope,
+	)
+
+	// If the index is a unique partial index, then rows that are not in the
+	// partial index cannot conflict with insert rows. Therefore, a Select
+	// wraps the scan on the right side of the anti-join with the partial
+	// index predicate expression as the filter.
+	if predExpr != nil {
+		texpr := fetchScope.resolveAndRequireType(predExpr, types.Bool)
+		predScalar := mb.b.buildScalar(texpr, fetchScope, nil, nil, nil)
+		fetchScope.expr = mb.b.factory.ConstructSelect(
+			fetchScope.expr,
+			memo.FiltersExpr{mb.b.factory.ConstructFiltersItem(predScalar)},
+		)
+	}
+
+	// Build the join condition by creating a conjunction of equality conditions
+	// that test each conflict column:
+	//
+	//   ON ins.x = scan.a AND ins.y = scan.b
+	//
+	var on memo.FiltersExpr
+	for i := 0; i < colCount; i++ {
+		ord := colOrdinal(i)
+		fetchCol := fetchScope.getColumnForTableOrdinal(ord)
+		if fetchCol == nil {
+			panic(errors.AssertionFailedf("missing column in fetchScope"))
+		}
+
+		condition := mb.b.factory.ConstructEq(
+			mb.b.factory.ConstructVariable(mb.insertColIDs[ord]),
+			mb.b.factory.ConstructVariable(fetchCol.id),
+		)
+		on = append(on, mb.b.factory.ConstructFiltersItem(condition))
+	}
+
+	// If the index is a unique partial index, then insert rows that do not
+	// satisfy the partial index predicate cannot conflict with existing
+	// rows in the unique partial index. Therefore, the partial index
+	// predicate expression is added to the ON filters.
+	if predExpr != nil {
+		texpr := mb.outScope.resolveAndRequireType(predExpr, types.Bool)
+		predScalar := mb.b.buildScalar(texpr, mb.outScope, nil, nil, nil)
+		on = append(on, mb.b.factory.ConstructFiltersItem(predScalar))
+	}
+
+	// Construct the anti-join.
+	mb.outScope.expr = mb.b.factory.ConstructAntiJoin(
+		mb.outScope.expr,
+		fetchScope.expr,
+		on,
+		memo.EmptyJoinPrivate,
+	)
+}
+
+// buildDistinctOnForDoNothingArbiter adds an UpsertDistinctOn operator for a
+// single arbiter index or constraint.
+//
+//   - colCount is the number of columns in the constraint or lax key columns
+//     in the index.
+//   - colOrdinal is a function that returns the position of the ith constraint
+//     or index column in its table.
+//   - partialIndexDistinctCol is a column that allows the UpsertDistinctOn to
+//     only de-duplicate insert rows that satisfy the partial index predicate.
+//     If the arbiter is not a partial index, partialIndexDistinctCol is nil.
+//
+func (mb *mutationBuilder) buildDistinctOnForDoNothingArbiter(
+	insertColScope *scope,
+	colCount int,
+	colOrdinal func(int) int,
+	partialIndexDistinctCol *scopeColumn,
+) {
+	// Add an UpsertDistinctOn operator to ensure there are no duplicate input
+	// rows for this arbiter. Duplicate rows can trigger conflict errors at
+	// runtime, which DO NOTHING is not supposed to do. See issue #37880.
+	var conflictCols opt.ColSet
+	for i := 0; i < colCount; i++ {
+		conflictCols.Add(mb.insertColIDs[colOrdinal(i)])
+	}
+	if partialIndexDistinctCol != nil {
+		conflictCols.Add(partialIndexDistinctCol.id)
+	}
+
+	// Treat NULL values as distinct from one another. And if duplicates are
+	// detected, remove them rather than raising an error.
+	mb.outScope = mb.b.buildDistinctOn(
+		conflictCols, mb.outScope, true /* nullsAreDistinct */, "" /* errorOnDup */)
+
+	// Remove the partialIndexDistinctCol from the output.
+	if partialIndexDistinctCol != nil {
+		projectionScope := mb.outScope.replace()
+		projectionScope.appendColumnsFromScope(insertColScope)
+		mb.b.constructProjectForScope(mb.outScope, projectionScope)
+		mb.outScope = projectionScope
+	}
+}
+
+// projectPartialIndexDistinctColumn projects a column to facilitate
+// de-duplicating insert rows for UPSERT/INSERT ON CONFLICT when the arbiter
+// index is a partial index. Only those insert rows that satisfy the partial
+// index predicate should be de-duplicated. For example:
+//
+//   CREATE TABLE t (a INT, b INT, UNIQUE INDEX (a) WHERE b > 0)
+//   INSERT INTO t VALUES (1, 1), (1, 2), (1, -1), (1, -10) ON CONFLICT DO NOTHING
+//
+// The rows (1, 1), (1, -1), and (1, -10) should be inserted. (1, -1)
+// and (1, -10) should not be removed from the input set. Even though
+// their values for a conflict with the other input rows, their values
+// for b are less than 0, so they will not conflict given the unique
+// partial index predicate.
+//
+// In order to avoid de-duplicating all input rows, we project a new
+// column to group by. This column is true if the predicate is satisfied
+// and NULL otherwise. For the example above, the projected column would
+// be (b > 0) OR NULL. The values of the projected rows would be:
+//
+//   (1, 1)   -> (1, 1, true)
+//   (1, 2)   -> (1, 2, true)
+//   (1, -1)  -> (1, -1, NULL)
+//   (1, -10) -> (1, -10, NULL)
+//
+// The set of conflict columns to be used for de-duplication includes a and the
+// newly projected column. The UpsertDistinctOn considers NULL values as unique,
+// so the rows remaining would be (1, 1, true), (1, -1, NULL), and (1, -10,
+// NULL).
+//
+// The newly project scopeColumn is returned.
+func (mb *mutationBuilder) projectPartialIndexDistinctColumn(
+	insertScope *scope, idx cat.IndexOrdinal,
+) *scopeColumn {
+	projectionScope := mb.outScope.replace()
+	projectionScope.appendColumnsFromScope(insertScope)
+
+	predExpr := mb.parsePartialIndexPredicateExpr(idx)
+	expr := &tree.OrExpr{
+		Left:  predExpr,
+		Right: tree.DNull,
+	}
+	texpr := insertScope.resolveAndRequireType(expr, types.Bool)
+
+	alias := fmt.Sprintf("upsert_partial_index_distinct%d", idx)
+	scopeCol := projectionScope.addColumn(alias, texpr)
+	mb.b.buildScalar(texpr, mb.outScope, projectionScope, scopeCol, nil)
+
+	mb.b.constructProjectForScope(mb.outScope, projectionScope)
+	mb.outScope = projectionScope
+
+	return scopeCol
+}

--- a/pkg/sql/opt/optbuilder/mutation_builder_arbiter.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_arbiter.go
@@ -11,6 +11,8 @@
 package optbuilder
 
 import (
+	"fmt"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
@@ -334,7 +336,7 @@ func (mb *mutationBuilder) buildDistinctOnForDoNothingArbiter(
 //
 // The newly project scopeColumn is returned.
 func (mb *mutationBuilder) projectPartialArbiterDistinctColumn(
-	insertScope *scope, pred tree.Expr, alias string,
+	insertScope *scope, pred tree.Expr, arbiterName string,
 ) *scopeColumn {
 	projectionScope := mb.outScope.replace()
 	projectionScope.appendColumnsFromScope(insertScope)
@@ -345,6 +347,7 @@ func (mb *mutationBuilder) projectPartialArbiterDistinctColumn(
 	}
 	texpr := insertScope.resolveAndRequireType(expr, types.Bool)
 
+	alias := fmt.Sprintf("arbiter_%s_distinct", arbiterName)
 	scopeCol := projectionScope.addColumn(alias, texpr)
 	mb.b.buildScalar(texpr, mb.outScope, projectionScope, scopeCol, nil)
 

--- a/pkg/sql/opt/optbuilder/mutation_builder_arbiter.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_arbiter.go
@@ -11,8 +11,6 @@
 package optbuilder
 
 import (
-	"fmt"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
@@ -42,26 +40,38 @@ import (
 //   2. If it is a partial index, its predicate must be implied by the
 //      arbiterPredicate supplied by the user.
 //
-// An arbiter constraint must have columns that match the columns in
-// conflictOrds. Unique constraints without an index cannot be "partial",
-// so they have no predicate to check for implication with arbiterPredicate.
-// TODO(rytaft): revisit this for the case of implicitly partitioned partial
-//  unique indexes (see #59195).
+// An arbiter constraint:
+//
+//   1. Must have columns that match the columns in conflictOrds.
+//   2. If it is a partial constraint, its predicate must be implied by the
+//      arbiterPredicate supplied by the user.
 //
 // If conflictOrds is empty then all unique indexes and unique without index
 // constraints are returned as arbiters. This is required to support a
 // DO NOTHING with no ON CONFLICT columns. In this case, all unique indexes
 // and constraints are used to check for conflicts.
 //
-// If a non-partial or pseudo-partial arbiter index is found, the return set
-// contains only that index. No other arbiter is necessary because a non-partial
-// or pseudo-partial index guarantees uniqueness of its columns across all
-// rows.
+// If conflictOrds is non-empty, there is an intentional preference for certain
+// types of arbiters. Indexes are preferred over constraints because they will
+// likely lead to a more efficient query plan. Non-partial or pseudo-partial
+// indexes and constraints are preferred over partial indexes and constraints
+// because a non-partial or pseudo-partial index or constraint guarantees
+// uniqueness of its columns across all rows; there is no need for an additional
+// arbiter for a subset of rows. If there are no non-partial or pseudo-partial
+// indexes or constraints found, all valid partial indexes and partial
+// constraints are returned so that uniqueness is guaranteed on the respective
+// subsets of rows. In summary, if conflictOrds is non-empty, this function:
+//
+//   1. Returns a single non-partial or pseudo-partial arbiter index, if found.
+//   2. Return a single non-partial or pseudo-partial arbiter constraint, if
+//      found.
+//   3. Otherwise, returns all partial arbiter indexes and constraints.
+//
 func (mb *mutationBuilder) arbiterIndexesAndConstraints(
 	conflictOrds util.FastIntSet, arbiterPredicate tree.Expr,
 ) (indexes util.FastIntSet, uniqueConstraints util.FastIntSet) {
-	// If conflictOrds is empty, then all unique indexes and unique without index
-	// constraints are arbiters.
+	// If conflictOrds is empty, then all unique indexes and unique without
+	// index constraints are arbiters.
 	if conflictOrds.Empty() {
 		for idx, idxCount := 0, mb.tab.IndexCount(); idx < idxCount; idx++ {
 			if mb.tab.Index(idx).IsUnique() {
@@ -96,12 +106,10 @@ func (mb *mutationBuilder) arbiterIndexesAndConstraints(
 			continue
 		}
 
-		_, isPartial := index.Predicate()
-
 		// If the index is not a partial index, it can always be an arbiter.
 		// Furthermore, it is the only arbiter needed because it guarantees
 		// uniqueness of its columns across all rows.
-		if !isPartial {
+		if _, isPartial := index.Predicate(); !isPartial {
 			return util.MakeFastIntSet(idx), util.FastIntSet{}
 		}
 
@@ -133,22 +141,47 @@ func (mb *mutationBuilder) arbiterIndexesAndConstraints(
 			continue
 		}
 
-		// Determine whether the conflict columns match the columns in the unique
-		// constraint. If not, the constraint cannot be an arbiter.
+		// Determine whether the conflict columns match the columns in the
+		// unique constraint. If not, the constraint cannot be an arbiter. We
+		// check the number of columns first to avoid unnecessarily collecting
+		// the unique constraint ordinals and determining set equality.
+		if uniqueConstraint.ColumnCount() != conflictOrds.Len() {
+			continue
+		}
 		ucOrds := getUniqueConstraintOrdinals(mb.tab, uniqueConstraint)
-		if ucOrds.Equals(conflictOrds) {
+		if !ucOrds.Equals(conflictOrds) {
+			continue
+		}
+
+		// If the unique constraint is not partial, it should be returned
+		// without any partial index arbiters.
+		if _, isPartial := uniqueConstraint.Predicate(); !isPartial {
 			return util.FastIntSet{}, util.MakeFastIntSet(uc)
+		}
+
+		// If the constraint is a pseudo-partial unique constraint, it can
+		// always be an arbiter. It should be returned without any partial index
+		// arbiters.
+		pred := h.partialUniqueConstraintPredicate(uc)
+		if pred.IsTrue() {
+			return util.FastIntSet{}, util.MakeFastIntSet(uc)
+		}
+
+		// If the unique constraint is partial, then it can only be an arbiter
+		// if the arbiterPredicate implies it.
+		if h.predicateIsImpliedByArbiterPredicate(pred) {
+			uniqueConstraints.Add(uc)
 		}
 	}
 
-	// There are no full indexes or constraints, so return any partial indexes
-	// that were found.
-	if !indexes.Empty() {
-		return indexes, util.FastIntSet{}
+	// Err if we did not previously return and did not find partial indexes or
+	// partial unique constraints.
+	if indexes.Empty() && uniqueConstraints.Empty() {
+		panic(pgerror.Newf(pgcode.InvalidColumnReference,
+			"there is no unique or exclusion constraint matching the ON CONFLICT specification"))
 	}
 
-	panic(pgerror.Newf(pgcode.InvalidColumnReference,
-		"there is no unique or exclusion constraint matching the ON CONFLICT specification"))
+	return indexes, uniqueConstraints
 }
 
 // buildAntiJoinForDoNothingArbiter builds an anti-join for a single arbiter index
@@ -158,11 +191,11 @@ func (mb *mutationBuilder) arbiterIndexesAndConstraints(
 //
 // 	 - columnOrds is the set of table column ordinals that the arbiter
 //     guarantees uniqueness of.
-// 	 - predExpr is the partial index predicate. If the arbiter is not a partial
-//     index, predExpr is nil.
+// 	 - pred is the partial index or constraint predicate. If the arbiter is
+//     not a partial index or constraint, pred is nil.
 //
 func (mb *mutationBuilder) buildAntiJoinForDoNothingArbiter(
-	inScope *scope, columnOrds util.FastIntSet, predExpr tree.Expr,
+	inScope *scope, columnOrds util.FastIntSet, pred tree.Expr,
 ) {
 	// Build the right side of the anti-join. Use a new metadata instance
 	// of the mutation table so that a different set of column IDs are used for
@@ -184,8 +217,8 @@ func (mb *mutationBuilder) buildAntiJoinForDoNothingArbiter(
 	// partial index cannot conflict with insert rows. Therefore, a Select
 	// wraps the scan on the right side of the anti-join with the partial
 	// index predicate expression as the filter.
-	if predExpr != nil {
-		texpr := fetchScope.resolveAndRequireType(predExpr, types.Bool)
+	if pred != nil {
+		texpr := fetchScope.resolveAndRequireType(pred, types.Bool)
 		predScalar := mb.b.buildScalar(texpr, fetchScope, nil, nil, nil)
 		fetchScope.expr = mb.b.factory.ConstructSelect(
 			fetchScope.expr,
@@ -216,8 +249,8 @@ func (mb *mutationBuilder) buildAntiJoinForDoNothingArbiter(
 	// satisfy the partial index predicate cannot conflict with existing
 	// rows in the unique partial index. Therefore, the partial index
 	// predicate expression is added to the ON filters.
-	if predExpr != nil {
-		texpr := mb.outScope.resolveAndRequireType(predExpr, types.Bool)
+	if pred != nil {
+		texpr := mb.outScope.resolveAndRequireType(pred, types.Bool)
 		predScalar := mb.b.buildScalar(texpr, mb.outScope, nil, nil, nil)
 		on = append(on, mb.b.factory.ConstructFiltersItem(predScalar))
 	}
@@ -236,12 +269,13 @@ func (mb *mutationBuilder) buildAntiJoinForDoNothingArbiter(
 //
 // 	 - columnOrds is the set of table column ordinals that the arbiter
 //     guarantees uniqueness of.
-//   - partialIndexDistinctCol is a column that allows the UpsertDistinctOn to
-//     only de-duplicate insert rows that satisfy the partial index predicate.
-//     If the arbiter is not a partial index, partialIndexDistinctCol is nil.
+//   - partialArbiterDistinctCol is a column that allows the UpsertDistinctOn to
+//     only de-duplicate insert rows that satisfy the partial index or
+//     constraint predicate. If the arbiter is not a partial index or
+//     constraint, partialArbiterDistinctCol is nil.
 //
 func (mb *mutationBuilder) buildDistinctOnForDoNothingArbiter(
-	insertColScope *scope, colOrds util.FastIntSet, partialIndexDistinctCol *scopeColumn,
+	insertColScope *scope, colOrds util.FastIntSet, partialArbiterDistinctCol *scopeColumn,
 ) {
 	// Add an UpsertDistinctOn operator to ensure there are no duplicate input
 	// rows for this arbiter. Duplicate rows can trigger conflict errors at
@@ -250,8 +284,8 @@ func (mb *mutationBuilder) buildDistinctOnForDoNothingArbiter(
 	for i, ok := colOrds.Next(0); ok; i, ok = colOrds.Next(i + 1) {
 		conflictCols.Add(mb.insertColIDs[i])
 	}
-	if partialIndexDistinctCol != nil {
-		conflictCols.Add(partialIndexDistinctCol.id)
+	if partialArbiterDistinctCol != nil {
+		conflictCols.Add(partialArbiterDistinctCol.id)
 	}
 
 	// Treat NULL values as distinct from one another. And if duplicates are
@@ -259,8 +293,8 @@ func (mb *mutationBuilder) buildDistinctOnForDoNothingArbiter(
 	mb.outScope = mb.b.buildDistinctOn(
 		conflictCols, mb.outScope, true /* nullsAreDistinct */, "" /* errorOnDup */)
 
-	// Remove the partialIndexDistinctCol from the output.
-	if partialIndexDistinctCol != nil {
+	// Remove the partialArbiterDistinctCol from the output.
+	if partialArbiterDistinctCol != nil {
 		projectionScope := mb.outScope.replace()
 		projectionScope.appendColumnsFromScope(insertColScope)
 		mb.b.constructProjectForScope(mb.outScope, projectionScope)
@@ -268,10 +302,11 @@ func (mb *mutationBuilder) buildDistinctOnForDoNothingArbiter(
 	}
 }
 
-// projectPartialIndexDistinctColumn projects a column to facilitate
+// projectPartialArbiterDistinctColumn projects a column to facilitate
 // de-duplicating insert rows for UPSERT/INSERT ON CONFLICT when the arbiter
-// index is a partial index. Only those insert rows that satisfy the partial
-// index predicate should be de-duplicated. For example:
+// index or constraint is partial. Only those insert rows that satisfy the
+// partial index or unique constraint predicate should be de-duplicated. For
+// example:
 //
 //   CREATE TABLE t (a INT, b INT, UNIQUE INDEX (a) WHERE b > 0)
 //   INSERT INTO t VALUES (1, 1), (1, 2), (1, -1), (1, -10) ON CONFLICT DO NOTHING
@@ -298,20 +333,18 @@ func (mb *mutationBuilder) buildDistinctOnForDoNothingArbiter(
 // NULL).
 //
 // The newly project scopeColumn is returned.
-func (mb *mutationBuilder) projectPartialIndexDistinctColumn(
-	insertScope *scope, idx cat.IndexOrdinal,
+func (mb *mutationBuilder) projectPartialArbiterDistinctColumn(
+	insertScope *scope, pred tree.Expr, alias string,
 ) *scopeColumn {
 	projectionScope := mb.outScope.replace()
 	projectionScope.appendColumnsFromScope(insertScope)
 
-	predExpr := mb.parsePartialIndexPredicateExpr(idx)
 	expr := &tree.OrExpr{
-		Left:  predExpr,
+		Left:  pred,
 		Right: tree.DNull,
 	}
 	texpr := insertScope.resolveAndRequireType(expr, types.Bool)
 
-	alias := fmt.Sprintf("upsert_partial_index_distinct%d", idx)
 	scopeCol := projectionScope.addColumn(alias, texpr)
 	mb.b.buildScalar(texpr, mb.outScope, projectionScope, scopeCol, nil)
 
@@ -321,8 +354,8 @@ func (mb *mutationBuilder) projectPartialIndexDistinctColumn(
 	return scopeCol
 }
 
-// arbiterPredicateHelper is used to determine if a partial index can be used as
-// an arbiter.
+// arbiterPredicateHelper is used to determine if a partial index or constraint
+// can be used as an arbiter.
 type arbiterPredicateHelper struct {
 	mb               *mutationBuilder
 	tabMeta          *opt.TableMeta
@@ -388,6 +421,21 @@ func (h *arbiterPredicateHelper) partialIndexPredicate(idx cat.IndexOrdinal) mem
 
 	pred, _ := h.tabMeta.PartialIndexPredicate(idx)
 	return *pred.(*memo.FiltersExpr)
+}
+
+// partialUniqueConstraintPredicate returns the predicate of the given unique
+// constraint.
+func (h *arbiterPredicateHelper) partialUniqueConstraintPredicate(
+	idx cat.UniqueOrdinal,
+) memo.FiltersExpr {
+	// Build and normalize the unique constraint predicate expression.
+	pred, err := h.mb.b.buildPartialIndexPredicate(
+		h.tabMeta, h.tableScope(), h.mb.parseUniqueConstraintPredicateExpr(idx), "unique constraint predicate",
+	)
+	if err != nil {
+		panic(err)
+	}
+	return pred
 }
 
 // arbiterFilters returns a scalar expression representing the arbiter

--- a/pkg/sql/opt/optbuilder/mutation_builder_arbiter.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_arbiter.go
@@ -76,10 +76,8 @@ func (mb *mutationBuilder) arbiterIndexesAndConstraints(
 		return indexes, uniqueConstraints
 	}
 
-	tabMeta := mb.md.TableMeta(mb.tabID)
-	var tableScope *scope
-	var im *partialidx.Implicator
-	var arbiterFilters memo.FiltersExpr
+	h := &mb.arbiterPredicateHelper
+	h.init(mb, arbiterPredicate)
 	for idx, idxCount := 0, mb.tab.IndexCount(); idx < idxCount; idx++ {
 		index := mb.tab.Index(idx)
 
@@ -107,62 +105,18 @@ func (mb *mutationBuilder) arbiterIndexesAndConstraints(
 			return util.MakeFastIntSet(idx), util.FastIntSet{}
 		}
 
-		// Initialize tableScope once and only if needed. We need to build a scan
-		// so we can use the logical properties of the scan to fully normalize the
-		// index predicates.
-		if tableScope == nil {
-			tableScope = mb.b.buildScan(
-				tabMeta, tableOrdinals(tabMeta.Table, columnKinds{
-					includeMutations:       false,
-					includeSystem:          false,
-					includeVirtualInverted: false,
-					includeVirtualComputed: true,
-				}),
-				nil, /* indexFlags */
-				noRowLocking,
-				mb.b.allocScope(),
-			)
-		}
-
-		// Fetch the partial index predicate which was added to tabMeta in the
-		// call to buildScan above.
-		p, _ := tabMeta.PartialIndexPredicate(idx)
-		predFilter := *p.(*memo.FiltersExpr)
-
 		// If the index is a pseudo-partial index, it can always be an arbiter.
 		// Furthermore, it is the only arbiter needed because it guarantees
 		// uniqueness of its columns across all rows.
-		if predFilter.IsTrue() {
+		pred := h.partialIndexPredicate(idx)
+		if pred.IsTrue() {
 			return util.MakeFastIntSet(idx), util.FastIntSet{}
 		}
 
 		// If the index is a partial index, then it can only be an arbiter if
 		// the arbiterPredicate implies it.
-		if arbiterPredicate != nil {
-
-			// Initialize the Implicator once.
-			if im == nil {
-				im = &partialidx.Implicator{}
-				im.Init(mb.b.factory, mb.md, mb.b.evalCtx)
-			}
-
-			// Build the arbiter filters once.
-			if arbiterFilters == nil {
-				var err error
-				arbiterFilters, err = mb.b.buildPartialIndexPredicate(
-					tabMeta, tableScope, arbiterPredicate, "arbiter predicate",
-				)
-				if err != nil {
-					// The error is due to a non-immutable operator in the arbiter
-					// predicate. Continue on to see if a matching non-partial or
-					// pseudo-partial index exists.
-					continue
-				}
-			}
-
-			if _, ok := im.FiltersImplyPredicate(arbiterFilters, predFilter); ok {
-				indexes.Add(idx)
-			}
+		if h.predicateIsImpliedByArbiterPredicate(pred) {
+			indexes.Add(idx)
 		}
 	}
 
@@ -365,4 +319,116 @@ func (mb *mutationBuilder) projectPartialIndexDistinctColumn(
 	mb.outScope = projectionScope
 
 	return scopeCol
+}
+
+// arbiterPredicateHelper is used to determine if a partial index can be used as
+// an arbiter.
+type arbiterPredicateHelper struct {
+	mb               *mutationBuilder
+	tabMeta          *opt.TableMeta
+	im               partialidx.Implicator
+	arbiterPredicate tree.Expr
+
+	// tableScopeLazy is a lazily initialized scope including all the columns of
+	// the mutation table and a scan on the table as an expression. Do NOT
+	// access it directly, use the tableScope method instead.
+	tableScopeLazy *scope
+
+	// arbiterFiltersLazy is a lazily initialized scalar expression that is the
+	// result of building arbiterPredicate. Do NOT access it directly, use the
+	// arbiterFilters method instead.
+	arbiterFiltersLazy memo.FiltersExpr
+
+	// invalidArbiterPredicate is true if the arbiterPredicate contains
+	// non-immutable operators. Such a predicate cannot imply any filters.
+	invalidArbiterPredicate bool
+}
+
+// init initializes the helper for the given arbiter predicate.
+func (h *arbiterPredicateHelper) init(mb *mutationBuilder, arbiterPredicate tree.Expr) {
+	// This initialization pattern ensures that fields are not unwittingly
+	// reused. Field reuse must be explicit.
+	*h = arbiterPredicateHelper{
+		mb:               mb,
+		tabMeta:          mb.md.TableMeta(mb.tabID),
+		arbiterPredicate: arbiterPredicate,
+	}
+	h.im.Init(mb.b.factory, mb.md, mb.b.evalCtx)
+}
+
+// tableScope returns a scope that can be used to build predicate expressions.
+// The scope contains a Scan expression. The logical properties of the Scan are
+// used to fully normalize predicate expressions.
+func (h *arbiterPredicateHelper) tableScope() *scope {
+	if h.tableScopeLazy == nil {
+		h.tableScopeLazy = h.mb.b.buildScan(
+			h.tabMeta, tableOrdinals(h.tabMeta.Table, columnKinds{
+				includeMutations:       false,
+				includeSystem:          false,
+				includeVirtualInverted: false,
+				includeVirtualComputed: true,
+			}),
+			nil, /* indexFlags */
+			noRowLocking,
+			h.mb.b.allocScope(),
+		)
+	}
+	return h.tableScopeLazy
+}
+
+// partialIndexPredicate returns the partial index predicate of the given index.
+// Rather than build the predicate scalar expression from the tree.Expr in the
+// catalog, it fetches the predicates from the table metadata. These predicates
+// are populated when the Scan expression is built for the tableScope. This
+// eliminates unnecessarily rebuilding partial index predicate expressions.
+func (h *arbiterPredicateHelper) partialIndexPredicate(idx cat.IndexOrdinal) memo.FiltersExpr {
+	// Call tableScope to ensure that buildScan has been called to populate
+	// tabMeta with partial index predicates.
+	h.tableScope()
+
+	pred, _ := h.tabMeta.PartialIndexPredicate(idx)
+	return *pred.(*memo.FiltersExpr)
+}
+
+// arbiterFilters returns a scalar expression representing the arbiter
+// predicate. If the arbiter predicate contains non-immutable operators,
+// ok=true is returned.
+func (h *arbiterPredicateHelper) arbiterFilters() (_ memo.FiltersExpr, ok bool) {
+	// The filters have been initialized if they are non-nil or
+	// invalidArbiterPredicate has been set to true.
+	arbiterFiltersInitialized := h.arbiterFiltersLazy != nil || h.invalidArbiterPredicate
+
+	if !arbiterFiltersInitialized {
+		filters, err := h.mb.b.buildPartialIndexPredicate(
+			h.tabMeta, h.tableScope(), h.arbiterPredicate, "arbiter predicate",
+		)
+		if err == nil {
+			h.arbiterFiltersLazy = filters
+		} else {
+			// The error is due to a non-immutable operator in the arbiter
+			// predicate. Such a predicate cannot imply any filters, so we mark
+			// it as invalid.
+			h.invalidArbiterPredicate = true
+		}
+	}
+	return h.arbiterFiltersLazy, !h.invalidArbiterPredicate
+}
+
+// predicateIsImpliedByArbiterPredicate returns true if the arbiterPredicate
+// implies pred. If there is no arbiterPredicate (it is nil), or it contains
+// non-immutable operators, it cannot imply any predicate, so false is returned.
+func (h *arbiterPredicateHelper) predicateIsImpliedByArbiterPredicate(pred memo.FiltersExpr) bool {
+	if h.arbiterPredicate == nil {
+		return false
+	}
+
+	arbiterFilters, ok := h.arbiterFilters()
+	if !ok {
+		// The arbiterPredicate contains non-immutable operators and cannot
+		// imply any predicate.
+		return false
+	}
+
+	_, ok = h.im.FiltersImplyPredicate(arbiterFilters, pred)
+	return ok
 }

--- a/pkg/sql/opt/optbuilder/testdata/partial-indexes
+++ b/pkg/sql/opt/optbuilder/testdata/partial-indexes
@@ -898,10 +898,10 @@ insert uniq
       ├── project
       │    ├── columns: column1:5!null column2:6!null column3:7!null
       │    └── upsert-distinct-on
-      │         ├── columns: column1:5!null column2:6!null column3:7!null upsert_partial_index_distinct1:16
-      │         ├── grouping columns: column2:6!null upsert_partial_index_distinct1:16
+      │         ├── columns: column1:5!null column2:6!null column3:7!null arbiter_secondary_distinct:16
+      │         ├── grouping columns: column2:6!null arbiter_secondary_distinct:16
       │         ├── project
-      │         │    ├── columns: upsert_partial_index_distinct1:16 column1:5!null column2:6!null column3:7!null
+      │         │    ├── columns: arbiter_secondary_distinct:16 column1:5!null column2:6!null column3:7!null
       │         │    ├── upsert-distinct-on
       │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
       │         │    │    ├── grouping columns: column1:5!null
@@ -937,7 +937,7 @@ insert uniq
       │         │    │         └── first-agg [as=column3:7]
       │         │    │              └── column3:7
       │         │    └── projections
-      │         │         └── (column3:7 = 'foo') OR NULL::BOOL [as=upsert_partial_index_distinct1:16]
+      │         │         └── (column3:7 = 'foo') OR NULL::BOOL [as=arbiter_secondary_distinct:16]
       │         └── aggregations
       │              ├── first-agg [as=column1:5]
       │              │    └── column1:5
@@ -967,17 +967,17 @@ insert uniq
       ├── project
       │    ├── columns: column1:5!null column2:6!null column3:7!null
       │    └── upsert-distinct-on
-      │         ├── columns: column1:5!null column2:6!null column3:7!null upsert_partial_index_distinct2:17
-      │         ├── grouping columns: column2:6!null upsert_partial_index_distinct2:17
+      │         ├── columns: column1:5!null column2:6!null column3:7!null arbiter_u2_distinct:17
+      │         ├── grouping columns: column2:6!null arbiter_u2_distinct:17
       │         ├── project
-      │         │    ├── columns: upsert_partial_index_distinct2:17 column1:5!null column2:6!null column3:7!null
+      │         │    ├── columns: arbiter_u2_distinct:17 column1:5!null column2:6!null column3:7!null
       │         │    ├── project
       │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
       │         │    │    └── upsert-distinct-on
-      │         │    │         ├── columns: column1:5!null column2:6!null column3:7!null upsert_partial_index_distinct1:16
-      │         │    │         ├── grouping columns: column2:6!null upsert_partial_index_distinct1:16
+      │         │    │         ├── columns: column1:5!null column2:6!null column3:7!null arbiter_secondary_distinct:16
+      │         │    │         ├── grouping columns: column2:6!null arbiter_secondary_distinct:16
       │         │    │         ├── project
-      │         │    │         │    ├── columns: upsert_partial_index_distinct1:16 column1:5!null column2:6!null column3:7!null
+      │         │    │         │    ├── columns: arbiter_secondary_distinct:16 column1:5!null column2:6!null column3:7!null
       │         │    │         │    ├── anti-join (hash)
       │         │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
       │         │    │         │    │    ├── anti-join (hash)
@@ -1014,14 +1014,14 @@ insert uniq
       │         │    │         │    │         ├── column2:6 = b:13
       │         │    │         │    │         └── column3:7 = 'bar'
       │         │    │         │    └── projections
-      │         │    │         │         └── (column3:7 = 'foo') OR NULL::BOOL [as=upsert_partial_index_distinct1:16]
+      │         │    │         │         └── (column3:7 = 'foo') OR NULL::BOOL [as=arbiter_secondary_distinct:16]
       │         │    │         └── aggregations
       │         │    │              ├── first-agg [as=column1:5]
       │         │    │              │    └── column1:5
       │         │    │              └── first-agg [as=column3:7]
       │         │    │                   └── column3:7
       │         │    └── projections
-      │         │         └── (column3:7 = 'bar') OR NULL::BOOL [as=upsert_partial_index_distinct2:17]
+      │         │         └── (column3:7 = 'bar') OR NULL::BOOL [as=arbiter_u2_distinct:17]
       │         └── aggregations
       │              ├── first-agg [as=column1:5]
       │              │    └── column1:5
@@ -1169,15 +1169,15 @@ upsert uniq
       │    │    │    ├── project
       │    │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
       │    │    │    │    └── ensure-upsert-distinct-on
-      │    │    │    │         ├── columns: column1:5!null column2:6!null column3:7!null upsert_partial_index_distinct1:8
-      │    │    │    │         ├── grouping columns: column2:6!null upsert_partial_index_distinct1:8
+      │    │    │    │         ├── columns: column1:5!null column2:6!null column3:7!null arbiter_secondary_distinct:8
+      │    │    │    │         ├── grouping columns: column2:6!null arbiter_secondary_distinct:8
       │    │    │    │         ├── project
-      │    │    │    │         │    ├── columns: upsert_partial_index_distinct1:8 column1:5!null column2:6!null column3:7!null
+      │    │    │    │         │    ├── columns: arbiter_secondary_distinct:8 column1:5!null column2:6!null column3:7!null
       │    │    │    │         │    ├── values
       │    │    │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
       │    │    │    │         │    │    └── (1, 1, 'bar')
       │    │    │    │         │    └── projections
-      │    │    │    │         │         └── (column3:7 = 'foo') OR NULL::BOOL [as=upsert_partial_index_distinct1:8]
+      │    │    │    │         │         └── (column3:7 = 'foo') OR NULL::BOOL [as=arbiter_secondary_distinct:8]
       │    │    │    │         └── aggregations
       │    │    │    │              ├── first-agg [as=column1:5]
       │    │    │    │              │    └── column1:5
@@ -1241,10 +1241,10 @@ upsert ambig
       │    │    │    ├── project
       │    │    │    │    ├── columns: column1:5!null column2:6!null column7:7
       │    │    │    │    └── ensure-upsert-distinct-on
-      │    │    │    │         ├── columns: column1:5!null column2:6!null column7:7 upsert_partial_index_distinct1:8
-      │    │    │    │         ├── grouping columns: column1:5!null upsert_partial_index_distinct1:8
+      │    │    │    │         ├── columns: column1:5!null column2:6!null column7:7 arbiter_secondary_distinct:8
+      │    │    │    │         ├── grouping columns: column1:5!null arbiter_secondary_distinct:8
       │    │    │    │         ├── project
-      │    │    │    │         │    ├── columns: upsert_partial_index_distinct1:8 column1:5!null column2:6!null column7:7
+      │    │    │    │         │    ├── columns: arbiter_secondary_distinct:8 column1:5!null column2:6!null column7:7
       │    │    │    │         │    ├── project
       │    │    │    │         │    │    ├── columns: column7:7 column1:5!null column2:6!null
       │    │    │    │         │    │    ├── values
@@ -1253,7 +1253,7 @@ upsert ambig
       │    │    │    │         │    │    └── projections
       │    │    │    │         │    │         └── unique_rowid() [as=column7:7]
       │    │    │    │         │    └── projections
-      │    │    │    │         │         └── (column1:5 > 0) OR NULL::BOOL [as=upsert_partial_index_distinct1:8]
+      │    │    │    │         │         └── (column1:5 > 0) OR NULL::BOOL [as=arbiter_secondary_distinct:8]
       │    │    │    │         └── aggregations
       │    │    │    │              ├── first-agg [as=column2:6]
       │    │    │    │              │    └── column2:6
@@ -1308,10 +1308,10 @@ insert comp
       ├── project
       │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
       │    └── upsert-distinct-on
-      │         ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11 upsert_partial_index_distinct3:24
-      │         ├── grouping columns: column2:8!null upsert_partial_index_distinct3:24
+      │         ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11 arbiter_u1_distinct:24
+      │         ├── grouping columns: column2:8!null arbiter_u1_distinct:24
       │         ├── project
-      │         │    ├── columns: upsert_partial_index_distinct3:24 column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      │         │    ├── columns: arbiter_u1_distinct:24 column1:7!null column2:8!null column3:9!null column10:10 column11:11
       │         │    ├── upsert-distinct-on
       │         │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
       │         │    │    ├── grouping columns: column1:7!null
@@ -1382,7 +1382,7 @@ insert comp
       │         │    │         └── first-agg [as=column11:11]
       │         │    │              └── column11:11
       │         │    └── projections
-      │         │         └── (column10:10 = 'foo') OR NULL::BOOL [as=upsert_partial_index_distinct3:24]
+      │         │         └── (column10:10 = 'foo') OR NULL::BOOL [as=arbiter_u1_distinct:24]
       │         └── aggregations
       │              ├── first-agg [as=column1:7]
       │              │    └── column1:7
@@ -1420,17 +1420,17 @@ insert comp
       ├── project
       │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
       │    └── upsert-distinct-on
-      │         ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11 upsert_partial_index_distinct4:25
-      │         ├── grouping columns: column2:8!null upsert_partial_index_distinct4:25
+      │         ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11 arbiter_u2_distinct:25
+      │         ├── grouping columns: column2:8!null arbiter_u2_distinct:25
       │         ├── project
-      │         │    ├── columns: upsert_partial_index_distinct4:25 column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      │         │    ├── columns: arbiter_u2_distinct:25 column1:7!null column2:8!null column3:9!null column10:10 column11:11
       │         │    ├── project
       │         │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
       │         │    │    └── upsert-distinct-on
-      │         │    │         ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11 upsert_partial_index_distinct3:24
-      │         │    │         ├── grouping columns: column2:8!null upsert_partial_index_distinct3:24
+      │         │    │         ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11 arbiter_u1_distinct:24
+      │         │    │         ├── grouping columns: column2:8!null arbiter_u1_distinct:24
       │         │    │         ├── project
-      │         │    │         │    ├── columns: upsert_partial_index_distinct3:24 column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      │         │    │         │    ├── columns: arbiter_u1_distinct:24 column1:7!null column2:8!null column3:9!null column10:10 column11:11
       │         │    │         │    ├── anti-join (hash)
       │         │    │         │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
       │         │    │         │    │    ├── anti-join (hash)
@@ -1498,7 +1498,7 @@ insert comp
       │         │    │         │    │         ├── column2:8 = b:19
       │         │    │         │    │         └── column11:11 = 'bar'
       │         │    │         │    └── projections
-      │         │    │         │         └── (column10:10 = 'foo') OR NULL::BOOL [as=upsert_partial_index_distinct3:24]
+      │         │    │         │         └── (column10:10 = 'foo') OR NULL::BOOL [as=arbiter_u1_distinct:24]
       │         │    │         └── aggregations
       │         │    │              ├── first-agg [as=column1:7]
       │         │    │              │    └── column1:7
@@ -1509,7 +1509,7 @@ insert comp
       │         │    │              └── first-agg [as=column11:11]
       │         │    │                   └── column11:11
       │         │    └── projections
-      │         │         └── (column11:11 = 'bar') OR NULL::BOOL [as=upsert_partial_index_distinct4:25]
+      │         │         └── (column11:11 = 'bar') OR NULL::BOOL [as=arbiter_u2_distinct:25]
       │         └── aggregations
       │              ├── first-agg [as=column1:7]
       │              │    └── column1:7
@@ -1644,10 +1644,10 @@ upsert comp
       │    │    │    │    ├── project
       │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
       │    │    │    │    │    └── ensure-upsert-distinct-on
-      │    │    │    │    │         ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11 upsert_partial_index_distinct3:12
-      │    │    │    │    │         ├── grouping columns: column2:8!null upsert_partial_index_distinct3:12
+      │    │    │    │    │         ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11 arbiter_u1_distinct:12
+      │    │    │    │    │         ├── grouping columns: column2:8!null arbiter_u1_distinct:12
       │    │    │    │    │         ├── project
-      │    │    │    │    │         │    ├── columns: upsert_partial_index_distinct3:12 column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      │    │    │    │    │         │    ├── columns: arbiter_u1_distinct:12 column1:7!null column2:8!null column3:9!null column10:10 column11:11
       │    │    │    │    │         │    ├── project
       │    │    │    │    │         │    │    ├── columns: column10:10 column11:11 column1:7!null column2:8!null column3:9!null
       │    │    │    │    │         │    │    ├── values
@@ -1657,7 +1657,7 @@ upsert comp
       │    │    │    │    │         │    │         ├── lower(column3:9) [as=column10:10]
       │    │    │    │    │         │    │         └── upper(column3:9) [as=column11:11]
       │    │    │    │    │         │    └── projections
-      │    │    │    │    │         │         └── (column10:10 = 'foo') OR NULL::BOOL [as=upsert_partial_index_distinct3:12]
+      │    │    │    │    │         │         └── (column10:10 = 'foo') OR NULL::BOOL [as=arbiter_u1_distinct:12]
       │    │    │    │    │         └── aggregations
       │    │    │    │    │              ├── first-agg [as=column1:7]
       │    │    │    │    │              │    └── column1:7

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
@@ -893,6 +893,150 @@ insert uniq_partial
       ├── (1, NULL::INT8, 1)
       └── (2, NULL::INT8, 2)
 
+# Use all the unique constraint as an arbiter for DO NOTHING with no conflict
+# columns.
+# TODO(rytaft/mgartner): we should be able to remove the unique checks in this
+# case (see #59119).
+build
+INSERT INTO uniq_partial VALUES (1, 2, 3), (2, 2, 3) ON CONFLICT DO NOTHING
+----
+insert uniq_partial
+ ├── columns: <none>
+ ├── arbiter indexes: primary
+ ├── arbiter constraints: unique_a
+ ├── insert-mapping:
+ │    ├── column1:5 => uniq_partial.k:1
+ │    ├── column2:6 => uniq_partial.a:2
+ │    └── column3:7 => uniq_partial.b:3
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: column1:5!null column2:6!null column3:7!null
+ │    └── upsert-distinct-on
+ │         ├── columns: column1:5!null column2:6!null column3:7!null upsert_partial_constraint_distinct0:16
+ │         ├── grouping columns: column2:6!null upsert_partial_constraint_distinct0:16
+ │         ├── project
+ │         │    ├── columns: upsert_partial_constraint_distinct0:16 column1:5!null column2:6!null column3:7!null
+ │         │    ├── upsert-distinct-on
+ │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+ │         │    │    ├── grouping columns: column1:5!null
+ │         │    │    ├── anti-join (hash)
+ │         │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+ │         │    │    │    ├── anti-join (hash)
+ │         │    │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+ │         │    │    │    │    ├── values
+ │         │    │    │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+ │         │    │    │    │    │    ├── (1, 2, 3)
+ │         │    │    │    │    │    └── (2, 2, 3)
+ │         │    │    │    │    ├── scan uniq_partial
+ │         │    │    │    │    │    └── columns: uniq_partial.k:8!null uniq_partial.a:9 uniq_partial.b:10
+ │         │    │    │    │    └── filters
+ │         │    │    │    │         └── column1:5 = uniq_partial.k:8
+ │         │    │    │    ├── select
+ │         │    │    │    │    ├── columns: uniq_partial.k:12!null uniq_partial.a:13 uniq_partial.b:14!null
+ │         │    │    │    │    ├── scan uniq_partial
+ │         │    │    │    │    │    └── columns: uniq_partial.k:12!null uniq_partial.a:13 uniq_partial.b:14
+ │         │    │    │    │    └── filters
+ │         │    │    │    │         └── uniq_partial.b:14 > 0
+ │         │    │    │    └── filters
+ │         │    │    │         ├── column2:6 = uniq_partial.a:13
+ │         │    │    │         └── column3:7 > 0
+ │         │    │    └── aggregations
+ │         │    │         ├── first-agg [as=column2:6]
+ │         │    │         │    └── column2:6
+ │         │    │         └── first-agg [as=column3:7]
+ │         │    │              └── column3:7
+ │         │    └── projections
+ │         │         └── (column3:7 > 0) OR NULL::BOOL [as=upsert_partial_constraint_distinct0:16]
+ │         └── aggregations
+ │              ├── first-agg [as=column1:5]
+ │              │    └── column1:5
+ │              └── first-agg [as=column3:7]
+ │                   └── column3:7
+ └── unique-checks
+      └── unique-checks-item: uniq_partial(a)
+           └── semi-join (hash)
+                ├── columns: k:21!null a:22!null b:23!null
+                ├── with-scan &1
+                │    ├── columns: k:21!null a:22!null b:23!null
+                │    └── mapping:
+                │         ├──  column1:5 => k:21
+                │         ├──  column2:6 => a:22
+                │         └──  column3:7 => b:23
+                ├── scan uniq_partial
+                │    └── columns: uniq_partial.k:17!null uniq_partial.a:18 uniq_partial.b:19
+                └── filters
+                     ├── a:22 = uniq_partial.a:18
+                     ├── b:23 > 0
+                     ├── uniq_partial.b:19 > 0
+                     └── k:21 != uniq_partial.k:17
+
+# Error when there is no arbiter predicate to match the partial unique
+# constraint predicate.
+build
+INSERT INTO uniq_partial VALUES (1, 2, 3) ON CONFLICT (a) DO NOTHING
+----
+error (42P10): there is no unique or exclusion constraint matching the ON CONFLICT specification
+
+# On conflict clause references unique without index constraint.
+# TODO(rytaft/mgartner): we should be able to remove the unique check for a in
+# this case (see #59119).
+build
+INSERT INTO uniq_partial VALUES (1, 2, 3) ON CONFLICT (a) WHERE b > 0 DO NOTHING
+----
+insert uniq_partial
+ ├── columns: <none>
+ ├── arbiter constraints: unique_a
+ ├── insert-mapping:
+ │    ├── column1:5 => uniq_partial.k:1
+ │    ├── column2:6 => uniq_partial.a:2
+ │    └── column3:7 => uniq_partial.b:3
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: column1:5!null column2:6!null column3:7!null
+ │    └── upsert-distinct-on
+ │         ├── columns: column1:5!null column2:6!null column3:7!null upsert_partial_constraint_distinct0:12
+ │         ├── grouping columns: column2:6!null upsert_partial_constraint_distinct0:12
+ │         ├── project
+ │         │    ├── columns: upsert_partial_constraint_distinct0:12 column1:5!null column2:6!null column3:7!null
+ │         │    ├── anti-join (hash)
+ │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+ │         │    │    ├── values
+ │         │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+ │         │    │    │    └── (1, 2, 3)
+ │         │    │    ├── select
+ │         │    │    │    ├── columns: uniq_partial.k:8!null uniq_partial.a:9 uniq_partial.b:10!null
+ │         │    │    │    ├── scan uniq_partial
+ │         │    │    │    │    └── columns: uniq_partial.k:8!null uniq_partial.a:9 uniq_partial.b:10
+ │         │    │    │    └── filters
+ │         │    │    │         └── uniq_partial.b:10 > 0
+ │         │    │    └── filters
+ │         │    │         ├── column2:6 = uniq_partial.a:9
+ │         │    │         └── column3:7 > 0
+ │         │    └── projections
+ │         │         └── (column3:7 > 0) OR NULL::BOOL [as=upsert_partial_constraint_distinct0:12]
+ │         └── aggregations
+ │              ├── first-agg [as=column1:5]
+ │              │    └── column1:5
+ │              └── first-agg [as=column3:7]
+ │                   └── column3:7
+ └── unique-checks
+      └── unique-checks-item: uniq_partial(a)
+           └── semi-join (hash)
+                ├── columns: k:17!null a:18!null b:19!null
+                ├── with-scan &1
+                │    ├── columns: k:17!null a:18!null b:19!null
+                │    └── mapping:
+                │         ├──  column1:5 => k:17
+                │         ├──  column2:6 => a:18
+                │         └──  column3:7 => b:19
+                ├── scan uniq_partial
+                │    └── columns: uniq_partial.k:13!null uniq_partial.a:14 uniq_partial.b:15
+                └── filters
+                     ├── a:18 = uniq_partial.a:14
+                     ├── b:19 > 0
+                     ├── uniq_partial.b:15 > 0
+                     └── k:17 != uniq_partial.k:13
+
 # Insert with non-constant input.
 build
 INSERT INTO uniq_partial SELECT k, v, w FROM other
@@ -1174,3 +1318,247 @@ insert uniq_partial_hidden_pk
                      ├── c:22 > 0
                      ├── uniq_partial_hidden_pk.c:17 > 0
                      └── rowid:23 != uniq_partial_hidden_pk.rowid:18
+
+exec-ddl
+CREATE TABLE uniq_partial_constraint_and_index (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT,
+  UNIQUE INDEX (a) WHERE true,
+  UNIQUE WITHOUT INDEX (a) WHERE b > 10
+)
+----
+
+# Use a pseudo-partial index as the only arbiter. Note that we use the "norm"
+# directive instead of "build" to ensure that partial index predicates are fully
+# normalized when choosing arbiter indexes.
+norm
+INSERT INTO uniq_partial_constraint_and_index VALUES (1, 1, 1)
+ON CONFLICT (a) WHERE b > 10 DO NOTHING
+----
+insert uniq_partial_constraint_and_index
+ ├── columns: <none>
+ ├── arbiter indexes: secondary
+ ├── insert-mapping:
+ │    ├── column1:5 => uniq_partial_constraint_and_index.k:1
+ │    ├── column2:6 => uniq_partial_constraint_and_index.a:2
+ │    └── column3:7 => uniq_partial_constraint_and_index.b:3
+ ├── partial index put columns: partial_index_put1:13
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: partial_index_put1:13!null column1:5!null column2:6!null column3:7!null
+ │    ├── anti-join (cross)
+ │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+ │    │    ├── values
+ │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+ │    │    │    └── (1, 1, 1)
+ │    │    ├── select
+ │    │    │    ├── columns: uniq_partial_constraint_and_index.a:9!null
+ │    │    │    ├── scan uniq_partial_constraint_and_index
+ │    │    │    │    ├── columns: uniq_partial_constraint_and_index.a:9
+ │    │    │    │    └── partial index predicates
+ │    │    │    │         └── secondary: filters (true)
+ │    │    │    └── filters
+ │    │    │         └── uniq_partial_constraint_and_index.a:9 = 1
+ │    │    └── filters (true)
+ │    └── projections
+ │         └── true [as=partial_index_put1:13]
+ └── unique-checks
+      └── unique-checks-item: uniq_partial_constraint_and_index(a)
+           └── semi-join (hash)
+                ├── columns: k:18!null a:19!null b:20!null
+                ├── select
+                │    ├── columns: k:18!null a:19!null b:20!null
+                │    ├── with-scan &1
+                │    │    ├── columns: k:18!null a:19!null b:20!null
+                │    │    └── mapping:
+                │    │         ├──  column1:5 => k:18
+                │    │         ├──  column2:6 => a:19
+                │    │         └──  column3:7 => b:20
+                │    └── filters
+                │         └── b:20 > 10
+                ├── select
+                │    ├── columns: uniq_partial_constraint_and_index.k:14!null uniq_partial_constraint_and_index.a:15 uniq_partial_constraint_and_index.b:16!null
+                │    ├── scan uniq_partial_constraint_and_index
+                │    │    ├── columns: uniq_partial_constraint_and_index.k:14!null uniq_partial_constraint_and_index.a:15 uniq_partial_constraint_and_index.b:16
+                │    │    └── partial index predicates
+                │    │         └── secondary: filters (true)
+                │    └── filters
+                │         └── uniq_partial_constraint_and_index.b:16 > 10
+                └── filters
+                     ├── a:19 = uniq_partial_constraint_and_index.a:15
+                     └── k:18 != uniq_partial_constraint_and_index.k:14
+
+exec-ddl
+CREATE TABLE uniq_constraint_and_partial_index (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT,
+  UNIQUE INDEX (a) WHERE b > 0,
+  UNIQUE WITHOUT INDEX (a) WHERE true
+)
+----
+
+# Use a pseudo-partial constraint as the only arbiter. Note that we use the
+# "norm" directive instead of "build" to ensure that partial index predicates
+# are fully normalized when choosing arbiter indexes.
+norm
+INSERT INTO uniq_constraint_and_partial_index VALUES (1, 1, 1)
+ON CONFLICT (a) WHERE b > 0 DO NOTHING
+----
+insert uniq_constraint_and_partial_index
+ ├── columns: <none>
+ ├── arbiter constraints: unique_a
+ ├── insert-mapping:
+ │    ├── column1:5 => uniq_constraint_and_partial_index.k:1
+ │    ├── column2:6 => uniq_constraint_and_partial_index.a:2
+ │    └── column3:7 => uniq_constraint_and_partial_index.b:3
+ ├── partial index put columns: partial_index_put1:13
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: partial_index_put1:13!null column1:5!null column2:6!null column3:7!null
+ │    ├── anti-join (cross)
+ │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+ │    │    ├── values
+ │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+ │    │    │    └── (1, 1, 1)
+ │    │    ├── select
+ │    │    │    ├── columns: uniq_constraint_and_partial_index.a:9!null
+ │    │    │    ├── scan uniq_constraint_and_partial_index
+ │    │    │    │    ├── columns: uniq_constraint_and_partial_index.a:9
+ │    │    │    │    └── partial index predicates
+ │    │    │    │         └── secondary: filters
+ │    │    │    │              └── uniq_constraint_and_partial_index.b:10 > 0
+ │    │    │    └── filters
+ │    │    │         └── uniq_constraint_and_partial_index.a:9 = 1
+ │    │    └── filters (true)
+ │    └── projections
+ │         └── column3:7 > 0 [as=partial_index_put1:13]
+ └── unique-checks
+      └── unique-checks-item: uniq_constraint_and_partial_index(a)
+           └── semi-join (hash)
+                ├── columns: k:18!null a:19!null b:20!null
+                ├── with-scan &1
+                │    ├── columns: k:18!null a:19!null b:20!null
+                │    └── mapping:
+                │         ├──  column1:5 => k:18
+                │         ├──  column2:6 => a:19
+                │         └──  column3:7 => b:20
+                ├── scan uniq_constraint_and_partial_index
+                │    ├── columns: uniq_constraint_and_partial_index.k:14!null uniq_constraint_and_partial_index.a:15
+                │    └── partial index predicates
+                │         └── secondary: filters
+                │              └── uniq_constraint_and_partial_index.b:16 > 0
+                └── filters
+                     ├── a:19 = uniq_constraint_and_partial_index.a:15
+                     └── k:18 != uniq_constraint_and_partial_index.k:14
+
+exec-ddl
+CREATE TABLE uniq_partial_constraint_and_partial_index (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT,
+  UNIQUE INDEX (a) WHERE b > 0,
+  UNIQUE WITHOUT INDEX (a) WHERE b > 10
+)
+----
+
+# Use both a partial index and partial constraint as arbiters when both
+# predicates are implied by the arbiter predicate.
+build
+INSERT INTO uniq_partial_constraint_and_partial_index VALUES (1, 1, 1)
+ON CONFLICT (a) WHERE b > 10 DO NOTHING
+----
+insert uniq_partial_constraint_and_partial_index
+ ├── columns: <none>
+ ├── arbiter indexes: secondary
+ ├── arbiter constraints: unique_a
+ ├── insert-mapping:
+ │    ├── column1:5 => uniq_partial_constraint_and_partial_index.k:1
+ │    ├── column2:6 => uniq_partial_constraint_and_partial_index.a:2
+ │    └── column3:7 => uniq_partial_constraint_and_partial_index.b:3
+ ├── partial index put columns: partial_index_put1:18
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: partial_index_put1:18!null column1:5!null column2:6!null column3:7!null
+ │    ├── project
+ │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+ │    │    └── upsert-distinct-on
+ │    │         ├── columns: column1:5!null column2:6!null column3:7!null upsert_partial_constraint_distinct0:17
+ │    │         ├── grouping columns: column2:6!null upsert_partial_constraint_distinct0:17
+ │    │         ├── project
+ │    │         │    ├── columns: upsert_partial_constraint_distinct0:17 column1:5!null column2:6!null column3:7!null
+ │    │         │    ├── project
+ │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+ │    │         │    │    └── upsert-distinct-on
+ │    │         │    │         ├── columns: column1:5!null column2:6!null column3:7!null upsert_partial_index_distinct1:16
+ │    │         │    │         ├── grouping columns: column2:6!null upsert_partial_index_distinct1:16
+ │    │         │    │         ├── project
+ │    │         │    │         │    ├── columns: upsert_partial_index_distinct1:16 column1:5!null column2:6!null column3:7!null
+ │    │         │    │         │    ├── anti-join (hash)
+ │    │         │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+ │    │         │    │         │    │    ├── anti-join (hash)
+ │    │         │    │         │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+ │    │         │    │         │    │    │    ├── values
+ │    │         │    │         │    │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+ │    │         │    │         │    │    │    │    └── (1, 1, 1)
+ │    │         │    │         │    │    │    ├── select
+ │    │         │    │         │    │    │    │    ├── columns: uniq_partial_constraint_and_partial_index.k:8!null uniq_partial_constraint_and_partial_index.a:9 uniq_partial_constraint_and_partial_index.b:10!null
+ │    │         │    │         │    │    │    │    ├── scan uniq_partial_constraint_and_partial_index
+ │    │         │    │         │    │    │    │    │    ├── columns: uniq_partial_constraint_and_partial_index.k:8!null uniq_partial_constraint_and_partial_index.a:9 uniq_partial_constraint_and_partial_index.b:10
+ │    │         │    │         │    │    │    │    │    └── partial index predicates
+ │    │         │    │         │    │    │    │    │         └── secondary: filters
+ │    │         │    │         │    │    │    │    │              └── uniq_partial_constraint_and_partial_index.b:10 > 0
+ │    │         │    │         │    │    │    │    └── filters
+ │    │         │    │         │    │    │    │         └── uniq_partial_constraint_and_partial_index.b:10 > 0
+ │    │         │    │         │    │    │    └── filters
+ │    │         │    │         │    │    │         ├── column2:6 = uniq_partial_constraint_and_partial_index.a:9
+ │    │         │    │         │    │    │         └── column3:7 > 0
+ │    │         │    │         │    │    ├── select
+ │    │         │    │         │    │    │    ├── columns: uniq_partial_constraint_and_partial_index.k:12!null uniq_partial_constraint_and_partial_index.a:13 uniq_partial_constraint_and_partial_index.b:14!null
+ │    │         │    │         │    │    │    ├── scan uniq_partial_constraint_and_partial_index
+ │    │         │    │         │    │    │    │    ├── columns: uniq_partial_constraint_and_partial_index.k:12!null uniq_partial_constraint_and_partial_index.a:13 uniq_partial_constraint_and_partial_index.b:14
+ │    │         │    │         │    │    │    │    └── partial index predicates
+ │    │         │    │         │    │    │    │         └── secondary: filters
+ │    │         │    │         │    │    │    │              └── uniq_partial_constraint_and_partial_index.b:14 > 0
+ │    │         │    │         │    │    │    └── filters
+ │    │         │    │         │    │    │         └── uniq_partial_constraint_and_partial_index.b:14 > 10
+ │    │         │    │         │    │    └── filters
+ │    │         │    │         │    │         ├── column2:6 = uniq_partial_constraint_and_partial_index.a:13
+ │    │         │    │         │    │         └── column3:7 > 10
+ │    │         │    │         │    └── projections
+ │    │         │    │         │         └── (column3:7 > 0) OR NULL::BOOL [as=upsert_partial_index_distinct1:16]
+ │    │         │    │         └── aggregations
+ │    │         │    │              ├── first-agg [as=column1:5]
+ │    │         │    │              │    └── column1:5
+ │    │         │    │              └── first-agg [as=column3:7]
+ │    │         │    │                   └── column3:7
+ │    │         │    └── projections
+ │    │         │         └── (column3:7 > 10) OR NULL::BOOL [as=upsert_partial_constraint_distinct0:17]
+ │    │         └── aggregations
+ │    │              ├── first-agg [as=column1:5]
+ │    │              │    └── column1:5
+ │    │              └── first-agg [as=column3:7]
+ │    │                   └── column3:7
+ │    └── projections
+ │         └── column3:7 > 0 [as=partial_index_put1:18]
+ └── unique-checks
+      └── unique-checks-item: uniq_partial_constraint_and_partial_index(a)
+           └── semi-join (hash)
+                ├── columns: k:23!null a:24!null b:25!null
+                ├── with-scan &1
+                │    ├── columns: k:23!null a:24!null b:25!null
+                │    └── mapping:
+                │         ├──  column1:5 => k:23
+                │         ├──  column2:6 => a:24
+                │         └──  column3:7 => b:25
+                ├── scan uniq_partial_constraint_and_partial_index
+                │    ├── columns: uniq_partial_constraint_and_partial_index.k:19!null uniq_partial_constraint_and_partial_index.a:20 uniq_partial_constraint_and_partial_index.b:21
+                │    └── partial index predicates
+                │         └── secondary: filters
+                │              └── uniq_partial_constraint_and_partial_index.b:21 > 0
+                └── filters
+                     ├── a:24 = uniq_partial_constraint_and_partial_index.a:20
+                     ├── b:25 > 10
+                     ├── uniq_partial_constraint_and_partial_index.b:21 > 10
+                     └── k:23 != uniq_partial_constraint_and_partial_index.k:19

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
@@ -368,7 +368,7 @@ insert uniq
 # TODO(rytaft): we should be able to remove the unique check for w in this case
 # (see #59119).
 build
-INSERT INTO UNIQ VALUES (1, 2, 3, 4, 5) ON CONFLICT (W) DO NOTHING
+INSERT INTO uniq VALUES (1, 2, 3, 4, 5) ON CONFLICT (w) DO NOTHING
 ----
 insert uniq
  ├── columns: <none>

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
@@ -912,10 +912,10 @@ insert uniq_partial
  ├── project
  │    ├── columns: column1:5!null column2:6!null column3:7!null
  │    └── upsert-distinct-on
- │         ├── columns: column1:5!null column2:6!null column3:7!null upsert_partial_constraint_distinct0:16
- │         ├── grouping columns: column2:6!null upsert_partial_constraint_distinct0:16
+ │         ├── columns: column1:5!null column2:6!null column3:7!null arbiter_unique_a_distinct:16
+ │         ├── grouping columns: column2:6!null arbiter_unique_a_distinct:16
  │         ├── project
- │         │    ├── columns: upsert_partial_constraint_distinct0:16 column1:5!null column2:6!null column3:7!null
+ │         │    ├── columns: arbiter_unique_a_distinct:16 column1:5!null column2:6!null column3:7!null
  │         │    ├── upsert-distinct-on
  │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
  │         │    │    ├── grouping columns: column1:5!null
@@ -946,7 +946,7 @@ insert uniq_partial
  │         │    │         └── first-agg [as=column3:7]
  │         │    │              └── column3:7
  │         │    └── projections
- │         │         └── (column3:7 > 0) OR NULL::BOOL [as=upsert_partial_constraint_distinct0:16]
+ │         │         └── (column3:7 > 0) OR NULL::BOOL [as=arbiter_unique_a_distinct:16]
  │         └── aggregations
  │              ├── first-agg [as=column1:5]
  │              │    └── column1:5
@@ -994,10 +994,10 @@ insert uniq_partial
  ├── project
  │    ├── columns: column1:5!null column2:6!null column3:7!null
  │    └── upsert-distinct-on
- │         ├── columns: column1:5!null column2:6!null column3:7!null upsert_partial_constraint_distinct0:12
- │         ├── grouping columns: column2:6!null upsert_partial_constraint_distinct0:12
+ │         ├── columns: column1:5!null column2:6!null column3:7!null arbiter_unique_a_distinct:12
+ │         ├── grouping columns: column2:6!null arbiter_unique_a_distinct:12
  │         ├── project
- │         │    ├── columns: upsert_partial_constraint_distinct0:12 column1:5!null column2:6!null column3:7!null
+ │         │    ├── columns: arbiter_unique_a_distinct:12 column1:5!null column2:6!null column3:7!null
  │         │    ├── anti-join (hash)
  │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
  │         │    │    ├── values
@@ -1013,7 +1013,7 @@ insert uniq_partial
  │         │    │         ├── column2:6 = uniq_partial.a:9
  │         │    │         └── column3:7 > 0
  │         │    └── projections
- │         │         └── (column3:7 > 0) OR NULL::BOOL [as=upsert_partial_constraint_distinct0:12]
+ │         │         └── (column3:7 > 0) OR NULL::BOOL [as=arbiter_unique_a_distinct:12]
  │         └── aggregations
  │              ├── first-agg [as=column1:5]
  │              │    └── column1:5
@@ -1484,17 +1484,17 @@ insert uniq_partial_constraint_and_partial_index
  │    ├── project
  │    │    ├── columns: column1:5!null column2:6!null column3:7!null
  │    │    └── upsert-distinct-on
- │    │         ├── columns: column1:5!null column2:6!null column3:7!null upsert_partial_constraint_distinct0:17
- │    │         ├── grouping columns: column2:6!null upsert_partial_constraint_distinct0:17
+ │    │         ├── columns: column1:5!null column2:6!null column3:7!null arbiter_unique_a_distinct:17
+ │    │         ├── grouping columns: column2:6!null arbiter_unique_a_distinct:17
  │    │         ├── project
- │    │         │    ├── columns: upsert_partial_constraint_distinct0:17 column1:5!null column2:6!null column3:7!null
+ │    │         │    ├── columns: arbiter_unique_a_distinct:17 column1:5!null column2:6!null column3:7!null
  │    │         │    ├── project
  │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
  │    │         │    │    └── upsert-distinct-on
- │    │         │    │         ├── columns: column1:5!null column2:6!null column3:7!null upsert_partial_index_distinct1:16
- │    │         │    │         ├── grouping columns: column2:6!null upsert_partial_index_distinct1:16
+ │    │         │    │         ├── columns: column1:5!null column2:6!null column3:7!null arbiter_secondary_distinct:16
+ │    │         │    │         ├── grouping columns: column2:6!null arbiter_secondary_distinct:16
  │    │         │    │         ├── project
- │    │         │    │         │    ├── columns: upsert_partial_index_distinct1:16 column1:5!null column2:6!null column3:7!null
+ │    │         │    │         │    ├── columns: arbiter_secondary_distinct:16 column1:5!null column2:6!null column3:7!null
  │    │         │    │         │    ├── anti-join (hash)
  │    │         │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
  │    │         │    │         │    │    ├── anti-join (hash)
@@ -1527,14 +1527,14 @@ insert uniq_partial_constraint_and_partial_index
  │    │         │    │         │    │         ├── column2:6 = uniq_partial_constraint_and_partial_index.a:13
  │    │         │    │         │    │         └── column3:7 > 10
  │    │         │    │         │    └── projections
- │    │         │    │         │         └── (column3:7 > 0) OR NULL::BOOL [as=upsert_partial_index_distinct1:16]
+ │    │         │    │         │         └── (column3:7 > 0) OR NULL::BOOL [as=arbiter_secondary_distinct:16]
  │    │         │    │         └── aggregations
  │    │         │    │              ├── first-agg [as=column1:5]
  │    │         │    │              │    └── column1:5
  │    │         │    │              └── first-agg [as=column3:7]
  │    │         │    │                   └── column3:7
  │    │         │    └── projections
- │    │         │         └── (column3:7 > 10) OR NULL::BOOL [as=upsert_partial_constraint_distinct0:17]
+ │    │         │         └── (column3:7 > 10) OR NULL::BOOL [as=arbiter_unique_a_distinct:17]
  │    │         └── aggregations
  │    │              ├── first-agg [as=column1:5]
  │    │              │    └── column1:5

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -577,8 +577,8 @@ insert xyz
       │    │    │    ├── scan xyz
       │    │    │    │    └── columns: x:16!null y:17 z:18
       │    │    │    └── filters
-      │    │    │         ├── column3:7 = z:18
-      │    │    │         └── column2:6 = y:17
+      │    │    │         ├── column2:6 = y:17
+      │    │    │         └── column3:7 = z:18
       │    │    └── aggregations
       │    │         ├── first-agg [as=column2:6]
       │    │         │    └── column2:6


### PR DESCRIPTION
#### opt: move INSERT DO NOTHING arbiter code to mutation_builder_arbiter.go

Arbiter-related code in `pkg/sql/opt/optbuilder/insert.go` has grown
unruly due to the added complexity of partial indexes and unique
constraints. This commit moves some arbiter-related functions to a new
file to accommodate the growth. It also breaks some anonymous closures
into independent functions, for clarity.

Release note: None

#### opt: pass column ordinals directly to arbiter building functions

This commit makes the arguments of `buildAntiJoinForDoNothingArbiter` and
`buildDistinctOnForDoNothingArbiter` more intuitive. Columns ordinals
are now passed directly to these functions, rather than a column count
and ordinal-returning callback.

Release note: None

#### opt: create arbiterPredicateHelper for picking partial index arbiters

This commit adds a new helper struct that can determine if a partial
index can be used as an arbiter based on the arbiter predicate of an
`INSERT ON CONFLICT` statement. This will also be a useful utility to
determine if partial unique constraints can be used as arbiters.

Release note: None

#### opt: support INSERT ON CONFLICT DO NOTHING with partial unique constraints

To support INSERT ON CONFLICT DO NOTHING statements on tables with
partial UNIQUE WITHOUT INDEX constraints, partial constraints are now
selected as arbiters. These arbiters are used to filter out insert rows
that would conflict with existing rows in the table.

Informs #59195

There is no release note because these constraints are gated behind the
experimental_enable_unique_without_index_constraints session variable.

Release note: None
