### PR TITLE
kv: implement commit-wait for future time transaction commits

### DIFF
--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -48,7 +48,6 @@ go_library(
         "//pkg/storage/enginepb",
         "//pkg/util",
         "//pkg/util/ctxgroup",
-        "//pkg/util/duration",
         "//pkg/util/errorutil/unimplemented",
         "//pkg/util/grpcutil",
         "//pkg/util/hlc",

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -15,13 +15,11 @@ import (
 	"context"
 	"fmt"
 	"runtime/debug"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
-	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -412,17 +410,17 @@ func generateTxnDeadlineExceededErr(
 		roachpb.NewTransactionRetryError(roachpb.RETRY_COMMIT_DEADLINE_EXCEEDED, extraMsg), txn)
 }
 
-// finalizeReadOnlyTxnLocked finalizes a read-only txn, either marking it as
+// finalizeNonLockingTxnLocked finalizes a non-locking txn, either marking it as
 // committed or aborted. It is equivalent, but cheaper than, sending an
-// EndTxnRequest. A read-only txn doesn't have a transaction record, so there's
-// no need to send any request to the server. An EndTxnRequest for a read-only
-// txn is elided by the txnCommitter interceptor. However, calling this and
-// short-circuting even earlier is even more efficient (and shows in
+// EndTxnRequest. A non-locking txn doesn't have a transaction record, so
+// there's no need to send any request to the server. An EndTxnRequest for a
+// non-locking txn is elided by the txnCommitter interceptor. However, calling
+// this and short-circuting even earlier is even more efficient (and shows in
 // benchmarks).
 // TODO(nvanbenschoten): we could have this call into txnCommitter's
 // sendLockedWithElidedEndTxn method, but we would want to confirm
 // that doing so doesn't cut into the speed-up we see from this fast-path.
-func (tc *TxnCoordSender) finalizeReadOnlyTxnLocked(
+func (tc *TxnCoordSender) finalizeNonLockingTxnLocked(
 	ctx context.Context, ba roachpb.BatchRequest,
 ) *roachpb.Error {
 	et := ba.Requests[0].GetEndTxn()
@@ -443,6 +441,9 @@ func (tc *TxnCoordSender) finalizeReadOnlyTxnLocked(
 		tc.mu.txn.Status = roachpb.ABORTED
 	}
 	tc.finalizeAndCleanupTxnLocked(ctx)
+	if et.Commit {
+		tc.maybeCommitWait(ctx)
+	}
 	return nil
 }
 
@@ -464,10 +465,8 @@ func (tc *TxnCoordSender) Send(
 	}
 
 	if ba.IsSingleEndTxnRequest() && !tc.interceptorAlloc.txnPipeliner.hasAcquiredLocks() {
-		return nil, tc.finalizeReadOnlyTxnLocked(ctx, ba)
+		return nil, tc.finalizeNonLockingTxnLocked(ctx, ba)
 	}
-
-	startNs := tc.clock.PhysicalNow()
 
 	ctx, sp := tc.AnnotateCtxWithSpan(ctx, OpTxnCoordSender)
 	defer sp.Finish()
@@ -512,7 +511,7 @@ func (tc *TxnCoordSender) Send(
 		if (et.Commit && pErr == nil) || !et.Commit {
 			tc.finalizeAndCleanupTxnLocked(ctx)
 			if et.Commit {
-				tc.maybeSleepForLinearizable(ctx, br, startNs)
+				tc.maybeCommitWait(ctx)
 			}
 		}
 	}
@@ -528,29 +527,91 @@ func (tc *TxnCoordSender) Send(
 	return br, nil
 }
 
-// maybeSleepForLinearizable sleeps if the linearizable flag is set. We want to
-// make sure that all the clocks in the system are past the commit timestamp of
-// the transaction. This is guaranteed if either:
-// - the commit timestamp is MaxOffset behind startNs
-// - MaxOffset ns were spent in this function when returning to the
-// client.
-// Below we choose the option that involves less waiting, which is likely the
-// first one unless a transaction commits with an odd timestamp.
-func (tc *TxnCoordSender) maybeSleepForLinearizable(
-	ctx context.Context, br *roachpb.BatchResponse, startNs int64,
-) {
-	if tsNS := br.Txn.WriteTimestamp.WallTime; startNs > tsNS {
-		startNs = tsNS
+// maybeCommitWait performs a "commit-wait" sleep, if doing so is deemed
+// necessary for consistency.
+//
+// By default, commit-wait is only necessary for transactions that commit
+// with a future-time timestamp that leads the local HLC clock. This is
+// because CockroachDB's consistency model depends on all transactions
+// waiting until their commit timestamp is below their gateway clock. In
+// doing so, transactions ensure that at the time that they complete, all
+// other clocks in the system (i.e. on all possible gateways) will be no
+// more than the max_offset below the transaction's commit timestamp. This
+// property ensures that all causally dependent transactions will have an
+// uncertainty interval (see GlobalUncertaintyLimit) that exceeds the
+// original transaction's commit timestamp, preventing stale reads. Without
+// the wait, it would be possible for a read-write transaction to write a
+// future-time value and then for a causally dependent transaction to read
+// below that future-time value, violating "read your writes".
+//
+// The property must also hold for read-only transactions, which may have a
+// commit timestamp in the future due to an uncertainty restart after
+// observing a future-time value in their uncertainty interval. In such
+// cases, the property that the transaction must wait for the local HLC
+// clock to exceed its commit timestamp is not necessary to prevent stale
+// reads, but it is necessary to ensure monotonic reads. Without the wait,
+// it would be possible for a read-only transaction coordinated on a gateway
+// with a fast clock to return a future-time value and then for a causally
+// dependent read-only transaction coordinated on a gateway with a slow
+// clock to read below that future-time value, violating "monotonic reads".
+//
+// In practice, most transactions do not need to wait at all, because their
+// commit timestamps were pulled from an HLC clock (i.e. are not synthetic)
+// and so they will be guaranteed to lead the local HLC's clock, assuming
+// proper HLC time propagation. Only transactions whose commit timestamps
+// were pushed into the future will need to wait, like those who wrote to a
+// global_read range and got bumped by the closed timestamp or those who
+// conflicted (write-read or write-write) with an existing future-time
+// value.
+//
+// However, CockroachDB also supports a stricter model of consistency
+// through its "linearizable" flag. When in linearizable mode (also known as
+// "strict serializable" mode), all writing transactions (but not read-only
+// transactions) must wait an additional max_offset after committing to
+// ensure that their commit timestamp is below the current HLC clock time of
+// any other node in the system. In doing so, all causally dependent
+// transactions are guaranteed to start with higher timestamps, regardless
+// of the gateway they use. This ensures that all causally dependent
+// transactions commit with higher timestamps, even if their read and writes
+// sets do not conflict with the original transaction's. This obviates the
+// need for uncertainty intervals and prevents the "causal reverse" anamoly
+// which can be observed by a third, concurrent transaction.
+//
+// For more, see https://www.cockroachlabs.com/blog/consistency-model/ and
+// docs/RFCS/20200811_non_blocking_txns.md.
+func (tc *TxnCoordSender) maybeCommitWait(ctx context.Context) {
+	if tc.mu.txn.Status != roachpb.COMMITTED {
+		log.Fatalf(ctx, "maybeCommitWait called when not committed")
 	}
-	sleepNS := tc.clock.MaxOffset() -
-		time.Duration(tc.clock.PhysicalNow()-startNs)
 
-	if tc.linearizable && sleepNS > 0 {
-		// TODO(andrei): perhaps we shouldn't sleep with the lock held.
-		log.VEventf(ctx, 2, "%v: waiting %s on EndTxn for linearizability",
-			br.Txn.Short(), duration.Truncate(sleepNS, time.Millisecond))
-		time.Sleep(sleepNS)
+	commitTS := tc.mu.txn.WriteTimestamp
+	readOnly := tc.mu.txn.Sequence == 0
+	linearizable := tc.linearizable
+	needWait := commitTS.Synthetic || (linearizable && !readOnly)
+	if !needWait {
+		// No need to wait. If !Synthetic then we know the commit timestamp
+		// leads the local HLC clock, and since that's all we'd need to wait
+		// for, we can short-circuit.
+		return
 	}
+
+	waitUntil := commitTS
+	if linearizable && !readOnly {
+		waitUntil = waitUntil.Add(tc.clock.MaxOffset().Nanoseconds(), 0)
+	}
+
+	before := tc.clock.PhysicalTime()
+	est := waitUntil.GoTime().Sub(before)
+	log.VEventf(ctx, 2, "performing commit-wait sleep for ~%s", est)
+
+	// NB: unlock while sleeping to avoid holding the lock for commit-wait.
+	tc.mu.Unlock()
+	tc.clock.SleepUntil(waitUntil)
+	tc.mu.Lock()
+
+	after := tc.clock.PhysicalTime()
+	log.VEventf(ctx, 2, "completed commit-wait sleep, took %s", after.Sub(before))
+	tc.metrics.CommitWaits.Inc(1)
 }
 
 // maybeRejectClientLocked checks whether the transaction is in a state that

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -1082,9 +1082,7 @@ func setupMetricsTest(t *testing.T) (*localtestcluster.LocalTestCluster, TxnMetr
 
 	metrics := MakeTxnMetrics(metric.TestSampleInterval)
 	s.DB.GetFactory().(*TxnCoordSenderFactory).metrics = metrics
-	return s, metrics, func() {
-		s.Stop()
-	}
+	return s, metrics, s.Stop
 }
 
 // Test a normal transaction. This and the other metrics tests below use real KV operations,
@@ -1279,6 +1277,148 @@ func TestTxnDurations(t *testing.T) {
 	if min, thresh := hist.Min(), incr-10; min < thresh {
 		t.Fatalf("min %d < %d", min, thresh)
 	}
+}
+
+// TestTxnCommitWait tests the commit-wait sleep phase of transactions under
+// various conditions. It verifies that transactions sleep for the correct
+// amount of time and verifies that metrics are correctly updated to reflect
+// these commit-wait sleeps. For more, see TxnCoordSender.maybeCommitWait.
+func TestTxnCommitWait(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	// Testing parameters:
+	//
+	// - linearizable: is linearizable mode enabled?
+	// - commit:       does the transaction commit or rollback?
+	// - readOnly:     does the transaction perform any writes?
+	// - futureTime:   does the transaction commit in the future?
+	//
+	testFn := func(t *testing.T, linearizable, commit, readOnly, futureTime bool) {
+		s, metrics, cleanupFn := setupMetricsTest(t)
+		s.DB.GetFactory().(*TxnCoordSenderFactory).linearizable = linearizable
+		defer cleanupFn()
+
+		// maxClockOffset defines the maximum clock offset between nodes in the
+		// cluster. When in linearizable mode, all writing transactions must
+		// wait this additional duration after committing to ensure that their
+		// commit timestamp is below the current HLC clock time of any other
+		// node in the system. In doing so, all causally dependent transactions
+		// are guaranteed to start with higher timestamps, regardless of the
+		// gateway they use. This ensures that all causally dependent
+		// transactions commit with higher timestamps, even if their read and
+		// writes sets do not conflict with the original transaction's. This, in
+		// turn, prevents the "causal reverse" anamoly which can be observed by
+		// a third, concurrent transaction. See the following blog post for
+		// more: https://www.cockroachlabs.com/blog/consistency-model/.
+		maxClockOffset := s.Clock.MaxOffset()
+		// futureOffset defines how far in the future the test transaction will
+		// commit, if futureTime is true. We set it to less than the maximum
+		// clock offset as a convenience, so that a value this far in the future
+		// falls within the uncertainty interval of a read, which allows the
+		// test to cause a read-only transaction to commit with a future
+		// timestamp, if readOnly is true.
+		futureOffset := maxClockOffset / 2
+
+		txn := kv.NewTxn(ctx, s.DB, 0 /* gatewayNodeID */)
+		readyC := make(chan struct{})
+		errC := make(chan error, 1)
+		go func() {
+			errC <- func() error {
+				key := roachpb.Key("a")
+
+				// If we want the transaction to commit in the future, we
+				// perform a write in its near future. If the transaction is
+				// read-only, it will restart due to uncertainty. If the
+				// transaction is read-write, it will need to bump its write
+				// timestamp above the other value.
+				if futureTime {
+					ts := txn.TestingCloneTxn().WriteTimestamp.
+						Add(futureOffset.Nanoseconds(), 0).
+						WithSynthetic(true)
+					h := roachpb.Header{Timestamp: ts}
+					put := roachpb.NewPut(key, roachpb.Value{})
+					if _, pErr := kv.SendWrappedWith(ctx, s.DB.NonTransactionalSender(), h, put); pErr != nil {
+						return pErr.GoError()
+					}
+				}
+
+				if readOnly {
+					if _, err := txn.Get(ctx, key); err != nil {
+						return err
+					}
+				} else {
+					if err := txn.Put(ctx, key, "val"); err != nil {
+						return err
+					}
+				}
+
+				close(readyC)
+				if !commit {
+					return txn.Rollback(ctx)
+				}
+				return txn.Commit(ctx)
+			}()
+		}()
+
+		// Wait until the transaction is about to commit / rollback.
+		<-readyC
+
+		if !commit {
+			// If the transaction rolled back, it should immediately return,
+			// without waiting.
+			require.NoError(t, <-errC)
+			require.Equal(t, int64(0), metrics.CommitWaits.Count())
+			return
+		}
+
+		// If the transaction committed, it will need to wait at least until its
+		// commit timestamp is below the HLC clock. If linearizable mode is
+		// enabled and this transaction wrote then it will need to wait an
+		// additional max_offset.
+		expWait := time.Duration(0)
+		if linearizable && !readOnly {
+			expWait += maxClockOffset
+		}
+		if futureTime {
+			expWait += futureOffset
+		}
+		expMetric := int64(0)
+		if expWait > 0 {
+			expMetric = 1
+		}
+
+		// Advance the manual clock slowly. If the commit-wait sleep completes
+		// too early, we'll catch it with the require.Empty. If it completes too
+		// late, we'll stall when pulling from the channel.
+		for expWait > 0 {
+			require.Empty(t, errC)
+
+			adv := futureOffset / 5
+			expWait -= adv
+			s.Manual.Increment(adv.Nanoseconds())
+		}
+		require.NoError(t, <-errC)
+		require.Equal(t, expMetric, metrics.CommitWaits.Count())
+
+		// Validate the transaction's commit timestamp in relation to the local
+		// HLC clock.
+		minClockTS := txn.TestingCloneTxn().WriteTimestamp
+		if linearizable && !readOnly {
+			minClockTS = minClockTS.Add(maxClockOffset.Nanoseconds(), 0)
+		}
+		require.True(t, minClockTS.Less(s.Clock.Now()))
+	}
+	testutils.RunTrueAndFalse(t, "linearizable", func(t *testing.T, linearizable bool) {
+		testutils.RunTrueAndFalse(t, "commit", func(t *testing.T, commit bool) {
+			testutils.RunTrueAndFalse(t, "readOnly", func(t *testing.T, readOnly bool) {
+				testutils.RunTrueAndFalse(t, "futureTime", func(t *testing.T, futureTime bool) {
+					testFn(t, linearizable, commit, readOnly, futureTime)
+				})
+			})
+		})
+	})
 }
 
 // TestAbortTransactionOnCommitErrors verifies that transactions are

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
@@ -281,10 +281,13 @@ func (tc *txnCommitter) sendLockedWithElidedEndTxn(
 		br.Txn = ba.Txn
 	}
 
-	// Check if the (read-only) txn was pushed above its deadline.
-	deadline := et.Deadline
-	if deadline != nil && deadline.LessEq(br.Txn.WriteTimestamp) {
-		return nil, generateTxnDeadlineExceededErr(ba.Txn, *deadline)
+	// Check if the (read-only) txn was pushed above its deadline, if the
+	// transaction is trying to commit.
+	if et.Commit {
+		deadline := et.Deadline
+		if deadline != nil && deadline.LessEq(br.Txn.WriteTimestamp) {
+			return nil, generateTxnDeadlineExceededErr(ba.Txn, *deadline)
+		}
 	}
 
 	// Update the response's transaction proto. This normally happens on the

--- a/pkg/kv/kvclient/kvcoord/txn_metrics.go
+++ b/pkg/kv/kvclient/kvcoord/txn_metrics.go
@@ -23,6 +23,7 @@ type TxnMetrics struct {
 	Commits         *metric.Counter
 	Commits1PC      *metric.Counter // Commits which finished in a single phase
 	ParallelCommits *metric.Counter // Commits which entered the STAGING state
+	CommitWaits     *metric.Counter // Commits that waited for linearizability
 
 	RefreshSuccess                *metric.Counter
 	RefreshFail                   *metric.Counter
@@ -68,6 +69,14 @@ var (
 	metaParallelCommitsRates = metric.Metadata{
 		Name:        "txn.parallelcommits",
 		Help:        "Number of KV transaction parallel commit attempts",
+		Measurement: "KV Transactions",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaCommitWaitRates = metric.Metadata{
+		Name: "txn.commit_waits",
+		Help: "Number of KV transactions that had to commit-wait on commit " +
+			"in order to ensure linearizability. This generally happens to " +
+			"transactions writing to global ranges.",
 		Measurement: "KV Transactions",
 		Unit:        metric.Unit_COUNT,
 	}
@@ -207,6 +216,7 @@ func MakeTxnMetrics(histogramWindow time.Duration) TxnMetrics {
 		Commits:                       metric.NewCounter(metaCommitsRates),
 		Commits1PC:                    metric.NewCounter(metaCommits1PCRates),
 		ParallelCommits:               metric.NewCounter(metaParallelCommitsRates),
+		CommitWaits:                   metric.NewCounter(metaCommitWaitRates),
 		RefreshSuccess:                metric.NewCounter(metaRefreshSuccess),
 		RefreshFail:                   metric.NewCounter(metaRefreshFail),
 		RefreshFailWithCondensedSpans: metric.NewCounter(metaRefreshFailWithCondensedSpans),

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -765,8 +765,8 @@ func TestEnsureInitialWallTimeMonotonicity(t *testing.T) {
 			m := hlc.NewManualClock(test.clockStartTime)
 			c := hlc.NewClock(m.UnixNano, maxOffset)
 
-			sleepUntilFn := func(until int64, currentTime func() int64) {
-				delta := until - currentTime()
+			sleepUntilFn := func(t hlc.Timestamp) {
+				delta := t.WallTime - c.Now().WallTime
 				if delta > 0 {
 					m.Increment(delta)
 				}

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -946,6 +946,7 @@ var charts = []sectionDescription{
 					"txn.commits",
 					"txn.commits1PC",
 					"txn.parallelcommits",
+					"txn.commit_waits",
 				},
 			},
 			{

--- a/pkg/util/timeutil/time.go
+++ b/pkg/util/timeutil/time.go
@@ -53,24 +53,6 @@ func Unix(sec, nsec int64) time.Time {
 	return time.Unix(sec, nsec).UTC()
 }
 
-// SleepUntil sleeps until the given time. The current time is
-// refreshed every second in case there was a clock jump
-//
-// untilNanos is the target time to sleep till in epoch nanoseconds
-// currentTimeNanos is a function returning current time in epoch nanoseconds
-func SleepUntil(untilNanos int64, currentTimeNanos func() int64) {
-	for {
-		d := time.Duration(untilNanos - currentTimeNanos())
-		if d <= 0 {
-			break
-		}
-		if d > time.Second {
-			d = time.Second
-		}
-		time.Sleep(d)
-	}
-}
-
 // ReplaceLibPQTimePrefix replaces unparsable lib/pq dates used for timestamps
 // (0000-01-01) with timestamps that can be parsed by date libraries.
 func ReplaceLibPQTimePrefix(s string) string {


### PR DESCRIPTION
Fixes #57687.
Related to #52745.

This PR introduces a "commit-wait" sleep stage after a transaction commits, which is entered if doing so is deemed necessary for consistency.

By default, commit-wait is only necessary for transactions that commit with a future-time timestamp that leads the local HLC clock. This is because CockroachDB's consistency model depends on all transactions waiting until their commit timestamp is below their gateway clock. In doing so, transactions ensure that at the time that they complete, all other clocks in the system (i.e. on all possible gateways) will be no more than the max_offset below the transaction's commit timestamp. This property ensures that all causally dependent transactions will have an uncertainty interval (see GlobalUncertaintyLimit) that exceeds the original transaction's commit timestamp, preventing stale reads. Without the wait, it would be possible for a read-write transaction to write a future-time value and then for a causally dependent transaction to read below that future-time value, violating "read your writes".

The property must also hold for read-only transactions, which may have a commit timestamp in the future due to an uncertainty restart after observing a future-time value in their uncertainty interval. In such cases, the property that the transaction must wait for the local HLC clock to exceed its commit timestamp is not necessary to prevent stale reads, but it is necessary to ensure monotonic reads. Without the wait, it would be possible for a read-only transaction coordinated on a gateway with a fast clock to return a future-time value and then for a causally dependent read-only transaction coordinated on a gateway with a slow clock to read below that future-time value, violating "monotonic reads".

In practice, most transactions do not need to wait at all, because their commit timestamps were pulled from an HLC clock (i.e. are not synthetic) and so they will be guaranteed to lead the local HLC's clock, assuming proper HLC time propagation. Only transactions whose commit timestamps were pushed into the future will need to wait, like those who wrote to a global_read range and got bumped by the closed timestamp or those who conflicted (write-read or write-write) with an existing future-time value.

However, CockroachDB also supports a stricter model of consistency through its "linearizable" flag. When in linearizable mode (also known as "strict serializable" mode), all writing transactions (but not read-only transactions) must wait an additional max_offset after committing to ensure that their commit timestamp is below the current HLC clock time of any other node in the system. In doing so, all causally dependent transactions are guaranteed to start with higher timestamps, regardless of the gateway they use. This ensures that all causally dependent transactions commit with higher timestamps, even if their read and writes sets do not conflict with the original transaction's. This obviates the need for uncertainty intervals and prevents the "causal reverse" anamoly which can be observed by a third, concurrent transaction.

For more, see https://www.cockroachlabs.com/blog/consistency-model/ and [docs/RFCS/20200811_non_blocking_txns.md](https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/20200811_non_blocking_txns.md).

----

The PR also fixes a bug by properly marking read-only txn as aborted on rollback, which was missed in a85115a.

We were assuming that all calls to `commitReadOnlyTxnLocked` were for `EndTxn` requests with the Commit flag set to true, but this is not the case. This was not only confusing, but it was also leading to the `txn.commit` metric being incremented on rollback of a read-only transaction, instead of the `txn.aborts` metric.

Release justification: New functionality.