### PR TITLE
bazel: correct BUILD file generation order

### DIFF
--- a/build/bazelutil/bazel-generate.sh
+++ b/build/bazelutil/bazel-generate.sh
@@ -3,5 +3,5 @@
 set -exuo pipefail
 
 bazel run //:gazelle -- update-repos -from_file=go.mod -build_file_proto_mode=disable_global -to_macro=DEPS.bzl%go_deps -prune=true
-bazel run //:gazelle
 bazel run //pkg/cmd/generate-test-suites --run_under="cd $PWD && " > pkg/BUILD.bazel
+bazel run //:gazelle


### PR DESCRIPTION
pkg/BUILD.bazel has the (auto-generated) directive that instructs bazel
to strip out the /pkg prefix. If we start off without
pkg/BUILD.bazel[1], the earlier gazelle invocations don't learn about
the prefix strip.

[1]: Maybe we shouldn't be able to, I was testing to see if there were
     no extraneous diffs by re-generating the file entirely.

Release note: None