### PR TITLE
kvserver: unskip TestGossipHandlesReplacedNode

### DIFF
--- a/pkg/kv/kvserver/gossip_test.go
+++ b/pkg/kv/kvserver/gossip_test.go
@@ -145,9 +145,6 @@ func TestGossipHandlesReplacedNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// Skipping as part of test-infra-team flaky test cleanup.
-	skip.WithIssue(t, 50024)
-
 	// As of Nov 2018 it takes 3.6s.
 	skip.UnderShort(t)
 	ctx := context.Background()


### PR DESCRIPTION
Fixes #50024

The stooper code was re-worked in #59041 and ranged feed
retries were improved here #50283. After these change this
test should no longer flake on master. This was stressed locally
for 30 minutes with no failures, so it should be safe to unskip
on master. `

Release note: None