### PR TITLE
sql: hide display of partitions on SHOW CREATE for REGIONAL BY ROW tables

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2315,6 +2315,11 @@ The swap_ordinate_string parameter is a 2-character string naming the ordinates 
 </span></td></tr>
 <tr><td><a name="convert_to"></a><code>convert_to(str: <a href="string.html">string</a>, enc: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Encode the string <code>str</code> as a byte array using encoding <code>enc</code>. Supports encodings ‘UTF8’ and ‘LATIN1’.</p>
 </span></td></tr>
+<tr><td><a name="crdb_internal.filter_multiregion_fields_from_zone_config_sql"></a><code>crdb_internal.filter_multiregion_fields_from_zone_config_sql(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Takes in a CONFIGURE ZONE SQL statement and returns a modified
+SQL statement omitting multi-region related zone configuration fields.
+If the CONFIGURE ZONE statement can be inferred by the database’s or
+table’s zone configuration this will return NULL.</p>
+</span></td></tr>
 <tr><td><a name="crdb_internal.show_create_all_tables"></a><code>crdb_internal.show_create_all_tables(dbName: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns a flat log of CREATE table statements followed by
 ALTER table statements that add table constraints. The flat log can be used
 to recreate a database.’</p>

--- a/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
+++ b/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
@@ -30,41 +30,40 @@ CREATE TABLE regional_by_row (
 query TT
 SHOW CREATE TABLE regional_by_row
 ----
-regional_by_row  CREATE TABLE public.regional_by_row (
-                 pk INT8 NOT NULL,
-                 i INT8 NULL,
-                 crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
-                 CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                 INDEX regional_by_row_i_idx (i ASC),
-                 FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
-) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_row@regional_by_row_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_row@regional_by_row_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_row@regional_by_row_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+regional_by_row             CREATE TABLE public.regional_by_row (
+                            pk INT8 NOT NULL,
+                            i INT8 NULL,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                            INDEX regional_by_row_i_idx (i ASC),
+                            FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -88,41 +87,40 @@ CREATE TABLE regional_by_row_as (
 query TT
 SHOW CREATE TABLE regional_by_row_as
 ----
-regional_by_row_as  CREATE TABLE public.regional_by_row_as (
-                    pk INT8 NOT NULL,
-                    i INT8 NULL,
-                    cr public.crdb_internal_region NOT NULL DEFAULT 'ap-southeast-2':::public.crdb_internal_region,
-                    CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                    INDEX regional_by_row_as_i_idx (i ASC),
-                    FAMILY fam_0_cr_pk_i (cr, pk, i)
-) LOCALITY REGIONAL BY ROW AS cr;
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_row_as@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_row_as@regional_by_row_as_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_row_as@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_row_as@regional_by_row_as_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_row_as@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_row_as@regional_by_row_as_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+regional_by_row_as                CREATE TABLE public.regional_by_row_as (
+                                  pk INT8 NOT NULL,
+                                  i INT8 NULL,
+                                  cr public.crdb_internal_region NOT NULL DEFAULT 'ap-southeast-2':::public.crdb_internal_region,
+                                  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                                  INDEX regional_by_row_as_i_idx (i ASC),
+                                  FAMILY fam_0_cr_pk_i (cr, pk, i)
+) LOCALITY REGIONAL BY ROW AS cr
+
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_as
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_as
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -151,8 +149,31 @@ regional_by_table_in_primary_region             CREATE TABLE public.regional_by_
                                                 FAMILY fam_0_pk_i (pk, i)
 ) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_primary_region
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_primary_region
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -181,8 +202,31 @@ regional_by_table_no_region                     CREATE TABLE public.regional_by_
                                                 FAMILY fam_0_pk_i (pk, i)
 ) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_no_region
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_no_region
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -211,8 +255,31 @@ regional_by_table_in_us_east                 CREATE TABLE public.regional_by_tab
                                              FAMILY fam_0_pk_i (pk, i)
 ) LOCALITY REGIONAL BY TABLE IN "us-east-1"
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_us_east
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_us_east
 ----
 TABLE regional_by_table_in_us_east  ALTER TABLE regional_by_table_in_us_east CONFIGURE ZONE USING
                                     range_min_bytes = 134217728,
@@ -237,8 +304,31 @@ created_as_global  CREATE TABLE public.created_as_global (
                    FAMILY fam_0_pk_i (pk, i)
 ) LOCALITY GLOBAL
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE created_as_global
+SHOW ZONE CONFIGURATION FROM TABLE created_as_global
 ----
 TABLE created_as_global  ALTER TABLE created_as_global CONFIGURE ZONE USING
                          range_min_bytes = 134217728,
@@ -265,8 +355,31 @@ created_as_global                               CREATE TABLE public.created_as_g
                                                 FAMILY fam_0_pk_i (pk, i)
 ) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE created_as_global
+SHOW ZONE CONFIGURATION FROM TABLE created_as_global
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -295,18 +408,41 @@ created_as_global                                 CREATE TABLE public.created_as
                                                   FAMILY fam_0_pk_i (pk, i)
 ) LOCALITY REGIONAL BY TABLE IN "ap-southeast-2"
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE created_as_global
+SHOW ZONE CONFIGURATION FROM TABLE created_as_global
 ----
 TABLE created_as_global  ALTER TABLE created_as_global CONFIGURE ZONE USING
-              range_min_bytes = 134217728,
-              range_max_bytes = 536870912,
-              gc.ttlseconds = 90000,
-              num_replicas = 5,
-              num_voters = 3,
-              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-              voter_constraints = '[+region=ap-southeast-2]',
-              lease_preferences = '[[+region=ap-southeast-2]]'
+                         range_min_bytes = 134217728,
+                         range_max_bytes = 536870912,
+                         gc.ttlseconds = 90000,
+                         num_replicas = 5,
+                         num_voters = 3,
+                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                         voter_constraints = '[+region=ap-southeast-2]',
+                         lease_preferences = '[[+region=ap-southeast-2]]'
 
 # Alter back, to get back to original state
 statement ok
@@ -325,8 +461,31 @@ created_as_global                               CREATE TABLE public.created_as_g
                                                 FAMILY fam_0_pk_i (pk, i)
 ) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE created_as_global
+SHOW ZONE CONFIGURATION FROM TABLE created_as_global
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -369,19 +528,42 @@ CREATE TABLE created_as_global (
 ) LOCALITY GLOBAL;
 INSERT INTO created_as_global VALUES (0, 1, 2)
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE created_as_global
+SHOW ZONE CONFIGURATION FROM TABLE created_as_global
 ----
 TABLE created_as_global  ALTER TABLE created_as_global CONFIGURE ZONE USING
-              range_min_bytes = 134217728,
-              range_max_bytes = 536870912,
-              gc.ttlseconds = 90000,
-              global_reads = true,
-              num_replicas = 5,
-              num_voters = 3,
-              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-              voter_constraints = '[+region=ca-central-1]',
-              lease_preferences = '[[+region=ca-central-1]]'
+                         range_min_bytes = 134217728,
+                         range_max_bytes = 536870912,
+                         gc.ttlseconds = 90000,
+                         global_reads = true,
+                         num_replicas = 5,
+                         num_voters = 3,
+                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                         voter_constraints = '[+region=ca-central-1]',
+                         lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 ALTER TABLE created_as_global ADD COLUMN crdb_region INT;
@@ -405,55 +587,42 @@ ALTER TABLE created_as_global SET LOCALITY REGIONAL BY ROW
 query TT
 SHOW CREATE TABLE created_as_global
 ----
-created_as_global  CREATE TABLE public.created_as_global (
-                   pk INT8 NOT NULL,
-                   i INT8 NULL,
-                   b INT8 NULL,
-                   crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
-                   CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                   INDEX created_as_global_b_idx (b ASC),
-                   UNIQUE INDEX created_as_global_i_key (i ASC),
-                   FAMILY fam_0_pk_i_b (pk, i, b, crdb_region)
-) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.created_as_global@created_as_global_b_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.created_as_global@created_as_global_i_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.created_as_global@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.created_as_global@created_as_global_b_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.created_as_global@created_as_global_i_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.created_as_global@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.created_as_global@created_as_global_b_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.created_as_global@created_as_global_i_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.created_as_global@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+created_as_global           CREATE TABLE public.created_as_global (
+                            pk INT8 NOT NULL,
+                            i INT8 NULL,
+                            b INT8 NULL,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                            INDEX created_as_global_b_idx (b ASC),
+                            UNIQUE INDEX created_as_global_i_key (i ASC),
+                            FAMILY fam_0_pk_i_b (pk, i, b, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE created_as_global
+SHOW ZONE CONFIGURATION FROM TABLE created_as_global
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -517,55 +686,42 @@ ALTER TABLE created_as_global SET LOCALITY REGIONAL BY ROW
 query TT
 SHOW CREATE TABLE created_as_global
 ----
-created_as_global  CREATE TABLE public.created_as_global (
-                   pk INT8 NOT NULL,
-                   i INT8 NULL,
-                   b INT8 NULL,
-                   crdb_region public.crdb_internal_region NOT NULL,
-                   CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                   INDEX created_as_global_b_idx (b ASC),
-                   UNIQUE INDEX created_as_global_i_key (i ASC),
-                   FAMILY fam_0_pk_i_b_crdb_region (pk, i, b, crdb_region)
-) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.created_as_global@created_as_global_b_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.created_as_global@created_as_global_i_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.created_as_global@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.created_as_global@created_as_global_b_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.created_as_global@created_as_global_i_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.created_as_global@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.created_as_global@created_as_global_b_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.created_as_global@created_as_global_i_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.created_as_global@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+created_as_global           CREATE TABLE public.created_as_global (
+                            pk INT8 NOT NULL,
+                            i INT8 NULL,
+                            b INT8 NULL,
+                            crdb_region public.crdb_internal_region NOT NULL,
+                            CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                            INDEX created_as_global_b_idx (b ASC),
+                            UNIQUE INDEX created_as_global_i_key (i ASC),
+                            FAMILY fam_0_pk_i_b_crdb_region (pk, i, b, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE created_as_global
+SHOW ZONE CONFIGURATION FROM TABLE created_as_global
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -580,52 +736,16 @@ DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE 
 query TT
 SHOW CREATE TABLE created_as_global
 ----
-created_as_global  CREATE TABLE public.created_as_global (
-                   pk INT8 NOT NULL,
-                   i INT8 NULL,
-                   b INT8 NULL,
-                   crdb_region public.crdb_internal_region NOT NULL,
-                   CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                   INDEX created_as_global_b_idx (b ASC),
-                   UNIQUE INDEX created_as_global_i_key (i ASC),
-                   FAMILY fam_0_pk_i_b_crdb_region (pk, i, b, crdb_region)
-) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.created_as_global@created_as_global_b_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.created_as_global@created_as_global_i_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.created_as_global@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.created_as_global@created_as_global_b_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.created_as_global@created_as_global_i_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.created_as_global@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.created_as_global@created_as_global_b_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.created_as_global@created_as_global_i_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.created_as_global@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+created_as_global           CREATE TABLE public.created_as_global (
+                            pk INT8 NOT NULL,
+                            i INT8 NULL,
+                            b INT8 NULL,
+                            crdb_region public.crdb_internal_region NOT NULL,
+                            CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                            INDEX created_as_global_b_idx (b ASC),
+                            UNIQUE INDEX created_as_global_i_key (i ASC),
+                            FAMILY fam_0_pk_i_b_crdb_region (pk, i, b, crdb_region)
+) LOCALITY REGIONAL BY ROW
 
 # Test altering to REGIONAL BY ROW AS <col>.
 statement ok
@@ -665,55 +785,42 @@ ALTER TABLE created_as_global SET LOCALITY REGIONAL BY ROW AS "cr"
 query TT
 SHOW CREATE TABLE created_as_global
 ----
-created_as_global  CREATE TABLE public.created_as_global (
-                   pk INT8 NOT NULL,
-                   i INT8 NULL,
-                   b INT8 NULL,
-                   cr public.crdb_internal_region NOT NULL,
-                   CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                   INDEX created_as_global_b_idx (b ASC),
-                   UNIQUE INDEX created_as_global_i_key (i ASC),
-                   FAMILY fam_0_pk_i_b_cr (pk, i, b, cr)
-) LOCALITY REGIONAL BY ROW AS cr;
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.created_as_global@created_as_global_b_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.created_as_global@created_as_global_i_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.created_as_global@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.created_as_global@created_as_global_b_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.created_as_global@created_as_global_i_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.created_as_global@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.created_as_global@created_as_global_b_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.created_as_global@created_as_global_i_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.created_as_global@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+created_as_global                 CREATE TABLE public.created_as_global (
+                                  pk INT8 NOT NULL,
+                                  i INT8 NULL,
+                                  b INT8 NULL,
+                                  cr public.crdb_internal_region NOT NULL,
+                                  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                                  INDEX created_as_global_b_idx (b ASC),
+                                  UNIQUE INDEX created_as_global_i_key (i ASC),
+                                  FAMILY fam_0_pk_i_b_cr (pk, i, b, cr)
+) LOCALITY REGIONAL BY ROW AS cr
+
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE created_as_global
+SHOW ZONE CONFIGURATION FROM TABLE created_as_global
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -743,8 +850,31 @@ regional_by_table_in_primary_region               CREATE TABLE public.regional_b
                                                   FAMILY fam_0_pk_i (pk, i)
 ) LOCALITY REGIONAL BY TABLE IN "ap-southeast-2"
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_primary_region
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_primary_region
 ----
 TABLE regional_by_table_in_primary_region  ALTER TABLE regional_by_table_in_primary_region CONFIGURE ZONE USING
                                            range_min_bytes = 134217728,
@@ -770,8 +900,31 @@ regional_by_table_in_primary_region             CREATE TABLE public.regional_by_
                                                 FAMILY fam_0_pk_i (pk, i)
 ) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_primary_region
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_primary_region
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -797,8 +950,31 @@ regional_by_table_in_primary_region             CREATE TABLE public.regional_by_
                                                 FAMILY fam_0_pk_i (pk, i)
 ) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_primary_region
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_primary_region
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -823,8 +999,31 @@ regional_by_table_in_primary_region             CREATE TABLE public.regional_by_
                                                 FAMILY fam_0_pk_i (pk, i)
 ) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_primary_region
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_primary_region
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -849,8 +1048,31 @@ regional_by_table_in_primary_region  CREATE TABLE public.regional_by_table_in_pr
                                      FAMILY fam_0_pk_i (pk, i)
 ) LOCALITY GLOBAL
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_primary_region
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_primary_region
 ----
 TABLE regional_by_table_in_primary_region  ALTER TABLE regional_by_table_in_primary_region CONFIGURE ZONE USING
                                            range_min_bytes = 134217728,
@@ -890,8 +1112,31 @@ regional_by_table_no_region                     CREATE TABLE public.regional_by_
                                                 FAMILY fam_0_pk_i (pk, i)
 ) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_no_region
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_no_region
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -927,8 +1172,31 @@ regional_by_table_no_region                       CREATE TABLE public.regional_b
                                                   FAMILY fam_0_pk_i (pk, i)
 ) LOCALITY REGIONAL BY TABLE IN "ap-southeast-2"
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_no_region
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_no_region
 ----
 TABLE regional_by_table_no_region  ALTER TABLE regional_by_table_no_region CONFIGURE ZONE USING
                                    range_min_bytes = 134217728,
@@ -960,8 +1228,31 @@ regional_by_table_no_region                     CREATE TABLE public.regional_by_
                                                 FAMILY "primary" (i, rowid)
 ) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_no_region
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_no_region
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -986,8 +1277,31 @@ regional_by_table_no_region  CREATE TABLE public.regional_by_table_no_region (
                              FAMILY "primary" (i, rowid)
 ) LOCALITY GLOBAL
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_no_region
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_no_region
 ----
 TABLE regional_by_table_no_region  ALTER TABLE regional_by_table_no_region CONFIGURE ZONE USING
                                    range_min_bytes = 134217728,
@@ -1029,43 +1343,7 @@ regional_by_table_no_region  CREATE TABLE public.regional_by_table_no_region (
                              INDEX regional_by_table_no_region_b_idx (b ASC),
                              UNIQUE INDEX regional_by_table_no_region_i_key (i ASC),
                              FAMILY fam_0_pk_i_b (pk, i, b, crdb_region)
-) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_table_no_region@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_table_no_region@regional_by_table_no_region_b_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_table_no_region@regional_by_table_no_region_i_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_table_no_region@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_table_no_region@regional_by_table_no_region_b_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_table_no_region@regional_by_table_no_region_i_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_table_no_region@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_table_no_region@regional_by_table_no_region_b_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_table_no_region@regional_by_table_no_region_i_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+) LOCALITY REGIONAL BY ROW
 
 statement ok
 DROP TABLE regional_by_table_no_region;
@@ -1080,8 +1358,31 @@ CREATE TABLE regional_by_table_no_region (
 ) LOCALITY REGIONAL BY TABLE;
 INSERT INTO regional_by_table_no_region VALUES (0, 1, 2, 'us-east-1')
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_no_region
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_no_region
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -1114,55 +1415,42 @@ ALTER TABLE regional_by_table_no_region SET LOCALITY REGIONAL BY ROW AS "cr"
 query TT
 SHOW CREATE TABLE regional_by_table_no_region
 ----
-regional_by_table_no_region  CREATE TABLE public.regional_by_table_no_region (
-                             pk INT8 NOT NULL,
-                             i INT8 NULL,
-                             b INT8 NULL,
-                             cr public.crdb_internal_region NOT NULL,
-                             CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                             INDEX regional_by_table_no_region_b_idx (b ASC),
-                             UNIQUE INDEX regional_by_table_no_region_i_key (i ASC),
-                             FAMILY fam_0_pk_i_b_cr (pk, i, b, cr)
-) LOCALITY REGIONAL BY ROW AS cr;
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_table_no_region@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_table_no_region@regional_by_table_no_region_b_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_table_no_region@regional_by_table_no_region_i_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_table_no_region@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_table_no_region@regional_by_table_no_region_b_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_table_no_region@regional_by_table_no_region_i_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_table_no_region@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_table_no_region@regional_by_table_no_region_b_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_table_no_region@regional_by_table_no_region_i_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+regional_by_table_no_region       CREATE TABLE public.regional_by_table_no_region (
+                                  pk INT8 NOT NULL,
+                                  i INT8 NULL,
+                                  b INT8 NULL,
+                                  cr public.crdb_internal_region NOT NULL,
+                                  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                                  INDEX regional_by_table_no_region_b_idx (b ASC),
+                                  UNIQUE INDEX regional_by_table_no_region_i_key (i ASC),
+                                  FAMILY fam_0_pk_i_b_cr (pk, i, b, cr)
+) LOCALITY REGIONAL BY ROW AS cr
+
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_no_region
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_no_region
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -1189,8 +1477,31 @@ regional_by_table_in_us_east                    CREATE TABLE public.regional_by_
                                                 FAMILY fam_0_pk_i (pk, i)
 ) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_us_east
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_us_east
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -1218,8 +1529,31 @@ regional_by_table_in_us_east                      CREATE TABLE public.regional_b
                                                   FAMILY fam_0_pk_i (pk, i)
 ) LOCALITY REGIONAL BY TABLE IN "ap-southeast-2"
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_us_east
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_us_east
 ----
 TABLE regional_by_table_in_us_east  ALTER TABLE regional_by_table_in_us_east CONFIGURE ZONE USING
                                     range_min_bytes = 134217728,
@@ -1247,8 +1581,31 @@ regional_by_table_in_us_east                    CREATE TABLE public.regional_by_
                                                 FAMILY fam_0_pk_i (pk, i)
 ) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_us_east
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_us_east
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -1273,8 +1630,31 @@ regional_by_table_in_us_east  CREATE TABLE public.regional_by_table_in_us_east (
                               FAMILY fam_0_pk_i (pk, i)
 ) LOCALITY GLOBAL
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_us_east
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_us_east
 ----
 TABLE regional_by_table_in_us_east  ALTER TABLE regional_by_table_in_us_east CONFIGURE ZONE USING
                                     range_min_bytes = 134217728,
@@ -1314,46 +1694,33 @@ regional_by_table_in_us_east  CREATE TABLE public.regional_by_table_in_us_east (
                               INDEX regional_by_table_in_us_east_b_idx (b ASC),
                               UNIQUE INDEX regional_by_table_in_us_east_i_key (i ASC),
                               FAMILY fam_0_pk_i_b (pk, i, b, crdb_region)
-) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_table_in_us_east@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_table_in_us_east@regional_by_table_in_us_east_b_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_table_in_us_east@regional_by_table_in_us_east_i_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_table_in_us_east@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_table_in_us_east@regional_by_table_in_us_east_b_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_table_in_us_east@regional_by_table_in_us_east_i_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_table_in_us_east@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_table_in_us_east@regional_by_table_in_us_east_b_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_table_in_us_east@regional_by_table_in_us_east_i_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+) LOCALITY REGIONAL BY ROW
+
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_us_east
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_us_east
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -1384,55 +1751,42 @@ ALTER TABLE regional_by_table_in_us_east SET LOCALITY REGIONAL BY ROW AS "cr"
 query TT
 SHOW CREATE TABLE regional_by_table_in_us_east
 ----
-regional_by_table_in_us_east  CREATE TABLE public.regional_by_table_in_us_east (
-                              pk INT8 NOT NULL,
-                              i INT8 NULL,
-                              b INT8 NULL,
-                              cr public.crdb_internal_region NOT NULL,
-                              CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                              INDEX regional_by_table_in_us_east_b_idx (b ASC),
-                              UNIQUE INDEX regional_by_table_in_us_east_i_key (i ASC),
-                              FAMILY fam_0_pk_i_b_cr (pk, i, b, cr)
-) LOCALITY REGIONAL BY ROW AS cr;
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_table_in_us_east@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_table_in_us_east@regional_by_table_in_us_east_b_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_table_in_us_east@regional_by_table_in_us_east_i_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_table_in_us_east@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_table_in_us_east@regional_by_table_in_us_east_b_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_table_in_us_east@regional_by_table_in_us_east_i_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_table_in_us_east@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_table_in_us_east@regional_by_table_in_us_east_b_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_table_in_us_east@regional_by_table_in_us_east_i_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+regional_by_table_in_us_east      CREATE TABLE public.regional_by_table_in_us_east (
+                                  pk INT8 NOT NULL,
+                                  i INT8 NULL,
+                                  b INT8 NULL,
+                                  cr public.crdb_internal_region NOT NULL,
+                                  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                                  INDEX regional_by_table_in_us_east_b_idx (b ASC),
+                                  UNIQUE INDEX regional_by_table_in_us_east_i_key (i ASC),
+                                  FAMILY fam_0_pk_i_b_cr (pk, i, b, cr)
+) LOCALITY REGIONAL BY ROW AS cr
+
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_us_east
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_us_east
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -1462,8 +1816,13 @@ regional_by_row                                 CREATE TABLE public.regional_by_
                                                 FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
 ) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -1498,8 +1857,13 @@ regional_by_row                                   CREATE TABLE public.regional_b
                                                   FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
 ) LOCALITY REGIONAL BY TABLE IN "ap-southeast-2"
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 TABLE regional_by_row  ALTER TABLE regional_by_row CONFIGURE ZONE USING
                        range_min_bytes = 134217728,
@@ -1534,8 +1898,13 @@ regional_by_row                                 CREATE TABLE public.regional_by_
                                                 FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
 ) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -1570,8 +1939,13 @@ regional_by_row    CREATE TABLE public.regional_by_row (
                    FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
 ) LOCALITY GLOBAL
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 TABLE regional_by_row  ALTER TABLE regional_by_row CONFIGURE ZONE USING
                        range_min_bytes = 134217728,
@@ -1598,41 +1972,40 @@ ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY ROW
 query TT
 SHOW CREATE TABLE regional_by_row
 ----
-regional_by_row  CREATE TABLE public.regional_by_row (
-                 pk INT8 NOT NULL,
-                 i INT8 NULL,
-                 crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
-                 CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                 INDEX regional_by_row_i_idx (i ASC),
-                 FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
-) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_row@regional_by_row_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_row@regional_by_row_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_row@regional_by_row_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+regional_by_row             CREATE TABLE public.regional_by_row (
+                            pk INT8 NOT NULL,
+                            i INT8 NULL,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                            INDEX regional_by_row_i_idx (i ASC),
+                            FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -1650,41 +2023,40 @@ ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY ROW AS crdb_region
 query TT
 SHOW CREATE TABLE regional_by_row
 ----
-regional_by_row  CREATE TABLE public.regional_by_row (
-                 pk INT8 NOT NULL,
-                 i INT8 NULL,
-                 crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
-                 CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                 INDEX regional_by_row_i_idx (i ASC),
-                 FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
-) LOCALITY REGIONAL BY ROW AS crdb_region;
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_row@regional_by_row_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_row@regional_by_row_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_row@regional_by_row_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+regional_by_row                            CREATE TABLE public.regional_by_row (
+                                           pk INT8 NOT NULL,
+                                           i INT8 NULL,
+                                           crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                                           CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                                           INDEX regional_by_row_i_idx (i ASC),
+                                           FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
+) LOCALITY REGIONAL BY ROW AS crdb_region
+
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -1703,41 +2075,40 @@ ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY ROW
 query TT
 SHOW CREATE TABLE regional_by_row
 ----
-regional_by_row  CREATE TABLE public.regional_by_row (
-                 pk INT8 NOT NULL,
-                 i INT8 NULL,
-                 crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
-                 CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                 INDEX regional_by_row_i_idx (i ASC),
-                 FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
-) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_row@regional_by_row_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_row@regional_by_row_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_row@regional_by_row_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+regional_by_row             CREATE TABLE public.regional_by_row (
+                            pk INT8 NOT NULL,
+                            i INT8 NULL,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                            INDEX regional_by_row_i_idx (i ASC),
+                            FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -1771,34 +2142,33 @@ regional_by_row_to_regional_by_row_as  CREATE TABLE public.regional_by_row_to_re
                                        CONSTRAINT "primary" PRIMARY KEY (pk ASC),
                                        INDEX regional_by_row_to_regional_by_row_as_i_idx (i ASC),
                                        FAMILY fam_0_pk_i_cr_crdb_region (pk, i, cr, crdb_region)
-) LOCALITY REGIONAL BY ROW AS cr;
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_row_to_regional_by_row_as@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_row_to_regional_by_row_as@regional_by_row_to_regional_by_row_as_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_row_to_regional_by_row_as@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_row_to_regional_by_row_as@regional_by_row_to_regional_by_row_as_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_row_to_regional_by_row_as@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_row_to_regional_by_row_as@regional_by_row_to_regional_by_row_as_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+) LOCALITY REGIONAL BY ROW AS cr
+
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_to_regional_by_row_as
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_to_regional_by_row_as
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -1828,8 +2198,31 @@ regional_by_row_as                              CREATE TABLE public.regional_by_
                                                 FAMILY fam_0_cr_pk_i (cr, pk, i)
 ) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_as
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_as
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -1865,8 +2258,31 @@ regional_by_row_as                                CREATE TABLE public.regional_b
                                                   FAMILY fam_0_cr_pk_i (cr, pk, i)
 ) LOCALITY REGIONAL BY TABLE IN "ap-southeast-2"
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_as
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_as
 ----
 TABLE regional_by_row_as  ALTER TABLE regional_by_row_as CONFIGURE ZONE USING
                           range_min_bytes = 134217728,
@@ -1902,8 +2318,31 @@ regional_by_row_as                              CREATE TABLE public.regional_by_
                                                 FAMILY fam_0_cr_pk_i (cr, pk, i)
 ) LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_as
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_as
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -1939,8 +2378,31 @@ regional_by_row_as  CREATE TABLE public.regional_by_row_as (
                     FAMILY fam_0_cr_pk_i (cr, pk, i)
 ) LOCALITY GLOBAL
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_as
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_as
 ----
 TABLE regional_by_row_as  ALTER TABLE regional_by_row_as CONFIGURE ZONE USING
                           range_min_bytes = 134217728,
@@ -1975,34 +2437,33 @@ regional_by_row_as_to_regional_by_row  CREATE TABLE public.regional_by_row_as_to
                                        CONSTRAINT "primary" PRIMARY KEY (pk ASC),
                                        INDEX regional_by_row_as_to_regional_by_row_i_idx (i ASC),
                                        FAMILY fam_0_cr_pk_i (cr, pk, i, crdb_region)
-) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_row_as_to_regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_row_as_to_regional_by_row@regional_by_row_as_to_regional_by_row_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_row_as_to_regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_row_as_to_regional_by_row@regional_by_row_as_to_regional_by_row_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_row_as_to_regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_row_as_to_regional_by_row@regional_by_row_as_to_regional_by_row_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+) LOCALITY REGIONAL BY ROW
+
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_as_to_regional_by_row
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_as_to_regional_by_row
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -2029,41 +2490,40 @@ ALTER TABLE regional_by_row_as SET LOCALITY REGIONAL BY ROW AS "cr"
 query TT
 SHOW CREATE TABLE regional_by_row_as
 ----
-regional_by_row_as  CREATE TABLE public.regional_by_row_as (
-                    pk INT8 NOT NULL,
-                    i INT8 NULL,
-                    cr public.crdb_internal_region NOT NULL DEFAULT 'ap-southeast-2':::public.crdb_internal_region,
-                    CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                    INDEX regional_by_row_as_i_idx (i ASC),
-                    FAMILY fam_0_cr_pk_i (cr, pk, i)
-) LOCALITY REGIONAL BY ROW AS cr;
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_row_as@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX alter_locality_test.public.regional_by_row_as@regional_by_row_as_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_row_as@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX alter_locality_test.public.regional_by_row_as@regional_by_row_as_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_row_as@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX alter_locality_test.public.regional_by_row_as@regional_by_row_as_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+regional_by_row_as                CREATE TABLE public.regional_by_row_as (
+                                  pk INT8 NOT NULL,
+                                  i INT8 NULL,
+                                  cr public.crdb_internal_region NOT NULL DEFAULT 'ap-southeast-2':::public.crdb_internal_region,
+                                  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                                  INDEX regional_by_row_as_i_idx (i ASC),
+                                  FAMILY fam_0_cr_pk_i (cr, pk, i)
+) LOCALITY REGIONAL BY ROW AS cr
+
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_as
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_as
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
                               range_min_bytes = 134217728,
@@ -2081,8 +2541,31 @@ DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE 
 statement ok
 CREATE TABLE rbt_table_gc_ttl () LOCALITY REGIONAL BY TABLE IN "us-east-1"
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE rbt_table_gc_ttl
+SHOW ZONE CONFIGURATION FROM TABLE rbt_table_gc_ttl
 ----
 TABLE rbt_table_gc_ttl  ALTER TABLE rbt_table_gc_ttl CONFIGURE ZONE USING
                         range_min_bytes = 134217728,
@@ -2098,8 +2581,31 @@ statement ok
 ALTER TABLE rbt_table_gc_ttl CONFIGURE ZONE USING gc.ttlseconds = 999;
 ALTER TABLE rbt_table_gc_ttl SET LOCALITY REGIONAL BY TABLE IN PRIMARY REGION
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE rbt_table_gc_ttl
+SHOW ZONE CONFIGURATION FROM TABLE rbt_table_gc_ttl
 ----
 TABLE rbt_table_gc_ttl  ALTER TABLE rbt_table_gc_ttl CONFIGURE ZONE USING
                         range_min_bytes = 134217728,
@@ -2110,4 +2616,3 @@ TABLE rbt_table_gc_ttl  ALTER TABLE rbt_table_gc_ttl CONFIGURE ZONE USING
                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
                         voter_constraints = '[+region=ca-central-1]',
                         lease_preferences = '[[+region=ca-central-1]]'
-

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_backup
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_backup
@@ -46,8 +46,13 @@ CREATE TABLE regional_by_table_in_ca_central_1 (
   FAMILY (pk, i)
 ) LOCALITY REGIONAL BY TABLE IN "ca-central-1"
 
+query TTT
+SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE global_table]
+ORDER BY partition_name, index_name
+----
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE global_table
+SHOW ZONE CONFIGURATION FROM TABLE global_table
 ----
 TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
                     range_min_bytes = 134217728,
@@ -60,8 +65,49 @@ TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
                     voter_constraints = '[+region=ca-central-1]',
                     lease_preferences = '[[+region=ca-central-1]]'
 
+query TTT
+SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_row_table]
+ORDER BY partition_name, index_name
+----
+ap-southeast-2  regional_by_row_table@primary  num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ap-southeast-2                                    regional_by_row_table@regional_by_row_table_a_idx  num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ap-southeast-2                                    regional_by_row_table@regional_by_row_table_b_key  num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ap-southeast-2                                    regional_by_row_table@regional_by_row_table_j_idx  num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ca-central-1                                      regional_by_row_table@primary  num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+ca-central-1                                    regional_by_row_table@regional_by_row_table_a_idx  num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+ca-central-1                                    regional_by_row_table@regional_by_row_table_b_key  num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+ca-central-1                                    regional_by_row_table@regional_by_row_table_j_idx  num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+us-east-1                                       regional_by_row_table@primary  num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+us-east-1                                    regional_by_row_table@regional_by_row_table_a_idx  num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+us-east-1                                    regional_by_row_table@regional_by_row_table_b_key  num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+us-east-1                                    regional_by_row_table@regional_by_row_table_j_idx  num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_table
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_table
 ----
 DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
                         range_min_bytes = 134217728,
@@ -76,70 +122,27 @@ DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
 query TT
 SHOW CREATE TABLE regional_by_row_table
 ----
-regional_by_row_table  CREATE TABLE public.regional_by_row_table (
-                       pk INT8 NOT NULL,
-                       pk2 INT8 NOT NULL,
-                       a INT8 NOT NULL,
-                       b INT8 NOT NULL,
-                       j JSONB NULL,
-                       crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
-                       CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                       INDEX regional_by_row_table_a_idx (a ASC),
-                       UNIQUE INDEX regional_by_row_table_b_key (b ASC),
-                       INVERTED INDEX regional_by_row_table_j_idx (j),
-                       FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
-) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-1".public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-1".public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX "mr-backup-1".public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+regional_by_row_table       CREATE TABLE public.regional_by_row_table (
+                            pk INT8 NOT NULL,
+                            pk2 INT8 NOT NULL,
+                            a INT8 NOT NULL,
+                            b INT8 NOT NULL,
+                            j JSONB NULL,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                            INDEX regional_by_row_table_a_idx (a ASC),
+                            UNIQUE INDEX regional_by_row_table_b_key (b ASC),
+                            INVERTED INDEX regional_by_row_table_j_idx (j),
+                            FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+query TTT
+SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_table_in_primary_region]
+ORDER BY partition_name, index_name
+----
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_primary_region
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_primary_region
 ----
 DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
                         range_min_bytes = 134217728,
@@ -151,8 +154,13 @@ DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
                         voter_constraints = '[+region=ca-central-1]',
                         lease_preferences = '[[+region=ca-central-1]]'
 
+query TTT
+SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_table_in_ca_central_1]
+ORDER BY partition_name, index_name
+----
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_ca_central_1
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_ca_central_1
 ----
 TABLE regional_by_table_in_ca_central_1  ALTER TABLE regional_by_table_in_ca_central_1 CONFIGURE ZONE USING
                                          range_min_bytes = 134217728,
@@ -198,8 +206,13 @@ CREATE TABLE regional_by_table_in_ca_central_1 (
   FAMILY (pk, i)
 ) LOCALITY REGIONAL BY TABLE IN "ca-central-1"
 
+query TTT
+SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE global_table]
+ORDER BY partition_name, index_name
+----
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE global_table
+SHOW ZONE CONFIGURATION FROM TABLE global_table
 ----
 TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
                     range_min_bytes = 134217728,
@@ -212,8 +225,49 @@ TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
                     voter_constraints = '[+region=ap-southeast-2]',
                     lease_preferences = '[[+region=ap-southeast-2]]'
 
+query TTT
+SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_row_table]
+ORDER BY partition_name, index_name
+----
+ap-southeast-2  regional_by_row_table@primary  num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ap-southeast-2                                    regional_by_row_table@regional_by_row_table_a_idx  num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ap-southeast-2                                    regional_by_row_table@regional_by_row_table_b_key  num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ap-southeast-2                                    regional_by_row_table@regional_by_row_table_j_idx  num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ca-central-1                                      regional_by_row_table@primary  num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+ca-central-1                                    regional_by_row_table@regional_by_row_table_a_idx  num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+ca-central-1                                    regional_by_row_table@regional_by_row_table_b_key  num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+ca-central-1                                    regional_by_row_table@regional_by_row_table_j_idx  num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+us-east-1                                       regional_by_row_table@primary  num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+us-east-1                                    regional_by_row_table@regional_by_row_table_a_idx  num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+us-east-1                                    regional_by_row_table@regional_by_row_table_b_key  num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+us-east-1                                    regional_by_row_table@regional_by_row_table_j_idx  num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_table
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_table
 ----
 DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
                         range_min_bytes = 134217728,
@@ -228,70 +282,27 @@ DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
 query TT
 SHOW CREATE TABLE regional_by_row_table
 ----
-regional_by_row_table  CREATE TABLE public.regional_by_row_table (
-                       pk INT8 NOT NULL,
-                       pk2 INT8 NOT NULL,
-                       a INT8 NOT NULL,
-                       b INT8 NOT NULL,
-                       j JSONB NULL,
-                       crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
-                       CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                       INDEX regional_by_row_table_a_idx (a ASC),
-                       UNIQUE INDEX regional_by_row_table_b_key (b ASC),
-                       INVERTED INDEX regional_by_row_table_j_idx (j),
-                       FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
-) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-2".public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-2".public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX "mr-backup-2".public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+regional_by_row_table       CREATE TABLE public.regional_by_row_table (
+                            pk INT8 NOT NULL,
+                            pk2 INT8 NOT NULL,
+                            a INT8 NOT NULL,
+                            b INT8 NOT NULL,
+                            j JSONB NULL,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                            INDEX regional_by_row_table_a_idx (a ASC),
+                            UNIQUE INDEX regional_by_row_table_b_key (b ASC),
+                            INVERTED INDEX regional_by_row_table_j_idx (j),
+                            FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+query TTT
+SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_table_in_primary_region]
+ORDER BY partition_name, index_name
+----
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_primary_region
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_primary_region
 ----
 DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
                         range_min_bytes = 134217728,
@@ -303,8 +314,13 @@ DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
                         voter_constraints = '[+region=ap-southeast-2]',
                         lease_preferences = '[[+region=ap-southeast-2]]'
 
+query TTT
+SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_table_in_ca_central_1]
+ORDER BY partition_name, index_name
+----
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_ca_central_1
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_ca_central_1
 ----
 TABLE regional_by_table_in_ca_central_1  ALTER TABLE regional_by_table_in_ca_central_1 CONFIGURE ZONE USING
                                          range_min_bytes = 134217728,
@@ -402,8 +418,13 @@ DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
 statement ok
 use "mr-backup-1"
 
+query TTT
+SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE global_table]
+ORDER BY partition_name, index_name
+----
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE global_table
+SHOW ZONE CONFIGURATION FROM TABLE global_table
 ----
 TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
                     range_min_bytes = 134217728,
@@ -416,8 +437,49 @@ TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
                     voter_constraints = '[+region=ca-central-1]',
                     lease_preferences = '[[+region=ca-central-1]]'
 
+query TTT
+SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_row_table]
+ORDER BY partition_name, index_name
+----
+ap-southeast-2  regional_by_row_table@primary  num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ap-southeast-2                                    regional_by_row_table@regional_by_row_table_a_idx  num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ap-southeast-2                                    regional_by_row_table@regional_by_row_table_b_key  num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ap-southeast-2                                    regional_by_row_table@regional_by_row_table_j_idx  num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ca-central-1                                      regional_by_row_table@primary  num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+ca-central-1                                    regional_by_row_table@regional_by_row_table_a_idx  num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+ca-central-1                                    regional_by_row_table@regional_by_row_table_b_key  num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+ca-central-1                                    regional_by_row_table@regional_by_row_table_j_idx  num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+us-east-1                                       regional_by_row_table@primary  num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+us-east-1                                    regional_by_row_table@regional_by_row_table_a_idx  num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+us-east-1                                    regional_by_row_table@regional_by_row_table_b_key  num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+us-east-1                                    regional_by_row_table@regional_by_row_table_j_idx  num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_table
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_table
 ----
 DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
                         range_min_bytes = 134217728,
@@ -432,70 +494,27 @@ DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
 query TT
 SHOW CREATE TABLE regional_by_row_table
 ----
-regional_by_row_table  CREATE TABLE public.regional_by_row_table (
-                       pk INT8 NOT NULL,
-                       pk2 INT8 NOT NULL,
-                       a INT8 NOT NULL,
-                       b INT8 NOT NULL,
-                       j JSONB NULL,
-                       crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
-                       CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                       INDEX regional_by_row_table_a_idx (a ASC),
-                       UNIQUE INDEX regional_by_row_table_b_key (b ASC),
-                       INVERTED INDEX regional_by_row_table_j_idx (j),
-                       FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
-) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-1".public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-1".public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX "mr-backup-1".public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+regional_by_row_table       CREATE TABLE public.regional_by_row_table (
+                            pk INT8 NOT NULL,
+                            pk2 INT8 NOT NULL,
+                            a INT8 NOT NULL,
+                            b INT8 NOT NULL,
+                            j JSONB NULL,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                            INDEX regional_by_row_table_a_idx (a ASC),
+                            UNIQUE INDEX regional_by_row_table_b_key (b ASC),
+                            INVERTED INDEX regional_by_row_table_j_idx (j),
+                            FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+query TTT
+SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_table_in_primary_region]
+ORDER BY partition_name, index_name
+----
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_primary_region
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_primary_region
 ----
 DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
                         range_min_bytes = 134217728,
@@ -507,8 +526,13 @@ DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
                         voter_constraints = '[+region=ca-central-1]',
                         lease_preferences = '[[+region=ca-central-1]]'
 
+query TTT
+SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_table_in_ca_central_1]
+ORDER BY partition_name, index_name
+----
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_ca_central_1
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_ca_central_1
 ----
 TABLE regional_by_table_in_ca_central_1  ALTER TABLE regional_by_table_in_ca_central_1 CONFIGURE ZONE USING
                                          range_min_bytes = 134217728,
@@ -549,8 +573,13 @@ DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
 statement ok
 use "mr-backup-2"
 
+query TTT
+SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE global_table]
+ORDER BY partition_name, index_name
+----
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE global_table
+SHOW ZONE CONFIGURATION FROM TABLE global_table
 ----
 TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
                     range_min_bytes = 134217728,
@@ -563,8 +592,49 @@ TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
                     voter_constraints = '[+region=ap-southeast-2]',
                     lease_preferences = '[[+region=ap-southeast-2]]'
 
+query TTT
+SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_row_table]
+ORDER BY partition_name, index_name
+----
+ap-southeast-2  regional_by_row_table@primary  num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ap-southeast-2                                    regional_by_row_table@regional_by_row_table_a_idx  num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ap-southeast-2                                    regional_by_row_table@regional_by_row_table_b_key  num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ap-southeast-2                                    regional_by_row_table@regional_by_row_table_j_idx  num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ca-central-1                                      regional_by_row_table@primary  num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+ca-central-1                                    regional_by_row_table@regional_by_row_table_a_idx  num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+ca-central-1                                    regional_by_row_table@regional_by_row_table_b_key  num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+ca-central-1                                    regional_by_row_table@regional_by_row_table_j_idx  num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+us-east-1                                       regional_by_row_table@primary  num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+us-east-1                                    regional_by_row_table@regional_by_row_table_a_idx  num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+us-east-1                                    regional_by_row_table@regional_by_row_table_b_key  num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+us-east-1                                    regional_by_row_table@regional_by_row_table_j_idx  num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_table
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_table
 ----
 DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
                         range_min_bytes = 134217728,
@@ -579,70 +649,27 @@ DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
 query TT
 SHOW CREATE TABLE regional_by_row_table
 ----
-regional_by_row_table  CREATE TABLE public.regional_by_row_table (
-                       pk INT8 NOT NULL,
-                       pk2 INT8 NOT NULL,
-                       a INT8 NOT NULL,
-                       b INT8 NOT NULL,
-                       j JSONB NULL,
-                       crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
-                       CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                       INDEX regional_by_row_table_a_idx (a ASC),
-                       UNIQUE INDEX regional_by_row_table_b_key (b ASC),
-                       INVERTED INDEX regional_by_row_table_j_idx (j),
-                       FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
-) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-2".public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-2".public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX "mr-backup-2".public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+regional_by_row_table       CREATE TABLE public.regional_by_row_table (
+                            pk INT8 NOT NULL,
+                            pk2 INT8 NOT NULL,
+                            a INT8 NOT NULL,
+                            b INT8 NOT NULL,
+                            j JSONB NULL,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                            INDEX regional_by_row_table_a_idx (a ASC),
+                            UNIQUE INDEX regional_by_row_table_b_key (b ASC),
+                            INVERTED INDEX regional_by_row_table_j_idx (j),
+                            FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+query TTT
+SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_table_in_primary_region]
+ORDER BY partition_name, index_name
+----
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_primary_region
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_primary_region
 ----
 DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
                         range_min_bytes = 134217728,
@@ -654,8 +681,13 @@ DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
                         voter_constraints = '[+region=ap-southeast-2]',
                         lease_preferences = '[[+region=ap-southeast-2]]'
 
+query TTT
+SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_table_in_ca_central_1]
+ORDER BY partition_name, index_name
+----
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_ca_central_1
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_ca_central_1
 ----
 TABLE regional_by_table_in_ca_central_1  ALTER TABLE regional_by_table_in_ca_central_1 CONFIGURE ZONE USING
                                          range_min_bytes = 134217728,
@@ -721,8 +753,13 @@ DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
 statement ok
 use "mr-backup-1"
 
+query TTT
+SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE global_table]
+ORDER BY partition_name, index_name
+----
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE global_table
+SHOW ZONE CONFIGURATION FROM TABLE global_table
 ----
 TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
                     range_min_bytes = 134217728,
@@ -735,8 +772,49 @@ TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
                     voter_constraints = '[+region=ca-central-1]',
                     lease_preferences = '[[+region=ca-central-1]]'
 
+query TTT
+SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_row_table]
+ORDER BY partition_name, index_name
+----
+ap-southeast-2  regional_by_row_table@primary  num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ap-southeast-2                                    regional_by_row_table@regional_by_row_table_a_idx  num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ap-southeast-2                                    regional_by_row_table@regional_by_row_table_b_key  num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ap-southeast-2                                    regional_by_row_table@regional_by_row_table_j_idx  num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ca-central-1                                      regional_by_row_table@primary  num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+ca-central-1                                    regional_by_row_table@regional_by_row_table_a_idx  num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+ca-central-1                                    regional_by_row_table@regional_by_row_table_b_key  num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+ca-central-1                                    regional_by_row_table@regional_by_row_table_j_idx  num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+us-east-1                                       regional_by_row_table@primary  num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+us-east-1                                    regional_by_row_table@regional_by_row_table_a_idx  num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+us-east-1                                    regional_by_row_table@regional_by_row_table_b_key  num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+us-east-1                                    regional_by_row_table@regional_by_row_table_j_idx  num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_table
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_table
 ----
 DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
                         range_min_bytes = 134217728,
@@ -751,70 +829,27 @@ DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
 query TT
 SHOW CREATE TABLE regional_by_row_table
 ----
-regional_by_row_table  CREATE TABLE public.regional_by_row_table (
-                       pk INT8 NOT NULL,
-                       pk2 INT8 NOT NULL,
-                       a INT8 NOT NULL,
-                       b INT8 NOT NULL,
-                       j JSONB NULL,
-                       crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
-                       CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                       INDEX regional_by_row_table_a_idx (a ASC),
-                       UNIQUE INDEX regional_by_row_table_b_key (b ASC),
-                       INVERTED INDEX regional_by_row_table_j_idx (j),
-                       FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
-) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-1".public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-1".public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX "mr-backup-1".public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX "mr-backup-1".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+regional_by_row_table       CREATE TABLE public.regional_by_row_table (
+                            pk INT8 NOT NULL,
+                            pk2 INT8 NOT NULL,
+                            a INT8 NOT NULL,
+                            b INT8 NOT NULL,
+                            j JSONB NULL,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                            INDEX regional_by_row_table_a_idx (a ASC),
+                            UNIQUE INDEX regional_by_row_table_b_key (b ASC),
+                            INVERTED INDEX regional_by_row_table_j_idx (j),
+                            FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+query TTT
+SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_table_in_primary_region]
+ORDER BY partition_name, index_name
+----
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_primary_region
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_primary_region
 ----
 DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
                         range_min_bytes = 134217728,
@@ -826,8 +861,13 @@ DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
                         voter_constraints = '[+region=ca-central-1]',
                         lease_preferences = '[[+region=ca-central-1]]'
 
+query TTT
+SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_table_in_ca_central_1]
+ORDER BY partition_name, index_name
+----
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_ca_central_1
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_ca_central_1
 ----
 TABLE regional_by_table_in_ca_central_1  ALTER TABLE regional_by_table_in_ca_central_1 CONFIGURE ZONE USING
                                          range_min_bytes = 134217728,
@@ -842,8 +882,13 @@ TABLE regional_by_table_in_ca_central_1  ALTER TABLE regional_by_table_in_ca_cen
 statement ok
 use "mr-backup-2"
 
+query TTT
+SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE global_table]
+ORDER BY partition_name, index_name
+----
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE global_table
+SHOW ZONE CONFIGURATION FROM TABLE global_table
 ----
 TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
                     range_min_bytes = 134217728,
@@ -856,8 +901,49 @@ TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
                     voter_constraints = '[+region=ap-southeast-2]',
                     lease_preferences = '[[+region=ap-southeast-2]]'
 
+query TTT
+SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_row_table]
+ORDER BY partition_name, index_name
+----
+ap-southeast-2  regional_by_row_table@primary  num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ap-southeast-2                                    regional_by_row_table@regional_by_row_table_a_idx  num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ap-southeast-2                                    regional_by_row_table@regional_by_row_table_b_key  num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ap-southeast-2                                    regional_by_row_table@regional_by_row_table_j_idx  num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'
+ca-central-1                                      regional_by_row_table@primary  num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+ca-central-1                                    regional_by_row_table@regional_by_row_table_a_idx  num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+ca-central-1                                    regional_by_row_table@regional_by_row_table_b_key  num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+ca-central-1                                    regional_by_row_table@regional_by_row_table_j_idx  num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'
+us-east-1                                       regional_by_row_table@primary  num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+us-east-1                                    regional_by_row_table@regional_by_row_table_a_idx  num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+us-east-1                                    regional_by_row_table@regional_by_row_table_b_key  num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+us-east-1                                    regional_by_row_table@regional_by_row_table_j_idx  num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_table
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_table
 ----
 DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
                         range_min_bytes = 134217728,
@@ -872,70 +958,27 @@ DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
 query TT
 SHOW CREATE TABLE regional_by_row_table
 ----
-regional_by_row_table  CREATE TABLE public.regional_by_row_table (
-                       pk INT8 NOT NULL,
-                       pk2 INT8 NOT NULL,
-                       a INT8 NOT NULL,
-                       b INT8 NOT NULL,
-                       j JSONB NULL,
-                       crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
-                       CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                       INDEX regional_by_row_table_a_idx (a ASC),
-                       UNIQUE INDEX regional_by_row_table_b_key (b ASC),
-                       INVERTED INDEX regional_by_row_table_j_idx (j),
-                       FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
-) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-2".public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-2".public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX "mr-backup-2".public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX "mr-backup-2".public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+regional_by_row_table       CREATE TABLE public.regional_by_row_table (
+                            pk INT8 NOT NULL,
+                            pk2 INT8 NOT NULL,
+                            a INT8 NOT NULL,
+                            b INT8 NOT NULL,
+                            j JSONB NULL,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                            INDEX regional_by_row_table_a_idx (a ASC),
+                            UNIQUE INDEX regional_by_row_table_b_key (b ASC),
+                            INVERTED INDEX regional_by_row_table_j_idx (j),
+                            FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+query TTT
+SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_table_in_primary_region]
+ORDER BY partition_name, index_name
+----
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_primary_region
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_primary_region
 ----
 DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
                         range_min_bytes = 134217728,
@@ -947,8 +990,13 @@ DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
                         voter_constraints = '[+region=ap-southeast-2]',
                         lease_preferences = '[[+region=ap-southeast-2]]'
 
+query TTT
+SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_table_in_ca_central_1]
+ORDER BY partition_name, index_name
+----
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_table_in_ca_central_1
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_ca_central_1
 ----
 TABLE regional_by_table_in_ca_central_1  ALTER TABLE regional_by_table_in_ca_central_1 CONFIGURE ZONE USING
                                          range_min_bytes = 134217728,

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -85,24 +85,39 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE regional_by_row_table_explicit_crdb_region_column]
 ----
 CREATE TABLE public.regional_by_row_table_explicit_crdb_region_column (
-  pk INT8 NOT NULL,
-  a INT8 NULL,
-  crdb_region public.crdb_internal_region NOT NULL,
-  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-  FAMILY fam_0_pk_a_crdb_region (pk, a, crdb_region)
-) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table_explicit_crdb_region_column@primary CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ap-southeast-2: 2}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table_explicit_crdb_region_column@primary CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ca-central-1: 2}',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table_explicit_crdb_region_column@primary CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=us-east-1: 2}',
-  lease_preferences = '[[+region=us-east-1]]'
+                            pk INT8 NOT NULL,
+                            a INT8 NULL,
+                            crdb_region public.crdb_internal_region NOT NULL,
+                            CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                            FAMILY fam_0_pk_a_crdb_region (pk, a, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row_table_explicit_crdb_region_column]
+ORDER BY partition_name, index_name
+----
+num_voters = 5,
+voter_constraints = '{+region=ap-southeast-2: 2}',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table_explicit_crdb_region_column@primary  ap-southeast-2
+num_voters = 5,
+voter_constraints = '{+region=ca-central-1: 2}',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row_table_explicit_crdb_region_column@primary  ca-central-1
+num_voters = 5,
+voter_constraints = '{+region=us-east-1: 2}',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row_table_explicit_crdb_region_column@primary  us-east-1
+
+query TT
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_table_explicit_crdb_region_column
+----
+DATABASE multi_region_test_db  ALTER DATABASE multi_region_test_db CONFIGURE ZONE USING
+                               range_min_bytes = 134217728,
+                               range_max_bytes = 536870912,
+                               gc.ttlseconds = 90000,
+                               num_replicas = 5,
+                               num_voters = 5,
+                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                               voter_constraints = '{+region=ca-central-1: 2}',
+                               lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 CREATE TABLE regional_by_row_table (
@@ -117,71 +132,76 @@ CREATE TABLE regional_by_row_table (
   FAMILY (pk, pk2, a, b)
 ) LOCALITY REGIONAL BY ROW
 
-# TODO(#59362): ensure this CREATE TABLE statement round trips.
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE regional_by_row_table]
 ----
 CREATE TABLE public.regional_by_row_table (
-  pk INT8 NOT NULL,
-  pk2 INT8 NOT NULL,
-  a INT8 NOT NULL,
-  b INT8 NOT NULL,
-  j JSONB NULL,
-  crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
-  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-  INDEX regional_by_row_table_a_idx (a ASC),
-  UNIQUE INDEX regional_by_row_table_b_key (b ASC),
-  INVERTED INDEX regional_by_row_table_j_idx (j),
-  FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
-) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ap-southeast-2: 2}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ap-southeast-2: 2}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ap-southeast-2: 2}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ap-southeast-2: 2}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ca-central-1: 2}',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ca-central-1: 2}',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ca-central-1: 2}',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ca-central-1: 2}',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=us-east-1: 2}',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=us-east-1: 2}',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=us-east-1: 2}',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=us-east-1: 2}',
-  lease_preferences = '[[+region=us-east-1]]'
+                            pk INT8 NOT NULL,
+                            pk2 INT8 NOT NULL,
+                            a INT8 NOT NULL,
+                            b INT8 NOT NULL,
+                            j JSONB NULL,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                            INDEX regional_by_row_table_a_idx (a ASC),
+                            UNIQUE INDEX regional_by_row_table_b_key (b ASC),
+                            INVERTED INDEX regional_by_row_table_j_idx (j),
+                            FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row_table]
+ORDER BY partition_name, index_name
+----
+num_voters = 5,
+voter_constraints = '{+region=ap-southeast-2: 2}',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table@primary  ap-southeast-2
+num_voters = 5,
+voter_constraints = '{+region=ap-southeast-2: 2}',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table@regional_by_row_table_a_idx  ap-southeast-2
+num_voters = 5,
+voter_constraints = '{+region=ap-southeast-2: 2}',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table@regional_by_row_table_b_key  ap-southeast-2
+num_voters = 5,
+voter_constraints = '{+region=ap-southeast-2: 2}',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table@regional_by_row_table_j_idx  ap-southeast-2
+num_voters = 5,
+voter_constraints = '{+region=ca-central-1: 2}',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row_table@primary  ca-central-1
+num_voters = 5,
+voter_constraints = '{+region=ca-central-1: 2}',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row_table@regional_by_row_table_a_idx  ca-central-1
+num_voters = 5,
+voter_constraints = '{+region=ca-central-1: 2}',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row_table@regional_by_row_table_b_key  ca-central-1
+num_voters = 5,
+voter_constraints = '{+region=ca-central-1: 2}',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row_table@regional_by_row_table_j_idx  ca-central-1
+num_voters = 5,
+voter_constraints = '{+region=us-east-1: 2}',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row_table@primary  us-east-1
+num_voters = 5,
+voter_constraints = '{+region=us-east-1: 2}',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row_table@regional_by_row_table_a_idx  us-east-1
+num_voters = 5,
+voter_constraints = '{+region=us-east-1: 2}',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row_table@regional_by_row_table_b_key  us-east-1
+num_voters = 5,
+voter_constraints = '{+region=us-east-1: 2}',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row_table@regional_by_row_table_j_idx  us-east-1
+
+query TT
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_table
+----
+DATABASE multi_region_test_db  ALTER DATABASE multi_region_test_db CONFIGURE ZONE USING
+                               range_min_bytes = 134217728,
+                               range_max_bytes = 536870912,
+                               gc.ttlseconds = 90000,
+                               num_replicas = 5,
+                               num_voters = 5,
+                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                               voter_constraints = '{+region=ca-central-1: 2}',
+                               lease_preferences = '[[+region=ca-central-1]]'
 
 query T
 EXPLAIN (OPT, CATALOG) SELECT * FROM regional_by_row_table
@@ -393,6 +413,30 @@ schema_name  table_name                                         type   owner  es
 public       regional_by_row_table                              table  root   0                    REGIONAL BY ROW
 public       regional_by_row_table_explicit_crdb_region_column  table  root   0                    REGIONAL BY ROW
 
+# Add a gc.ttlseconds to a partition and ensure it displays.
+statement ok
+ALTER PARTITION "us-east-1" OF INDEX public.regional_by_row_table@regional_by_row_table_a_idx
+CONFIGURE ZONE USING gc.ttlseconds = 10
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE regional_by_row_table]
+----
+CREATE TABLE public.regional_by_row_table (
+  pk INT8 NOT NULL,
+  pk2 INT8 NOT NULL,
+  a INT8 NOT NULL,
+  b INT8 NOT NULL,
+  j JSONB NULL,
+  crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+  INDEX regional_by_row_table_a_idx (a ASC),
+  UNIQUE INDEX regional_by_row_table_b_key (b ASC),
+  INVERTED INDEX regional_by_row_table_j_idx (j),
+  FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
+) LOCALITY REGIONAL BY ROW;
+ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING "gc.ttlseconds" = 10
+
+# Insert some rows into the regional_by_row_table.
 query TI
 INSERT INTO regional_by_row_table (pk, pk2, a, b, j) VALUES
 (1, 1, 2, 3, '{"a": "b"}'), (4, 4, 5, 6, '{"c": "d"}')
@@ -780,78 +824,7 @@ CREATE TABLE public.regional_by_row_table (
   UNIQUE INDEX unique_b_a (b ASC, a ASC),
   FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
 ) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@new_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ap-southeast-2: 2}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ap-southeast-2: 2}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ap-southeast-2: 2}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ap-southeast-2: 2}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ap-southeast-2: 2}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table@unique_b_a CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ap-southeast-2: 2}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@new_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ca-central-1: 2}',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ca-central-1: 2}',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ca-central-1: 2}',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ca-central-1: 2}',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ca-central-1: 2}',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table@unique_b_a CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ca-central-1: 2}',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@new_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=us-east-1: 2}',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@primary CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=us-east-1: 2}',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=us-east-1: 2}',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_b_key CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=us-east-1: 2}',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_j_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=us-east-1: 2}',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@unique_b_a CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=us-east-1: 2}',
-  lease_preferences = '[[+region=us-east-1]]'
+ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING "gc.ttlseconds" = 10
 
 query TTB colnames
 SELECT index_name, column_name, implicit FROM crdb_internal.index_columns
@@ -890,28 +863,28 @@ DELETE FROM regional_by_row_table WHERE pk = 1000
 statement ok
 ALTER TABLE regional_by_row_table ALTER PRIMARY KEY USING COLUMNS (pk2)
 
-# ALTER PRIMARY KEY can change the order of ALTER PARTITION, so we need to sort them.
 query T
 SELECT
-  split_part(create_statement, ';', 1)
+  create_statement
 FROM [SHOW CREATE TABLE regional_by_row_table]
 ----
 CREATE TABLE public.regional_by_row_table (
-                            pk INT8 NOT NULL,
-                            pk2 INT8 NOT NULL,
-                            a INT8 NOT NULL,
-                            b INT8 NOT NULL,
-                            j JSONB NULL,
-                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
-                            CONSTRAINT "primary" PRIMARY KEY (pk2 ASC),
-                            UNIQUE INDEX regional_by_row_table_pk_key (pk ASC),
-                            INDEX regional_by_row_table_a_idx (a ASC),
-                            UNIQUE INDEX regional_by_row_table_b_key (b ASC),
-                            INVERTED INDEX regional_by_row_table_j_idx (j),
-                            INDEX new_idx (a ASC, b ASC),
-                            UNIQUE INDEX unique_b_a (b ASC, a ASC),
-                            FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
-) LOCALITY REGIONAL BY ROW
+  pk INT8 NOT NULL,
+  pk2 INT8 NOT NULL,
+  a INT8 NOT NULL,
+  b INT8 NOT NULL,
+  j JSONB NULL,
+  crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+  CONSTRAINT "primary" PRIMARY KEY (pk2 ASC),
+  UNIQUE INDEX regional_by_row_table_pk_key (pk ASC),
+  INDEX regional_by_row_table_a_idx (a ASC),
+  UNIQUE INDEX regional_by_row_table_b_key (b ASC),
+  INVERTED INDEX regional_by_row_table_j_idx (j),
+  INDEX new_idx (a ASC, b ASC),
+  UNIQUE INDEX unique_b_a (b ASC, a ASC),
+  FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
+) LOCALITY REGIONAL BY ROW;
+ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING "gc.ttlseconds" = 10
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@primary
@@ -949,23 +922,11 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE regional_by_row_table_pk_defined_separately]
 ----
 CREATE TABLE public.regional_by_row_table_pk_defined_separately (
-  pk INT8 NOT NULL,
-  crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
-  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-  FAMILY "primary" (pk, crdb_region)
-) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table_pk_defined_separately@primary CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ap-southeast-2: 2}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table_pk_defined_separately@primary CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ca-central-1: 2}',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table_pk_defined_separately@primary CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=us-east-1: 2}',
-  lease_preferences = '[[+region=us-east-1]]'
+                            pk INT8 NOT NULL,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                            FAMILY "primary" (pk, crdb_region)
+) LOCALITY REGIONAL BY ROW
 
 # Tests for REGIONAL BY TABLE AS
 statement error cannot use column crdb_region_col which has type INT8 in REGIONAL BY ROW\nDETAIL: REGIONAL BY ROW AS must reference a column of type crdb_internal_region
@@ -999,51 +960,60 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE regional_by_row_table_as]
 ----
 CREATE TABLE public.regional_by_row_table_as (
-  pk INT8 NOT NULL,
-  a INT8 NULL,
-  b INT8 NULL,
-  crdb_region_col public.crdb_internal_region NOT NULL AS (CASE WHEN pk <= 10:::INT8 THEN 'us-east-1':::public.crdb_internal_region ELSE 'ap-southeast-2':::public.crdb_internal_region END) STORED,
-  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-  INDEX regional_by_row_table_as_a_idx (a ASC),
-  UNIQUE INDEX regional_by_row_table_as_b_key (b ASC),
-  FAMILY fam_0_pk_a_b_crdb_region_col (pk, a, b, crdb_region_col)
-) LOCALITY REGIONAL BY ROW AS crdb_region_col;
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table_as@primary CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ap-southeast-2: 2}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table_as@regional_by_row_table_as_a_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ap-southeast-2: 2}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table_as@regional_by_row_table_as_b_key CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ap-southeast-2: 2}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table_as@primary CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ca-central-1: 2}',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table_as@regional_by_row_table_as_a_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ca-central-1: 2}',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table_as@regional_by_row_table_as_b_key CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ca-central-1: 2}',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table_as@primary CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=us-east-1: 2}',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table_as@regional_by_row_table_as_a_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=us-east-1: 2}',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table_as@regional_by_row_table_as_b_key CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=us-east-1: 2}',
-  lease_preferences = '[[+region=us-east-1]]'
+                                               pk INT8 NOT NULL,
+                                               a INT8 NULL,
+                                               b INT8 NULL,
+                                               crdb_region_col public.crdb_internal_region NOT NULL AS (CASE WHEN pk <= 10:::INT8 THEN 'us-east-1':::public.crdb_internal_region ELSE 'ap-southeast-2':::public.crdb_internal_region END) STORED,
+                                               CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                                               INDEX regional_by_row_table_as_a_idx (a ASC),
+                                               UNIQUE INDEX regional_by_row_table_as_b_key (b ASC),
+                                               FAMILY fam_0_pk_a_b_crdb_region_col (pk, a, b, crdb_region_col)
+) LOCALITY REGIONAL BY ROW AS crdb_region_col
+
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row_table_as]
+ORDER BY partition_name, index_name
+----
+num_voters = 5,
+voter_constraints = '{+region=ap-southeast-2: 2}',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table_as@primary  ap-southeast-2
+num_voters = 5,
+voter_constraints = '{+region=ap-southeast-2: 2}',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table_as@regional_by_row_table_as_a_idx  ap-southeast-2
+num_voters = 5,
+voter_constraints = '{+region=ap-southeast-2: 2}',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table_as@regional_by_row_table_as_b_key  ap-southeast-2
+num_voters = 5,
+voter_constraints = '{+region=ca-central-1: 2}',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row_table_as@primary  ca-central-1
+num_voters = 5,
+voter_constraints = '{+region=ca-central-1: 2}',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row_table_as@regional_by_row_table_as_a_idx  ca-central-1
+num_voters = 5,
+voter_constraints = '{+region=ca-central-1: 2}',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row_table_as@regional_by_row_table_as_b_key  ca-central-1
+num_voters = 5,
+voter_constraints = '{+region=us-east-1: 2}',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row_table_as@primary  us-east-1
+num_voters = 5,
+voter_constraints = '{+region=us-east-1: 2}',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row_table_as@regional_by_row_table_as_a_idx  us-east-1
+num_voters = 5,
+voter_constraints = '{+region=us-east-1: 2}',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row_table_as@regional_by_row_table_as_b_key  us-east-1
+
+query TT
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_table_as
+----
+DATABASE multi_region_test_db  ALTER DATABASE multi_region_test_db CONFIGURE ZONE USING
+                               range_min_bytes = 134217728,
+                               range_max_bytes = 536870912,
+                               gc.ttlseconds = 90000,
+                               num_replicas = 5,
+                               num_voters = 5,
+                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                               voter_constraints = '{+region=ca-central-1: 2}',
+                               lease_preferences = '[[+region=ca-central-1]]'
 
 query TI
 INSERT INTO regional_by_row_table_as (pk) VALUES (1), (10), (20)
@@ -1077,7 +1047,7 @@ statement ok
 CREATE TABLE t_regional_by_row () LOCALITY REGIONAL BY ROW
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE t_regional_by_row PARTITION "us-east-1"
+SHOW ZONE CONFIGURATION FROM TABLE t_regional_by_row PARTITION "us-east-1"
 ----
 PARTITION "us-east-1" OF TABLE t_regional_by_row  ALTER PARTITION "us-east-1" OF TABLE t_regional_by_row CONFIGURE ZONE USING
                                                   range_min_bytes = 134217728,
@@ -1089,8 +1059,36 @@ PARTITION "us-east-1" OF TABLE t_regional_by_row  ALTER PARTITION "us-east-1" OF
                                                   voter_constraints = '{+region=us-east-1: 2}',
                                                   lease_preferences = '[[+region=us-east-1]]'
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE t_regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 5,
+voter_constraints = '{+region=ap-southeast-2: 2}',
+lease_preferences = '[[+region=ap-southeast-2]]'  t_regional_by_row@primary  ap-southeast-2
+num_voters = 5,
+voter_constraints = '{+region=ca-central-1: 2}',
+lease_preferences = '[[+region=ca-central-1]]'  t_regional_by_row@primary  ca-central-1
+num_voters = 5,
+voter_constraints = '{+region=us-east-1: 2}',
+lease_preferences = '[[+region=us-east-1]]'  t_regional_by_row@primary  us-east-1
+
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE t_regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 5,
+voter_constraints = '{+region=ap-southeast-2: 2}',
+lease_preferences = '[[+region=ap-southeast-2]]'  t_regional_by_row@primary  ap-southeast-2
+num_voters = 5,
+voter_constraints = '{+region=ca-central-1: 2}',
+lease_preferences = '[[+region=ca-central-1]]'  t_regional_by_row@primary  ca-central-1
+num_voters = 5,
+voter_constraints = '{+region=us-east-1: 2}',
+lease_preferences = '[[+region=us-east-1]]'  t_regional_by_row@primary  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE t_regional_by_row
+SHOW ZONE CONFIGURATION FROM TABLE t_regional_by_row
 ----
 DATABASE alter_survive_db  ALTER DATABASE alter_survive_db CONFIGURE ZONE USING
                            range_min_bytes = 134217728,
@@ -1106,7 +1104,7 @@ statement ok
 ALTER DATABASE alter_survive_db SURVIVE ZONE FAILURE
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE t_regional_by_row PARTITION "us-east-1"
+SHOW ZONE CONFIGURATION FROM TABLE t_regional_by_row PARTITION "us-east-1"
 ----
 PARTITION "us-east-1" OF TABLE t_regional_by_row  ALTER PARTITION "us-east-1" OF TABLE t_regional_by_row CONFIGURE ZONE USING
                                                   range_min_bytes = 134217728,
@@ -1122,8 +1120,36 @@ PARTITION "us-east-1" OF TABLE t_regional_by_row  ALTER PARTITION "us-east-1" OF
 statement ok
 ALTER TABLE t_regional_by_row CONFIGURE ZONE USING gc.ttlseconds = 999
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE t_regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  t_regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  t_regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  t_regional_by_row@primary  us-east-1
+
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE t_regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  t_regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  t_regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  t_regional_by_row@primary  us-east-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE t_regional_by_row
+SHOW ZONE CONFIGURATION FROM TABLE t_regional_by_row
 ----
 TABLE t_regional_by_row  ALTER TABLE t_regional_by_row CONFIGURE ZONE USING
                          range_min_bytes = 134217728,
@@ -1136,7 +1162,7 @@ TABLE t_regional_by_row  ALTER TABLE t_regional_by_row CONFIGURE ZONE USING
                          lease_preferences = '[[+region=us-east-1]]'
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE t_regional_by_row PARTITION "us-east-1"
+SHOW ZONE CONFIGURATION FROM TABLE t_regional_by_row PARTITION "us-east-1"
 ----
 PARTITION "us-east-1" OF TABLE t_regional_by_row  ALTER PARTITION "us-east-1" OF TABLE t_regional_by_row CONFIGURE ZONE USING
                                                   range_min_bytes = 134217728,
@@ -1203,25 +1229,28 @@ CREATE TABLE regional_by_row_as (
 query TT
 SHOW CREATE TABLE regional_by_row
 ----
-regional_by_row  CREATE TABLE public.regional_by_row (
-                 pk INT8 NOT NULL,
-                 i INT8 NULL,
-                 crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
-                 CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                 INDEX regional_by_row_i_idx (i ASC),
-                 FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
-) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ca-central-1" OF INDEX add_regions.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX add_regions.public.regional_by_row@regional_by_row_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]'
+regional_by_row             CREATE TABLE public.regional_by_row (
+                            pk INT8 NOT NULL,
+                            i INT8 NULL,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                            INDEX regional_by_row_i_idx (i ASC),
+                            FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 DATABASE add_regions  ALTER DATABASE add_regions CONFIGURE ZONE USING
                       range_min_bytes = 134217728,
@@ -1232,39 +1261,32 @@ DATABASE add_regions  ALTER DATABASE add_regions CONFIGURE ZONE USING
                       constraints = '{+region=ca-central-1: 1}',
                       voter_constraints = '[+region=ca-central-1]',
                       lease_preferences = '[[+region=ca-central-1]]'
-
-query TTT
-SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_row] ORDER BY partition_name, index_name
-----
-ca-central-1  regional_by_row@primary  num_voters = 3,
-voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
-ca-central-1                                    regional_by_row@regional_by_row_i_idx  num_voters = 3,
-voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW CREATE TABLE regional_by_row_as
 ----
-regional_by_row_as  CREATE TABLE public.regional_by_row_as (
-                    pk INT8 NOT NULL,
-                    i INT8 NULL,
-                    cr public.crdb_internal_region NOT NULL DEFAULT 'ca-central-1':::public.crdb_internal_region,
-                    CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                    INDEX regional_by_row_as_i_idx (i ASC),
-                    FAMILY fam_0_cr_pk_i (cr, pk, i)
-) LOCALITY REGIONAL BY ROW AS cr;
-ALTER PARTITION "ca-central-1" OF INDEX add_regions.public.regional_by_row_as@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX add_regions.public.regional_by_row_as@regional_by_row_as_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]'
+regional_by_row_as                CREATE TABLE public.regional_by_row_as (
+                                  pk INT8 NOT NULL,
+                                  i INT8 NULL,
+                                  cr public.crdb_internal_region NOT NULL DEFAULT 'ca-central-1':::public.crdb_internal_region,
+                                  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                                  INDEX regional_by_row_as_i_idx (i ASC),
+                                  FAMILY fam_0_cr_pk_i (cr, pk, i)
+) LOCALITY REGIONAL BY ROW AS cr
+
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row_as]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row_as@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row_as@regional_by_row_as_i_idx  ca-central-1
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_as
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_as
 ----
 DATABASE add_regions  ALTER DATABASE add_regions CONFIGURE ZONE USING
                       range_min_bytes = 134217728,
@@ -1275,16 +1297,6 @@ DATABASE add_regions  ALTER DATABASE add_regions CONFIGURE ZONE USING
                       constraints = '{+region=ca-central-1: 1}',
                       voter_constraints = '[+region=ca-central-1]',
                       lease_preferences = '[[+region=ca-central-1]]'
-
-query TTT
-SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_row_as] ORDER BY partition_name, index_name
-----
-ca-central-1  regional_by_row_as@primary  num_voters = 3,
-voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
-ca-central-1                                    regional_by_row_as@regional_by_row_as_i_idx  num_voters = 3,
-voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
 
 # Next, add a region. We expect this thing to succeed and add a partition +
 # zone config corresponding to the regions to both the regional by row tables.
@@ -1294,33 +1306,34 @@ ALTER DATABASE add_regions ADD REGION "us-east-1"
 query TT
 SHOW CREATE TABLE regional_by_row
 ----
-regional_by_row  CREATE TABLE public.regional_by_row (
-                 pk INT8 NOT NULL,
-                 i INT8 NULL,
-                 crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
-                 CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                 INDEX regional_by_row_i_idx (i ASC),
-                 FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
-) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ca-central-1" OF INDEX add_regions.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX add_regions.public.regional_by_row@regional_by_row_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX add_regions.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX add_regions.public.regional_by_row@regional_by_row_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+regional_by_row             CREATE TABLE public.regional_by_row (
+                            pk INT8 NOT NULL,
+                            i INT8 NULL,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                            INDEX regional_by_row_i_idx (i ASC),
+                            FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 DATABASE add_regions  ALTER DATABASE add_regions CONFIGURE ZONE USING
                       range_min_bytes = 134217728,
@@ -1335,34 +1348,35 @@ DATABASE add_regions  ALTER DATABASE add_regions CONFIGURE ZONE USING
 query TT
 SHOW CREATE TABLE regional_by_row_as
 ----
-regional_by_row_as  CREATE TABLE public.regional_by_row_as (
-                    pk INT8 NOT NULL,
-                    i INT8 NULL,
-                    cr public.crdb_internal_region NOT NULL DEFAULT 'ca-central-1':::public.crdb_internal_region,
-                    CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                    INDEX regional_by_row_as_i_idx (i ASC),
-                    FAMILY fam_0_cr_pk_i (cr, pk, i)
-) LOCALITY REGIONAL BY ROW AS cr;
-ALTER PARTITION "ca-central-1" OF INDEX add_regions.public.regional_by_row_as@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX add_regions.public.regional_by_row_as@regional_by_row_as_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX add_regions.public.regional_by_row_as@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX add_regions.public.regional_by_row_as@regional_by_row_as_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+regional_by_row_as                CREATE TABLE public.regional_by_row_as (
+                                  pk INT8 NOT NULL,
+                                  i INT8 NULL,
+                                  cr public.crdb_internal_region NOT NULL DEFAULT 'ca-central-1':::public.crdb_internal_region,
+                                  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                                  INDEX regional_by_row_as_i_idx (i ASC),
+                                  FAMILY fam_0_cr_pk_i (cr, pk, i)
+) LOCALITY REGIONAL BY ROW AS cr
 
+
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row_as]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row_as@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row_as@regional_by_row_as_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row_as@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row_as@regional_by_row_as_i_idx  us-east-1
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_as
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_as
 ----
 DATABASE add_regions  ALTER DATABASE add_regions CONFIGURE ZONE USING
                       range_min_bytes = 134217728,
@@ -1373,22 +1387,6 @@ DATABASE add_regions  ALTER DATABASE add_regions CONFIGURE ZONE USING
                       constraints = '{+region=ca-central-1: 1, +region=us-east-1: 1}',
                       voter_constraints = '[+region=ca-central-1]',
                       lease_preferences = '[[+region=ca-central-1]]'
-
-query TTT
-SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_row_as] ORDER BY partition_name, index_name
-----
-ca-central-1  regional_by_row_as@primary  num_voters = 3,
-voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
-ca-central-1                                    regional_by_row_as@regional_by_row_as_i_idx  num_voters = 3,
-voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
-us-east-1                                       regional_by_row_as@primary  num_voters = 3,
-voter_constraints = '[+region=us-east-1]',
-lease_preferences = '[[+region=us-east-1]]'
-us-east-1                                    regional_by_row_as@regional_by_row_as_i_idx  num_voters = 3,
-voter_constraints = '[+region=us-east-1]',
-lease_preferences = '[[+region=us-east-1]]'
 
 # Do the same thing as above, except with a different region.
 statement ok
@@ -1397,42 +1395,41 @@ ALTER DATABASE add_regions ADD REGION "ap-southeast-2"
 query TT
 SHOW CREATE TABLE regional_by_row
 ----
-regional_by_row  CREATE TABLE public.regional_by_row (
-                 pk INT8 NOT NULL,
-                 i INT8 NULL,
-                 crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
-                 CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                 INDEX regional_by_row_i_idx (i ASC),
-                 FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
-) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX add_regions.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX add_regions.public.regional_by_row@regional_by_row_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX add_regions.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX add_regions.public.regional_by_row@regional_by_row_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX add_regions.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX add_regions.public.regional_by_row@regional_by_row_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+regional_by_row             CREATE TABLE public.regional_by_row (
+                            pk INT8 NOT NULL,
+                            i INT8 NULL,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                            INDEX regional_by_row_i_idx (i ASC),
+                            FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
+) LOCALITY REGIONAL BY ROW
 
+
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 DATABASE add_regions  ALTER DATABASE add_regions CONFIGURE ZONE USING
                       range_min_bytes = 134217728,
@@ -1447,41 +1444,40 @@ DATABASE add_regions  ALTER DATABASE add_regions CONFIGURE ZONE USING
 query TT
 SHOW CREATE TABLE regional_by_row_as
 ----
-regional_by_row_as  CREATE TABLE public.regional_by_row_as (
-                    pk INT8 NOT NULL,
-                    i INT8 NULL,
-                    cr public.crdb_internal_region NOT NULL DEFAULT 'ca-central-1':::public.crdb_internal_region,
-                    CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                    INDEX regional_by_row_as_i_idx (i ASC),
-                    FAMILY fam_0_cr_pk_i (cr, pk, i)
-) LOCALITY REGIONAL BY ROW AS cr;
-ALTER PARTITION "ap-southeast-2" OF INDEX add_regions.public.regional_by_row_as@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX add_regions.public.regional_by_row_as@regional_by_row_as_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX add_regions.public.regional_by_row_as@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX add_regions.public.regional_by_row_as@regional_by_row_as_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX add_regions.public.regional_by_row_as@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX add_regions.public.regional_by_row_as@regional_by_row_as_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+regional_by_row_as                CREATE TABLE public.regional_by_row_as (
+                                  pk INT8 NOT NULL,
+                                  i INT8 NULL,
+                                  cr public.crdb_internal_region NOT NULL DEFAULT 'ca-central-1':::public.crdb_internal_region,
+                                  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                                  INDEX regional_by_row_as_i_idx (i ASC),
+                                  FAMILY fam_0_cr_pk_i (cr, pk, i)
+) LOCALITY REGIONAL BY ROW AS cr
+
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row_as]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_as@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_as@regional_by_row_as_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row_as@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row_as@regional_by_row_as_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row_as@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row_as@regional_by_row_as_i_idx  us-east-1
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_as
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_as
 ----
 DATABASE add_regions  ALTER DATABASE add_regions CONFIGURE ZONE USING
                       range_min_bytes = 134217728,
@@ -1492,28 +1488,6 @@ DATABASE add_regions  ALTER DATABASE add_regions CONFIGURE ZONE USING
                       constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
                       voter_constraints = '[+region=ca-central-1]',
                       lease_preferences = '[[+region=ca-central-1]]'
-
-query TTT
-SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_row_as] ORDER BY partition_name, index_name
-----
-ap-southeast-2  regional_by_row_as@primary  num_voters = 3,
-voter_constraints = '[+region=ap-southeast-2]',
-lease_preferences = '[[+region=ap-southeast-2]]'
-ap-southeast-2                                    regional_by_row_as@regional_by_row_as_i_idx  num_voters = 3,
-voter_constraints = '[+region=ap-southeast-2]',
-lease_preferences = '[[+region=ap-southeast-2]]'
-ca-central-1                                      regional_by_row_as@primary  num_voters = 3,
-voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
-ca-central-1                                    regional_by_row_as@regional_by_row_as_i_idx  num_voters = 3,
-voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
-us-east-1                                       regional_by_row_as@primary  num_voters = 3,
-voter_constraints = '[+region=us-east-1]',
-lease_preferences = '[[+region=us-east-1]]'
-us-east-1                                    regional_by_row_as@regional_by_row_as_i_idx  num_voters = 3,
-voter_constraints = '[+region=us-east-1]',
-lease_preferences = '[[+region=us-east-1]]'
 
 statement ok
 CREATE DATABASE add_regions_in_txn WITH PRIMARY REGION "ca-central-1";
@@ -1546,41 +1520,40 @@ COMMIT;
 query TT
 SHOW CREATE TABLE regional_by_row
 ----
-regional_by_row  CREATE TABLE public.regional_by_row (
-                 pk INT8 NOT NULL,
-                 i INT8 NULL,
-                 crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
-                 CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                 INDEX regional_by_row_i_idx (i ASC),
-                 FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
-) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX add_regions_in_txn.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX add_regions_in_txn.public.regional_by_row@regional_by_row_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX add_regions_in_txn.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX add_regions_in_txn.public.regional_by_row@regional_by_row_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX add_regions_in_txn.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX add_regions_in_txn.public.regional_by_row@regional_by_row_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+regional_by_row             CREATE TABLE public.regional_by_row (
+                            pk INT8 NOT NULL,
+                            i INT8 NULL,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                            INDEX regional_by_row_i_idx (i ASC),
+                            FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 DATABASE add_regions_in_txn  ALTER DATABASE add_regions_in_txn CONFIGURE ZONE USING
                              range_min_bytes = 134217728,
@@ -1591,67 +1564,44 @@ DATABASE add_regions_in_txn  ALTER DATABASE add_regions_in_txn CONFIGURE ZONE US
                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
                              voter_constraints = '[+region=ca-central-1]',
                              lease_preferences = '[[+region=ca-central-1]]'
-
-query TTT
-SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_row] ORDER BY partition_name, index_name
-----
-ap-southeast-2  regional_by_row@primary  num_voters = 3,
-voter_constraints = '[+region=ap-southeast-2]',
-lease_preferences = '[[+region=ap-southeast-2]]'
-ap-southeast-2                                    regional_by_row@regional_by_row_i_idx  num_voters = 3,
-voter_constraints = '[+region=ap-southeast-2]',
-lease_preferences = '[[+region=ap-southeast-2]]'
-ca-central-1                                      regional_by_row@primary  num_voters = 3,
-voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
-ca-central-1                                    regional_by_row@regional_by_row_i_idx  num_voters = 3,
-voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
-us-east-1                                       regional_by_row@primary  num_voters = 3,
-voter_constraints = '[+region=us-east-1]',
-lease_preferences = '[[+region=us-east-1]]'
-us-east-1                                    regional_by_row@regional_by_row_i_idx  num_voters = 3,
-voter_constraints = '[+region=us-east-1]',
-lease_preferences = '[[+region=us-east-1]]'
 
 query TT
 SHOW CREATE TABLE regional_by_row_as
 ----
-regional_by_row_as  CREATE TABLE public.regional_by_row_as (
-                    pk INT8 NOT NULL,
-                    i INT8 NULL,
-                    cr public.crdb_internal_region NOT NULL DEFAULT 'ca-central-1':::public.crdb_internal_region,
-                    CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                    INDEX regional_by_row_as_i_idx (i ASC),
-                    FAMILY fam_0_cr_pk_i (cr, pk, i)
-) LOCALITY REGIONAL BY ROW AS cr;
-ALTER PARTITION "ap-southeast-2" OF INDEX add_regions_in_txn.public.regional_by_row_as@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX add_regions_in_txn.public.regional_by_row_as@regional_by_row_as_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX add_regions_in_txn.public.regional_by_row_as@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX add_regions_in_txn.public.regional_by_row_as@regional_by_row_as_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX add_regions_in_txn.public.regional_by_row_as@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX add_regions_in_txn.public.regional_by_row_as@regional_by_row_as_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+regional_by_row_as                CREATE TABLE public.regional_by_row_as (
+                                  pk INT8 NOT NULL,
+                                  i INT8 NULL,
+                                  cr public.crdb_internal_region NOT NULL DEFAULT 'ca-central-1':::public.crdb_internal_region,
+                                  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                                  INDEX regional_by_row_as_i_idx (i ASC),
+                                  FAMILY fam_0_cr_pk_i (cr, pk, i)
+) LOCALITY REGIONAL BY ROW AS cr
+
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row_as]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_as@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_as@regional_by_row_as_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row_as@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row_as@regional_by_row_as_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row_as@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row_as@regional_by_row_as_i_idx  us-east-1
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_as
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_as
 ----
 DATABASE add_regions_in_txn  ALTER DATABASE add_regions_in_txn CONFIGURE ZONE USING
                              range_min_bytes = 134217728,
@@ -1662,28 +1612,6 @@ DATABASE add_regions_in_txn  ALTER DATABASE add_regions_in_txn CONFIGURE ZONE US
                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
                              voter_constraints = '[+region=ca-central-1]',
                              lease_preferences = '[[+region=ca-central-1]]'
-
-query TTT
-SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_row_as] ORDER BY partition_name, index_name
-----
-ap-southeast-2  regional_by_row_as@primary  num_voters = 3,
-voter_constraints = '[+region=ap-southeast-2]',
-lease_preferences = '[[+region=ap-southeast-2]]'
-ap-southeast-2                                    regional_by_row_as@regional_by_row_as_i_idx  num_voters = 3,
-voter_constraints = '[+region=ap-southeast-2]',
-lease_preferences = '[[+region=ap-southeast-2]]'
-ca-central-1                                      regional_by_row_as@primary  num_voters = 3,
-voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
-ca-central-1                                    regional_by_row_as@regional_by_row_as_i_idx  num_voters = 3,
-voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
-us-east-1                                       regional_by_row_as@primary  num_voters = 3,
-voter_constraints = '[+region=us-east-1]',
-lease_preferences = '[[+region=us-east-1]]'
-us-east-1                                    regional_by_row_as@regional_by_row_as_i_idx  num_voters = 3,
-voter_constraints = '[+region=us-east-1]',
-lease_preferences = '[[+region=us-east-1]]'
 
 statement ok
 CREATE DATABASE drop_regions PRIMARY REGION "ca-central-1" REGIONS "us-east-1", "ap-southeast-2";
@@ -1706,23 +1634,24 @@ statement ok
 ALTER DATABASE drop_regions DROP REGION "us-east-1"
 
 query TTT
-SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_row] ORDER BY partition_name, index_name
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
 ----
-ap-southeast-2  regional_by_row@primary  num_voters = 3,
+num_voters = 3,
 voter_constraints = '[+region=ap-southeast-2]',
-lease_preferences = '[[+region=ap-southeast-2]]'
-ap-southeast-2                                    regional_by_row@regional_by_row_i_idx  num_voters = 3,
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
 voter_constraints = '[+region=ap-southeast-2]',
-lease_preferences = '[[+region=ap-southeast-2]]'
-ca-central-1                                      regional_by_row@primary  num_voters = 3,
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
 voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
-ca-central-1                                    regional_by_row@regional_by_row_i_idx  num_voters = 3,
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
 voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 DATABASE drop_regions  ALTER DATABASE drop_regions CONFIGURE ZONE USING
                        range_min_bytes = 134217728,
@@ -1737,50 +1666,34 @@ DATABASE drop_regions  ALTER DATABASE drop_regions CONFIGURE ZONE USING
 query TT
 SHOW CREATE TABLE regional_by_row
 ----
-regional_by_row  CREATE TABLE public.regional_by_row (
-                 pk INT8 NOT NULL,
-                 i INT8 NULL,
-                 crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
-                 CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                 INDEX regional_by_row_i_idx (i ASC),
-                 FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
-) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ap-southeast-2" OF INDEX drop_regions.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX drop_regions.public.regional_by_row@regional_by_row_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX drop_regions.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX drop_regions.public.regional_by_row@regional_by_row_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]'
-
+regional_by_row             CREATE TABLE public.regional_by_row (
+                            pk INT8 NOT NULL,
+                            i INT8 NULL,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                            INDEX regional_by_row_i_idx (i ASC),
+                            FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
+) LOCALITY REGIONAL BY ROW
 
 query TTT
-SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_row_as] ORDER BY partition_name, index_name
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row_as]
+ORDER BY partition_name, index_name
 ----
-ap-southeast-2  regional_by_row_as@primary  num_voters = 3,
+num_voters = 3,
 voter_constraints = '[+region=ap-southeast-2]',
-lease_preferences = '[[+region=ap-southeast-2]]'
-ap-southeast-2                                    regional_by_row_as@regional_by_row_as_i_idx  num_voters = 3,
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_as@primary  ap-southeast-2
+num_voters = 3,
 voter_constraints = '[+region=ap-southeast-2]',
-lease_preferences = '[[+region=ap-southeast-2]]'
-ca-central-1                                      regional_by_row_as@primary  num_voters = 3,
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_as@regional_by_row_as_i_idx  ap-southeast-2
+num_voters = 3,
 voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
-ca-central-1                                    regional_by_row_as@regional_by_row_as_i_idx  num_voters = 3,
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row_as@primary  ca-central-1
+num_voters = 3,
 voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row_as@regional_by_row_as_i_idx  ca-central-1
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_as
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_as
 ----
 DATABASE drop_regions  ALTER DATABASE drop_regions CONFIGURE ZONE USING
                        range_min_bytes = 134217728,
@@ -1795,30 +1708,14 @@ DATABASE drop_regions  ALTER DATABASE drop_regions CONFIGURE ZONE USING
 query TT
 SHOW CREATE TABLE regional_by_row_as
 ----
-regional_by_row_as  CREATE TABLE public.regional_by_row_as (
-                    pk INT8 NOT NULL,
-                    i INT8 NULL,
-                    cr public.crdb_internal_region NOT NULL DEFAULT 'ca-central-1':::public.crdb_internal_region,
-                    CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                    INDEX regional_by_row_as_i_idx (i ASC),
-                    FAMILY fam_0_cr_pk_i (cr, pk, i)
-) LOCALITY REGIONAL BY ROW AS cr;
-ALTER PARTITION "ap-southeast-2" OF INDEX drop_regions.public.regional_by_row_as@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX drop_regions.public.regional_by_row_as@regional_by_row_as_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ap-southeast-2]',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX drop_regions.public.regional_by_row_as@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX drop_regions.public.regional_by_row_as@regional_by_row_as_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]'
+regional_by_row_as                CREATE TABLE public.regional_by_row_as (
+                                  pk INT8 NOT NULL,
+                                  i INT8 NULL,
+                                  cr public.crdb_internal_region NOT NULL DEFAULT 'ca-central-1':::public.crdb_internal_region,
+                                  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                                  INDEX regional_by_row_as_i_idx (i ASC),
+                                  FAMILY fam_0_cr_pk_i (cr, pk, i)
+) LOCALITY REGIONAL BY ROW AS cr
 
 
 # Add and remove a region in the same txn.
@@ -1828,25 +1725,25 @@ ALTER DATABASE drop_regions ADD REGION "us-east-1";
 ALTER DATABASE drop_regions DROP REGION "ap-southeast-2";
 COMMIT;
 
-
 query TTT
-SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_row] ORDER BY partition_name, index_name
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
 ----
-ca-central-1  regional_by_row@primary  num_voters = 3,
+num_voters = 3,
 voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
-ca-central-1                                    regional_by_row@regional_by_row_i_idx  num_voters = 3,
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
 voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
-us-east-1                                       regional_by_row@primary  num_voters = 3,
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_voters = 3,
 voter_constraints = '[+region=us-east-1]',
-lease_preferences = '[[+region=us-east-1]]'
-us-east-1                                    regional_by_row@regional_by_row_i_idx  num_voters = 3,
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
 voter_constraints = '[+region=us-east-1]',
-lease_preferences = '[[+region=us-east-1]]'
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 DATABASE drop_regions  ALTER DATABASE drop_regions CONFIGURE ZONE USING
                        range_min_bytes = 134217728,
@@ -1861,50 +1758,34 @@ DATABASE drop_regions  ALTER DATABASE drop_regions CONFIGURE ZONE USING
 query TT
 SHOW CREATE TABLE regional_by_row
 ----
-regional_by_row  CREATE TABLE public.regional_by_row (
-                 pk INT8 NOT NULL,
-                 i INT8 NULL,
-                 crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
-                 CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                 INDEX regional_by_row_i_idx (i ASC),
-                 FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
-) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "ca-central-1" OF INDEX drop_regions.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX drop_regions.public.regional_by_row@regional_by_row_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX drop_regions.public.regional_by_row@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX drop_regions.public.regional_by_row@regional_by_row_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
-
+regional_by_row             CREATE TABLE public.regional_by_row (
+                            pk INT8 NOT NULL,
+                            i INT8 NULL,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                            INDEX regional_by_row_i_idx (i ASC),
+                            FAMILY fam_0_pk_i_crdb_region (pk, i, crdb_region)
+) LOCALITY REGIONAL BY ROW
 
 query TTT
-SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_row_as] ORDER BY partition_name, index_name
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row_as]
+ORDER BY partition_name, index_name
 ----
-ca-central-1  regional_by_row_as@primary  num_voters = 3,
+num_voters = 3,
 voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
-ca-central-1                                    regional_by_row_as@regional_by_row_as_i_idx  num_voters = 3,
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row_as@primary  ca-central-1
+num_voters = 3,
 voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
-us-east-1                                       regional_by_row_as@primary  num_voters = 3,
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row_as@regional_by_row_as_i_idx  ca-central-1
+num_voters = 3,
 voter_constraints = '[+region=us-east-1]',
-lease_preferences = '[[+region=us-east-1]]'
-us-east-1                                    regional_by_row_as@regional_by_row_as_i_idx  num_voters = 3,
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row_as@primary  us-east-1
+num_voters = 3,
 voter_constraints = '[+region=us-east-1]',
-lease_preferences = '[[+region=us-east-1]]'
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row_as@regional_by_row_as_i_idx  us-east-1
 
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_as
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_as
 ----
 DATABASE drop_regions  ALTER DATABASE drop_regions CONFIGURE ZONE USING
                        range_min_bytes = 134217728,
@@ -1919,37 +1800,45 @@ DATABASE drop_regions  ALTER DATABASE drop_regions CONFIGURE ZONE USING
 query TT
 SHOW CREATE TABLE regional_by_row_as
 ----
-regional_by_row_as  CREATE TABLE public.regional_by_row_as (
-                    pk INT8 NOT NULL,
-                    i INT8 NULL,
-                    cr public.crdb_internal_region NOT NULL DEFAULT 'ca-central-1':::public.crdb_internal_region,
-                    CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-                    INDEX regional_by_row_as_i_idx (i ASC),
-                    FAMILY fam_0_cr_pk_i (cr, pk, i)
-) LOCALITY REGIONAL BY ROW AS cr;
-ALTER PARTITION "ca-central-1" OF INDEX drop_regions.public.regional_by_row_as@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX drop_regions.public.regional_by_row_as@regional_by_row_as_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=ca-central-1]',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX drop_regions.public.regional_by_row_as@primary CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX drop_regions.public.regional_by_row_as@regional_by_row_as_i_idx CONFIGURE ZONE USING
-  num_voters = 3,
-  voter_constraints = '[+region=us-east-1]',
-  lease_preferences = '[[+region=us-east-1]]'
+regional_by_row_as                CREATE TABLE public.regional_by_row_as (
+                                  pk INT8 NOT NULL,
+                                  i INT8 NULL,
+                                  cr public.crdb_internal_region NOT NULL DEFAULT 'ca-central-1':::public.crdb_internal_region,
+                                  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                                  INDEX regional_by_row_as_i_idx (i ASC),
+                                  FAMILY fam_0_cr_pk_i (cr, pk, i)
+) LOCALITY REGIONAL BY ROW AS cr
 
 # Drop us-east-1 so that only the primary region remains.
 statement ok
 ALTER DATABASE drop_regions DROP REGION "us-east-1";
 
+query TTT
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+
 query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
+----
+DATABASE drop_regions  ALTER DATABASE drop_regions CONFIGURE ZONE USING
+                       range_min_bytes = 134217728,
+                       range_max_bytes = 536870912,
+                       gc.ttlseconds = 90000,
+                       num_replicas = 5,
+                       num_voters = 3,
+                       constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                       voter_constraints = '[+region=ca-central-1]',
+                       lease_preferences = '[[+region=ca-central-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_as
 ----
 DATABASE drop_regions  ALTER DATABASE drop_regions CONFIGURE ZONE USING
                        range_min_bytes = 134217728,
@@ -1962,37 +1851,15 @@ DATABASE drop_regions  ALTER DATABASE drop_regions CONFIGURE ZONE USING
                        lease_preferences = '[[+region=ca-central-1]]'
 
 query TTT
-SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_row] ORDER BY partition_name, index_name
+SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row_as]
+ORDER BY partition_name, index_name
 ----
-ca-central-1  regional_by_row@primary  num_voters = 3,
+num_voters = 3,
 voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
-ca-central-1                                    regional_by_row@regional_by_row_i_idx  num_voters = 3,
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row_as@primary  ca-central-1
+num_voters = 3,
 voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
-
-query TT
-SHOW ZONE CONFIGURATION FOR TABLE regional_by_row_as
-----
-DATABASE drop_regions  ALTER DATABASE drop_regions CONFIGURE ZONE USING
-                       range_min_bytes = 134217728,
-                       range_max_bytes = 536870912,
-                       gc.ttlseconds = 90000,
-                       num_replicas = 5,
-                       num_voters = 3,
-                       constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                       voter_constraints = '[+region=ca-central-1]',
-                       lease_preferences = '[[+region=ca-central-1]]'
-
-query TTT
-SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_row_as] ORDER BY partition_name, index_name
-----
-ca-central-1  regional_by_row_as@primary  num_voters = 3,
-voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
-ca-central-1                                    regional_by_row_as@regional_by_row_as_i_idx  num_voters = 3,
-voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row_as@regional_by_row_as_i_idx  ca-central-1
 
 # Can't drop the primary region while regional by row tables still exist in the database.
 statement error removing primary region from database drop_regions: cannot drop type "crdb_internal_region" because other objects \(\[drop_regions.public.regional_by_row drop_regions.public.regional_by_row_as\]\) still depend on it

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_rename_column
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_rename_column
@@ -83,48 +83,12 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE regional_by_row_table_as]
 ----
 CREATE TABLE public.regional_by_row_table_as (
-  pk INT8 NOT NULL,
-  a INT8 NULL,
-  b INT8 NULL,
-  cr public.crdb_internal_region NOT NULL AS (CASE WHEN pk <= 10:::INT8 THEN 'us-east-1':::public.crdb_internal_region ELSE 'ap-southeast-2':::public.crdb_internal_region END) STORED,
-  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
-  INDEX regional_by_row_table_as_a_idx (a ASC),
-  UNIQUE INDEX regional_by_row_table_as_b_key (b ASC),
-  FAMILY fam_0_pk_a_b_crdb_region_col (pk, a, b, cr)
-) LOCALITY REGIONAL BY ROW AS cr;
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table_as@primary CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ap-southeast-2: 2}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table_as@regional_by_row_table_as_a_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ap-southeast-2: 2}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ap-southeast-2" OF INDEX multi_region_test_db.public.regional_by_row_table_as@regional_by_row_table_as_b_key CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ap-southeast-2: 2}',
-  lease_preferences = '[[+region=ap-southeast-2]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table_as@primary CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ca-central-1: 2}',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table_as@regional_by_row_table_as_a_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ca-central-1: 2}',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "ca-central-1" OF INDEX multi_region_test_db.public.regional_by_row_table_as@regional_by_row_table_as_b_key CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=ca-central-1: 2}',
-  lease_preferences = '[[+region=ca-central-1]]';
-ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table_as@primary CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=us-east-1: 2}',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table_as@regional_by_row_table_as_a_idx CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=us-east-1: 2}',
-  lease_preferences = '[[+region=us-east-1]]';
-ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table_as@regional_by_row_table_as_b_key CONFIGURE ZONE USING
-  num_voters = 5,
-  voter_constraints = '{+region=us-east-1: 2}',
-  lease_preferences = '[[+region=us-east-1]]'
+                                  pk INT8 NOT NULL,
+                                  a INT8 NULL,
+                                  b INT8 NULL,
+                                  cr public.crdb_internal_region NOT NULL AS (CASE WHEN pk <= 10:::INT8 THEN 'us-east-1':::public.crdb_internal_region ELSE 'ap-southeast-2':::public.crdb_internal_region END) STORED,
+                                  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                                  INDEX regional_by_row_table_as_a_idx (a ASC),
+                                  UNIQUE INDEX regional_by_row_table_as_b_key (b ASC),
+                                  FAMILY fam_0_pk_a_b_crdb_region_col (pk, a, b, cr)
+) LOCALITY REGIONAL BY ROW AS cr

--- a/pkg/ccl/multiregionccl/regional_by_row_test.go
+++ b/pkg/ccl/multiregionccl/regional_by_row_test.go
@@ -421,15 +421,15 @@ func TestRepartitionFailureRollback(t *testing.T) {
 	defer cleanup()
 
 	_, err := sqlDB.Exec(
-		`CREATE DATABASE db WITH PRIMARY REGION "us-east1" REGIONS "us-east2"; 
+		`CREATE DATABASE db WITH PRIMARY REGION "us-east1" REGIONS "us-east2";
 CREATE TABLE db.t(k INT PRIMARY KEY) LOCALITY REGIONAL BY ROW`)
 	require.NoError(t, err)
 	if err != nil {
 		t.Error(err)
 	}
 
-	_, err = sqlDB.Exec(`BEGIN; 
-ALTER DATABASE db ADD REGION "us-east3"; 
+	_, err = sqlDB.Exec(`BEGIN;
+ALTER DATABASE db ADD REGION "us-east3";
 ALTER DATABASE db DROP REGION "us-east2";
 COMMIT;`)
 	require.Error(t, err, "boom")

--- a/pkg/ccl/multiregionccl/show_test.go
+++ b/pkg/ccl/multiregionccl/show_test.go
@@ -74,15 +74,7 @@ func TestShowCreateTable(t *testing.T) {
 	CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
 	INDEX a_idx (a ASC),
 	FAMILY "primary" (a, crdb_region, rowid)
-) LOCALITY REGIONAL BY ROW;
-ALTER PARTITION "us-west1" OF INDEX mrdb.public.%[1]s@a_idx CONFIGURE ZONE USING
-	num_voters = 3,
-	voter_constraints = '[+region=us-west1]',
-	lease_preferences = '[[+region=us-west1]]';
-ALTER PARTITION "us-west1" OF INDEX mrdb.public.%[1]s@primary CONFIGURE ZONE USING
-	num_voters = 3,
-	voter_constraints = '[+region=us-west1]',
-	lease_preferences = '[[+region=us-west1]]'`,
+) LOCALITY REGIONAL BY ROW`,
 			Database: "mrdb",
 		},
 		{
@@ -98,15 +90,7 @@ ALTER PARTITION "us-west1" OF INDEX mrdb.public.%[1]s@primary CONFIGURE ZONE USI
 	CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
 	INDEX a_idx (a ASC),
 	FAMILY "primary" (a, crdb_region_col, rowid)
-) LOCALITY REGIONAL BY ROW AS crdb_region_col;
-ALTER PARTITION "us-west1" OF INDEX mrdb.public.%[1]s@a_idx CONFIGURE ZONE USING
-	num_voters = 3,
-	voter_constraints = '[+region=us-west1]',
-	lease_preferences = '[[+region=us-west1]]';
-ALTER PARTITION "us-west1" OF INDEX mrdb.public.%[1]s@primary CONFIGURE ZONE USING
-	num_voters = 3,
-	voter_constraints = '[+region=us-west1]',
-	lease_preferences = '[[+region=us-west1]]'`,
+) LOCALITY REGIONAL BY ROW AS crdb_region_col`,
 			Database: "mrdb",
 		},
 	}

--- a/pkg/config/zonepb/zone.go
+++ b/pkg/config/zonepb/zone.go
@@ -57,6 +57,27 @@ var NamedZonesByID = func() map[uint32]string {
 	return out
 }()
 
+// MultiRegionZoneConfigFields are the fields on a zone configuration which
+// may be set by the system for multi-region objects".
+var MultiRegionZoneConfigFields = []tree.Name{
+	"global_reads",
+	"num_replicas",
+	"num_voters",
+	"constraints",
+	"voter_constraints",
+	"lease_preferences",
+}
+
+// MultiRegionZoneConfigFieldsSet contain the items in
+// MultiRegionZoneConfigFields but in a set form for fast lookup.
+var MultiRegionZoneConfigFieldsSet = func() map[tree.Name]struct{} {
+	ret := make(map[tree.Name]struct{}, len(MultiRegionZoneConfigFields))
+	for _, f := range MultiRegionZoneConfigFields {
+		ret[f] = struct{}{}
+	}
+	return ret
+}()
+
 // ZoneSpecifierFromID creates a tree.ZoneSpecifier for the zone with the
 // given ID.
 func ZoneSpecifierFromID(

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1839,6 +1839,7 @@ CREATE TABLE crdb_internal.create_statements (
   alter_statements              STRING[] NOT NULL,
   validate_statements           STRING[] NOT NULL,
   has_partitions                BOOL NOT NULL,
+	is_multi_region               BOOL NOT NULL,
   INDEX(descriptor_id)
 )
 `, virtualOnce, false, /* includesIndexEntries */
@@ -1906,6 +1907,7 @@ CREATE TABLE crdb_internal.create_statements (
 			alterStmts,
 			validateStmts,
 			tree.MakeDBool(tree.DBool(hasPartitions)),
+			tree.MakeDBool(tree.DBool(db != nil && db.IsMultiRegion())),
 		)
 	})
 
@@ -2789,20 +2791,20 @@ var crdbInternalZonesTable = virtualSchemaTable{
 	comment: "decoded zone configurations from system.zones (KV scan)",
 	schema: `
 CREATE TABLE crdb_internal.zones (
-  zone_id          INT NOT NULL,
-  subzone_id       INT NOT NULL,
-  target           STRING,
-  range_name       STRING,
-  database_name    STRING,
-  table_name       STRING,
-  index_name       STRING,
-  partition_name   STRING,
+  zone_id              INT NOT NULL,
+  subzone_id           INT NOT NULL,
+  target               STRING,
+  range_name           STRING,
+  database_name        STRING,
+  table_name           STRING,
+  index_name           STRING,
+  partition_name       STRING,
   raw_config_yaml      STRING NOT NULL,
   raw_config_sql       STRING, -- this column can be NULL if there is no specifier syntax
-                           -- possible (e.g. the object was deleted).
+                               -- possible (e.g. the object was deleted).
 	raw_config_protobuf  BYTES NOT NULL,
-	full_config_yaml STRING NOT NULL,
-	full_config_sql STRING
+	full_config_yaml     STRING NOT NULL,
+	full_config_sql      STRING
 )
 `,
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -214,10 +214,10 @@ SELECT * FROM crdb_internal.builtin_functions WHERE function = ''
 ----
 function  signature  category  details
 
-query ITTITTTTTTTT colnames
+query ITTITTTTTTTBB colnames
 SELECT * FROM crdb_internal.create_statements WHERE database_name = ''
 ----
-database_id  database_name  schema_name  descriptor_id  descriptor_type  descriptor_name  create_statement  state  create_nofks  alter_statements  validate_statements  has_partitions
+database_id  database_name  schema_name  descriptor_id  descriptor_type  descriptor_name  create_statement  state  create_nofks  alter_statements  validate_statements  has_partitions  is_multi_region
 
 query ITITTBTB colnames
 SELECT * FROM crdb_internal.table_columns WHERE descriptor_name = ''

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
@@ -226,10 +226,10 @@ SELECT * FROM crdb_internal.builtin_functions WHERE function = ''
 ----
 function  signature  category  details
 
-query ITTITTTTTTTT colnames
+query ITTITTTTTTTBB colnames
 SELECT * FROM crdb_internal.create_statements WHERE database_name = ''
 ----
-database_id  database_name  schema_name  descriptor_id  descriptor_type  descriptor_name  create_statement  state  create_nofks  alter_statements  validate_statements  has_partitions
+database_id  database_name  schema_name  descriptor_id  descriptor_type  descriptor_name  create_statement  state  create_nofks  alter_statements  validate_statements  has_partitions  is_multi_region
 
 query ITITTBTB colnames
 SELECT * FROM crdb_internal.table_columns WHERE descriptor_name = ''

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -133,11 +133,11 @@ CREATE SEQUENCE ignored_options_test NO CYCLE
 statement ok
 CREATE SEQUENCE show_create_test
 
-query ITTITTTTTTTB colnames
+query ITTITTTTTTTBB colnames
 SELECT * FROM crdb_internal.create_statements WHERE descriptor_name = 'show_create_test'
 ----
-database_id  database_name  schema_name  descriptor_id  descriptor_type  descriptor_name   create_statement                                                                                     state   create_nofks                                                                                         alter_statements  validate_statements  has_partitions
-52           test           public       63             sequence         show_create_test  CREATE SEQUENCE public.show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1  PUBLIC  CREATE SEQUENCE public.show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1  {}                {}                   false
+database_id  database_name  schema_name  descriptor_id  descriptor_type  descriptor_name   create_statement                                                                                     state   create_nofks                                                                                         alter_statements  validate_statements  has_partitions  is_multi_region
+52           test           public       63             sequence         show_create_test  CREATE SEQUENCE public.show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1  PUBLIC  CREATE SEQUENCE public.show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1  {}                {}                   false           false
 
 query TT colnames
 SHOW CREATE SEQUENCE show_create_test

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -323,15 +323,6 @@ func synthesizeVoterConstraints(
 	}
 }
 
-var multiRegionZoneConfigFields = []tree.Name{
-	"global_reads",
-	"num_replicas",
-	"num_voters",
-	"constraints",
-	"voter_constraints",
-	"lease_preferences",
-}
-
 // zoneConfigForMultiRegionTable generates a ZoneConfig stub for a
 // regional-by-table or global table in a multi-region database.
 //
@@ -344,7 +335,7 @@ var multiRegionZoneConfigFields = []tree.Name{
 // configuration is required.
 //
 // Relevant multi-region configured fields (as defined in
-// `multiRegionZoneConfigFields`) will be overwritten by the calling function
+// `zonepb.MultiRegionZoneConfigFields`) will be overwritten by the calling function
 // into an existing ZoneConfig.
 func zoneConfigForMultiRegionTable(
 	localityConfig descpb.TableDescriptor_LocalityConfig,
@@ -482,7 +473,7 @@ func applyZoneConfigForMultiRegionTableOptionTableNewConfig(
 		if err != nil {
 			return false, zonepb.ZoneConfig{}, err
 		}
-		zc.CopyFromZone(*localityZoneConfig, multiRegionZoneConfigFields)
+		zc.CopyFromZone(*localityZoneConfig, zonepb.MultiRegionZoneConfigFields)
 		return false, zc, nil
 	}
 }
@@ -503,7 +494,7 @@ var ApplyZoneConfigForMultiRegionTableOptionTableAndIndexes = func(
 	if err != nil {
 		return false, zonepb.ZoneConfig{}, err
 	}
-	zc.CopyFromZone(*localityZoneConfig, multiRegionZoneConfigFields)
+	zc.CopyFromZone(*localityZoneConfig, zonepb.MultiRegionZoneConfigFields)
 
 	hasNewSubzones := table.IsLocalityRegionalByRow()
 	if hasNewSubzones {

--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/base",
         "//pkg/build",
         "//pkg/clusterversion",
+        "//pkg/config/zonepb",
         "//pkg/geo",
         "//pkg/geo/geogfn",
         "//pkg/geo/geoindex",


### PR DESCRIPTION
Resolves #60656 

sql: hide display of partitions on SHOW CREATE for REGIONAL BY ROW tables

This commit hides the partition zone configuration for REGIONAL BY ROW
tables.

This is achieved by the following:
* Introduce a is_multi_region column for crdb_internal.create_statements
* Introduce a builtin
  `crdb_internal.filter_multiregion_fields_from_zone_config_sql` which
  removes multi region zone config fields.
* Filter the partition statements out from the SHOW CREATE TABLE
  delegate function.
* Change REGIONAL BY ROW tests to read from SHOW PARTITIONS so that
  we can still see the zone configurations and partitions.

Release justification: low risk change to new functionality

Release note (sql change): Introduced a new is_multi_region column to
crdb_internal.create_statements, which informs whether the database of
the object is a multi-region database.

Release note (sql change): Introduced a new built-in
`crdb_internal.filter_multiregion_fields_from_zone_config_sql` which
removes multi-region fields from a CONFIGURE ZONE statement.

