### PR TITLE
geomfn: fix ST_Node panicking on MULTILINESTRING EMPTY

### DIFF
--- a/pkg/geo/geomfn/node_test.go
+++ b/pkg/geo/geomfn/node_test.go
@@ -96,6 +96,18 @@ func TestNode(t *testing.T) {
 			geo.Geometry{},
 			true,
 		},
+		{
+			"EMPTY LineString",
+			geo.MustParseGeometry("SRID=4326;LINESTRING EMPTY"),
+			geo.MustParseGeometry("SRID=4326;GEOMETRYCOLLECTION EMPTY"),
+			false,
+		},
+		{
+			"EMPTY MultiLineString",
+			geo.MustParseGeometry("SRID=4326;MULTILINESTRING EMPTY"),
+			geo.MustParseGeometry("SRID=4326;GEOMETRYCOLLECTION EMPTY"),
+			false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Release note (bug fix): Fixed a bug where ST_Node would panic if passed
in MULTILINESTRING EMPTY.