### PR TITLE
execinfrapb: panic in test builds when encountering malformed metadata

### DIFF
--- a/pkg/sql/execinfrapb/data.go
+++ b/pkg/sql/execinfrapb/data.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/errors"
@@ -308,10 +309,12 @@ func LocalMetaToRemoteProducerMeta(
 		rpm.Value = &RemoteProducerMetadata_Metrics_{
 			Metrics: meta.Metrics,
 		}
-	} else {
+	} else if meta.Err != nil {
 		rpm.Value = &RemoteProducerMetadata_Error{
 			Error: NewError(ctx, meta.Err),
 		}
+	} else if util.CrdbTestBuild {
+		panic("unhandled field in local meta or all fields are nil")
 	}
 	return rpm
 }


### PR DESCRIPTION
Closes #60002 

We've seen cases where no metadata fields are set, causing a panic because we
assume that at least one field is set. This commit adds a panic in test builds
if this is the case and adds some protection against malformed metadata by
ignoring it if no fields are set.

Release note: None