### PR TITLE
colexec: call StartInternal in Columnarizer

### DIFF
--- a/pkg/sql/colexec/BUILD.bazel
+++ b/pkg/sql/colexec/BUILD.bazel
@@ -66,6 +66,7 @@ go_library(
         "//pkg/sql/sqlerrors",
         "//pkg/sql/sqltelemetry",  # keep
         "//pkg/sql/types",
+        "//pkg/util",
         "//pkg/util/duration",  # keep
         "//pkg/util/encoding",  # keep
         "//pkg/util/humanizeutil",

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -72,6 +72,10 @@ func wrapRowSources(
 		// necessarily a execinfra.RowSource, so remove the unnecessary
 		// conversion.
 		if c, ok := input.(*colexec.Columnarizer); ok {
+			// Since this Columnarizer has been previously added to Closers and
+			// MetadataSources, this call ensures that all future calls are noops.
+			// Modifying the slices at this stage is difficult.
+			c.MarkAsRemovedFromFlow()
 			toWrapInputs = append(toWrapInputs, c.Input())
 		} else {
 			// Note that this materializer is *not* added to the set of

--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -60,6 +60,11 @@ type Columnarizer struct {
 	accumulatedMeta []execinfrapb.ProducerMetadata
 	ctx             context.Context
 	typs            []*types.T
+
+	// removedFromFlow marks this Columnarizer as having been removed from the
+	// flow. This renders all future calls to Init, Next, Close, and DrainMeta
+	// noops.
+	removedFromFlow bool
 }
 
 var _ colexecop.Operator = &Columnarizer{}
@@ -136,6 +141,9 @@ func newColumnarizer(
 
 // Init is part of the Operator interface.
 func (c *Columnarizer) Init() {
+	if c.removedFromFlow {
+		return
+	}
 	// We don't want to call Start on the input to columnarizer and allocating
 	// internal objects several times if Init method is called more than once, so
 	// we have this check in place.
@@ -149,6 +157,9 @@ func (c *Columnarizer) Init() {
 
 // Next is part of the Operator interface.
 func (c *Columnarizer) Next(context.Context) coldata.Batch {
+	if c.removedFromFlow {
+		return coldata.ZeroBatch
+	}
 	var reallocated bool
 	switch c.mode {
 	case columnarizerBufferingMode:
@@ -232,6 +243,9 @@ var (
 
 // DrainMeta is part of the MetadataSource interface.
 func (c *Columnarizer) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
+	if c.removedFromFlow {
+		return nil
+	}
 	c.MoveToDraining(nil /* err */)
 	for {
 		meta := c.DrainHelper()
@@ -245,6 +259,9 @@ func (c *Columnarizer) DrainMeta(ctx context.Context) []execinfrapb.ProducerMeta
 
 // Close is part of the Operator interface.
 func (c *Columnarizer) Close(ctx context.Context) error {
+	if c.removedFromFlow {
+		return nil
+	}
 	c.InternalClose()
 	return nil
 }
@@ -273,4 +290,14 @@ func (c *Columnarizer) Child(nth int, verbose bool) execinfra.OpNode {
 // Input returns the input of this columnarizer.
 func (c *Columnarizer) Input() execinfra.RowSource {
 	return c.input
+}
+
+// MarkAsRemovedFromFlow is called by planning code to make all future calls on
+// this columnarizer noops. It exists to support an execution optimization where
+// a Columnarizer is removed from a flow in cases where it would be the input to
+// a Materializer (which is redundant). Simply bypassing the Columnarizer is not
+// enough because it is added to a slice of Closers and MetadataSources that are
+// difficult to change once physical planning moves on from the Columnarizer.
+func (c *Columnarizer) MarkAsRemovedFromFlow() {
+	c.removedFromFlow = true
 }

--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/errors"
 )
 
@@ -117,7 +118,15 @@ func newColumnarizer(
 		processorID,
 		nil, /* output */
 		nil, /* memMonitor */
-		execinfra.ProcStateOpts{InputsToDrain: []execinfra.RowSource{input}},
+		execinfra.ProcStateOpts{
+			InputsToDrain: []execinfra.RowSource{input},
+			TrailingMetaCallback: func(ctx context.Context) []execinfrapb.ProducerMetadata {
+				if err := c.Close(ctx); util.CrdbTestBuild && err != nil {
+					// Close never returns an error.
+					colexecerror.InternalError(errors.AssertionFailedf("unexpected error %v from Columnarizer.Close", err))
+				}
+				return nil
+			}},
 	); err != nil {
 		return nil, err
 	}
@@ -132,6 +141,7 @@ func (c *Columnarizer) Init() {
 	// we have this check in place.
 	if c.initStatus == colexecop.OperatorNotInitialized {
 		c.accumulatedMeta = make([]execinfrapb.ProducerMetadata, 0, 1)
+		c.ctx = c.StartInternalNoSpan(c.ctx)
 		c.input.Start(c.ctx)
 		c.initStatus = colexecop.OperatorInitialized
 	}
@@ -235,7 +245,7 @@ func (c *Columnarizer) DrainMeta(ctx context.Context) []execinfrapb.ProducerMeta
 
 // Close is part of the Operator interface.
 func (c *Columnarizer) Close(ctx context.Context) error {
-	c.input.ConsumerClosed()
+	c.InternalClose()
 	return nil
 }
 

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -711,6 +711,15 @@ func (pb *ProcessorBase) moveToTrailingMeta() {
 			pb.trailingMeta = append(pb.trailingMeta, execinfrapb.ProducerMetadata{TraceData: trace})
 		}
 	}
+
+	if util.CrdbTestBuild && pb.Ctx == nil {
+		panic(
+			errors.AssertionFailedf(
+				"unexpected nil ProcessorBase.Ctx when draining. Was StartInternal called?",
+			),
+		)
+	}
+
 	// trailingMetaCallback is called after reading the tracing data because it
 	// generally calls InternalClose, indirectly, which switches the context and
 	// the span.
@@ -864,11 +873,30 @@ func ProcessorSpan(ctx context.Context, name string) (context.Context, *tracing.
 //   < other initialization >
 // so that the caller doesn't mistakenly use old ctx object.
 func (pb *ProcessorBase) StartInternal(ctx context.Context, name string) context.Context {
+	return pb.startImpl(ctx, true /* createSpan */, name)
+}
+
+// StartInternalNoSpan does the same as StartInternal except that it does not
+// start a span. This is used by pass-through components whose goal is to be a
+// silent translation layer for components that actually do work (e.g. a
+// planNodeToRowSource wrapping an insertNode, or a columnarizer wrapping a
+// rowexec flow).
+func (pb *ProcessorBase) StartInternalNoSpan(ctx context.Context) context.Context {
+	return pb.startImpl(ctx, false /* createSpan */, "")
+}
+
+func (pb *ProcessorBase) startImpl(
+	ctx context.Context, createSpan bool, spanName string,
+) context.Context {
 	pb.origCtx = ctx
-	pb.Ctx, pb.span = ProcessorSpan(ctx, name)
-	if pb.span != nil && pb.span.IsVerbose() {
-		pb.span.SetTag(execinfrapb.FlowIDTagKey, pb.FlowCtx.ID.String())
-		pb.span.SetTag(execinfrapb.ProcessorIDTagKey, pb.processorID)
+	if createSpan {
+		pb.Ctx, pb.span = ProcessorSpan(ctx, spanName)
+		if pb.span != nil && pb.span.IsVerbose() {
+			pb.span.SetTag(execinfrapb.FlowIDTagKey, pb.FlowCtx.ID.String())
+			pb.span.SetTag(execinfrapb.ProcessorIDTagKey, pb.processorID)
+		}
+	} else {
+		pb.Ctx = ctx
 	}
 	pb.EvalCtx.Context = pb.Ctx
 	return pb.Ctx

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -116,9 +116,7 @@ func (p *planNodeToRowSource) SetInput(ctx context.Context, input execinfra.RowS
 }
 
 func (p *planNodeToRowSource) Start(ctx context.Context) {
-	// We do not call p.StartInternal to avoid creating a span. Only the context
-	// needs to be set.
-	p.Ctx = ctx
+	ctx = p.StartInternalNoSpan(ctx)
 	p.params.ctx = ctx
 	if !p.started {
 		p.started = true


### PR DESCRIPTION
Fixes #60994 
Fixes #58366

Release justification: fixes a possible crash.

Release note (bug fix): fixed an npe observed with a SpanFromContext call in
the stack trace.