### PR TITLE
sql: fix ParameterDescription for function argument placeholders

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/with
+++ b/pkg/sql/opt/memo/testdata/logprops/with
@@ -125,14 +125,14 @@ WITH foo AS (SELECT $1::INT) SELECT 1 FROM foo
 with &1 (foo)
  ├── columns: "?column?":3(int!null)
  ├── cardinality: [1 - 1]
- ├── immutable, has-placeholder
+ ├── has-placeholder
  ├── key: ()
  ├── fd: ()-->(3)
  ├── prune: (3)
  ├── project
  │    ├── columns: int8:1(int)
  │    ├── cardinality: [1 - 1]
- │    ├── immutable, has-placeholder
+ │    ├── has-placeholder
  │    ├── key: ()
  │    ├── fd: ()-->(1)
  │    ├── prune: (1)
@@ -141,8 +141,7 @@ with &1 (foo)
  │    │    ├── key: ()
  │    │    └── tuple [type=tuple]
  │    └── projections
- │         └── cast: INT8 [as=int8:1, type=int, immutable]
- │              └── placeholder: $1 [type=string]
+ │         └── placeholder: $1 [as=int8:1, type=int]
  └── project
       ├── columns: "?column?":3(int!null)
       ├── cardinality: [1 - 1]

--- a/pkg/sql/opt/norm/testdata/rules/project
+++ b/pkg/sql/opt/norm/testdata/rules/project
@@ -461,10 +461,10 @@ project
  ├── values
  │    ├── columns: column1:1
  │    ├── cardinality: [1 - 1]
- │    ├── immutable, has-placeholder
+ │    ├── has-placeholder
  │    ├── key: ()
  │    ├── fd: ()-->(1)
- │    └── ($1::INT8,)
+ │    └── ($1,)
  └── projections
       ├── column1:1 + 1 [as="?column?":3, outer=(1), immutable]
       └── 3 [as="?column?":4]

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -980,24 +980,24 @@ where
 ----
 project
  ├── columns: id1_2_:1!null address2_2_:2 createdo3_2_:3 name4_2_:4 nickname5_2_:5 version6_2_:6!null
- ├── immutable, has-placeholder
+ ├── has-placeholder
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  └── inner-join (lookup person [as=person0_])
       ├── columns: person0_.id:1!null address:2 createdon:3 name:4 nickname:5 version:6!null person_id:11!null
       ├── key columns: [11] = [1]
       ├── lookup columns are key
-      ├── immutable, has-placeholder
+      ├── has-placeholder
       ├── key: (11)
       ├── fd: (1)-->(2-6), (1)==(11), (11)==(1)
       ├── distinct-on
       │    ├── columns: person_id:11
       │    ├── grouping columns: person_id:11
-      │    ├── immutable, has-placeholder
+      │    ├── has-placeholder
       │    ├── key: (11)
       │    └── select
       │         ├── columns: phones1_.id:8!null person_id:11
-      │         ├── immutable, has-placeholder
+      │         ├── has-placeholder
       │         ├── key: (8)
       │         ├── fd: (8)-->(11)
       │         ├── scan phone [as=phones1_]
@@ -1005,7 +1005,7 @@ project
       │         │    ├── key: (8)
       │         │    └── fd: (8)-->(11)
       │         └── filters
-      │              └── phones1_.id:8 = $1::INT8 [outer=(8), immutable, constraints=(/8: (/NULL - ])]
+      │              └── phones1_.id:8 = $1 [outer=(8), constraints=(/8: (/NULL - ])]
       └── filters (true)
 
 opt
@@ -1030,24 +1030,24 @@ where
 ----
 project
  ├── columns: id1_2_:1!null address2_2_:2 createdo3_2_:3 name4_2_:4 nickname5_2_:5 version6_2_:6!null
- ├── immutable, has-placeholder
+ ├── has-placeholder
  ├── key: (1)
  ├── fd: (1)-->(2-6)
  └── inner-join (lookup person [as=person0_])
       ├── columns: person0_.id:1!null address:2 createdon:3 name:4 nickname:5 version:6!null person_id:11!null
       ├── key columns: [11] = [1]
       ├── lookup columns are key
-      ├── immutable, has-placeholder
+      ├── has-placeholder
       ├── key: (11)
       ├── fd: (1)-->(2-6), (1)==(11), (11)==(1)
       ├── distinct-on
       │    ├── columns: person_id:11
       │    ├── grouping columns: person_id:11
-      │    ├── immutable, has-placeholder
+      │    ├── has-placeholder
       │    ├── key: (11)
       │    └── select
       │         ├── columns: phones1_.id:8!null person_id:11
-      │         ├── immutable, has-placeholder
+      │         ├── has-placeholder
       │         ├── key: (8)
       │         ├── fd: (8)-->(11)
       │         ├── scan phone [as=phones1_]
@@ -1055,7 +1055,7 @@ project
       │         │    ├── key: (8)
       │         │    └── fd: (8)-->(11)
       │         └── filters
-      │              └── phones1_.id:8 = $1::INT8 [outer=(8), immutable, constraints=(/8: (/NULL - ])]
+      │              └── phones1_.id:8 = $1 [outer=(8), constraints=(/8: (/NULL - ])]
       └── filters (true)
 
 opt
@@ -1116,7 +1116,7 @@ where
 ----
 anti-join (hash)
  ├── columns: id1_4_:1!null phone_nu2_4_:2 person_i4_4_:4 phone_ty3_4_:3
- ├── stable, has-placeholder
+ ├── immutable, has-placeholder
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  ├── scan phone [as=phone0_]
@@ -1125,11 +1125,11 @@ anti-join (hash)
  │    └── fd: (1)-->(2-4)
  ├── select
  │    ├── columns: phone_id:7!null repairtimestamps:8
- │    ├── stable, has-placeholder
+ │    ├── immutable, has-placeholder
  │    ├── scan phone_repairtimestamps [as=repairtime1_]
  │    │    └── columns: phone_id:7!null repairtimestamps:8
  │    └── filters
- │         └── (repairtimestamps:8 >= $1::DATE) IS NOT false [outer=(8), stable]
+ │         └── (repairtimestamps:8 >= $1) IS NOT false [outer=(8), immutable]
  └── filters
       └── id:1 = phone_id:7 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
 

--- a/pkg/sql/pgwire/testdata/pgtest/parameter_description
+++ b/pkg/sql/pgwire/testdata/pgtest/parameter_description
@@ -1,0 +1,117 @@
+# This test verifies that we're correctly typing placeholder arguments
+# in prepared statements.
+
+# 83 = ASCII 'S' for Statement
+# 50 = ASCII '2'
+# ParameterFormatCodes = [0] for text format
+send
+Parse {"Name": "s1", "Query": "select n::int4 from generate_series(0,$1::int4) n"}
+Describe {"ObjectType": 83, "Name": "s1"}
+Bind {"DestinationPortal": "p1", "PreparedStatement": "s1", "ParameterFormatCodes": [0], "Parameters": [[50]]}
+Execute {"Portal": "p1"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[23]}
+{"Type":"RowDescription","Fields":[{"Name":"n","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":23,"DataTypeSize":4,"TypeModifier":-1,"Format":0}]}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"0"}]}
+{"Type":"DataRow","Values":[{"text":"1"}]}
+{"Type":"DataRow","Values":[{"text":"2"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 3"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+
+# 83 = ASCII 'S' for Statement
+# 50 = ASCII '2'
+# ParameterFormatCodes = [0] for text format
+send
+Parse {"Name": "s3", "Query": "select n::int4, lower($1) from generate_series(0,$1::int) as n"}
+Describe {"ObjectType": 83, "Name": "s3"}
+Bind {"DestinationPortal": "p3", "PreparedStatement": "s3", "ParameterFormatCodes": [0], "Parameters": [[50]]}
+Execute {"Portal": "p3"}
+Sync
+----
+
+# Postgres returns error code 42883 (undefined function). CRDB returns code
+# 42804 (datatype mismatch). Both make sense here.
+until mapError=(42883, 42804)
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ErrorResponse","Code":"42804"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+
+send
+Query {"String": "DROP TABLE IF EXISTS tab1 CASCADE"}
+----
+
+until ignore=NoticeResponse
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DROP TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+
+send
+Query {"String": "CREATE TABLE tab1 (a UUID PRIMARY KEY, b TIMESTAMPTZ, c TEXT[])"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+
+# 83 = ASCII 'S' for Statement
+send
+Parse {"Name": "s4", "Query": "UPDATE tab1 SET c = array(select unnest(c::text[]) except select unnest ($2::text[]) union select unnest($3::text[])), b = $1 WHERE a = $4"}
+Describe {"ObjectType": 83, "Name": "s4"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[1184,1009,1009,2950]}
+{"Type":"NoData"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+
+# 83 = ASCII 'S' for Statement
+send
+Parse {"Name": "s5", "Query": "SELECT $2 > 0"}
+Describe {"ObjectType": 83, "Name": "s5"}
+Sync
+----
+
+until
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ErrorResponse","Code":"42P18"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+
+# 83 = ASCII 'S' for Statement
+send
+Parse {"Name": "s6", "Query": "SELECT 3 + CASE (4) WHEN 4 THEN $1 END"}
+Describe {"ObjectType": 83, "Name": "s6"}
+Sync
+----
+
+# Postgres returns error code 42883 (undefined function). CRDB returns code
+# 42P18 (indeterminate datatype). Both make sense here.
+until mapError=(42883, 42P18)
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ErrorResponse","Code":"42P18"}
+{"Type":"ReadyForQuery","TxStatus":"I"}


### PR DESCRIPTION
fixes #60732 
fixes #60907

Release justification: Low-risk, high-benefit change to existing
functionality.

Release note (bug fix): Prepared statements would sometimes get the
wrong type OID for placeholder arguments used in function parameters.
This is now fixed.