### PR TITLE
sql: validate partial unique constraints

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -843,3 +843,39 @@ CREATE UNIQUE INDEX uniq_on_t ON t(v)
 statement ok
 DELETE FROM t WHERE partition_by = 2;
 CREATE UNIQUE INDEX uniq_on_t ON t(v)
+
+# Tests adding a new partial UNIQUE index with implicit partitioning.
+statement ok
+DROP TABLE t;
+CREATE TABLE t (partition_by INT, a INT, b INT);
+INSERT INTO t VALUES (1, 1, 1), (1, 2, 2), (2, 1, 1), (2, 2, -2);
+
+statement error could not create unique constraint "uniq_on_t"\nDETAIL: Key \(a\)=\(1\) is duplicated
+CREATE UNIQUE INDEX uniq_on_t ON t(a) PARTITION BY LIST (partition_by) (
+   PARTITION one VALUES IN (1),
+   PARTITION two VALUES IN (2)
+) WHERE b > 0
+
+statement ok
+DELETE FROM t WHERE partition_by = 1 AND a = 1;
+CREATE UNIQUE INDEX uniq_on_t ON t(a) PARTITION BY LIST (partition_by) (
+   PARTITION one VALUES IN (1),
+   PARTITION two VALUES IN (2)
+) WHERE b > 0
+
+# Tests adding a partial UNIQUE index with PARTITION ALL BY implicit
+# partitioning.
+statement ok
+DROP TABLE t;
+CREATE TABLE t (partition_by INT, a INT, b INT) PARTITION ALL BY LIST (partition_by) (
+   PARTITION one VALUES IN (1),
+   PARTITION two VALUES IN (2)
+);
+INSERT INTO t VALUES (1, 1, 1), (1, 2, 2), (2, 1, 1), (2, 2, -2);
+
+statement error could not create unique constraint "uniq_on_t"\nDETAIL: Key \(a\)=\(1\) is duplicated
+CREATE UNIQUE INDEX uniq_on_t ON t(a) WHERE b > 0
+
+statement ok
+DELETE FROM t WHERE partition_by = 1 AND a = 1;
+CREATE UNIQUE INDEX uniq_on_t ON t(a) WHERE b > 0

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -476,6 +476,22 @@ uniq_idx                     crdb_region  true
 statement ok
 DROP INDEX uniq_idx
 
+statement ok
+INSERT INTO multi_region_test_db.regional_by_row_table (crdb_region, pk, pk2, a, b) VALUES
+  ('ca-central-1', 5, 5, 5, 5),
+  ('ca-central-1', 6, 6, 5, -5)
+
+statement error could not create unique constraint "uniq_idx"\nDETAIL: Key \(a\)=\(5\) is duplicated
+CREATE UNIQUE INDEX uniq_idx ON regional_by_row_table(a) WHERE b > 0
+
+statement ok
+DELETE FROM regional_by_row_table WHERE pk = 5;
+CREATE UNIQUE INDEX uniq_idx ON regional_by_row_table(a) WHERE b > 0
+
+statement ok
+DELETE FROM regional_by_row_table WHERe pk = 6;
+DROP INDEX uniq_idx
+
 query TI
 INSERT INTO regional_by_row_table (crdb_region, pk, pk2, a, b) VALUES
 ('ca-central-1', 7, 7, 8, 9)

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -775,7 +775,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 							"constraint %q in the middle of being added, try again later", t.Constraint)
 					}
 					if err := validateUniqueWithoutIndexConstraintInTxn(
-						params.ctx, params.p.LeaseMgr(), params.EvalContext(), n.tableDesc, params.EvalContext().Txn, name,
+						params.ctx, params.EvalContext(), n.tableDesc, params.EvalContext().Txn, name,
 					); err != nil {
 						return err
 					}

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1515,6 +1515,41 @@ ALTER TABLE unique_without_index VALIDATE CONSTRAINT unique_b;
 ALTER TABLE unique_without_index VALIDATE CONSTRAINT unique_a_b;
 ALTER TABLE unique_without_index VALIDATE CONSTRAINT unique_without_index_c_key
 
+statement ok
+CREATE TABLE unique_without_index_partial (
+  a INT,
+  b INT,
+  c INT
+);
+INSERT INTO unique_without_index_partial VALUES
+  (1, 1, 1),
+  (2, 2, 2),
+  (1, 3, -3),
+  (2, -2, -2),
+  (NULL, 4, 4),
+  (NULL, 5, 5);
+
+# Trying to add a partial unique constraint fails when there are duplicates.
+statement error pgcode 23505 pq: could not create unique constraint "uniq_a_1"\nDETAIL: Key \(a\)=\(1\) is duplicated\.
+ALTER TABLE unique_without_index_partial ADD CONSTRAINT uniq_a_1 UNIQUE WITHOUT INDEX (a) WHERE b > 0 OR c > 0
+
+# We can create not-valid constraints, however.
+statement ok
+ALTER TABLE unique_without_index_partial ADD CONSTRAINT uniq_a_1 UNIQUE WITHOUT INDEX (a) WHERE b > 0 OR c > 0 NOT VALID
+
+# Trying to validate the constraint will fail.
+statement error pgcode 23505 pq: could not create unique constraint "uniq_a_1"\nDETAIL: Key \(a\)=\(1\) is duplicated\.
+ALTER TABLE unique_without_index_partial VALIDATE CONSTRAINT uniq_a_1
+
+# But after we delete a row, validation should succeed.
+statement ok
+DELETE FROM unique_without_index_partial WHERE a = 1 AND b = 3 AND c = -3;
+ALTER TABLE unique_without_index_partial VALIDATE CONSTRAINT uniq_a_1;
+
+# Creating a new validated constraint should also succeed.
+statement ok
+ALTER TABLE unique_without_index_partial ADD CONSTRAINT uniq_a_2 UNIQUE WITHOUT INDEX (a) WHERE b > 0 OR c > 0
+
 query TTTTB colnames
 SHOW CONSTRAINTS FROM unique_without_index
 ----


### PR DESCRIPTION
Validation for partial unique constraints now takes into account the
constraint's predicate expression. This allows creating implicitly
partitioned unique partial indexes on tables with duplicate unique
column values for rows that do not satisfy the predicate.

Release note: None

Release justification: Correct validation of partial unique constraints
is required for supporting implicitly partitioned partial unique
indexes.
