### PR TITLE
builtins: implement ST_Z, ST_M, and ST_Zmflag

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1925,6 +1925,8 @@ calculated, the result is transformed back into a Geography with SRID 4326.</p>
 <tr><td><a name="st_longestline"></a><code>st_longestline(geometry_a: geometry, geometry_b: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns the LineString corresponds to the max distance across every pair of points comprising the given geometries.</p>
 <p>Note if geometries are the same, it will return the LineString with the maximum distance between the geometry’s vertexes. The function will return the longest line that was discovered first when comparing maximum distances if more than one is found.</p>
 </span></td></tr>
+<tr><td><a name="st_m"></a><code>st_m(geometry: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the M coordinate of a geometry if it is a Point.</p>
+</span></td></tr>
 <tr><td><a name="st_makebox2d"></a><code>st_makebox2d(geometry_a: geometry, geometry_b: geometry) &rarr; box2d</code></td><td><span class="funcdesc"><p>Creates a box2d from two points. Errors if arguments are not two non-empty points.</p>
 </span></td></tr>
 <tr><td><a name="st_makepoint"></a><code>st_makepoint(x: <a href="float.html">float</a>, y: <a href="float.html">float</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a new Point with the given X and Y coordinates.</p>
@@ -2279,6 +2281,10 @@ The swap_ordinate_string parameter is a 2-character string naming the ordinates 
 <tr><td><a name="st_x"></a><code>st_x(geometry: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the X coordinate of a geometry if it is a Point.</p>
 </span></td></tr>
 <tr><td><a name="st_y"></a><code>st_y(geometry: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the Y coordinate of a geometry if it is a Point.</p>
+</span></td></tr>
+<tr><td><a name="st_z"></a><code>st_z(geometry: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the Z coordinate of a geometry if it is a Point.</p>
+</span></td></tr>
+<tr><td><a name="st_zmflag"></a><code>st_zmflag(geometry: geometry) &rarr; int2</code></td><td><span class="funcdesc"><p>Returns a code based on the ZM coordinate dimension of a geometry (XY = 0, XYM = 1, XYZ = 2, XYZM = 3).</p>
 </span></td></tr></tbody>
 </table>
 

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -3395,8 +3395,8 @@ Square overlapping left and right square  NULL  POLYGON ((-0.1 0, 1 0, 1 1, -0.1
 # Point specific operations
 query RR
 SELECT
-  ST_X(a.geom),
-  ST_Y(a.geom)
+  st_x(a.geom),
+  st_y(a.geom)
 FROM (VALUES
   ('POINT(1.0 2.0)'::geometry),
   ('POINT(33.0 66.0)'::geometry),
@@ -3407,11 +3407,11 @@ FROM (VALUES
 33    66
 NULL  NULL
 
-statement error argument to ST_X\(\) must have shape POINT
-SELECT ST_X('LINESTRING(0.0 0.0, 1.0 1.0)')
+statement error argument to st_x\(\) must have shape POINT
+SELECT st_x('LINESTRING(0.0 0.0, 1.0 1.0)')
 
-statement error argument to ST_Y\(\) must have shape POINT
-SELECT ST_Y('LINESTRING(0.0 0.0, 1.0 1.0)')
+statement error argument to st_y\(\) must have shape POINT
+SELECT st_y('LINESTRING(0.0 0.0, 1.0 1.0)')
 
 # LineString specific operations
 query TTITTTTT

--- a/pkg/sql/logictest/testdata/logic_test/geospatial_zm
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial_zm
@@ -106,3 +106,55 @@ SELECT ST_AsEWKT(ST_Affine(the_geom, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, pi()/2, pi()
 	FROM (SELECT ST_GeomFromEWKT('LINESTRING(1 2 3, 4 5 6, 7 8 9)') AS the_geom) AS _;
 ----
 LINESTRING Z (24 33.571 53.142, 42 78.571 125.142, 60 123.571 197.142)
+
+# Point specific operations
+query RRRRI
+SELECT
+  st_x(a.geom),
+  st_y(a.geom),
+  st_z(a.geom),
+  st_m(a.geom),
+  st_zmflag(a.geom)
+FROM (VALUES
+  (NULL::geometry),
+  ('POINT EMPTY'::geometry),
+  ('POINT M EMPTY'::geometry),
+  ('POINT Z EMPTY'::geometry),
+  ('POINT ZM EMPTY'::geometry),
+  ('POINT(1 2)'::geometry),
+  ('POINT M (1 2 3)'::geometry),
+  ('POINT(1 2 3)'::geometry),
+  ('POINT(1 2 3 4)'::geometry)
+) a(geom)
+----
+NULL  NULL  NULL  NULL  NULL
+NULL  NULL  NULL  NULL  0
+NULL  NULL  NULL  NULL  1
+NULL  NULL  NULL  NULL  2
+NULL  NULL  NULL  NULL  3
+1     2     NULL  NULL  0
+1     2     NULL  3     1
+1     2     3     NULL  2
+1     2     3     4     3
+
+statement error argument to st_z\(\) must have shape POINT
+SELECT st_z('LINESTRING(0 0 0, 1 1 1)')
+
+statement error argument to st_m\(\) must have shape POINT
+SELECT st_m('LINESTRING M (0 0 0, 1 1 1)')
+
+# ST_Zmflag tests
+query I
+SELECT
+  ST_Zmflag(a.geom)
+FROM (VALUES
+  ('GEOMETRYCOLLECTION EMPTY'::geometry),
+  ('GEOMETRYCOLLECTION M EMPTY'::geometry),
+  ('GEOMETRYCOLLECTION Z EMPTY'::geometry),
+  ('GEOMETRYCOLLECTION ZM EMPTY'::geometry)
+) a(geom)
+----
+0
+1
+2
+3

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -2519,7 +2519,7 @@ The requested number of points must be not larger than 65336.`,
 					return tree.NewDFloat(tree.DFloat(t.X())), nil
 				}
 				// Ideally we should return NULL here, but following PostGIS on this.
-				return nil, errors.Newf("argument to ST_X() must have shape POINT")
+				return nil, errors.Newf("argument to st_x() must have shape POINT")
 			},
 			types.Float,
 			infoBuilder{
@@ -2544,11 +2544,89 @@ The requested number of points must be not larger than 65336.`,
 					return tree.NewDFloat(tree.DFloat(t.Y())), nil
 				}
 				// Ideally we should return NULL here, but following PostGIS on this.
-				return nil, errors.Newf("argument to ST_Y() must have shape POINT")
+				return nil, errors.Newf("argument to st_y() must have shape POINT")
 			},
 			types.Float,
 			infoBuilder{
 				info: "Returns the Y coordinate of a geometry if it is a Point.",
+			},
+			tree.VolatilityImmutable,
+		),
+	),
+	"st_z": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(evalContext *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				t, err := g.Geometry.AsGeomT()
+				if err != nil {
+					return nil, err
+				}
+				switch t := t.(type) {
+				case *geom.Point:
+					if t.Empty() || t.Layout().ZIndex() == -1 {
+						return tree.DNull, nil
+					}
+					return tree.NewDFloat(tree.DFloat(t.Z())), nil
+				}
+				// Ideally we should return NULL here, but following PostGIS on this.
+				return nil, errors.Newf("argument to st_z() must have shape POINT")
+			},
+			types.Float,
+			infoBuilder{
+				info: "Returns the Z coordinate of a geometry if it is a Point.",
+			},
+			tree.VolatilityImmutable,
+		),
+	),
+	"st_m": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(evalContext *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				t, err := g.Geometry.AsGeomT()
+				if err != nil {
+					return nil, err
+				}
+				switch t := t.(type) {
+				case *geom.Point:
+					if t.Empty() || t.Layout().MIndex() == -1 {
+						return tree.DNull, nil
+					}
+					return tree.NewDFloat(tree.DFloat(t.M())), nil
+				}
+				// Ideally we should return NULL here, but following PostGIS on this.
+				return nil, errors.Newf("argument to st_m() must have shape POINT")
+			},
+			types.Float,
+			infoBuilder{
+				info: "Returns the M coordinate of a geometry if it is a Point.",
+			},
+			tree.VolatilityImmutable,
+		),
+	),
+	"st_zmflag": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(evalContext *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				t, err := g.Geometry.AsGeomT()
+				if err != nil {
+					return nil, err
+				}
+				switch layout := t.Layout(); layout {
+				case geom.XY:
+					return tree.NewDInt(tree.DInt(0)), nil
+				case geom.XYM:
+					return tree.NewDInt(tree.DInt(1)), nil
+				case geom.XYZ:
+					return tree.NewDInt(tree.DInt(2)), nil
+				case geom.XYZM:
+					return tree.NewDInt(tree.DInt(3)), nil
+				default:
+					return nil, errors.Newf("unknown geom.Layout %d", layout)
+				}
+			},
+			types.Int2,
+			infoBuilder{
+				info: "Returns a code based on the ZM coordinate dimension of a geometry (XY = 0, XYM = 1, XYZ = 2, XYZM = 3).",
 			},
 			tree.VolatilityImmutable,
 		),


### PR DESCRIPTION
This patch implements the geometry builtins `ST_Z`, `ST_M`,
and `ST_Zmflag`.

Resolves #60898.
Resolves #60899.
Resolves #60890.

Release justification: low-risk update to new functionality
Release note (sql change): The `ST_Z`, `ST_M`, and `ST_Zmflag`
builtins are now available for use.