### PR TITLE
sql: Block table-level backup and restore for multi-region databases

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -840,6 +840,10 @@ func backupPlanHook(
 			return err
 		}
 
+		if err := validateMultiRegionBackup(backupStmt, targetDescs, tables); err != nil {
+			return err
+		}
+
 		makeCloudStorage := p.ExecCfg().DistSQLSrv.ExternalStorageFromURI
 
 		switch encryptionParams.encryptMode {

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -546,17 +546,30 @@ func allocateDescriptorRewrites(
 				}
 
 				// Check privileges.
-				{
-					parentDB, err := catalogkv.MustGetDatabaseDescByID(ctx, txn, p.ExecCfg().Codec, parentID)
-					if err != nil {
-						return errors.Wrapf(err,
-							"failed to lookup parent DB %d", errors.Safe(parentID))
-					}
-
-					if err := p.CheckPrivilege(ctx, parentDB, privilege.CREATE); err != nil {
-						return err
-					}
+				parentDB, err := catalogkv.MustGetDatabaseDescByID(ctx, txn, p.ExecCfg().Codec, parentID)
+				if err != nil {
+					return errors.Wrapf(err,
+						"failed to lookup parent DB %d", errors.Safe(parentID))
 				}
+				if err := p.CheckPrivilege(ctx, parentDB, privilege.CREATE); err != nil {
+					return err
+				}
+
+				// We're restoring a table and not its parent database.  If the
+				// new database we're placing the table in is a multi-region database,
+				// block the restore. We do this because we currently have no way to
+				// modify this table and make it multi-region friendly. Long-term we'd
+				// want to modify the table so that it can exist in the multi-region
+				// database.
+				// https://github.com/cockroachdb/cockroach/issues/59804
+				if parentDB.GetRegionConfig() != nil {
+					return pgerror.Newf(pgcode.FeatureNotSupported,
+						"cannot restore individual table %d into multi-region database %d",
+						table.GetID(),
+						parentDB.GetID(),
+					)
+				}
+
 				// Create the table rewrite with the new parent ID. We've done all the
 				// up-front validation that we can.
 				descriptorRewrites[table.ID] = &jobspb.RestoreDetails_DescriptorRewrite{ParentID: parentID}

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_backup
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_backup
@@ -969,3 +969,16 @@ BACKUP TABLE regional_by_table_in_ca_central_1 TO 'nodelocal://1/rbr_table/';
 
 statement error cannot backup individual table
 BACKUP TABLE global_table TO 'nodelocal://1/rbr_table/';
+
+statement ok
+CREATE DATABASE non_mr_backup;
+USE non_mr_backup
+
+statement ok
+CREATE TABLE non_mr_table (i int)
+
+statement ok
+BACKUP TABLE non_mr_table TO 'nodelocal://1/non_mr_table/'
+
+statement error cannot restore individual table
+RESTORE TABLE non_mr_table FROM 'nodelocal://1/non_mr_table/' WITH into_db = 'mr-backup-1'

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_backup
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_backup
@@ -8,10 +8,10 @@ ca-central-1    {ca-az1,ca-az2,ca-az3}  {}  {}
 us-east-1       {us-az1,us-az2,us-az3}  {}  {}
 
 statement ok
-CREATE DATABASE mr_backup_1 primary region "ca-central-1" regions "ap-southeast-2", "us-east-1"
+CREATE DATABASE "mr-backup-1" primary region "ca-central-1" regions "ap-southeast-2", "us-east-1"
 
 statement ok
-use mr_backup_1;
+use "mr-backup-1";
 CREATE TABLE global_table (pk INT PRIMARY KEY, i int, FAMILY (pk, i)) LOCALITY GLOBAL
 
 statement ok
@@ -61,15 +61,15 @@ TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_table
 ----
-DATABASE mr_backup_1  ALTER DATABASE mr_backup_1 CONFIGURE ZONE USING
-                      range_min_bytes = 134217728,
-                      range_max_bytes = 536870912,
-                      gc.ttlseconds = 90000,
-                      num_replicas = 5,
-                      num_voters = 3,
-                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                      voter_constraints = '[+region=ca-central-1]',
-                      lease_preferences = '[[+region=ca-central-1]]'
+DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 90000,
+                        num_replicas = 5,
+                        num_voters = 3,
+                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                        voter_constraints = '[+region=ca-central-1]',
+                        lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW CREATE TABLE regional_by_row_table
@@ -87,51 +87,51 @@ regional_by_row_table  CREATE TABLE public.regional_by_row_table (
                        INVERTED INDEX regional_by_row_table_j_idx (j),
                        FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
 ) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX mr_backup_1.public.regional_by_row_table@primary CONFIGURE ZONE USING
+ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-1".public.regional_by_row_table@primary CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ap-southeast-2]',
   lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX mr_backup_1.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
+ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ap-southeast-2]',
   lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX mr_backup_1.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
+ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ap-southeast-2]',
   lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX mr_backup_1.public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
+ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ap-southeast-2]',
   lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX mr_backup_1.public.regional_by_row_table@primary CONFIGURE ZONE USING
+ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-1".public.regional_by_row_table@primary CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ca-central-1]',
   lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX mr_backup_1.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
+ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ca-central-1]',
   lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX mr_backup_1.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
+ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ca-central-1]',
   lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX mr_backup_1.public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
+ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ca-central-1]',
   lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX mr_backup_1.public.regional_by_row_table@primary CONFIGURE ZONE USING
+ALTER PARTITION "us-east-1" OF INDEX "mr-backup-1".public.regional_by_row_table@primary CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=us-east-1]',
   lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX mr_backup_1.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
+ALTER PARTITION "us-east-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=us-east-1]',
   lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX mr_backup_1.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
+ALTER PARTITION "us-east-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=us-east-1]',
   lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX mr_backup_1.public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
+ALTER PARTITION "us-east-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=us-east-1]',
   lease_preferences = '[[+region=us-east-1]]'
@@ -139,15 +139,15 @@ ALTER PARTITION "us-east-1" OF INDEX mr_backup_1.public.regional_by_row_table@re
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_primary_region
 ----
-DATABASE mr_backup_1  ALTER DATABASE mr_backup_1 CONFIGURE ZONE USING
-                      range_min_bytes = 134217728,
-                      range_max_bytes = 536870912,
-                      gc.ttlseconds = 90000,
-                      num_replicas = 5,
-                      num_voters = 3,
-                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                      voter_constraints = '[+region=ca-central-1]',
-                      lease_preferences = '[[+region=ca-central-1]]'
+DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 90000,
+                        num_replicas = 5,
+                        num_voters = 3,
+                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                        voter_constraints = '[+region=ca-central-1]',
+                        lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_ca_central_1
@@ -163,10 +163,10 @@ TABLE regional_by_table_in_ca_central_1  ALTER TABLE regional_by_table_in_ca_cen
                                          lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
-CREATE DATABASE mr_backup_2 primary region "ap-southeast-2" regions "ca-central-1", "us-east-1"
+CREATE DATABASE "mr-backup-2" primary region "ap-southeast-2" regions "ca-central-1", "us-east-1"
 
 statement ok
-use mr_backup_2;
+use "mr-backup-2";
 CREATE TABLE global_table (pk INT PRIMARY KEY, i int, FAMILY (pk, i)) LOCALITY GLOBAL
 
 statement ok
@@ -213,15 +213,15 @@ TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_table
 ----
-DATABASE mr_backup_2  ALTER DATABASE mr_backup_2 CONFIGURE ZONE USING
-                      range_min_bytes = 134217728,
-                      range_max_bytes = 536870912,
-                      gc.ttlseconds = 90000,
-                      num_replicas = 5,
-                      num_voters = 3,
-                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                      voter_constraints = '[+region=ap-southeast-2]',
-                      lease_preferences = '[[+region=ap-southeast-2]]'
+DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 90000,
+                        num_replicas = 5,
+                        num_voters = 3,
+                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                        voter_constraints = '[+region=ap-southeast-2]',
+                        lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TT
 SHOW CREATE TABLE regional_by_row_table
@@ -239,51 +239,51 @@ regional_by_row_table  CREATE TABLE public.regional_by_row_table (
                        INVERTED INDEX regional_by_row_table_j_idx (j),
                        FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
 ) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX mr_backup_2.public.regional_by_row_table@primary CONFIGURE ZONE USING
+ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-2".public.regional_by_row_table@primary CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ap-southeast-2]',
   lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX mr_backup_2.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
+ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ap-southeast-2]',
   lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX mr_backup_2.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
+ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ap-southeast-2]',
   lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX mr_backup_2.public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
+ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ap-southeast-2]',
   lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX mr_backup_2.public.regional_by_row_table@primary CONFIGURE ZONE USING
+ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-2".public.regional_by_row_table@primary CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ca-central-1]',
   lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX mr_backup_2.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
+ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ca-central-1]',
   lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX mr_backup_2.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
+ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ca-central-1]',
   lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX mr_backup_2.public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
+ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ca-central-1]',
   lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX mr_backup_2.public.regional_by_row_table@primary CONFIGURE ZONE USING
+ALTER PARTITION "us-east-1" OF INDEX "mr-backup-2".public.regional_by_row_table@primary CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=us-east-1]',
   lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX mr_backup_2.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
+ALTER PARTITION "us-east-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=us-east-1]',
   lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX mr_backup_2.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
+ALTER PARTITION "us-east-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=us-east-1]',
   lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX mr_backup_2.public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
+ALTER PARTITION "us-east-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=us-east-1]',
   lease_preferences = '[[+region=us-east-1]]'
@@ -291,15 +291,15 @@ ALTER PARTITION "us-east-1" OF INDEX mr_backup_2.public.regional_by_row_table@re
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_primary_region
 ----
-DATABASE mr_backup_2  ALTER DATABASE mr_backup_2 CONFIGURE ZONE USING
-                      range_min_bytes = 134217728,
-                      range_max_bytes = 536870912,
-                      gc.ttlseconds = 90000,
-                      num_replicas = 5,
-                      num_voters = 3,
-                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                      voter_constraints = '[+region=ap-southeast-2]',
-                      lease_preferences = '[[+region=ap-southeast-2]]'
+DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 90000,
+                        num_replicas = 5,
+                        num_voters = 3,
+                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                        voter_constraints = '[+region=ap-southeast-2]',
+                        lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_ca_central_1
@@ -315,54 +315,54 @@ TABLE regional_by_table_in_ca_central_1  ALTER TABLE regional_by_table_in_ca_cen
                                          lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
-SHOW ZONE CONFIGURATION FOR DATABASE mr_backup_1
+SHOW ZONE CONFIGURATION FOR DATABASE "mr-backup-1"
 ----
-DATABASE mr_backup_1  ALTER DATABASE mr_backup_1 CONFIGURE ZONE USING
-                    range_min_bytes = 134217728,
-                    range_max_bytes = 536870912,
-                    gc.ttlseconds = 90000,
-                    num_replicas = 5,
-                    num_voters = 3,
-                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                    voter_constraints = '[+region=ca-central-1]',
-                    lease_preferences = '[[+region=ca-central-1]]'
+DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 90000,
+                        num_replicas = 5,
+                        num_voters = 3,
+                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                        voter_constraints = '[+region=ca-central-1]',
+                        lease_preferences = '[[+region=ca-central-1]]'
 
 
 query TT
-SHOW ZONE CONFIGURATION FOR DATABASE mr_backup_2
+SHOW ZONE CONFIGURATION FOR DATABASE "mr-backup-2"
 ----
-DATABASE mr_backup_2  ALTER DATABASE mr_backup_2 CONFIGURE ZONE USING
-                      range_min_bytes = 134217728,
-                      range_max_bytes = 536870912,
-                      gc.ttlseconds = 90000,
-                      num_replicas = 5,
-                      num_voters = 3,
-                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                      voter_constraints = '[+region=ap-southeast-2]',
-                      lease_preferences = '[[+region=ap-southeast-2]]'
+DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 90000,
+                        num_replicas = 5,
+                        num_voters = 3,
+                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                        voter_constraints = '[+region=ap-southeast-2]',
+                        lease_preferences = '[[+region=ap-southeast-2]]'
 
 statement ok
-ALTER DATABASE mr_backup_1 CONFIGURE ZONE USING gc.ttlseconds = 1;
-ALTER DATABASE mr_backup_2 CONFIGURE ZONE USING gc.ttlseconds = 1
+ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING gc.ttlseconds = 1;
+ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING gc.ttlseconds = 1
 
 statement ok
-BACKUP DATABASE mr_backup_1 TO 'nodelocal://self/mr_backup_1/';
-BACKUP DATABASE mr_backup_2 TO 'nodelocal://self/mr_backup_2/';
-BACKUP DATABASE mr_backup_1, mr_backup_2 TO 'nodelocal://self/mr_backup_combined/'
+BACKUP DATABASE "mr-backup-1" TO 'nodelocal://1/mr-backup-1/';
+BACKUP DATABASE "mr-backup-2" TO 'nodelocal://1/mr-backup-2/';
+BACKUP DATABASE "mr-backup-1", "mr-backup-2" TO 'nodelocal://1/mr-backup-combined/'
 
 query T
 select database_name from [show databases]
 ----
 defaultdb
-mr_backup_1
-mr_backup_2
+mr-backup-1
+mr-backup-2
 postgres
 system
 test
 
 statement ok
-DROP DATABASE mr_backup_1;
-DROP DATABASE mr_backup_2
+DROP DATABASE "mr-backup-1";
+DROP DATABASE "mr-backup-2"
 
 query T
 select database_name from [show databases]
@@ -373,32 +373,32 @@ system
 test
 
 statement ok
-RESTORE DATABASE mr_backup_1 FROM 'nodelocal://self/mr_backup_1/'
+RESTORE DATABASE "mr-backup-1" FROM 'nodelocal://1/mr-backup-1/'
 
 query T
 select database_name from [show databases]
 ----
 defaultdb
-mr_backup_1
+mr-backup-1
 postgres
 system
 test
 
 query TT
-SHOW ZONE CONFIGURATION FOR DATABASE mr_backup_1
+SHOW ZONE CONFIGURATION FOR DATABASE "mr-backup-1"
 ----
-DATABASE mr_backup_1  ALTER DATABASE mr_backup_1 CONFIGURE ZONE USING
-                    range_min_bytes = 134217728,
-                    range_max_bytes = 536870912,
-                    gc.ttlseconds = 90000,
-                    num_replicas = 5,
-                    num_voters = 3,
-                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                    voter_constraints = '[+region=ca-central-1]',
-                    lease_preferences = '[[+region=ca-central-1]]'
+DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 90000,
+                        num_replicas = 5,
+                        num_voters = 3,
+                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                        voter_constraints = '[+region=ca-central-1]',
+                        lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
-use mr_backup_1
+use "mr-backup-1"
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE global_table
@@ -417,15 +417,15 @@ TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_table
 ----
-DATABASE mr_backup_1  ALTER DATABASE mr_backup_1 CONFIGURE ZONE USING
-                      range_min_bytes = 134217728,
-                      range_max_bytes = 536870912,
-                      gc.ttlseconds = 90000,
-                      num_replicas = 5,
-                      num_voters = 3,
-                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                      voter_constraints = '[+region=ca-central-1]',
-                      lease_preferences = '[[+region=ca-central-1]]'
+DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 90000,
+                        num_replicas = 5,
+                        num_voters = 3,
+                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                        voter_constraints = '[+region=ca-central-1]',
+                        lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW CREATE TABLE regional_by_row_table
@@ -443,51 +443,51 @@ regional_by_row_table  CREATE TABLE public.regional_by_row_table (
                        INVERTED INDEX regional_by_row_table_j_idx (j),
                        FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
 ) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX mr_backup_1.public.regional_by_row_table@primary CONFIGURE ZONE USING
+ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-1".public.regional_by_row_table@primary CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ap-southeast-2]',
   lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX mr_backup_1.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
+ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ap-southeast-2]',
   lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX mr_backup_1.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
+ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ap-southeast-2]',
   lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX mr_backup_1.public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
+ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ap-southeast-2]',
   lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX mr_backup_1.public.regional_by_row_table@primary CONFIGURE ZONE USING
+ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-1".public.regional_by_row_table@primary CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ca-central-1]',
   lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX mr_backup_1.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
+ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ca-central-1]',
   lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX mr_backup_1.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
+ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ca-central-1]',
   lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX mr_backup_1.public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
+ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ca-central-1]',
   lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX mr_backup_1.public.regional_by_row_table@primary CONFIGURE ZONE USING
+ALTER PARTITION "us-east-1" OF INDEX "mr-backup-1".public.regional_by_row_table@primary CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=us-east-1]',
   lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX mr_backup_1.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
+ALTER PARTITION "us-east-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=us-east-1]',
   lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX mr_backup_1.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
+ALTER PARTITION "us-east-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=us-east-1]',
   lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX mr_backup_1.public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
+ALTER PARTITION "us-east-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=us-east-1]',
   lease_preferences = '[[+region=us-east-1]]'
@@ -495,15 +495,15 @@ ALTER PARTITION "us-east-1" OF INDEX mr_backup_1.public.regional_by_row_table@re
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_primary_region
 ----
-DATABASE mr_backup_1  ALTER DATABASE mr_backup_1 CONFIGURE ZONE USING
-                      range_min_bytes = 134217728,
-                      range_max_bytes = 536870912,
-                      gc.ttlseconds = 90000,
-                      num_replicas = 5,
-                      num_voters = 3,
-                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                      voter_constraints = '[+region=ca-central-1]',
-                      lease_preferences = '[[+region=ca-central-1]]'
+DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 90000,
+                        num_replicas = 5,
+                        num_voters = 3,
+                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                        voter_constraints = '[+region=ca-central-1]',
+                        lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_ca_central_1
@@ -519,326 +519,33 @@ TABLE regional_by_table_in_ca_central_1  ALTER TABLE regional_by_table_in_ca_cen
                                          lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
-RESTORE DATABASE mr_backup_2 FROM 'nodelocal://self/mr_backup_2/'
+RESTORE DATABASE "mr-backup-2" FROM 'nodelocal://1/mr-backup-2/'
 
 query T
 select database_name from [show databases]
 ----
 defaultdb
-mr_backup_1
-mr_backup_2
+mr-backup-1
+mr-backup-2
 postgres
 system
 test
 
 query TT
-SHOW ZONE CONFIGURATION FOR DATABASE mr_backup_2
+SHOW ZONE CONFIGURATION FOR DATABASE "mr-backup-2"
 ----
-DATABASE mr_backup_2  ALTER DATABASE mr_backup_2 CONFIGURE ZONE USING
-                      range_min_bytes = 134217728,
-                      range_max_bytes = 536870912,
-                      gc.ttlseconds = 90000,
-                      num_replicas = 5,
-                      num_voters = 3,
-                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                      voter_constraints = '[+region=ap-southeast-2]',
-                      lease_preferences = '[[+region=ap-southeast-2]]'
+DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 90000,
+                        num_replicas = 5,
+                        num_voters = 3,
+                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                        voter_constraints = '[+region=ap-southeast-2]',
+                        lease_preferences = '[[+region=ap-southeast-2]]'
 
 statement ok
-use mr_backup_2
-
-query TT
-SHOW ZONE CONFIGURATION FOR TABLE global_table
-----
-TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
-                    range_min_bytes = 134217728,
-                    range_max_bytes = 536870912,
-                    gc.ttlseconds = 90000,
-                    global_reads = true,
-                    num_replicas = 5,
-                    num_voters = 3,
-                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                    voter_constraints = '[+region=ap-southeast-2]',
-                    lease_preferences = '[[+region=ap-southeast-2]]'
-
-query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_table
-----
-DATABASE mr_backup_2  ALTER DATABASE mr_backup_2 CONFIGURE ZONE USING
-                      range_min_bytes = 134217728,
-                      range_max_bytes = 536870912,
-                      gc.ttlseconds = 90000,
-                      num_replicas = 5,
-                      num_voters = 3,
-                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                      voter_constraints = '[+region=ap-southeast-2]',
-                      lease_preferences = '[[+region=ap-southeast-2]]'
-
-query TT
-SHOW CREATE TABLE regional_by_row_table
-----
-regional_by_row_table  CREATE TABLE public.regional_by_row_table (
-                       pk INT8 NOT NULL,
-                       pk2 INT8 NOT NULL,
-                       a INT8 NOT NULL,
-                       b INT8 NOT NULL,
-                       j JSONB NULL,
-                       crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
-                       CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                       INDEX regional_by_row_table_a_idx (a ASC),
-                       UNIQUE INDEX regional_by_row_table_b_key (b ASC),
-                       INVERTED INDEX regional_by_row_table_j_idx (j),
-                       FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
-) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX mr_backup_2.public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX mr_backup_2.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX mr_backup_2.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX mr_backup_2.public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX mr_backup_2.public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX mr_backup_2.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX mr_backup_2.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX mr_backup_2.public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX mr_backup_2.public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX mr_backup_2.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX mr_backup_2.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX mr_backup_2.public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
-
-query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_primary_region
-----
-DATABASE mr_backup_2  ALTER DATABASE mr_backup_2 CONFIGURE ZONE USING
-                      range_min_bytes = 134217728,
-                      range_max_bytes = 536870912,
-                      gc.ttlseconds = 90000,
-                      num_replicas = 5,
-                      num_voters = 3,
-                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                      voter_constraints = '[+region=ap-southeast-2]',
-                      lease_preferences = '[[+region=ap-southeast-2]]'
-
-query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_ca_central_1
-----
-TABLE regional_by_table_in_ca_central_1  ALTER TABLE regional_by_table_in_ca_central_1 CONFIGURE ZONE USING
-                                         range_min_bytes = 134217728,
-                                         range_max_bytes = 536870912,
-                                         gc.ttlseconds = 90000,
-                                         num_replicas = 5,
-                                         num_voters = 3,
-                                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                         voter_constraints = '[+region=ca-central-1]',
-                                         lease_preferences = '[[+region=ca-central-1]]'
-
-statement ok
-DROP DATABASE mr_backup_1;
-DROP DATABASE mr_backup_2
-
-query T
-select database_name from [show databases]
-----
-defaultdb
-postgres
-system
-test
-
-statement ok
-RESTORE DATABASE mr_backup_1, mr_backup_2 FROM 'nodelocal://self/mr_backup_combined/'
-
-query T
-select database_name from [show databases]
-----
-defaultdb
-mr_backup_1
-mr_backup_2
-postgres
-system
-test
-
-query TT
-SHOW ZONE CONFIGURATION FOR DATABASE mr_backup_1
-----
-DATABASE mr_backup_1  ALTER DATABASE mr_backup_1 CONFIGURE ZONE USING
-                    range_min_bytes = 134217728,
-                    range_max_bytes = 536870912,
-                    gc.ttlseconds = 90000,
-                    num_replicas = 5,
-                    num_voters = 3,
-                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                    voter_constraints = '[+region=ca-central-1]',
-                    lease_preferences = '[[+region=ca-central-1]]'
-
-query TT
-SHOW ZONE CONFIGURATION FOR DATABASE mr_backup_2
-----
-DATABASE mr_backup_2  ALTER DATABASE mr_backup_2 CONFIGURE ZONE USING
-                      range_min_bytes = 134217728,
-                      range_max_bytes = 536870912,
-                      gc.ttlseconds = 90000,
-                      num_replicas = 5,
-                      num_voters = 3,
-                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                      voter_constraints = '[+region=ap-southeast-2]',
-                      lease_preferences = '[[+region=ap-southeast-2]]'
-
-statement ok
-use mr_backup_1
-
-query TT
-SHOW ZONE CONFIGURATION FOR TABLE global_table
-----
-TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
-                    range_min_bytes = 134217728,
-                    range_max_bytes = 536870912,
-                    gc.ttlseconds = 90000,
-                    global_reads = true,
-                    num_replicas = 5,
-                    num_voters = 3,
-                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                    voter_constraints = '[+region=ca-central-1]',
-                    lease_preferences = '[[+region=ca-central-1]]'
-
-query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_table
-----
-DATABASE mr_backup_1  ALTER DATABASE mr_backup_1 CONFIGURE ZONE USING
-                      range_min_bytes = 134217728,
-                      range_max_bytes = 536870912,
-                      gc.ttlseconds = 90000,
-                      num_replicas = 5,
-                      num_voters = 3,
-                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                      voter_constraints = '[+region=ca-central-1]',
-                      lease_preferences = '[[+region=ca-central-1]]'
-
-query TT
-SHOW CREATE TABLE regional_by_row_table
-----
-regional_by_row_table  CREATE TABLE public.regional_by_row_table (
-                       pk INT8 NOT NULL,
-                       pk2 INT8 NOT NULL,
-                       a INT8 NOT NULL,
-                       b INT8 NOT NULL,
-                       j JSONB NULL,
-                       crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
-                       CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                       INDEX regional_by_row_table_a_idx (a ASC),
-                       UNIQUE INDEX regional_by_row_table_b_key (b ASC),
-                       INVERTED INDEX regional_by_row_table_j_idx (j),
-                       FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
-) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX mr_backup_1.public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX mr_backup_1.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX mr_backup_1.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX mr_backup_1.public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX mr_backup_1.public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX mr_backup_1.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX mr_backup_1.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX mr_backup_1.public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX mr_backup_1.public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX mr_backup_1.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX mr_backup_1.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX mr_backup_1.public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
-
-query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_primary_region
-----
-DATABASE mr_backup_1  ALTER DATABASE mr_backup_1 CONFIGURE ZONE USING
-                      range_min_bytes = 134217728,
-                      range_max_bytes = 536870912,
-                      gc.ttlseconds = 90000,
-                      num_replicas = 5,
-                      num_voters = 3,
-                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                      voter_constraints = '[+region=ca-central-1]',
-                      lease_preferences = '[[+region=ca-central-1]]'
-
-query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_ca_central_1
-----
-TABLE regional_by_table_in_ca_central_1  ALTER TABLE regional_by_table_in_ca_central_1 CONFIGURE ZONE USING
-                                         range_min_bytes = 134217728,
-                                         range_max_bytes = 536870912,
-                                         gc.ttlseconds = 90000,
-                                         num_replicas = 5,
-                                         num_voters = 3,
-                                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                         voter_constraints = '[+region=ca-central-1]',
-                                         lease_preferences = '[[+region=ca-central-1]]'
-
-statement ok
-use mr_backup_2
+use "mr-backup-2"
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE global_table
@@ -857,15 +564,15 @@ TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_table
 ----
-DATABASE mr_backup_2  ALTER DATABASE mr_backup_2 CONFIGURE ZONE USING
-                      range_min_bytes = 134217728,
-                      range_max_bytes = 536870912,
-                      gc.ttlseconds = 90000,
-                      num_replicas = 5,
-                      num_voters = 3,
-                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                      voter_constraints = '[+region=ap-southeast-2]',
-                      lease_preferences = '[[+region=ap-southeast-2]]'
+DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 90000,
+                        num_replicas = 5,
+                        num_voters = 3,
+                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                        voter_constraints = '[+region=ap-southeast-2]',
+                        lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TT
 SHOW CREATE TABLE regional_by_row_table
@@ -883,51 +590,51 @@ regional_by_row_table  CREATE TABLE public.regional_by_row_table (
                        INVERTED INDEX regional_by_row_table_j_idx (j),
                        FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
 ) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX mr_backup_2.public.regional_by_row_table@primary CONFIGURE ZONE USING
+ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-2".public.regional_by_row_table@primary CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ap-southeast-2]',
   lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX mr_backup_2.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
+ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ap-southeast-2]',
   lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX mr_backup_2.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
+ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ap-southeast-2]',
   lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX mr_backup_2.public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
+ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ap-southeast-2]',
   lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX mr_backup_2.public.regional_by_row_table@primary CONFIGURE ZONE USING
+ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-2".public.regional_by_row_table@primary CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ca-central-1]',
   lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX mr_backup_2.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
+ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ca-central-1]',
   lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX mr_backup_2.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
+ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ca-central-1]',
   lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX mr_backup_2.public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
+ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=ca-central-1]',
   lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX mr_backup_2.public.regional_by_row_table@primary CONFIGURE ZONE USING
+ALTER PARTITION "us-east-1" OF INDEX "mr-backup-2".public.regional_by_row_table@primary CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=us-east-1]',
   lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX mr_backup_2.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
+ALTER PARTITION "us-east-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=us-east-1]',
   lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX mr_backup_2.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
+ALTER PARTITION "us-east-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=us-east-1]',
   lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX mr_backup_2.public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
+ALTER PARTITION "us-east-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
   num_voters = 3,
   voter_constraints = '[+region=us-east-1]',
   lease_preferences = '[[+region=us-east-1]]'
@@ -935,15 +642,15 @@ ALTER PARTITION "us-east-1" OF INDEX mr_backup_2.public.regional_by_row_table@re
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_primary_region
 ----
-DATABASE mr_backup_2  ALTER DATABASE mr_backup_2 CONFIGURE ZONE USING
-                      range_min_bytes = 134217728,
-                      range_max_bytes = 536870912,
-                      gc.ttlseconds = 90000,
-                      num_replicas = 5,
-                      num_voters = 3,
-                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                      voter_constraints = '[+region=ap-southeast-2]',
-                      lease_preferences = '[[+region=ap-southeast-2]]'
+DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 90000,
+                        num_replicas = 5,
+                        num_voters = 3,
+                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                        voter_constraints = '[+region=ap-southeast-2]',
+                        lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_ca_central_1
@@ -957,3 +664,308 @@ TABLE regional_by_table_in_ca_central_1  ALTER TABLE regional_by_table_in_ca_cen
                                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
                                          voter_constraints = '[+region=ca-central-1]',
                                          lease_preferences = '[[+region=ca-central-1]]'
+
+statement ok
+DROP DATABASE "mr-backup-1";
+DROP DATABASE "mr-backup-2"
+
+query T
+select database_name from [show databases]
+----
+defaultdb
+postgres
+system
+test
+
+statement ok
+RESTORE DATABASE "mr-backup-1", "mr-backup-2" FROM 'nodelocal://1/mr-backup-combined/'
+
+query T
+select database_name from [show databases]
+----
+defaultdb
+mr-backup-1
+mr-backup-2
+postgres
+system
+test
+
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE "mr-backup-1"
+----
+DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 90000,
+                        num_replicas = 5,
+                        num_voters = 3,
+                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                        voter_constraints = '[+region=ca-central-1]',
+                        lease_preferences = '[[+region=ca-central-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE "mr-backup-2"
+----
+DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 90000,
+                        num_replicas = 5,
+                        num_voters = 3,
+                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                        voter_constraints = '[+region=ap-southeast-2]',
+                        lease_preferences = '[[+region=ap-southeast-2]]'
+
+statement ok
+use "mr-backup-1"
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE global_table
+----
+TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
+                    range_min_bytes = 134217728,
+                    range_max_bytes = 536870912,
+                    gc.ttlseconds = 90000,
+                    global_reads = true,
+                    num_replicas = 5,
+                    num_voters = 3,
+                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                    voter_constraints = '[+region=ca-central-1]',
+                    lease_preferences = '[[+region=ca-central-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_table
+----
+DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 90000,
+                        num_replicas = 5,
+                        num_voters = 3,
+                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                        voter_constraints = '[+region=ca-central-1]',
+                        lease_preferences = '[[+region=ca-central-1]]'
+
+query TT
+SHOW CREATE TABLE regional_by_row_table
+----
+regional_by_row_table  CREATE TABLE public.regional_by_row_table (
+                       pk INT8 NOT NULL,
+                       pk2 INT8 NOT NULL,
+                       a INT8 NOT NULL,
+                       b INT8 NOT NULL,
+                       j JSONB NULL,
+                       crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                       CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                       INDEX regional_by_row_table_a_idx (a ASC),
+                       UNIQUE INDEX regional_by_row_table_b_key (b ASC),
+                       INVERTED INDEX regional_by_row_table_j_idx (j),
+                       FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
+) LOCALITY REGIONAL BY ROW;
+ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-1".public.regional_by_row_table@primary CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=ap-southeast-2]',
+  lease_preferences = '[[+region=ap-southeast-2]]';
+ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=ap-southeast-2]',
+  lease_preferences = '[[+region=ap-southeast-2]]';
+ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=ap-southeast-2]',
+  lease_preferences = '[[+region=ap-southeast-2]]';
+ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=ap-southeast-2]',
+  lease_preferences = '[[+region=ap-southeast-2]]';
+ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-1".public.regional_by_row_table@primary CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=ca-central-1]',
+  lease_preferences = '[[+region=ca-central-1]]';
+ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=ca-central-1]',
+  lease_preferences = '[[+region=ca-central-1]]';
+ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=ca-central-1]',
+  lease_preferences = '[[+region=ca-central-1]]';
+ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=ca-central-1]',
+  lease_preferences = '[[+region=ca-central-1]]';
+ALTER PARTITION "us-east-1" OF INDEX "mr-backup-1".public.regional_by_row_table@primary CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=us-east-1]',
+  lease_preferences = '[[+region=us-east-1]]';
+ALTER PARTITION "us-east-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=us-east-1]',
+  lease_preferences = '[[+region=us-east-1]]';
+ALTER PARTITION "us-east-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=us-east-1]',
+  lease_preferences = '[[+region=us-east-1]]';
+ALTER PARTITION "us-east-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=us-east-1]',
+  lease_preferences = '[[+region=us-east-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_primary_region
+----
+DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 90000,
+                        num_replicas = 5,
+                        num_voters = 3,
+                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                        voter_constraints = '[+region=ca-central-1]',
+                        lease_preferences = '[[+region=ca-central-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_ca_central_1
+----
+TABLE regional_by_table_in_ca_central_1  ALTER TABLE regional_by_table_in_ca_central_1 CONFIGURE ZONE USING
+                                         range_min_bytes = 134217728,
+                                         range_max_bytes = 536870912,
+                                         gc.ttlseconds = 90000,
+                                         num_replicas = 5,
+                                         num_voters = 3,
+                                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                         voter_constraints = '[+region=ca-central-1]',
+                                         lease_preferences = '[[+region=ca-central-1]]'
+
+statement ok
+use "mr-backup-2"
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE global_table
+----
+TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
+                    range_min_bytes = 134217728,
+                    range_max_bytes = 536870912,
+                    gc.ttlseconds = 90000,
+                    global_reads = true,
+                    num_replicas = 5,
+                    num_voters = 3,
+                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                    voter_constraints = '[+region=ap-southeast-2]',
+                    lease_preferences = '[[+region=ap-southeast-2]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_table
+----
+DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 90000,
+                        num_replicas = 5,
+                        num_voters = 3,
+                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                        voter_constraints = '[+region=ap-southeast-2]',
+                        lease_preferences = '[[+region=ap-southeast-2]]'
+
+query TT
+SHOW CREATE TABLE regional_by_row_table
+----
+regional_by_row_table  CREATE TABLE public.regional_by_row_table (
+                       pk INT8 NOT NULL,
+                       pk2 INT8 NOT NULL,
+                       a INT8 NOT NULL,
+                       b INT8 NOT NULL,
+                       j JSONB NULL,
+                       crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                       CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                       INDEX regional_by_row_table_a_idx (a ASC),
+                       UNIQUE INDEX regional_by_row_table_b_key (b ASC),
+                       INVERTED INDEX regional_by_row_table_j_idx (j),
+                       FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
+) LOCALITY REGIONAL BY ROW;
+ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-2".public.regional_by_row_table@primary CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=ap-southeast-2]',
+  lease_preferences = '[[+region=ap-southeast-2]]';
+ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=ap-southeast-2]',
+  lease_preferences = '[[+region=ap-southeast-2]]';
+ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=ap-southeast-2]',
+  lease_preferences = '[[+region=ap-southeast-2]]';
+ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=ap-southeast-2]',
+  lease_preferences = '[[+region=ap-southeast-2]]';
+ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-2".public.regional_by_row_table@primary CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=ca-central-1]',
+  lease_preferences = '[[+region=ca-central-1]]';
+ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=ca-central-1]',
+  lease_preferences = '[[+region=ca-central-1]]';
+ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=ca-central-1]',
+  lease_preferences = '[[+region=ca-central-1]]';
+ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=ca-central-1]',
+  lease_preferences = '[[+region=ca-central-1]]';
+ALTER PARTITION "us-east-1" OF INDEX "mr-backup-2".public.regional_by_row_table@primary CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=us-east-1]',
+  lease_preferences = '[[+region=us-east-1]]';
+ALTER PARTITION "us-east-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=us-east-1]',
+  lease_preferences = '[[+region=us-east-1]]';
+ALTER PARTITION "us-east-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=us-east-1]',
+  lease_preferences = '[[+region=us-east-1]]';
+ALTER PARTITION "us-east-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
+  num_voters = 3,
+  voter_constraints = '[+region=us-east-1]',
+  lease_preferences = '[[+region=us-east-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_primary_region
+----
+DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 90000,
+                        num_replicas = 5,
+                        num_voters = 3,
+                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                        voter_constraints = '[+region=ap-southeast-2]',
+                        lease_preferences = '[[+region=ap-southeast-2]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_ca_central_1
+----
+TABLE regional_by_table_in_ca_central_1  ALTER TABLE regional_by_table_in_ca_central_1 CONFIGURE ZONE USING
+                                         range_min_bytes = 134217728,
+                                         range_max_bytes = 536870912,
+                                         gc.ttlseconds = 90000,
+                                         num_replicas = 5,
+                                         num_voters = 3,
+                                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                         voter_constraints = '[+region=ca-central-1]',
+                                         lease_preferences = '[[+region=ca-central-1]]'
+
+statement error cannot backup individual table
+BACKUP TABLE regional_by_row_table TO 'nodelocal://1/rbr_table/';
+
+statement error cannot backup individual table
+BACKUP TABLE regional_by_table_in_primary_region TO 'nodelocal://1/rbr_table/';
+
+statement error cannot backup individual table
+BACKUP TABLE regional_by_table_in_ca_central_1 TO 'nodelocal://1/rbr_table/';
+
+statement error cannot backup individual table
+BACKUP TABLE global_table TO 'nodelocal://1/rbr_table/';


### PR DESCRIPTION
Multi-region databases can't currently handle the restore of individual tables.  To prevent users from getting into problems, this PR blocks the backup of tables in multi-region databases, and prevent restoring a non-multi-region table into a multi-region database.

Resolves #60254.