### PR TITLE
cluster: use WaitConditionNextExit

### DIFF
--- a/pkg/acceptance/cluster/dockercluster.go
+++ b/pkg/acceptance/cluster/dockercluster.go
@@ -241,7 +241,7 @@ func (l *DockerCluster) OneShot(
 	if err := l.oneshot.Start(ctx); err != nil {
 		return err
 	}
-	return l.oneshot.Wait(ctx, container.WaitConditionNotRunning)
+	return l.oneshot.Wait(ctx, container.WaitConditionNextExit)
 }
 
 // stopOnPanic is invoked as a deferred function in Start in order to attempt
@@ -377,7 +377,7 @@ func (l *DockerCluster) initCluster(ctx context.Context) {
 	// and it'll get in the way of future runs.
 	l.vols = c
 	maybePanic(c.Start(ctx))
-	maybePanic(c.Wait(ctx, container.WaitConditionNotRunning))
+	maybePanic(c.Wait(ctx, container.WaitConditionNextExit))
 }
 
 // cockroachEntryPoint returns the value to be used as


### PR DESCRIPTION
There is a chance that this will address an issue that causes spurious
failures on CI, where it looks like we're janking the file system out
from under a running process. For context, see:

https://github.com/cockroachdb/cockroach/issues/58955

Release note: None
