### PR TITLE
sql: copy partial unique constraints in CREATE TABLE LIKE

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -2491,6 +2491,12 @@ func replaceLikeTableOpts(n *tree.CreateTable, params runParams) (tree.TableDefs
 					def.Columns = append(def.Columns, tree.IndexElem{Column: tree.Name(colNames[i])})
 				}
 				defs = append(defs, &def)
+				if c.IsPartial() {
+					def.Predicate, err = parser.ParseExpr(c.Predicate)
+					if err != nil {
+						return nil, err
+					}
+				}
 			}
 		}
 		if opts.Has(tree.LikeTableOptIndexes) {

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -132,7 +132,8 @@ CREATE TABLE like_table (
   UNIQUE INDEX foo (b DESC, c),
   INDEX (c) STORING (j),
   INVERTED INDEX (j),
-  UNIQUE WITHOUT INDEX (h)
+  UNIQUE WITHOUT INDEX (h),
+  UNIQUE WITHOUT INDEX (h) WHERE h > 0
 )
 
 statement ok
@@ -171,7 +172,8 @@ like_constraints  CREATE TABLE public.like_constraints (
                   FAMILY "primary" (a, b, c, h, j, k, rowid),
                   CONSTRAINT check_a CHECK (a > 3:::INT8),
                   CONSTRAINT unique_k UNIQUE WITHOUT INDEX (k),
-                  CONSTRAINT unique_h UNIQUE WITHOUT INDEX (h)
+                  CONSTRAINT unique_h UNIQUE WITHOUT INDEX (h),
+                  CONSTRAINT unique_h_1 UNIQUE WITHOUT INDEX (h) WHERE h > 0:::INT8
 )
 
 statement ok
@@ -251,7 +253,8 @@ like_all  CREATE TABLE public.like_all (
           FAMILY "primary" (a, b, c, h, j, k),
           CONSTRAINT check_a CHECK (a > 3:::INT8),
           CONSTRAINT unique_k UNIQUE WITHOUT INDEX (k),
-          CONSTRAINT unique_h UNIQUE WITHOUT INDEX (h)
+          CONSTRAINT unique_h UNIQUE WITHOUT INDEX (h),
+          CONSTRAINT unique_h_1 UNIQUE WITHOUT INDEX (h) WHERE h > 0:::INT8
 )
 
 statement ok


### PR DESCRIPTION
This commit updates `CREATE TABLE ... LIKE` to copy partial unique
constraints from the source table.

There is no release note because these constraints are gated behind the
experimental_enable_unique_without_index_constraints session variable.

Release note: None