### PR TITLE
sql/opt: propagate row-level locking mode to index, lookup, inverted, and zigzag joins

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -456,6 +456,13 @@ func checkSupportForPlanNode(node planNode) (distRecommendation, error) {
 		return rec.compose(shouldDistribute), nil
 
 	case *indexJoinNode:
+		if n.table.lockingStrength != descpb.ScanLockingStrength_FOR_NONE {
+			// Index joins that are performing row-level locking cannot
+			// currently be distributed because their locks would not be
+			// propagated back to the root transaction coordinator.
+			// TODO(nvanbenschoten): lift this restriction.
+			return cannotDistribute, cannotDistributeRowLevelLockingErr
+		}
 		// n.table doesn't have meaningful spans, but we need to check support (e.g.
 		// for any filtering expression).
 		if _, err := checkSupportForPlanNode(n.table); err != nil {
@@ -467,6 +474,13 @@ func checkSupportForPlanNode(node planNode) (distRecommendation, error) {
 		return checkSupportForInvertedFilterNode(n)
 
 	case *invertedJoinNode:
+		if n.table.lockingStrength != descpb.ScanLockingStrength_FOR_NONE {
+			// Inverted joins that are performing row-level locking cannot
+			// currently be distributed because their locks would not be
+			// propagated back to the root transaction coordinator.
+			// TODO(nvanbenschoten): lift this restriction.
+			return cannotDistribute, cannotDistributeRowLevelLockingErr
+		}
 		if err := checkExpr(n.onExpr); err != nil {
 			return cannotDistribute, err
 		}
@@ -2425,6 +2439,8 @@ func (dsp *DistSQLPlanner) createPlanForInvertedJoin(
 		Type:                              n.joinType,
 		MaintainOrdering:                  len(n.reqOrdering) > 0,
 		OutputGroupContinuationForLeftRow: n.isFirstJoinInPairedJoiner,
+		LockingStrength:                   n.table.lockingStrength,
+		LockingWaitPolicy:                 n.table.lockingWaitPolicy,
 	}
 
 	fetchColIDs := make([]descpb.ColumnID, len(n.table.cols))

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -253,16 +253,14 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 	if err := rowenc.InitIndexFetchSpec(&trSpec.FetchSpec, e.planner.ExecCfg().Codec, tabDesc, idx, columnIDs); err != nil {
 		return nil, err
 	}
-	if params.Locking.IsLocking() {
-		trSpec.LockingStrength = descpb.ToScanLockingStrength(params.Locking.Strength)
-		trSpec.LockingWaitPolicy = descpb.ToScanLockingWaitPolicy(params.Locking.WaitPolicy)
-		if trSpec.LockingStrength != descpb.ScanLockingStrength_FOR_NONE {
-			// Scans that are performing row-level locking cannot currently be
-			// distributed because their locks would not be propagated back to
-			// the root transaction coordinator.
-			// TODO(nvanbenschoten): lift this restriction.
-			recommendation = cannotDistribute
-		}
+	trSpec.LockingStrength = descpb.ToScanLockingStrength(params.Locking.Strength)
+	trSpec.LockingWaitPolicy = descpb.ToScanLockingWaitPolicy(params.Locking.WaitPolicy)
+	if trSpec.LockingStrength != descpb.ScanLockingStrength_FOR_NONE {
+		// Scans that are performing row-level locking cannot currently be
+		// distributed because their locks would not be propagated back to
+		// the root transaction coordinator.
+		// TODO(nvanbenschoten): lift this restriction.
+		recommendation = cannotDistribute
 	}
 
 	// Note that we don't do anything about the possible filter here since we
@@ -646,6 +644,7 @@ func (e *distSQLSpecExecFactory) ConstructIndexJoin(
 	keyCols []exec.NodeColumnOrdinal,
 	tableCols exec.TableColumnOrdinalSet,
 	reqOrdering exec.OutputOrdering,
+	locking opt.Locking,
 	limitHint int64,
 ) (exec.Node, error) {
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: index join")
@@ -683,6 +682,7 @@ func (e *distSQLSpecExecFactory) ConstructInvertedJoin(
 	onCond tree.TypedExpr,
 	isFirstJoinInPairedJoiner bool,
 	reqOrdering exec.OutputOrdering,
+	locking opt.Locking,
 ) (exec.Node, error) {
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: inverted join")
 }

--- a/pkg/sql/execinfrapb/processors_sql.proto
+++ b/pkg/sql/execinfrapb/processors_sql.proto
@@ -118,7 +118,7 @@ message TableReaderSpec {
 
   // Indicates the policy to be used by the scan for handling conflicting locks
   // held by other active transactions when attempting to lock rows. Always set
-  // to BLOCK when locking_stength is FOR_NONE.
+  // to BLOCK when locking_strength is FOR_NONE.
   optional sqlbase.ScanLockingWaitPolicy locking_wait_policy = 11 [(gogoproto.nullable) = false];
 
   reserved 1, 2, 4, 6, 7, 8, 13, 14, 15, 16, 19;
@@ -158,7 +158,7 @@ message IndexSkipTableReaderSpec {
 
   // Indicates the policy to be used by the scan for handling conflicting locks
   // held by other active transactions when attempting to lock rows. Always set
-  // to BLOCK when locking_stength is FOR_NONE.
+  // to BLOCK when locking_strength is FOR_NONE.
   optional sqlbase.ScanLockingWaitPolicy locking_wait_policy = 7 [(gogoproto.nullable) = false];
 }
 
@@ -348,7 +348,7 @@ message JoinReaderSpec {
 
   // Indicates the policy to be used by the join for handling conflicting locks
   // held by other active transactions when attempting to lock rows. Always set
-  // to BLOCK when locking_stength is FOR_NONE.
+  // to BLOCK when locking_strength is FOR_NONE.
   optional sqlbase.ScanLockingWaitPolicy locking_wait_policy = 10 [(gogoproto.nullable) = false];
 
   // Indicates that the join reader should maintain the ordering of the input
@@ -709,6 +709,15 @@ message InvertedJoinerSpec {
   // prefix_equality_columns should be equal to the number of non-inverted
   // prefix columns in the index.
   repeated uint32 prefix_equality_columns = 9 [packed = true];
+
+  // Indicates the row-level locking strength to be used by the scan. If set to
+  // FOR_NONE, no row-level locking should be performed.
+  optional sqlbase.ScanLockingStrength locking_strength = 12 [(gogoproto.nullable) = false];
+
+  // Indicates the policy to be used by the scan for handling conflicting locks
+  // held by other active transactions when attempting to lock rows. Always set
+  // to BLOCK when locking_strength is FOR_NONE.
+  optional sqlbase.ScanLockingWaitPolicy locking_wait_policy = 13 [(gogoproto.nullable) = false];
 }
 
 // InvertedFiltererSpec is the specification of a processor that does filtering

--- a/pkg/sql/execinfrapb/processors_sql.proto
+++ b/pkg/sql/execinfrapb/processors_sql.proto
@@ -470,6 +470,15 @@ message ZigzagJoinerSpec {
 
     // Fixed values, corresponding to a prefix of the index key columns.
     optional ValuesCoreSpec fixed_values = 3 [(gogoproto.nullable) = false];
+
+    // Indicates the row-level locking strength to be used by the scan. If set to
+    // FOR_NONE, no row-level locking should be performed.
+    optional sqlbase.ScanLockingStrength locking_strength = 4 [(gogoproto.nullable) = false];
+
+    // Indicates the policy to be used by the scan for handling conflicting locks
+    // held by other active transactions when attempting to lock rows. Always set
+    // to BLOCK when locking_strength is FOR_NONE.
+    optional sqlbase.ScanLockingWaitPolicy locking_wait_policy = 5 [(gogoproto.nullable) = false];
   }
 
   repeated Side sides = 7 [(gogoproto.nullable) = false];

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -570,6 +570,8 @@ func (b *Builder) scanParams(
 	}
 
 	// Raise error if row-level locking is part of a read-only transaction.
+	// TODO(nvanbenschoten): this check should be shared across all expressions
+	// that can perform row-level locking.
 	if locking.IsLocking() && b.evalCtx.TxnReadOnly {
 		return exec.ScanParams{}, opt.ColMap{}, pgerror.Newf(pgcode.ReadOnlySQLTransaction,
 			"cannot execute %s in a read-only transaction", locking.Strength.String())
@@ -1720,9 +1722,15 @@ func (b *Builder) buildIndexJoin(join *memo.IndexJoinExpr) (execPlan, error) {
 
 	cols := join.Cols
 	needed, output := b.getColumns(cols, join.Table)
+
+	locking := join.Locking
+	if b.forceForUpdateLocking {
+		locking = forUpdateLocking
+	}
+
 	res := execPlan{outputCols: output}
 	res.root, err = b.factory.ConstructIndexJoin(
-		input.root, tab, keyCols, needed, res.reqOrdering(join), join.RequiredPhysical().LimitHintInt64(),
+		input.root, tab, keyCols, needed, res.reqOrdering(join), locking, join.RequiredPhysical().LimitHintInt64(),
 	)
 	if err != nil {
 		return execPlan{}, err
@@ -1811,7 +1819,7 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 	tab := md.Table(join.Table)
 	idx := tab.Index(join.Index)
 
-	var locking opt.Locking
+	locking := join.Locking
 	if b.forceForUpdateLocking {
 		locking = forUpdateLocking
 	}
@@ -1926,6 +1934,11 @@ func (b *Builder) buildInvertedJoin(join *memo.InvertedJoinExpr) (execPlan, erro
 		return execPlan{}, err
 	}
 
+	locking := join.Locking
+	if b.forceForUpdateLocking {
+		locking = forUpdateLocking
+	}
+
 	res.root, err = b.factory.ConstructInvertedJoin(
 		joinOpToJoinType(join.JoinType),
 		invertedExpr,
@@ -1937,6 +1950,7 @@ func (b *Builder) buildInvertedJoin(join *memo.InvertedJoinExpr) (execPlan, erro
 		onExpr,
 		join.IsFirstJoinInPairedJoiner,
 		res.reqOrdering(join),
+		locking,
 	)
 	if err != nil {
 		return execPlan{}, err

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1999,6 +1999,13 @@ func (b *Builder) buildZigzagJoin(join *memo.ZigzagJoinExpr) (execPlan, error) {
 	leftOrdinals, leftColMap := b.getColumns(leftCols, join.LeftTable)
 	rightOrdinals, rightColMap := b.getColumns(rightCols, join.RightTable)
 
+	leftLocking := join.LeftLocking
+	rightLocking := join.RightLocking
+	if b.forceForUpdateLocking {
+		leftLocking = forUpdateLocking
+		rightLocking = forUpdateLocking
+	}
+
 	allCols := joinOutputMap(leftColMap, rightColMap)
 
 	res := execPlan{outputCols: allCols}
@@ -2039,11 +2046,13 @@ func (b *Builder) buildZigzagJoin(join *memo.ZigzagJoinExpr) (execPlan, error) {
 		leftOrdinals,
 		leftFixedVals,
 		leftEqCols,
+		leftLocking,
 		rightTable,
 		rightIndex,
 		rightOrdinals,
 		rightFixedVals,
 		rightEqCols,
+		rightLocking,
 		onExpr,
 		res.reqOrdering(join),
 	)

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
@@ -1824,28 +1824,29 @@ EXPLAIN (VERBOSE) SELECT * FROM inverted WHERE b @> '{1, 2}' FOR UPDATE
 distribution: local
 vectorized: true
 ·
-• index join
+• lookup join (inner)
 │ columns: (a, b, c)
 │ estimated row count: 12 (missing stats)
 │ table: inverted@inverted_pkey
-│ key columns: a
+│ equality: (a) = (a)
+│ equality cols are key
+│ pred: b @> ARRAY[1,2]
 │ locking strength: for update
 │
 └── • project
     │ columns: (a)
-    │ estimated row count: 111 (missing stats)
+    │ estimated row count: 12 (missing stats)
     │
-    └── • inverted filter
-        │ columns: (a, b_inverted_key)
-        │ inverted column: b_inverted_key
-        │ num spans: 1
-        │
-        └── • scan
-              columns: (a, b_inverted_key)
-              estimated row count: 111 (missing stats)
-              table: inverted@b_inv
-              spans: /1-/3
-              locking strength: for update
+    └── • zigzag join
+          columns: (a, b_inverted_key, a, b_inverted_key)
+          left table: inverted@b_inv
+          left columns: (a, b_inverted_key)
+          left fixed values: 1 column
+          left locking strength: for update
+          right table: inverted@b_inv
+          right columns: (a, b_inverted_key)
+          right fixed values: 1 column
+          right locking strength: for update
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM inverted WHERE b <@ '{1, 2}' FOR UPDATE
@@ -1915,6 +1916,73 @@ vectorized: true
                   table: inverted@inverted_pkey
                   spans: FULL SCAN
                   locking strength: for update
+
+# ------------------------------------------------------------------------------
+# Tests with zigzag joins.
+# ------------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE zigzag (
+  a INT PRIMARY KEY,
+  b INT,
+  c FLOAT,
+  d JSONB,
+  INDEX b_idx(b),
+  INDEX c_idx(c),
+  INVERTED INDEX d_idx(d)
+)
+
+query T
+EXPLAIN (VERBOSE) SELECT a,b,c FROM zigzag WHERE b = 5 AND c = 6.0 FOR UPDATE
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, c)
+│ estimated row count: 1 (missing stats)
+│
+└── • zigzag join
+      columns: (a, b, a, c)
+      pred: (b = 5) AND (c = 6.0)
+      left table: zigzag@b_idx
+      left columns: (a, b)
+      left fixed values: 1 column
+      left locking strength: for update
+      right table: zigzag@c_idx
+      right columns: (a, c)
+      right fixed values: 1 column
+      right locking strength: for update
+
+query T
+EXPLAIN (VERBOSE) SELECT * from zigzag where d @> '{"a": {"b": "c"}, "f": "g"}' FOR UPDATE
+----
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b, c, d)
+│ estimated row count: 12 (missing stats)
+│ table: zigzag@zigzag_pkey
+│ equality: (a) = (a)
+│ equality cols are key
+│ pred: d @> '{"a": {"b": "c"}, "f": "g"}'
+│ locking strength: for update
+│
+└── • project
+    │ columns: (a)
+    │ estimated row count: 12 (missing stats)
+    │
+    └── • zigzag join
+          columns: (a, d_inverted_key, a, d_inverted_key)
+          left table: zigzag@d_idx
+          left columns: (a, d_inverted_key)
+          left fixed values: 1 column
+          left locking strength: for update
+          right table: zigzag@d_idx
+          right columns: (a, d_inverted_key)
+          right fixed values: 1 column
+          right locking strength: for update
 
 # ------------------------------------------------------------------------------
 # Tests with the NOWAIT lock wait policy.

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
@@ -703,6 +703,56 @@ vectorized: true
               locking strength: for update
 
 query T
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a IN (SELECT a FROM t) FOR UPDATE
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1,000 (missing stats)
+  table: t@t_pkey
+  spans: FULL SCAN
+  locking strength: for update
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a IN (SELECT a FROM t FOR UPDATE)
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1,000 (missing stats)
+  table: t@t_pkey
+  spans: FULL SCAN
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a IN (SELECT a FROM t) FOR UPDATE OF t
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1,000 (missing stats)
+  table: t@t_pkey
+  spans: FULL SCAN
+  locking strength: for update
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a IN (SELECT a FROM t FOR UPDATE OF t)
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1,000 (missing stats)
+  table: t@t_pkey
+  spans: FULL SCAN
+
+query T
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE a IN (SELECT b FROM t) FOR UPDATE
 ----
 distribution: local
@@ -718,6 +768,7 @@ vectorized: true
     │ table: t@t_pkey
     │ equality: (b) = (a)
     │ equality cols are key
+    │ locking strength: for update
     │
     └── • distinct
         │ columns: (b)
@@ -775,6 +826,7 @@ vectorized: true
     │ table: t@t_pkey
     │ equality: (b) = (a)
     │ equality cols are key
+    │ locking strength: for update
     │
     └── • distinct
         │ columns: (b)
@@ -1618,6 +1670,251 @@ vectorized: true
       table: u@u_pkey
       spans: FULL SCAN
       locking strength: for update
+
+# ------------------------------------------------------------------------------
+# Tests with index joins.
+# ------------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE indexed (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  INDEX b_idx(b)
+)
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM indexed WHERE b = 2 FOR UPDATE
+----
+distribution: local
+vectorized: true
+·
+• index join
+│ columns: (a, b, c)
+│ estimated row count: 10 (missing stats)
+│ table: indexed@indexed_pkey
+│ key columns: a
+│ locking strength: for update
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 10 (missing stats)
+      table: indexed@b_idx
+      spans: /2-/3
+      locking strength: for update
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM indexed WHERE b BETWEEN 2 AND 10 FOR UPDATE
+----
+distribution: local
+vectorized: true
+·
+• index join
+│ columns: (a, b, c)
+│ estimated row count: 90 (missing stats)
+│ table: indexed@indexed_pkey
+│ key columns: a
+│ locking strength: for update
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 90 (missing stats)
+      table: indexed@b_idx
+      spans: /2-/11
+      locking strength: for update
+
+# ------------------------------------------------------------------------------
+# Tests with lookup joins.
+# ------------------------------------------------------------------------------
+
+query T
+EXPLAIN (VERBOSE) SELECT c FROM t JOIN u ON t.b = u.a WHERE t.a = 2 FOR UPDATE
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (c)
+│ estimated row count: 1 (missing stats)
+│
+└── • lookup join (inner)
+    │ columns: (a, b, a, c)
+    │ estimated row count: 1 (missing stats)
+    │ table: u@u_pkey
+    │ equality: (b) = (a)
+    │ equality cols are key
+    │ locking strength: for update
+    │
+    └── • scan
+          columns: (a, b)
+          estimated row count: 1 (missing stats)
+          table: t@t_pkey
+          spans: /2/0
+          locking strength: for update
+
+query T
+EXPLAIN (VERBOSE) SELECT c FROM t JOIN u ON t.b = u.a WHERE t.a BETWEEN 2 AND 10 FOR UPDATE
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (c)
+│ estimated row count: 9 (missing stats)
+│
+└── • lookup join (inner)
+    │ columns: (a, b, a, c)
+    │ estimated row count: 9 (missing stats)
+    │ table: u@u_pkey
+    │ equality: (b) = (a)
+    │ equality cols are key
+    │ locking strength: for update
+    │
+    └── • scan
+          columns: (a, b)
+          estimated row count: 9 (missing stats)
+          table: t@t_pkey
+          spans: /2-/11
+          parallel
+          locking strength: for update
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t JOIN indexed ON t.b = indexed.b WHERE t.a = 2 FOR UPDATE
+----
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b, a, b, c)
+│ estimated row count: 10 (missing stats)
+│ table: indexed@indexed_pkey
+│ equality: (a) = (a)
+│ equality cols are key
+│ locking strength: for update
+│
+└── • lookup join (inner)
+    │ columns: (a, b, a, b)
+    │ estimated row count: 10 (missing stats)
+    │ table: indexed@b_idx
+    │ equality: (b) = (b)
+    │ locking strength: for update
+    │
+    └── • scan
+          columns: (a, b)
+          estimated row count: 1 (missing stats)
+          table: t@t_pkey
+          spans: /2/0
+          locking strength: for update
+
+# ------------------------------------------------------------------------------
+# Tests with inverted filters and joins.
+# ------------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE inverted (
+  a INT PRIMARY KEY,
+  b INT[],
+  c INT,
+  INVERTED INDEX b_inv(b)
+)
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM inverted WHERE b @> '{1, 2}' FOR UPDATE
+----
+distribution: local
+vectorized: true
+·
+• index join
+│ columns: (a, b, c)
+│ estimated row count: 12 (missing stats)
+│ table: inverted@inverted_pkey
+│ key columns: a
+│ locking strength: for update
+│
+└── • project
+    │ columns: (a)
+    │ estimated row count: 111 (missing stats)
+    │
+    └── • inverted filter
+        │ columns: (a, b_inverted_key)
+        │ inverted column: b_inverted_key
+        │ num spans: 1
+        │
+        └── • scan
+              columns: (a, b_inverted_key)
+              estimated row count: 111 (missing stats)
+              table: inverted@b_inv
+              spans: /1-/3
+              locking strength: for update
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM inverted WHERE b <@ '{1, 2}' FOR UPDATE
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b, c)
+│ estimated row count: 333 (missing stats)
+│ filter: b <@ ARRAY[1,2]
+│
+└── • index join
+    │ columns: (a, b, c)
+    │ estimated row count: 111 (missing stats)
+    │ table: inverted@inverted_pkey
+    │ key columns: a
+    │ locking strength: for update
+    │
+    └── • project
+        │ columns: (a)
+        │ estimated row count: 111 (missing stats)
+        │
+        └── • inverted filter
+            │ columns: (a, b_inverted_key)
+            │ inverted column: b_inverted_key
+            │ num spans: 2
+            │
+            └── • scan
+                  columns: (a, b_inverted_key)
+                  estimated row count: 111 (missing stats)
+                  table: inverted@b_inv
+                  spans: /[]-/"D" /1-/3
+                  locking strength: for update
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM inverted@b_inv AS i1, inverted AS i2 WHERE i1.b @> i2.b FOR UPDATE
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, c, a, b, c)
+│ estimated row count: 10,000 (missing stats)
+│
+└── • lookup join (inner)
+    │ columns: (a, b, c, a, a, b, c)
+    │ table: inverted@inverted_pkey
+    │ equality: (a) = (a)
+    │ equality cols are key
+    │ pred: b @> b
+    │ locking strength: for update
+    │
+    └── • project
+        │ columns: (a, b, c, a)
+        │ estimated row count: 10,000 (missing stats)
+        │
+        └── • inverted join (inner)
+            │ columns: (a, b, c, a, b_inverted_key)
+            │ table: inverted@b_inv
+            │ inverted expr: b_inverted_key @> b
+            │ locking strength: for update
+            │
+            └── • scan
+                  columns: (a, b, c)
+                  estimated row count: 1,000 (missing stats)
+                  table: inverted@inverted_pkey
+                  spans: FULL SCAN
+                  locking strength: for update
 
 # ------------------------------------------------------------------------------
 # Tests with the NOWAIT lock wait policy.

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -263,6 +263,7 @@ vectorized: true
         │ estimated row count: 990 (missing stats)
         │ table: xyz@xyz_pkey
         │ key columns: x
+        │ locking strength: for update
         │
         └── • scan
               columns: (x, y)
@@ -562,6 +563,7 @@ vectorized: true
     │
     └── • index join
         │ table: kv3@kv3_pkey
+        │ locking strength: for update
         │
         └── • scan
               missing stats
@@ -582,6 +584,7 @@ vectorized: true
 │
 └── • index join
     │ table: kv3@kv3_pkey
+    │ locking strength: for update
     │
     └── • scan
           missing stats

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
@@ -638,6 +638,7 @@ vectorized: true
                 │ estimated row count: 333 (missing stats)
                 │ table: t_idx@t_idx_pkey
                 │ key columns: a
+                │ locking strength: for update
                 │
                 └── • scan
                       columns: (a)

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -558,6 +558,7 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 			}
 		}
 		ob.VAttr("key columns", strings.Join(cols, ", "))
+		e.emitLockingPolicy(a.Locking)
 
 	case groupByOp:
 		a := n.args.(*groupByArgs)
@@ -685,6 +686,7 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 		if a.OnCond != tree.DBoolTrue {
 			ob.Expr("on", a.OnCond, cols)
 		}
+		e.emitLockingPolicy(a.Locking)
 
 	case projectSetOp:
 		a := n.args.(*projectSetArgs)

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -666,11 +666,13 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 		if n := len(a.LeftFixedVals); n > 0 {
 			ob.Attrf("left fixed values", "%d column%s", n, util.Pluralize(int64(n)))
 		}
+		e.emitLockingPolicyWithPrefix("left ", a.LeftLocking)
 		e.emitTableAndIndex("right table", a.RightTable, a.RightIndex)
 		ob.Attrf("right columns", "(%s)", printColumns(rightCols))
 		if n := len(a.RightFixedVals); n > 0 {
 			ob.Attrf("right fixed values", "%d column%s", n, util.Pluralize(int64(n)))
 		}
+		e.emitLockingPolicyWithPrefix("right ", a.RightLocking)
 
 	case invertedFilterOp:
 		a := n.args.(*invertedFilterArgs)
@@ -943,13 +945,17 @@ func (e *emitter) spansStr(table cat.Table, index cat.Index, scanParams exec.Sca
 }
 
 func (e *emitter) emitLockingPolicy(locking opt.Locking) {
+	e.emitLockingPolicyWithPrefix("", locking)
+}
+
+func (e *emitter) emitLockingPolicyWithPrefix(keyPrefix string, locking opt.Locking) {
 	strength := descpb.ToScanLockingStrength(locking.Strength)
 	waitPolicy := descpb.ToScanLockingWaitPolicy(locking.WaitPolicy)
 	if strength != descpb.ScanLockingStrength_FOR_NONE {
-		e.ob.Attr("locking strength", strength.PrettyString())
+		e.ob.Attr(keyPrefix+"locking strength", strength.PrettyString())
 	}
 	if waitPolicy != descpb.ScanLockingWaitPolicy_BLOCK {
-		e.ob.Attr("locking wait policy", waitPolicy.PrettyString())
+		e.ob.Attr(keyPrefix+"locking wait policy", waitPolicy.PrettyString())
 	}
 }
 

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -60,6 +60,7 @@ type ScanParams struct {
 	// scanned. It should not be set if there is a hard or soft limit.
 	Parallelize bool
 
+	// Row-level locking properties.
 	Locking opt.Locking
 
 	EstimatedRowCount float64

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -249,6 +249,7 @@ define IndexJoin {
     KeyCols []exec.NodeColumnOrdinal
     TableCols exec.TableColumnOrdinalSet
     ReqOrdering exec.OutputOrdering
+    Locking opt.Locking
     LimitHint int64
 }
 
@@ -310,6 +311,7 @@ define InvertedJoin {
     OnCond tree.TypedExpr
     IsFirstJoinInPairedJoiner bool
     ReqOrdering exec.OutputOrdering
+    Locking opt.Locking
 }
 
 # ZigzagJoin performs a zigzag join.

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -336,6 +336,9 @@ define ZigzagJoin {
     # corresponding 1-1 to RightEqCols.
     LeftEqCols []exec.TableColumnOrdinal
 
+    # Left row-level locking properties.
+    LeftLocking opt.Locking
+
     # Right table and index.
     RightTable cat.Table
     RightIndex cat.Index
@@ -350,6 +353,9 @@ define ZigzagJoin {
     # RightEqCols are the right table columns that have equality constraints,
     # corresponding 1-1 to LeftEqCols.
     RightEqCols []exec.TableColumnOrdinal
+
+    # Right row-level locking properties.
+    RightLocking opt.Locking
 
     # OnCond is an extra filter that is evaluated on the results.
     # TODO(radu): remove this (it can be a separate Select).

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -462,33 +462,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			}
 			tp.Child(b.String())
 		}
-		if private.Locking.IsLocking() {
-			strength := ""
-			switch private.Locking.Strength {
-			case tree.ForNone:
-			case tree.ForKeyShare:
-				strength = "for-key-share"
-			case tree.ForShare:
-				strength = "for-share"
-			case tree.ForNoKeyUpdate:
-				strength = "for-no-key-update"
-			case tree.ForUpdate:
-				strength = "for-update"
-			default:
-				panic(errors.AssertionFailedf("unexpected strength"))
-			}
-			wait := ""
-			switch private.Locking.WaitPolicy {
-			case tree.LockWaitBlock:
-			case tree.LockWaitSkip:
-				wait = ",skip-locked"
-			case tree.LockWaitError:
-				wait = ",nowait"
-			default:
-				panic(errors.AssertionFailedf("unexpected wait policy"))
-			}
-			tp.Childf("locking: %s%s", strength, wait)
-		}
+		f.formatLocking(tp, private.Locking)
 
 	case *InvertedFilterExpr:
 		var b strings.Builder
@@ -500,6 +474,9 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			n := tp.Childf("pre-filterer expression")
 			f.formatExpr(t.PreFiltererState.Expr, n)
 		}
+
+	case *IndexJoinExpr:
+		f.formatLocking(tp, t.Locking)
 
 	case *LookupJoinExpr:
 		if !t.Flags.Empty() {
@@ -532,6 +509,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		if t.IsSecondJoinInPairedJoiner {
 			tp.Childf("second join in paired joiner")
 		}
+		f.formatLocking(tp, t.Locking)
 
 	case *InvertedJoinExpr:
 		if !t.Flags.Empty() {
@@ -550,6 +528,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		}
 		n := tp.Child("inverted-expr")
 		f.formatExpr(t.InvertedExpr, n)
+		f.formatLocking(tp, t.Locking)
 
 	case *ZigzagJoinExpr:
 		if !f.HasFlags(ExprFmtHideColumns) {
@@ -1413,6 +1392,39 @@ func (f *ExprFmtCtx) formatCol(label string, id opt.ColumnID, notNullCols opt.Co
 	if parenOpen {
 		f.Buffer.WriteByte(')')
 	}
+}
+
+// formatLocking adds a new treeprinter child for the row-level locking policy,
+// if the policy is configured to perform row-level locking.
+func (f *ExprFmtCtx) formatLocking(tp treeprinter.Node, locking opt.Locking) {
+	if !locking.IsLocking() {
+		return
+	}
+	strength := ""
+	switch locking.Strength {
+	case tree.ForNone:
+	case tree.ForKeyShare:
+		strength = "for-key-share"
+	case tree.ForShare:
+		strength = "for-share"
+	case tree.ForNoKeyUpdate:
+		strength = "for-no-key-update"
+	case tree.ForUpdate:
+		strength = "for-update"
+	default:
+		panic(errors.AssertionFailedf("unexpected strength"))
+	}
+	wait := ""
+	switch locking.WaitPolicy {
+	case tree.LockWaitBlock:
+	case tree.LockWaitSkip:
+		wait = ",skip-locked"
+	case tree.LockWaitError:
+		wait = ",nowait"
+	default:
+		panic(errors.AssertionFailedf("unexpected wait policy"))
+	}
+	tp.Childf("locking: %s%s", strength, wait)
 }
 
 // ScanIsReverseFn is a callback that is used to figure out if a scan needs to

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -546,6 +546,8 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			tp.Childf("left fixed columns: %v = %v", t.LeftFixedCols, leftVals)
 			tp.Childf("right fixed columns: %v = %v", t.RightFixedCols, rightVals)
 		}
+		f.formatLockingWithPrefix(tp, "left ", t.LeftLocking)
+		f.formatLockingWithPrefix(tp, "right ", t.RightLocking)
 
 	case *MergeJoinExpr:
 		if !t.Flags.Empty() {
@@ -1397,6 +1399,12 @@ func (f *ExprFmtCtx) formatCol(label string, id opt.ColumnID, notNullCols opt.Co
 // formatLocking adds a new treeprinter child for the row-level locking policy,
 // if the policy is configured to perform row-level locking.
 func (f *ExprFmtCtx) formatLocking(tp treeprinter.Node, locking opt.Locking) {
+	f.formatLockingWithPrefix(tp, "", locking)
+}
+
+func (f *ExprFmtCtx) formatLockingWithPrefix(
+	tp treeprinter.Node, labelPrefix string, locking opt.Locking,
+) {
 	if !locking.IsLocking() {
 		return
 	}
@@ -1424,7 +1432,7 @@ func (f *ExprFmtCtx) formatLocking(tp treeprinter.Node, locking opt.Locking) {
 	default:
 		panic(errors.AssertionFailedf("unexpected wait policy"))
 	}
-	tp.Childf("locking: %s%s", strength, wait)
+	tp.Childf("%slocking: %s%s", labelPrefix, strength, wait)
 }
 
 // ScanIsReverseFn is a callback that is used to figure out if a scan needs to

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -631,6 +631,22 @@ define ZigzagJoinPrivate {
     LeftFixedCols ColList
     RightFixedCols ColList
 
+    # LeftLocking and RightLocking represent the row-level locking modes of the
+    # scans over the ZigzagJoin's two tables. Most zigzag joins leave these
+    # unset (Strength = ForNone), which indicates that no row-level locking will
+    # be performed while joining the two tables. Stronger locking modes are used
+    # by SELECT .. FOR [KEY] UPDATE/SHARE statements and by the initial row
+    # retrieval of DELETE and UPDATE statements.
+    #
+    # The row-level locking modes also dictates the policy used by the
+    # ZigzagJoin when handling conflicting locks held by other active
+    # transactions. Most zigzag joins leave the policies set to the default
+    # (WaitPolicy = Block), but different wait policies are used by SELECT ..
+    # FOR UPDATE/SHARE SKIP LOCKED/NOWAIT statements to react differently to
+    # conflicting locks.
+    LeftLocking Locking
+    RightLocking Locking
+
     # Cols is the set of columns produced by the zigzag join. This set can
     # contain columns from either side's index.
     Cols ColSet

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -314,6 +314,20 @@ define IndexJoinPrivate {
     # Cols specifies the set of columns that the index join operator projects.
     # This may be a subset of the columns that the table contains.
     Cols ColSet
+
+    # Locking represents the row-level locking mode of the IndexJoin in the
+    # lookup table's primary index. Most index joins leave this unset (Strength
+    # = ForNone), which indicates that no row-level locking will be performed
+    # while joining with the table's index. Stronger locking modes are used by
+    # SELECT .. FOR [KEY] UPDATE/SHARE statements and by the initial row
+    # retrieval of DELETE and UPDATE statements.
+    #
+    # The row-level locking mode also dictates the policy used by the IndexJoin
+    # when handling conflicting locks held by other active transactions. Most
+    # index joins leave the policy set to its default (WaitPolicy = Block), but
+    # different wait policies are used by SELECT .. FOR UPDATE/SHARE SKIP
+    # LOCKED/NOWAIT statements to react differently to conflicting locks.
+    Locking Locking
 }
 
 # LookupJoin represents a join between an input expression and an index. The
@@ -437,6 +451,20 @@ define LookupJoinPrivate {
     # conditions on the KeyCols. These filters are needed by the statistics code to
     # correctly estimate selectivity.
     ConstFilters FiltersExpr
+
+    # Locking represents the row-level locking mode of the LookupJoin in the
+    # lookup table. Most lookup joins leave this unset (Strength = ForNone),
+    # which indicates that no row-level locking will be performed while joining
+    # with the table. Stronger locking modes are used by SELECT .. FOR [KEY]
+    # UPDATE/SHARE statements and by the initial row retrieval of DELETE and
+    # UPDATE statements.
+    #
+    # The row-level locking mode also dictates the policy used by the LookupJoin
+    # when handling conflicting locks held by other active transactions. Most
+    # lookup joins leave the policy set to its default (WaitPolicy = Block), but
+    # different wait policies are used by SELECT .. FOR UPDATE/SHARE SKIP
+    # LOCKED/NOWAIT statements to react differently to conflicting locks.
+    Locking Locking
     _ JoinPrivate
 }
 
@@ -496,6 +524,21 @@ define InvertedJoinPrivate {
     # equality conditions on the PrefixKeyCols. These filters are needed by the
     # statistics code to correctly estimate selectivity.
     ConstFilters FiltersExpr
+
+    # Locking represents the row-level locking mode of the InvertedJoin in the
+    # lookup table. Most inverted joins leave this unset (Strength = ForNone),
+    # which indicates that no row-level locking will be performed while joining
+    # with the table. Stronger locking modes are used by SELECT .. FOR [KEY]
+    # UPDATE/SHARE statements and by the initial row retrieval of DELETE and
+    # UPDATE statements.
+    #
+    # The row-level locking mode also dictates the policy used by the
+    # InvertedJoin when handling conflicting locks held by other active
+    # transactions. Most inverted joins leave the policy set to its default
+    # (WaitPolicy = Block), but different wait policies are used by SELECT ..
+    # FOR UPDATE/SHARE SKIP LOCKED/NOWAIT statements to react differently to
+    # conflicting locks.
+    Locking Locking
     _ JoinPrivate
 }
 

--- a/pkg/sql/opt/optbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/optbuilder/testdata/select_for_update
@@ -1164,6 +1164,48 @@ project
            └── i1.b:2 @> i2.b:8
 
 # ------------------------------------------------------------------------------
+# Tests with zigzag joins.
+# ------------------------------------------------------------------------------
+
+exec-ddl
+CREATE TABLE zigzag (
+  a INT PRIMARY KEY,
+  b INT,
+  c FLOAT,
+  d JSONB,
+  INDEX b_idx(b),
+  INDEX c_idx(c),
+  INVERTED INDEX d_idx(d)
+)
+----
+
+build
+SELECT a,b,c FROM zigzag WHERE b = 5 AND c = 6.0 FOR UPDATE
+----
+project
+ ├── columns: a:1!null b:2!null c:3!null
+ └── select
+      ├── columns: a:1!null b:2!null c:3!null d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+      ├── scan zigzag
+      │    ├── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+      │    └── locking: for-update
+      └── filters
+           └── (b:2 = 5) AND (c:3 = 6.0)
+
+build
+SELECT * from zigzag where d @> '{"a": {"b": "c"}, "f": "g"}' FOR UPDATE
+----
+project
+ ├── columns: a:1!null b:2 c:3 d:4!null
+ └── select
+      ├── columns: a:1!null b:2 c:3 d:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+      ├── scan zigzag
+      │    ├── columns: a:1!null b:2 c:3 d:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+      │    └── locking: for-update
+      └── filters
+           └── d:4 @> '{"a": {"b": "c"}, "f": "g"}'
+
+# ------------------------------------------------------------------------------
 # Tests with virtual tables.
 # ------------------------------------------------------------------------------
 

--- a/pkg/sql/opt/optbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/optbuilder/testdata/select_for_update
@@ -493,6 +493,78 @@ project
                 │         └── locking: for-update
                 └── a:1
 
+build
+SELECT * FROM t WHERE a IN (SELECT b FROM t) FOR UPDATE
+----
+project
+ ├── columns: a:1!null b:2
+ └── select
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      ├── scan t
+      │    ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      │    └── locking: for-update
+      └── filters
+           └── any: eq
+                ├── project
+                │    ├── columns: b:6
+                │    └── scan t
+                │         └── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+                └── a:1
+
+build
+SELECT * FROM t WHERE a IN (SELECT b FROM t FOR UPDATE)
+----
+project
+ ├── columns: a:1!null b:2
+ └── select
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      ├── scan t
+      │    └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      └── filters
+           └── any: eq
+                ├── project
+                │    ├── columns: b:6
+                │    └── scan t
+                │         ├── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+                │         └── locking: for-update
+                └── a:1
+
+build
+SELECT * FROM t WHERE a IN (SELECT b FROM t) FOR UPDATE OF t
+----
+project
+ ├── columns: a:1!null b:2
+ └── select
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      ├── scan t
+      │    ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      │    └── locking: for-update
+      └── filters
+           └── any: eq
+                ├── project
+                │    ├── columns: b:6
+                │    └── scan t
+                │         └── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+                └── a:1
+
+build
+SELECT * FROM t WHERE a IN (SELECT b FROM t FOR UPDATE OF t)
+----
+project
+ ├── columns: a:1!null b:2
+ └── select
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      ├── scan t
+      │    └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      └── filters
+           └── any: eq
+                ├── project
+                │    ├── columns: b:6
+                │    └── scan t
+                │         ├── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+                │         └── locking: for-update
+                └── a:1
+
 # ------------------------------------------------------------------------------
 # Tests with common-table expressions.
 #
@@ -928,6 +1000,168 @@ project
       │         ├── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
       │         └── locking: for-update
       └── filters (true)
+
+# ------------------------------------------------------------------------------
+# Tests with index joins.
+# ------------------------------------------------------------------------------
+
+exec-ddl
+CREATE TABLE indexed (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  INDEX b_idx(b)
+)
+----
+
+build
+SELECT * FROM indexed WHERE b = 2 FOR UPDATE
+----
+project
+ ├── columns: a:1!null b:2!null c:3
+ └── select
+      ├── columns: a:1!null b:2!null c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      ├── scan indexed
+      │    ├── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      │    └── locking: for-update
+      └── filters
+           └── b:2 = 2
+
+build
+SELECT * FROM indexed WHERE b BETWEEN 2 AND 10 FOR UPDATE
+----
+project
+ ├── columns: a:1!null b:2!null c:3
+ └── select
+      ├── columns: a:1!null b:2!null c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      ├── scan indexed
+      │    ├── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      │    └── locking: for-update
+      └── filters
+           └── (b:2 >= 2) AND (b:2 <= 10)
+
+# ------------------------------------------------------------------------------
+# Tests with lookup joins.
+# ------------------------------------------------------------------------------
+
+build
+SELECT c FROM t JOIN u ON t.b = u.a WHERE t.a = 2 FOR UPDATE
+----
+project
+ ├── columns: c:6
+ └── select
+      ├── columns: t.a:1!null b:2!null t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+      ├── inner-join (hash)
+      │    ├── columns: t.a:1!null b:2!null t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+      │    ├── scan t
+      │    │    ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
+      │    │    └── locking: for-update
+      │    ├── scan u
+      │    │    ├── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+      │    │    └── locking: for-update
+      │    └── filters
+      │         └── b:2 = u.a:5
+      └── filters
+           └── t.a:1 = 2
+
+build
+SELECT c FROM t JOIN u ON t.b = u.a WHERE t.a BETWEEN 2 AND 10 FOR UPDATE
+----
+project
+ ├── columns: c:6
+ └── select
+      ├── columns: t.a:1!null b:2!null t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+      ├── inner-join (hash)
+      │    ├── columns: t.a:1!null b:2!null t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+      │    ├── scan t
+      │    │    ├── columns: t.a:1!null b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
+      │    │    └── locking: for-update
+      │    ├── scan u
+      │    │    ├── columns: u.a:5!null c:6 u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
+      │    │    └── locking: for-update
+      │    └── filters
+      │         └── b:2 = u.a:5
+      └── filters
+           └── (t.a:1 >= 2) AND (t.a:1 <= 10)
+
+build
+SELECT * FROM t JOIN indexed ON t.b = indexed.b WHERE t.a = 2 FOR UPDATE
+----
+project
+ ├── columns: a:1!null b:2!null a:5!null b:6!null c:7
+ └── select
+      ├── columns: t.a:1!null t.b:2!null t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 indexed.a:5!null indexed.b:6!null c:7 indexed.crdb_internal_mvcc_timestamp:8 indexed.tableoid:9
+      ├── inner-join (hash)
+      │    ├── columns: t.a:1!null t.b:2!null t.crdb_internal_mvcc_timestamp:3 t.tableoid:4 indexed.a:5!null indexed.b:6!null c:7 indexed.crdb_internal_mvcc_timestamp:8 indexed.tableoid:9
+      │    ├── scan t
+      │    │    ├── columns: t.a:1!null t.b:2 t.crdb_internal_mvcc_timestamp:3 t.tableoid:4
+      │    │    └── locking: for-update
+      │    ├── scan indexed
+      │    │    ├── columns: indexed.a:5!null indexed.b:6 c:7 indexed.crdb_internal_mvcc_timestamp:8 indexed.tableoid:9
+      │    │    └── locking: for-update
+      │    └── filters
+      │         └── t.b:2 = indexed.b:6
+      └── filters
+           └── t.a:1 = 2
+
+# ------------------------------------------------------------------------------
+# Tests with inverted filters and joins.
+# ------------------------------------------------------------------------------
+
+exec-ddl
+CREATE TABLE inverted (
+  a INT PRIMARY KEY,
+  b INT[],
+  c INT,
+  INVERTED INDEX b_inv(b)
+)
+----
+
+build
+SELECT * FROM inverted WHERE b @> '{1, 2}' FOR UPDATE
+----
+project
+ ├── columns: a:1!null b:2!null c:3
+ └── select
+      ├── columns: a:1!null b:2!null c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      ├── scan inverted
+      │    ├── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      │    └── locking: for-update
+      └── filters
+           └── b:2 @> ARRAY[1,2]
+
+build
+SELECT * FROM inverted WHERE b <@ '{1, 2}' FOR UPDATE
+----
+project
+ ├── columns: a:1!null b:2 c:3
+ └── select
+      ├── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      ├── scan inverted
+      │    ├── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      │    └── locking: for-update
+      └── filters
+           └── b:2 <@ ARRAY[1,2]
+
+build
+SELECT * FROM inverted@b_inv AS i1, inverted AS i2 WHERE i1.b @> i2.b FOR UPDATE
+----
+project
+ ├── columns: a:1!null b:2 c:3 a:7!null b:8 c:9
+ └── select
+      ├── columns: i1.a:1!null i1.b:2 i1.c:3 i1.crdb_internal_mvcc_timestamp:4 i1.tableoid:5 i2.a:7!null i2.b:8 i2.c:9 i2.crdb_internal_mvcc_timestamp:10 i2.tableoid:11
+      ├── inner-join (cross)
+      │    ├── columns: i1.a:1!null i1.b:2 i1.c:3 i1.crdb_internal_mvcc_timestamp:4 i1.tableoid:5 i2.a:7!null i2.b:8 i2.c:9 i2.crdb_internal_mvcc_timestamp:10 i2.tableoid:11
+      │    ├── scan inverted [as=i1]
+      │    │    ├── columns: i1.a:1!null i1.b:2 i1.c:3 i1.crdb_internal_mvcc_timestamp:4 i1.tableoid:5
+      │    │    ├── flags: force-index=b_inv
+      │    │    └── locking: for-update
+      │    ├── scan inverted [as=i2]
+      │    │    ├── columns: i2.a:7!null i2.b:8 i2.c:9 i2.crdb_internal_mvcc_timestamp:10 i2.tableoid:11
+      │    │    └── locking: for-update
+      │    └── filters (true)
+      └── filters
+           └── i1.b:2 @> i2.b:8
 
 # ------------------------------------------------------------------------------
 # Tests with virtual tables.

--- a/pkg/sql/opt/xform/index_scan_builder.go
+++ b/pkg/sql/opt/xform/index_scan_builder.go
@@ -170,8 +170,9 @@ func (b *indexScanBuilder) AddIndexJoin(cols opt.ColSet) {
 		panic(errors.AssertionFailedf("cannot call AddIndexJoin after an outer filter has been added"))
 	}
 	b.indexJoinPrivate = memo.IndexJoinPrivate{
-		Table: b.tabID,
-		Cols:  cols,
+		Table:   b.tabID,
+		Cols:    cols,
+		Locking: b.scanPrivate.Locking,
 	}
 }
 

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -398,6 +398,7 @@ func (c *CustomFuncs) generateLookupJoinsImpl(
 		lookupJoin.JoinType = joinType
 		lookupJoin.Table = scanPrivate.Table
 		lookupJoin.Index = index.Ordinal()
+		lookupJoin.Locking = scanPrivate.Locking
 
 		lookupJoin.KeyCols = make(opt.ColList, 0, numIndexKeyCols)
 		rightSideCols := make(opt.ColList, 0, numIndexKeyCols)
@@ -728,6 +729,7 @@ func (c *CustomFuncs) generateLookupJoinsImpl(
 		indexJoin.KeyCols = pkCols
 		indexJoin.Cols = rightCols.Union(inputProps.OutputCols)
 		indexJoin.LookupColsAreTableKey = true
+		indexJoin.Locking = scanPrivate.Locking
 		if pairedJoins {
 			indexJoin.IsSecondJoinInPairedJoiner = true
 		}
@@ -1116,6 +1118,7 @@ func (c *CustomFuncs) GenerateInvertedJoins(
 		invertedJoin.Index = index.Ordinal()
 		invertedJoin.InvertedExpr = invertedExpr
 		invertedJoin.Cols = indexCols.Union(inputCols)
+		invertedJoin.Locking = scanPrivate.Locking
 		if continuationCol != 0 {
 			invertedJoin.Cols.Add(continuationCol)
 			invertedJoin.IsFirstJoinInPairedJoiner = true
@@ -1157,6 +1160,7 @@ func (c *CustomFuncs) GenerateInvertedJoins(
 		indexJoin.KeyCols = c.getPkCols(invertedJoin.Table)
 		indexJoin.Cols = scanPrivate.Cols.Union(inputCols)
 		indexJoin.LookupColsAreTableKey = true
+		indexJoin.Locking = scanPrivate.Locking
 		if continuationCol != 0 {
 			indexJoin.IsSecondJoinInPairedJoiner = true
 		}
@@ -1471,6 +1475,7 @@ func (c *CustomFuncs) ConvertIndexToLookupJoinPrivate(
 		Cols:                  outCols,
 		LookupColsAreTableKey: true,
 		ConstFilters:          nil,
+		Locking:               indexPrivate.Locking,
 		JoinPrivate:           memo.JoinPrivate{},
 	}
 }

--- a/pkg/sql/opt/xform/rules/select.opt
+++ b/pkg/sql/opt/xform/rules/select.opt
@@ -58,17 +58,8 @@
 # constant values in the filters. See comments in GenerateZigzagJoin and
 # sql.rowexec.zigzagJoiner for more details on when a zigzag join can be
 # planned.
-#
-# Zigzag joins are prohibited when the source Scan operator has been configured
-# with a row-level locking mode. This is mostly out of convenience so that these
-# row-level locking modes don't need to added to the ZigzagJoin operator. There
-# doesn't seem to be a strong reason to support this, but if one comes up, it
-# should be possible to lift this restriction.
 [GenerateZigzagJoins, Explore]
-(Select
-    (Scan $scan:*) & (IsCanonicalScan $scan) & ^(IsLocking $scan)
-    $filters:*
-)
+(Select (Scan $scan:*) & (IsCanonicalScan $scan) $filters:*)
 =>
 (GenerateZigzagJoins $scan $filters)
 
@@ -78,17 +69,10 @@
 # row in the primary index could generate multiple inverted index keys. This
 # property can be exploited by zigzag joining on the same inverted index, fixed
 # at any two of the JSON paths we are querying for.
-#
-# Zigzag joins are prohibited when the source Scan operator has been configured
-# with a row-level locking mode. This is mostly out of convenience so that these
-# row-level locking modes don't need to added to the ZigzagJoin operator. There
-# doesn't seem to be a strong reason to support this, but if one comes up, it
-# should be possible to lift this restriction.
 [GenerateInvertedIndexZigzagJoins, Explore]
 (Select
     (Scan $scan:*) &
         (IsCanonicalScan $scan) &
-        ^(IsLocking $scan) &
         (HasInvertedIndexes $scan)
     $filters:*
 )

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -34,6 +34,9 @@ func (c *CustomFuncs) IsLocking(scan *memo.ScanPrivate) bool {
 	return scan.IsLocking()
 }
 
+// Silence unused warning.
+var _ = (*CustomFuncs).IsLocking
+
 // GeneratePartialIndexScans generates unconstrained index scans over all
 // non-inverted, partial indexes with predicates that are implied by the
 // filters. Partial indexes with predicates which cannot be proven to be implied
@@ -1144,6 +1147,8 @@ func (c *CustomFuncs) GenerateZigzagJoins(
 					RightEqCols:    rightEqCols,
 					LeftFixedCols:  leftFixedCols,
 					RightFixedCols: rightFixedCols,
+					LeftLocking:    scanPrivate.Locking,
+					RightLocking:   scanPrivate.Locking,
 				},
 			}
 
@@ -1451,10 +1456,12 @@ func (c *CustomFuncs) GenerateInvertedIndexZigzagJoins(
 		zigzagJoin := memo.ZigzagJoinExpr{
 			On: filters,
 			ZigzagJoinPrivate: memo.ZigzagJoinPrivate{
-				LeftTable:  scanPrivate.Table,
-				LeftIndex:  index.Ordinal(),
-				RightTable: scanPrivate.Table,
-				RightIndex: index.Ordinal(),
+				LeftTable:    scanPrivate.Table,
+				LeftIndex:    index.Ordinal(),
+				RightTable:   scanPrivate.Table,
+				RightIndex:   index.Ordinal(),
+				LeftLocking:  scanPrivate.Locking,
+				RightLocking: scanPrivate.Locking,
 			},
 		}
 

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -1205,6 +1205,7 @@ func (c *CustomFuncs) GenerateZigzagJoins(
 			indexJoin.KeyCols = pkCols
 			indexJoin.Cols = scanPrivate.Cols
 			indexJoin.LookupColsAreTableKey = true
+			indexJoin.Locking = scanPrivate.Locking
 
 			// Create the LookupJoin for the index join in the same group as the
 			// original select.
@@ -1566,6 +1567,7 @@ func (c *CustomFuncs) GenerateInvertedIndexZigzagJoins(
 		indexJoin.KeyCols = pkCols
 		indexJoin.Cols = scanPrivate.Cols
 		indexJoin.LookupColsAreTableKey = true
+		indexJoin.Locking = scanPrivate.Locking
 
 		// Create the LookupJoin for the index join in the same group as the
 		// original select.

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -1133,6 +1133,7 @@ SELECT * FROM b WHERE v >= 1 AND v <= 10 FOR UPDATE
 ----
 index-join b
  ├── columns: k:1!null u:2 v:3!null j:4
+ ├── locking: for-update
  ├── cardinality: [0 - 10]
  ├── volatile
  ├── key: (1)
@@ -1157,6 +1158,7 @@ select
  ├── fd: (1)-->(2-4), (3)-->(1,2,4)
  ├── index-join b
  │    ├── columns: k:1!null u:2 v:3 j:4
+ │    ├── locking: for-update
  │    ├── cardinality: [0 - 10]
  │    ├── volatile
  │    ├── key: (1)
@@ -6161,6 +6163,7 @@ select
  ├── fd: ()-->(2,3)
  ├── index-join pqr
  │    ├── columns: q:2 r:3
+ │    ├── locking: for-update
  │    ├── volatile
  │    ├── fd: ()-->(2)
  │    └── scan pqr@q
@@ -6466,6 +6469,7 @@ SELECT * FROM b WHERE j @> '{"a":1, "c":2}' FOR UPDATE
 ----
 index-join b
  ├── columns: k:1!null u:2 v:3 j:4!null
+ ├── locking: for-update
  ├── volatile
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)~~>(1,2,4)

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -6153,27 +6153,21 @@ memo (optimized, ~7KB, required=[presentation: c:3])
  ├── G7: (variable b)
  └── G8: (const 1)
 
-# GenerateZigzagJoins is disabled in the presence of a row-level locking clause.
-opt
+# GenerateZigzagJoins propagates row-level locking information.
+opt expect=GenerateZigzagJoins
 SELECT q,r FROM pqr WHERE q = 1 AND r = 2 FOR UPDATE
 ----
-select
+inner-join (zigzag pqr@q pqr@r)
  ├── columns: q:2!null r:3!null
+ ├── eq columns: [1] = [1]
+ ├── left fixed columns: [2] = [1]
+ ├── right fixed columns: [3] = [2]
+ ├── left locking: for-update
+ ├── right locking: for-update
  ├── volatile
  ├── fd: ()-->(2,3)
- ├── index-join pqr
- │    ├── columns: q:2 r:3
- │    ├── locking: for-update
- │    ├── volatile
- │    ├── fd: ()-->(2)
- │    └── scan pqr@q
- │         ├── columns: p:1!null q:2!null
- │         ├── constraint: /2/1: [/1 - /1]
- │         ├── locking: for-update
- │         ├── volatile
- │         ├── key: (1)
- │         └── fd: ()-->(2)
  └── filters
+      ├── q:2 = 1 [outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
       └── r:3 = 2 [outer=(3), constraints=(/3: [/2 - /2]; tight), fd=()-->(3)]
 
 # Zigzag join hinting tests
@@ -6462,41 +6456,28 @@ select
  └── filters
       └── (j:4 @> '[3]') OR (j:4 @> '[[1, 2]]') [outer=(4), immutable, constraints=(/4: (/NULL - ])]
 
-# GenerateInvertedIndexZigzagJoins is disabled in the presence of a row-level
-# locking clause.
-opt expect-not=GenerateInvertedIndexZigzagJoins
+# GenerateInvertedIndexZigzagJoins propagates row-level locking information.
+opt expect=GenerateInvertedIndexZigzagJoins
 SELECT * FROM b WHERE j @> '{"a":1, "c":2}' FOR UPDATE
 ----
-index-join b
+inner-join (lookup b)
  ├── columns: k:1!null u:2 v:3 j:4!null
+ ├── key columns: [1] = [1]
+ ├── lookup columns are key
  ├── locking: for-update
  ├── volatile
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
- └── inverted-filter
-      ├── columns: k:1!null
-      ├── inverted expression: /9
-      │    ├── tight: true, unique: true
-      │    ├── union spans: empty
-      │    └── INTERSECTION
-      │         ├── span expression
-      │         │    ├── tight: true, unique: true
-      │         │    └── union spans: ["7a\x00\x01*\x02\x00", "7a\x00\x01*\x02\x00"]
-      │         └── span expression
-      │              ├── tight: true, unique: true
-      │              └── union spans: ["7c\x00\x01*\x04\x00", "7c\x00\x01*\x04\x00"]
-      ├── volatile
-      ├── key: (1)
-      └── scan b@j_inv_idx
-           ├── columns: k:1!null j_inverted_key:9!null
-           ├── inverted constraint: /9/1
-           │    └── spans
-           │         ├── ["7a\x00\x01*\x02\x00", "7a\x00\x01*\x02\x00"]
-           │         └── ["7c\x00\x01*\x04\x00", "7c\x00\x01*\x04\x00"]
-           ├── locking: for-update
-           ├── volatile
-           ├── key: (1)
-           └── fd: (1)-->(9)
+ ├── inner-join (zigzag b@j_inv_idx b@j_inv_idx)
+ │    ├── columns: k:1!null
+ │    ├── eq columns: [1] = [1]
+ │    ├── left fixed columns: [9] = ['\x376100012a0200']
+ │    ├── right fixed columns: [9] = ['\x376300012a0400']
+ │    ├── left locking: for-update
+ │    ├── right locking: for-update
+ │    └── filters (true)
+ └── filters
+      └── j:4 @> '{"a": 1, "c": 2}' [outer=(4), immutable, constraints=(/4: (/NULL - ])]
 
 # Zigzag join should not be produced when there is a NO_ZIGZAG_JOIN hint.
 opt expect-not=GenerateInvertedIndexZigzagJoins

--- a/pkg/sql/opt/xform/testdata/rules/select_for_update
+++ b/pkg/sql/opt/xform/testdata/rules/select_for_update
@@ -1,0 +1,296 @@
+exec-ddl
+CREATE TABLE t (a INT PRIMARY KEY, b INT)
+----
+
+exec-ddl
+CREATE TABLE u (a INT PRIMARY KEY, c INT)
+----
+
+# ------------------------------------------------------------------------------
+# Tests with index joins.
+# ------------------------------------------------------------------------------
+
+exec-ddl
+CREATE TABLE indexed (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  INDEX b_idx(b)
+)
+----
+
+opt
+SELECT * FROM indexed WHERE b = 2 FOR UPDATE
+----
+index-join indexed
+ ├── columns: a:1!null b:2!null c:3
+ ├── locking: for-update
+ ├── volatile
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3)
+ └── scan indexed@b_idx
+      ├── columns: a:1!null b:2!null
+      ├── constraint: /2/1: [/2 - /2]
+      ├── locking: for-update
+      ├── volatile
+      ├── key: (1)
+      └── fd: ()-->(2)
+
+opt
+SELECT * FROM indexed WHERE b BETWEEN 2 AND 10 FOR UPDATE
+----
+index-join indexed
+ ├── columns: a:1!null b:2!null c:3
+ ├── locking: for-update
+ ├── volatile
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ └── scan indexed@b_idx
+      ├── columns: a:1!null b:2!null
+      ├── constraint: /2/1: [/2 - /10]
+      ├── locking: for-update
+      ├── volatile
+      ├── key: (1)
+      └── fd: (1)-->(2)
+
+# ------------------------------------------------------------------------------
+# Tests with lookup joins.
+# ------------------------------------------------------------------------------
+
+opt expect=GenerateLookupJoins
+SELECT c FROM t JOIN u ON t.b = u.a WHERE t.a = 2 FOR UPDATE
+----
+project
+ ├── columns: c:6
+ ├── cardinality: [0 - 1]
+ ├── volatile
+ ├── key: ()
+ ├── fd: ()-->(6)
+ └── inner-join (lookup u)
+      ├── columns: t.a:1!null b:2!null u.a:5!null c:6
+      ├── key columns: [2] = [5]
+      ├── lookup columns are key
+      ├── locking: for-update
+      ├── cardinality: [0 - 1]
+      ├── volatile
+      ├── key: ()
+      ├── fd: ()-->(1,2,5,6), (5)==(2), (2)==(5)
+      ├── scan t
+      │    ├── columns: t.a:1!null b:2
+      │    ├── constraint: /1: [/2 - /2]
+      │    ├── locking: for-update
+      │    ├── cardinality: [0 - 1]
+      │    ├── volatile
+      │    ├── key: ()
+      │    └── fd: ()-->(1,2)
+      └── filters (true)
+
+opt expect=GenerateLookupJoins
+SELECT c FROM t JOIN u ON t.b = u.a WHERE t.a BETWEEN 2 AND 10 FOR UPDATE
+----
+project
+ ├── columns: c:6
+ ├── cardinality: [0 - 9]
+ ├── volatile
+ └── inner-join (lookup u)
+      ├── columns: t.a:1!null b:2!null u.a:5!null c:6
+      ├── key columns: [2] = [5]
+      ├── lookup columns are key
+      ├── locking: for-update
+      ├── cardinality: [0 - 9]
+      ├── volatile
+      ├── key: (1)
+      ├── fd: (1)-->(2), (5)-->(6), (2)==(5), (5)==(2)
+      ├── scan t
+      │    ├── columns: t.a:1!null b:2
+      │    ├── constraint: /1: [/2 - /10]
+      │    ├── locking: for-update
+      │    ├── cardinality: [0 - 9]
+      │    ├── volatile
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      └── filters (true)
+
+opt expect=GenerateLookupJoins
+SELECT * FROM t JOIN indexed ON t.b = indexed.b WHERE t.a = 2 FOR UPDATE
+----
+inner-join (lookup indexed)
+ ├── columns: a:1!null b:2!null a:5!null b:6!null c:7
+ ├── key columns: [5] = [5]
+ ├── lookup columns are key
+ ├── locking: for-update
+ ├── volatile
+ ├── key: (5)
+ ├── fd: ()-->(1,2,6), (5)-->(7), (2)==(6), (6)==(2)
+ ├── inner-join (lookup indexed@b_idx)
+ │    ├── columns: t.a:1!null t.b:2!null indexed.a:5!null indexed.b:6!null
+ │    ├── key columns: [2] = [6]
+ │    ├── locking: for-update
+ │    ├── volatile
+ │    ├── key: (5)
+ │    ├── fd: ()-->(1,2,6), (2)==(6), (6)==(2)
+ │    ├── scan t
+ │    │    ├── columns: t.a:1!null t.b:2
+ │    │    ├── constraint: /1: [/2 - /2]
+ │    │    ├── locking: for-update
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── volatile
+ │    │    ├── key: ()
+ │    │    └── fd: ()-->(1,2)
+ │    └── filters (true)
+ └── filters (true)
+
+# ------------------------------------------------------------------------------
+# Tests with inverted filters and joins.
+# ------------------------------------------------------------------------------
+
+exec-ddl
+CREATE TABLE inverted (
+  a INT PRIMARY KEY,
+  b INT[],
+  c INT,
+  INVERTED INDEX b_inv(b)
+)
+----
+
+opt expect=(GenerateInvertedIndexScans,GenerateInvertedIndexZigzagJoins)
+SELECT * FROM inverted WHERE b @> '{1, 2}' FOR UPDATE
+----
+inner-join (lookup inverted)
+ ├── columns: a:1!null b:2!null c:3
+ ├── key columns: [1] = [1]
+ ├── lookup columns are key
+ ├── locking: for-update
+ ├── volatile
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── inner-join (zigzag inverted@b_inv inverted@b_inv)
+ │    ├── columns: a:1!null
+ │    ├── eq columns: [1] = [1]
+ │    ├── left fixed columns: [6] = ['\x89']
+ │    ├── right fixed columns: [6] = ['\x8a']
+ │    ├── left locking: for-update
+ │    ├── right locking: for-update
+ │    └── filters (true)
+ └── filters
+      └── b:2 @> ARRAY[1,2] [outer=(2), immutable, constraints=(/2: (/NULL - ])]
+
+opt expect=GenerateInvertedIndexScans
+SELECT * FROM inverted WHERE b <@ '{1, 2}' FOR UPDATE
+----
+select
+ ├── columns: a:1!null b:2 c:3
+ ├── volatile
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── index-join inverted
+ │    ├── columns: a:1!null b:2 c:3
+ │    ├── locking: for-update
+ │    ├── volatile
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    └── inverted-filter
+ │         ├── columns: a:1!null
+ │         ├── inverted expression: /6
+ │         │    ├── tight: false, unique: false
+ │         │    └── union spans
+ │         │         ├── ["C", "C"]
+ │         │         └── ["\x89", "\x8b")
+ │         ├── volatile
+ │         ├── key: (1)
+ │         └── scan inverted@b_inv
+ │              ├── columns: a:1!null b_inverted_key:6!null
+ │              ├── inverted constraint: /6/1
+ │              │    └── spans
+ │              │         ├── ["C", "C"]
+ │              │         └── ["\x89", "\x8b")
+ │              ├── locking: for-update
+ │              ├── volatile
+ │              ├── key: (1)
+ │              └── fd: (1)-->(6)
+ └── filters
+      └── b:2 <@ ARRAY[1,2] [outer=(2), immutable]
+
+opt expect=GenerateInvertedJoins
+SELECT * FROM inverted@b_inv AS i1, inverted AS i2 WHERE i1.b @> i2.b FOR UPDATE
+----
+inner-join (lookup inverted [as=i1])
+ ├── columns: a:1!null b:2 c:3 a:7!null b:8 c:9
+ ├── key columns: [19] = [1]
+ ├── lookup columns are key
+ ├── locking: for-update
+ ├── volatile
+ ├── key: (1,7)
+ ├── fd: (1)-->(2,3), (7)-->(8,9)
+ ├── inner-join (inverted inverted@b_inv [as=i1])
+ │    ├── columns: i2.a:7!null i2.b:8 i2.c:9 i1.a:19!null
+ │    ├── inverted-expr
+ │    │    └── i1.b:20 @> i2.b:8
+ │    ├── locking: for-update
+ │    ├── volatile
+ │    ├── key: (7,19)
+ │    ├── fd: (7)-->(8,9)
+ │    ├── scan inverted [as=i2]
+ │    │    ├── columns: i2.a:7!null i2.b:8 i2.c:9
+ │    │    ├── locking: for-update
+ │    │    ├── volatile
+ │    │    ├── key: (7)
+ │    │    └── fd: (7)-->(8,9)
+ │    └── filters (true)
+ └── filters
+      └── i1.b:2 @> i2.b:8 [outer=(2,8), immutable]
+
+# ------------------------------------------------------------------------------
+# Tests with zigzag joins.
+# ------------------------------------------------------------------------------
+
+exec-ddl
+CREATE TABLE zigzag (
+  a INT PRIMARY KEY,
+  b INT,
+  c FLOAT,
+  d JSONB,
+  INDEX b_idx(b),
+  INDEX c_idx(c),
+  INVERTED INDEX d_idx(d)
+)
+----
+
+opt expect=GenerateZigzagJoins
+SELECT a,b,c FROM zigzag WHERE b = 5 AND c = 6.0 FOR UPDATE
+----
+inner-join (zigzag zigzag@b_idx zigzag@c_idx)
+ ├── columns: a:1!null b:2!null c:3!null
+ ├── eq columns: [1] = [1]
+ ├── left fixed columns: [2] = [5]
+ ├── right fixed columns: [3] = [6.0]
+ ├── left locking: for-update
+ ├── right locking: for-update
+ ├── volatile
+ ├── key: (1)
+ ├── fd: ()-->(2,3)
+ └── filters
+      ├── b:2 = 5 [outer=(2), constraints=(/2: [/5 - /5]; tight), fd=()-->(2)]
+      └── c:3 = 6.0 [outer=(3), constraints=(/3: [/6.0 - /6.0]; tight), fd=()-->(3)]
+
+opt expect=(GenerateInvertedIndexScans,GenerateInvertedIndexZigzagJoins)
+SELECT * from zigzag where d @> '{"a": {"b": "c"}, "f": "g"}' FOR UPDATE
+----
+inner-join (lookup zigzag)
+ ├── columns: a:1!null b:2 c:3 d:4!null
+ ├── key columns: [1] = [1]
+ ├── lookup columns are key
+ ├── locking: for-update
+ ├── volatile
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── inner-join (zigzag zigzag@d_idx zigzag@d_idx)
+ │    ├── columns: a:1!null
+ │    ├── eq columns: [1] = [1]
+ │    ├── left fixed columns: [7] = ['\x3761000262000112630001']
+ │    ├── right fixed columns: [7] = ['\x3766000112670001']
+ │    ├── left locking: for-update
+ │    ├── right locking: for-update
+ │    └── filters (true)
+ └── filters
+      └── d:4 @> '{"a": {"b": "c"}, "f": "g"}' [outer=(4), immutable, constraints=(/4: (/NULL - ])]

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -118,10 +118,8 @@ func (ef *execFactory) ConstructScan(
 	}
 	scan.reqOrdering = ReqOrdering(reqOrdering)
 	scan.estimatedRowCount = uint64(params.EstimatedRowCount)
-	if params.Locking.IsLocking() {
-		scan.lockingStrength = descpb.ToScanLockingStrength(params.Locking.Strength)
-		scan.lockingWaitPolicy = descpb.ToScanLockingWaitPolicy(params.Locking.WaitPolicy)
-	}
+	scan.lockingStrength = descpb.ToScanLockingStrength(params.Locking.Strength)
+	scan.lockingWaitPolicy = descpb.ToScanLockingWaitPolicy(params.Locking.WaitPolicy)
 	scan.localityOptimized = params.LocalityOptimized
 	if !ef.isExplain && !ef.planner.isInternalPlanner {
 		idxUsageKey := roachpb.IndexUsageKey{
@@ -597,6 +595,7 @@ func (ef *execFactory) ConstructIndexJoin(
 	keyCols []exec.NodeColumnOrdinal,
 	tableCols exec.TableColumnOrdinalSet,
 	reqOrdering exec.OutputOrdering,
+	locking opt.Locking,
 	limitHint int64,
 ) (exec.Node, error) {
 	tabDesc := table.(*optTable).desc
@@ -613,6 +612,8 @@ func (ef *execFactory) ConstructIndexJoin(
 	idx := tabDesc.GetPrimaryIndex()
 	tableScan.index = idx
 	tableScan.disableBatchLimit()
+	tableScan.lockingStrength = descpb.ToScanLockingStrength(locking.Strength)
+	tableScan.lockingWaitPolicy = descpb.ToScanLockingWaitPolicy(locking.WaitPolicy)
 
 	if !ef.isExplain {
 		idxUsageKey := roachpb.IndexUsageKey{
@@ -671,10 +672,8 @@ func (ef *execFactory) ConstructLookupJoin(
 	}
 
 	tableScan.index = idx
-	if locking.IsLocking() {
-		tableScan.lockingStrength = descpb.ToScanLockingStrength(locking.Strength)
-		tableScan.lockingWaitPolicy = descpb.ToScanLockingWaitPolicy(locking.WaitPolicy)
-	}
+	tableScan.lockingStrength = descpb.ToScanLockingStrength(locking.Strength)
+	tableScan.lockingWaitPolicy = descpb.ToScanLockingWaitPolicy(locking.WaitPolicy)
 
 	if !ef.isExplain {
 		idxUsageKey := roachpb.IndexUsageKey{
@@ -794,6 +793,7 @@ func (ef *execFactory) ConstructInvertedJoin(
 	onCond tree.TypedExpr,
 	isFirstJoinInPairedJoiner bool,
 	reqOrdering exec.OutputOrdering,
+	locking opt.Locking,
 ) (exec.Node, error) {
 	tabDesc := table.(*optTable).desc
 	idx := index.(*optIndex).idx
@@ -805,6 +805,8 @@ func (ef *execFactory) ConstructInvertedJoin(
 		return nil, err
 	}
 	tableScan.index = idx
+	tableScan.lockingStrength = descpb.ToScanLockingStrength(locking.Strength)
+	tableScan.lockingWaitPolicy = descpb.ToScanLockingWaitPolicy(locking.WaitPolicy)
 
 	if !ef.isExplain {
 		idxUsageKey := roachpb.IndexUsageKey{

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -291,10 +291,12 @@ func newInvertedJoiner(
 	if err := fetcher.Init(
 		flowCtx.EvalCtx.Context,
 		row.FetcherInitArgs{
-			LockTimeout: flowCtx.EvalCtx.SessionData().LockTimeout,
-			Alloc:       &ij.alloc,
-			MemMonitor:  flowCtx.EvalCtx.Mon,
-			Spec:        &spec.FetchSpec,
+			LockStrength:   spec.LockingStrength,
+			LockWaitPolicy: spec.LockingWaitPolicy,
+			LockTimeout:    flowCtx.EvalCtx.SessionData().LockTimeout,
+			Alloc:          &ij.alloc,
+			MemMonitor:     flowCtx.EvalCtx.Mon,
+			Spec:           &spec.FetchSpec,
 		},
 	); err != nil {
 		return nil, err

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -457,10 +457,12 @@ func (z *zigzagJoiner) setupInfo(
 	if err := fetcher.Init(
 		flowCtx.EvalCtx.Context,
 		row.FetcherInitArgs{
-			LockTimeout: flowCtx.EvalCtx.SessionData().LockTimeout,
-			Alloc:       &info.alloc,
-			MemMonitor:  flowCtx.EvalCtx.Mon,
-			Spec:        &spec.FetchSpec,
+			LockStrength:   spec.LockingStrength,
+			LockWaitPolicy: spec.LockingWaitPolicy,
+			LockTimeout:    flowCtx.EvalCtx.SessionData().LockTimeout,
+			Alloc:          &info.alloc,
+			MemMonitor:     flowCtx.EvalCtx.Mon,
+			Spec:           &spec.FetchSpec,
 		},
 	); err != nil {
 		return err


### PR DESCRIPTION
Fixes #56941.

The first commit updates the execbuilder to propagate row-level locking modes
through transformations from standard Scan and Join operations to
specialized IndexJoin, LookupJoin, and InvertedJoin operations.

The second commit updates the execbuilder to propagate row-level locking modes
through transformations from standard Scan and Join operations to
ZigZagJoins, and allows for the use of zigzag joins when explicit
row-level locking modes are in use.

Release note (sql change): table scans performed as a part of index
joins, lookup joins, and inverted joins now respect the row-level
locking strength and wait policy specified by the optional
FOR SHARE/UPDATE [NOWAIT] clause on SELECT statements.

Release note (sql change): table scans performed as a part of zigzag
joins now respect the row-level locking strength and wait policy
specified by the optional FOR SHARE/UPDATE [NOWAIT] clause on SELECT
statements.