### PR TITLE
opt: increase cost of full index scan with partitions

### DIFF
--- a/pkg/sql/opt/xform/testdata/coster/scan
+++ b/pkg/sql/opt/xform/testdata/coster/scan
@@ -139,3 +139,132 @@ select
  │    └── key: (1)
  └── filters
       └── (id:1 % 16) = 0 [outer=(1), immutable]
+
+# Regression test for #60493. Account for the cost of visiting multiple
+# partitions.
+exec-ddl
+CREATE TABLE t60493 (
+  pk INT8 NOT NULL,
+  region STRING NOT NULL,
+  CONSTRAINT "primary" PRIMARY KEY (region ASC, pk ASC),
+  FAMILY "primary" (pk, region)
+) PARTITION BY LIST (region) (
+  PARTITION useast VALUES IN (('useast')),
+  PARTITION uswest VALUES IN (('uswest')),
+  PARTITION europe VALUES IN (('europe'))
+)
+----
+
+exec-ddl
+ALTER PARTITION useast OF INDEX t60493@primary CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=us-east1: 3}',
+  lease_preferences = '[[+region=us-east1]]'
+----
+
+exec-ddl
+ALTER PARTITION uswest OF INDEX t60493@primary CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=us-west1: 3}',
+  lease_preferences = '[[+region=us-west1]]'
+----
+
+exec-ddl
+ALTER PARTITION europe OF INDEX t60493@primary CONFIGURE ZONE USING
+  num_replicas = 3,
+  constraints = '{+region=europe-west1: 3}',
+  lease_preferences = '[[+region=europe-west1]]'
+----
+
+exec-ddl
+ALTER TABLE t60493 INJECT STATISTICS '[
+    {
+        "columns": [
+            "region"
+        ],
+        "created_at": "2021-02-23 04:14:01.849711",
+        "distinct_count": 3,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "europe"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "useast"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "uswest"
+            }
+        ],
+        "histo_col_type": "STRING",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 3
+    },
+    {
+        "columns": [
+            "pk"
+        ],
+        "created_at": "2021-02-23 04:14:01.849711",
+        "distinct_count": 3,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "1"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "2"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "3"
+            }
+        ],
+        "histo_col_type": "INT8",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 3
+    },
+    {
+        "columns": [
+            "region",
+            "pk"
+        ],
+        "created_at": "2021-02-23 04:14:01.849711",
+        "distinct_count": 3,
+        "histo_col_type": "",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 3
+    }
+]';
+----
+
+opt
+SELECT * FROM t60493 WHERE region IN ('useast':::STRING, 'uswest':::STRING)
+----
+scan t60493
+ ├── columns: pk:1!null region:2!null
+ ├── constraint: /2/1
+ │    ├── [/'useast' - /'useast']
+ │    └── [/'uswest' - /'uswest']
+ ├── stats: [rows=2, distinct(2)=2, null(2)=0]
+ │   histogram(2)=  0     1      0     1
+ │                <--- 'useast' --- 'uswest'
+ ├── cost: 10.09
+ └── key: (1,2)


### PR DESCRIPTION
This commit increases the cost of a full index scan when the scan
has more than one partition. This is necessary because there were
cases where the optimizer was preferring a full scan over a multi-span
constrained scan due to the random I/O cost of visiting the spans.
However, this ignores the fact that the full scan would also need to
pay that random I/O cost to visit the different partitions anyway.
This commit adds a cost for those visits so the constrained scan
is preferred over a full scan.

Informs #60493

Release justification: This commit is a low risk, high benefit
change to existing functionality.

Release note (performance improvement): Improved the optimizer's
cost estimation of index scans that must visit multiple partitions.
When an index has multiple partitions, the optimizer is now more
likely to choose a constrained scan rather than a full index scan.
This can lead to better plans and improved performance. It also
improves the ability of the database to serve queries if one of the
partitions is unavailable.