### PR TITLE
sql: drop default value when its dependent sequence is dropped

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -439,7 +439,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 				return err
 			}
 
-			if err := params.p.dropSequencesOwnedByCol(params.ctx, colToDrop.ColumnDesc(), true /* queueJob */); err != nil {
+			if err := params.p.dropSequencesOwnedByCol(params.ctx, colToDrop.ColumnDesc(), true /* queueJob */, t.DropBehavior); err != nil {
 				return err
 			}
 

--- a/pkg/sql/drop_cascade.go
+++ b/pkg/sql/drop_cascade.go
@@ -192,13 +192,11 @@ func (d *dropCascadeState) dropAllCollectedObjects(ctx context.Context, p *plann
 		var cascadedObjects []string
 		var err error
 		if desc.IsView() {
-			// TODO(knz): The names of dependent dropped views should be qualified here.
 			cascadedObjects, err = p.dropViewImpl(ctx, desc, false /* queueJob */, "", tree.DropCascade)
 		} else if desc.IsSequence() {
 			err = p.dropSequenceImpl(ctx, desc, false /* queueJob */, "", tree.DropCascade)
 		} else {
-			// TODO(knz): The names of dependent dropped tables should be qualified here.
-			cascadedObjects, err = p.dropTableImpl(ctx, desc, true /* droppingParent */, "")
+			cascadedObjects, err = p.dropTableImpl(ctx, desc, true /* droppingParent */, "", tree.DropCascade)
 		}
 		if err != nil {
 			return err

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -133,6 +133,7 @@ func (n *dropTableNode) startExec(params runParams) error {
 			droppedDesc,
 			false, /* droppingDatabase */
 			tree.AsStringWithFQNames(n.n, params.Ann()),
+			n.n.DropBehavior,
 		)
 		if err != nil {
 			return err
@@ -270,7 +271,11 @@ func (p *planner) removeInterleave(ctx context.Context, ref descpb.ForeignKeyRef
 // dropped due to `cascade` behavior. droppingParent indicates whether this
 // table's parent (either database or schema) is being dropped
 func (p *planner) dropTableImpl(
-	ctx context.Context, tableDesc *tabledesc.Mutable, droppingParent bool, jobDesc string,
+	ctx context.Context,
+	tableDesc *tabledesc.Mutable,
+	droppingParent bool,
+	jobDesc string,
+	behavior tree.DropBehavior,
 ) ([]string, error) {
 	var droppedViews []string
 
@@ -322,7 +327,7 @@ func (p *planner) dropTableImpl(
 
 	// Drop sequences that the columns of the table own.
 	for _, col := range tableDesc.Columns {
-		if err := p.dropSequencesOwnedByCol(ctx, &col, !droppingParent); err != nil {
+		if err := p.dropSequencesOwnedByCol(ctx, &col, !droppingParent, behavior); err != nil {
 			return droppedViews, err
 		}
 	}

--- a/pkg/sql/logictest/testdata/logic_test/drop_sequence
+++ b/pkg/sql/logictest/testdata/logic_test/drop_sequence
@@ -1,6 +1,12 @@
 # see also file `sequences`
 
 statement ok
+SET sql_safe_updates = true
+
+# Test dropping sequences with/without CASCADE
+subtest drop_sequence
+
+statement ok
 CREATE SEQUENCE drop_test
 
 statement ok
@@ -14,3 +20,314 @@ CREATE SEQUENCE drop_if_exists_test
 
 statement ok
 DROP SEQUENCE IF EXISTS drop_if_exists_test
+
+statement ok
+CREATE SEQUENCE drop_test
+
+statement ok
+CREATE TABLE t1 (i INT NOT NULL DEFAULT nextval('drop_test'))
+
+query TT
+SHOW CREATE TABLE t1
+----
+t1  CREATE TABLE public.t1 (
+    i INT8 NOT NULL DEFAULT nextval('test.public.drop_test':::STRING::REGCLASS),
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+    FAMILY "primary" (i, rowid)
+)
+
+query T
+SELECT pg_get_serial_sequence('t1', 'i')
+----
+public.drop_test
+
+statement error pq: cannot drop sequence drop_test because other objects depend on it
+DROP SEQUENCE drop_test
+
+statement ok
+DROP SEQUENCE drop_test CASCADE
+
+query TT
+SHOW CREATE TABLE t1
+----
+t1  CREATE TABLE public.t1 (
+    i INT8 NOT NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+    FAMILY "primary" (i, rowid)
+)
+
+query T
+SELECT pg_get_serial_sequence('t1', 'i')
+----
+NULL
+
+statement ok
+INSERT INTO t1 VALUES (1)
+
+
+# Test that if a database is dropped with CASCADE and it
+# contains a sequence, that sequence is dropped and any DEFAULT
+# expressions using that sequence will also be dropped.
+subtest drop_database_cascade
+
+statement ok
+CREATE DATABASE other_db
+
+statement ok
+CREATE SEQUENCE other_db.s
+
+statement ok
+CREATE SEQUENCE s
+
+statement ok
+CREATE TABLE foo (
+  i INT NOT NULL DEFAULT nextval('other_db.s'),
+  j INT NOT NULL DEFAULT nextval('s'),
+  FAMILY (i, j)
+)
+
+query TT
+SHOW CREATE TABLE foo
+----
+foo  CREATE TABLE public.foo (
+     i INT8 NOT NULL DEFAULT nextval('other_db.public.s':::STRING::REGCLASS),
+     j INT8 NOT NULL DEFAULT nextval('test.public.s':::STRING::REGCLASS),
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+     FAMILY fam_0_i_j_rowid (i, j, rowid)
+)
+
+query TT
+SELECT pg_get_serial_sequence('foo', 'i'), pg_get_serial_sequence('foo', 'j')
+----
+public.s  public.s
+
+statement error DROP DATABASE on non-empty database without explicit CASCADE
+DROP DATABASE other_db
+
+statement ok
+DROP DATABASE other_db CASCADE
+
+query TT
+SHOW CREATE TABLE foo
+----
+foo  CREATE TABLE public.foo (
+     i INT8 NOT NULL,
+     j INT8 NOT NULL DEFAULT nextval('test.public.s':::STRING::REGCLASS),
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+     FAMILY fam_0_i_j_rowid (i, j, rowid)
+)
+
+query TT
+SELECT pg_get_serial_sequence('foo', 'i'), pg_get_serial_sequence('foo', 'j')
+----
+NULL  public.s
+
+statement ok
+INSERT INTO foo VALUES (1, default)
+
+
+# Test that if a schema is dropped and it contains a sequence,
+# any DEFAULT expressions using that sequence will also be dropped.
+subtest drop_schema_cascade
+
+statement ok
+CREATE SCHEMA other_sc
+
+statement ok
+CREATE SEQUENCE other_sc.s
+
+statement ok
+CREATE TABLE bar (
+  i INT NOT NULL DEFAULT nextval('other_sc.s'),
+  j INT NOT NULL DEFAULT nextval('s'),
+  FAMILY (i, j)
+)
+
+query TT
+SHOW CREATE TABLE bar
+----
+bar  CREATE TABLE public.bar (
+     i INT8 NOT NULL DEFAULT nextval('test.other_sc.s':::STRING::REGCLASS),
+     j INT8 NOT NULL DEFAULT nextval('test.public.s':::STRING::REGCLASS),
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+     FAMILY fam_0_i_j_rowid (i, j, rowid)
+)
+
+query TT
+SELECT pg_get_serial_sequence('bar', 'i'), pg_get_serial_sequence('bar', 'j')
+----
+other_sc.s  public.s
+
+statement error schema "other_sc" is not empty and CASCADE was not specified
+DROP SCHEMA other_sc
+
+statement ok
+DROP SCHEMA other_sc CASCADE
+
+query TT
+SHOW CREATE TABLE bar
+----
+bar  CREATE TABLE public.bar (
+     i INT8 NOT NULL,
+     j INT8 NOT NULL DEFAULT nextval('test.public.s':::STRING::REGCLASS),
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+     FAMILY fam_0_i_j_rowid (i, j, rowid)
+)
+
+query TT
+SELECT pg_get_serial_sequence('bar', 'i'), pg_get_serial_sequence('bar', 'j')
+----
+NULL  public.s
+
+statement ok
+INSERT INTO bar VALUES (1, default)
+
+
+# Test that sequences owned by tables are dropped properly,
+# and if CASCADE is specified, DEFAULT expressions are dropped
+subtest drop_table_cascade
+
+statement ok
+CREATE TABLE t2 (i INT NOT NULL)
+
+statement ok
+CREATE SEQUENCE s2 OWNED BY t2.i
+
+statement ok
+CREATE TABLE t3 (i INT NOT NULL DEFAULT nextval('s2'))
+
+query T
+SELECT pg_get_serial_sequence('t3', 'i')
+----
+public.s2
+
+statement error cannot drop table t2 because other objects depend on it
+DROP TABLE t2
+
+statement ok
+DROP TABLE t2 CASCADE
+
+query TT
+SHOW CREATE TABLE t3
+----
+t3  CREATE TABLE public.t3 (
+    i INT8 NOT NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+    FAMILY "primary" (i, rowid)
+)
+
+query T
+SELECT pg_get_serial_sequence('t3', 'i')
+----
+NULL
+
+statement ok
+INSERT INTO t3 VALUES (1)
+
+statement ok
+CREATE SEQUENCE s3
+
+statement ok
+CREATE TABLE t4 (i INT NOT NULL DEFAULT nextval('s3'))
+
+statement ok
+ALTER SEQUENCE s3 OWNED BY t3.i
+
+query T
+SELECT pg_get_serial_sequence('t4', 'i')
+----
+public.s3
+
+statement ok
+DROP TABLE t3 CASCADE
+
+query TT
+SHOW CREATE TABLE t4
+----
+t4  CREATE TABLE public.t4 (
+    i INT8 NOT NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+    FAMILY "primary" (i, rowid)
+)
+
+query T
+SELECT pg_get_serial_sequence('t4', 'i')
+----
+NULL
+
+statement ok
+INSERT INTO t4 VALUES (1)
+
+
+# Test that sequences owned by columns are dropped properly,
+# and if CASCADE is specified, DEFAULT expressions are dropped
+subtest drop_column_cascade
+
+statement ok
+CREATE TABLE t5 (i INT NOT NULL)
+
+statement ok
+CREATE SEQUENCE s5 OWNED BY t5.i
+
+statement ok
+CREATE TABLE t6 (i INT NOT NULL DEFAULT nextval('s5'))
+
+query T
+SELECT pg_get_serial_sequence('t6', 'i')
+----
+public.s5
+
+statement error ALTER TABLE DROP COLUMN will remove all data in that column
+ALTER TABLE t5 DROP COLUMN i
+
+statement ok
+SET sql_safe_updates = false
+
+statement ok
+ALTER TABLE t5 DROP COLUMN i CASCADE
+
+query TT
+SHOW CREATE TABLE t6
+----
+t6  CREATE TABLE public.t6 (
+    i INT8 NOT NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+    FAMILY "primary" (i, rowid)
+)
+
+query T
+SELECT pg_get_serial_sequence('t6', 'i')
+----
+NULL
+
+statement ok
+INSERT INTO t6 VALUES (1)
+
+
+# Test that sequences owned by columns are dropped properly,
+# and if CASCADE is specified, DEFAULT expressions are dropped
+subtest drop_view
+
+statement ok
+CREATE SEQUENCE s6
+
+statement ok
+CREATE VIEW v AS SELECT nextval('s6')
+
+statement error cannot drop sequence s6 because other objects depend on it
+DROP SEQUENCE s6
+
+statement ok
+DROP SEQUENCE s6 CASCADE
+
+statement error relation "v" does not exist
+SELECT * from v

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -723,7 +723,7 @@ func maybeAddSequenceDependencies(
 // dropSequencesOwnedByCol drops all the sequences from col.OwnsSequenceIDs.
 // Called when the respective column (or the whole table) is being dropped.
 func (p *planner) dropSequencesOwnedByCol(
-	ctx context.Context, col *descpb.ColumnDescriptor, queueJob bool,
+	ctx context.Context, col *descpb.ColumnDescriptor, queueJob bool, behavior tree.DropBehavior,
 ) error {
 	// Copy out the sequence IDs as the code to drop the sequence will reach
 	// back around and update the descriptor from underneath us.
@@ -749,7 +749,7 @@ func (p *planner) dropSequencesOwnedByCol(
 		// Note that this call will end up resolving and modifying the table
 		// descriptor.
 		if err := p.dropSequenceImpl(
-			ctx, seqDesc, queueJob, jobDesc, tree.DropRestrict,
+			ctx, seqDesc, queueJob, jobDesc, behavior,
 		); err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/51889 and https://github.com/cockroachdb/cockroach/issues/20965.

Previously, we did not support `DROP SEQUENCE ... CASCADE`,
and we simply disallowed dropping sequences that have usages by 
tables when a user tries to drop a sequence.

However,  we did not make this check when doing 
`DROP DATABASE/SCHEMA ... CASCADE`. As a result,
if a sequence is used by a table in a different database/schema,
we end up dropping a sequence that the table still relies on,
resulting in a corrupted default expression.

This patch addresses this issue by implementing 
`DROP SCHEMA ... CASCADE`, which solves the above issue.
When we drop anything that contains/owns a sequence with
`CASCADE`, we drop those sequences as if 
`DROP SCHEMA ... CASCADE` was called on them, which
prevents the `DEFAULT` expressions from being corrupted, 
and also allows users to use `DROP SEQUENCE ... CASCADE.

`DROP SEQUENCE ... CASCADE` behaves as in Postgres, 
wherein any default expressions that rely on the dropped 
sequences are also dropped.

Release note (bug fix): Fixed a bug which could result in corrupted descriptors when dropping a database which contains a sequence that was referenced from another database.

Release note (bug fix): Fixed a bug where DROP SEQUENCE CASCADE would not properly remove references to itself from table default expressions.

Release note (sql change): Added support for dropping a table which owns a sequence. 

Release justification: low risk bug fix for existing functionality