### PR TITLE
partitionccl: make CreatePartitioning idempotent for implicit columns

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -814,6 +814,34 @@ ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row
   voter_constraints = '{+region=us-east-1: 2}',
   lease_preferences = '[[+region=us-east-1]]'
 
+statement ok
+CREATE TABLE regional_by_row_table_pk_defined_separately (
+  pk int,
+  CONSTRAINT "primary" PRIMARY KEY (pk ASC)
+) LOCALITY REGIONAL BY ROW
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE regional_by_row_table_pk_defined_separately]
+----
+CREATE TABLE public.regional_by_row_table_pk_defined_separately (
+  pk INT8 NOT NULL,
+  crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+  FAMILY "primary" (pk, crdb_region)
+) LOCALITY REGIONAL BY ROW;
+ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table_pk_defined_separately@primary CONFIGURE ZONE USING
+  num_voters = 5,
+  voter_constraints = '{+region=ap-southeast-2: 2}',
+  lease_preferences = '[[+region=ap-southeast-2]]';
+ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table_pk_defined_separately@primary CONFIGURE ZONE USING
+  num_voters = 5,
+  voter_constraints = '{+region=ca-central-1: 2}',
+  lease_preferences = '[[+region=ca-central-1]]';
+ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table_pk_defined_separately@primary CONFIGURE ZONE USING
+  num_voters = 5,
+  voter_constraints = '{+region=us-east-1: 2}',
+  lease_preferences = '[[+region=us-east-1]]'
+
 # Tests for REGIONAL BY TABLE AS
 statement error  cannot use column crdb_region_col which has type INT8 in REGIONAL BY ROW AS\nDETAIL:\s+REGIONAL BY ROW AS must reference a column of type crdb_internal_region.
 CREATE TABLE regional_by_row_table_as (

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -447,10 +447,7 @@ func (p *planner) AlterPrimaryKey(
 		// PARTITION BY statements. We currently do not support this and ignore
 		// these old statements.
 		//
-		// Detect partitioning if we are newly adding a PARTITION BY ALL statement.
-		// If the table is already PARTITION ALL BY, we already have the correct implicit
-		// column descriptor in front of each index, and calling CreatePartitioning again
-		// will make these indexes explicit.
+		// Create partitioning if we are newly adding a PARTITION BY ALL statement.
 		if isNewPartitionAllBy {
 			if *newIndex, err = CreatePartitioning(
 				ctx,


### PR DESCRIPTION
Previously, calling CreatePartitioning twice on an implicitly
partitioned index would un-implicitly partition that index. This commit
changes CreatePartitioning to not un-implicitly partition the index in
such a case.

Release note: None