### PR TITLE
colflow: check for unsupported router types

### DIFF
--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -1347,6 +1347,14 @@ func IsSupported(mode sessiondatapb.VectorizeExecMode, spec *execinfrapb.FlowSpe
 		if err := colbuilder.IsSupported(mode, &spec.Processors[pIdx]); err != nil {
 			return err
 		}
+		for _, procOutput := range spec.Processors[pIdx].Output {
+			switch procOutput.Type {
+			case execinfrapb.OutputRouterSpec_PASS_THROUGH,
+				execinfrapb.OutputRouterSpec_BY_HASH:
+			default:
+				return errors.New("only pass-through and hash routers are supported")
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Apart from the supported pass-through and hash router types we have
mirror and range routers in the row-based flow (the mirror routers
are currently not being used at all whereas the range routers are used
by some BulkIO processors). This commit includes a check for unsupported
router types into `IsSupported` method for the sake of completeness
(currently, we would never try to plan such a router because the
relevant BulkIO processors cannot be wrapped into the vectorized flow).

Release note: None