### PR TITLE
sql: update database zone configurations after region drop finalization

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -1083,3 +1083,35 @@ ALTER TABLE drop_primary_regions_db.primary SET LOCALITY REGIONAL BY TABLE IN PR
 
 statement ok
 ALTER DATABASE drop_primary_regions_db DROP REGION "ca-central-1"
+
+statement ok
+CREATE DATABASE zone_config_drop_region PRIMARY REGION "ca-central-1" REGIONS "us-east-1", "ap-southeast-2"
+
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE zone_config_drop_region
+----
+DATABASE zone_config_drop_region  ALTER DATABASE zone_config_drop_region CONFIGURE ZONE USING
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 90000,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ca-central-1]',
+                          lease_preferences = '[[+region=ca-central-1]]'
+
+statement ok
+ALTER DATABASE zone_config_drop_region DROP REGION "us-east-1"
+
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE zone_config_drop_region
+----
+DATABASE zone_config_drop_region  ALTER DATABASE zone_config_drop_region CONFIGURE ZONE USING
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 90000,
+                          num_replicas = 4,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
+                          voter_constraints = '[+region=ca-central-1]',
+                          lease_preferences = '[[+region=ca-central-1]]'

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -1816,9 +1816,9 @@ DATABASE drop_regions  ALTER DATABASE drop_regions CONFIGURE ZONE USING
                        range_min_bytes = 134217728,
                        range_max_bytes = 536870912,
                        gc.ttlseconds = 90000,
-                       num_replicas = 5,
+                       num_replicas = 4,
                        num_voters = 3,
-                       constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                       constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
                        voter_constraints = '[+region=ca-central-1]',
                        lease_preferences = '[[+region=ca-central-1]]'
 
@@ -1858,9 +1858,9 @@ DATABASE drop_regions  ALTER DATABASE drop_regions CONFIGURE ZONE USING
                        range_min_bytes = 134217728,
                        range_max_bytes = 536870912,
                        gc.ttlseconds = 90000,
-                       num_replicas = 5,
+                       num_replicas = 4,
                        num_voters = 3,
-                       constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                       constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
                        voter_constraints = '[+region=ca-central-1]',
                        lease_preferences = '[[+region=ca-central-1]]'
 
@@ -1908,9 +1908,9 @@ DATABASE drop_regions  ALTER DATABASE drop_regions CONFIGURE ZONE USING
                        range_min_bytes = 134217728,
                        range_max_bytes = 536870912,
                        gc.ttlseconds = 90000,
-                       num_replicas = 5,
+                       num_replicas = 4,
                        num_voters = 3,
-                       constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                       constraints = '{+region=ca-central-1: 1, +region=us-east-1: 1}',
                        voter_constraints = '[+region=ca-central-1]',
                        lease_preferences = '[[+region=ca-central-1]]'
 
@@ -1950,9 +1950,9 @@ DATABASE drop_regions  ALTER DATABASE drop_regions CONFIGURE ZONE USING
                        range_min_bytes = 134217728,
                        range_max_bytes = 536870912,
                        gc.ttlseconds = 90000,
-                       num_replicas = 5,
+                       num_replicas = 4,
                        num_voters = 3,
-                       constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                       constraints = '{+region=ca-central-1: 1, +region=us-east-1: 1}',
                        voter_constraints = '[+region=ca-central-1]',
                        lease_preferences = '[[+region=ca-central-1]]'
 
@@ -1990,9 +1990,9 @@ DATABASE drop_regions  ALTER DATABASE drop_regions CONFIGURE ZONE USING
                        range_min_bytes = 134217728,
                        range_max_bytes = 536870912,
                        gc.ttlseconds = 90000,
-                       num_replicas = 5,
+                       num_replicas = 3,
                        num_voters = 3,
-                       constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                       constraints = '{+region=ca-central-1: 1}',
                        voter_constraints = '[+region=ca-central-1]',
                        lease_preferences = '[[+region=ca-central-1]]'
 
@@ -2003,9 +2003,9 @@ DATABASE drop_regions  ALTER DATABASE drop_regions CONFIGURE ZONE USING
                        range_min_bytes = 134217728,
                        range_max_bytes = 536870912,
                        gc.ttlseconds = 90000,
-                       num_replicas = 5,
+                       num_replicas = 3,
                        num_voters = 3,
-                       constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                       constraints = '{+region=ca-central-1: 1}',
                        voter_constraints = '[+region=ca-central-1]',
                        lease_preferences = '[[+region=ca-central-1]]'
 

--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
     ],
     deps = [
         "//pkg/base",
+        "//pkg/ccl/multiregionccl/multiregionccltestutils",
         "//pkg/ccl/partitionccl",
         "//pkg/ccl/utilccl",
         "//pkg/jobs",

--- a/pkg/ccl/multiregionccl/multiregion_test.go
+++ b/pkg/ccl/multiregionccl/multiregion_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl/multiregionccltestutils"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -26,7 +27,9 @@ func TestMultiRegionNoLicense(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	defer utilccl.TestingDisableEnterprise()()
 
-	_, sqlDB, cleanup := createTestMultiRegionCluster(t, 3, base.TestingKnobs{})
+	_, sqlDB, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
+		t, 3 /* numServers */, base.TestingKnobs{},
+	)
 	defer cleanup()
 
 	_, err := sqlDB.Exec(`CREATE DATABASE test`)
@@ -51,7 +54,9 @@ func TestMultiRegionAfterEnterpriseDisabled(t *testing.T) {
 
 	skip.UnderRace(t, "#61163")
 
-	_, sqlDB, cleanup := createTestMultiRegionCluster(t, 3, base.TestingKnobs{})
+	_, sqlDB, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
+		t, 3 /* numServers */, base.TestingKnobs{},
+	)
 	defer cleanup()
 
 	_, err := sqlDB.Exec(`

--- a/pkg/ccl/multiregionccl/multiregionccltestutils/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/multiregionccltestutils/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "multiregionccltestutils",
+    srcs = ["testutils.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl/multiregionccltestutils",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/base",
+        "//pkg/roachpb",
+        "//pkg/testutils/serverutils",
+    ],
+)

--- a/pkg/ccl/multiregionccl/multiregionccltestutils/testutils.go
+++ b/pkg/ccl/multiregionccl/multiregionccltestutils/testutils.go
@@ -1,0 +1,56 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package multiregionccltestutils
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+)
+
+// TestingCreateMultiRegionCluster creates a test cluster with numServers number
+// of nodes and the provided testing knobs applied to each of the nodes. Every
+// node is placed in its own locality, named "us-east1", "us-east2", and so on.
+func TestingCreateMultiRegionCluster(
+	t *testing.T, numServers int, knobs base.TestingKnobs,
+) (serverutils.TestClusterInterface, *gosql.DB, func()) {
+	serverArgs := make(map[int]base.TestServerArgs)
+	regionNames := make([]string, numServers)
+	for i := 0; i < numServers; i++ {
+		// "us-east1", "us-east2"...
+		regionNames[i] = fmt.Sprintf("us-east%d", i+1)
+	}
+
+	for i := 0; i < numServers; i++ {
+		serverArgs[i] = base.TestServerArgs{
+			Knobs: knobs,
+			Locality: roachpb.Locality{
+				Tiers: []roachpb.Tier{{Key: "region", Value: regionNames[i]}},
+			},
+		}
+	}
+
+	tc := serverutils.StartNewTestCluster(t, numServers, base.TestClusterArgs{
+		ServerArgsPerNode: serverArgs,
+	})
+
+	ctx := context.Background()
+	cleanup := func() {
+		tc.Stopper().Stop(ctx)
+	}
+
+	sqlDB := tc.ServerConn(0)
+
+	return tc, sqlDB, cleanup
+}

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -227,17 +227,6 @@ func (n *alterDatabaseAddRegionNode) startExec(params runParams) error {
 		return err
 	}
 
-	// Update the database's zone configuration.
-	if err := ApplyZoneConfigFromDatabaseRegionConfig(
-		params.ctx,
-		n.desc.ID,
-		*n.desc.RegionConfig,
-		params.p.txn,
-		params.p.execCfg,
-	); err != nil {
-		return err
-	}
-
 	// Log Alter Database Add Region event. This is an auditable log event and is
 	// recorded in the same transaction as the database descriptor, type
 	// descriptor, and zone configuration updates.


### PR DESCRIPTION
Previously, database level zone configurations weren't updated when the
region drop was finalized. This patch adds that support.

This patch also moves setting zone configurations on ADD REGION from
the user txn to the type schema changer. This ensures that zone
configurations are added transactionally -- if the ADD REGION fails for
whatever reason, we no longer leave behind dangling zone config.

Lastly, I've refactored some test setup code that was being duplicated
and improved the tests around rollback to test additional scenarios.

Closes #60435
Closes #60750

Release note: None

Release justification: bug fixes and low-risk updates to new
functionality