### PR TITLE
Release process: cleanup docker directory on exit

### DIFF
--- a/build/release/teamcity-support.sh
+++ b/build/release/teamcity-support.sh
@@ -3,6 +3,7 @@
 remove_files_on_exit() {
   rm -f .google-credentials.json
   rm -f .cockroach-teamcity-key
+  rm -rf ~/.docker
 }
 trap remove_files_on_exit EXIT
 


### PR DESCRIPTION
As a part of docker publishing we save the docker credentials under
`~/.docker`, but never remove them.

It would be better to clean up the whole `~/.docker` in order to cleap
the agents clean across multiple runs.

Release justification: non-production code changes
Release note: None