### PR TITLE
sql: do not allow reference FK partial unique constraints

### DIFF
--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -362,6 +362,13 @@ func FindFKReferencedUniqueConstraint(
 	uniqueWithoutIndexConstraints := referencedTable.GetUniqueWithoutIndexConstraints()
 	for i := range uniqueWithoutIndexConstraints {
 		c := &uniqueWithoutIndexConstraints[i]
+
+		// A partial unique constraint cannot be a reference constraint for a
+		// FK.
+		if c.IsPartial() {
+			continue
+		}
+
 		// TODO(rytaft): We should allow out-of-order unique constraints, as long
 		// as they have the same columns.
 		if descpb.ColumnIDs(c.ColumnIDs).Equals(referencedColIDs) {

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -3634,11 +3634,18 @@ statement ok
 CREATE TABLE child2 (c INT PRIMARY KEY, p INT REFERENCES db1.public.parent(p))
 
 # Test that foreign keys cannot reference columns that are indexed by a partial
-# unique index. Partial unique indexes do not guarantee uniqueness in the entire
-# table.
+# unique index or a partial unique constraint. Partial unique indexes and
+# constraints do not guarantee uniqueness in the entire table.
 
 statement ok
-CREATE TABLE partial_parent (p INT, UNIQUE INDEX (p) WHERE p > 100)
+SET experimental_enable_unique_without_index_constraints = true
+
+statement ok
+CREATE TABLE partial_parent (
+  p INT,
+  UNIQUE INDEX (p) WHERE p > 100,
+  UNIQUE WITHOUT INDEX (p) WHERE p > 0
+)
 
 statement error there is no unique constraint matching given keys for referenced table partial_parent
 CREATE TABLE partial_child (p INT REFERENCES partial_parent (p))


### PR DESCRIPTION
This commit prevents users from creating a FK with a reference column
that has a partial unique constraint. These constraints do not guarantee
uniqueness in the entire table so they cannot be used.

There is no release note because these constraints are gated behind the
experimental_enable_unique_without_index_constraints session variable.

Release note: None