### PR TITLE
sql: audit all usages of QueryEx to use iterator pattern

### DIFF
--- a/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
@@ -704,6 +704,17 @@ func (ie *wrappedInternalExecutor) QueryRowExWithCols(
 	panic("not implemented")
 }
 
+func (ie *wrappedInternalExecutor) QueryBufferedEx(
+	ctx context.Context,
+	opName string,
+	txn *kv.Txn,
+	session sessiondata.InternalExecutorOverride,
+	stmt string,
+	qargs ...interface{},
+) ([]tree.Datums, error) {
+	panic("not implemented")
+}
+
 func (ie *wrappedInternalExecutor) QueryIterator(
 	ctx context.Context, opName string, txn *kv.Txn, stmt string, qargs ...interface{},
 ) (sqlutil.InternalRows, error) {

--- a/pkg/server/auto_upgrade.go
+++ b/pkg/server/auto_upgrade.go
@@ -140,7 +140,7 @@ func (s *Server) upgradeStatus(ctx context.Context) (bool, error) {
 	// Check if auto upgrade is enabled at current version. This is read from
 	// the KV store so that it's in effect on all nodes immediately following a
 	// SET CLUSTER SETTING.
-	datums, err := s.sqlServer.internalExecutor.QueryEx(
+	row, err := s.sqlServer.internalExecutor.QueryRowEx(
 		ctx, "read-downgrade", nil, /* txn */
 		sessiondata.InternalExecutorOverride{User: security.RootUserName()},
 		"SELECT value FROM system.settings WHERE name = 'cluster.preserve_downgrade_option';",
@@ -149,8 +149,7 @@ func (s *Server) upgradeStatus(ctx context.Context) (bool, error) {
 		return false, err
 	}
 
-	if len(datums) != 0 {
-		row := datums[0]
+	if row != nil {
 		downgradeVersion := string(tree.MustBeDString(row[0]))
 
 		if clusterVersion == downgradeVersion {
@@ -165,7 +164,7 @@ func (s *Server) upgradeStatus(ctx context.Context) (bool, error) {
 // (which returns the version from the KV store as opposed to the possibly
 // lagging settings subsystem).
 func (s *Server) clusterVersion(ctx context.Context) (string, error) {
-	datums, err := s.sqlServer.internalExecutor.QueryEx(
+	row, err := s.sqlServer.internalExecutor.QueryRowEx(
 		ctx, "show-version", nil, /* txn */
 		sessiondata.InternalExecutorOverride{User: security.RootUserName()},
 		"SHOW CLUSTER SETTING version;",
@@ -173,10 +172,9 @@ func (s *Server) clusterVersion(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if len(datums) == 0 {
+	if row == nil {
 		return "", errors.New("cluster version is not set")
 	}
-	row := datums[0]
 	clusterVersion := string(tree.MustBeDString(row[0]))
 
 	return clusterVersion, nil

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -431,7 +431,7 @@ func (p *planner) HasRoleOption(ctx context.Context, roleOption roleoption.Optio
 		return true, nil
 	}
 
-	hasRolePrivilege, err := p.ExecCfg().InternalExecutor.QueryEx(
+	hasRolePrivilege, err := p.ExecCfg().InternalExecutor.QueryRowEx(
 		ctx, "has-role-option", p.Txn(),
 		sessiondata.InternalExecutorOverride{User: security.RootUserName()},
 		fmt.Sprintf(

--- a/pkg/sql/execstats/traceanalyzer_test.go
+++ b/pkg/sql/execstats/traceanalyzer_test.go
@@ -119,7 +119,7 @@ func TestTraceAnalyzer(t *testing.T) {
 				},
 			},
 		)
-		_, err := ie.QueryEx(
+		_, err := ie.ExecEx(
 			ctx,
 			t.Name(),
 			nil, /* txn */

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -372,15 +372,17 @@ func (r *rowsIterator) Types() colinfo.ResultColumns {
 func (ie *InternalExecutor) Query(
 	ctx context.Context, opName string, txn *kv.Txn, stmt string, qargs ...interface{},
 ) ([]tree.Datums, error) {
-	return ie.QueryEx(ctx, opName, txn, ie.maybeRootSessionDataOverride(opName), stmt, qargs...)
+	return ie.QueryBufferedEx(ctx, opName, txn, ie.maybeRootSessionDataOverride(opName), stmt, qargs...)
 }
 
-// QueryEx is like Query, but allows the caller to override some session data
-// fields (e.g. the user).
+// QueryBufferedEx executes the supplied SQL statement and returns the resulting
+// rows (meaning all of them are buffered at once).
+//
+// If txn is not nil, the statement will be executed in the respective txn.
 //
 // The fields set in session that are set override the respective fields if they
 // have previously been set through SetSessionData().
-func (ie *InternalExecutor) QueryEx(
+func (ie *InternalExecutor) QueryBufferedEx(
 	ctx context.Context,
 	opName string,
 	txn *kv.Txn,

--- a/pkg/sql/internal_test.go
+++ b/pkg/sql/internal_test.go
@@ -546,7 +546,7 @@ func TestInternalExecutorInLeafTxnDoesNotPanic(t *testing.T) {
 	leafTxn := kv.NewLeafTxn(ctx, kvDB, roachpb.NodeID(1), &ltis)
 
 	ie := s.InternalExecutor().(*sql.InternalExecutor)
-	_, err := ie.QueryEx(
+	_, err := ie.ExecEx(
 		ctx, "leaf-query", leafTxn, sessiondata.InternalExecutorOverride{User: security.RootUserName()}, "SELECT 1",
 	)
 	require.NoError(t, err)

--- a/pkg/sql/sqlutil/internal_executor.go
+++ b/pkg/sql/sqlutil/internal_executor.go
@@ -84,6 +84,22 @@ type InternalExecutor interface {
 		qargs ...interface{},
 	) (tree.Datums, colinfo.ResultColumns, error)
 
+	// QueryBufferedEx executes the supplied SQL statement and returns the
+	// resulting rows (meaning all of them are buffered at once).
+	//
+	// If txn is not nil, the statement will be executed in the respective txn.
+	//
+	// The fields set in session that are set override the respective fields if
+	// they have previously been set through SetSessionData().
+	QueryBufferedEx(
+		ctx context.Context,
+		opName string,
+		txn *kv.Txn,
+		session sessiondata.InternalExecutorOverride,
+		stmt string,
+		qargs ...interface{},
+	) ([]tree.Datums, error)
+
 	// QueryIterator executes the query, returning an iterator that can be used
 	// to get the results. If the call is successful, the returned iterator
 	// *must* be closed.

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -111,7 +111,7 @@ func retrieveUserAndPassword(
 	}
 
 	// Perform the lookup with a timeout.
-	err = runFn(func(ctx context.Context) error {
+	err = runFn(func(ctx context.Context) (retErr error) {
 		// Use fully qualified table name to avoid looking up "".system.users.
 		const getHashedPassword = `SELECT "hashedPassword" FROM system.public.users ` +
 			`WHERE username=$1`
@@ -137,7 +137,7 @@ func retrieveUserAndPassword(
 		getLoginDependencies := `SELECT option, value FROM system.public.role_options ` +
 			`WHERE username=$1 AND option IN ('NOLOGIN', 'VALID UNTIL')`
 
-		loginDependencies, err := ie.QueryEx(
+		it, err := ie.QueryIteratorEx(
 			ctx, "get-login-dependencies", nil, /* txn */
 			sessiondata.InternalExecutorOverride{User: security.RootUserName()},
 			getLoginDependencies,
@@ -146,11 +146,16 @@ func retrieveUserAndPassword(
 		if err != nil {
 			return errors.Wrapf(err, "error looking up user %s", normalizedUsername)
 		}
+		// We have to make sure to close the iterator since we might return from
+		// the for loop early (before Next() returns false).
+		defer func() { retErr = errors.CombineErrors(retErr, it.Close()) }()
 
 		// To support users created before 20.1, allow all USERS/ROLES to login
 		// if NOLOGIN is not found.
 		canLogin = true
-		for _, row := range loginDependencies {
+		var ok bool
+		for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
+			row := it.Cur()
 			option := string(tree.MustBeDString(row[0]))
 
 			if option == "NOLOGIN" {
@@ -173,7 +178,7 @@ func retrieveUserAndPassword(
 			}
 		}
 
-		return nil
+		return err
 	})
 
 	if err != nil {
@@ -194,7 +199,7 @@ var userLoginTimeout = settings.RegisterDurationSetting(
 // GetAllRoles returns a "set" (map) of Roles -> true.
 func (p *planner) GetAllRoles(ctx context.Context) (map[security.SQLUsername]bool, error) {
 	query := `SELECT username FROM system.users`
-	rows, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryEx(
+	it, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryIteratorEx(
 		ctx, "read-users", p.txn,
 		sessiondata.InternalExecutorOverride{User: security.RootUserName()},
 		query)
@@ -203,10 +208,14 @@ func (p *planner) GetAllRoles(ctx context.Context) (map[security.SQLUsername]boo
 	}
 
 	users := make(map[security.SQLUsername]bool)
-	for _, row := range rows {
-		username := tree.MustBeDString(row[0])
+	var ok bool
+	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
+		username := tree.MustBeDString(it.Cur()[0])
 		// The usernames in system.users are already normalized.
 		users[security.MakeSQLUsernameFromPreNormalizedString(string(username))] = true
+	}
+	if err != nil {
+		return nil, err
 	}
 	return users, nil
 }

--- a/pkg/storage/cloudimpl/filetable/BUILD.bazel
+++ b/pkg/storage/cloudimpl/filetable/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/sql/parser",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
+        "//pkg/sql/sqlutil",
         "//pkg/storage/cloud",
         "//pkg/util/log",
         "@com_github_cockroachdb_errors//:errors",


### PR DESCRIPTION
This commit audits the usage of `QueryEx` method of the internal
executor in the following manner:
- if the caller only needed to execute the statement, `ExecEx` is now
used
- if the query can return at most one row, then `QueryRowEx` is now used
- if the caller can be refactored to use the iterator pattern, it is
done so.

As a result, almost all usages have been refactored (most notably the
virtual `crdb_internal.jobs` table now uses the iterator pattern, thus
aleviating OOM concerns - the ad-hoc memory accounting logic has been
removed).

`QueryEx` has been renamed to `QueryBufferedEx` to highlight that the
full buffering occurs, and it was added to `sqlutil.InternalExecutor`
interface. The method is now used only in two places.

Addresses: #48595.

Release justification: bug fix.

Release note (bug fix): `crdb_internal.jobs` virtual table is now
populated in a paginated fashion, thus, alleviating memory related
concerns when previously we could encounter OOM crash.