### PR TITLE
sql,tabledesc: do some validation on virtual tables

### DIFF
--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -66,6 +66,7 @@ go_test(
         "//pkg/sql",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catalogkv",
+        "//pkg/sql/catalog/catconstants",
         "//pkg/sql/catalog/dbdesc",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/typedesc",

--- a/pkg/sql/catalog/tabledesc/structured_test.go
+++ b/pkg/sql/catalog/tabledesc/structured_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	. "github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -222,8 +223,6 @@ func TestValidateTableDesc(t *testing.T) {
 			descpb.TableDescriptor{ID: 0, Name: "foo"}},
 		{`invalid parent ID 0`,
 			descpb.TableDescriptor{ID: 2, Name: "foo"}},
-		{`table "foo" is encoded using using version 0, but this client only supports version 2 and 3`,
-			descpb.TableDescriptor{ID: 2, ParentID: 1, Name: "foo"}},
 		{`table must contain at least 1 column`,
 			descpb.TableDescriptor{
 				ID:            2,
@@ -239,6 +238,16 @@ func TestValidateTableDesc(t *testing.T) {
 				FormatVersion: descpb.FamilyFormatVersion,
 				Columns: []descpb.ColumnDescriptor{
 					{ID: 0},
+				},
+				NextColumnID: 2,
+			}},
+		{`table "foo" is encoded using using version 0, but this client only supports version 2 and 3`,
+			descpb.TableDescriptor{
+				ID:       2,
+				ParentID: 1,
+				Name:     "foo",
+				Columns: []descpb.ColumnDescriptor{
+					{ID: 1, Name: "bar"},
 				},
 				NextColumnID: 2,
 			}},
@@ -284,6 +293,18 @@ func TestValidateTableDesc(t *testing.T) {
 			descpb.TableDescriptor{
 				ID:            2,
 				ParentID:      1,
+				Name:          "foo",
+				FormatVersion: descpb.FamilyFormatVersion,
+				Columns: []descpb.ColumnDescriptor{
+					{ID: 1, Name: "bar"},
+					{ID: 1, Name: "bar"},
+				},
+				NextColumnID: 2,
+			}},
+		{`duplicate column name: "bar"`,
+			descpb.TableDescriptor{
+				ID:            catconstants.CrdbInternalBackwardDependenciesTableID,
+				ParentID:      0,
 				Name:          "foo",
 				FormatVersion: descpb.FamilyFormatVersion,
 				Columns: []descpb.ColumnDescriptor{

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -644,10 +644,15 @@ func NewVirtualSchemaHolder(
 					return nil, errors.NewAssertionErrorWithWrappedErrf(err, "programmer error")
 				}
 			}
+			td := tabledesc.NewImmutable(tableDesc)
+			if err := td.ValidateSelf(ctx); err != nil {
+				return nil, errors.NewAssertionErrorWithWrappedErrf(err,
+					"failed to validate virtual table %s: programmer error", errors.Safe(td.GetName()))
+			}
 
 			entry := &virtualDefEntry{
 				virtualDef:                 def,
-				desc:                       tabledesc.NewImmutable(tableDesc),
+				desc:                       td,
 				validWithNoDatabaseContext: schema.validWithNoDatabaseContext,
 				comment:                    def.getComment(),
 			}


### PR DESCRIPTION
A rebase and fixup of https://github.com/cockroachdb/cockroach/pull/59012 

This commit makes it harder to make a bad definition for a virtual table.
We still don't validate much on virtual tables, just that there aren't
duplicate columns.

After this change, if there's a duplicate column in a virtual table,
startup will fail like:

```
$ ./cockroach demo
*
* ERROR: creating virtual schema holder: failed to initialize
* CREATE TABLE pg_catalog.pg_user (
* 	usename NAME,
*       usename NAME,
* 	usesysid OID,
* 	usecreatedb BOOL,
* 	usesuper BOOL,
* 	userepl  BOOL,
* 	usebypassrls BOOL,
* 	passwd TEXT,
* 	valuntil TIMESTAMP,
* 	useconfig TEXT[]
* ): duplicate column name: "usename"
*
ERROR: creating virtual schema holder: failed to initialize
```

Fixes #59006.

Release note: None