### PR TITLE
protectedts: raise max_spans limit to 32768

### DIFF
--- a/pkg/kv/kvserver/protectedts/settings.go
+++ b/pkg/kv/kvserver/protectedts/settings.go
@@ -33,7 +33,7 @@ var MaxBytes = settings.RegisterIntSetting(
 var MaxSpans = settings.RegisterIntSetting(
 	"kv.protectedts.max_spans",
 	"if non-zero the limit of the number of spans which can be protected",
-	4096,
+	32768,
 	settings.NonNegativeInt,
 )
 


### PR DESCRIPTION
This commit increases the default value for the maxiumum number of spans which
the protectedts system can protect from 4096 to 32768. The previous value has
proven to be too low and has caused backups to fail on some clusters until the
limit was raised.

This commit doesn't change the default limit on `max_bytes` because these bytes
must be cached on every host in the cluster, so it is reasonable to not want to
protect too many bytes worth of data.

Fixes #59067

Release note (general change): Raises the default limit on the maximum number
of spans which can be protected by the protectedts subsystem. This limit can be
configured using the `kv.protectedts.max_spans` cluster setting.