### PR TITLE
kv: reject lease transfers during in-progress range merge

### DIFF
--- a/pkg/kv/kvnemesis/validator.go
+++ b/pkg/kv/kvnemesis/validator.go
@@ -346,6 +346,9 @@ func (v *validator) processOp(txnID *string, op Operation) {
 		} else if resultIsErrorStr(t.Result, `unable to find store \d+ in range`) {
 			// A lease transfer that races with a replica removal may find that
 			// the store it was targeting is no longer part of the range.
+		} else if resultIsErrorStr(t.Result, `cannot transfer lease while merge in progress`) {
+			// A lease transfer is not permitted while a range merge is in its
+			// critical phase.
 		} else if resultIsError(t.Result, liveness.ErrRecordCacheMiss) {
 			// If the existing leaseholder has not yet heard about the transfer
 			// target's liveness record through gossip, it will return an error.

--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -184,43 +184,39 @@ func (ba *BatchRequest) IsSingleSkipLeaseCheckRequest() bool {
 	return ba.IsSingleRequest() && ba.hasFlag(skipLeaseCheck)
 }
 
+func (ba *BatchRequest) isSingleRequestWithMethod(m Method) bool {
+	return ba.IsSingleRequest() && ba.Requests[0].GetInner().Method() == m
+}
+
+// IsSingleTransferLeaseRequest returns true iff the batch contains a single
+// request, and that request is a TransferLease.
+func (ba *BatchRequest) IsSingleTransferLeaseRequest() bool {
+	return ba.isSingleRequestWithMethod(TransferLease)
+}
+
 // IsSinglePushTxnRequest returns true iff the batch contains a single
-// request, and that request is for a PushTxn.
+// request, and that request is a PushTxn.
 func (ba *BatchRequest) IsSinglePushTxnRequest() bool {
-	if ba.IsSingleRequest() {
-		_, ok := ba.Requests[0].GetInner().(*PushTxnRequest)
-		return ok
-	}
-	return false
+	return ba.isSingleRequestWithMethod(PushTxn)
 }
 
 // IsSingleHeartbeatTxnRequest returns true iff the batch contains a single
 // request, and that request is a HeartbeatTxn.
 func (ba *BatchRequest) IsSingleHeartbeatTxnRequest() bool {
-	if ba.IsSingleRequest() {
-		_, ok := ba.Requests[0].GetInner().(*HeartbeatTxnRequest)
-		return ok
-	}
-	return false
+	return ba.isSingleRequestWithMethod(HeartbeatTxn)
 }
 
 // IsSingleEndTxnRequest returns true iff the batch contains a single request,
 // and that request is an EndTxnRequest.
 func (ba *BatchRequest) IsSingleEndTxnRequest() bool {
-	if ba.IsSingleRequest() {
-		_, ok := ba.Requests[0].GetInner().(*EndTxnRequest)
-		return ok
-	}
-	return false
+	return ba.isSingleRequestWithMethod(EndTxn)
 }
 
 // IsSingleAbortTxnRequest returns true iff the batch contains a single request,
 // and that request is an EndTxnRequest(commit=false).
 func (ba *BatchRequest) IsSingleAbortTxnRequest() bool {
-	if ba.IsSingleRequest() {
-		if et, ok := ba.Requests[0].GetInner().(*EndTxnRequest); ok {
-			return !et.Commit
-		}
+	if ba.isSingleRequestWithMethod(EndTxn) {
+		return !ba.Requests[0].GetInner().(*EndTxnRequest).Commit
 	}
 	return false
 }
@@ -228,40 +224,27 @@ func (ba *BatchRequest) IsSingleAbortTxnRequest() bool {
 // IsSingleSubsumeRequest returns true iff the batch contains a single request,
 // and that request is an SubsumeRequest.
 func (ba *BatchRequest) IsSingleSubsumeRequest() bool {
-	if ba.IsSingleRequest() {
-		_, ok := ba.Requests[0].GetInner().(*SubsumeRequest)
-		return ok
-	}
-	return false
+	return ba.isSingleRequestWithMethod(Subsume)
 }
 
 // IsSingleComputeChecksumRequest returns true iff the batch contains a single
 // request, and that request is a ComputeChecksumRequest.
 func (ba *BatchRequest) IsSingleComputeChecksumRequest() bool {
-	if ba.IsSingleRequest() {
-		_, ok := ba.Requests[0].GetInner().(*ComputeChecksumRequest)
-		return ok
-	}
-	return false
+	return ba.isSingleRequestWithMethod(ComputeChecksum)
 }
 
 // IsSingleCheckConsistencyRequest returns true iff the batch contains a single
 // request, and that request is a CheckConsistencyRequest.
 func (ba *BatchRequest) IsSingleCheckConsistencyRequest() bool {
-	if ba.IsSingleRequest() {
-		_, ok := ba.Requests[0].GetInner().(*CheckConsistencyRequest)
-		return ok
-	}
-	return false
+	return ba.isSingleRequestWithMethod(CheckConsistency)
 }
 
 // IsSingleAddSSTableRequest returns true iff the batch contains a single
 // request, and that request is an AddSSTableRequest that will ingest as an SST,
 // (i.e. does not have IngestAsWrites set)
 func (ba *BatchRequest) IsSingleAddSSTableRequest() bool {
-	if ba.IsSingleRequest() {
-		req, ok := ba.Requests[0].GetInner().(*AddSSTableRequest)
-		return ok && !req.IngestAsWrites
+	if ba.isSingleRequestWithMethod(AddSSTable) {
+		return !ba.Requests[0].GetInner().(*AddSSTableRequest).IngestAsWrites
 	}
 	return false
 }


### PR DESCRIPTION
Found with kvnemesis's new ability to issue lease transfers.

This commit prevents TransferLease requests from waiting on in-progress
merges, instead rejecting them in `handleMergeInProgressError`. This is
necessary because the merge may need to acquire a range lease in order
to complete if it still needs to perform its Subsume request, which it
likely will if this lease transfer revoked the leaseholder's existing
range lease. Any concurrent lease acquisition attempt will be blocked on
this lease transfer because a replica only performs a single lease
operation at a time, so we reject to prevent a deadlock.

The commit adds a new `TestStoreRangeMergeRHSLeaseTransfers` test which
reliably hit this deadlock before the issue was fixed.

Release note (bug fix): Fixes a rare deadlock where a series of lease
transfers concurrent with a Range merge could block each other from
ever completing.

Release justification: bug fix