### PR TITLE
docs/RFCS: add an RFC for asynchronous SQL jobs

### DIFF
--- a/docs/RFCS/20210224_sql_jobs.md
+++ b/docs/RFCS/20210224_sql_jobs.md
@@ -1,0 +1,332 @@
+- Feature Name: SQL Jobs
+- Status: draft
+- Start Date: 2021-02-24
+- Authors: Andrew Werner
+- RFC PR: (PR # after acceptance of initial draft)
+- Cockroach Issue: (one or more # from the issue tracker)
+
+# Summary
+
+This RFC proposes a new job type that allows running of arbitrary sql
+statements. The most proximate motivation for this feature is to allow users
+the ability queue schema changes in a fault-tolerant way; something they
+may be used to but we have a strong desire to remove. The proposal lends itself
+to extensions which combine with the scheduled jobs infrastructure which might
+be used to effectively enable periodic materializations of aggregations. 
+
+# Motivation
+
+The driving motivation behind this RFC is to deal with the topic of queueing of asynchronous, potentially dependent schema migrations. The following section
+deals with explaining that problem and motivating the proposed solution. The
+proposed solution happens to lend itself to other use cases like implementing
+things like TTLs and data roll-ups and that, likely far more exciting topic, is
+explored in Future Work. 
+
+## Queueing Dependent Schema Changes
+
+In the current version of cockroach, schema changes are performed via a per-
+descriptor asynchronous job that follows from the user transaction committing
+that job. Much has been said about this in previous RFCs but most importantly
+this is described in the Future Work section of 
+[Transactional Schema Changes][transactional schema changes].
+
+We are in the process of building [a new, more principled, modular, and
+extensible schema change architecture][declarative schema changer]. This schema
+changer dramatically improves the internals of schema changes and paves the
+path to the transactional future, but in finding that sanity it risks breaking
+some user stories which rely on some things being, well, insane.
+
+### Today: The Per-Table Job Schema Changer
+
+One property that exists in today's schema changes is that we allow arbitrary
+queuing of schema changes. The legacy behind this is long and much of its
+implications have been bug prone and poorly understood. For example:
+
+```sql
+CREATE TABLE foo (k INT PRIMARY KEY, v STRING);
+-- ... load lots of data into foo.
+ 
+-- Connection 1:
+ALTER TABLE foo ADD COLUMN c INT DEFAULT 42; -- blocks, but creates a job
+
+-- Connection 2:
+-- Find job ID for above schema change from connection.
+PAUSE JOB $jobid
+
+BEGIN;
+    ALTER TABLE foo ADD COLUMN c2 INT AS (c) STORED;
+    ALTER TABLE foo ADD CONSTRAINT c2 UNIQUE;
+COMMIT; -- blocks, but if you check the job exists, can close connection
+
+-- ... and so on, setting up more, potentially dependent schema changes
+```
+
+In practice, this arbitrary ability to enqueue schema changes wasn't altogether
+planned; it was something of a happening of the structure of the code and then
+an accepted approach that came to be. For some cases, though it's proven to be
+extremely fruitful. The main case where I believe customers attain value out of
+this model is the ability to enqueue secondary index creations.
+
+The desire to add secondary indexes in an asynchronous manner seems worthy
+enough that Postgres explicitly supports it with a `CONCURRENTLY` keyword
+(though the semantics are a bit wonky in places). We'll revisit their special
+case later in alternatives but suffice it to say that somebody has seen some
+value in telling some story around this topic. We have seen users discover this
+behavior in the wild.
+
+### Tomorrow: The Per-Transaction Declarative Job Schema Changer
+
+So, you might ask, why is it that we don't want to support these exact
+semantics? The devil is a bit in the details, but the main one is that currently
+all of these jobs are on a **per table** basis. That means if, in a transaction,
+schema changes touch many tables, each one gets its own job. If any one of them
+fails, then only the schema changes on that table are attempted to be reverted.
+This will certainly not work in the transactional world and is really just odd.
+This topic too is explored elsewhere.
+
+So, with the new schema changer, before we reach fully transactional semantics,
+we'll still have jobs to perform schema changes, but these jobs will be **per
+transaction**. This will allow rollbacks (only of DDLs) to retain a certain
+amount of sanity.
+
+To make this concrete, in the new schema change world, the following would
+happen:
+
+```sql
+CREATE TABLE foo (k INT PRIMARY KEY, v STRING);
+-- ... load lots of data into foo.
+ 
+-- Connection 1:
+ALTER TABLE foo ADD COLUMN c INT DEFAULT 42; -- blocks, but creates a job
+
+-- Connection 2:
+-- Find job ID for above schema change from connection.
+PAUSE JOB $jobid
+
+BEGIN;
+    ALTER TABLE foo ADD COLUMN c2 INT AS (c) STORED;
+    -- Now this statement will block forever until the dependent job completes
+    -- at which time a serializable restart will be returned.
+    -- NOTE no job can be created while another job is operating on a table.
+```
+
+The purpose of this RFC isn't so much to discuss the above behavior but to note
+that it differs from the existing behavior: while users will be able to schedule
+fault-tolerant schema changes they will not be able to queue them.
+
+### The Day After Tomorrow: Transactional Schema Changes
+
+The ultimate goal of the schema team is to get to transactional, online
+schema changes. That fundamentally requires that schema change operations occur
+during statement execution (at least in an explicit transaction). Looking back
+at the previous two examples, putting the initial `ALTER` inside an explicit
+transaction would not in any way change the behavior. In the transactional
+world, the single-statement `ALTER` could still, potentially, create a job
+and behave identically to the above described scenario. However, imagine instead
+that we do the following:
+
+```sql
+BEGIN;
+    -- The below alter blocks until the backfill completes which may be a very
+    -- long time. It does not create a job and it is not visible until a
+    -- subsequent COMMIT. In the previous two worlds, this statement would
+    -- execute almost instantaneously; it merely sets up a job.
+    ALTER TABLE foo ADD COLUMN c INT DEFAULT 42;
+```
+
+This above scenario is a potentially radical loss of usability for customers
+which perhaps have come to trust that they can fire off a big transactions of
+schema changes, go check on jobs, and then close a connection. Furthermore, in
+this world it should be more obvious that concurrent attempts to "queue" schema
+changes make a heck of a lot less sense given that, in the transaction case, we
+need to know that the current schema change's side effects have been realized
+and thus we definitely need to know that any previous ones have been too.
+
+At the end of the day, the desire to set up schema changes to run, one after
+another, in a fault tolerant way, has no real reason to be coupled to schema
+changes at all! This proposal runs with that idea and instead introduces a new
+concept 
+
+### Summary of Schema Change Issues
+
+Today, you can sort of arbitrarily queue schema changes. The semantics are
+unclear and per table, but it does work. In the next iteration, you'll be able
+to set up a fault-tolerant job to do schema changes so long as there aren't any
+already running on any of the relevant tables; it's a loss but perhaps not so
+bad. In the following iteration, for schema changes more complex than a single
+statement, it's not clear that we'll be able to do any sort of fault tolerance.
+
+
+
+Audience: PMs, end-users, CockroachDB team members.
+
+# Technical design
+
+For all of the long-winded motivation, the design of this proposal is quite
+succinct. The driving force behind the design is a new job implementation, the
+`SQLJob`.
+
+## `SQLJob` Definition
+
+Jobs are defined primarily by their payload. A `SQLJob` consists of a list of 
+SQL statements which constitute a single transaction. It also consists of other
+session information like session variables and the user who created it. Lastly,
+a `SQLJob` may contain the ID of another `SQLJob` on which it depends.
+
+The proposed structure is:
+
+```protobuf
+message SQLJobPayload {
+    
+    // Statements are the statements to be executed as a transaction.
+    repeated string statements = 2;
+    
+    string user = 2 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/security.SQLUsernameProto"];
+
+    map<string, string> sessionVars = 3;
+
+    // DependsOn is an optional job on which this job depends.
+    int64 depends_on = 4; 
+}
+```
+
+## Syntax
+
+(Note: I am very flexible on the syntax)
+
+The syntax to create a job could be something like:
+
+```sql
+CREATE ASYNCHRONOUS JOB AS 
+  (<statement string>,)*
+  <statement string>
+[WITH 
+ [DESCRIPTION <description string>]
+ [USER <user name which this user has been granted>]
+ [DEPENDS ON <job ID>]
+ [VARIABLE <varibale name> = <value>]]
+```
+The statement would return a job ID associated with this job.
+
+Session variables will generally be inherited from the current session. We may
+want to make certain exceptions to this rule, perhaps disallowing some
+variables or making some not implicitly inherited. I could see not wanting to
+implicitly inherit timeouts, for example. 
+
+Note that results of queries are thrown away so running scans is not generally
+very helpful. 
+
+## Statement Execution
+
+During statement execution when creating the job, the statements are planned
+but not executed to ensure their validity. That planning is done with the
+session data as it will be in the job. Also, obviously, the user privileges are
+checked to ensure that the user has the appropriate privileges to execute these
+statements as the designated user.
+
+Certain statements should likely be disallowed, for example, `CHANGEFEED`.
+
+## Job Execution
+
+Jobs which depend on other jobs will fail if their prerequisite fails. Jobs
+will be launched eagerly by the system but will wait until their prerequisite
+enters a terminal state. This could be implemented with polling or we could
+build a more advanced rangefeed-based system.
+
+Once the prerequisite is known to be done, the job will update its progress to
+record that fact (in case the prerequisite record gets GC'd). It will then
+create a transaction to run the statements. It will properly inject the
+appropriate session state. At the end of the last statement, the job will
+update its progress as part of the transaction to indicate that execution has
+occurred. It will also store in its progress any schema change jobs which have
+been run. 
+
+## Drawbacks
+
+### Too much power, not enough control
+
+This feature, as proposed, is extremely powerful. It is easy to imagine how
+it could evolve into a batch processing system. Without controls over things
+like priority and admission control, it could be used for great harm. One
+funny idea is that users might be able to build workflows using these things
+if the statements could figure out a way to then launch jobs.
+
+## Rationale and Alternatives
+
+### Is the schema change thing even really a problem?
+
+One important note is that maybe this problem isn't such a big deal. That
+was the point made by Ben Darnell  the review of transactional schema changes:
+
+> I don't think an async mode is important (if it's important, it would be
+> important for other databases too and no one else seems to have implemented
+> it).
+>
+> This might be desirable if it makes the process more robust to connection
+> failures. If my connection drops (or if the gateway node restarts) during a
+> multi-hour schema change, I'd like it to run to completion. (in an explicit
+> transaction there's no hope because the COMMIT will never come, but in an
+> implicit txn it would be ideal if the schema change would have a high
+> probability of completing even if the connection failed). Ideally I'd be
+> running my schema migration tool from some sort of daemon (or at least 
+> screen/tmux), but without that it would be nice to be able to just had the 
+> change off to the job system and walk away.
+
+In particular, if we have the ability to run single-statement fault-tolerant
+schema changes (even without queueing) maybe that's enough. All current
+proposals intend to keep the fault-tolerance for single-statement schema
+changes.
+
+### Just do `CREATE INDEX ... CONCURRENTLY` and call it a day
+
+Combined with the above point, perhaps a very reasonable conclusion is that
+maybe you want to be able to set up and even execute multiple schema changes
+on the same table but limit those schema changes to just be secondary index
+construction. Secondary index construction has a much more understandable
+interaction space than all schema changes. 
+
+# Explain it to folk outside of your team
+
+The motivation section does a lot of it, the rest is left as a TODO.
+
+# Future Work: Scheduled SQL Jobs
+
+Once you've got the ability to run these SQL jobs, then immediately you start
+to wonder about how this integrates with the wonderful work from the [scheduled
+jobs RFC][scheduled jobs RFC]. One use case would be to run periodic roll-ups
+or aggregations. This feels like it would enable a number of time-series use-
+cases.
+
+However, care would need to be taken to avoid the transactions from getting too
+large. Perhaps one would want to allow limits and repetition. There is a
+slippery slope to `PL/pgSQL` and procedures.
+
+
+# Unresolved questions
+
+* Should the set of statements be one transaction or should it permit multiple?
+    * Should there be a different grouping concept?
+    * Relatedly, what sort of check-pointing should exist?
+    * If users are permitted to run explicit transactions in their SQL then
+      a checkpoint cannot be created as part of an explicit transaction.
+    * Perhaps the way the job should be set up would be disallow explicit
+      transactions but rather to define the job a list of statements which
+      comprise a single transaction. 
+* How would we represent repetition?
+    * A GC TTL might effectively be written as a `DELETE`, however, we know
+      that very large deletes perform very poorly in cockroach. Better would be
+      a `DELETE` with a `LIMIT` that is run until it affects no rows. That isn't
+      hard to represent but how exactly to represent it is an open question.
+      If we had PL/pgSQL then we'd use that and make it a procedure but we
+      clearly don't and that feels like way overkill.
+    * Straw man is that we could literally just have a flag that says repeat
+      until statement affects no rows.
+* How exactly will the resumer execute the statements?
+    * It should construct a `connExecutor`.
+* What should not be allowed within a statement of a job?
+
+Audience: all participants to the RFC review.
+
+[transactional schema changes]: ../20200909_transactional_schema_changes.md
+[declarative schema changer]: https://github.com/lucy-zhang/cockroach/blob/schema-changer-rfc/docs/RFCS/20210115_new_schema_changer.md
+[scheduled jobs RFC]: ../20200414_scheduled_jobs.md


### PR DESCRIPTION
This RFC is serious, but not the outcome I necessarily want to see. It attempts
to provide a clear picture on how we might allow users to schedule schema
change jobs without complicating or coupling anything to the schema change
implementation itself. Personally, I'm bullish on what's written in the
`Alternatives` section, but it wouldn't be responsible to commit to that
without exploring other options like this and understanding customer
expectations and use cases.

Release justification: not code.

Release note: None