### PR TITLE
roachprod: do not add DNS entries for VMs without public IP

### DIFF
--- a/pkg/cmd/roachprod/vm/gce/utils.go
+++ b/pkg/cmd/roachprod/vm/gce/utils.go
@@ -165,11 +165,12 @@ func SyncDNS(vms vm.List) error {
 
 	var zoneBuilder strings.Builder
 	for _, vm := range vms {
-		if len(vm.Name) < 60 {
-			zoneBuilder.WriteString(fmt.Sprintf("%s 60 IN A %s\n", vm.Name, vm.PublicIP))
-		} else {
-			fmt.Printf("WARN: not adding `%s' to the zone file because it is longer than 60 characters\n", vm.Name)
+		entry, err := vm.ZoneEntry()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "WARN: skipping: %s\n", err)
+			continue
 		}
+		zoneBuilder.WriteString(entry)
 	}
 	fmt.Fprint(f, zoneBuilder.String())
 	f.Close()

--- a/pkg/cmd/roachprod/vm/vm.go
+++ b/pkg/cmd/roachprod/vm/vm.go
@@ -89,6 +89,19 @@ func (vm *VM) Locality() string {
 	return fmt.Sprintf("cloud=%s,region=%s,zone=%s", vm.Provider, region, vm.Zone)
 }
 
+// ZoneEntry returns a line representing the VMs DNS zone entry
+func (vm VM) ZoneEntry() (string, error) {
+	if len(vm.Name) >= 60 {
+		return "", errors.Errorf("Name too long: %s", vm.Name)
+	}
+	if vm.PublicIP == "" {
+		return "", errors.Errorf("Missing IP address: %s", vm.Name)
+	}
+	// TODO(rail): We should probably skip local VMs too. They add a bunch of
+	// entries for localhost.roachprod.crdb.io pointing to 127.0.0.1.
+	return fmt.Sprintf("%s 60 IN A %s\n", vm.Name, vm.PublicIP), nil
+}
+
 // List represents a list of VMs.
 type List []VM
 

--- a/pkg/cmd/roachprod/vm/vm_test.go
+++ b/pkg/cmd/roachprod/vm/vm_test.go
@@ -68,3 +68,43 @@ func TestExpandZonesFlag(t *testing.T) {
 		})
 	}
 }
+
+func TestVM_ZoneEntry(t *testing.T) {
+	cases := []struct {
+		description string
+		vm          VM
+		expected    string
+		expErr      string
+	}{
+		{
+			description: "Normal length",
+			vm:          VM{Name: "just_a_test", PublicIP: "1.1.1.1"},
+			expected:    "just_a_test 60 IN A 1.1.1.1\n",
+		},
+		{
+			description: "Too long name",
+			vm: VM{
+				Name:     "very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_name",
+				PublicIP: "1.1.1.1",
+			},
+			expErr: "Name too long",
+		},
+		{
+			description: "Missing IP",
+			vm:          VM{Name: "just_a_test"},
+			expErr:      "Missing IP address",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			expanded, err := c.vm.ZoneEntry()
+			if c.expErr != "" {
+				if assert.Error(t, err) {
+					assert.Regexp(t, c.expErr, err.Error())
+				}
+			} else {
+				assert.EqualValues(t, c.expected, expanded)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #58905

In some cases some VMs don't have a public IP assigned. This happens
when they are still being provisioned or destroyed.

Previously, we tried to add these VMs and the generated zone line was
missing the IP. This caused a syntax error when `gcloud` tried to import
the malformed zone file.

To address the issue, this change makes the DNS sync function skip VMs
that have no public IP address assigned.

Release note: None