### PR TITLE
kvserver: re-add spuriously removed nil check in `relocateOne`

### DIFF
--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -2925,6 +2925,10 @@ func (s *Store) relocateOne(
 			existingNonVoters,
 			s.allocator.scorerOptions(),
 			args.targetType)
+		if targetStore == nil {
+			return nil, nil, fmt.Errorf("none of the remaining %ss %v are legal additions to %v",
+				args.targetType, args.targetsToAdd, desc.Replicas())
+		}
 
 		target := roachpb.ReplicationTarget{
 			NodeID:  targetStore.Node.NodeID,


### PR DESCRIPTION
bce8317 introduced a bug by spuriously
removing a nil check over the result of a call to
`allocateTargetFromList`. This commit re-adds the check.

The bug could cause a panic when `AdminRelocateRange` was called by the
`StoreRebalancer` or the `mergeQueue` if one (or more) of the stores
that are supposed to receive a replica for a range become unfit for
receiving the replica (due to balancing reasons / or shifting
constraints) _between when rebalancing decision is made and when it's
executed_.

Resolves #60812

Release justification: fixes bug that causes a panic
Release note: None