### PR TITLE
geo/wkt: add line and pos numbers to WKT parser syntax errors

### DIFF
--- a/pkg/geo/parse_test.go
+++ b/pkg/geo/parse_test.go
@@ -355,9 +355,9 @@ func TestParseGeometry(t *testing.T) {
 		{
 			"invalid",
 			Geometry{},
-			`lex error: invalid keyword at pos 0
-invalid
-^`,
+			`syntax error: invalid keyword at line 1, pos 0
+LINE 1: invalid
+        ^`,
 		},
 		{
 			"",
@@ -571,9 +571,9 @@ func TestParseGeography(t *testing.T) {
 		{
 			"invalid",
 			Geography{},
-			`lex error: invalid keyword at pos 0
-invalid
-^`,
+			`syntax error: invalid keyword at line 1, pos 0
+LINE 1: invalid
+        ^`,
 		},
 		{
 			"",

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -5006,10 +5006,10 @@ false  false  97  false  false
 
 # Test for 2+ string arguments for Geometry where one side of the arguments
 # raises an error.
-statement error pq: st_intersects\(\): lex error: invalid keyword at pos 0\nabc\n\^
+statement error pq: st_intersects\(\): syntax error: invalid keyword at line 1, pos 0
 SELECT ST_Intersects('abc'::string, 'POINT(1 0)'::string)
 
-statement error pq: st_intersects\(\): lex error: invalid keyword at pos 0\nabc\n\^
+statement error pq: st_intersects\(\): syntax error: invalid keyword at line 1, pos 0
 SELECT ST_Intersects('POINT(1 0)'::string, 'abc'::string)
 
 query T


### PR DESCRIPTION
This patch enhances the WKT parser to show line and position
numbers in syntax error messages.

Refs: #53091

Release note: None