### PR TITLE
bulkio: Avoid using AssertionFailed error when planning replication.

### DIFF
--- a/pkg/ccl/streamingccl/streamproducer/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamproducer/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
         "//pkg/util/hlc",
-        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 

--- a/pkg/ccl/streamingccl/streamproducer/replication_stream_planning.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_stream_planning.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/errors"
 )
 
 // replicationStreamEval is a representation of tree.ReplicationStream, prepared
@@ -128,7 +127,7 @@ func doCreateReplicationStream(
 
 	if sinkURI != "" {
 		// TODO(yevgeniy): Support replication stream sinks.
-		return errors.AssertionFailedf("replication streaming into sink not supported")
+		return pgerror.New(pgcode.FeatureNotSupported, "replication streaming into sink not supported")
 	}
 
 	var scanStart hlc.Timestamp
@@ -141,7 +140,7 @@ func doCreateReplicationStream(
 	var spans []roachpb.Span
 	if eval.Targets.Tenant == (roachpb.TenantID{}) {
 		// TODO(yevgeniy): Only tenant streaming supported now; Support granular streaming.
-		return errors.AssertionFailedf("granular replication streaming not supported")
+		return pgerror.New(pgcode.FeatureNotSupported, "granular replication streaming not supported")
 	}
 
 	telemetry.Count(`replication.create.tenant`)


### PR DESCRIPTION
AssertionFailed error message is not appropriate.
Return "unsupported error" instead.

Release Notes: None