### PR TITLE
opt: improve extraction of constant values from constraints

### DIFF
--- a/pkg/sql/opt/constraint/constraint_set.go
+++ b/pkg/sql/opt/constraint/constraint_set.go
@@ -290,7 +290,7 @@ func (s *Set) ExtractConstCols(evalCtx *tree.EvalContext) opt.ColSet {
 }
 
 // ExtractValueForConstCol extracts the value for a constant column returned
-// by ExtractConstCols.
+// by ExtractConstCols. If the given column is not constant, nil is returned.
 func (s *Set) ExtractValueForConstCol(evalCtx *tree.EvalContext, col opt.ColumnID) tree.Datum {
 	if s == Unconstrained || s == Contradiction {
 		return nil
@@ -304,8 +304,7 @@ func (s *Set) ExtractValueForConstCol(evalCtx *tree.EvalContext, col opt.ColumnI
 				break
 			}
 		}
-		// The column must be part of the constraint's "exact prefix".
-		if colOrd != -1 && c.ExactPrefix(evalCtx) > colOrd {
+		if colOrd != -1 && s.ExtractConstCols(evalCtx).Contains(col) {
 			return c.Spans.Get(0).StartKey().Value(colOrd)
 		}
 	}


### PR DESCRIPTION
This commit improves `Constraint.ExtractConstCols` so that it can identify
constant columns that are not part of the exact prefix. For example,
prior to this commit, we would only identify column `a` as constant
in the following constraint:
```
  /a/b/c: [/1/1/1 - /1/1/1] [/1/4/1 - /1/4/1]
```
However, column `c` is also guaranteed to be constant, and this commit
improves `Constraint.ExtractConstCols` to identify it as such.

This improvement will be necessary to support locality optimized search
in a following commit. For example, the following constraint may be
eligible for locality optimized search:
```
  /a/b: [/'us-east1'/1 - /'us-east1'/1] [/'us-west1'/1 - /'us-west1'/1]
```
In order to apply the locality optimized search optimization, we must
know that column `b` is constant.

Informs #55185

Release note (performance improvement): Improved the optimizer's ability
to identify constant columns in scans. This can enable different types of
optimizations and result in improved plans.