### PR TITLE
release-20.2: build: cross-compile the `workload` binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1742,8 +1742,12 @@ bins = \
   bin/uptodate \
   bin/urlcheck \
 	bin/whoownsit \
-  bin/workload \
   bin/zerosum
+
+# `xbins` contains binaries that should be compiled for the target architecture
+# (not the host), and should therefore be built with `xgo`.
+xbins = \
+  bin/workload
 
 testbins = \
   bin/logictest \
@@ -1773,6 +1777,12 @@ $(bins): bin/%: bin/%.d | bin/prereqs bin/.submodules-initialized
 	bin/prereqs $(if $($*-package),$($*-package),./pkg/cmd/$*) > $@.d.tmp
 	mv -f $@.d.tmp $@.d
 	@$(GO_INSTALL) -v $(if $($*-package),$($*-package),./pkg/cmd/$*)
+
+$(xbins): bin/%: bin/%.d | bin/prereqs bin/.submodules-initialized
+	@echo go build -v $(GOFLAGS) $(GOMODVENDORFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -o $@ $*
+	bin/prereqs $(if $($*-package),$($*-package),./pkg/cmd/$*) > $@.d.tmp
+	mv -f $@.d.tmp $@.d
+	$(xgo) build -v $(GOFLAGS) $(GOMODVENDORFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -o $@ $(if $($*-package),$($*-package),./pkg/cmd/$*)
 
 $(testbins): bin/%: bin/%.d | bin/prereqs $(SUBMODULES_TARGET)
 	@echo go test -c $($*-package)

--- a/build/teamcity-nightly-roachtest.sh
+++ b/build/teamcity-nightly-roachtest.sh
@@ -23,7 +23,7 @@ chmod o+rwx "${artifacts}"
 # Disable global -json flag.
 export PATH=$PATH:$(GOFLAGS=; go env GOPATH)/bin
 
-make bin/workload bin/roachtest bin/roachprod > "${artifacts}/build.txt" 2>&1 || cat "${artifacts}/build.txt"
+build/builder/mkrelease.sh amd64-linux-gnu bin/workload bin/roachtest bin/roachprod > "${artifacts}/build.txt" 2>&1 || cat "${artifacts}/build.txt"
 
 # Set up Google credentials. Note that we need this for all clouds since we upload
 # perf artifacts to Google Storage at the end.

--- a/pkg/cmd/roachtest/README.md
+++ b/pkg/cmd/roachtest/README.md
@@ -8,7 +8,7 @@ separate) tool `roachprod`.
 
 1. [Set up `roachprod`](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachprod/README.md), if you haven't already. This includes making sure `$PWD/bin` is on your `PATH` and `gcloud` is installed and properly configured.
 1. Build a linux release binary of `cockroach`: `build/builder.sh mkrelease amd64-linux-gnu`
-1. Build a linux binary of the `workload` tool: `build/builder.sh make bin/workload`
+1. Build a linux binary of the `workload` tool: `build/builder.sh mkrelease amd64-linux-gnu bin/workload`
 1. Build a local binary of `roachtest`: `make bin/roachtest`
 
 # Usage

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -174,6 +174,7 @@ func findBinaryOrLibrary(binOrLib string, name string) (string, error) {
 			filepath.Join(gopath, "/src/github.com/cockroachdb/cockroach/"),
 			filepath.Join(gopath, "/src/github.com/cockroachdb/cockroach", binOrLib+suffix),
 			filepath.Join(os.ExpandEnv("$PWD"), binOrLib+suffix),
+			filepath.Join(gopath, "/src/github.com/cockroachdb/cockroach", binOrLib),
 		}
 		for _, dir := range dirs {
 			path = filepath.Join(dir, name)

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -109,7 +109,7 @@ func WithMakeReleaseOptionExecFn(r ExecFn) MakeReleaseOption {
 
 // MakeWorkload makes the bin/workload binary.
 func MakeWorkload(pkgDir string) error {
-	cmd := exec.Command("make", "bin/workload")
+	cmd := exec.Command("mkrelease", "amd64-linux-gnu", "bin/workload")
 	cmd.Dir = pkgDir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
Backport 1/1 commits from #60635.

/cc @cockroachdb/release

---

We tried to address cockroachdb/dev-inf#300
with `110fa0d391f838287a13647aa5f94940ebe175cd`, which cross-compiled
*all* binaries. This didn't work, since some binaries that are
cross-compiled need to run on the host (rather than target) machine.
Instead, we take a more targeted approach, cross-compiling only
`bin/workload`, which is what's failing to get compiled correctly in
this case.

I validated that roachtests pass with the latest builder image with this
change, and that we can still cross-compile to non-Linux systems as
well.

Ref:
  80a8344

Release note: None

Co-authored-by: Steven Danna <danna@cockroachlabs.com>
