### PR TITLE
geo: replace GEOS with new WKT parser for EWKT parsing

### DIFF
--- a/pkg/geo/BUILD.bazel
+++ b/pkg/geo/BUILD.bazel
@@ -20,7 +20,7 @@ go_library(
         "//pkg/geo/geographiclib",
         "//pkg/geo/geopb",
         "//pkg/geo/geoprojbase",
-        "//pkg/geo/geos",
+        "//pkg/geo/wkt",
         "//pkg/util",
         "//pkg/util/errorutil/unimplemented",
         "//pkg/util/protoutil",

--- a/pkg/geo/geogfn/covers_test.go
+++ b/pkg/geo/geogfn/covers_test.go
@@ -351,7 +351,7 @@ func TestCovers(t *testing.T) {
 		{
 			"multiple MULTIPOLYGONs required to cover MULTIPOINTS",
 			"MULTIPOLYGON(((0.0 0.0, 1.0 0.0, 1.0 1.0, 0.0 1.0, 0.0 0.0)), ((1.0 0.0, 2.0 0.0, 2.0 1.0, 1.0 1.0, 1.0 0.0)))",
-			"MULTIPOINT((0.5 0.5), (1.5 0.5))'",
+			"MULTIPOINT((0.5 0.5), (1.5 0.5))",
 			true,
 		},
 		{

--- a/pkg/geo/geomfn/remove_repeated_points_test.go
+++ b/pkg/geo/geomfn/remove_repeated_points_test.go
@@ -44,7 +44,7 @@ func TestRemoveRepeatedPoints(t *testing.T) {
 			"MULTILINESTRING ((1 2, 3 4, 1 2), EMPTY, (1 2, 3 4))",
 		},
 		{
-			"MULTILINESTRING ((1 2, 1 2, 3 4), (1 2, 3 4, 3 4), (1 2, 1 2, 1 2, 1 2)))",
+			"MULTILINESTRING ((1 2, 1 2, 3 4), (1 2, 3 4, 3 4), (1 2, 1 2, 1 2, 1 2))",
 			"MULTILINESTRING ((1 2, 3 4), (1 2, 3 4), (1 2, 1 2))",
 		},
 		{"POLYGON EMPTY", "POLYGON EMPTY"},

--- a/pkg/geo/geos/geos.go
+++ b/pkg/geo/geos/geos.go
@@ -266,19 +266,6 @@ func statusToError(s C.CR_GEOS_Status) error {
 	return &Error{msg: string(cStringToSafeGoBytes(s))}
 }
 
-// WKTToEWKB parses a WKT into WKB using the GEOS library.
-func WKTToEWKB(wkt geopb.WKT, srid geopb.SRID) (geopb.EWKB, error) {
-	g, err := ensureInitInternal()
-	if err != nil {
-		return nil, err
-	}
-	var cEWKB C.CR_GEOS_String
-	if err := statusToError(C.CR_GEOS_WKTToEWKB(g, goToCSlice([]byte(wkt)), C.int(srid), &cEWKB)); err != nil {
-		return nil, err
-	}
-	return cStringToSafeGoBytes(cEWKB), nil
-}
-
 // BufferParamsJoinStyle maps to the GEOSBufJoinStyles enum in geos_c.h.in.
 type BufferParamsJoinStyle int
 

--- a/pkg/geo/parse_test.go
+++ b/pkg/geo/parse_test.go
@@ -246,9 +246,8 @@ func TestParseEWKT(t *testing.T) {
 		expectedErr string
 	}{
 		{"POINT Z (1 2 3)", "unimplemented: dimension XYZ is not currently supported"},
-		// GEOS assumes all M coordinates as Z coordinates, so the error message is not great here.
-		{"POINT M (1 2 3)", "unimplemented: dimension XYZ is not currently supported"},
-		{"POINT ZM (1 2 3 4)", "unimplemented: dimension XYZ is not currently supported"},
+		{"POINT M (1 2 3)", "unimplemented: dimension XYM is not currently supported"},
+		{"POINT ZM (1 2 3 4)", "unimplemented: dimension XYZM is not currently supported"},
 	}
 	for _, tc := range errorTestCases {
 		t.Run(string(tc.wkt), func(t *testing.T) {
@@ -372,7 +371,9 @@ func TestParseGeometry(t *testing.T) {
 		{
 			"invalid",
 			Geometry{},
-			"geos error: ParseException: Unknown type: 'INVALID'",
+			`lex error: invalid keyword at pos 0
+invalid
+^`,
 		},
 		{
 			"",
@@ -586,7 +587,9 @@ func TestParseGeography(t *testing.T) {
 		{
 			"invalid",
 			Geography{},
-			"geos error: ParseException: Unknown type: 'INVALID'",
+			`lex error: invalid keyword at pos 0
+invalid
+^`,
 		},
 		{
 			"",

--- a/pkg/geo/wkt/wkt_test.go
+++ b/pkg/geo/wkt/wkt_test.go
@@ -30,6 +30,11 @@ func TestUnmarshal(t *testing.T) {
 			expected:    geom.NewPointFlat(geom.XY, []float64{0, 1}),
 		},
 		{
+			desc:        "parse 2D point with scientific notation",
+			equivInputs: []string{"POINT(1e-2 2e3)", "POINT(0.1e-1 2e3)", "POINT(0.01e-0 2e+3)", "POINT(0.01 2000)"},
+			expected:    geom.NewPointFlat(geom.XY, []float64{1e-2, 2e3}),
+		},
+		{
 			desc:        "parse 2D+M point",
 			equivInputs: []string{"POINT M (-2 0 0.5)", "POINTM(-2 0 0.5)", "POINTM(-2 0 .5)"},
 			expected:    geom.NewPointFlat(geom.XYM, []float64{-2, 0, 0.5}),
@@ -620,6 +625,27 @@ DOT(0 0)
 			expectedErrStr: `lex error: invalid number at pos 8
 POINT(2 2.3.7)
         ^`,
+		},
+		{
+			desc:  "invalid scientific notation number missing number before the e",
+			input: "POINT(e-1 2)",
+			expectedErrStr: `lex error: invalid keyword at pos 6
+POINT(e-1 2)
+      ^`,
+		},
+		{
+			desc:  "invalid scientific notation number with non-integer power",
+			input: "POINT(5e-1.5 2)",
+			expectedErrStr: `lex error: invalid number at pos 6
+POINT(5e-1.5 2)
+      ^`,
+		},
+		{
+			desc:  "invalid number with a + at the start (PostGIS does not allow this)",
+			input: "POINT(+1 2)",
+			expectedErrStr: `lex error: invalid character at pos 6
+POINT(+1 2)
+      ^`,
 		},
 		{
 			desc:  "invalid keyword when extraneous spaces are present in ZM",

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -4998,10 +4998,10 @@ false  false  97  false  false
 
 # Test for 2+ string arguments for Geometry where one side of the arguments
 # raises an error.
-statement error Unknown type: 'ABC'
+statement error pq: st_intersects\(\): lex error: invalid keyword at pos 0\nabc\n\^
 SELECT ST_Intersects('abc'::string, 'POINT(1 0)'::string)
 
-statement error Unknown type: 'ABC'
+statement error pq: st_intersects\(\): lex error: invalid keyword at pos 0\nabc\n\^
 SELECT ST_Intersects('POINT(1 0)'::string, 'abc'::string)
 
 query T
@@ -5258,7 +5258,7 @@ SELECT
   ST_AsText(ST_LineMerge(g::geometry))
 FROM ( VALUES
   ('MULTILINESTRING ((1 2, 3 4), (3 4, 5 6))'),
-  ('MULTILINESTRING ((1 2, 3 4), (5 6, 7 8)))'),
+  ('MULTILINESTRING ((1 2, 3 4), (5 6, 7 8))'),
   ('POINT (1 2)')
   )
  t(g)

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1020,7 +1020,7 @@ func TestLint(t *testing.T) {
 
 		if err := stream.ForEach(stream.Sequence(
 			filter,
-			stream.GrepNot(`(json|jsonpb|yaml|xml|protoutil|toml|Codec|ewkb|wkb)\.Unmarshal\(`),
+			stream.GrepNot(`(json|jsonpb|yaml|xml|protoutil|toml|Codec|ewkb|wkb|wkt)\.Unmarshal\(`),
 		), func(s string) {
 			t.Errorf("\n%s <- forbidden; use 'protoutil.Unmarshal' instead", s)
 		}); err != nil {


### PR DESCRIPTION
Previously, the `parseEWKT` function used GEOS to parse WKT strings.
This was inadequate because GEOS has issues with parsing Z and M
dimensions. To address this, a new WKT parser was implemented with
goyacc and this patch integrates it into CockroachDB.

Refs: #53091

Release note: None