### PR TITLE
sql: fix drop type with non-existent type

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/drop_type
+++ b/pkg/sql/logictest/testdata/logic_test/drop_type
@@ -352,6 +352,13 @@ DROP TYPE d."b+c"
 statement ok
 DROP DATABASE d
 
+# Check IF EXISTS with one type that exists, one that does not.
+subtest regression_58461
+
+statement ok
+CREATE TYPE pet AS ENUM('cat');
+DROP TYPE IF EXISTS pet, alien;
+
 # Test that dropping a schema which contains a type which refers to things
 # outside of that schema works.
 

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -1041,12 +1041,14 @@ func (p *planner) ResolveMutableTypeDescriptor(
 	if err != nil {
 		return nil, err
 	}
-	name.SetAnnotation(&p.semaCtx.Annotations, tn)
 
 	if desc != nil {
 		// Ensure that the user can access the target schema.
 		if err := p.canResolveDescUnderSchema(ctx, desc.GetParentSchemaID(), desc); err != nil {
 			return nil, err
+		}
+		if tn != nil {
+			name.SetAnnotation(&p.semaCtx.Annotations, tn)
 		}
 	}
 


### PR DESCRIPTION
fixes #58461 

Release note (bug fix): Previously DROP TYPE IF EXISTS with one
existent and another non-existent type would cause an unhandled
error. This is now fixed.