### PR TITLE
bazel: pin c++ toolchain to a particular clang version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -133,6 +133,30 @@ load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
 
+# Load up the pinned clang toolchain.
+
+http_archive(
+    name = "com_grail_bazel_toolchain",
+    sha256 = "b924b102adc0c3368d38a19bd971cb4fa75362a27bc363d0084b90ca6877d3f0",
+    strip_prefix = "bazel-toolchain-0.5.7",
+    urls = ["https://github.com/grailbio/bazel-toolchain/archive/0.5.7.tar.gz"],
+)
+
+load("@com_grail_bazel_toolchain//toolchain:deps.bzl", "bazel_toolchain_dependencies")
+
+bazel_toolchain_dependencies()
+
+load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
+
+llvm_toolchain(
+    name = "llvm_toolchain",
+    llvm_version = "10.0.0",
+)
+
+load("@llvm_toolchain//:toolchains.bzl", "llvm_register_toolchains")
+
+llvm_register_toolchains()
+
 # Load up cockroachdb's go dependencies (the ones listed under go.mod). The
 # `DEPS.bzl` file is kept up to date using the `update-repos` Gazelle command
 # (see `make bazel-generate`).

--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -6,7 +6,6 @@ RUN apt-get update \
     autoconf \
     bison \
     ca-certificates \
-    clang-10 \
     cmake \
     curl \
     flex \
@@ -14,9 +13,8 @@ RUN apt-get update \
     gnupg2 \
     libncurses-dev \
     make \
+    python3 \
     unzip \
- && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100 \
-    --slave /usr/bin/clang++ clang++ /usr/bin/clang++-10 \
  && apt-get clean
 
 # We need a newer version of cmake.

--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -1,1 +1,1 @@
-BAZEL_IMAGE=cockroachdb/bazel:20210201-174432
+BAZEL_IMAGE=cockroachdb/bazel:20210219-135943


### PR DESCRIPTION
This was a planned work item anyway, but we're seeing more and more
issues arise due to a lack of toolchain pinning (for example,
https://github.com/cockroachdb/dev-inf/issues/307), so we should just
get started on this now.

Use the open-source grailbio/bazel-toolchain library to pin to clang
v10.0. I selected this library because it appears to be the most
complete Clang toolchain in the open-source world for Bazel, and
it didn't seem like writing my own thing from scratch was particularly
useful.

The open-source library is deficient in several important ways, namely
that the toolchain detection is based on which OS you're using, so
remote execution builds and cross-compiled builds are very likely to not
work. We have to solve both of these problems anyway, and neither is in
use for Cockroach now, so this doesn't seem to be a huge issue for now.
As we implement that logic, we can submit pull requests/fork as
appropriate.

Release note: None