### PR TITLE
sql: fix error message for virtual schema creation

### DIFF
--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -176,7 +176,7 @@ func (t virtualSchemaTable) initVirtualTableDesc(
 		tree.PersistencePermanent,
 	)
 	if err != nil {
-		return mutDesc.TableDescriptor, err
+		return descpb.TableDescriptor{}, err
 	}
 	for _, index := range mutDesc.PublicNonPrimaryIndexes() {
 		if index.NumColumns() > 1 {


### PR DESCRIPTION
Previously, if mutDesc returned from NewTableDesc was nil, the error
message would not correctly be shown because of a nil pointer exception.

Release note: None