### PR TITLE
kv: return empty LeaseStatus from leaseGoodToGoRLocked during follower reads

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1251,7 +1251,8 @@ func (r *Replica) checkExecutionCanProceed(
 			if !r.canServeFollowerReadRLocked(ctx, ba, err) {
 				return st, err
 			}
-			err = nil // ignoring error
+			err = nil                     // ignore error
+			st = kvserverpb.LeaseStatus{} // already empty for follower reads, but be explicit
 		}
 	}
 

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -702,7 +702,7 @@ func (r *Replica) collectSpans(
 type endCmds struct {
 	repl *Replica
 	g    *concurrency.Guard
-	st   kvserverpb.LeaseStatus
+	st   kvserverpb.LeaseStatus // empty for follower reads
 }
 
 // move moves the endCmds into the return value, clearing and making a call to


### PR DESCRIPTION
Fixes #60830.

This was broken in c44b357 and started causing problems after 0668efb.
A non-empty LeaseStatus during follower reads was tripping up logic that
assumed that a VALID LeaseStatus indicated that the serving replica was
the leaseholder. This assumption used to hold, but unintentionally did
not anymore.

Returning an empty LeaseStatus on follower reads instead of expanding
the meaning of a VALID LeaseStatus to include follower reads seems like
the right change. This is because we want to get to a place where the
lease is only checked if a replica does not have a sufficient closed
timestamp, so follower reads should never even need to consult the
lease - see #57992.