### PR TITLE
sql/catalog/lease: ensure purgeOldVersions keeps the latest version

### DIFF
--- a/pkg/sql/catalog/errors.go
+++ b/pkg/sql/catalog/errors.go
@@ -66,12 +66,6 @@ func HasAddingTableError(err error) bool {
 	return errors.HasType(err, (*addingTableError)(nil))
 }
 
-// HasInactiveDescriptorError returns true if the error contains an
-// inactiveDescriptorError.
-func HasInactiveDescriptorError(err error) bool {
-	return errors.HasType(err, (*inactiveDescriptorError)(nil))
-}
-
 // NewInactiveDescriptorError wraps an error in a new inactiveDescriptorError.
 func NewInactiveDescriptorError(err error) error {
 	return &inactiveDescriptorError{err}

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-// Note that there's also lease_internal_test.go, in package sql.
+// Note that there's also lease_internal_test.go, in package lease.
 
 package lease_test
 


### PR DESCRIPTION
This commit refactors purgeOldVersions to be more explicit about leasing
the latest version of the descriptor to maintain. We no longer call
`descriptorState.findForTimestamp(clock.Now())` to find the latest
version. Instead, we call `descriptorState.findNewest` directly. In
doing so, we fix an issue I've seen with GLOBAL tables where the latest
descriptor version could have a modification time slightly in advance of
the current clock. This led to the function purging the wrong
descriptor, leading to `WaitForOneVersion` either getting stuck
indefinitely or at least stuck for minutes. This refactor fixes this
issue.

Release justification: bug fix needed for new functionality.