### PR TITLE
logic_test: skip RENAME COLUMN test

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -719,100 +719,14 @@ PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@unique_b_a  ALTER PART
                                                                       lease_preferences = '[[+region=ap-southeast-2]]'
 
 # Tests renaming a referenced implicit column in REGIONAL BY ROW succeeds.
-statement ok
-ALTER TABLE regional_by_row_table RENAME COLUMN crdb_region TO crdb_region2
+# Skipped due to #60717.
 
-query T
-SELECT create_statement FROM [SHOW CREATE TABLE regional_by_row_table]
-----
-CREATE TABLE public.regional_by_row_table (
-  pk INT8 NOT NULL,
-  pk2 INT8 NOT NULL,
-  a INT8 NOT NULL,
-  b INT8 NOT NULL,
-  j JSONB NULL,
-  crdb_region2 public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
-  CONSTRAINT "primary" PRIMARY KEY (pk2 ASC),
-  UNIQUE INDEX regional_by_row_table_pk_key (pk ASC),
-  INDEX regional_by_row_table_a_idx (a ASC),
-  UNIQUE INDEX regional_by_row_table_b_key (b ASC),
-  INVERTED INDEX regional_by_row_table_j_idx (j),
-  INDEX new_idx (a ASC, b ASC),
-  UNIQUE INDEX unique_b_a (b ASC, a ASC),
-  FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region2)
-) LOCALITY REGIONAL BY ROW AS crdb_region2;
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@new_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ap-southeast-2: 2}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ap-southeast-2: 2}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ap-southeast-2: 2}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ap-southeast-2: 2}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ap-southeast-2: 2}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@unique_b_a CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ap-southeast-2: 2}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@new_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ca-central-1: 2}',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ca-central-1: 2}',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ca-central-1: 2}',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ca-central-1: 2}',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ca-central-1: 2}',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@unique_b_a CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ca-central-1: 2}',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@new_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=us-east-1: 2}',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=us-east-1: 2}',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=us-east-1: 2}',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=us-east-1: 2}',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=us-east-1: 2}',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@unique_b_a CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=us-east-1: 2}',
-  lease_preferences = '[[+region=us-east-1]]'
+#statement ok
+#ALTER TABLE regional_by_row_table RENAME COLUMN crdb_region TO crdb_region2
+
+#query T
+#SELECT create_statement FROM [SHOW CREATE TABLE regional_by_row_table]
+#----
 
 statement ok
 CREATE TABLE regional_by_row_table_pk_defined_separately (


### PR DESCRIPTION
This seems to flake, no idea why, let's not block CI.

Release note: None