### PR TITLE
logictestccl: temporarily disable flaky test

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
+++ b/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
@@ -1749,66 +1749,27 @@ DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE 
                               voter_constraints = '[+region=ca-central-1]',
                               lease_preferences = '[[+region=ca-central-1]]'
 
-statement ok
-CREATE TABLE regional_by_row_to_regional_by_row_as (
-  pk INT PRIMARY KEY,
-  i INT,
-  cr crdb_internal_region NOT NULL DEFAULT 'ap-southeast-2',
-  INDEX(i),
-  FAMILY (pk, i)
-) LOCALITY REGIONAL BY ROW;
-INSERT INTO regional_by_row_to_regional_by_row_as (pk, i) VALUES (1, 1);
-ALTER TABLE regional_by_row_to_regional_by_row_as SET LOCALITY REGIONAL BY ROW AS "cr"
+# TODO(#60606): this is flaky because REGIONAL BY ROW CREATE TABLE statements
+# do not round trip.
 
-query TT
-SHOW CREATE TABLE regional_by_row_to_regional_by_row_as
-----
-regional_by_row_to_regional_by_row_as  CREATE TABLE public.regional_by_row_to_regional_by_row_as (
-                                       pk INT8 NOT NULL,
-                                       i INT8 NULL,
-                                       cr public.crdb_internal_region NOT NULL DEFAULT 'ap-southeast-2':::public.crdb_internal_region,
-                                       crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
-                                       CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                                       INDEX regional_by_row_to_regional_by_row_as_i_idx (i ASC),
-                                       FAMILY fam_0_pk_i_cr_crdb_region (pk, i, cr, crdb_region)
-) LOCALITY REGIONAL BY ROW AS cr;
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_row_to_regional_by_row_as@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_row_to_regional_by_row_as@regional_by_row_to_regional_by_row_as_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_row_to_regional_by_row_as@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_row_to_regional_by_row_as@regional_by_row_to_regional_by_row_as_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_row_to_regional_by_row_as@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_row_to_regional_by_row_as@regional_by_row_to_regional_by_row_as_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+#statement ok
+#CREATE TABLE regional_by_row_to_regional_by_row_as (
+#  pk INT PRIMARY KEY,
+#  i INT,
+#  cr crdb_internal_region NOT NULL DEFAULT 'ap-southeast-2',
+#  INDEX(i),
+#  FAMILY (pk, i)
+#) LOCALITY REGIONAL BY ROW;
+#INSERT INTO regional_by_row_to_regional_by_row_as (pk, i) VALUES (1, 1);
+#ALTER TABLE regional_by_row_to_regional_by_row_as SET LOCALITY REGIONAL BY ROW AS "cr"
 
-query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_to_regional_by_row_as
-----
-DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+#query TT
+#SHOW CREATE TABLE regional_by_row_to_regional_by_row_as
+#----
+
+#query TT
+#SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_to_regional_by_row_as
+#----
 
 # Altering from REGIONAL BY ROW AS
 


### PR DESCRIPTION
I think this test fails because the logic test code does
something funky where it uses the pretty print syntax which
does not round trip for REGIONAL BY ROW. As such, temporarily
disable until that's allowed.

Refs: #60606

Release note: None