### PR TITLE
sql: include table name when constraint doesn't exist for alters

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -681,7 +681,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 					continue
 				}
 				return pgerror.Newf(pgcode.UndefinedObject,
-					"constraint %q does not exist", t.Constraint)
+					"constraint %q of relation %q does not exist", t.Constraint, n.tableDesc.Name)
 			}
 			if err := n.tableDesc.DropConstraint(
 				params.ctx,
@@ -707,7 +707,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 			constraint, ok := info[name]
 			if !ok {
 				return pgerror.Newf(pgcode.UndefinedObject,
-					"constraint %q does not exist", t.Constraint)
+					"constraint %q of relation %q does not exist", t.Constraint, n.tableDesc.Name)
 			}
 			if !constraint.Unvalidated {
 				continue
@@ -896,7 +896,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 			details, ok := info[string(t.Constraint)]
 			if !ok {
 				return pgerror.Newf(pgcode.UndefinedObject,
-					"constraint %q does not exist", tree.ErrString(&t.Constraint))
+					"constraint %q of relation %q does not exist", tree.ErrString(&t.Constraint), n.tableDesc.Name)
 			}
 			if t.Constraint == t.NewName {
 				// Nothing to do.

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -146,7 +146,7 @@ t  fk_f_ref_other  FOREIGN KEY  FOREIGN KEY (f) REFERENCES other(b)  true
 t  foo             UNIQUE       UNIQUE (b ASC)                       true
 t  primary         PRIMARY KEY  PRIMARY KEY (a ASC)                  true
 
-statement error constraint "typo" does not exist
+statement error constraint "typo" of relation "t" does not exist
 ALTER TABLE t VALIDATE CONSTRAINT typo
 
 # TODO(erik): re-enable test when unvalidated checks can be added
@@ -180,7 +180,7 @@ ALTER TABLE t DROP IF EXISTS d
 statement error column "a" is referenced by the primary key
 ALTER TABLE t DROP a
 
-statement error constraint "bar" does not exist
+statement error constraint "bar" of relation "t" does not exist
 ALTER TABLE t DROP CONSTRAINT bar
 
 statement ok
@@ -1534,7 +1534,7 @@ unique_without_index  unique_without_index_c_key  UNIQUE           UNIQUE (c ASC
 statement ok
 ALTER TABLE unique_without_index RENAME COLUMN a TO aa
 
-statement error pgcode 42704 constraint \"unique_b_2\" does not exist
+statement error pgcode 42704 constraint \"unique_b_2\" of relation \"unique_without_index\" does not exist
 ALTER TABLE unique_without_index RENAME CONSTRAINT unique_b_2 TO unique_b_3
 
 statement error pgcode 42710 duplicate constraint name: \"unique_b_1\"
@@ -1561,7 +1561,7 @@ unique_without_index  unique_without_index_c_key  UNIQUE  UNIQUE (c ASC)        
 statement error pgcode 0A000 cannot drop UNIQUE constraint \"unique_without_index_c_key\"
 ALTER TABLE unique_without_index DROP CONSTRAINT unique_without_index_c_key
 
-statement error pgcode 42704 constraint \"unique_b\" does not exist
+statement error pgcode 42704 constraint \"unique_b\" of relation \"unique_without_index\" does not exist
 ALTER TABLE unique_without_index DROP CONSTRAINT unique_b
 
 # Drop a valid constraint.


### PR DESCRIPTION
Fixes: #60920

Previously, when altering a table to validate, drop, or remove
a constraint that does not exist the error would not include the table
name. This behaviour was inconsistent with Postgres. To address this
inconsistency, this patch updates the undefined object error to include
the table name.

Release note: None

Release justification: bug fix and low risk change to an existing error
message.