### PR TITLE
release-20.2: sql: fix SHOW CREATE output for partitioned and interleaved partial indexes

### DIFF
--- a/pkg/ccl/importccl/read_import_mysql_test.go
+++ b/pkg/ccl/importccl/read_import_mysql_test.go
@@ -216,11 +216,11 @@ func compareTables(t *testing.T, expected, got *descpb.TableDescriptor) {
 		tableName := &descpb.AnonymousTable
 		expectedDesc := tabledesc.NewImmutable(*expected)
 		gotDesc := tabledesc.NewImmutable(*got)
-		e, err := schemaexpr.FormatIndexForDisplay(ctx, expectedDesc, tableName, &expected.Indexes[i], &semaCtx)
+		e, err := schemaexpr.FormatIndexForDisplay(ctx, expectedDesc, tableName, &expected.Indexes[i], "" /* partition */, &semaCtx)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
-		g, err := schemaexpr.FormatIndexForDisplay(ctx, gotDesc, tableName, &got.Indexes[i], &semaCtx)
+		g, err := schemaexpr.FormatIndexForDisplay(ctx, gotDesc, tableName, &got.Indexes[i], "" /* partition */, &semaCtx)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}

--- a/pkg/ccl/importccl/read_import_mysql_test.go
+++ b/pkg/ccl/importccl/read_import_mysql_test.go
@@ -216,11 +216,15 @@ func compareTables(t *testing.T, expected, got *descpb.TableDescriptor) {
 		tableName := &descpb.AnonymousTable
 		expectedDesc := tabledesc.NewImmutable(*expected)
 		gotDesc := tabledesc.NewImmutable(*got)
-		e, err := schemaexpr.FormatIndexForDisplay(ctx, expectedDesc, tableName, &expected.Indexes[i], "" /* partition */, &semaCtx)
+		e, err := schemaexpr.FormatIndexForDisplay(
+			ctx, expectedDesc, tableName, &expected.Indexes[i], "" /* partition */, "" /* interleave */, &semaCtx,
+		)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
-		g, err := schemaexpr.FormatIndexForDisplay(ctx, gotDesc, tableName, &got.Indexes[i], "" /* partition */, &semaCtx)
+		g, err := schemaexpr.FormatIndexForDisplay(
+			ctx, gotDesc, tableName, &got.Indexes[i], "" /* partition */, "" /* interleave */, &semaCtx,
+		)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_index
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_index
@@ -150,3 +150,31 @@ indexes  CREATE TABLE public.indexes (
          FAMILY "primary" (a, b)
 )
 -- Warning: Partitioned table with no zone configurations.
+
+# Regression test for #60019. The index predicate should be formatted after the
+# PARTITION BY clause to match the syntax that is accepted.
+statement ok
+CREATE TABLE t60019 (
+  pk INT PRIMARY KEY,
+  a INT,
+  b INT,
+  INDEX (a, b) PARTITION BY LIST (a) (
+    PARTITION c_implicit VALUES IN (3)
+  ) WHERE b > 0,
+  FAMILY (pk, a, b)
+)
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t60019]
+----
+CREATE TABLE public.t60019 (
+  pk INT8 NOT NULL,
+  a INT8 NULL,
+  b INT8 NULL,
+  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+  INDEX t60019_a_b_idx (a ASC, b ASC) PARTITION BY LIST (a) (
+    PARTITION c_implicit VALUES IN ((3))
+  ) WHERE b > 0:::INT8,
+  FAMILY fam_0_pk_a_b (pk, a, b)
+)
+-- Warning: Partitioned table with no zone configurations.

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1907,7 +1907,7 @@ func showCreateIndexWithInterleave(
 	semaCtx *tree.SemaContext,
 ) error {
 	f.WriteString("CREATE ")
-	idxStr, err := schemaexpr.FormatIndexForDisplay(ctx, table, &tableName, idx, semaCtx)
+	idxStr, err := schemaexpr.FormatIndexForDisplay(ctx, table, &tableName, idx, "" /* partition */, semaCtx)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1907,7 +1907,9 @@ func showCreateIndexWithInterleave(
 	semaCtx *tree.SemaContext,
 ) error {
 	f.WriteString("CREATE ")
-	idxStr, err := schemaexpr.FormatIndexForDisplay(ctx, table, &tableName, idx, "" /* partition */, semaCtx)
+	idxStr, err := schemaexpr.FormatIndexForDisplay(
+		ctx, table, &tableName, idx, "" /* partition */, "" /* interleave */, semaCtx,
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/logictest/testdata/logic_test/show_create
+++ b/pkg/sql/logictest/testdata/logic_test/show_create
@@ -30,3 +30,24 @@ c           CREATE TABLE public.c (
 COMMENT ON TABLE public.c IS 'table';
 COMMENT ON COLUMN public.c.a IS 'column';
 COMMENT ON INDEX public.c@c_a_b_idx IS 'index'
+
+# Regression test for #60701. In the SHOW CREATE output of a table with a
+# partial interleaved index, the INTERLEAVE clause should precede the WHERE
+# clause. This matches the accepted syntax for creating partial interleaved
+# indexes.
+statement ok
+CREATE TABLE t60701_a (a INT PRIMARY KEY, FAMILY (a));
+CREATE TABLE t60701_b (b INT PRIMARY KEY, a INT REFERENCES t60701_a (a), FAMILY (b, a));
+CREATE INDEX i ON t60701_b (a) INTERLEAVE IN PARENT t60701_a (a) WHERE b > 0;
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t60701_b]
+----
+CREATE TABLE public.t60701_b (
+   b INT8 NOT NULL,
+   a INT8 NULL,
+   CONSTRAINT "primary" PRIMARY KEY (b ASC),
+   CONSTRAINT fk_a_ref_t60701_a FOREIGN KEY (a) REFERENCES public.t60701_a(a),
+   INDEX i (a ASC) INTERLEAVE IN PARENT public.t60701_a (a) WHERE b > 0:::INT8,
+   FAMILY fam_0_b_a (b, a)
+)

--- a/pkg/sql/schemaexpr/partial_index.go
+++ b/pkg/sql/schemaexpr/partial_index.go
@@ -99,6 +99,7 @@ func FormatIndexForDisplay(
 	table catalog.TableDescriptor,
 	tableName *tree.TableName,
 	index *descpb.IndexDescriptor,
+	partition string,
 	semaCtx *tree.SemaContext,
 ) (string, error) {
 	f := tree.NewFmtCtx(tree.FmtSimple)
@@ -133,6 +134,8 @@ func FormatIndexForDisplay(
 		}
 		f.WriteByte(')')
 	}
+
+	f.WriteString(partition)
 
 	if index.GeoConfig.S2Geometry != nil || index.GeoConfig.S2Geography != nil {
 		var s2Config *geoindex.S2Config

--- a/pkg/sql/schemaexpr/partial_index.go
+++ b/pkg/sql/schemaexpr/partial_index.go
@@ -100,6 +100,7 @@ func FormatIndexForDisplay(
 	tableName *tree.TableName,
 	index *descpb.IndexDescriptor,
 	partition string,
+	interleave string,
 	semaCtx *tree.SemaContext,
 ) (string, error) {
 	f := tree.NewFmtCtx(tree.FmtSimple)
@@ -135,6 +136,7 @@ func FormatIndexForDisplay(
 		f.WriteByte(')')
 	}
 
+	f.WriteString(interleave)
 	f.WriteString(partition)
 
 	if index.GeoConfig.S2Geometry != nil || index.GeoConfig.S2Geography != nil {

--- a/pkg/sql/schemaexpr/partial_index_test.go
+++ b/pkg/sql/schemaexpr/partial_index_test.go
@@ -152,28 +152,46 @@ func TestFormatIndexForDisplay(t *testing.T) {
 	partialIndex.Predicate = "a > 1:::INT8"
 
 	testData := []struct {
-		index     descpb.IndexDescriptor
-		tableName tree.TableName
-		partition string
-		expected  string
+		index      descpb.IndexDescriptor
+		tableName  tree.TableName
+		partition  string
+		interleave string
+		expected   string
 	}{
-		{baseIndex, descpb.AnonymousTable, "", "INDEX baz (a ASC, b DESC)"},
-		{baseIndex, tableName, "", "INDEX baz ON foo.public.bar (a ASC, b DESC)"},
-		{uniqueIndex, descpb.AnonymousTable, "", "UNIQUE INDEX baz (a ASC, b DESC)"},
-		{invertedIndex, descpb.AnonymousTable, "", "INVERTED INDEX baz (a)"},
-		{storingIndex, descpb.AnonymousTable, "", "INDEX baz (a ASC, b DESC) STORING (c)"},
-		{partialIndex, descpb.AnonymousTable, "", "INDEX baz (a ASC, b DESC) WHERE a > 1:::INT8"},
+		{baseIndex, descpb.AnonymousTable, "", "", "INDEX baz (a ASC, b DESC)"},
+		{baseIndex, tableName, "", "", "INDEX baz ON foo.public.bar (a ASC, b DESC)"},
+		{uniqueIndex, descpb.AnonymousTable, "", "", "UNIQUE INDEX baz (a ASC, b DESC)"},
+		{invertedIndex, descpb.AnonymousTable, "", "", "INVERTED INDEX baz (a)"},
+		{storingIndex, descpb.AnonymousTable, "", "", "INDEX baz (a ASC, b DESC) STORING (c)"},
+		{partialIndex, descpb.AnonymousTable, "", "", "INDEX baz (a ASC, b DESC) WHERE a > 1:::INT8"},
 		{
 			partialIndex,
 			descpb.AnonymousTable,
 			" PARTITION BY LIST (a) (PARTITION p VALUES IN (2))",
+			"",
 			"INDEX baz (a ASC, b DESC) PARTITION BY LIST (a) (PARTITION p VALUES IN (2)) WHERE a > 1:::INT8",
+		},
+		{
+			partialIndex,
+			descpb.AnonymousTable,
+			"",
+			" INTERLEAVE IN PARENT par (a)",
+			"INDEX baz (a ASC, b DESC) INTERLEAVE IN PARENT par (a) WHERE a > 1:::INT8",
+		},
+		{
+			partialIndex,
+			descpb.AnonymousTable,
+			" PARTITION BY LIST (a) (PARTITION p VALUES IN (2))",
+			" INTERLEAVE IN PARENT par (a)",
+			"INDEX baz (a ASC, b DESC) INTERLEAVE IN PARENT par (a) PARTITION BY LIST (a) (PARTITION p VALUES IN (2)) WHERE a > 1:::INT8",
 		},
 	}
 
 	for testIdx, tc := range testData {
 		t.Run(strconv.Itoa(testIdx), func(t *testing.T) {
-			got, err := schemaexpr.FormatIndexForDisplay(ctx, tableDesc, &tc.tableName, &tc.index, tc.partition, &semaCtx)
+			got, err := schemaexpr.FormatIndexForDisplay(
+				ctx, tableDesc, &tc.tableName, &tc.index, tc.partition, tc.interleave, &semaCtx,
+			)
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			}

--- a/pkg/sql/schemaexpr/partial_index_test.go
+++ b/pkg/sql/schemaexpr/partial_index_test.go
@@ -154,19 +154,26 @@ func TestFormatIndexForDisplay(t *testing.T) {
 	testData := []struct {
 		index     descpb.IndexDescriptor
 		tableName tree.TableName
+		partition string
 		expected  string
 	}{
-		{baseIndex, descpb.AnonymousTable, "INDEX baz (a ASC, b DESC)"},
-		{baseIndex, tableName, "INDEX baz ON foo.public.bar (a ASC, b DESC)"},
-		{uniqueIndex, descpb.AnonymousTable, "UNIQUE INDEX baz (a ASC, b DESC)"},
-		{invertedIndex, descpb.AnonymousTable, "INVERTED INDEX baz (a)"},
-		{storingIndex, descpb.AnonymousTable, "INDEX baz (a ASC, b DESC) STORING (c)"},
-		{partialIndex, descpb.AnonymousTable, "INDEX baz (a ASC, b DESC) WHERE a > 1:::INT8"},
+		{baseIndex, descpb.AnonymousTable, "", "INDEX baz (a ASC, b DESC)"},
+		{baseIndex, tableName, "", "INDEX baz ON foo.public.bar (a ASC, b DESC)"},
+		{uniqueIndex, descpb.AnonymousTable, "", "UNIQUE INDEX baz (a ASC, b DESC)"},
+		{invertedIndex, descpb.AnonymousTable, "", "INVERTED INDEX baz (a)"},
+		{storingIndex, descpb.AnonymousTable, "", "INDEX baz (a ASC, b DESC) STORING (c)"},
+		{partialIndex, descpb.AnonymousTable, "", "INDEX baz (a ASC, b DESC) WHERE a > 1:::INT8"},
+		{
+			partialIndex,
+			descpb.AnonymousTable,
+			" PARTITION BY LIST (a) (PARTITION p VALUES IN (2))",
+			"INDEX baz (a ASC, b DESC) PARTITION BY LIST (a) (PARTITION p VALUES IN (2)) WHERE a > 1:::INT8",
+		},
 	}
 
 	for testIdx, tc := range testData {
 		t.Run(strconv.Itoa(testIdx), func(t *testing.T) {
-			got, err := schemaexpr.FormatIndexForDisplay(ctx, tableDesc, &tc.tableName, &tc.index, &semaCtx)
+			got, err := schemaexpr.FormatIndexForDisplay(ctx, tableDesc, &tc.tableName, &tc.index, tc.partition, &semaCtx)
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			}

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -159,14 +159,21 @@ func ShowCreateTable(
 		}
 		if idx.ID != desc.GetPrimaryIndex().ID && includeInterleaveClause {
 			// Showing the primary index is handled above.
+
+			// Build the PARTITION BY clause.
+			var partitionBuf bytes.Buffer
+			if err := ShowCreatePartitioning(
+				a, p.ExecCfg().Codec, desc, idx, &idx.Partitioning, &partitionBuf, 1 /* indent */, 0, /* colOffset */
+			); err != nil {
+				return "", err
+			}
+
 			f.WriteString(",\n\t")
-			idxStr, err := schemaexpr.FormatIndexForDisplay(ctx, desc, &descpb.AnonymousTable, idx, &p.RunParams(ctx).p.semaCtx)
+			idxStr, err := schemaexpr.FormatIndexForDisplay(ctx, desc, &descpb.AnonymousTable, idx, partitionBuf.String(), &p.RunParams(ctx).p.semaCtx)
 			if err != nil {
 				return "", err
 			}
 			f.WriteString(idxStr)
-			// Showing the INTERLEAVE and PARTITION BY for the primary index are
-			// handled last.
 
 			// Add interleave or Foreign Key indexes only to the create_table columns,
 			// and not the create_nofks column.
@@ -174,11 +181,6 @@ func ShowCreateTable(
 				if err := showCreateInterleave(idx, &f.Buffer, dbPrefix, lCtx); err != nil {
 					return "", err
 				}
-			}
-			if err := ShowCreatePartitioning(
-				a, p.ExecCfg().Codec, desc, idx, &idx.Partitioning, &f.Buffer, 1 /* indent */, 0, /* colOffset */
-			); err != nil {
-				return "", err
 			}
 		}
 	}


### PR DESCRIPTION
Backport 2/2 commits from #60590.

/cc @cockroachdb/release

---

#### sql: fix SHOW CREATE output for partitioned partial indexes

The accepted syntax for creating partitioned partial indexes requires
the `PARTITION BY` clause to precede the `WHERE` predicate clause.
Previously, `SHOW CREATE` formatted indexes with the `WHERE` clause
preceding the `PARTITION BY` clause. This commit fixes `SHOW CREATE` to
match the parser's accepted ordering of clauses.

Release note (bug fix): The `SHOW CREATE` output of a partitioned
partial index now lists the `PARTITION BY` and `WHERE` clauses in the
order accepted by the parser.

Release justification: Fixes a bug that makes `SHOW CREATE` not
round-trippable.

#### sql: fix SHOW CREATE output for partial interleaved indexes

The accepted syntax for creating partial interleaved indexes requires
the `INTERLEAVE` clause to precede the `WHERE` clause. This commit fixes
the output of partial interleaved indexes in `SHOW CREATE` to match this
syntax.

Release note (bug fix): The `SHOW CREATE` output of a partial
interleaved index now lists the `INTERLEAVED` and `WHERE` clauses in the
order accepted by the parser.

Release justification: Fixes a bug that makes `SHOW CREATE` not
round-trippable.

