### PR TITLE
multiregionccl: gate multi-region database configuration behind a license

### DIFF
--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/ccl/utilccl",
         "//pkg/clusterversion",
         "//pkg/sql",
         "//pkg/sql/catalog/catalogkv",
@@ -20,6 +21,7 @@ go_test(
     name = "multiregionccl_test",
     srcs = [
         "main_test.go",
+        "multiregion_test.go",
         "region_test.go",
         "regional_by_row_test.go",
         "show_test.go",
@@ -41,6 +43,7 @@ go_test(
         "//pkg/sql/tests",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/testcluster",
         "//pkg/util",
         "//pkg/util/leaktest",

--- a/pkg/ccl/multiregionccl/multiregion.go
+++ b/pkg/ccl/multiregionccl/multiregion.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"sort"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
@@ -35,6 +36,15 @@ func createRegionConfig(
 	regions []tree.Name,
 ) (descpb.DatabaseDescriptor_RegionConfig, error) {
 	if err := checkClusterSupportsMultiRegion(evalCtx); err != nil {
+		return descpb.DatabaseDescriptor_RegionConfig{}, err
+	}
+
+	if err := utilccl.CheckEnterpriseEnabled(
+		execCfg.Settings,
+		execCfg.ClusterID(),
+		execCfg.Organization(),
+		"multi-region features",
+	); err != nil {
 		return descpb.DatabaseDescriptor_RegionConfig{}, err
 	}
 

--- a/pkg/ccl/multiregionccl/multiregion_test.go
+++ b/pkg/ccl/multiregionccl/multiregion_test.go
@@ -1,0 +1,101 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package multiregionccl_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+const multiRegionNoEnterpriseContains = "use of multi-region features requires an enterprise license"
+
+func TestMultiRegionNoLicense(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	defer utilccl.TestingDisableEnterprise()()
+
+	_, sqlDB, cleanup := createTestMultiRegionCluster(t, 3, base.TestingKnobs{})
+	defer cleanup()
+
+	_, err := sqlDB.Exec(`CREATE DATABASE test`)
+	require.NoError(t, err)
+
+	for _, errorStmt := range []string{
+		`CREATE DATABASE db WITH PRIMARY REGION "us-east1" REGIONS "us-east2"`,
+		`ALTER DATABASE test PRIMARY REGION "us-east2"`,
+	} {
+		t.Run(errorStmt, func(t *testing.T) {
+			_, err := sqlDB.Exec(errorStmt)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), multiRegionNoEnterpriseContains)
+		})
+	}
+}
+
+func TestMultiRegionAfterEnterpriseDisabled(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	defer utilccl.TestingEnableEnterprise()()
+
+	skip.UnderRace(t, "#61163")
+
+	_, sqlDB, cleanup := createTestMultiRegionCluster(t, 3, base.TestingKnobs{})
+	defer cleanup()
+
+	_, err := sqlDB.Exec(`
+CREATE DATABASE test PRIMARY REGION "us-east1" REGIONS "us-east2";
+USE test;
+CREATE TABLE t1 () LOCALITY GLOBAL;
+CREATE TABLE t2 () LOCALITY REGIONAL BY TABLE;
+CREATE TABLE t3 () LOCALITY REGIONAL BY TABLE IN "us-east2";
+CREATE TABLE t4 () LOCALITY REGIONAL BY ROW
+	`)
+	require.NoError(t, err)
+
+	defer utilccl.TestingDisableEnterprise()()
+
+	// Test certain commands are no longer usable.
+	t.Run("no new multi-region items", func(t *testing.T) {
+		for _, errorStmt := range []string{
+			`CREATE DATABASE db WITH PRIMARY REGION "us-east1" REGIONS "us-east2"`,
+		} {
+			t.Run(errorStmt, func(t *testing.T) {
+				_, err := sqlDB.Exec(errorStmt)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), multiRegionNoEnterpriseContains)
+			})
+		}
+	})
+
+	// Test we can still drop multi-region functionality.
+	t.Run("drop multi-region", func(t *testing.T) {
+		for _, tc := range []struct {
+			stmt string
+		}{
+			{stmt: `ALTER DATABASE test PRIMARY REGION "us-east2"`},
+			{stmt: `ALTER TABLE t2 SET LOCALITY REGIONAL BY TABLE`},
+			{stmt: `ALTER TABLE t3 SET LOCALITY REGIONAL BY TABLE`},
+			{stmt: `ALTER TABLE t4 SET LOCALITY REGIONAL BY TABLE`},
+			{stmt: `ALTER TABLE t4 DROP COLUMN crdb_region`},
+			{stmt: `ALTER DATABASE test DROP REGION "us-east1"`},
+			{stmt: `ALTER DATABASE test DROP REGION "us-east2"`},
+		} {
+			t.Run(tc.stmt, func(t *testing.T) {
+				_, err := sqlDB.Exec(tc.stmt)
+				require.NoError(t, err)
+			})
+		}
+	})
+}

--- a/pkg/ccl/multiregionccl/regional_by_row_test.go
+++ b/pkg/ccl/multiregionccl/regional_by_row_test.go
@@ -33,9 +33,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// REGIONAL BY ROW tests are defined in multiregionccl as REGIONAL BY ROW
-// requires CCL to operate.
-
 // createTestMultiRegionCluster creates a test cluster with numServers number of
 // nodes with the provided testing knobs applied to each of the nodes. Every
 // node is placed in its own locality, named "us-east1", "us-east2", and so on.


### PR DESCRIPTION
Resolves #59668 

Release justification: low risk changes to new functionality

Release note (enterprise change): Multi-region database creations are
permitted as long as the cluster has a CockroachDB subscription.