### PR TITLE
tracing: improve helpers to assert on trace structures

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1614,6 +1614,9 @@ func (st *SessionTracing) StartTracing(
 		if sp == nil {
 			return errors.Errorf("no txn span for SessionTracing")
 		}
+		// We want to clear out any existing recordings so they don't show up in
+		// future traces.
+		sp.ResetRecording()
 		sp.SetVerbose(true)
 		st.firstTxnSpan = sp
 	}

--- a/pkg/util/log/ambient_context_test.go
+++ b/pkg/util/log/ambient_context_test.go
@@ -60,13 +60,13 @@ func TestAnnotateCtxSpan(t *testing.T) {
 	sp1.Finish()
 
 	if err := tracing.TestingCheckRecordedSpans(sp1.GetRecording(), `
-		Span root:
+		span: root
 			tags: _verbose=1
 			event: a
 			event: c
-		Span child:
-			tags: _verbose=1 ambient=
-			event: [ambient] b
+			span: child
+				tags: _verbose=1 ambient=
+				event: [ambient] b
 	`); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/util/log/trace_test.go
+++ b/pkg/util/log/trace_test.go
@@ -79,12 +79,12 @@ func TestTrace(t *testing.T) {
 	sp.Finish()
 
 	if err := tracing.TestingCheckRecordedSpans(sp.GetRecording(), `
-		Span s:
-		  tags: _verbose=1
-		  event: test1
-		  event: test2
-		  event: testerr
-		  event: log
+		span: s
+			tags: _verbose=1
+			event: test1
+			event: test2
+			event: testerr
+			event: log
 	`); err != nil {
 		t.Fatal(err)
 	}
@@ -106,12 +106,12 @@ func TestTraceWithTags(t *testing.T) {
 
 	sp.Finish()
 	if err := tracing.TestingCheckRecordedSpans(sp.GetRecording(), `
-		Span s:
-		  tags: _verbose=1
-		  event: [tag=1] test1
-		  event: [tag=1] test2
-		  event: [tag=1] testerr
-		  event: [tag=1] log
+		span: s
+			tags: _verbose=1
+			event: [tag=1] test1
+			event: [tag=1] test2
+			event: [tag=1] testerr
+			event: [tag=1] log
 	`); err != nil {
 		t.Fatal(err)
 	}
@@ -197,11 +197,11 @@ func TestEventLogAndTrace(t *testing.T) {
 	el.Finish()
 
 	if err := tracing.TestingCheckRecordedSpans(sp.GetRecording(), `
-		Span s:
-		  tags: _verbose=1
-		  event: test3
-		  event: test4
-		  event: test5err
+		span: s
+			tags: _verbose=1
+			event: test3
+			event: test4
+			event: test5err
 	`); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/util/tracing/BUILD.bazel
+++ b/pkg/util/tracing/BUILD.bazel
@@ -21,7 +21,6 @@ go_library(
     deps = [
         "//pkg/settings",
         "//pkg/util",
-        "//pkg/util/caller",
         "//pkg/util/envutil",
         "//pkg/util/iterutil",
         "//pkg/util/protoutil",
@@ -39,6 +38,7 @@ go_library(
         "@com_github_opentracing_opentracing_go//log",
         "@com_github_openzipkin_contrib_zipkin_go_opentracing//:zipkin-go-opentracing",
         "@com_github_petermattis_goid//:goid",
+        "@com_github_pmezard_go_difflib//difflib",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//metadata",

--- a/pkg/util/tracing/grpc_interceptor_test.go
+++ b/pkg/util/tracing/grpc_interceptor_test.go
@@ -208,12 +208,11 @@ func TestGRPCInterceptors(t *testing.T) {
 			require.Equal(t, 1, n)
 
 			exp := fmt.Sprintf(`
-Span %[1]s:
-Span /cockroach.testutils.grpcutils.GRPCTest/%[1]s:
-  tags: component=gRPC span.kind=client test-baggage-key=test-baggage-value
-Span /cockroach.testutils.grpcutils.GRPCTest/%[1]s:
-  tags: component=gRPC span.kind=server test-baggage-key=test-baggage-value`,
-				tc.name)
+				span: %[1]s
+					span: /cockroach.testutils.grpcutils.GRPCTest/%[1]s
+						tags: component=gRPC span.kind=client test-baggage-key=test-baggage-value
+					span: /cockroach.testutils.grpcutils.GRPCTest/%[1]s
+						tags: component=gRPC span.kind=server test-baggage-key=test-baggage-value`, tc.name)
 			require.NoError(t, tracing.TestingCheckRecordedSpans(finalRecs, exp))
 		})
 	}

--- a/pkg/util/tracing/recording.go
+++ b/pkg/util/tracing/recording.go
@@ -19,12 +19,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/util/caller"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/errors"
 	jaegerjson "github.com/jaegertracing/jaeger/model/json"
 	"github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
+	"github.com/pmezard/go-difflib/difflib"
 )
 
 // RecordingType is the type of recording that a Span might be performing.
@@ -375,19 +375,18 @@ type TraceCollection struct {
 }
 
 // TestingCheckRecordedSpans checks whether a recording looks like an expected
-// one represented by a string with one line per expected Span and one line per
-// expected event (i.e. log message).
+// one represented by a string with one line per expected span and one line per
+// expected event (i.e. log message), with a tab-indentation for child spans.
 //
-// Use with something like:
-// 	 if err := TestingCheckRecordedSpans(Span.GetRecording(), `
-//     Span root:
-//       event: a
-//       event: c
-//     Span child:
-//       event: [ambient] b
-//   `); err != nil {
-//   	t.Fatal(err)
-//   }
+//      if err := TestingCheckRecordedSpans(Span.GetRecording(), `
+//          span: root
+//              event: a
+//              span: child
+//                  event: [ambient] b
+//                  event: c
+//      `); err != nil {
+//        t.Fatal(err)
+//      }
 //
 // The event lines can (and generally should) omit the file:line part that they
 // might contain (depending on the level at which they were logged).
@@ -395,62 +394,145 @@ type TraceCollection struct {
 // Note: this test function is in this file because it needs to be used by
 // both tests in the tracing package and tests outside of it, and the function
 // itself depends on tracing.
-func TestingCheckRecordedSpans(recSpans []tracingpb.RecordedSpan, expected string) error {
-	expected = strings.TrimSpace(expected)
-	var rows []string
-	row := func(format string, args ...interface{}) {
-		rows = append(rows, fmt.Sprintf(format, args...))
+func TestingCheckRecordedSpans(rec Recording, expected string) error {
+	normalize := func(rec string) string {
+		// normalize the string form of a recording for ease of comparison.
+		//
+		// 1. Strip out any leading new lines.
+		rec = strings.TrimLeft(rec, "\n")
+		// 2. Strip out trailing whitespace.
+		rec = strings.TrimRight(rec, "\n\t ")
+		// 3. Strip out file:line information from the recordings.
+		//
+		// 	 Before |  "event: util/log/trace_test.go:111 log"
+		// 	 After  |  "event: log"
+		re := regexp.MustCompile(`event: .*:[0-9]*`)
+		rec = string(re.ReplaceAll([]byte(rec), []byte("event:")))
+		// 4. Change all tabs to four spaces.
+		rec = strings.ReplaceAll(rec, "\t", "    ")
+		// 5. Compute the outermost indentation.
+		indent := strings.Repeat(" ", len(rec)-len(strings.TrimLeft(rec, " ")))
+		// 6. Outdent each line by that amount.
+		var lines []string
+		for _, line := range strings.Split(rec, "\n") {
+			lines = append(lines, strings.TrimPrefix(line, indent))
+		}
+		// 7. Stitch everything together.
+		return strings.Join(lines, "\n")
 	}
 
-	for _, rs := range recSpans {
-		row("Span %s:", rs.Operation)
+	var rows []string
+	row := func(depth int, format string, args ...interface{}) {
+		rows = append(rows, strings.Repeat("    ", depth)+fmt.Sprintf(format, args...))
+	}
+
+	mapping := make(map[uint64]uint64) // spanID -> parentSpanID
+	for _, rs := range rec {
+		mapping[rs.SpanID] = rs.ParentSpanID
+	}
+	depth := func(spanID uint64) int {
+		// Traverse up the parent links until one is not found.
+		curSpanID := spanID
+		d := 0
+		for {
+			var ok bool
+			curSpanID, ok = mapping[curSpanID]
+			if !ok {
+				break
+			}
+			d++
+		}
+		return d
+	}
+
+	for _, rs := range rec {
+		d := depth(rs.SpanID)
+		row(d, "span: %s", rs.Operation)
 		if len(rs.Tags) > 0 {
 			var tags []string
 			for k, v := range rs.Tags {
 				tags = append(tags, fmt.Sprintf("%s=%v", k, v))
 			}
 			sort.Strings(tags)
-			row("  tags: %s", strings.Join(tags, " "))
+			row(d, "    tags: %s", strings.Join(tags, " "))
 		}
 		for _, l := range rs.Logs {
-			msg := ""
+			var msg string
 			for _, f := range l.Fields {
-				msg = msg + fmt.Sprintf("  %s: %v", f.Key, f.Value)
+				msg = msg + fmt.Sprintf("    %s: %v", f.Key, f.Value)
 			}
-			row("%s", msg)
+			row(d, "%s", msg)
 		}
 	}
-	var expRows []string
-	if expected != "" {
-		expRows = strings.Split(expected, "\n")
-	}
-	match := false
-	if len(expRows) == len(rows) {
-		match = true
-		for i := range expRows {
-			e := strings.Trim(expRows[i], " \t")
-			r := strings.Trim(rows[i], " \t")
-			if e != r && !matchesWithoutFileLine(r, e) {
-				match = false
-				break
-			}
+
+	exp := normalize(expected)
+	got := normalize(strings.Join(rows, "\n"))
+	if got != exp {
+		diff := difflib.UnifiedDiff{
+			A:        difflib.SplitLines(exp),
+			FromFile: "exp",
+			B:        difflib.SplitLines(got),
+			ToFile:   "got",
+			Context:  4,
 		}
-	}
-	if !match {
-		file, line, _ := caller.Lookup(1)
-		return errors.Errorf(
-			"%s:%d expected:\n%s\ngot:\n%s",
-			file, line, expected, strings.Join(rows, "\n"))
+		diffText, _ := difflib.GetUnifiedDiffString(diff)
+		return errors.Newf("unexpected diff:\n%s\n%s", diffText, rec.String())
 	}
 	return nil
 }
 
-// matchesWithoutFileLine tries to match an event by stripping a file:line from
-// it. For example:
-// "event: util/log/trace_test.go:111 log" will match "event: log".
+// TestingCheckRecording checks whether a recording looks like the expected
+// one. The expected string is allowed to elide timing information, and the
+// outer-most indentation level is adjusted for when comparing.
 //
-// Returns true if it matches.
-func matchesWithoutFileLine(msg string, expected string) bool {
-	groups := regexp.MustCompile(`^(event: ).*:[0-9]* (.*)$`).FindStringSubmatch(msg)
-	return len(groups) == 3 && fmt.Sprintf("event: %s", groups[2]) == expected
+//       if err := TestingCheckRecording(sp.GetRecording(), `
+//           === operation:root
+//           event:root 1
+//               === operation:remote child
+//               event:remote child 1
+//       `); err != nil {
+//           t.Fatal(err)
+//       }
+//
+func TestingCheckRecording(rec Recording, expected string) error {
+	normalize := func(rec string) string {
+		// normalize the string form of a recording for ease of comparison.
+		//
+		// 1. Strip out any leading new lines.
+		rec = strings.TrimLeft(rec, "\n")
+		// 2. Strip out trailing space.
+		rec = strings.TrimRight(rec, "\n\t ")
+		// 3. Strip out all timing information from the recordings.
+		//
+		// 	 Before |  "0.007ms      0.007ms    event:root 1"
+		// 	 After  |  "event:root 1"
+		re := regexp.MustCompile(`.*s.*s\s{4}`)
+		rec = string(re.ReplaceAll([]byte(rec), nil))
+		// 4. Change all tabs to four spaces.
+		rec = strings.ReplaceAll(rec, "\t", "    ")
+		// 5. Compute the outermost indentation.
+		indent := strings.Repeat(" ", len(rec)-len(strings.TrimLeft(rec, " ")))
+		// 6. Outdent each line by that amount.
+		var lines []string
+		for _, line := range strings.Split(rec, "\n") {
+			lines = append(lines, strings.TrimPrefix(line, indent))
+		}
+		// 6. Stitch everything together.
+		return strings.Join(lines, "\n")
+	}
+
+	exp := normalize(expected)
+	got := normalize(rec.String())
+	if got != exp {
+		diff := difflib.UnifiedDiff{
+			A:        difflib.SplitLines(exp),
+			FromFile: "exp",
+			B:        difflib.SplitLines(got),
+			ToFile:   "got",
+			Context:  4,
+		}
+		diffText, _ := difflib.GetUnifiedDiffString(diff)
+		return errors.Newf("unexpected diff:\n%s", diffText)
+	}
+	return nil
 }

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -134,7 +134,8 @@ func (sp *Span) SetVerbose(to bool) {
 	sp.i.SetVerbose(to)
 }
 
-// ResetRecording clears any previously recorded information.
+// ResetRecording clears any previously recorded information. This doesn't
+// affect any auxiliary trace sinks such as net/trace or zipkin.
 func (sp *Span) ResetRecording() {
 	sp.i.ResetRecording()
 }

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -122,9 +122,6 @@ func (sp *Span) Meta() *SpanMeta {
 // descendants of this Span will do so automatically as well. This does not
 // apply to past derived Spans, which may in fact be noop spans.
 //
-// As a side effect, calls to `SetVerbose(true)` on a span that was not already
-// verbose will reset any past recording stored on this Span.
-//
 // When set to 'false', Record will cede to add data to the recording (though
 // they may still be collected, should the Span have been set up with an
 // auxiliary trace sink). This does not apply to Spans derived from this one
@@ -135,6 +132,11 @@ func (sp *Span) SetVerbose(to bool) {
 	// prevented the toggling we could end up in weird states since IsVerbose()
 	// won't reflect what the caller asked for.
 	sp.i.SetVerbose(to)
+}
+
+// ResetRecording clears any previously recorded information.
+func (sp *Span) ResetRecording() {
+	sp.i.ResetRecording()
 }
 
 // IsVerbose returns true if the Span is verbose. See SetVerbose for details.
@@ -277,16 +279,14 @@ func (s *spanInner) SetVerbose(to bool) {
 		panic(errors.AssertionFailedf("SetVerbose called on NoopSpan; use the WithForceRealSpan option for StartSpan"))
 	}
 	if to {
-		// If we're already recording (perhaps because the parent was recording when
-		// this Span was created), there's nothing to do. Avoid the call to enableRecording
-		// because it would clear the existing recording.
-		recType := RecordingVerbose
-		if recType != s.crdb.recordingType() {
-			s.crdb.enableRecording(nil /* parent */, recType)
-		}
+		s.crdb.enableRecording(nil /* parent */, RecordingVerbose)
 	} else {
 		s.crdb.disableRecording()
 	}
+}
+
+func (s *spanInner) ResetRecording() {
+	s.crdb.resetRecording()
 }
 
 func (s *spanInner) GetRecording() Recording {

--- a/pkg/util/tracing/tags_test.go
+++ b/pkg/util/tracing/tags_test.go
@@ -28,8 +28,8 @@ func TestLogTags(t *testing.T) {
 	sp1.SetVerbose(true)
 	sp1.Finish()
 	require.NoError(t, TestingCheckRecordedSpans(sp1.GetRecording(), `
-		Span foo:
-		  tags: _verbose=1 tag1=val1 tag2=val2
+		span: foo
+			tags: _verbose=1 tag1=val1 tag2=val2
 	`))
 	require.NoError(t, shadowTracer.expectSingleSpanWithTags("tag1", "tag2"))
 	shadowTracer.clear()
@@ -41,7 +41,7 @@ func TestLogTags(t *testing.T) {
 	sp2.SetVerbose(true)
 	sp2.Finish()
 	require.NoError(t, TestingCheckRecordedSpans(sp2.GetRecording(), `
-		Span bar:
+		span: bar
 			tags: _verbose=1 one=val1 two=val2
 	`))
 	require.NoError(t, shadowTracer.expectSingleSpanWithTags("one", "two"))
@@ -51,7 +51,7 @@ func TestLogTags(t *testing.T) {
 	sp3.SetVerbose(true)
 	sp3.Finish()
 	require.NoError(t, TestingCheckRecordedSpans(sp3.GetRecording(), `
-		Span baz:
+		span: baz
 			tags: _verbose=1 one=val1 two=val2
 	`))
 	require.NoError(t, shadowTracer.expectSingleSpanWithTags("one", "two"))


### PR DESCRIPTION
The earlier implementation was a bit difficult to follow, and didn't
assert on the structure of recordings (events from parent and child
spans could appear at the same level). The helpers here are a bit more
powerful, and ergonomic enough to allow authors to use arbitrary
top-level indentation (as long as internal indentation is consistent).
This lets us write tests of the form:

        if err := TestingCheckRecordedSpans(Span.GetRecording(), `
            span: root
                event: a
                span: child
                    event: [ambient] b
                    event: c
        `); err != nil {
            t.Fatal(err)
        }

Release note: None

---

First commit is from #60735.