### PR TITLE
ui: update README with clearer NodeJS and Yarn version recommendations

### DIFF
--- a/pkg/ui/README.md
+++ b/pkg/ui/README.md
@@ -16,9 +16,9 @@ you'll be able to access the UI at <http://localhost:8080>.
 Our UI is compiled using a collection of tools that depends on
 [Node.js](https://nodejs.org/) and are managed with
 [Yarn](https://yarnpkg.com), a package manager that offers more deterministic
-package installation than NPM. NodeJS 6.x and Yarn 1.7.0 are known to work.
-[Chrome](https://www.google.com/chrome/), Google's internet browser. Unit tests
-are run using Chrome's "Headless" mode.
+package installation than NPM. LTS versions of NodeJS and Yarn v1.x.x are known
+to work. [Chrome](https://www.google.com/chrome/), Google's internet browser.
+Unit tests are run using Chrome's "Headless" mode.
 
 With Node and Yarn installed, bootstrap local development by running `make` in
 this directory. This will run `yarn install` to install our Node dependencies,


### PR DESCRIPTION
While running through my new machine setup to run the ui, I noticed that the recommended NodeJS version was quite a bit out of date. This updates the README to point to the LTS version of NodeJS instead which should also be compatible. 

Release justification: non-production change

Release note: none