### PR TITLE
bazel: quash dependencies on `go_sdk` from genrules

### DIFF
--- a/build/STRINGER.bzl
+++ b/build/STRINGER.bzl
@@ -5,18 +5,11 @@ def stringer(src, typ, name):
       name = name,
       srcs = [src], # Accessed below using `$<`.
       outs = [typ.lower() + "_string.go"],
-      # golang.org/x/tools executes commands via
-      # golang.org/x/sys/execabs which requires all PATH lookups to
-      # result in absolute paths. To account for this, we resolve the
-      # relative path returned by location to an absolute path.
       cmd = """
-         GO_REL_PATH=`dirname $(location @go_sdk//:bin/go)`
-         GO_ABS_PATH=`cd $$GO_REL_PATH && pwd`
-         env PATH=$$GO_ABS_PATH HOME=$(GENDIR) \
-         $(location @org_golang_x_tools//cmd/stringer:stringer) -output=$@ -type={} $<
+         HOME=$$TMPDIR/gohome \
+           $(location @org_golang_x_tools//cmd/stringer:stringer) -output=$@ -type={} $<
       """.format(typ),
       tools = [
-         "@go_sdk//:bin/go",
          "@org_golang_x_tools//cmd/stringer",
        ],
    )

--- a/pkg/sql/opt/BUILD.bazel
+++ b/pkg/sql/opt/BUILD.bazel
@@ -104,20 +104,13 @@ genrule(
         ":gen-rulenames",
     ],
     outs = ["rule_name_string.go"],
-    # golang.org/x/tools executes commands via
-    # golang.org/x/sys/execabs which requires all PATH lookups to
-    # result in absolute paths. To account for this, we resolve the
-    # relative path returned by location to an absolute path.
     cmd = """
-      cp $(location rule_name.go) `dirname $(location :gen-rulenames)`/rule_name.go
-      GO_REL_PATH=`dirname $(location @go_sdk//:bin/go)`
-      GO_ABS_PATH=`cd $$GO_REL_PATH && pwd`
-      env PATH=$$GO_ABS_PATH HOME=$(GENDIR) \
+    cp $(location rule_name.go) `dirname $(location :gen-rulenames)`/rule_name.go
+    HOME=$$TMPDIR/gohome \
       $(location @org_golang_x_tools//cmd/stringer:stringer) -output=$@ \
       -type=RuleName `dirname $(location :gen-rulenames)`/rule_name.go $(location :gen-rulenames)
     """,
     tools = [
-        "@go_sdk//:bin/go",
         "@org_golang_x_tools//cmd/stringer",
     ],
 )

--- a/pkg/sql/schemachange/BUILD.bazel
+++ b/pkg/sql/schemachange/BUILD.bazel
@@ -51,18 +51,11 @@ genrule(
         "alter_column_type.go",
     ],
     outs = ["columnconversionkind_string.go"],
-    # golang.org/x/tools executes commands via
-    # golang.org/x/sys/execabs which requires all PATH lookups to
-    # result in absolute paths. To account for this, we resolve the
-    # relative path returned by location to an absolute path.
     cmd = """
-       GO_REL_PATH=`dirname $(location @go_sdk//:bin/go)`
-       GO_ABS_PATH=`cd $$GO_REL_PATH && pwd`
-       env PATH=$$GO_ABS_PATH HOME=$(GENDIR) \
-       $(location @org_golang_x_tools//cmd/stringer:stringer) -output=$@ -type=ColumnConversionKind -trimprefix ColumnConversion $<
+       HOME=$$TMPDIR/gohome \
+         $(location @org_golang_x_tools//cmd/stringer:stringer) -output=$@ -type=ColumnConversionKind -trimprefix ColumnConversion $<
     """,
     tools = [
-        "@go_sdk//:bin/go",
         "@org_golang_x_tools//cmd/stringer",
     ],
 )


### PR DESCRIPTION
These were never necessary -- we can just set the `HOME` directory
appropriately to trick `stringer` into putting stuff there.

Fixes #59855.

Release note: None