### PR TITLE
geo: rename To2DShapeType to To2D, introduce ShapeType2D method

### DIFF
--- a/pkg/geo/geo.go
+++ b/pkg/geo/geo.go
@@ -305,6 +305,11 @@ func (g *Geometry) ShapeType() geopb.ShapeType {
 	return g.spatialObject.ShapeType
 }
 
+// ShapeType2D returns the 2D shape type of the Geometry.
+func (g *Geometry) ShapeType2D() geopb.ShapeType {
+	return g.ShapeType().To2D()
+}
+
 // CartesianBoundingBox returns a Cartesian bounding box.
 func (g *Geometry) CartesianBoundingBox() *CartesianBoundingBox {
 	if g.spatialObject.BoundingBox == nil {
@@ -550,6 +555,11 @@ func (g *Geography) SRID() geopb.SRID {
 // ShapeType returns the shape type of the Geography.
 func (g *Geography) ShapeType() geopb.ShapeType {
 	return g.spatialObject.ShapeType
+}
+
+// ShapeType2D returns the 2D shape type of the Geography.
+func (g *Geography) ShapeType2D() geopb.ShapeType {
+	return g.ShapeType().To2D()
 }
 
 // Spheroid returns the spheroid represented by the given Geography.

--- a/pkg/geo/geopb/types.go
+++ b/pkg/geo/geopb/types.go
@@ -29,8 +29,8 @@ const (
 	MShapeTypeFlag = 1 << 29
 )
 
-// To2DShapeType returns the ShapeType for the corresponding 2D geometry type.
-func (s ShapeType) To2DShapeType() ShapeType {
+// To2D returns the ShapeType for the corresponding 2D geometry type.
+func (s ShapeType) To2D() ShapeType {
 	return ShapeType(uint32(s) & (MShapeTypeFlag - 1))
 }
 

--- a/pkg/geo/geopb/types_test.go
+++ b/pkg/geo/geopb/types_test.go
@@ -37,9 +37,9 @@ func TestShapeType(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.base.String(), func(t *testing.T) {
-			require.Equal(t, tc.base, tc.z.To2DShapeType())
-			require.Equal(t, tc.base, tc.m.To2DShapeType())
-			require.Equal(t, tc.base, tc.zm.To2DShapeType())
+			require.Equal(t, tc.base, tc.z.To2D())
+			require.Equal(t, tc.base, tc.m.To2D())
+			require.Equal(t, tc.base, tc.zm.To2D())
 
 			require.Equal(t, tc.z, tc.base|ZShapeTypeFlag)
 			require.Equal(t, tc.m, tc.base|MShapeTypeFlag)

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -130,7 +130,7 @@ func geometryFromTextCheckShapeBuiltin(shapeType geopb.ShapeType) builtinDefinit
 				if err != nil {
 					return nil, err
 				}
-				if g.ShapeType().To2DShapeType() != shapeType {
+				if g.ShapeType2D() != shapeType {
 					return tree.DNull, nil
 				}
 				return tree.NewDGeometry(g), nil
@@ -154,7 +154,7 @@ func geometryFromTextCheckShapeBuiltin(shapeType geopb.ShapeType) builtinDefinit
 				if err != nil {
 					return nil, err
 				}
-				if g.ShapeType().To2DShapeType() != shapeType {
+				if g.ShapeType2D() != shapeType {
 					return tree.DNull, nil
 				}
 				return tree.NewDGeometry(g), nil
@@ -180,7 +180,7 @@ func geometryFromWKBCheckShapeBuiltin(shapeType geopb.ShapeType) builtinDefiniti
 				if err != nil {
 					return nil, err
 				}
-				if g.ShapeType().To2DShapeType() != shapeType {
+				if g.ShapeType2D() != shapeType {
 					return tree.DNull, nil
 				}
 				return tree.NewDGeometry(g), nil
@@ -204,7 +204,7 @@ func geometryFromWKBCheckShapeBuiltin(shapeType geopb.ShapeType) builtinDefiniti
 				if err != nil {
 					return nil, err
 				}
-				if g.ShapeType().To2DShapeType() != shapeType {
+				if g.ShapeType2D() != shapeType {
 					return tree.DNull, nil
 				}
 				return tree.NewDGeometry(g), nil
@@ -494,7 +494,7 @@ var geoBuiltins = map[string]builtinDefinition{
 				if g.Geometry.Empty() {
 					return tree.DBoolFalse, nil
 				}
-				if g.Geometry.ShapeType().To2DShapeType() == geopb.ShapeType_Point {
+				if g.Geometry.ShapeType2D() == geopb.ShapeType_Point {
 					return tree.DBoolFalse, nil
 				}
 				return tree.DBoolTrue, nil
@@ -1873,7 +1873,7 @@ Negative azimuth values and values greater than 2π (360 degrees) are supported.
 					return nil, err
 				}
 
-				summary, err := geo.Summary(t, g.SpatialObject().BoundingBox != nil, g.ShapeType().To2DShapeType(), false)
+				summary, err := geo.Summary(t, g.SpatialObject().BoundingBox != nil, g.ShapeType2D(), false)
 				if err != nil {
 					return nil, err
 				}
@@ -1901,7 +1901,7 @@ Flags shown square brackets after the geometry type have the following meaning:
 					return nil, err
 				}
 
-				summary, err := geo.Summary(t, g.SpatialObject().BoundingBox != nil, g.ShapeType().To2DShapeType(), true)
+				summary, err := geo.Summary(t, g.SpatialObject().BoundingBox != nil, g.ShapeType2D(), true)
 				if err != nil {
 					return nil, err
 				}
@@ -2582,7 +2582,7 @@ The requested number of points must be not larger than 65336.`,
 		defProps(),
 		geometryOverload1(
 			func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
-				return tree.NewDString(g.ShapeType().To2DShapeType().String()), nil
+				return tree.NewDString(g.ShapeType2D().String()), nil
 			},
 			types.String,
 			infoBuilder{
@@ -2596,7 +2596,7 @@ The requested number of points must be not larger than 65336.`,
 		defProps(),
 		geometryOverload1(
 			func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
-				return tree.NewDString(fmt.Sprintf("ST_%s", g.ShapeType().To2DShapeType().String())), nil
+				return tree.NewDString(fmt.Sprintf("ST_%s", g.ShapeType2D().String())), nil
 			},
 			types.String,
 			infoBuilder{


### PR DESCRIPTION
This avoids the ShapeType().To2DShapeType() verbosity.

Release note: None