### PR TITLE
cli: add new pgdump/mysqldump flags to import cli command

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -104,10 +104,10 @@ const (
 	avroSchema    = "schema"
 	avroSchemaURI = "schema_uri"
 
-	pgDumpIgnoreAllUnsupported     = "ignore_unsupported"
-	pgDumpIgnoreShuntFileDest      = "ignored_stmt_log"
+	pgDumpIgnoreAllUnsupported     = "ignore_unsupported_statements"
+	pgDumpIgnoreShuntFileDest      = "log_ignored_statements"
 	pgDumpUnsupportedSchemaStmtLog = "unsupported_schema_stmts"
-	pgDumpUnsupportedDataStmtLog   = "unsupported_data-_stmts"
+	pgDumpUnsupportedDataStmtLog   = "unsupported_data_stmts"
 	pgDumpMaxLoggedStmts           = 10
 
 	// RunningStatusImportBundleParseSchema indicates to the user that a bundle format
@@ -635,7 +635,7 @@ func importPlanHook(
 
 			if dest, ok := opts[pgDumpIgnoreShuntFileDest]; ok {
 				if !format.PgDump.IgnoreUnsupported {
-					return errors.New("cannot log unsupported PGDUMP stmts without `ignore_unsupported` option")
+					return errors.New("cannot log unsupported PGDUMP stmts without `ignore_unsupported_statements` option")
 				}
 				format.PgDump.IgnoreUnsupportedLog = dest
 			}

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1289,6 +1289,30 @@ may need to be tweaked if the Postgres dump file has extremely long lines.
 `,
 	}
 
+	ImportIgnoreUnsupportedStatements = FlagInfo{
+		Name: "ignore-unsupported-statements",
+		Description: `
+Ignore statements that are unsupported during an import from a PGDUMP file.
+`,
+	}
+
+	ImportLogIgnoredStatements = FlagInfo{
+		Name: "log-ignored-statements",
+		Description: `
+Log unsupported statements that are ignored during an import from a PGDUMP file to the specified
+destination. This flag should be used in conjunction with the ignore-unsupported-statements flag
+that ignores the unsupported statements during an import.
+`,
+	}
+
+	ImportRowLimit = FlagInfo{
+		Name: "row-limit",
+		Description: `
+Specify the number of rows that will be imported for each table during a PGDUMP or MYSQLDUMP import.
+This can be used to check schema and data correctness without running the entire import.
+`,
+	}
+
 	Log = FlagInfo{
 		Name:        "log",
 		Description: `Logging configuration. See the documentation for details.`,

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -610,13 +610,19 @@ func setStmtDiagContextDefaults() {
 
 // importCtx captures the command-line parameters of the 'import' command.
 var importCtx struct {
-	maxRowSize      int
-	skipForeignKeys bool
+	maxRowSize           int
+	skipForeignKeys      bool
+	ignoreUnsupported    bool
+	ignoreUnsupportedLog string
+	rowLimit             int
 }
 
 func setImportContextDefaults() {
 	importCtx.maxRowSize = 512 * (1 << 10) // 512 KiB
 	importCtx.skipForeignKeys = false
+	importCtx.ignoreUnsupported = false
+	importCtx.ignoreUnsupportedLog = ""
+	importCtx.rowLimit = 0
 }
 
 // GetServerCfgStores provides direct public access to the StoreSpecList inside

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -777,10 +777,16 @@ func init() {
 		d := importDumpFileCmd.Flags()
 		boolFlag(d, &importCtx.skipForeignKeys, cliflags.ImportSkipForeignKeys)
 		intFlag(d, &importCtx.maxRowSize, cliflags.ImportMaxRowSize)
+		intFlag(d, &importCtx.rowLimit, cliflags.ImportRowLimit)
+		boolFlag(d, &importCtx.ignoreUnsupported, cliflags.ImportIgnoreUnsupportedStatements)
+		stringFlag(d, &importCtx.ignoreUnsupportedLog, cliflags.ImportLogIgnoredStatements)
 
 		t := importDumpTableCmd.Flags()
 		boolFlag(t, &importCtx.skipForeignKeys, cliflags.ImportSkipForeignKeys)
 		intFlag(t, &importCtx.maxRowSize, cliflags.ImportMaxRowSize)
+		intFlag(t, &importCtx.rowLimit, cliflags.ImportRowLimit)
+		boolFlag(t, &importCtx.ignoreUnsupported, cliflags.ImportIgnoreUnsupportedStatements)
+		stringFlag(t, &importCtx.ignoreUnsupportedLog, cliflags.ImportLogIgnoredStatements)
 	}
 
 	// sqlfmt command.

--- a/pkg/cli/import.go
+++ b/pkg/cli/import.go
@@ -169,6 +169,16 @@ func runImport(
 		if importCtx.skipForeignKeys {
 			optionsClause = optionsClause + ", skip_foreign_keys"
 		}
+		if importCtx.rowLimit > 0 {
+			optionsClause = fmt.Sprintf("%s, row_limit='%d'", optionsClause, importCtx.rowLimit)
+		}
+		if importCtx.ignoreUnsupported {
+			optionsClause = fmt.Sprintf("%s, ignore_unsupported_statements", optionsClause)
+		}
+		if importCtx.ignoreUnsupportedLog != "" {
+			optionsClause = fmt.Sprintf("%s, log_ignored_statements=%s", optionsClause,
+				importCtx.ignoreUnsupportedLog)
+		}
 		switch mode {
 		case singleTable:
 			importQuery = fmt.Sprintf(`IMPORT TABLE %s FROM PGDUMP '%s' %s`, tableName,
@@ -180,6 +190,9 @@ func runImport(
 		var optionsClause string
 		if importCtx.skipForeignKeys {
 			optionsClause = " WITH skip_foreign_keys"
+		}
+		if importCtx.rowLimit > 0 {
+			optionsClause = fmt.Sprintf("%s, row_limit='%d'", optionsClause, importCtx.rowLimit)
 		}
 		switch mode {
 		case singleTable:

--- a/pkg/cli/import_test.go
+++ b/pkg/cli/import_test.go
@@ -107,12 +107,14 @@ func TestImportCLI(t *testing.T) {
 			"pgdump-with-options",
 			"PGDUMP",
 			"testdata/import/db.sql",
-			"--max-row-size=1000 --skip-foreign-keys=true",
+			"--max-row-size=1000 --skip-foreign-keys=true --row-limit=10 " +
+				"--ignore-unsupported-statements=true --log-ignored-statements='foo://bar'",
 			"IMPORT PGDUMP 'userfile://defaultdb.public.userfiles_root/db." +
-				"sql' WITH max_row_size='1000', skip_foreign_keys",
+				"sql' WITH max_row_size='1000', skip_foreign_keys, row_limit='10', ignore_unsupported_statements, " +
+				"log_ignored_statements='foo://bar'",
 			"IMPORT TABLE foo FROM PGDUMP " +
 				"'userfile://defaultdb.public.userfiles_root/db.sql' WITH max_row_size='1000', " +
-				"skip_foreign_keys",
+				"skip_foreign_keys, row_limit='10', ignore_unsupported_statements, log_ignored_statements='foo://bar'",
 		},
 		{
 			"mysql",
@@ -120,18 +122,17 @@ func TestImportCLI(t *testing.T) {
 			"testdata/import/db.sql",
 			"",
 			"IMPORT MYSQLDUMP 'userfile://defaultdb.public.userfiles_root/db.sql'",
-			"IMPORT TABLE foo FROM MYSQLDUMP " +
-				"'userfile://defaultdb.public.userfiles_root/db.sql'",
+			"IMPORT TABLE foo FROM MYSQLDUMP 'userfile://defaultdb.public.userfiles_root/db.sql'",
 		},
 		{
 			"mysql-with-options",
 			"MYSQLDUMP",
 			"testdata/import/db.sql",
-			"--skip-foreign-keys=true",
+			"--skip-foreign-keys=true --row-limit=10",
 			"IMPORT MYSQLDUMP 'userfile://defaultdb.public.userfiles_root/db." +
-				"sql' WITH skip_foreign_keys",
+				"sql' WITH skip_foreign_keys, row_limit='10'",
 			"IMPORT TABLE foo FROM MYSQLDUMP " +
-				"'userfile://defaultdb.public.userfiles_root/db.sql' WITH skip_foreign_keys",
+				"'userfile://defaultdb.public.userfiles_root/db.sql' WITH skip_foreign_keys, row_limit='10'",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -142,7 +143,7 @@ func TestImportCLI(t *testing.T) {
 
 			output := runImportCLICommand(ctx, t, importDumpCLICmd, tc.dumpFilePath, c)
 
-			require.Equal(t, output, tc.expectedImportQuery)
+			require.Equal(t, tc.expectedImportQuery, output)
 		})
 
 		t.Run(tc.name+"_table", func(t *testing.T) {
@@ -153,7 +154,7 @@ func TestImportCLI(t *testing.T) {
 
 			output := runImportCLICommand(ctx, t, importDumpCLICmd, tc.dumpFilePath, c)
 
-			require.Equal(t, output, tc.expectedImportTableQuery)
+			require.Equal(t, tc.expectedImportTableQuery, output)
 		})
 	}
 }


### PR DESCRIPTION
Release note (cli change):
This change adds the `ignore-unsupported-statements`,
`log-ignored-statements` and `row-limit` flags to the import CLI command.

`log-ignored-statements`: Log unsupported statements that are ignored during
an import from a PGDUMP file to the specified
destination.

`ignore-unsupported-statements`: Ignore statements that are unsupported during
an import from a PGDUMP file.

`row-limit`: Specify the number of rows that will be imported for each
table during a PGDUMP or MYSQLDUMP import.
This can be used to check schema and data correctness without running
the entire import.

Release justification: low-risk, high-benefit change (adding missing IMPORT options as CLI flags) 

Fixes: #60816