### PR TITLE
colexec: improve merge partition ordering in external sort

### DIFF
--- a/pkg/sql/colexec/external_sort.go
+++ b/pkg/sql/colexec/external_sort.go
@@ -139,8 +139,6 @@ type externalSorter struct {
 	partitionerToOperators []*partitionerToOperator
 	// numPartitions is the current number of partitions.
 	numPartitions int
-	// firstPartitionIdx is the index of the first partition to merge next.
-	firstPartitionIdx int
 	// maxNumberPartitions determines the maximum number of active partitions
 	// we can have at once. This number can be limited by the number of FDs
 	// available as well as by dynamically computed limit when the memory usage
@@ -153,14 +151,23 @@ type externalSorter struct {
 	numForcedMerges                       int
 
 	// partitionsInfo tracks some information about all current partitions
-	// (those in [firstPartitionIdx, firstPartitionIdx+numPartitions) range).
+	// (those in currentPartitionIdxs).
 	partitionsInfo struct {
-		// TODO(yuzefovich): use this information to change the order of merging
-		// the partitions (currently, the first partition can become very large
-		// and is constantly being merged).
-		totalSize       []int64
+		// totalSize is used for logging purposes.
+		totalSize []int64
+		// maxBatchMemSize decides how many partitions to have at once,
+		// potentially reducing maxNumberPartitions
 		maxBatchMemSize []int64
 	}
+
+	// currentPartitionIdx keeps track of the next available partition index.
+	currentPartitionIdx int
+	// currentPartitionIdxs is a slice of size maxNumberPartitions containing
+	// the mapping of all partitions to their corresponding partition indices.
+	currentPartitionIdxs []int
+	// maxMerged is a slice of size maxNumberPartitions containing
+	// the mapping of all partitions to their maximum number of merges.
+	maxMerged []int
 
 	// fdState is used to acquire file descriptors up front.
 	fdState struct {
@@ -271,11 +278,13 @@ func NewExternalSorter(
 		partitionerCreator: func() colcontainer.PartitionedQueue {
 			return colcontainer.NewPartitionedDiskQueue(inputTypes, diskQueueCfg, partitionedDiskQueueSemaphore, colcontainer.PartitionerStrategyCloseOnNewPartition, diskAcc)
 		},
-		inputTypes:          inputTypes,
-		ordering:            ordering,
-		columnOrdering:      execinfrapb.ConvertToColumnOrdering(ordering),
-		maxNumberPartitions: maxNumberPartitions,
-		numForcedMerges:     numForcedMerges,
+		inputTypes:           inputTypes,
+		ordering:             ordering,
+		columnOrdering:       execinfrapb.ConvertToColumnOrdering(ordering),
+		maxNumberPartitions:  maxNumberPartitions,
+		numForcedMerges:      numForcedMerges,
+		currentPartitionIdxs: make([]int, maxNumberPartitions),
+		maxMerged:            make([]int, maxNumberPartitions),
 	}
 	es.partitionsInfo.totalSize = make([]int64, maxNumberPartitions)
 	es.partitionsInfo.maxBatchMemSize = make([]int64, maxNumberPartitions)
@@ -326,8 +335,11 @@ func (s *externalSorter) Next(ctx context.Context) coldata.Batch {
 				// inputPartitioningOperator).
 				s.inMemSorterInput.interceptReset = true
 				s.inMemSorter.Reset(ctx)
+				s.currentPartitionIdxs[s.numPartitions] = s.currentPartitionIdx
+				s.maxMerged[s.numPartitions] = 0
 				s.numPartitions++
-				if s.shouldMergeAllPartitions() {
+				s.currentPartitionIdx++
+				if s.shouldMergeSomePartitions() {
 					s.state = externalSorterRepeatedMerging
 					continue
 				}
@@ -336,10 +348,13 @@ func (s *externalSorter) Next(ctx context.Context) coldata.Batch {
 			}
 
 		case externalSorterRepeatedMerging:
-			// We will merge all partitions in range [s.firstPartitionIdx,
-			// s.firstPartitionIdx+s.numPartitions) and will spill all the
-			// resulting batches into a new partition with the next available
-			// index.
+			// We will merge at least 2 partitions (the 2 most recently
+			// created partitions), along with any partitions that share
+			// the same maxMerged value as the second most recently
+			// created partition (because the most recently created
+			// partition will always have merge value 0), and will spill
+			// all the resulting batches into a new partition with the
+			// next available index.
 			//
 			// The merger will be using some amount of RAM for the output batch,
 			// will register it with the output unlimited allocator and will
@@ -349,13 +364,19 @@ func (s *externalSorter) Next(ctx context.Context) coldata.Batch {
 			// Note that the memory used for dequeueing batches from the
 			// partitions is retained and is registered with the merge unlimited
 			// allocator.
-			merger, err := s.createMergerForPartitions(ctx)
+			n := 2
+			for i := s.numPartitions - 2; i > 0; i-- {
+				if s.maxMerged[i] != s.maxMerged[i-1] {
+					break
+				}
+				n++
+			}
+			merger, err := s.createMergerForPartitions(ctx, n)
 			if err != nil {
 				colexecerror.InternalError(err)
 			}
 			merger.Init()
-			s.firstPartitionIdx += s.numPartitions
-			s.numPartitions = 0
+			s.numPartitions -= n
 			s.partitionsInfo.totalSize[s.numPartitions] = 0
 			s.partitionsInfo.maxBatchMemSize[s.numPartitions] = 0
 			for b := merger.Next(ctx); ; b = merger.Next(ctx) {
@@ -364,7 +385,10 @@ func (s *externalSorter) Next(ctx context.Context) coldata.Batch {
 					break
 				}
 			}
-			s.numPartitions = 1
+			s.maxMerged[s.numPartitions]++
+			s.currentPartitionIdxs[s.numPartitions] = s.currentPartitionIdx
+			s.numPartitions++
+			s.currentPartitionIdx++
 			// We are now done with the merger, so we can release the memory
 			// used for the output batches (all of which have been enqueued into
 			// the new partition).
@@ -382,11 +406,11 @@ func (s *externalSorter) Next(ctx context.Context) coldata.Batch {
 				s.state = externalSorterFinished
 				continue
 			} else if s.numPartitions == 1 {
-				s.createPartitionerToOperators()
+				s.createPartitionerToOperators(s.numPartitions)
 				s.emitter = s.partitionerToOperators[0]
 			} else {
 				var err error
-				s.emitter, err = s.createMergerForPartitions(ctx)
+				s.emitter, err = s.createMergerForPartitions(ctx, s.numPartitions)
 				if err != nil {
 					colexecerror.InternalError(err)
 				}
@@ -415,7 +439,7 @@ func (s *externalSorter) Next(ctx context.Context) coldata.Batch {
 }
 
 // enqueue enqueues b to the current partition (which has index
-// firstPartitionIdx + numPartitions) as well as updates the information about
+// currentPartitionIdx) as well as updates the information about
 // the partition.
 func (s *externalSorter) enqueue(ctx context.Context, b coldata.Batch) {
 	if b.Length() > 0 {
@@ -425,18 +449,17 @@ func (s *externalSorter) enqueue(ctx context.Context, b coldata.Batch) {
 			s.partitionsInfo.maxBatchMemSize[s.numPartitions] = batchMemSize
 		}
 	}
-	curPartitionIdx := s.firstPartitionIdx + s.numPartitions
 	// Note that b will never have a selection vector set because the allSpooler
 	// performs a deselection when buffering up the tuples, and the in-memory
 	// sorter has allSpooler as its input.
-	if err := s.partitioner.Enqueue(ctx, curPartitionIdx, b); err != nil {
+	if err := s.partitioner.Enqueue(ctx, s.currentPartitionIdx, b); err != nil {
 		colexecerror.InternalError(err)
 	}
 }
 
-// shouldMergeAllPartitions returns true if we need to merge all current
+// shouldMergeSomePartitions returns true if we need to merge some current
 // partitions into one before proceeding to spilling a new partition.
-func (s *externalSorter) shouldMergeAllPartitions() bool {
+func (s *externalSorter) shouldMergeSomePartitions() bool {
 	if s.numPartitions <= 1 {
 		return false
 	}
@@ -501,7 +524,7 @@ func (s *externalSorter) Reset(ctx context.Context) {
 	}
 	// Reset closed so that the sorter may be closed again.
 	s.Closed = false
-	s.firstPartitionIdx = 0
+	s.currentPartitionIdx = 0
 	s.numPartitions = 0
 	// Note that we consciously do not reset maxNumberPartitions and
 	// maxNumberPartitionsDynamicallyReduced (when the latter is true) since we
@@ -528,47 +551,47 @@ func (s *externalSorter) Close(ctx context.Context) error {
 }
 
 // createPartitionerToOperators updates s.partitionerToOperators to correspond
-// to all current partitions.
-func (s *externalSorter) createPartitionerToOperators() {
+// to the last n current partitions to be merged.
+func (s *externalSorter) createPartitionerToOperators(n int) {
 	oldPartitioners := s.partitionerToOperators
-	if len(oldPartitioners) < s.numPartitions {
-		s.partitionerToOperators = make([]*partitionerToOperator, s.numPartitions)
+	if len(oldPartitioners) < n {
+		s.partitionerToOperators = make([]*partitionerToOperator, n)
 		copy(s.partitionerToOperators, oldPartitioners)
-		for i := len(oldPartitioners); i < s.numPartitions; i++ {
+		for i := len(oldPartitioners); i < n; i++ {
 			s.partitionerToOperators[i] = newPartitionerToOperator(
 				s.mergeUnlimitedAllocator, s.inputTypes, s.partitioner,
 			)
 		}
 	}
-	for i := 0; i < s.numPartitions; i++ {
+	for i := 0; i < n; i++ {
 		// We only need to set the partitioner and partitionIdx fields because
 		// all others will not change when these operators are reused.
 		s.partitionerToOperators[i].partitioner = s.partitioner
-		s.partitionerToOperators[i].partitionIdx = s.firstPartitionIdx + i
+		s.partitionerToOperators[i].partitionIdx = s.currentPartitionIdxs[s.numPartitions-n+i]
 	}
 }
 
 // createMergerForPartitions creates an ordered synchronizer that will merge
-// partitions in [firstPartitionIdx, firstPartitionIdx+numPartitions) range.
+// the last n current partitions.
 func (s *externalSorter) createMergerForPartitions(
-	ctx context.Context,
+	ctx context.Context, n int,
 ) (colexecop.Operator, error) {
-	s.createPartitionerToOperators()
-	syncInputs := make([]SynchronizerInput, s.numPartitions)
+	s.createPartitionerToOperators(n)
+	syncInputs := make([]SynchronizerInput, n)
 	for i := range syncInputs {
 		syncInputs[i].Op = s.partitionerToOperators[i]
 	}
 	if log.V(2) {
 		var b strings.Builder
-		for i := 0; i < s.numPartitions; i++ {
+		for i := 0; i < n; i++ {
 			if i > 0 {
 				b.WriteString(", ")
 			}
-			b.WriteString(humanizeutil.IBytes(s.partitionsInfo.totalSize[i]))
+			b.WriteString(humanizeutil.IBytes(s.partitionsInfo.totalSize[s.numPartitions-n+i]))
 		}
 		log.Infof(ctx,
-			"external sorter is merging partitions in range [%d, %d) with sizes [%s]",
-			s.firstPartitionIdx, s.firstPartitionIdx+s.numPartitions, b.String(),
+			"external sorter is merging partitions with partition indices %v with sizes [%s]",
+			s.currentPartitionIdxs[s.numPartitions-n:s.numPartitions], b.String(),
 		)
 	}
 

--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -314,7 +314,7 @@ func TestExternalSortMemoryAccounting(t *testing.T) {
 	require.Zero(t, sem.GetCount(), "sem still reports open FDs")
 
 	externalSorter := sorter.(*diskSpillerBase).diskBackedOp.(*externalSorter)
-	numPartitionsCreated := externalSorter.firstPartitionIdx + externalSorter.numPartitions
+	numPartitionsCreated := externalSorter.currentPartitionIdx
 	// This maximum can be achieved when we have minimum required number of FDs
 	// as follows: we expect that each newly created partition contains about
 	// numInMemoryBufferedBatches number of batches with only the partition that


### PR DESCRIPTION
Release justification: bug fixes and low-risk updates.

Fixes: #60248

Previously, the partition merging algorithm was done linearly
so that the first partition would be constantly remerged,
resulting in time inefficiencies. The new optimization
merges partitions by prioritizing the equaling of the
number of merges per partition, so that the number of
redundant merges is minimized.

Let A:1 notation refer to partition A with merge count 1.
Let the max partition count be of size 4. The first merge
will happen with [A:0, B:0, C:0, D:0], resulting in
[E:1]. After adding more partitions, the next pre-merge
state is [E:1, F:0, G:0, H:0]. The old algorithm merges
all four of these partitions into one, resulting in
inefficient merging due to partition E being remerged
again (resulting in redundant merging for A, B, C, and D).
The new algorithm guarantees the merging of the two most
recent partitions, as well as any previous partitions that
share the same max merge value as the second to last
partition. In this case, the merge would result in
[E:1, I:1], where I:1 is the merge of F, G, and H.
Simple testing has proven results of 2x speed with
the new algorithm for merging, and this speed is expected
to go up with higher GB usage.

Release note (performance improvement): Optimize external sort
to merge partition data faster in colexec.