### PR TITLE
cli,storage/cloud: add CLI flag to disable outbound network storage access

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -560,6 +560,10 @@ type ExternalIODirConfig struct {
 	// This turns off implicit credentials, and requires the user to provide
 	// necessary access keys.
 	DisableImplicitCredentials bool
+
+	// DisableOutbound disables the use of any external-io that dials out such as
+	// to s3, gcs, or even `nodelocal` as it may need to dial another node.
+	DisableOutbound bool
 }
 
 // TempStorageConfigFromEnv creates a TempStorageConfig.

--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -101,13 +101,10 @@ func evalExport(
 	}
 
 	if makeExternalStorage {
-		// TODO(dt): this blanket ban means we must do all uploads from the caller
-		// which is nice and simple but imposes extra copies/overhead/cost. We might
-		// want to instead allow *some* forms of external storage for *some* tenants
-		// e.g. allow some tenants to dial out to s3 directly -- if we do though we
-		// would need to continue to restrict unsafe ones like userfile here.
 		if _, ok := roachpb.TenantFromContext(ctx); ok {
-			return result.Result{}, errors.Errorf("requests on behalf of tenants are not allowed to contact external storage")
+			if args.Storage.Provider == roachpb.ExternalStorageProvider_FileTable {
+				return result.Result{}, errors.Errorf("requests to userfile on behalf of tenants must be made by the tenant's SQL process")
+			}
 		}
 	}
 

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -678,6 +678,11 @@ Also see: ` + build.MakeIssueURL(53404) + `
 Disable use of implicit credentials when accessing external data.
 Instead, require the user to always specify access keys.`,
 	}
+	ExternalIODisabled = FlagInfo{
+		Name: "external-io-disabled",
+		Description: `
+Disable use of "external" IO, such as to S3, GCS, or the file system (nodelocal), or anything other than userfile.`,
+	}
 
 	// KeySize, CertificateLifetime, AllowKeyReuse, and OverwriteFiles are used for
 	// certificate generation functions.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -397,6 +397,7 @@ func init() {
 
 		// Enable/disable various external storage endpoints.
 		boolFlag(f, &serverCfg.ExternalIODirConfig.DisableHTTP, cliflags.ExternalIODisableHTTP)
+		boolFlag(f, &serverCfg.ExternalIODirConfig.DisableOutbound, cliflags.ExternalIODisabled)
 		boolFlag(f, &serverCfg.ExternalIODirConfig.DisableImplicitCredentials, cliflags.ExternalIODisableImplicitCredentials)
 
 		// Certificates directory. Use a server-specific flag and value to ignore environment
@@ -848,6 +849,11 @@ func init() {
 		stringSliceFlag(f, &serverCfg.SQLConfig.TenantKVAddrs, cliflags.KVAddrs)
 
 		durationFlag(f, &serverCfg.IdleExitAfter, cliflags.IdleExitAfter)
+
+		boolFlag(f, &serverCfg.ExternalIODirConfig.DisableHTTP, cliflags.ExternalIODisableHTTP)
+		boolFlag(f, &serverCfg.ExternalIODirConfig.DisableOutbound, cliflags.ExternalIODisabled)
+		boolFlag(f, &serverCfg.ExternalIODirConfig.DisableImplicitCredentials, cliflags.ExternalIODisableImplicitCredentials)
+
 	}
 }
 

--- a/pkg/storage/cloudimpl/aws_kms.go
+++ b/pkg/storage/cloudimpl/aws_kms.go
@@ -69,6 +69,9 @@ func resolveKMSURIParams(kmsURI url.URL) kmsURIParams {
 // MakeAWSKMS is the factory method which returns a configured, ready-to-use
 // AWS KMS object.
 func MakeAWSKMS(uri string, env cloud.KMSEnv) (cloud.KMS, error) {
+	if env.KMSConfig().DisableOutbound {
+		return nil, errors.New("external IO must be enabled to use AWS KMS")
+	}
 	kmsURI, err := url.ParseRequestURI(uri)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/cloudimpl/cloudimpltests/http_storage_test.go
+++ b/pkg/storage/cloudimpl/cloudimpltests/http_storage_test.go
@@ -308,6 +308,26 @@ func TestCanDisableHttp(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestCanDisableOutbound(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	conf := base.ExternalIODirConfig{
+		DisableOutbound: true,
+	}
+	for _, provider := range []roachpb.ExternalStorageProvider{
+		roachpb.ExternalStorageProvider_Http,
+		roachpb.ExternalStorageProvider_S3,
+		roachpb.ExternalStorageProvider_GoogleCloud,
+		roachpb.ExternalStorageProvider_LocalFile,
+	} {
+		s, err := cloudimpl.MakeExternalStorage(
+			context.Background(),
+			roachpb.ExternalStorage{Provider: provider},
+			conf, testSettings, blobs.TestEmptyBlobClientFactory, nil, nil)
+		require.Nil(t, s)
+		require.Error(t, err)
+	}
+}
+
 func TestExternalStorageCanUseHTTPProxy(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/storage/cloudimpl/external_storage.go
+++ b/pkg/storage/cloudimpl/external_storage.go
@@ -304,6 +304,9 @@ func MakeExternalStorage(
 	ie *sql.InternalExecutor,
 	kvDB *kv.DB,
 ) (cloud.ExternalStorage, error) {
+	if conf.DisableOutbound && dest.Provider != roachpb.ExternalStorageProvider_FileTable {
+		return nil, errors.New("external network access is disabled")
+	}
 	switch dest.Provider {
 	case roachpb.ExternalStorageProvider_LocalFile:
 		telemetry.Count("external-io.nodelocal")


### PR DESCRIPTION
Multi-tenant clusters will initially restrict outbound network access.
In addition to the firewall rules at deployment that will actually block the
network traffic itself, this CLI flag can be used to indeed prevent even trying
make such network requests and return a clearer error instead.

Release note: none.

Release justification: Low risk (opt-in flag), high reward (better errors
    for serverless users) changes to existing functionality.