### PR TITLE
tracing: elide tags from recording if not verbose

### DIFF
--- a/pkg/util/tracing/grpc_interceptor_test.go
+++ b/pkg/util/tracing/grpc_interceptor_test.go
@@ -55,7 +55,9 @@ func TestGRPCInterceptors(t *testing.T) {
 		}
 
 		sp.RecordStructured(&types.Int32Value{Value: magicValue})
+		sp.SetVerbose(true) // want the tags
 		recs := sp.GetRecording()
+		sp.SetVerbose(false)
 		if len(recs) != 1 {
 			return nil, errors.Newf("expected exactly one recorded span, not %+v", recs)
 		}
@@ -193,7 +195,9 @@ func TestGRPCInterceptors(t *testing.T) {
 			require.NoError(t, sp.ImportRemoteSpans([]tracingpb.RecordedSpan{rec}))
 			sp.Finish()
 			var n int
+			sp.SetVerbose(true) // to get the tags
 			finalRecs := sp.GetRecording()
+			sp.SetVerbose(false)
 			for _, rec := range finalRecs {
 				n += len(rec.InternalStructured)
 				// Remove all of the _unfinished tags. These crop up because
@@ -204,6 +208,7 @@ func TestGRPCInterceptors(t *testing.T) {
 				// Note that we check that we're not leaking spans at the end of
 				// the test.
 				delete(rec.Tags, "_unfinished")
+				delete(rec.Tags, "_verbose")
 			}
 			require.Equal(t, 1, n)
 

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -67,7 +67,6 @@ func TestTracerRecording(t *testing.T) {
 	// Initial recording of this fresh (real) span.
 	if err := TestingCheckRecordedSpans(s1.GetRecording(), `
 		span: a
-			tags: _unfinished=1
 	`); err != nil {
 		t.Fatal(err)
 	}
@@ -145,7 +144,6 @@ func TestTracerRecording(t *testing.T) {
 	s1.Recordf("x=%d", 100)
 	if err := TestingCheckRecordedSpans(s1.GetRecording(), `
 		span: a
-			tags: _unfinished=1
 	`); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This avoids some of the obviously problematic expensive stringifications
observed in https://github.com/cockroachdb/cockroach/issues/59379.

Release justification: low-risk performance optimization that unblocks sql stats.
Release note: None
