### PR TITLE
builtins: make default_to_database_primary_region avoid InternalExecutor

### DIFF
--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -208,6 +208,14 @@ func (so *importSequenceOperators) GetSerialSequenceNameFromColumn(
 	return nil, errors.WithStack(errSequenceOperators)
 }
 
+// CurrentDatabaseRegionConfig is part of the tree.EvalDatabase interface.
+func (so *importSequenceOperators) CurrentDatabaseRegionConfig() (
+	tree.DatabaseRegionConfig,
+	error,
+) {
+	return nil, errors.WithStack(errSequenceOperators)
+}
+
 // Implements the tree.EvalDatabase interface.
 func (so *importSequenceOperators) ParseQualifiedTableName(sql string) (*tree.TableName, error) {
 	name, err := parser.ParseTableName(sql)

--- a/pkg/sql/catalog/descpb/region_name.go
+++ b/pkg/sql/catalog/descpb/region_name.go
@@ -24,3 +24,24 @@ func (regions RegionNames) ToStrings() []string {
 	}
 	return ret
 }
+
+// IsValidRegionNameString implements the tree.DatabaseRegionConfig interface.
+func (cfg *DatabaseDescriptor_RegionConfig) IsValidRegionNameString(r string) bool {
+	if cfg == nil {
+		return false
+	}
+	for _, region := range cfg.Regions {
+		if string(region.Name) == r {
+			return true
+		}
+	}
+	return false
+}
+
+// PrimaryRegionString implements the tree.DatabaseRegionConfig interface.
+func (cfg *DatabaseDescriptor_RegionConfig) PrimaryRegionString() string {
+	if cfg == nil {
+		return ""
+	}
+	return string(cfg.PrimaryRegion)
+}

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -44,6 +44,11 @@ func (so *DummySequenceOperators) GetSerialSequenceNameFromColumn(
 	return nil, errors.WithStack(errSequenceOperators)
 }
 
+// CurrentDatabaseRegionConfig is part of the tree.EvalDatabase interface.
+func (so *DummySequenceOperators) CurrentDatabaseRegionConfig() (tree.DatabaseRegionConfig, error) {
+	return nil, errors.WithStack(errSequenceOperators)
+}
+
 // ParseQualifiedTableName is part of the tree.EvalDatabase interface.
 func (so *DummySequenceOperators) ParseQualifiedTableName(sql string) (*tree.TableName, error) {
 	return nil, errors.WithStack(errSequenceOperators)
@@ -164,6 +169,11 @@ var _ tree.EvalPlanner = &DummyEvalPlanner{}
 
 var errEvalPlanner = pgerror.New(pgcode.ScalarOperationCannotRunWithoutFullSessionContext,
 	"cannot evaluate scalar expressions using table lookups in this context")
+
+// CurrentDatabaseRegionConfig is part of the tree.EvalDatabase interface.
+func (ep *DummyEvalPlanner) CurrentDatabaseRegionConfig() (tree.DatabaseRegionConfig, error) {
+	return nil, errors.WithStack(errEvalPlanner)
+}
 
 // ParseQualifiedTableName is part of the tree.EvalDatabase interface.
 func (ep *DummyEvalPlanner) ParseQualifiedTableName(sql string) (*tree.TableName, error) {

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -772,3 +772,17 @@ func partitionByForRegionalByRow(
 		List:   listPartition,
 	}
 }
+
+// CurrentDatabaseRegionConfig is part of the tree.EvalDatabase interface.
+func (p *planner) CurrentDatabaseRegionConfig() (tree.DatabaseRegionConfig, error) {
+	_, dbDesc, err := p.Descriptors().GetImmutableDatabaseByName(
+		p.EvalContext().Ctx(),
+		p.txn,
+		p.CurrentDatabase(),
+		tree.DatabaseLookupFlags{Required: true},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return dbDesc.GetRegionConfig(), nil
+}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4927,40 +4927,22 @@ the locality flag on node startup. Returns an error if no region is set.`,
 		tree.FunctionProperties{Category: categoryMultiRegion},
 		stringOverload1(
 			func(evalCtx *tree.EvalContext, s string) (tree.Datum, error) {
-				r, err := evalCtx.InternalExecutor.QueryRow(
-					evalCtx.Ctx(),
-					DefaultToDatabasePrimaryRegionBuiltinName,
-					evalCtx.Txn,
-					`SELECT regions @> array[$1::string], primary_region
-				FROM crdb_internal.databases WHERE name = $2`,
-					s,
-					evalCtx.SessionData.Database,
-				)
+				regionConfig, err := evalCtx.Sequence.CurrentDatabaseRegionConfig()
 				if err != nil {
 					return nil, err
 				}
-				if len(r) == 0 {
+				if regionConfig.IsValidRegionNameString(s) {
+					return tree.NewDString(s), nil
+				}
+				primaryRegion := regionConfig.PrimaryRegionString()
+				if primaryRegion == "" {
 					return nil, pgerror.Newf(
 						pgcode.InvalidDatabaseDefinition,
-						"current database %s does not exist",
+						"current database %s is not multi-region enabled",
 						evalCtx.SessionData.Database,
 					)
 				}
-				// If region has been added to the database.
-				if *(r[0].(*tree.DBool)) {
-					return tree.NewDString(s), nil
-				}
-				// Otherwise, return the primary region if it exists.
-				if r[1] != tree.DNull {
-					return r[1], nil
-				}
-
-				// Not seeing any rows means the database is not multi-region enabled.
-				return nil, pgerror.Newf(
-					pgcode.InvalidDatabaseDefinition,
-					"current database %s is not multi-region enabled",
-					evalCtx.SessionData.Database,
-				)
+				return tree.NewDString(primaryRegion), nil
 			},
 			types.String,
 			`Returns the given region if the region has been added to the current database.

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3003,9 +3003,20 @@ func (e *MultipleResultsError) Error() string {
 	return fmt.Sprintf("%s: unexpected multiple results", e.SQL)
 }
 
+// DatabaseRegionConfig is a wrapper around DatabaseDescriptor_RegionConfig
+// related methods which avoids a circular dependency between descpb and tree.
+type DatabaseRegionConfig interface {
+	IsValidRegionNameString(r string) bool
+	PrimaryRegionString() string
+}
+
 // EvalDatabase consists of functions that reference the session database
 // and is to be used from EvalContext.
 type EvalDatabase interface {
+	// CurrentDatabaseRegionConfig returns the RegionConfig of the current
+	// session database.
+	CurrentDatabaseRegionConfig() (DatabaseRegionConfig, error)
+
 	// ParseQualifiedTableName parses a SQL string of the form
 	// `[ database_name . ] [ schema_name . ] table_name`.
 	// NB: this is deprecated! Use parser.ParseQualifiedTableName when possible.


### PR DESCRIPTION
Resolves #60995 

Using InternalExecutor for default_to_database_primary_region can result
in leasing on the sub-query, which can fail.

Instead, add another interface method onto EvalContext which allows
querying the database descriptor directly. Due to a circular dependency
which is unavoidable without heavy untangling, we are returning an
new interface that wraps RegionConfig. There is precedence for this
kind of thing in around in the `sql` package.

Release justification: low risk change to new functionality

Release note: None

