### PR TITLE
changefeedccl: send resolved timestamps newest to oldest

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -472,7 +472,12 @@ func (ca *changeAggregator) maybeFlush(resolvedSpan *jobspb.ResolvedSpan) error 
 		}
 	}
 
-	for _, resolvedSpan := range ca.spansToFlush {
+	// Iterate the spans in reverse so that if there are a very large number of
+	// spans which we're propagating upwards get processed in newest to oldest
+	// order. This will ultimately improve the efficiency of the checkpointing
+	// code which wants to checkpoint whenever the frontier changes.
+	for i := len(ca.spansToFlush) - 1; i >= 0; i-- {
+		resolvedSpan = ca.spansToFlush[i]
 		resolvedBytes, err := protoutil.Marshal(resolvedSpan)
 		if err != nil {
 			return err


### PR DESCRIPTION
The ChangeAggregator accumulates in memory a big slice of resolved
spans which it propagates periodically. This slice is ordered based
on when the span was recieved. This means that it will send the oldest
checkpoints first. The higher level, the ChangeFrontier, will checkpoint
any time its frontier moves. The frontier is likely to move in tiny
increments as old messages inch it forward. By sending the newest
checkpoints first, older messages are now likely to be no-ops.

This is not a perfect fix. There are more and better things we
can do but this fix is particularly good because it means that
if a client decreased the rate at which the ChangeAggregator
propagated resolved spans, it would decrease the number of
checkpoints.

Informs #59770.

Release note (bug fix): Fix a bug whereby high-latency global clusters
could sometimes fall behind checkpointing resolved timestamps.