### PR TITLE
sql: disallow creation of interleaved partitioned indexes

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_index
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_index
@@ -212,3 +212,15 @@ CREATE TABLE public.t60019 (
   FAMILY fam_0_pk_a_b (pk, a, b)
 )
 -- Warning: Partitioned table with no zone configurations.
+
+# Regression test for #60699. Do not allow creation of interleaved partitioned
+# indexes.
+statement ok
+SET CLUSTER SETTING sql.defaults.interleaved_tables.enabled = true;
+CREATE TABLE t60699_a (a INT PRIMARY KEY);
+CREATE TABLE t60699_b (b INT PRIMARY KEY, a INT REFERENCES t60699_a (a));
+
+statement error interleaved indexes cannot be partitioned
+CREATE INDEX i ON t60699_b (a) INTERLEAVE IN PARENT t60699_a (a) PARTITION BY LIST (a) (
+  partition part1 VALUES IN (1)
+)

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -425,6 +425,10 @@ func (n *createIndexNode) startExec(params runParams) error {
 	}
 
 	if n.n.Interleave != nil {
+		if n.n.PartitionByIndex != nil {
+			return pgerror.New(pgcode.FeatureNotSupported, "interleaved indexes cannot be partitioned")
+		}
+
 		if err := interleavedTableDeprecationAction(params); err != nil {
 			return err
 		}


### PR DESCRIPTION
Previously, creating interleaved partitioned indexes panicked. This
commit disallows their creation to prevent panicking.

Fixes #60699

Release justification: This is a low risk change that prevents panics
when attempting to create interleaved partitioned tables.

Release note (bug fix): Creating interleaved partitioned indexes is now
disallowed. Previously, the database would crash when trying to create
one.