### PR TITLE
tracing: remove trace.mode cluster setting

### DIFF
--- a/pkg/util/tracing/alloc_test.go
+++ b/pkg/util/tracing/alloc_test.go
@@ -30,7 +30,6 @@ func BenchmarkTracer_StartSpanCtx(b *testing.B) {
 
 	tr := NewTracer()
 	sv := settings.Values{}
-	tracingMode.Override(&sv, int64(modeBackground))
 	tr.Configure(&sv)
 
 	staticLogTags := logtags.Buffer{}
@@ -50,10 +49,21 @@ func BenchmarkTracer_StartSpanCtx(b *testing.B) {
 		opts []SpanOption
 	}{
 		{"none", nil},
-		{"logtag", []SpanOption{WithLogTags(&staticLogTags)}},
-		{"tag", []SpanOption{WithTags(staticTag)}},
-		{"autoparent", []SpanOption{WithParentAndAutoCollection(parSp)}},
-		{"manualparent", []SpanOption{WithParentAndManualCollection(parSp.Meta())}},
+		{"real", []SpanOption{
+			WithForceRealSpan(),
+		}},
+		{"real,logtag", []SpanOption{
+			WithForceRealSpan(), WithLogTags(&staticLogTags),
+		}},
+		{"real,tag", []SpanOption{
+			WithForceRealSpan(), WithTags(staticTag),
+		}},
+		{"real,autoparent", []SpanOption{
+			WithForceRealSpan(), WithParentAndAutoCollection(parSp),
+		}},
+		{"real,manualparent", []SpanOption{
+			WithForceRealSpan(), WithParentAndManualCollection(parSp.Meta()),
+		}},
 	} {
 		b.Run(fmt.Sprintf("opts=%s", tc.name), func(b *testing.B) {
 			b.ReportAllocs()
@@ -67,11 +77,9 @@ func BenchmarkTracer_StartSpanCtx(b *testing.B) {
 
 }
 
-// BenchmarkSpan_GetRecording microbenchmarks GetRecording
-// when background tracing is enabled.
+// BenchmarkSpan_GetRecording microbenchmarks GetRecording.
 func BenchmarkSpan_GetRecording(b *testing.B) {
 	var sv settings.Values
-	tracingMode.Override(&sv, int64(modeBackground))
 	tr := NewTracer()
 	tr.Configure(&sv)
 

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -291,7 +291,7 @@ func (s *spanInner) ResetRecording() {
 }
 
 func (s *spanInner) GetRecording() Recording {
-	return s.crdb.getRecording(s.tracer.mode(), s.tracer.TracingVerbosityIndependentSemanticsIsActive())
+	return s.crdb.getRecording(s.tracer.TracingVerbosityIndependentSemanticsIsActive())
 }
 
 func (s *spanInner) ImportRemoteSpans(remoteSpans []tracingpb.RecordedSpan) error {

--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -215,7 +215,6 @@ func TestSpanRecordStructured(t *testing.T) {
 
 func TestSpanRecordStructuredLimit(t *testing.T) {
 	tr := NewTracer()
-	tr._mode = int32(modeBackground)
 	sp := tr.StartSpan("root", WithForceRealSpan())
 	defer sp.Finish()
 
@@ -243,10 +242,9 @@ func TestSpanRecordStructuredLimit(t *testing.T) {
 
 func TestNonVerboseChildSpanRegisteredWithParent(t *testing.T) {
 	tr := NewTracer()
-	tr._mode = int32(modeBackground)
 	sp := tr.StartSpan("root", WithForceRealSpan())
 	defer sp.Finish()
-	ch := tr.StartSpan("child", WithParentAndAutoCollection(sp), WithForceRealSpan())
+	ch := tr.StartSpan("child", WithParentAndAutoCollection(sp))
 	defer ch.Finish()
 	require.Len(t, sp.i.crdb.mu.recording.children, 1)
 	require.Equal(t, ch.i.crdb, sp.i.crdb.mu.recording.children[0])


### PR DESCRIPTION
This was added experimentally in this release cycle and was determined
to not be suitable for inclusion in the release.

Release justification: remove functionality unsuitable for release
Release note: None
