### PR TITLE
execstats: ignore ComponentStats from other flows

### DIFF
--- a/pkg/sql/execinfrapb/api.go
+++ b/pkg/sql/execinfrapb/api.go
@@ -31,6 +31,16 @@ type FlowID struct {
 	uuid.UUID
 }
 
+// Equal returns whether the two FlowIDs are equal.
+func (f FlowID) Equal(other FlowID) bool {
+	return f.UUID.Equal(other.UUID)
+}
+
+// IsUnset returns whether the FlowID is unset.
+func (f FlowID) IsUnset() bool {
+	return f.UUID.Equal(uuid.Nil)
+}
+
 // DistSQLVersion identifies DistSQL engine versions.
 type DistSQLVersion uint32
 

--- a/pkg/sql/execstats/BUILD.bazel
+++ b/pkg/sql/execstats/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/base",
         "//pkg/roachpb",
         "//pkg/sql/execinfrapb",
+        "//pkg/util",
         "//pkg/util/tracing/tracingpb",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze_plans
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze_plans
@@ -276,6 +276,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+rows read from KV: 2 (16 B)
 maximum memory usage: <hidden>
 network usage: <hidden>
 ·


### PR DESCRIPTION
The TraceAnalyzer is initialized with a physical plan definition. Previously,
if it encountered unexpected stats in a trace, an error was returned. This
commit changes that behavior to only return an error if the unexpected stats
belong to a component of a flow the TraceAnalyzer was interested in. This is
done by matching the FlowID in the ComponentStats proto.

Release note: None

Fixes #60609 