### PR TITLE
backupccl,importccl: fix recently introduced race

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -109,11 +109,12 @@ func newBackupDataProcessor(
 
 // Start is part of the RowSource interface.
 func (bp *backupDataProcessor) Start(ctx context.Context) {
+	ctxCopy := ctx
 	go func() {
 		defer close(bp.progCh)
-		bp.backupErr = runBackupProcessor(ctx, bp.flowCtx, &bp.spec, bp.progCh)
+		bp.backupErr = runBackupProcessor(ctxCopy, bp.flowCtx, &bp.spec, bp.progCh)
 	}()
-	ctx = bp.StartInternal(ctx, backupProcessorName)
+	ctx = bp.StartInternal(ctxCopy, backupProcessorName)
 	// Go around "this value of ctx is never used" linter error. We do it this
 	// way instead of omitting the assignment to ctx above so that if in the
 	// future other initialization is added, the correct ctx is used.

--- a/pkg/ccl/backupccl/split_and_scatter_processor.go
+++ b/pkg/ccl/backupccl/split_and_scatter_processor.go
@@ -203,17 +203,18 @@ func newSplitAndScatterProcessor(
 
 // Start is part of the RowSource interface.
 func (ssp *splitAndScatterProcessor) Start(ctx context.Context) {
+	ctxCopy := ctx
 	go func() {
 		// Note that the loop over doneScatterCh in Next should prevent this
 		// goroutine from leaking when there are no errors. However, if that loop
 		// needs to exit early, runSplitAndScatter's context will be canceled.
-		scatterCtx, stopScattering := context.WithCancel(ctx)
+		scatterCtx, stopScattering := context.WithCancel(ctxCopy)
 		ssp.stopScattering = stopScattering
 
 		defer close(ssp.doneScatterCh)
 		ssp.scatterErr = ssp.runSplitAndScatter(scatterCtx, ssp.flowCtx, &ssp.spec, ssp.scatterer)
 	}()
-	ctx = ssp.StartInternal(ctx, splitAndScatterProcessorName)
+	ctx = ssp.StartInternal(ctxCopy, splitAndScatterProcessorName)
 	// Go around "this value of ctx is never used" linter error. We do it this
 	// way instead of omitting the assignment to ctx above so that if in the
 	// future other initialization is added, the correct ctx is used.

--- a/pkg/ccl/importccl/import_processor.go
+++ b/pkg/ccl/importccl/import_processor.go
@@ -100,14 +100,15 @@ func newReadImportDataProcessor(
 
 // Start is part of the RowSource interface.
 func (idp *readImportDataProcessor) Start(ctx context.Context) {
+	ctxCopy := ctx
 	// We don't have to worry about this go routine leaking because next we loop over progCh
 	// which is closed only after the go routine returns.
 	go func() {
 		defer close(idp.progCh)
-		idp.summary, idp.importErr = runImport(ctx, idp.flowCtx, &idp.spec, idp.progCh,
+		idp.summary, idp.importErr = runImport(ctxCopy, idp.flowCtx, &idp.spec, idp.progCh,
 			idp.seqChunkProvider)
 	}()
-	ctx = idp.StartInternal(ctx, readImportDataProcessorName)
+	ctx = idp.StartInternal(ctxCopy, readImportDataProcessorName)
 	// Go around "this value of ctx is never used" linter error. We do it this
 	// way instead of omitting the assignment to ctx above so that if in the
 	// future other initialization is added, the correct ctx is used.


### PR DESCRIPTION
f898d37942390a6f85a5ed93a8f8eaf2e7cf1392 refactored
`ProcessorBase.StartInternal` method, and by mistake introduced the
following race condition in several BulkIO processors: in `Start`
methods a new goroutine is kicked off and it is using the "original"
context, and after the change `ctx` variable is overwritten by
`StartInternal` call. To fix the issue we make a copy of the context and
pass that copy both into the new goroutine and `StartInternal` call.

The TODO still remains to check whether the new derived by
`StartInternal` context (stored in `ProcessorBase.Ctx`) should be used
by the new goroutines.

Related: #60940.

Release note: None