### PR TITLE
lint: add new leaktestcall pass

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -259,6 +259,7 @@ ALL_TESTS = [
     "//pkg/testutils/lint/passes/fmtsafe:fmtsafe_test",
     "//pkg/testutils/lint/passes/forbiddenmethod:forbiddenmethod_test",
     "//pkg/testutils/lint/passes/hash:hash_test",
+    "//pkg/testutils/lint/passes/leaktestcall:leaktestcall_test",
     "//pkg/testutils/lint/passes/nocopy:nocopy_test",
     "//pkg/testutils/lint/passes/passesutil:passesutil_test",
     "//pkg/testutils/lint/passes/returnerrcheck:returnerrcheck_test",

--- a/pkg/cmd/roachvet/BUILD.bazel
+++ b/pkg/cmd/roachvet/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/testutils/lint/passes/fmtsafe",
         "//pkg/testutils/lint/passes/forbiddenmethod",
         "//pkg/testutils/lint/passes/hash",
+        "//pkg/testutils/lint/passes/leaktestcall",
         "//pkg/testutils/lint/passes/nocopy",
         "//pkg/testutils/lint/passes/returnerrcheck",
         "//pkg/testutils/lint/passes/timer",

--- a/pkg/cmd/roachvet/main.go
+++ b/pkg/cmd/roachvet/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/fmtsafe"
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/forbiddenmethod"
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/hash"
+	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/leaktestcall"
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/nocopy"
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/returnerrcheck"
 	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/timer"
@@ -55,6 +56,7 @@ func main() {
 	as = append(as, forbiddenmethod.Analyzers...)
 	as = append(as,
 		hash.Analyzer,
+		leaktestcall.Analyzer,
 		nocopy.Analyzer,
 		returnerrcheck.Analyzer,
 		timer.Analyzer,

--- a/pkg/migration/migrations/foreign_key_representation_upgrade_external_test.go
+++ b/pkg/migration/migrations/foreign_key_representation_upgrade_external_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestForeignKeyMigration(t *testing.T) {
-	defer leaktest.AfterTest(t)
+	defer leaktest.AfterTest(t)()
 
 	/*
 	   These descriptors were crafted in v19.1 with the following SQL:

--- a/pkg/migration/migrations/namespace_migration_external_test.go
+++ b/pkg/migration/migrations/namespace_migration_external_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestNamespaceMigration(t *testing.T) {
-	defer leaktest.AfterTest(t)
+	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{

--- a/pkg/testutils/lint/passes/leaktestcall/BUILD.bazel
+++ b/pkg/testutils/lint/passes/leaktestcall/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "leaktestcall",
+    srcs = ["leaktestcall.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/leaktestcall",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@org_golang_x_tools//go/analysis",
+        "@org_golang_x_tools//go/analysis/passes/inspect",
+        "@org_golang_x_tools//go/ast/inspector",
+    ],
+)
+
+go_test(
+    name = "leaktestcall_test",
+    srcs = ["leaktestcall_test.go"],
+    data = glob(["testdata/**"]),
+    deps = [
+        ":leaktestcall",
+        "//pkg/testutils/skip",
+        "@org_golang_x_tools//go/analysis/analysistest",
+    ],
+)

--- a/pkg/testutils/lint/passes/leaktestcall/leaktestcall.go
+++ b/pkg/testutils/lint/passes/leaktestcall/leaktestcall.go
@@ -1,0 +1,53 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package leaktestcall defines an Analyzer that detects correct use
+// of leaktest.AfterTest(t).
+package leaktestcall
+
+import (
+	"go/ast"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+// Analyzer is an analysis pass that checks that the return value of
+// leaktest.AfterFunc(t) is called in defer statements.
+var Analyzer = &analysis.Analyzer{
+	Name:     "leaktestcall",
+	Doc:      "Check that the closure returned by leaktest.AfterFunc(t) is called",
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	astInspector := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	filter := []ast.Node{
+		(*ast.DeferStmt)(nil),
+	}
+
+	astInspector.Preorder(filter, func(n ast.Node) {
+		def := n.(*ast.DeferStmt)
+		switch funCall := def.Call.Fun.(type) {
+		case *ast.SelectorExpr:
+			packageIdent, ok := funCall.X.(*ast.Ident)
+			if !ok {
+				return
+			}
+			if packageIdent.Name == "leaktest" && funCall.Sel != nil && funCall.Sel.Name == "AfterTest" {
+				pass.Reportf(def.Call.Pos(), "leaktest.AfterTest return not called")
+			}
+		}
+	})
+
+	return nil, nil
+}

--- a/pkg/testutils/lint/passes/leaktestcall/leaktestcall_test.go
+++ b/pkg/testutils/lint/passes/leaktestcall/leaktestcall_test.go
@@ -1,0 +1,25 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package leaktestcall_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/leaktestcall"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func Test(t *testing.T) {
+	skip.UnderStress(t)
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, leaktestcall.Analyzer, "a")
+}

--- a/pkg/testutils/lint/passes/leaktestcall/testdata/src/a/a.go
+++ b/pkg/testutils/lint/passes/leaktestcall/testdata/src/a/a.go
@@ -1,0 +1,21 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package a
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func foo(t *testing.T) {
+	defer leaktest.AfterTest(t) // want `leaktest.AfterTest return not called`
+}

--- a/pkg/testutils/lint/passes/leaktestcall/testdata/src/github.com/cockroachdb/cockroach/pkg/util/leaktest/leaktest.go
+++ b/pkg/testutils/lint/passes/leaktestcall/testdata/src/github.com/cockroachdb/cockroach/pkg/util/leaktest/leaktest.go
@@ -1,0 +1,15 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package leaktest
+
+import "testing"
+
+func AfterTest(testing.TB) func() { return func() {} }


### PR DESCRIPTION
This new pass checks for

    defer leaktest.AfterTest(t)

which fails to call the func returned by AfterTest.

Release justification: Test-only changes
Release note: None