### PR TITLE
 jobs: make Job.id an int64 instead of *int64

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1441,7 +1441,7 @@ func (r *restoreResumer) ReportResults(ctx context.Context, resultsCh chan<- tre
 	case <-ctx.Done():
 		return ctx.Err()
 	case resultsCh <- tree.Datums{
-		tree.NewDInt(tree.DInt(*r.job.ID())),
+		tree.NewDInt(tree.DInt(r.job.ID())),
 		tree.NewDString(string(jobs.StatusSucceeded)),
 		tree.NewDFloat(tree.DFloat(1.0)),
 		tree.NewDInt(tree.DInt(r.restoreStats.Rows)),

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -543,7 +543,7 @@ func generateChangefeedSessionID() string {
 func (b *changefeedResumer) Resume(ctx context.Context, execCtx interface{}) error {
 	jobExec := execCtx.(sql.JobExecContext)
 	execCfg := jobExec.ExecCfg()
-	jobID := *b.job.ID()
+	jobID := b.job.ID()
 	details := b.job.Details().(jobspb.ChangefeedDetails)
 	progress := b.job.Progress()
 
@@ -679,7 +679,7 @@ func (b *changefeedResumer) OnPauseRequest(
 
 	execCfg := jobExec.(sql.JobExecContext).ExecCfg()
 	pts := execCfg.ProtectedTimestampProvider
-	return createProtectedTimestampRecord(ctx, execCfg.Codec, pts, txn, *b.job.ID(),
+	return createProtectedTimestampRecord(ctx, execCfg.Codec, pts, txn, b.job.ID(),
 		details.Targets, *resolved, cp)
 }
 

--- a/pkg/ccl/importccl/import_processor_test.go
+++ b/pkg/ccl/importccl/import_processor_test.go
@@ -549,7 +549,7 @@ type cancellableImportResumer struct {
 }
 
 func (r *cancellableImportResumer) Resume(ctx context.Context, execCtx interface{}) error {
-	r.jobID = *r.wrapped.job.ID()
+	r.jobID = r.wrapped.job.ID()
 	r.jobIDCh <- r.jobID
 	if err := r.wrapped.Resume(r.ctx, execCtx); err != nil {
 		return err

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -1304,7 +1304,7 @@ func (r *importResumer) prepareTableDescsForIngestion(
 func (r *importResumer) ReportResults(ctx context.Context, resultsCh chan<- tree.Datums) error {
 	select {
 	case resultsCh <- tree.Datums{
-		tree.NewDInt(tree.DInt(*r.job.ID())),
+		tree.NewDInt(tree.DInt(r.job.ID())),
 		tree.NewDString(string(jobs.StatusSucceeded)),
 		tree.NewDFloat(tree.DFloat(1.0)),
 		tree.NewDInt(tree.DInt(r.res.Rows)),
@@ -1505,7 +1505,7 @@ func (r *importResumer) parseBundleSchemaIfNeeded(ctx context.Context, phs inter
 		if err := r.job.RunningStatus(ctx, nil /* txn */, func(_ context.Context, _ jobspb.Details) (jobs.RunningStatus, error) {
 			return runningStatusImportBundleParseSchema, nil
 		}); err != nil {
-			return errors.Wrapf(err, "failed to update running status of job %d", errors.Safe(*r.job.ID()))
+			return errors.Wrapf(err, "failed to update running status of job %d", errors.Safe(r.job.ID()))
 		}
 
 		var tableDescs []*tabledesc.Mutable

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -4752,7 +4752,7 @@ func TestImportControlJobRBAC(t *testing.T) {
 			rootJob := startLeasedJob(t, rootJobRecord)
 
 			// Test root can control root job.
-			rootDB.Exec(t, tc.controlQuery, *rootJob.ID())
+			rootDB.Exec(t, tc.controlQuery, rootJob.ID())
 			require.NoError(t, err)
 
 			// Start import job as non-admin user.
@@ -4761,7 +4761,7 @@ func TestImportControlJobRBAC(t *testing.T) {
 			userJob := startLeasedJob(t, nonAdminJobRecord)
 
 			// Test testuser can control testuser job.
-			_, err := testuser.Exec(tc.controlQuery, *userJob.ID())
+			_, err := testuser.Exec(tc.controlQuery, userJob.ID())
 			require.NoError(t, err)
 
 			// Start second import job as root.
@@ -4771,11 +4771,11 @@ func TestImportControlJobRBAC(t *testing.T) {
 			userJob2 := startLeasedJob(t, nonAdminJobRecord)
 
 			// Test root can control testuser job.
-			rootDB.Exec(t, tc.controlQuery, *userJob2.ID())
+			rootDB.Exec(t, tc.controlQuery, userJob2.ID())
 			require.NoError(t, err)
 
 			// Test testuser CANNOT control root job.
-			_, err = testuser.Exec(tc.controlQuery, *rootJob2.ID())
+			_, err = testuser.Exec(tc.controlQuery, rootJob2.ID())
 			require.True(t, testutils.IsError(err, "only admins can control jobs owned by other admins"))
 		})
 	}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -85,7 +85,7 @@ func (s *streamIngestionResumer) Resume(ctx context.Context, execCtx interface{}
 	p := execCtx.(sql.JobExecContext)
 
 	err := ingest(ctx, p, details.StreamAddress, s.job.Progress(),
-		*s.job.ID())
+		s.job.ID())
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/streamingccl/streamingutils/utils_test.go
+++ b/pkg/ccl/streamingccl/streamingutils/utils_test.go
@@ -64,12 +64,12 @@ func TestCutoverBuiltin(t *testing.T) {
 	err = db.QueryRowContext(
 		ctx,
 		`SELECT crdb_internal.complete_stream_ingestion_job($1, $2)`,
-		*job.ID(), cutoverTime).Scan(&jobID)
+		job.ID(), cutoverTime).Scan(&jobID)
 	require.NoError(t, err)
-	require.Equal(t, *job.ID(), int64(jobID))
+	require.Equal(t, job.ID(), int64(jobID))
 
 	// Check that sentinel is set on the job progress.
-	sj, err := registry.LoadJob(ctx, *job.ID())
+	sj, err := registry.LoadJob(ctx, job.ID())
 	require.NoError(t, err)
 	progress = sj.Progress()
 	sp, ok = progress.GetDetails().(*jobspb.Progress_StreamIngest)

--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -190,7 +190,7 @@ FROM system.jobs WHERE id = $1 AND claim_session_id = $2`,
 	if err != nil {
 		return err
 	}
-	job := &Job{id: &jobID, registry: r}
+	job := &Job{id: jobID, registry: r}
 	job.mu.payload = *payload
 	job.mu.progress = *progress
 	job.sessionID = s.ID()
@@ -241,7 +241,7 @@ func (r *Registry) runJob(
 	// Bookkeeping.
 	execCtx, cleanup := r.execCtx("resume-"+taskName, username)
 	defer cleanup()
-	spanName := fmt.Sprintf(`%s-%d`, typ, *job.ID())
+	spanName := fmt.Sprintf(`%s-%d`, typ, job.ID())
 	var span *tracing.Span
 	ctx, span = r.ac.AnnotateCtxWithSpan(ctx, spanName)
 	defer span.Finish()
@@ -252,9 +252,9 @@ func (r *Registry) runJob(
 	// as presumably they are due to the context cancellation which commonly
 	// happens during shutdown.
 	if err != nil && ctx.Err() == nil {
-		log.Errorf(ctx, "job %d: adoption completed with error %v", *job.ID(), err)
+		log.Errorf(ctx, "job %d: adoption completed with error %v", job.ID(), err)
 	}
-	r.unregister(*job.ID())
+	r.unregister(job.ID())
 	return err
 }
 
@@ -294,7 +294,7 @@ RETURNING id, status`,
 		}
 		for _, row := range rows {
 			id := int64(*row[0].(*tree.DInt))
-			job := &Job{id: &id, registry: r}
+			job := &Job{id: id, registry: r}
 			statusString := *row[1].(*tree.DString)
 			switch Status(statusString) {
 			case StatusPaused:

--- a/pkg/jobs/deprecated.go
+++ b/pkg/jobs/deprecated.go
@@ -228,7 +228,7 @@ WHERE status IN ($1, $2, $3, $4, $5) ORDER BY created DESC`
 
 		// Below we know that this node holds the lease on the job, or that we want
 		// to adopt it anyway because the leaseholder seems dead.
-		job := &Job{id: id, registry: r}
+		job := &Job{id: *id, registry: r}
 		resumeCtx, cancel := r.makeCtx()
 
 		if pauseRequested := status == StatusPauseRequested; pauseRequested {
@@ -344,7 +344,7 @@ func (r *Registry) deprecatedResume(ctx context.Context, resumer Resumer, job *J
 		payload := job.Payload()
 		execCtx, cleanup := r.execCtx("resume-"+job.taskName(), payload.UsernameProto.Decode())
 		defer cleanup()
-		spanName := fmt.Sprintf(`%s-%d`, payload.Type(), *job.ID())
+		spanName := fmt.Sprintf(`%s-%d`, payload.Type(), job.ID())
 		var span *tracing.Span
 		ctx, span = r.ac.AnnotateCtxWithSpan(ctx, spanName)
 		defer span.Finish()
@@ -358,16 +358,16 @@ func (r *Registry) deprecatedResume(ctx context.Context, resumer Resumer, job *J
 			}
 			err = r.stepThroughStateMachine(ctx, execCtx, resumer, job, status, finalResumeError)
 			if err != nil {
-				log.Errorf(ctx, "job %d: adoption completed with error %v", *job.ID(), err)
+				log.Errorf(ctx, "job %d: adoption completed with error %v", job.ID(), err)
 			}
 			status, err := job.CurrentStatus(ctx, nil /* txn */)
 			if err != nil {
-				log.Errorf(ctx, "job %d: failed querying status: %v", *job.ID(), err)
+				log.Errorf(ctx, "job %d: failed querying status: %v", job.ID(), err)
 			} else {
-				log.Infof(ctx, "job %d: status %s after adoption finished", *job.ID(), status)
+				log.Infof(ctx, "job %d: status %s after adoption finished", job.ID(), status)
 			}
 		}
-		r.unregister(*job.ID())
+		r.unregister(job.ID())
 	}); err != nil {
 		return err
 	}
@@ -443,7 +443,7 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8);`
 	}); err != nil {
 		return err
 	}
-	j.id = &id
+	j.id = id
 	return nil
 }
 

--- a/pkg/jobs/helpers_test.go
+++ b/pkg/jobs/helpers_test.go
@@ -68,7 +68,7 @@ func (j *Job) Started(ctx context.Context) error {
 
 // Created is a test only function that inserts a new jobs table row.
 func (j *Job) Created(ctx context.Context) error {
-	return j.deprecatedInsert(ctx, nil /* txn */, *j.ID(), nil /* lease */, nil /* session */)
+	return j.deprecatedInsert(ctx, nil /* txn */, j.ID(), nil /* lease */, nil /* session */)
 }
 
 // Paused is a wrapper around the internal function that moves a job to the

--- a/pkg/jobs/jobsprotectedts/jobs_protected_ts_test.go
+++ b/pkg/jobs/jobsprotectedts/jobs_protected_ts_test.go
@@ -84,11 +84,11 @@ func TestJobsProtectedTimestamp(t *testing.T) {
 	}
 	jMovedToFailed, recMovedToFailed := mkJobAndRecord()
 	require.NoError(t, s0.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		return jr.Failed(ctx, txn, *jMovedToFailed.ID(), io.ErrUnexpectedEOF)
+		return jr.Failed(ctx, txn, jMovedToFailed.ID(), io.ErrUnexpectedEOF)
 	}))
 	jFinished, recFinished := mkJobAndRecord()
 	require.NoError(t, s0.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		return jr.Succeeded(ctx, txn, *jFinished.ID())
+		return jr.Succeeded(ctx, txn, jFinished.ID())
 	}))
 	_, recRemains := mkJobAndRecord()
 	ensureNotExists := func(ctx context.Context, txn *kv.Txn, ptsID uuid.UUID) (err error) {

--- a/pkg/jobs/registry_external_test.go
+++ b/pkg/jobs/registry_external_test.go
@@ -160,7 +160,7 @@ func TestRegistryResumeExpiredLease(t *testing.T) {
 				case <-done:
 				}
 				lock.Lock()
-				resumeCounts[*job.ID()]++
+				resumeCounts[job.ID()]++
 				lock.Unlock()
 				select {
 				case <-ctx.Done():
@@ -185,7 +185,7 @@ func TestRegistryResumeExpiredLease(t *testing.T) {
 		// Wait until the job is running.
 		<-resumeCalled
 		lock.Lock()
-		jobMap[nodeid] = *job.ID()
+		jobMap[nodeid] = job.ID()
 		lock.Unlock()
 	}
 
@@ -272,7 +272,7 @@ func TestRegistryResumeActiveLease(t *testing.T) {
 				select {
 				case <-ctx.Done():
 					return ctx.Err()
-				case resumeCh <- *job.ID():
+				case resumeCh <- job.ID():
 					return nil
 				}
 			},

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2368,7 +2368,7 @@ func (s *statusServer) JobStatus(
 		Payload:  &jobspb.Payload{},
 		Progress: &jobspb.Progress{},
 	}
-	res.Id = *j.ID()
+	res.Id = j.ID()
 	// j is not escaping this function and hence is immutable so a shallow copy
 	// is fine. Also we can't really clone the field Payload as it may contain
 	// types that are not supported by Clone().

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -2146,12 +2146,12 @@ func TestJobStatusResponse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	request.JobId = *job.ID()
+	request.JobId = job.ID()
 	response, err = client.JobStatus(context.Background(), request)
 	if err != nil {
 		t.Fatal(err)
 	}
-	require.Equal(t, *job.ID(), response.Job.Id)
+	require.Equal(t, job.ID(), response.Job.Id)
 	require.Equal(t, job.Payload(), *response.Job.Payload)
 	require.Equal(t, job.Progress(), *response.Job.Progress)
 }

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -342,7 +342,7 @@ func (sc *SchemaChanger) runBackfill(ctx context.Context) error {
 	log.Infof(ctx, "completed backfill for %q, v=%d", tableDesc.Name, tableDesc.Version)
 
 	if sc.testingKnobs.RunAfterBackfill != nil {
-		if err := sc.testingKnobs.RunAfterBackfill(*sc.job.ID()); err != nil {
+		if err := sc.testingKnobs.RunAfterBackfill(sc.job.ID()); err != nil {
 			return err
 		}
 	}
@@ -1382,7 +1382,7 @@ func (sc *SchemaChanger) updateJobRunningStatus(
 				ctx context.Context, details jobspb.Details) (jobs.RunningStatus, error) {
 				return status, nil
 			}); err != nil {
-				return errors.Wrapf(err, "failed to update running status of job %d", errors.Safe(*sc.job.ID()))
+				return errors.Wrapf(err, "failed to update running status of job %d", errors.Safe(sc.job.ID()))
 			}
 		}
 		return nil

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -602,7 +602,7 @@ func (r *createStatsResumer) Resume(ctx context.Context, execCtx interface{}) er
 func checkRunningJobs(ctx context.Context, job *jobs.Job, p JobExecContext) error {
 	var jobID int64
 	if job != nil {
-		jobID = *job.ID()
+		jobID = job.ID()
 	}
 	const stmt = `SELECT id, payload FROM system.jobs WHERE status IN ($1, $2, $3) ORDER BY created`
 

--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -125,7 +125,7 @@ func makeImportReaderSpecs(
 				Tables: tables,
 				Format: format,
 				Progress: execinfrapb.JobProgress{
-					JobID: *job.ID(),
+					JobID: job.ID(),
 					Slot:  int32(i),
 				},
 				WalltimeNanos: walltime,

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -202,11 +202,6 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 		))
 	}
 
-	var jobID int64
-	if job.ID() != nil {
-		jobID = *job.ID()
-	}
-
 	// Set up the final SampleAggregator stage.
 	agg := &execinfrapb.SampleAggregatorSpec{
 		Sketches:         sketchSpecs,
@@ -214,7 +209,7 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 		SampleSize:       sampler.SampleSize,
 		SampledColumnIDs: sampledColumnIDs,
 		TableID:          desc.GetID(),
-		JobID:            jobID,
+		JobID:            job.ID(),
 		RowsExpected:     rowsExpected,
 	}
 	// Plan the SampleAggregator on the gateway, unless we have a single Sampler.

--- a/pkg/sql/gcjob/gc_job.go
+++ b/pkg/sql/gcjob/gc_job.go
@@ -184,7 +184,7 @@ func (r schemaChangeGCResumer) OnFailOrCancel(context.Context, interface{}) erro
 func init() {
 	createResumerFn := func(job *jobs.Job, settings *cluster.Settings) jobs.Resumer {
 		return &schemaChangeGCResumer{
-			jobID: *job.ID(),
+			jobID: job.ID(),
 		}
 	}
 	jobs.RegisterConstructor(jobspb.TypeSchemaChangeGC, createResumerFn)

--- a/pkg/sql/gcjob_test/gc_job_test.go
+++ b/pkg/sql/gcjob_test/gc_job_test.go
@@ -203,7 +203,7 @@ func TestSchemaChangeGCJob(t *testing.T) {
 			}
 
 			// Check that the job started.
-			jobIDStr := strconv.Itoa(int(*job.ID()))
+			jobIDStr := strconv.Itoa(int(job.ID()))
 			if err := jobutils.VerifyRunningSystemJob(t, sqlDB, 0, jobspb.TypeSchemaChangeGC, sql.RunningStatusWaitingGC, lookupJR); err != nil {
 				t.Fatal(err)
 			}
@@ -367,7 +367,7 @@ func TestGCResumer(t *testing.T) {
 		sj, err := jobs.TestingCreateAndStartJob(ctx, jobRegistry, kvDB, record)
 		require.NoError(t, err)
 		require.NoError(t, sj.AwaitCompletion(ctx))
-		job, err := jobRegistry.LoadJob(ctx, *sj.ID())
+		job, err := jobRegistry.LoadJob(ctx, sj.ID())
 		require.NoError(t, err)
 		st, err := job.CurrentStatus(ctx, nil /* txn */)
 		require.NoError(t, err)
@@ -397,7 +397,7 @@ func TestGCResumer(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, sj.AwaitCompletion(ctx))
 
-		job, err := jobRegistry.LoadJob(ctx, *sj.ID())
+		job, err := jobRegistry.LoadJob(ctx, sj.ID())
 		require.NoError(t, err)
 		st, err := job.CurrentStatus(ctx, nil /* txn */)
 		require.NoError(t, err)

--- a/pkg/sql/row/expr_walker_test.go
+++ b/pkg/sql/row/expr_walker_test.go
@@ -190,7 +190,7 @@ func TestJobBackedSeqChunkProvider(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			job := createMockImportJob(ctx, t, registry, test.allocatedChunks, test.resumePos)
-			j := &SeqChunkProvider{Registry: registry, JobID: *job.ID()}
+			j := &SeqChunkProvider{Registry: registry, JobID: job.ID()}
 			annot := &CellInfoAnnotation{
 				sourceID: 0,
 				rowID:    test.rowID,
@@ -210,7 +210,7 @@ func TestJobBackedSeqChunkProvider(t *testing.T) {
 				getJobProgressQuery := `SELECT progress FROM system.jobs J WHERE J.id = $1`
 
 				var progressBytes []byte
-				require.NoError(t, sqlDB.QueryRow(getJobProgressQuery, *job.ID()).Scan(&progressBytes))
+				require.NoError(t, sqlDB.QueryRow(getJobProgressQuery, job.ID()).Scan(&progressBytes))
 				var progress jobspb.Progress
 				require.NoError(t, protoutil.Unmarshal(progressBytes, &progress))
 				chunks := progress.GetImport().SequenceDetails[0].SeqIdToChunks[int32(id)].Chunks

--- a/pkg/sql/schema.go
+++ b/pkg/sql/schema.go
@@ -66,7 +66,7 @@ func (p *planner) writeSchemaDescChange(
 		); err != nil {
 			return err
 		}
-		log.Infof(ctx, "job %d: updated with for change on schema %d", *job.ID(), desc.ID)
+		log.Infof(ctx, "job %d: updated with for change on schema %d", job.ID(), desc.ID)
 	} else {
 		// Or, create a new job.
 		jobRecord := jobs.Record{
@@ -85,7 +85,7 @@ func (p *planner) writeSchemaDescChange(
 		if err != nil {
 			return err
 		}
-		log.Infof(ctx, "queued new schema change job %d for schema %d", *newJob.ID(), desc.ID)
+		log.Infof(ctx, "queued new schema change job %d for schema %d", newJob.ID(), desc.ID)
 	}
 
 	return p.writeSchemaDesc(ctx, desc)

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -821,13 +821,13 @@ func (sc *SchemaChanger) initJobRunningStatus(ctx context.Context) error {
 }
 
 func (sc *SchemaChanger) rollbackSchemaChange(ctx context.Context, err error) error {
-	log.Warningf(ctx, "reversing schema change %d due to irrecoverable error: %s", *sc.job.ID(), err)
+	log.Warningf(ctx, "reversing schema change %d due to irrecoverable error: %s", sc.job.ID(), err)
 	if errReverse := sc.maybeReverseMutations(ctx, err); errReverse != nil {
 		return errReverse
 	}
 
 	if fn := sc.testingKnobs.RunAfterMutationReversal; fn != nil {
-		if err := fn(*sc.job.ID()); err != nil {
+		if err := fn(sc.job.ID()); err != nil {
 			return err
 		}
 	}
@@ -1537,7 +1537,7 @@ func (sc *SchemaChanger) refreshStats() {
 // all new indexes referencing the column will also be dropped.
 func (sc *SchemaChanger) maybeReverseMutations(ctx context.Context, causingError error) error {
 	if fn := sc.testingKnobs.RunBeforeMutationReversal; fn != nil {
-		if err := fn(*sc.job.ID()); err != nil {
+		if err := fn(sc.job.ID()); err != nil {
 			return err
 		}
 	}
@@ -2144,7 +2144,7 @@ func (r schemaChangeResumer) Resume(ctx context.Context, execCtx interface{}) er
 		return nil
 	}
 	if fn := p.ExecCfg().SchemaChangerTestingKnobs.RunBeforeResume; fn != nil {
-		if err := fn(*r.job.ID()); err != nil {
+		if err := fn(r.job.ID()); err != nil {
 			return err
 		}
 	}
@@ -2338,7 +2338,7 @@ func (r schemaChangeResumer) OnFailOrCancel(ctx context.Context, execCtx interfa
 	}
 
 	if fn := sc.testingKnobs.RunBeforeOnFailOrCancel; fn != nil {
-		if err := fn(*r.job.ID()); err != nil {
+		if err := fn(r.job.ID()); err != nil {
 			return err
 		}
 	}
@@ -2399,7 +2399,7 @@ func (r schemaChangeResumer) OnFailOrCancel(ctx context.Context, execCtx interfa
 	}
 
 	if fn := sc.testingKnobs.RunAfterOnFailOrCancel; fn != nil {
-		if err := fn(*r.job.ID()); err != nil {
+		if err := fn(r.job.ID()); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -67,7 +67,7 @@ func (p *planner) createDropDatabaseJob(
 	if err != nil {
 		return err
 	}
-	log.Infof(ctx, "queued new drop database job %d for database %d", *newJob.ID(), databaseID)
+	log.Infof(ctx, "queued new drop database job %d for database %d", newJob.ID(), databaseID)
 	return nil
 }
 
@@ -91,7 +91,7 @@ func (p *planner) createNonDropDatabaseChangeJob(
 	if err != nil {
 		return err
 	}
-	log.Infof(ctx, "queued new database schema change job %d for database %d", *newJob.ID(), databaseID)
+	log.Infof(ctx, "queued new database schema change job %d for database %d", newJob.ID(), databaseID)
 	return nil
 }
 
@@ -149,10 +149,10 @@ func (p *planner) createOrUpdateSchemaChangeJob(
 		// TODO (lucy): get rid of this when we get rid of MutationJobs.
 		if mutationID != descpb.InvalidMutationID {
 			tableDesc.MutationJobs = append(tableDesc.MutationJobs, descpb.TableDescriptor_MutationJob{
-				MutationID: mutationID, JobID: *newJob.ID()})
+				MutationID: mutationID, JobID: newJob.ID()})
 		}
 		log.Infof(ctx, "queued new schema change job %d for table %d, mutation %d",
-			*newJob.ID(), tableDesc.ID, mutationID)
+			newJob.ID(), tableDesc.ID, mutationID)
 	} else {
 		// Update the existing job.
 		oldDetails := job.Details().(jobspb.SchemaChangeDetails)
@@ -180,7 +180,7 @@ func (p *planner) createOrUpdateSchemaChangeJob(
 				// Also add a MutationJob on the table descriptor.
 				// TODO (lucy): get rid of this when we get rid of MutationJobs.
 				tableDesc.MutationJobs = append(tableDesc.MutationJobs, descpb.TableDescriptor_MutationJob{
-					MutationID: mutationID, JobID: *job.ID()})
+					MutationID: mutationID, JobID: job.ID()})
 			}
 		}
 		if err := job.SetDetails(ctx, p.txn, newDetails); err != nil {
@@ -197,7 +197,7 @@ func (p *planner) createOrUpdateSchemaChangeJob(
 			}
 		}
 		log.Infof(ctx, "job %d: updated with schema change for table %d, mutation %d",
-			*job.ID(), tableDesc.ID, mutationID)
+			job.ID(), tableDesc.ID, mutationID)
 	}
 	return nil
 }

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -106,7 +106,7 @@ func (p *planner) writeTypeSchemaChange(
 		); err != nil {
 			return err
 		}
-		log.Infof(ctx, "job %d: updated with type change for type %d", *job.ID(), typeDesc.ID)
+		log.Infof(ctx, "job %d: updated with type change for type %d", job.ID(), typeDesc.ID)
 	} else {
 		// Or, create a new job.
 		jobRecord := jobs.Record{
@@ -126,7 +126,7 @@ func (p *planner) writeTypeSchemaChange(
 			return err
 		}
 		p.extendedEvalCtx.SchemaChangeJobCache[typeDesc.ID] = newJob
-		log.Infof(ctx, "queued new type change job %d for type %d", *newJob.ID(), typeDesc.ID)
+		log.Infof(ctx, "queued new type change job %d for type %d", newJob.ID(), typeDesc.ID)
 	}
 
 	return p.writeTypeDesc(ctx, typeDesc)


### PR DESCRIPTION
It's no longer valid to create in-memory `Job`s without IDs, so there's
no reason to have the `id` field be a pointer anymore.

This commit should also banish the common mistake of logging a `*int64`
using `%d` when logging the job ID.

Release note: None