### PR TITLE
ptstorage: report correct errors when limits are disabled

### DIFF
--- a/pkg/kv/kvserver/protectedts/ptstorage/storage.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage.go
@@ -99,7 +99,7 @@ func (p *storage) Protect(ctx context.Context, txn *kv.Txn, r *ptpb.Record) erro
 	}
 	if failed := *row[0].(*tree.DBool); failed {
 		curNumSpans := int64(*row[1].(*tree.DInt))
-		if curNumSpans+int64(len(r.Spans)) > s.maxSpans {
+		if s.maxSpans > 0 && curNumSpans+int64(len(r.Spans)) > s.maxSpans {
 			return errors.WithHint(
 				errors.Errorf("protectedts: limit exceeded: %d+%d > %d spans", curNumSpans,
 					len(r.Spans), s.maxSpans),
@@ -107,7 +107,7 @@ func (p *storage) Protect(ctx context.Context, txn *kv.Txn, r *ptpb.Record) erro
 		}
 		curBytes := int64(*row[2].(*tree.DInt))
 		recordBytes := int64(len(encodedSpans) + len(r.Meta) + len(r.MetaType))
-		if curBytes+recordBytes > s.maxBytes {
+		if s.maxBytes > 0 && curBytes+recordBytes > s.maxBytes {
 			return errors.WithHint(
 				errors.Errorf("protectedts: limit exceeded: %d+%d > %d bytes", curBytes, recordBytes,
 					s.maxBytes),


### PR DESCRIPTION
When the cluster settings `kv.protectedts.max_spans` or
`kv.protectedts.max_bytes` are set to 0, the limits are disabled (see #54578).
However, if an error occurs when protecting a span, we would still check if the
limits had been exceeded, and report that the limit being exceeded was the cause
of the error. This commit ensures we do not erroneously report that an error was
caused by a limit being exceeded if the limit is disabled.

Release note (bug fix): Fixed bug that could report that a protected timestamp
limit was exceeded when the limit was disabled, if an error were to occur while
protecting a record.