### PR TITLE
release-20.2: sql: ensure type schema change cleanup job is resilient to retries

### DIFF
--- a/pkg/sql/type_change_test.go
+++ b/pkg/sql/type_change_test.go
@@ -12,6 +12,7 @@ package sql_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -25,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
 )
 
 // TestDrainingNamesAreCleanedTypeChangeOnFailure ensures that draining names
@@ -154,5 +156,69 @@ CREATE TYPE d.t AS ENUM();
 	// The retry should happen within the job and succeed.
 	if _, err := sqlDB.Exec(`ALTER TYPE d.t RENAME TO t2`); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestFailedTypeSchemaChangeRetriesTransparently fails the initial type schema
+// change operation and then tests that if the cleanup job runs into a
+// non-permanent error, it is retried transparently.
+func TestFailedTypeSchemaChangeRetriesTransparently(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Decrease the adopt loop interval so that retries happen quickly.
+	defer setTestJobsAdoptInterval()()
+
+	ctx := context.Background()
+	// Protects errReturned.
+	var mu syncutil.Mutex
+	// Ensures just the first try to cleanup returns a retryable error.
+	errReturned := false
+	params, _ := tests.CreateTestServerParams()
+	cleanupSuccessfullyFinished := make(chan struct{})
+	params.Knobs.SQLTypeSchemaChanger = &sql.TypeSchemaChangerTestingKnobs{
+		RunBeforeExec: func() error {
+			return errors.New("yikes")
+		},
+		RunAfterOnFailOrCancel: func() error {
+			mu.Lock()
+			defer mu.Unlock()
+			if errReturned {
+				return nil
+			}
+			errReturned = true
+			close(cleanupSuccessfullyFinished)
+			return context.DeadlineExceeded
+		},
+	}
+
+	s, sqlDB, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	// Create a type.
+	_, err := sqlDB.Exec(`
+CREATE DATABASE d;
+CREATE TYPE d.t AS ENUM();
+`)
+	require.NoError(t, err)
+
+	// The initial drop should fail.
+	_, err = sqlDB.Exec(`DROP TYPE d.t`)
+	testutils.IsError(err, "yikes")
+
+	// The cleanup job, which is expected to drain names, should retry
+	// transparently.
+	<-cleanupSuccessfullyFinished
+
+	// type descriptor name + array alias name.
+	namespaceEntries := []string{"t", "_t"}
+	for _, name := range namespaceEntries {
+		rows := sqlDB.QueryRow(fmt.Sprintf(`SELECT count(*) FROM system.namespace WHERE name= '%s'`, name))
+		var count int
+		err = rows.Scan(&count)
+		require.NoError(t, err)
+		if count != 0 {
+			t.Fatalf("expected namespace entries to be cleaned up for type desc %q", name)
+		}
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #60495.

/cc @cockroachdb/release

---

Previously if the type schema changer ran into a non-permanent error,
it wouldn't retry transparently. Instead, manual cleanup would be
required. This patch fixes this behavior.

This patch also adds a testing knob, `RunAfterOnFailOrCancel` to test
the afformentioned bug.

Fixes #60489

Release note (bug fix): Previosly, retryable errors in the cleanup
phase of the type schema changer wouldn't be retried automatically
in the background. This is now fixed.
