### PR TITLE
kvserver: fix flake in TestQuotaPool

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -2187,7 +2187,6 @@ func TestReplicateAddAndRemove(t *testing.T) {
 // to constantly catch up the slower node via snapshots. See #8659.
 func TestQuotaPool(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 59382, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	const quota = 10000
@@ -2208,29 +2207,8 @@ func TestQuotaPool(t *testing.T) {
 		})
 	defer tc.Stopper().Stop(ctx)
 
-	key := []byte("a")
-	tc.SplitRangeOrFatal(t, key)
+	key := tc.ScratchRange(t)
 	tc.AddVotersOrFatal(t, key, tc.Targets(1, 2)...)
-
-	assertEqualLastIndex := func() error {
-		var expectedIndex uint64
-		for i := range tc.Servers {
-			repl := tc.GetFirstStoreFromServer(t, i).LookupReplica(key)
-			require.NotNil(t, repl)
-
-			index, err := repl.GetLastIndex()
-			if err != nil {
-				t.Fatal(err)
-			}
-			if i == 0 {
-				expectedIndex = index
-			} else if expectedIndex != index {
-				return fmt.Errorf("%s: expected lastIndex %d, but found %d", repl, expectedIndex, index)
-			}
-		}
-		return nil
-	}
-	testutils.SucceedsSoon(t, assertEqualLastIndex)
 
 	// NB: See TestRaftBlockedReplica/#9914 for why we use a separate	goroutine.
 	raftLockReplica := func(repl *kvserver.Replica) {
@@ -2239,7 +2217,7 @@ func TestQuotaPool(t *testing.T) {
 		<-ch
 	}
 
-	leaderRepl := tc.GetRaftLeader(t, key)
+	leaderRepl := tc.GetRaftLeader(t, roachpb.RKey(key))
 	// Grab the raftMu to re-initialize the QuotaPool to ensure that we don't
 	// race with ongoing applications.
 	raftLockReplica(leaderRepl)
@@ -2247,9 +2225,24 @@ func TestQuotaPool(t *testing.T) {
 		t.Fatalf("failed to initialize quota pool: %v", err)
 	}
 	leaderRepl.RaftUnlock()
+	// Wait until the follower will is not ignored by updateProposalQuotaRaftMuLocked.
+	// Otherwise the quota gets prematurely released into the pool. We can use status.Applied
+	// instead of proposalQuotaBaseIndex because it's strictly ahead or the same.
+	testutils.SucceedsSoon(t, func() error {
+		var err error
+		status := leaderRepl.RaftStatus()
+		minIndex := status.Applied
+		for id, progress := range status.Progress {
+			if progress.Match < minIndex {
+				err = errors.Errorf("Replica %d is behind leader expected %d but was %d", id, minIndex, progress.Match)
+			}
+		}
+		return err
+	})
+
 	followerRepl := func() *kvserver.Replica {
 		for i := range tc.Servers {
-			repl := tc.GetFirstStoreFromServer(t, i).LookupReplica(key)
+			repl := tc.GetFirstStoreFromServer(t, i).LookupReplica(roachpb.RKey(key))
 			require.NotNil(t, repl)
 			if repl == leaderRepl {
 				continue
@@ -2281,10 +2274,10 @@ func TestQuotaPool(t *testing.T) {
 		// second write, previously blocked by virtue of there not being enough
 		// quota, is now free to proceed. We expect the final quota in the system
 		// to be the same as what we started with.
-		key := roachpb.Key("k")
+		keyToWrite := key.Next()
 		value := bytes.Repeat([]byte("v"), (3*quota)/4)
 		var ba roachpb.BatchRequest
-		ba.Add(putArgs(key, value))
+		ba.Add(putArgs(keyToWrite, value))
 		if err := ba.SetActiveTimestamp(tc.Servers[0].Clock().Now); err != nil {
 			t.Fatal(err)
 		}
@@ -2305,7 +2298,7 @@ func TestQuotaPool(t *testing.T) {
 
 		go func() {
 			var ba roachpb.BatchRequest
-			ba.Add(putArgs(key, value))
+			ba.Add(putArgs(keyToWrite, value))
 			if err := ba.SetActiveTimestamp(tc.Servers[0].Clock().Now); err != nil {
 				ch <- roachpb.NewError(err)
 				return


### PR DESCRIPTION
Fixes #59382

This commit fixes a race condition in TestQuotaPool. The quota pool
release mechanism in updateProposalQuotaRaftMuLocked specifically ignores
any follower whose appliedState is below the proposalQuotaBaseIndex of the leader.
This means if a follower has not caught up to the leader, it maybe ignored
for the purposes of figuring out if the quota should be returned to the pool.
The test was trying to control for this by checking the LastIndex on all the
replicas to make sure it's the same, but it's not enough as we need to make sure the
AppliedState is it is percieved by the leader is the same before we kick off the
write that tests the quota pool.

Release note: None