### PR TITLE
sql: include virtual table names in crash reports

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -430,6 +430,7 @@ go_test(
         "drop_test.go",
         "err_count_test.go",
         "event_log_test.go",
+        "exec_util_test.go",
         "explain_bundle_test.go",
         "explain_test.go",
         "explain_tree_test.go",

--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -615,25 +615,7 @@ func scrubStmtStatKey(vt VirtualTabler, key string) (string, bool) {
 
 	// Re-format to remove most names.
 	f := tree.NewFmtCtx(tree.FmtAnonymize)
-
-	reformatFn := func(ctx *tree.FmtCtx, tn *tree.TableName) {
-		virtual, err := vt.getVirtualTableEntry(tn)
-		if err != nil || virtual == nil {
-			ctx.WriteByte('_')
-			return
-		}
-		// Virtual table: we want to keep the name; however
-		// we need to scrub the database name prefix.
-		newTn := *tn
-		newTn.CatalogName = "_"
-
-		ctx.WithFlags(tree.FmtParsable, func() {
-			ctx.WithReformatTableNames(nil, func() {
-				ctx.FormatNode(&newTn)
-			})
-		})
-	}
-	f.SetReformatTableNames(reformatFn)
+	f.SetReformatTableNames(hideNonVirtualTableNameFunc(vt))
 	f.FormatNode(stmt.AST)
 	return f.CloseAndGetString(), true
 }

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -793,7 +793,8 @@ func (ex *connExecutor) closeWrapper(ctx context.Context, recovered interface{})
 
 			// Embed the statement in the error object for the telemetry
 			// report below. The statement gets anonymized.
-			panicErr = WithAnonymizedStatement(panicErr, ex.curStmtAST)
+			vt := ex.planner.extendedEvalCtx.VirtualSchemas
+			panicErr = WithAnonymizedStatement(panicErr, ex.curStmtAST, vt)
 		}
 
 		// Report the panic to telemetry in any case.
@@ -2818,6 +2819,6 @@ func init() {
 			return ""
 		}
 		// Anonymize the statement for reporting.
-		return anonymizeStmtAndConstants(stmt)
+		return anonymizeStmtAndConstants(stmt, nil /* VirtualTabler */)
 	})
 }

--- a/pkg/sql/exec_util_test.go
+++ b/pkg/sql/exec_util_test.go
@@ -1,0 +1,59 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHideNonVirtualTableNameFunc(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	s := cluster.MakeTestingClusterSettings()
+	vt, err := NewVirtualSchemaHolder(context.Background(), s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tableNameFunc := hideNonVirtualTableNameFunc(vt)
+
+	testData := []struct {
+		stmt     string
+		expected string
+	}{
+		{`SELECT * FROM a.b`,
+			`SELECT * FROM _`},
+		{`SELECT * FROM pg_type`,
+			`SELECT * FROM _`},
+		{`SELECT * FROM pg_catalog.pg_type`,
+			`SELECT * FROM pg_catalog.pg_type`},
+	}
+
+	for _, test := range testData {
+		stmt, err := parser.ParseOne(test.stmt)
+		if err != nil {
+			t.Fatal(err)
+		}
+		f := tree.NewFmtCtx(tree.FmtSimple)
+		f.SetReformatTableNames(tableNameFunc)
+		f.FormatNode(stmt.AST)
+		actual := f.CloseAndGetString()
+		require.Equal(t, test.expected, actual)
+	}
+}


### PR DESCRIPTION
This uses the functionality that we already had in place for telemetry
data. This might potentially make some crash reports more useful without
compromising privacy.

Release note (general change): Crash reports that are sent to Cockroach Labs
now no longer redact the names of builtin virtual tables from the
crdb_internal, information_schema, and pg_catalog schemas.