### PR TITLE
server: bug fix to correct path checks for existing certificates prior to generation

### DIFF
--- a/pkg/security/certificate_manager.go
+++ b/pkg/security/certificate_manager.go
@@ -457,7 +457,7 @@ func (cl CertsLocator) RPCServiceCACertPath() string {
 // RPCServiceCACertFilename returns the expected file name for the RPC service
 // certificate
 func RPCServiceCACertFilename() string {
-	return "service.rpc" + certExtension
+	return "service.ca.rpc" + certExtension
 }
 
 // RPCServiceCAKeyPath returns the expected file path for the RPC service key
@@ -468,7 +468,7 @@ func (cl CertsLocator) RPCServiceCAKeyPath() string {
 // RPCServiceCAKeyFilename returns the expected file name for the RPC service
 // certificate
 func RPCServiceCAKeyFilename() string {
-	return "service.rpc" + keyExtension
+	return "service.ca.rpc" + keyExtension
 }
 
 // CACert returns the CA cert. May be nil.


### PR DESCRIPTION
I erred in my use of os.Stat and no exists checks were correct. I've refactored the read/write
functions to perform these checks themselves. This also improves our resiliency against
races between time of check and time of use for cert/key file paths.

Part of #60632 

Release justification: bug fix to enable proper automatic generation of certificates
Release note: None
