### PR TITLE
roachprod: do not add DNS entries for VMs without public IP

### DIFF
--- a/pkg/cmd/roachprod/vm/gce/utils.go
+++ b/pkg/cmd/roachprod/vm/gce/utils.go
@@ -165,11 +165,15 @@ func SyncDNS(vms vm.List) error {
 
 	var zoneBuilder strings.Builder
 	for _, vm := range vms {
-		if len(vm.Name) < 60 {
-			zoneBuilder.WriteString(fmt.Sprintf("%s 60 IN A %s\n", vm.Name, vm.PublicIP))
-		} else {
+		if len(vm.Name) >= 60 {
 			fmt.Printf("WARN: not adding `%s' to the zone file because it is longer than 60 characters\n", vm.Name)
+			continue
 		}
+		if vm.PublicIP == "" {
+			fmt.Printf("WARN: not adding `%s' to the zone file because it does not have a public IP address\n", vm.Name)
+			continue
+		}
+		zoneBuilder.WriteString(fmt.Sprintf("%s 60 IN A %s\n", vm.Name, vm.PublicIP))
 	}
 	fmt.Fprint(f, zoneBuilder.String())
 	f.Close()


### PR DESCRIPTION
Fixes #58905

In some cases some VMs don't have a public IP assigned. This happens
when they are still being provisioned or destroyed.

Previously, we tried to add these VMs and the generated zone line was
missing the IP. This caused a syntax error when `gcloud` tried to import
the malformed zone file.

To address the issue, this change makes the DNS sync function skip VMs
that have no public IP address assigned.

Release note: None