### PR TITLE
opt: add partition info to the opt catalog

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -428,9 +428,13 @@ TABLE ok1
  └── PRIMARY INDEX primary
       ├── a int not null
       ├── b int not null
-      └── partition by list prefixes
-           ├── (1)
-           └── (2)
+      └── partitions
+           ├── p1
+           │    └── partition by list prefixes
+           │         └── (1)
+           └── p2
+                └── partition by list prefixes
+                     └── (2)
 scan ok1
 
 statement ok
@@ -472,9 +476,13 @@ TABLE ok2
  └── PRIMARY INDEX primary
       ├── a int not null
       ├── b int not null
-      └── partition by list prefixes
-           ├── (1)
-           └── (2)
+      └── partitions
+           ├── p1
+           │    └── partition by list prefixes
+           │         └── (1)
+           └── p2
+                └── partition by list prefixes
+                     └── (2)
 scan ok2
 
 statement ok
@@ -516,8 +524,13 @@ TABLE ok3
  └── PRIMARY INDEX primary
       ├── a int not null
       ├── b int not null
-      └── partition by list prefixes
-           └── (1)
+      └── partitions
+           ├── p1
+           │    └── partition by list prefixes
+           │         └── (1)
+           └── p2
+                └── partition by list prefixes
+                     └── ()
 scan ok3
 
 statement ok
@@ -563,10 +576,19 @@ TABLE ok4
  └── PRIMARY INDEX primary
       ├── a int not null
       ├── b int not null
-      └── partition by list prefixes
-           ├── (1, 1)
-           ├── (1)
-           └── (2, 3)
+      └── partitions
+           ├── p1
+           │    └── partition by list prefixes
+           │         └── (1, 1)
+           ├── p2
+           │    └── partition by list prefixes
+           │         └── (1)
+           ├── p3
+           │    └── partition by list prefixes
+           │         └── (2, 3)
+           └── p4
+                └── partition by list prefixes
+                     └── ()
 scan ok4
 
 statement ok
@@ -603,9 +625,16 @@ TABLE ok5
  └── PRIMARY INDEX primary
       ├── a int not null
       ├── b int not null
-      └── partition by list prefixes
-           ├── (1)
-           └── (2)
+      └── partitions
+           ├── p1
+           │    └── partition by list prefixes
+           │         └── (1)
+           ├── p2
+           │    └── partition by list prefixes
+           │         └── (2)
+           └── p3
+                └── partition by list prefixes
+                     └── ()
 scan ok5
 
 query TT
@@ -897,9 +926,13 @@ TABLE ok11
       ├── a int not null
       ├── b int not null
       ├── c int not null
-      └── partition by list prefixes
-           ├── (1)
-           └── (6)
+      └── partitions
+           ├── p1
+           │    └── partition by list prefixes
+           │         └── (1)
+           └── p2
+                └── partition by list prefixes
+                     └── (6)
 scan ok11
 
 statement ok
@@ -943,10 +976,16 @@ TABLE ok12
  └── PRIMARY INDEX primary
       ├── a int not null
       ├── b int not null
-      └── partition by list prefixes
-           ├── (NULL)
-           ├── (1)
-           └── (2)
+      └── partitions
+           ├── pu
+           │    └── partition by list prefixes
+           │         └── (NULL)
+           ├── p1
+           │    └── partition by list prefixes
+           │         └── (1)
+           └── p2
+                └── partition by list prefixes
+                     └── (2)
 scan ok12
 
 # Verify that creating a partition that includes NULL does not change the

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -149,6 +149,73 @@ CREATE TABLE public.t (
 )
 -- Warning: Partitioned table with no zone configurations.
 
+query T
+EXPLAIN (OPT, CATALOG) SELECT * FROM t
+----
+TABLE t
+ ├── pk int not null
+ ├── a int not null
+ ├── b int
+ ├── c int
+ ├── d int
+ ├── j jsonb
+ ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
+ ├── tableoid oid [hidden] [system]
+ ├── j_inverted_key bytes not null [virtual-inverted]
+ ├── FAMILY fam_0_pk_a_b_c_d_j (pk, a, b, c, d, j)
+ ├── PRIMARY INDEX primary
+ │    ├── a int not null (implicit)
+ │    ├── pk int not null
+ │    └── partitions
+ │         └── pk_implicit
+ │              └── partition by list prefixes
+ │                   └── (1)
+ ├── INDEX t_b_idx
+ │    ├── a int not null (implicit)
+ │    ├── b int
+ │    ├── pk int not null
+ │    └── partitions
+ │         └── b_implicit
+ │              └── partition by list prefixes
+ │                   └── (2)
+ ├── UNIQUE INDEX t_c_key
+ │    ├── a int not null (implicit)
+ │    ├── c int
+ │    ├── pk int not null (storing)
+ │    └── partitions
+ │         └── c_implicit
+ │              └── partition by list prefixes
+ │                   └── (3)
+ ├── INDEX t_a_b_c_idx
+ │    ├── d int (implicit)
+ │    ├── a int not null
+ │    ├── b int
+ │    ├── c int
+ │    ├── pk int not null
+ │    └── partitions
+ │         └── a_b_c_implicit
+ │              └── partition by list prefixes
+ │                   └── (4)
+ ├── INVERTED INDEX t_j_idx
+ │    ├── a int not null (implicit)
+ │    ├── j_inverted_key bytes not null [virtual-inverted]
+ │    ├── pk int not null
+ │    └── partitions
+ │         └── j_implicit
+ │              └── partition by list prefixes
+ │                   └── (5)
+ ├── INDEX new_idx
+ │    ├── a int not null (implicit)
+ │    ├── d int
+ │    ├── pk int not null
+ │    └── partitions
+ │         └── d_implicit
+ │              └── partition by list prefixes
+ │                   └── (1)
+ ├── UNIQUE WITHOUT INDEX (pk)
+ └── UNIQUE WITHOUT INDEX (c)
+scan t
+
 statement ok
 INSERT INTO t VALUES (1, 2, 3, 4, 5)
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -151,6 +151,194 @@ ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row
   voter_constraints = '{+region=us-east-1: 2}',
   lease_preferences = '[[+region=us-east-1]]'
 
+query T
+EXPLAIN (OPT, CATALOG) SELECT * FROM regional_by_row_table
+----
+TABLE regional_by_row_table
+ ├── pk int not null
+ ├── pk2 int not null
+ ├── a int not null
+ ├── b int not null
+ ├── j jsonb
+ ├── crdb_region crdb_internal_region not null default (default_to_database_primary_region(gateway_region())::@100054) [hidden]
+ ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
+ ├── tableoid oid [hidden] [system]
+ ├── j_inverted_key bytes not null [virtual-inverted]
+ ├── FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
+ ├── CHECK (crdb_region IN (b'\x40':::@100054, b'\x80':::@100054, b'\xc0':::@100054))
+ ├── PRIMARY INDEX primary
+ │    ├── crdb_region crdb_internal_region not null default (default_to_database_primary_region(gateway_region())::@100054) [hidden] (implicit)
+ │    ├── pk int not null
+ │    ├── ZONE
+ │    │    ├── replica constraints
+ │    │    │    ├── 1 replicas: [+region=ap-southeast-2]
+ │    │    │    ├── 1 replicas: [+region=ca-central-1]
+ │    │    │    ├── 1 replicas: [+region=us-east-1]
+ │    │    │    └── voter constraints: [+region=ca-central-1]
+ │    │    └── lease preference: [+region=ca-central-1]
+ │    └── partitions
+ │         ├── ap-southeast-2
+ │         │    ├── partition by list prefixes
+ │         │    │    └── ('ap-southeast-2')
+ │         │    └── ZONE
+ │         │         ├── replica constraints
+ │         │         │    ├── 1 replicas: [+region=ap-southeast-2]
+ │         │         │    ├── 1 replicas: [+region=ca-central-1]
+ │         │         │    ├── 1 replicas: [+region=us-east-1]
+ │         │         │    └── voter constraints: [+region=ap-southeast-2]
+ │         │         └── lease preference: [+region=ap-southeast-2]
+ │         ├── ca-central-1
+ │         │    ├── partition by list prefixes
+ │         │    │    └── ('ca-central-1')
+ │         │    └── ZONE
+ │         │         ├── replica constraints
+ │         │         │    ├── 1 replicas: [+region=ap-southeast-2]
+ │         │         │    ├── 1 replicas: [+region=ca-central-1]
+ │         │         │    ├── 1 replicas: [+region=us-east-1]
+ │         │         │    └── voter constraints: [+region=ca-central-1]
+ │         │         └── lease preference: [+region=ca-central-1]
+ │         └── us-east-1
+ │              ├── partition by list prefixes
+ │              │    └── ('us-east-1')
+ │              └── ZONE
+ │                   ├── replica constraints
+ │                   │    ├── 1 replicas: [+region=ap-southeast-2]
+ │                   │    ├── 1 replicas: [+region=ca-central-1]
+ │                   │    ├── 1 replicas: [+region=us-east-1]
+ │                   │    └── voter constraints: [+region=us-east-1]
+ │                   └── lease preference: [+region=us-east-1]
+ ├── INDEX regional_by_row_table_a_idx
+ │    ├── crdb_region crdb_internal_region not null default (default_to_database_primary_region(gateway_region())::@100054) [hidden] (implicit)
+ │    ├── a int not null
+ │    ├── pk int not null
+ │    ├── ZONE
+ │    │    ├── replica constraints
+ │    │    │    ├── 1 replicas: [+region=ap-southeast-2]
+ │    │    │    ├── 1 replicas: [+region=ca-central-1]
+ │    │    │    ├── 1 replicas: [+region=us-east-1]
+ │    │    │    └── voter constraints: [+region=ca-central-1]
+ │    │    └── lease preference: [+region=ca-central-1]
+ │    └── partitions
+ │         ├── ap-southeast-2
+ │         │    ├── partition by list prefixes
+ │         │    │    └── ('ap-southeast-2')
+ │         │    └── ZONE
+ │         │         ├── replica constraints
+ │         │         │    ├── 1 replicas: [+region=ap-southeast-2]
+ │         │         │    ├── 1 replicas: [+region=ca-central-1]
+ │         │         │    ├── 1 replicas: [+region=us-east-1]
+ │         │         │    └── voter constraints: [+region=ap-southeast-2]
+ │         │         └── lease preference: [+region=ap-southeast-2]
+ │         ├── ca-central-1
+ │         │    ├── partition by list prefixes
+ │         │    │    └── ('ca-central-1')
+ │         │    └── ZONE
+ │         │         ├── replica constraints
+ │         │         │    ├── 1 replicas: [+region=ap-southeast-2]
+ │         │         │    ├── 1 replicas: [+region=ca-central-1]
+ │         │         │    ├── 1 replicas: [+region=us-east-1]
+ │         │         │    └── voter constraints: [+region=ca-central-1]
+ │         │         └── lease preference: [+region=ca-central-1]
+ │         └── us-east-1
+ │              ├── partition by list prefixes
+ │              │    └── ('us-east-1')
+ │              └── ZONE
+ │                   ├── replica constraints
+ │                   │    ├── 1 replicas: [+region=ap-southeast-2]
+ │                   │    ├── 1 replicas: [+region=ca-central-1]
+ │                   │    ├── 1 replicas: [+region=us-east-1]
+ │                   │    └── voter constraints: [+region=us-east-1]
+ │                   └── lease preference: [+region=us-east-1]
+ ├── UNIQUE INDEX regional_by_row_table_b_key
+ │    ├── crdb_region crdb_internal_region not null default (default_to_database_primary_region(gateway_region())::@100054) [hidden] (implicit)
+ │    ├── b int not null
+ │    ├── pk int not null (storing)
+ │    ├── ZONE
+ │    │    ├── replica constraints
+ │    │    │    ├── 1 replicas: [+region=ap-southeast-2]
+ │    │    │    ├── 1 replicas: [+region=ca-central-1]
+ │    │    │    ├── 1 replicas: [+region=us-east-1]
+ │    │    │    └── voter constraints: [+region=ca-central-1]
+ │    │    └── lease preference: [+region=ca-central-1]
+ │    └── partitions
+ │         ├── ap-southeast-2
+ │         │    ├── partition by list prefixes
+ │         │    │    └── ('ap-southeast-2')
+ │         │    └── ZONE
+ │         │         ├── replica constraints
+ │         │         │    ├── 1 replicas: [+region=ap-southeast-2]
+ │         │         │    ├── 1 replicas: [+region=ca-central-1]
+ │         │         │    ├── 1 replicas: [+region=us-east-1]
+ │         │         │    └── voter constraints: [+region=ap-southeast-2]
+ │         │         └── lease preference: [+region=ap-southeast-2]
+ │         ├── ca-central-1
+ │         │    ├── partition by list prefixes
+ │         │    │    └── ('ca-central-1')
+ │         │    └── ZONE
+ │         │         ├── replica constraints
+ │         │         │    ├── 1 replicas: [+region=ap-southeast-2]
+ │         │         │    ├── 1 replicas: [+region=ca-central-1]
+ │         │         │    ├── 1 replicas: [+region=us-east-1]
+ │         │         │    └── voter constraints: [+region=ca-central-1]
+ │         │         └── lease preference: [+region=ca-central-1]
+ │         └── us-east-1
+ │              ├── partition by list prefixes
+ │              │    └── ('us-east-1')
+ │              └── ZONE
+ │                   ├── replica constraints
+ │                   │    ├── 1 replicas: [+region=ap-southeast-2]
+ │                   │    ├── 1 replicas: [+region=ca-central-1]
+ │                   │    ├── 1 replicas: [+region=us-east-1]
+ │                   │    └── voter constraints: [+region=us-east-1]
+ │                   └── lease preference: [+region=us-east-1]
+ ├── INVERTED INDEX regional_by_row_table_j_idx
+ │    ├── crdb_region crdb_internal_region not null default (default_to_database_primary_region(gateway_region())::@100054) [hidden] (implicit)
+ │    ├── j_inverted_key bytes not null [virtual-inverted]
+ │    ├── pk int not null
+ │    ├── ZONE
+ │    │    ├── replica constraints
+ │    │    │    ├── 1 replicas: [+region=ap-southeast-2]
+ │    │    │    ├── 1 replicas: [+region=ca-central-1]
+ │    │    │    ├── 1 replicas: [+region=us-east-1]
+ │    │    │    └── voter constraints: [+region=ca-central-1]
+ │    │    └── lease preference: [+region=ca-central-1]
+ │    └── partitions
+ │         ├── ap-southeast-2
+ │         │    ├── partition by list prefixes
+ │         │    │    └── ('ap-southeast-2')
+ │         │    └── ZONE
+ │         │         ├── replica constraints
+ │         │         │    ├── 1 replicas: [+region=ap-southeast-2]
+ │         │         │    ├── 1 replicas: [+region=ca-central-1]
+ │         │         │    ├── 1 replicas: [+region=us-east-1]
+ │         │         │    └── voter constraints: [+region=ap-southeast-2]
+ │         │         └── lease preference: [+region=ap-southeast-2]
+ │         ├── ca-central-1
+ │         │    ├── partition by list prefixes
+ │         │    │    └── ('ca-central-1')
+ │         │    └── ZONE
+ │         │         ├── replica constraints
+ │         │         │    ├── 1 replicas: [+region=ap-southeast-2]
+ │         │         │    ├── 1 replicas: [+region=ca-central-1]
+ │         │         │    ├── 1 replicas: [+region=us-east-1]
+ │         │         │    └── voter constraints: [+region=ca-central-1]
+ │         │         └── lease preference: [+region=ca-central-1]
+ │         └── us-east-1
+ │              ├── partition by list prefixes
+ │              │    └── ('us-east-1')
+ │              └── ZONE
+ │                   ├── replica constraints
+ │                   │    ├── 1 replicas: [+region=ap-southeast-2]
+ │                   │    ├── 1 replicas: [+region=ca-central-1]
+ │                   │    ├── 1 replicas: [+region=us-east-1]
+ │                   │    └── voter constraints: [+region=us-east-1]
+ │                   └── lease preference: [+region=us-east-1]
+ ├── UNIQUE WITHOUT INDEX (pk)
+ └── UNIQUE WITHOUT INDEX (b)
+scan regional_by_row_table
+ └── check constraint expressions
+      └── crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
+
 query TTB colnames
 SELECT index_name, column_name, implicit FROM crdb_internal.index_columns
 WHERE descriptor_name = 'regional_by_row_table' AND column_type = 'key'

--- a/pkg/config/zonepb/zone.go
+++ b/pkg/config/zonepb/zone.go
@@ -784,6 +784,16 @@ func (z *ZoneConfig) ReplicaConstraints(i int) cat.ReplicaConstraints {
 	return &z.Constraints[i]
 }
 
+// VoterConstraintsCount is part of the cat.Zone interface.
+func (z *ZoneConfig) VoterConstraintsCount() int {
+	return len(z.VoterConstraints)
+}
+
+// VoterConstraint is part of the cat.Zone interface.
+func (z *ZoneConfig) VoterConstraint(i int) cat.ReplicaConstraints {
+	return &z.VoterConstraints[i]
+}
+
 // LeasePreferenceCount is part of the cat.Zone interface.
 func (z *ZoneConfig) LeasePreferenceCount() int {
 	return len(z.LeasePreferences)

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -12,6 +12,7 @@ package testcat
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"reflect"
 	"sort"
@@ -19,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
@@ -153,6 +155,11 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 	)
 	tab.Columns = append(tab.Columns, mvcc)
 
+	// Cache the partitioning statement for the primary index.
+	if stmt.PartitionByTable != nil {
+		tab.partitionBy = stmt.PartitionByTable.PartitionBy
+	}
+
 	// Add the primary index.
 	if hasPrimaryIndex {
 		for _, def := range stmt.Defs {
@@ -171,9 +178,6 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 		}
 	} else {
 		tab.addPrimaryColumnIndex("rowid")
-	}
-	if stmt.PartitionByTable != nil {
-		tab.Indexes[0].partitionBy = stmt.PartitionByTable.PartitionBy
 	}
 
 	// Add check constraints.
@@ -603,10 +607,6 @@ func (tt *Table) addIndexWithVersion(
 		version:  version,
 	}
 
-	if def.PartitionByIndex != nil {
-		idx.partitionBy = def.PartitionByIndex.PartitionBy
-	}
-
 	// Look for name suffixes indicating this is a mutation index.
 	if name, ok := extractWriteOnlyIndex(def); ok {
 		idx.IdxName = name
@@ -658,6 +658,44 @@ func (tt *Table) addIndexWithVersion(
 						LevelMod: 1,
 						MaxCells: 3,
 					}},
+				}
+			}
+		}
+	}
+
+	// Add partitions.
+	var partitionBy *tree.PartitionBy
+	if def.PartitionByIndex != nil {
+		partitionBy = def.PartitionByIndex.PartitionBy
+	} else if typ == primaryIndex {
+		partitionBy = tt.partitionBy
+	}
+	if partitionBy != nil {
+		ctx := context.Background()
+		semaCtx := tree.MakeSemaContext()
+		evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+
+		if len(partitionBy.List) > 0 {
+			idx.partitions = make([]Partition, len(partitionBy.List))
+			for i := range partitionBy.Fields {
+				if i >= len(idx.Columns) || partitionBy.Fields[i] != idx.Columns[i].ColName() {
+					panic("partition by columns must be a prefix of the index columns")
+				}
+			}
+			for i := range partitionBy.List {
+				p := &partitionBy.List[i]
+				idx.partitions[i] = Partition{
+					name:   string(p.Name),
+					zone:   &zonepb.ZoneConfig{},
+					datums: make([]tree.Datums, 0, len(p.Exprs)),
+				}
+
+				// Get the partition values.
+				for _, e := range p.Exprs {
+					d := idx.partitionByListExprToDatums(ctx, &evalCtx, &semaCtx, e)
+					if d != nil {
+						idx.partitions[i].datums = append(idx.partitions[i].datums, d)
+					}
 				}
 			}
 		}
@@ -944,6 +982,47 @@ func (tt *Table) addPrimaryColumnIndex(colName string) {
 		Columns: tree.IndexElemList{{Column: tree.Name(colName), Direction: tree.Ascending}},
 	}
 	tt.addIndex(&def, primaryIndex)
+}
+
+// partitionByListExprToDatums converts an expression from a PARTITION BY LIST
+// clause to a list of datums.
+func (ti *Index) partitionByListExprToDatums(
+	ctx context.Context, evalCtx *tree.EvalContext, semaCtx *tree.SemaContext, e tree.Expr,
+) tree.Datums {
+	var vals []tree.Expr
+	switch t := e.(type) {
+	case *tree.Tuple:
+		vals = t.Exprs
+	default:
+		vals = []tree.Expr{e}
+	}
+
+	// Cut off at DEFAULT, if present.
+	for i := range vals {
+		if _, ok := vals[i].(tree.DefaultVal); ok {
+			vals = vals[:i]
+		}
+	}
+	if len(vals) == 0 {
+		return nil
+	}
+	d := make(tree.Datums, len(vals))
+	for i := range vals {
+		c := tree.CastExpr{Expr: vals[i], Type: ti.Columns[i].DatumType()}
+		cTyped, err := c.TypeCheck(ctx, semaCtx, types.Any)
+		if err != nil {
+			panic(err)
+		}
+		d[i], err = cTyped.Eval(evalCtx)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	// TODO(radu): split into multiple prefixes if Subpartition is also by list.
+	// Note that this functionality should be kept in sync with the real catalog
+	// implementation (opt_catalog.go).
+	return d
 }
 
 func extractInaccessibleColumn(def *tree.ColumnTableDef) (name tree.Name, ok bool) {

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -597,6 +597,10 @@ type Table struct {
 	inboundFKs  []ForeignKeyConstraint
 
 	uniqueConstraints []UniqueConstraint
+
+	// partitionBy is the partitioning clause that corresponds to the primary
+	// index. Used to initialize the partitioning for the primary index.
+	partitionBy *tree.PartitionBy
 }
 
 var _ cat.Table = &Table{}
@@ -781,9 +785,9 @@ type Index struct {
 	// table is a back reference to the table this index is on.
 	table *Table
 
-	// partitionBy is the partitioning clause that corresponds to this index. Used
-	// to implement PartitionByListPrefixes.
-	partitionBy *tree.PartitionBy
+	// partitions stores zone information and datums for PARTITION BY LIST
+	// partitions.
+	partitions []Partition
 
 	// predicate is the partial index predicate expression, if it exists.
 	predicate string
@@ -883,67 +887,6 @@ func (ti *Index) Predicate() (string, bool) {
 	return ti.predicate, ti.predicate != ""
 }
 
-// PartitionByListPrefixes is part of the cat.Index interface.
-func (ti *Index) PartitionByListPrefixes() []tree.Datums {
-	ctx := context.Background()
-	p := ti.partitionBy
-	if p == nil {
-		return nil
-	}
-	if len(p.List) == 0 {
-		return nil
-	}
-	var res []tree.Datums
-	semaCtx := tree.MakeSemaContext()
-	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
-	for i := range p.Fields {
-		if i >= len(ti.Columns) || p.Fields[i] != ti.Columns[i].ColName() {
-			panic("partition by columns must be a prefix of the index columns")
-		}
-	}
-	for i := range p.List {
-		// Exprs contains a list of values.
-		for _, e := range p.List[i].Exprs {
-			var vals []tree.Expr
-			switch t := e.(type) {
-			case *tree.Tuple:
-				vals = t.Exprs
-			default:
-				vals = []tree.Expr{e}
-			}
-
-			// Cut off at DEFAULT, if present.
-			for i := range vals {
-				if _, ok := vals[i].(tree.DefaultVal); ok {
-					vals = vals[:i]
-				}
-			}
-			if len(vals) == 0 {
-				continue
-			}
-			d := make(tree.Datums, len(vals))
-			for i := range vals {
-				c := tree.CastExpr{Expr: vals[i], Type: ti.Columns[i].DatumType()}
-				cTyped, err := c.TypeCheck(ctx, &semaCtx, types.Any)
-				if err != nil {
-					panic(err)
-				}
-				d[i], err = cTyped.Eval(&evalCtx)
-				if err != nil {
-					panic(err)
-				}
-			}
-
-			// TODO(radu): split into multiple prefixes if Subpartition is also by list.
-			// Note that this functionality should be kept in sync with the real catalog
-			// implementation (opt_catalog.go).
-
-			res = append(res, d)
-		}
-	}
-	return res
-}
-
 // ImplicitPartitioningColumnCount is part of the cat.Index interface.
 func (ti *Index) ImplicitPartitioningColumnCount() int {
 	return 0
@@ -977,6 +920,40 @@ func (ti *Index) GeoConfig() *geoindex.Config {
 // Version is part of the cat.Index interface.
 func (ti *Index) Version() descpb.IndexDescriptorVersion {
 	return ti.version
+}
+
+// PartitionCount is part of the cat.Index interface.
+func (ti *Index) PartitionCount() int {
+	return len(ti.partitions)
+}
+
+// Partition is part of the cat.Index interface.
+func (ti *Index) Partition(i int) cat.Partition {
+	return &ti.partitions[i]
+}
+
+// Partition implements the cat.Partition interface for testing purposes.
+type Partition struct {
+	name   string
+	zone   *zonepb.ZoneConfig
+	datums []tree.Datums
+}
+
+var _ cat.Partition = &Partition{}
+
+// Name is part of the cat.Partition interface.
+func (p *Partition) Name() string {
+	return p.name
+}
+
+// Zone is part of the cat.Partition interface.
+func (p *Partition) Zone() cat.Zone {
+	return p.zone
+}
+
+// PartitionByListPrefixes is part of the cat.Partition interface.
+func (p *Partition) PartitionByListPrefixes() []tree.Datums {
+	return p.datums
 }
 
 // TableStat implements the cat.TableStatistic interface for testing purposes.

--- a/pkg/sql/opt/testutils/testcat/testdata/table
+++ b/pkg/sql/opt/testutils/testcat/testdata/table
@@ -110,11 +110,17 @@ TABLE part1
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  └── PRIMARY INDEX primary
       ├── a int not null
-      └── partition by list prefixes
-           ├── (1)
-           ├── (3)
-           ├── (4)
-           └── (5)
+      └── partitions
+           ├── p1
+           │    └── partition by list prefixes
+           │         └── (1)
+           ├── p2
+           │    └── partition by list prefixes
+           │         ├── (3)
+           │         ├── (4)
+           │         └── (5)
+           └── p3
+                └── partition by list prefixes
 
 exec-ddl
 CREATE TABLE part2 (
@@ -145,19 +151,29 @@ TABLE part2
  │    ├── a string not null
  │    ├── b string not null
  │    ├── c int not null
- │    └── partition by list prefixes
- │         ├── ('foo', 'bar')
- │         ├── ('foo', 'baz')
- │         ├── ('qux', 'qux')
- │         └── ('waldo')
+ │    └── partitions
+ │         ├── p1
+ │         │    └── partition by list prefixes
+ │         │         ├── ('foo', 'bar')
+ │         │         ├── ('foo', 'baz')
+ │         │         └── ('qux', 'qux')
+ │         ├── p2
+ │         │    └── partition by list prefixes
+ │         │         └── ('waldo')
+ │         └── p3
+ │              └── partition by list prefixes
  └── INDEX secondary
       ├── c int not null
       ├── a string not null
       ├── b string not null
-      └── partition by list prefixes
-           ├── (1)
-           ├── (3)
-           └── (4)
+      └── partitions
+           ├── pi1
+           │    └── partition by list prefixes
+           │         └── (1)
+           └── pi2
+                └── partition by list prefixes
+                     ├── (3)
+                     └── (4)
 
 exec-ddl
 CREATE TABLE inv (

--- a/pkg/sql/opt/testutils/testcat/testdata/zone
+++ b/pkg/sql/opt/testutils/testcat/testdata/zone
@@ -175,3 +175,78 @@ TABLE abc
       ├── a int not null (storing)
       └── ZONE
            └── constraints: [+dc=west]
+
+exec-ddl
+CREATE TABLE abc_part (
+    r STRING NOT NULL CHECK (r IN ('east', 'west')),
+    a INT PRIMARY KEY,
+    b INT,
+    c STRING,
+    UNIQUE WITHOUT INDEX (b, c),
+    UNIQUE INDEX bc_idx (r, b, c) PARTITION BY LIST (r) (
+      PARTITION east VALUES IN (('east')),
+      PARTITION west VALUES IN (('west'))
+    ),
+    INDEX b_idx (r, b) PARTITION BY LIST (r) (
+      PARTITION east VALUES IN (('east')),
+      PARTITION west VALUES IN (('west'))
+    )
+)
+----
+
+exec-ddl
+ALTER PARTITION "east" OF INDEX abc_part@bc_idx CONFIGURE ZONE USING
+  num_voters = 5,
+  voter_constraints = '{+region=east: 2}',
+  lease_preferences = '[[+region=east]]'
+----
+
+exec-ddl
+ALTER PARTITION "west" OF INDEX abc_part@bc_idx CONFIGURE ZONE USING
+  num_voters = 5,
+  voter_constraints = '{+region=west: 2}',
+  lease_preferences = '[[+region=west]]';
+----
+
+exec-ddl
+SHOW CREATE abc_part
+----
+TABLE abc_part
+ ├── r string not null
+ ├── a int not null
+ ├── b int
+ ├── c string
+ ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
+ ├── CHECK (r IN ('east', 'west'))
+ ├── PRIMARY INDEX primary
+ │    └── a int not null
+ ├── UNIQUE INDEX bc_idx
+ │    ├── r string not null
+ │    ├── b int
+ │    ├── c string
+ │    ├── a int not null (storing)
+ │    └── partitions
+ │         ├── east
+ │         │    ├── partition by list prefixes
+ │         │    │    └── ('east')
+ │         │    └── ZONE
+ │         │         ├── voter constraints: [+region=east]
+ │         │         └── lease preference: [+region=east]
+ │         └── west
+ │              ├── partition by list prefixes
+ │              │    └── ('west')
+ │              └── ZONE
+ │                   ├── voter constraints: [+region=west]
+ │                   └── lease preference: [+region=west]
+ ├── INDEX b_idx
+ │    ├── r string not null
+ │    ├── b int
+ │    ├── a int not null
+ │    └── partitions
+ │         ├── east
+ │         │    └── partition by list prefixes
+ │         │         └── ('east')
+ │         └── west
+ │              └── partition by list prefixes
+ │                   └── ('west')
+ └── UNIQUE WITHOUT INDEX (b, c)

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -636,7 +636,10 @@ func (c *CustomFuncs) partitionValuesFilters(
 ) (partitionFilter, inBetweenFilter memo.FiltersExpr) {
 
 	// Find all the partition values
-	partitionValues := index.PartitionByListPrefixes()
+	partitionValues := make([]tree.Datums, 0, index.PartitionCount())
+	for i, n := 0, index.PartitionCount(); i < n; i++ {
+		partitionValues = append(partitionValues, index.Partition(i).PartitionByListPrefixes()...)
+	}
 	if len(partitionValues) == 0 {
 		return partitionFilter, inBetweenFilter
 	}


### PR DESCRIPTION
Prior to this commit, the opt catalog did not include zone information
or prefixes specific to each partition of an index. This commit adds this
information since it will be necessary to support locality optimized
search in a future commit.

Informs #55185

Release note: None