### PR TITLE
release-20.2: logictest: use the latest builder image for logictests

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20200818-182851
+version=${USE_BUILDER_IMAGE:-20200818-182851}
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/teamcity-sqllogictest.sh
+++ b/build/teamcity-sqllogictest.sh
@@ -14,11 +14,11 @@ export BUILDER_HIDE_GOPATH_SRC=0
 # Run SqlLite tests.
 # Need to specify the flex-types flag in order to skip past variations that have
 # numeric typing differences.
-run_json_test build/builder.sh \
+USE_BUILDER_IMAGE=20210205-000935 run_json_test build/builder.sh \
   stdbuf -oL -eL \
   make test GOTESTFLAGS=-json TESTFLAGS="-v -bigtest -flex-types" TESTTIMEOUT='24h' PKG='./pkg/sql/logictest' TESTS='^TestSqlLiteLogic$$'
 
 # Run the tests with a multitenant configuration.
-run_json_test build/builder.sh \
+USE_BUILDER_IMAGE=20210205-000935 run_json_test build/builder.sh \
   stdbuf -oL -eL \
   make test GOTESTFLAGS=-json TESTFLAGS="-v -bigtest -flex-types" TESTTIMEOUT='24h' PKG='./pkg/ccl/logictestccl' TESTS='^TestTenantSQLLiteLogic$$'


### PR DESCRIPTION
The sqlite logictests tests started failing due to a bug in the old
`clang` version used on the builder image for these releases. The new
builder image has a new `clang`, but it's too huge of a change to use
the new builder image for EVERYTHING, so just use it for those tests.

Release note: None