### PR TITLE
ui: fix initial node statuses on Metrics page

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/summaryBar.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/summaryBar.tsx
@@ -33,6 +33,7 @@ import { howAreCapacityMetricsCalculated } from "src/util/docs";
 interface ClusterSummaryProps {
   nodeSources: string[];
   nodesSummary: NodesSummary;
+  nodesSummaryValid: boolean;
 }
 
 /**
@@ -40,8 +41,8 @@ interface ClusterSummaryProps {
  * and their current liveness status.
  */
 function ClusterNodeTotals(props: ClusterSummaryProps) {
-  if (!props.nodesSummary || !props.nodesSummary.nodeSums) {
-    return;
+  if (!props.nodesSummaryValid) {
+    return null;
   }
   const { nodeCounts } = props.nodesSummary.nodeSums;
   let children: React.ReactNode;


### PR DESCRIPTION

Release justification: bug fix for existing functionality

Before, Node statuses on Metrics page displayed incorrect node statuses
when page was just loaded and liveness statuses weren't updated immediately
due to incorrect validation condition. It caused all nodes to be recognized
as dead.

Current change fixes validation for presence of liveness statuses in
`nodeSumsSelector` selector which assumes that it's not possible to
have all nodes dead (at least one has to be healthy). So this state
is possible only when no liveness statuses were requested from server yet.

In addition, props for `NodeGraphs` component is cleaned up. It doesn't
require `nodesQueryValid` and `livenessQueryValid` props because validation
on validness of data is performed in CachedDataReducer.refresh function on
every call.

Release note (bug fix): don't display incorrect node statuses on Metrics page,
when page just loaded.

Resolves #59253

Before:
![before](https://user-images.githubusercontent.com/3106437/108855067-3adc0d00-75f1-11eb-8f6f-9d0d97720ab6.gif)

After:
![after](https://user-images.githubusercontent.com/3106437/108855078-3fa0c100-75f1-11eb-8c8c-383e3d2115b6.gif)
