### PR TITLE
bulkio: use correct context in processor initialization

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -109,17 +109,11 @@ func newBackupDataProcessor(
 
 // Start is part of the RowSource interface.
 func (bp *backupDataProcessor) Start(ctx context.Context) {
+	ctx = bp.StartInternal(ctx, backupProcessorName)
 	go func() {
 		defer close(bp.progCh)
 		bp.backupErr = runBackupProcessor(ctx, bp.flowCtx, &bp.spec, bp.progCh)
 	}()
-	ctx = bp.StartInternal(ctx, backupProcessorName)
-	// Go around "this value of ctx is never used" linter error. We do it this
-	// way instead of omitting the assignment to ctx above so that if in the
-	// future other initialization is added, the correct ctx is used.
-	// TODO(bulkio): check whether this context should be used in the closure
-	// above.
-	_ = ctx
 }
 
 // Next is part of the RowSource interface.

--- a/pkg/ccl/backupccl/split_and_scatter_processor.go
+++ b/pkg/ccl/backupccl/split_and_scatter_processor.go
@@ -203,6 +203,7 @@ func newSplitAndScatterProcessor(
 
 // Start is part of the RowSource interface.
 func (ssp *splitAndScatterProcessor) Start(ctx context.Context) {
+	ctx = ssp.StartInternal(ctx, splitAndScatterProcessorName)
 	go func() {
 		// Note that the loop over doneScatterCh in Next should prevent this
 		// goroutine from leaking when there are no errors. However, if that loop
@@ -213,13 +214,6 @@ func (ssp *splitAndScatterProcessor) Start(ctx context.Context) {
 		defer close(ssp.doneScatterCh)
 		ssp.scatterErr = ssp.runSplitAndScatter(scatterCtx, ssp.flowCtx, &ssp.spec, ssp.scatterer)
 	}()
-	ctx = ssp.StartInternal(ctx, splitAndScatterProcessorName)
-	// Go around "this value of ctx is never used" linter error. We do it this
-	// way instead of omitting the assignment to ctx above so that if in the
-	// future other initialization is added, the correct ctx is used.
-	// TODO(bulkio): check whether this context should be used in the closure
-	// above.
-	_ = ctx
 }
 
 type entryNode struct {

--- a/pkg/ccl/importccl/import_processor.go
+++ b/pkg/ccl/importccl/import_processor.go
@@ -100,6 +100,7 @@ func newReadImportDataProcessor(
 
 // Start is part of the RowSource interface.
 func (idp *readImportDataProcessor) Start(ctx context.Context) {
+	ctx = idp.StartInternal(ctx, readImportDataProcessorName)
 	// We don't have to worry about this go routine leaking because next we loop over progCh
 	// which is closed only after the go routine returns.
 	go func() {
@@ -107,13 +108,6 @@ func (idp *readImportDataProcessor) Start(ctx context.Context) {
 		idp.summary, idp.importErr = runImport(ctx, idp.flowCtx, &idp.spec, idp.progCh,
 			idp.seqChunkProvider)
 	}()
-	ctx = idp.StartInternal(ctx, readImportDataProcessorName)
-	// Go around "this value of ctx is never used" linter error. We do it this
-	// way instead of omitting the assignment to ctx above so that if in the
-	// future other initialization is added, the correct ctx is used.
-	// TODO(bulkio): check whether this context should be used in the closure
-	// above.
-	_ = ctx
 }
 
 // Next is part of the RowSource interface.

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_backup
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_backup
@@ -1,5 +1,7 @@
 # LogicTest: multiregion-9node-3region-3azs
 
+skip flaky # see #60773
+
 query TTTT
 SHOW REGIONS
 ----
@@ -676,8 +678,6 @@ defaultdb
 postgres
 system
 test
-
-skip flaky # see #60773
 
 statement ok
 RESTORE DATABASE "mr-backup-1", "mr-backup-2" FROM 'nodelocal://1/mr-backup-combined/'


### PR DESCRIPTION
This commit ensures that producer goroutines created during the
initialization of bulk processors use the same context as bp.Ctx.

This does change the context that these goroutines were using,
but that shouldn't actually have any effects on the processors, other
than missing tracing capabilities.

Closes https://github.com/cockroachdb/cockroach/issues/60940.

Closes https://github.com/cockroachdb/cockroach/issues/60984
Closes https://github.com/cockroachdb/cockroach/issues/60983
Closes https://github.com/cockroachdb/cockroach/issues/60977
Closes https://github.com/cockroachdb/cockroach/issues/60990
Closes https://github.com/cockroachdb/cockroach/issues/60989
Closes https://github.com/cockroachdb/cockroach/issues/60979
Closes https://github.com/cockroachdb/cockroach/issues/60987
Closes https://github.com/cockroachdb/cockroach/issues/60986
Closes https://github.com/cockroachdb/cockroach/issues/60985
Closes https://github.com/cockroachdb/cockroach/issues/60981
Closes https://github.com/cockroachdb/cockroach/issues/60980
Closes https://github.com/cockroachdb/cockroach/issues/60978
Closes https://github.com/cockroachdb/cockroach/issues/60978
Closes https://github.com/cockroachdb/cockroach/issues/60976
Closes https://github.com/cockroachdb/cockroach/issues/60975

Release note: None