### PR TITLE
sql: add version upgrade test for sequences

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -91,6 +91,7 @@ go_library(
         "schemachange_random_load.go",
         "scrub.go",
         "secondary_indexes.go",
+        "sequence_upgrade.go",
         "slack.go",
         "split.go",
         "sqlalchemy.go",

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -87,6 +87,7 @@ func registerTests(r *testRegistry) {
 	registerScrubAllChecksTPCC(r)
 	registerScrubIndexOnlyTPCC(r)
 	registerSecondaryIndexesMultiVersionCluster(r)
+	registerSequenceUpgrade(r)
 	registerSQLAlchemy(r)
 	registerSQLSmith(r)
 	registerSyncTest(r)

--- a/pkg/cmd/roachtest/sequence_upgrade.go
+++ b/pkg/cmd/roachtest/sequence_upgrade.go
@@ -1,0 +1,114 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"context"
+	"fmt"
+)
+
+func registerSequenceUpgrade(r *testRegistry) {
+	r.Add(testSpec{
+		Name:       "version/sequence-upgrade",
+		Owner:      OwnerSQLSchema,
+		MinVersion: "v21.1.0",
+		Cluster:    makeClusterSpec(1),
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			runSequenceUpgradeMigration(ctx, t, c)
+		},
+	})
+}
+
+func statementStep(stmt string, node int, args ...interface{}) versionStep {
+	return func(ctx context.Context, t *test, u *versionUpgradeTest) {
+		db := u.conn(ctx, t, node)
+		_, err := db.ExecContext(ctx, stmt, args...)
+		if err != nil {
+			t.Fatal(fmt.Sprintf("error executing statement %s with args %v: %+v", stmt, args, err))
+		}
+	}
+}
+
+func createSequenceStep(node int, name string) versionStep {
+	stmt := fmt.Sprintf(`CREATE SEQUENCE %s`, name)
+	return statementStep(stmt, node)
+}
+
+func setSerialNormalizationStep(node int) versionStep {
+	stmt := `SET serial_normalization = 'sql_sequence'`
+	return statementStep(stmt, node)
+}
+
+func createSeqTableStep(node int, tblName string, seqName string) versionStep {
+	stmt := fmt.Sprintf(`CREATE TABLE %s (i SERIAL PRIMARY KEY, j INT NOT NULL DEFAULT nextval('%s'))`, tblName, seqName)
+	return statementStep(stmt, node)
+}
+
+func insertSeqTableStep(node int, name string) versionStep {
+	stmt := fmt.Sprintf(`INSERT INTO %s VALUES (default, default)`, name)
+	return statementStep(stmt, node)
+}
+
+func verifySequences(node int) versionStep {
+	return func(ctx context.Context, t *test, u *versionUpgradeTest) {
+		db := u.conn(ctx, t, node)
+
+		// Verify that sequences created in older versions cannot be renamed, nor can any
+		// databases that they are referencing.
+		_, err := db.ExecContext(ctx, `ALTER SEQUENCE test.public.s RENAME TO test.public.s_new`)
+		if err == nil {
+			t.Fatal("expected: cannot rename relation \"test.public.s\" because view \"t1\" depends on it")
+		}
+		_, err = db.ExecContext(ctx, `ALTER SEQUENCE t1_i_seq RENAME TO t1_i_seq_new`)
+		if err == nil {
+			t.Fatal("expected: cannot rename relation \"t1_i_seq\" because view \"test.public.t1\" depends on it")
+		}
+		_, err = db.ExecContext(ctx, `ALTER DATABASE test RENAME TO test_new`)
+		if err == nil {
+			t.Fatal("expected: cannot rename database because relation \"test.public.t1\" depends on relation \"test.public.s\"")
+		}
+	}
+}
+
+func runSequenceUpgradeMigration(ctx context.Context, t *test, c *cluster) {
+	const (
+		v20_2 = "20.2.4"
+		// An empty string means that the cockroach binary specified by flag
+		// `cockroach` will be used.
+		mainVersion = ""
+	)
+
+	roachNodes := c.All()
+	u := newVersionUpgradeTest(c,
+		// Set up descriptors in 20.2, when sequence renaming and other
+		// renaming involving sequence dependencies was unsupported.
+		uploadAndStart(roachNodes, v20_2),
+		waitForUpgradeStep(roachNodes),
+		preventAutoUpgradeStep(1),
+
+		createDBStep(1, "test"),
+		createSequenceStep(1, "test.public.s"),
+		setSerialNormalizationStep(1),
+		createSeqTableStep(1, "t1", "test.public.s"),
+
+		// Upgrade cluster to latest version, where renaming
+		// is supported.
+		allowAutoUpgradeStep(1),
+		binaryUpgradeStep(c.All(), mainVersion),
+		waitForUpgradeStep(roachNodes),
+
+		// Verify that the sequences created in older versions
+		// still behave as old sequences (i.e. cannot be renamed).
+		verifySequences(1),
+		insertSeqTableStep(1, "t1"),
+	)
+	u.run(ctx, t)
+}


### PR DESCRIPTION
This patch just adds some version upgrade tests
for sequences. Now that all new sequences are
referenced by ID and can be renamed, we want to test
that previously created sequences are not affected,
and still follow the old rules (i.e. cannot be renamed and
and are referenced by their names.
This test creates some sequences in 20.2.5, upgrades the
cluster, and verifies this behaviour.
Part of https://github.com/cockroachdb/cockroach/issues/51090.

In the future, we'll want to convert these old sequences to
new sequences (i.e. can be renamed and are referenced by ID, 
see https://github.com/cockroachdb/cockroach/issues/60942) which means these tests will need to change, but
for now, we'll keep the old sequences as is.

Release note: None

Release justification: only adds tests for existing functionality