### PR TITLE
sql: Fix flaky descriptor repair tests

### DIFF
--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -1363,9 +1363,9 @@ func (tc *Collection) addUncommittedDescriptor(
 	return ud, nil
 }
 
-// validateOnWriteEnabled is the cluster setting used to enable or disable
+// ValidateOnWriteEnabled is the cluster setting used to enable or disable
 // validating descriptors prior to writing.
-var validateOnWriteEnabled = settings.RegisterBoolSetting(
+var ValidateOnWriteEnabled = settings.RegisterBoolSetting(
 	"sql.catalog.descs.validate_on_write.enabled",
 	"set to true to validate descriptors prior to writing, false to disable; default is true",
 	true, /* defaultValue */
@@ -1377,7 +1377,7 @@ func (tc *Collection) WriteDescToBatch(
 	ctx context.Context, kvTrace bool, desc catalog.MutableDescriptor, b *kv.Batch,
 ) error {
 	desc.MaybeIncrementVersion()
-	if validateOnWriteEnabled.Get(&tc.settings.SV) {
+	if ValidateOnWriteEnabled.Get(&tc.settings.SV) {
 		if err := desc.ValidateSelf(ctx); err != nil {
 			return err
 		}
@@ -1449,7 +1449,7 @@ func (cdg collectionDescGetter) GetDesc(
 
 // ValidateUncommittedDescriptors validates all uncommitted descriptors
 func (tc *Collection) ValidateUncommittedDescriptors(ctx context.Context, txn *kv.Txn) error {
-	if !validateOnWriteEnabled.Get(&tc.settings.SV) {
+	if !ValidateOnWriteEnabled.Get(&tc.settings.SV) {
 		return nil
 	}
 	cdg := collectionDescGetter{tc: tc, txn: txn}

--- a/pkg/sql/tests/BUILD.bazel
+++ b/pkg/sql/tests/BUILD.bazel
@@ -66,6 +66,7 @@ go_test(
         "//pkg/sql/catalog/bootstrap",
         "//pkg/sql/catalog/catalogkv",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/systemschema",
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",


### PR DESCRIPTION
Previously the SET CLUSTER SETTING statement on which these tests relied
on would occasionally time out. This commit replaces this statement with
a setting value override instead, which does the same thing but without
timeouts.

Fixes #60803.

Release note: None