### PR TITLE
TeamCity: pin go version to 1.15

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -88,6 +88,8 @@ back to this document and perform these steps:
 * [ ] Bump the default installed version of Go in `bootstrap-debian.sh` ([source](./bootstrap/bootstrap-debian.sh#L40-42)).
 * [ ] Replace other mentions of the older version of go (grep for `golang:<old_version>` and `go<old_version>`).
 * [ ] Update the `builder.dockerImage` parameter in the TeamCity [`Cockroach`](https://teamcity.cockroachdb.com/admin/editProject.html?projectId=Cockroach&tab=projectParams) and [`Internal`](https://teamcity.cockroachdb.com/admin/editProject.html?projectId=Internal&tab=projectParams) projects.
+* [ ] Adjust `GO_VERSION` in the TeamCity agent image ([setup script](./packer/teamcity-agent.sh))
+  and ask the Developer Infrastructure team to deploy new images.
 
 You can test the new builder image in TeamCity by using the custom parameters
 UI (the "..." icon next to the "Run" button) to verify the image before

--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -33,16 +33,26 @@ apt-get update --yes
 apt-get install --yes sudo
 
 # Install the necessary dependencies. Keep this list small!
+GO_VERSION=1.15
+
 apt-get install --yes \
   docker-ce \
   docker-compose \
   gnome-keyring \
   gnupg2 \
   git \
-  golang-go \
+  golang-${GO_VERSION}-go \
   openjdk-11-jre-headless \
   pass \
   unzip
+
+# golang-X.Y-go does not install system wide symlinks, it's only done by the
+# golang-go package which points to the latest version. Explicitly symlink the
+# pinned version to /usr/bin.
+for f in go gofm; do
+    ln -s /usr/lib/go-${GO_VERSION}/bin/$f /usr/bin
+done
+
 # Installing gnome-keyring prevents the error described in
 # https://github.com/moby/moby/issues/34048
 


### PR DESCRIPTION
Installing `golang-go` brings the latest version of go, what may be
unwanted. In this case the acceptance test fails with go 1.16.

Additionally, pinning the go version makes the toolchain more
predictable.

One of the downsides of installing `golang-X.Y-go` is that we need to
add system-wide symlinks manually, because the package itself doesn't do
that, leaving that functionality to the `golang-go` package.

Release justification: non-production code changes
Release note: None