### PR TITLE
sql: simplify the UniqueViolation error from validateForwardIndexes

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1668,11 +1668,11 @@ func (sc *SchemaChanger) validateForwardIndexes(
 
 				if idxLen != expectedCount {
 					// TODO(vivek): find the offending row and include it in the error.
-					return pgerror.Newf(
-						pgcode.UniqueViolation,
-						"%d entries, expected %d violates unique constraint %q",
-						idxLen, expectedCount, idx.Name,
-					)
+					return pgerror.WithConstraintName(pgerror.Newf(pgcode.UniqueViolation,
+						"duplicate key value violates unique constraint %q",
+						idx.Name),
+						idx.Name)
+
 				}
 
 			case <-ctx.Done():

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -5226,7 +5226,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 
 	// Start schema change that eventually runs a backfill.
 	if _, err := sqlDB.Exec(`CREATE UNIQUE INDEX foo ON t.test (v)`); !testutils.IsError(
-		err, fmt.Sprintf("%d entries, expected %d violates unique constraint", maxValue, maxValue+1),
+		err, "duplicate key value violates unique constraint \"foo\"",
 	) {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fixes: #60491

Inside validateForwardIndexes an additional pass is done to validate
that the index is valid since concurrent writers are allowed to write
while the index is being constructed, which may lead to the index
being invalid for unique constraints. If it's not valid then a
UniqueViolation is generated.  Previously the current format contained
unnecessary information for the tuples counts in the index vs the table.
After this patch a simplified the error message to remove the 
unnecessary detail.

Release justification: This commit is a low risk change to an existing
error message.

Release note: None