### PR TITLE
sql: add check privileges before changing table/database owner

### DIFF
--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -57,15 +57,16 @@ func (p *planner) AlterDatabaseOwner(
 }
 
 func (n *alterDatabaseOwnerNode) startExec(params runParams) error {
-	privs := n.desc.GetPrivileges()
-
-	// If the owner we want to set to is the current owner, do a no-op.
 	newOwner := n.n.Owner
-	if newOwner == privs.Owner() {
-		return nil
-	}
+	oldOwner := n.desc.GetPrivileges().Owner()
+
 	if err := params.p.checkCanAlterDatabaseAndSetNewOwner(params.ctx, n.desc, newOwner); err != nil {
 		return err
+	}
+
+	// If the owner we want to set to is the current owner, do a no-op.
+	if newOwner == oldOwner {
+		return nil
 	}
 
 	if err := params.p.writeNonDropDatabaseChange(

--- a/pkg/sql/alter_schema.go
+++ b/pkg/sql/alter_schema.go
@@ -131,15 +131,15 @@ func (p *planner) alterSchemaOwner(
 	newOwner security.SQLUsername,
 	jobDescription string,
 ) error {
-	privs := scDesc.GetPrivileges()
-
-	// If the owner we want to set to is the current owner, do a no-op.
-	if newOwner == privs.Owner() {
-		return nil
-	}
+	oldOwner := scDesc.GetPrivileges().Owner()
 
 	if err := p.checkCanAlterSchemaAndSetNewOwner(ctx, scDesc, newOwner); err != nil {
 		return err
+	}
+
+	// If the owner we want to set to is the current owner, do a no-op.
+	if newOwner == oldOwner {
+		return nil
 	}
 
 	return p.writeSchemaDescChange(ctx, scDesc, jobDescription)

--- a/pkg/sql/alter_table_owner.go
+++ b/pkg/sql/alter_table_owner.go
@@ -74,16 +74,15 @@ func (n *alterTableOwnerNode) startExec(params runParams) error {
 	p := params.p
 	tableDesc := n.desc
 	newOwner := n.owner
-
-	privs := n.desc.GetPrivileges()
-
-	// If the owner we want to set to is the current owner, do a no-op.
-	if newOwner == privs.Owner() {
-		return nil
-	}
+	oldOwner := n.desc.GetPrivileges().Owner()
 
 	if err := p.checkCanAlterTableAndSetNewOwner(ctx, tableDesc, newOwner); err != nil {
 		return err
+	}
+
+	// If the owner we want to set to is the current owner, do a no-op.
+	if newOwner == oldOwner {
+		return nil
 	}
 
 	if err := p.writeSchemaChange(

--- a/pkg/sql/alter_type.go
+++ b/pkg/sql/alter_type.go
@@ -410,13 +410,7 @@ func (p *planner) alterTypeOwner(
 	ctx context.Context, n *alterTypeNode, newOwner security.SQLUsername,
 ) error {
 	typeDesc := n.desc
-
-	privs := typeDesc.GetPrivileges()
-
-	// If the owner we want to set to is the current owner, do a no-op.
-	if newOwner == privs.Owner() {
-		return nil
-	}
+	oldOwner := typeDesc.GetPrivileges().Owner()
 
 	arrayDesc, err := p.Descriptors().GetMutableTypeVersionByID(ctx, p.txn, typeDesc.ArrayTypeID)
 	if err != nil {
@@ -425,6 +419,11 @@ func (p *planner) alterTypeOwner(
 
 	if err := p.checkCanAlterTypeAndSetNewOwner(ctx, typeDesc, arrayDesc, newOwner); err != nil {
 		return err
+	}
+
+	// If the owner we want to set to is the current owner, do a no-op.
+	if newOwner == oldOwner {
+		return nil
 	}
 
 	if err := p.writeTypeSchemaChange(

--- a/pkg/sql/logictest/testdata/logic_test/alter_database_owner
+++ b/pkg/sql/logictest/testdata/logic_test/alter_database_owner
@@ -19,6 +19,10 @@ user testuser
 statement error must be owner of database d
 ALTER DATABASE d OWNER TO testuser
 
+# other users must be owner to alter the owner to the current owner again
+statement error must be owner of database d
+ALTER DATABASE d OWNER TO root
+
 # Non-superusers also must be a member of the new owning role.
 user root
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_schema_owner
+++ b/pkg/sql/logictest/testdata/logic_test/alter_schema_owner
@@ -15,6 +15,10 @@ user testuser
 statement error must be owner of schema "s"
 ALTER SCHEMA s OWNER TO testuser
 
+# other users must be owner to alter the owner to the current owner again
+statement error must be owner of schema "s"
+ALTER SCHEMA s OWNER TO root
+
 # Non-superusers also must be a member of the new owning role.
 user root
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_table_owner
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table_owner
@@ -36,6 +36,10 @@ user testuser
 statement error must be owner of table t
 ALTER TABLE t OWNER TO testuser2
 
+# other users must be owner to alter the owner to the current owner again
+statement error must be owner of table t
+ALTER TABLE t OWNER TO root
+
 # Non-superusers also must be a member of the new owning role.
 user root
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_type_owner
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type_owner
@@ -27,6 +27,10 @@ user testuser
 statement error must be owner of type typ
 ALTER TYPE s.typ OWNER TO testuser
 
+# other users must be owner to alter the owner to the current owner again
+statement error must be owner of type typ
+ALTER TYPE s.typ OWNER TO root
+
 # Non-superusers also must be a member of the new owning role.
 user root
 


### PR DESCRIPTION
sql: add check privileges before changing table/database owner

There is a logic implemented that checks if an old owner and a new one
are the same. In this case the operation is a no-op. Previously, this
check was done before privileges validation, hence it was possible for
a user without privileges to alter table/database to the current owner
again.
This patch moves the privileges validation before old/new owner check.

Fixes #58975

Release note (bug fix): add check privileges before changing table/database owner