### PR TITLE
sql: add logic test for crdb_internal.node_inflight_trace_spans

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inflight_trace_spans
+++ b/pkg/sql/logictest/testdata/logic_test/inflight_trace_spans
@@ -1,0 +1,45 @@
+# Verify that the crdb_internal.node_inflight_trace_spans vtable populates
+# correctly.
+
+statement ok
+GRANT ADMIN TO testuser
+
+statement ok
+CREATE TABLE kv (k VARCHAR PRIMARY KEY, v VARCHAR);
+
+query TT
+SELECT * FROM kv
+----
+
+user testuser
+
+statement ok
+BEGIN
+
+let $curr_trace_id
+SELECT * FROM crdb_internal.trace_id()
+
+# Save all rows representing spans of current trace in view.
+statement ok
+CREATE VIEW current_trace_spans(span_id, trace_id)
+  AS SELECT span_id, trace_id
+  FROM crdb_internal.node_inflight_trace_spans
+  WHERE trace_id = $curr_trace_id
+
+# Confirm that there is at least 1 trace with current trace ID.
+query B
+SELECT count(*) > 0
+  FROM current_trace_spans
+----
+true
+
+statement ok
+INSERT INTO kv VALUES('k', 'v');
+COMMIT
+
+# Confirm that the trace and its associated spans are no longer tracked.
+query B
+SELECT count(*) = 0
+  FROM current_trace_spans
+----
+true


### PR DESCRIPTION
Resolves #59873.

Previously, we were only testing the schema of the virtual table
`crdb_internal.node_inflight_trace_spans`. Now that we have a
built-in that retrieves the current trace's ID, we are able to
more robustly test that the virtual table correctly populates
the current trace's spans during a transaction, and when it ends
that the current trace ID and its associated spans are no longer
in the vtable.

Release note: None