### PR TITLE
streamingccl: add experimental setting to guard the replication features

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamingest/BUILD.bazel
@@ -30,6 +30,8 @@ go_library(
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/physicalplan",
         "//pkg/sql/rowenc",
         "//pkg/sql/rowexec",

--- a/pkg/ccl/streamingccl/streamproducer/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamproducer/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
         "//pkg/util/hlc",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -349,6 +349,13 @@ var experimentalUseNewSchemaChanger = settings.RegisterEnumSetting(
 	},
 )
 
+var experimentalStreamReplicationEnabled = settings.RegisterBoolSetting(
+	"sql.defaults.experimental_stream_replication.enabled",
+	"default value for experimental_stream_replication session setting;"+
+		"enables the ability to setup a replication stream",
+	false,
+)
+
 // ExperimentalDistSQLPlanningClusterSettingName is the name for the cluster
 // setting that controls experimentalDistSQLPlanningClusterMode below.
 const ExperimentalDistSQLPlanningClusterSettingName = "sql.defaults.experimental_distsql_planning"
@@ -2333,6 +2340,10 @@ func (m *sessionDataMutator) SetUniqueWithoutIndexConstraints(val bool) {
 
 func (m *sessionDataMutator) SetUseNewSchemaChanger(val sessiondata.NewSchemaChangerMode) {
 	m.data.NewSchemaChangerMode = val
+}
+
+func (m *sessionDataMutator) SetStreamReplicationEnabled(val bool) {
+	m.data.EnableStreamReplication = val
 }
 
 // RecordLatestSequenceValue records that value to which the session incremented

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4173,6 +4173,7 @@ default_transaction_use_follower_reads                off
 disable_partially_distributed_plans                   off
 disallow_full_table_scans                             off
 enable_experimental_alter_column_type_general         off
+enable_experimental_stream_replication                off
 enable_implicit_select_for_update                     on
 enable_insert_fast_path                               on
 enable_seqscan                                        on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2437,6 +2437,7 @@ disable_partially_distributed_plans                   off                 NULL  
 disallow_full_table_scans                             off                 NULL      NULL        NULL        string
 distsql                                               off                 NULL      NULL        NULL        string
 enable_experimental_alter_column_type_general         off                 NULL      NULL        NULL        string
+enable_experimental_stream_replication                off                 NULL      NULL        NULL        string
 enable_implicit_select_for_update                     on                  NULL      NULL        NULL        string
 enable_insert_fast_path                               on                  NULL      NULL        NULL        string
 enable_seqscan                                        on                  NULL      NULL        NULL        string
@@ -2514,6 +2515,7 @@ disable_partially_distributed_plans                   off                 NULL  
 disallow_full_table_scans                             off                 NULL  user     NULL      off                 off
 distsql                                               off                 NULL  user     NULL      off                 off
 enable_experimental_alter_column_type_general         off                 NULL  user     NULL      off                 off
+enable_experimental_stream_replication                off                 NULL  user     NULL      off                 off
 enable_implicit_select_for_update                     on                  NULL  user     NULL      on                  on
 enable_insert_fast_path                               on                  NULL  user     NULL      on                  on
 enable_seqscan                                        on                  NULL  user     NULL      on                  on
@@ -2587,6 +2589,7 @@ disable_partially_distributed_plans                   NULL    NULL     NULL     
 disallow_full_table_scans                             NULL    NULL     NULL     NULL        NULL
 distsql                                               NULL    NULL     NULL     NULL        NULL
 enable_experimental_alter_column_type_general         NULL    NULL     NULL     NULL        NULL
+enable_experimental_stream_replication                NULL    NULL     NULL     NULL        NULL
 enable_implicit_select_for_update                     NULL    NULL     NULL     NULL        NULL
 enable_insert_fast_path                               NULL    NULL     NULL     NULL        NULL
 enable_seqscan                                        NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -42,6 +42,7 @@ disable_partially_distributed_plans                   off
 disallow_full_table_scans                             off
 distsql                                               off
 enable_experimental_alter_column_type_general         off
+enable_experimental_stream_replication                off
 enable_implicit_select_for_update                     on
 enable_insert_fast_path                               on
 enable_seqscan                                        on

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -237,6 +237,10 @@ type LocalOnlySessionData struct {
 	// NewSchemaChangerMode indicates whether to use the new schema changer.
 	NewSchemaChangerMode NewSchemaChangerMode
 
+	// EnableStreamReplication indicates whether to allow setting up a replication
+	// stream.
+	EnableStreamReplication bool
+
 	// SequenceCache stores sequence values which have been cached using the
 	// CACHE sequence option.
 	SequenceCache SequenceCache

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -1244,7 +1244,7 @@ var varGen = map[string]sessionVar{
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
 			mode, ok := sessiondata.NewSchemaChangerModeFromString(s)
 			if !ok {
-				return newVarValueError(`experimental_user_new_schema_changer`, s,
+				return newVarValueError(`experimental_use_new_schema_changer`, s,
 					"off", "on", "unsafe_always")
 			}
 			m.SetUseNewSchemaChanger(mode)
@@ -1255,6 +1255,24 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return sessiondata.NewSchemaChangerMode(experimentalUseNewSchemaChanger.Get(sv)).String()
+		},
+	},
+
+	`enable_experimental_stream_replication`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`enable_experimental_stream_replication`),
+		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar(`enable_experimental_stream_replication`, s)
+			if err != nil {
+				return err
+			}
+			m.SetStreamReplicationEnabled(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) string {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData.EnableStreamReplication)
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return formatBoolAsPostgresSetting(experimentalStreamReplicationEnabled.Get(sv))
 		},
 	},
 }


### PR DESCRIPTION
Add `enable_experimental_stream_replication` session setting and `sql.defaults.experimental_stream_replication.enabled` cluster setting that enables creating a replication stream and/or an ingestion job.

Fixes: #60798

Release note(sql change): Add experimental
`enable_experimental_stream_replication` session setting and `sql.defaults.experimental_stream_replication.enabled` cluster setting to enable cluster streaming