### PR TITLE
release-20.2: ptstorage: report correct errors when limits are disabled

### DIFF
--- a/pkg/kv/kvserver/protectedts/ptstorage/storage.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage.go
@@ -90,7 +90,7 @@ func (p *storage) Protect(ctx context.Context, txn *kv.Txn, r *ptpb.Record) erro
 	row := rows[0]
 	if failed := *row[0].(*tree.DBool); failed {
 		curNumSpans := int64(*row[1].(*tree.DInt))
-		if curNumSpans+int64(len(r.Spans)) > s.maxSpans {
+		if s.maxSpans > 0 && curNumSpans+int64(len(r.Spans)) > s.maxSpans {
 			return errors.WithHint(
 				errors.Errorf("protectedts: limit exceeded: %d+%d > %d spans", curNumSpans,
 					len(r.Spans), s.maxSpans),
@@ -98,7 +98,7 @@ func (p *storage) Protect(ctx context.Context, txn *kv.Txn, r *ptpb.Record) erro
 		}
 		curBytes := int64(*row[2].(*tree.DInt))
 		recordBytes := int64(len(encodedSpans) + len(r.Meta) + len(r.MetaType))
-		if curBytes+recordBytes > s.maxBytes {
+		if s.maxBytes > 0 && curBytes+recordBytes > s.maxBytes {
 			return errors.WithHint(
 				errors.Errorf("protectedts: limit exceeded: %d+%d > %d bytes", curBytes, recordBytes,
 					s.maxBytes),

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
@@ -96,6 +96,16 @@ var testCases = []testCase{
 		ops: []op{
 			protectOp{spans: tableSpans(42)},
 			funcOp(func(ctx context.Context, t *testing.T, tCtx *testContext) {
+				// When max_bytes or max_spans is set to 0 (i.e. unlimited), and a
+				// protect op fails because the record already exists, we should report
+				// that the record already exists, and not erroneously report that the
+				// max_bytes or max_spans has been exceeded.
+				_, err := tCtx.tc.ServerConn(0).Exec("SET CLUSTER SETTING kv.protectedts.max_bytes = $1", 0)
+				require.NoError(t, err)
+				_, err = tCtx.tc.ServerConn(0).Exec("SET CLUSTER SETTING kv.protectedts.max_spans = $1", 0)
+				require.NoError(t, err)
+			}),
+			funcOp(func(ctx context.Context, t *testing.T, tCtx *testContext) {
 				rec := newRecord(tCtx.tc.Server(0).Clock().Now(), "", nil, tableSpan(42))
 				rec.ID = pickOneRecord(tCtx)
 				err := tCtx.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {


### PR DESCRIPTION
Backport 1/1 commits from #60913.

/cc @cockroachdb/release

---

When the cluster settings `kv.protectedts.max_spans` or
`kv.protectedts.max_bytes` are set to 0, the limits are disabled (see #54578).
However, if an error occurs when protecting a span, we would still check if the
limits had been exceeded, and report that the limit being exceeded was the cause
of the error. This commit ensures we do not erroneously report that an error was
caused by a limit being exceeded if the limit is disabled.

Release note (bug fix): Fixed bug that could report that a protected timestamp
limit was exceeded when the limit was disabled, if an error were to occur while
protecting a record.
