### PR TITLE
kv: return retriable error in AdminChangeReplicas when range replaced

### DIFF
--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -2945,13 +2945,13 @@ func TestChangeReplicasLeaveAtomicRacesWithMerge(t *testing.T) {
 				ctx, rhs, *rhsDesc, roachpb.MakeReplicationChanges(roachpb.ADD_VOTER, tc.Target(2)),
 			)
 			// We'll ultimately fail because we're going to race with the work below.
-			msg := "descriptor changed"
+			msg := `descriptor changed:`
 			if resplit {
-				// We don't convert ConditionFailedError to the "descriptor changed"
-				// error if the range ID changed.
-				msg = "unexpected value"
+				// We return a more detailed "descriptor changed" error if the
+				// range ID changed.
+				msg = `descriptor changed: .* \(range replaced\)`
 			}
-			require.True(t, testutils.IsError(err, msg), err)
+			require.Regexp(t, msg, err)
 		}()
 		// Wait until our goroutine is blocked.
 		testutils.SucceedsSoon(t, func() error {

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -71,8 +71,7 @@ func maybeDescriptorChangedError(
 		var actualDesc roachpb.RangeDescriptor
 		if !detail.ActualValue.IsPresent() {
 			return true, nil
-		} else if err := detail.ActualValue.GetProto(&actualDesc); err == nil &&
-			desc.RangeID == actualDesc.RangeID && !desc.Equal(&actualDesc) {
+		} else if err := detail.ActualValue.GetProto(&actualDesc); err == nil && !desc.Equal(&actualDesc) {
 			return true, &actualDesc
 		}
 	}


### PR DESCRIPTION
Fixes #59287.

This commit fixes the issues we've been seeing in #59287 where kvnemesis often
saw AdminChangeReplicas operations rejected with raw `ConditionFailedErrors`
instead of "retriable replication change errors" - those with the
`errMarkCanRetryReplicationChangeWithUpdatedDesc` marker. This was due to
situations where kvnemesis would rapidly merge and re-split at the same key,
creating a new range (i.e. different ID) in place of an old range. The
AdminChangeReplicas operation, upon arrival, would find that not only had the
descriptor it was attempting to update changed, but its range ID had also
changed.

This commit addresses this case by detecting range ID changes and returning a
retriable replication change error, but with a slightly different message.