### PR TITLE
sql: fix inefficient memory usage for SHOW CREATE ALL TABLES 

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2371,9 +2371,13 @@ SQL statement omitting multi-region related zone configuration fields.
 If the CONFIGURE ZONE statement can be inferred by the database’s or
 table’s zone configuration this will return NULL.</p>
 </span></td></tr>
-<tr><td><a name="crdb_internal.show_create_all_tables"></a><code>crdb_internal.show_create_all_tables(dbName: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns a flat log of CREATE table statements followed by
-ALTER table statements that add table constraints. The flat log can be used
-to recreate a database.’</p>
+<tr><td><a name="crdb_internal.show_create_all_tables"></a><code>crdb_internal.show_create_all_tables(dbName: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns a rows CREATE table statements followed by
+ALTER table statements that add table constraints. The rows are ordered
+by dependencies. All foreign keys are added after the creation of the table
+in the alter statements.
+It is not recommended to perform this operation on a database with many
+tables.
+The output can be used to recreate a database.’</p>
 </span></td></tr>
 <tr><td><a name="decode"></a><code>decode(text: <a href="string.html">string</a>, format: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Decodes <code>data</code> using <code>format</code> (<code>hex</code> / <code>escape</code> / <code>base64</code>).</p>
 </span></td></tr>

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2371,7 +2371,7 @@ SQL statement omitting multi-region related zone configuration fields.
 If the CONFIGURE ZONE statement can be inferred by the database’s or
 table’s zone configuration this will return NULL.</p>
 </span></td></tr>
-<tr><td><a name="crdb_internal.show_create_all_tables"></a><code>crdb_internal.show_create_all_tables(dbName: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns a rows CREATE table statements followed by
+<tr><td><a name="crdb_internal.show_create_all_tables"></a><code>crdb_internal.show_create_all_tables(database_name: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns rows of CREATE table statements followed by
 ALTER table statements that add table constraints. The rows are ordered
 by dependencies. All foreign keys are added after the creation of the table
 in the alter statements.

--- a/pkg/sql/logictest/testdata/logic_test/show_create_all_tables
+++ b/pkg/sql/logictest/testdata/logic_test/show_create_all_tables
@@ -8,7 +8,6 @@ query T colnames
 SHOW CREATE ALL TABLES
 ----
 create_statement
-·
 
 statement ok
 CREATE TABLE d.parent (
@@ -47,34 +46,31 @@ SHOW CREATE ALL TABLES
 ----
 create_statement
 CREATE TABLE public.parent (
-  x INT8 NULL,
-  y INT8 NULL,
-  z INT8 NULL,
-  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-  CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
-  UNIQUE INDEX parent_x_y_z_key (x ASC, y ASC, z ASC),
-  UNIQUE INDEX parent_x_key (x ASC),
-  FAMILY f1 (x, y, z, rowid)
+    x INT8 NULL,
+    y INT8 NULL,
+    z INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+    UNIQUE INDEX parent_x_y_z_key (x ASC, y ASC, z ASC),
+    UNIQUE INDEX parent_x_key (x ASC),
+    FAMILY f1 (x, y, z, rowid)
 );
 CREATE TABLE public.full_test (
-  x INT8 NULL,
-  y INT8 NULL,
-  z INT8 NULL,
-  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-  CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
-  UNIQUE INDEX full_test_x_key (x ASC),
-  FAMILY f1 (x, y, z, rowid)
+    x INT8 NULL,
+    y INT8 NULL,
+    z INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+    UNIQUE INDEX full_test_x_key (x ASC),
+    FAMILY f1 (x, y, z, rowid)
 );
-CREATE SEQUENCE public.s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
 CREATE VIEW public.vx ("?column?") AS SELECT 1;
+CREATE SEQUENCE public.s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
 ALTER TABLE public.full_test ADD CONSTRAINT fk_x_ref_parent FOREIGN KEY (x, y, z) REFERENCES public.parent(x, y, z) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE;
 ALTER TABLE public.full_test ADD CONSTRAINT test_fk FOREIGN KEY (x) REFERENCES public.parent(x) ON DELETE CASCADE;
 -- Validate foreign key constraints. These can fail if there was unvalidated data during the SHOW CREATE ALL TABLES
 ALTER TABLE public.full_test VALIDATE CONSTRAINT fk_x_ref_parent;
 ALTER TABLE public.full_test VALIDATE CONSTRAINT test_fk;
-
-
-
 
 # testuser does not have CONNECT on database d and cannot see any tables.
 user testuser
@@ -83,7 +79,6 @@ query T colnames
 SHOW CREATE ALL TABLES
 ----
 create_statement
-·
 
 user root
 
@@ -99,34 +94,31 @@ SHOW CREATE ALL TABLES
 ----
 create_statement
 CREATE TABLE public.parent (
-  x INT8 NULL,
-  y INT8 NULL,
-  z INT8 NULL,
-  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-  CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
-  UNIQUE INDEX parent_x_y_z_key (x ASC, y ASC, z ASC),
-  UNIQUE INDEX parent_x_key (x ASC),
-  FAMILY f1 (x, y, z, rowid)
+    x INT8 NULL,
+    y INT8 NULL,
+    z INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+    UNIQUE INDEX parent_x_y_z_key (x ASC, y ASC, z ASC),
+    UNIQUE INDEX parent_x_key (x ASC),
+    FAMILY f1 (x, y, z, rowid)
 );
 CREATE TABLE public.full_test (
-  x INT8 NULL,
-  y INT8 NULL,
-  z INT8 NULL,
-  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-  CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
-  UNIQUE INDEX full_test_x_key (x ASC),
-  FAMILY f1 (x, y, z, rowid)
+    x INT8 NULL,
+    y INT8 NULL,
+    z INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+    UNIQUE INDEX full_test_x_key (x ASC),
+    FAMILY f1 (x, y, z, rowid)
 );
-CREATE SEQUENCE public.s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
 CREATE VIEW public.vx ("?column?") AS SELECT 1;
+CREATE SEQUENCE public.s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
 ALTER TABLE public.full_test ADD CONSTRAINT fk_x_ref_parent FOREIGN KEY (x, y, z) REFERENCES public.parent(x, y, z) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE;
 ALTER TABLE public.full_test ADD CONSTRAINT test_fk FOREIGN KEY (x) REFERENCES public.parent(x) ON DELETE CASCADE;
 -- Validate foreign key constraints. These can fail if there was unvalidated data during the SHOW CREATE ALL TABLES
 ALTER TABLE public.full_test VALIDATE CONSTRAINT fk_x_ref_parent;
 ALTER TABLE public.full_test VALIDATE CONSTRAINT test_fk;
-
-
-
 
 user root
 
@@ -147,7 +139,6 @@ query T colnames
 SHOW CREATE ALL TABLES
 ----
 create_statement
-·
 
 # Test that a database with foreign keys has the right order.
 statement ok
@@ -170,57 +161,57 @@ CREATE TABLE c (i int REFERENCES d);
 CREATE SEQUENCE s;
 CREATE TABLE s_tbl (id INT PRIMARY KEY DEFAULT nextval('s'), v INT,  FAMILY f1 (id, v));
 
-# Table order should be B, A, E, G, F, D, C, sequence s, s_tbl.
+# Table order should be B, A, G, F, E, D, C, sequence s, s_tbl.
 query T colnames
 SHOW CREATE ALL TABLES
 ----
 create_statement
 CREATE TABLE public.b (
-  i INT8 NOT NULL,
-  CONSTRAINT "primary" PRIMARY KEY (i ASC),
-  FAMILY "primary" (i)
+    i INT8 NOT NULL,
+    CONSTRAINT "primary" PRIMARY KEY (i ASC),
+    FAMILY "primary" (i)
 );
 CREATE TABLE public.a (
-  i INT8 NULL,
-  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-  CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
-  FAMILY "primary" (i, rowid)
-);
-CREATE TABLE public.e (
-  i INT8 NOT NULL,
-  CONSTRAINT "primary" PRIMARY KEY (i ASC),
-  FAMILY "primary" (i)
+    i INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+    FAMILY "primary" (i, rowid)
 );
 CREATE TABLE public.g (
-  i INT8 NOT NULL,
-  CONSTRAINT "primary" PRIMARY KEY (i ASC),
-  FAMILY "primary" (i)
+    i INT8 NOT NULL,
+    CONSTRAINT "primary" PRIMARY KEY (i ASC),
+    FAMILY "primary" (i)
 );
 CREATE TABLE public.f (
-  i INT8 NOT NULL,
-  g INT8 NULL,
-  CONSTRAINT "primary" PRIMARY KEY (i ASC),
-  FAMILY f1 (i, g)
+    i INT8 NOT NULL,
+    g INT8 NULL,
+    CONSTRAINT "primary" PRIMARY KEY (i ASC),
+    FAMILY f1 (i, g)
+);
+CREATE TABLE public.e (
+    i INT8 NOT NULL,
+    CONSTRAINT "primary" PRIMARY KEY (i ASC),
+    FAMILY "primary" (i)
 );
 CREATE TABLE public.d (
-  i INT8 NOT NULL,
-  e INT8 NULL,
-  f INT8 NULL,
-  CONSTRAINT "primary" PRIMARY KEY (i ASC),
-  FAMILY f1 (i, e, f)
+    i INT8 NOT NULL,
+    e INT8 NULL,
+    f INT8 NULL,
+    CONSTRAINT "primary" PRIMARY KEY (i ASC),
+    FAMILY f1 (i, e, f)
 );
 CREATE TABLE public.c (
-  i INT8 NULL,
-  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-  CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
-  FAMILY "primary" (i, rowid)
+    i INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+    FAMILY "primary" (i, rowid)
 );
 CREATE SEQUENCE public.s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
 CREATE TABLE public.s_tbl (
-  id INT8 NOT NULL DEFAULT nextval('test_fk_order.public.s':::STRING::REGCLASS),
-  v INT8 NULL,
-  CONSTRAINT "primary" PRIMARY KEY (id ASC),
-  FAMILY f1 (id, v)
+    id INT8 NOT NULL DEFAULT nextval('test_fk_order.public.s':::STRING::REGCLASS),
+    v INT8 NULL,
+    CONSTRAINT "primary" PRIMARY KEY (id ASC),
+    FAMILY f1 (id, v)
 );
 ALTER TABLE public.a ADD CONSTRAINT fk_i_ref_b FOREIGN KEY (i) REFERENCES public.b(i);
 ALTER TABLE public.f ADD CONSTRAINT fk_g_ref_g FOREIGN KEY (g) REFERENCES public.g(i);
@@ -233,9 +224,6 @@ ALTER TABLE public.f VALIDATE CONSTRAINT fk_g_ref_g;
 ALTER TABLE public.d VALIDATE CONSTRAINT fk_e_ref_e;
 ALTER TABLE public.d VALIDATE CONSTRAINT fk_f_ref_f;
 ALTER TABLE public.c VALIDATE CONSTRAINT fk_i_ref_d;
-
-
-
 
 # Test that a cycle between two tables is handled correctly.
 statement ok
@@ -278,9 +266,6 @@ ALTER TABLE public.loop_a ADD CONSTRAINT b_id_delete_constraint FOREIGN KEY (b_i
 ALTER TABLE public.loop_b VALIDATE CONSTRAINT fk_a_id_ref_loop_a;
 ALTER TABLE public.loop_a VALIDATE CONSTRAINT b_id_delete_constraint;
 
-
-
-
 # Test that a primary key with a non-default name works.
 statement ok
 CREATE DATABASE test_primary_key;
@@ -295,12 +280,10 @@ SHOW CREATE ALL TABLES
 ----
 create_statement
 CREATE TABLE public.t (
-  i INT8 NOT NULL,
-  CONSTRAINT pk_name PRIMARY KEY (i ASC),
-  FAMILY "primary" (i)
+    i INT8 NOT NULL,
+    CONSTRAINT pk_name PRIMARY KEY (i ASC),
+    FAMILY "primary" (i)
 );
-
-
 
 # Test that computed columns are shown correctly.
 statement ok
@@ -317,14 +300,11 @@ SHOW CREATE ALL TABLES
 ----
 create_statement
 CREATE TABLE public.t (
-  a INT8 NOT NULL,
-  b INT8 NULL AS (a + 1:::INT8) STORED,
-  CONSTRAINT "primary" PRIMARY KEY (a ASC),
-  FAMILY f1 (a, b)
+    a INT8 NOT NULL,
+    b INT8 NULL AS (a + 1:::INT8) STORED,
+    CONSTRAINT "primary" PRIMARY KEY (a ASC),
+    FAMILY f1 (a, b)
 );
-
-
-
 
 # Test showing a table with a semicolon in the table, index, and
 # column names properly escapes.
@@ -339,15 +319,12 @@ SHOW CREATE ALL TABLES
 ----
 create_statement
 CREATE TABLE public.";" (
-  ";" INT8 NULL,
-  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-  CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
-  INDEX ";_;_idx" (";" ASC),
-  FAMILY "primary" (";", rowid)
+    ";" INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+    INDEX ";_;_idx" (";" ASC),
+    FAMILY "primary" (";", rowid)
 );
-
-
-
 
 # Ensure quotes in comments are properly escaped, also that the object names
 # are properly escaped in the output of the COMMENT statements.
@@ -372,8 +349,6 @@ COMMENT ON TABLE public."t   t" IS e'has \' quotes';
 COMMENT ON COLUMN public."t   t"."x'" IS e'i \' just \' love \' quotes';
 COMMENT ON INDEX public."t   t"@primary IS e'has \' more \' quotes';
 
-
-
 # Ensure schemas are shown correctly.
 statement ok
 CREATE DATABASE test_schema;
@@ -388,20 +363,17 @@ SHOW CREATE ALL TABLES
 ----
 create_statement
 CREATE TABLE sc1.t (
-  x INT8 NULL,
-  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-  CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
-  FAMILY "primary" (x, rowid)
+    x INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+    FAMILY "primary" (x, rowid)
 );
 CREATE TABLE sc2.t (
-  x INT8 NULL,
-  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-  CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
-  FAMILY "primary" (x, rowid)
+    x INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+    FAMILY "primary" (x, rowid)
 );
-
-
-
 
 # Ensure sequences are shown correctly.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/show_create_all_tables_builtin
+++ b/pkg/sql/logictest/testdata/logic_test/show_create_all_tables_builtin
@@ -1,7 +1,5 @@
-query T
+statement error pq: crdb_internal.show_create_all_tables: database "d" does not exist
 SELECT crdb_internal.show_create_all_tables('d')
-----
-·
 
 statement ok
 CREATE DATABASE d
@@ -9,7 +7,6 @@ CREATE DATABASE d
 query T
 SELECT crdb_internal.show_create_all_tables('d')
 ----
-·
 
 statement ok
 CREATE TABLE d.parent (
@@ -47,32 +44,31 @@ query T
 SELECT crdb_internal.show_create_all_tables('d')
 ----
 CREATE TABLE public.parent (
-  x INT8 NULL,
-  y INT8 NULL,
-  z INT8 NULL,
-  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-  CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
-  UNIQUE INDEX parent_x_y_z_key (x ASC, y ASC, z ASC),
-  UNIQUE INDEX parent_x_key (x ASC),
-  FAMILY f1 (x, y, z, rowid)
+    x INT8 NULL,
+    y INT8 NULL,
+    z INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+    UNIQUE INDEX parent_x_y_z_key (x ASC, y ASC, z ASC),
+    UNIQUE INDEX parent_x_key (x ASC),
+    FAMILY f1 (x, y, z, rowid)
 );
 CREATE TABLE public.full_test (
-  x INT8 NULL,
-  y INT8 NULL,
-  z INT8 NULL,
-  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-  CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
-  UNIQUE INDEX full_test_x_key (x ASC),
-  FAMILY f1 (x, y, z, rowid)
+    x INT8 NULL,
+    y INT8 NULL,
+    z INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+    UNIQUE INDEX full_test_x_key (x ASC),
+    FAMILY f1 (x, y, z, rowid)
 );
-CREATE SEQUENCE public.s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
 CREATE VIEW public.vx ("?column?") AS SELECT 1;
+CREATE SEQUENCE public.s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
 ALTER TABLE public.full_test ADD CONSTRAINT fk_x_ref_parent FOREIGN KEY (x, y, z) REFERENCES public.parent(x, y, z) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE;
 ALTER TABLE public.full_test ADD CONSTRAINT test_fk FOREIGN KEY (x) REFERENCES public.parent(x) ON DELETE CASCADE;
 -- Validate foreign key constraints. These can fail if there was unvalidated data during the SHOW CREATE ALL TABLES
 ALTER TABLE public.full_test VALIDATE CONSTRAINT fk_x_ref_parent;
 ALTER TABLE public.full_test VALIDATE CONSTRAINT test_fk;
-
 
 # testuser does not have CONNECT on database d and cannot see any tables.
 user testuser
@@ -80,7 +76,6 @@ user testuser
 query T
 SELECT crdb_internal.show_create_all_tables('d')
 ----
-·
 
 user root
 
@@ -95,32 +90,31 @@ query T
 SELECT crdb_internal.show_create_all_tables('d')
 ----
 CREATE TABLE public.parent (
-  x INT8 NULL,
-  y INT8 NULL,
-  z INT8 NULL,
-  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-  CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
-  UNIQUE INDEX parent_x_y_z_key (x ASC, y ASC, z ASC),
-  UNIQUE INDEX parent_x_key (x ASC),
-  FAMILY f1 (x, y, z, rowid)
+    x INT8 NULL,
+    y INT8 NULL,
+    z INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+    UNIQUE INDEX parent_x_y_z_key (x ASC, y ASC, z ASC),
+    UNIQUE INDEX parent_x_key (x ASC),
+    FAMILY f1 (x, y, z, rowid)
 );
 CREATE TABLE public.full_test (
-  x INT8 NULL,
-  y INT8 NULL,
-  z INT8 NULL,
-  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-  CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
-  UNIQUE INDEX full_test_x_key (x ASC),
-  FAMILY f1 (x, y, z, rowid)
+    x INT8 NULL,
+    y INT8 NULL,
+    z INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+    UNIQUE INDEX full_test_x_key (x ASC),
+    FAMILY f1 (x, y, z, rowid)
 );
-CREATE SEQUENCE public.s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
 CREATE VIEW public.vx ("?column?") AS SELECT 1;
+CREATE SEQUENCE public.s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
 ALTER TABLE public.full_test ADD CONSTRAINT fk_x_ref_parent FOREIGN KEY (x, y, z) REFERENCES public.parent(x, y, z) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE;
 ALTER TABLE public.full_test ADD CONSTRAINT test_fk FOREIGN KEY (x) REFERENCES public.parent(x) ON DELETE CASCADE;
 -- Validate foreign key constraints. These can fail if there was unvalidated data during the SHOW CREATE ALL TABLES
 ALTER TABLE public.full_test VALIDATE CONSTRAINT fk_x_ref_parent;
 ALTER TABLE public.full_test VALIDATE CONSTRAINT test_fk;
-
 
 user root
 
@@ -140,7 +134,6 @@ CREATE TEMPORARY TABLE t()
 query T
 SELECT crdb_internal.show_create_all_tables('temp_test')
 ----
-·
 
 # Test that a database with foreign keys has the right order.
 statement ok
@@ -168,51 +161,51 @@ query T
 SELECT crdb_internal.show_create_all_tables('test_fk_order')
 ----
 CREATE TABLE public.b (
-  i INT8 NOT NULL,
-  CONSTRAINT "primary" PRIMARY KEY (i ASC),
-  FAMILY "primary" (i)
+    i INT8 NOT NULL,
+    CONSTRAINT "primary" PRIMARY KEY (i ASC),
+    FAMILY "primary" (i)
 );
 CREATE TABLE public.a (
-  i INT8 NULL,
-  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-  CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
-  FAMILY "primary" (i, rowid)
-);
-CREATE TABLE public.e (
-  i INT8 NOT NULL,
-  CONSTRAINT "primary" PRIMARY KEY (i ASC),
-  FAMILY "primary" (i)
+    i INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+    FAMILY "primary" (i, rowid)
 );
 CREATE TABLE public.g (
-  i INT8 NOT NULL,
-  CONSTRAINT "primary" PRIMARY KEY (i ASC),
-  FAMILY "primary" (i)
+    i INT8 NOT NULL,
+    CONSTRAINT "primary" PRIMARY KEY (i ASC),
+    FAMILY "primary" (i)
 );
 CREATE TABLE public.f (
-  i INT8 NOT NULL,
-  g INT8 NULL,
-  CONSTRAINT "primary" PRIMARY KEY (i ASC),
-  FAMILY f1 (i, g)
+    i INT8 NOT NULL,
+    g INT8 NULL,
+    CONSTRAINT "primary" PRIMARY KEY (i ASC),
+    FAMILY f1 (i, g)
+);
+CREATE TABLE public.e (
+    i INT8 NOT NULL,
+    CONSTRAINT "primary" PRIMARY KEY (i ASC),
+    FAMILY "primary" (i)
 );
 CREATE TABLE public.d (
-  i INT8 NOT NULL,
-  e INT8 NULL,
-  f INT8 NULL,
-  CONSTRAINT "primary" PRIMARY KEY (i ASC),
-  FAMILY f1 (i, e, f)
+    i INT8 NOT NULL,
+    e INT8 NULL,
+    f INT8 NULL,
+    CONSTRAINT "primary" PRIMARY KEY (i ASC),
+    FAMILY f1 (i, e, f)
 );
 CREATE TABLE public.c (
-  i INT8 NULL,
-  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-  CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
-  FAMILY "primary" (i, rowid)
+    i INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+    FAMILY "primary" (i, rowid)
 );
 CREATE SEQUENCE public.s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
 CREATE TABLE public.s_tbl (
-  id INT8 NOT NULL DEFAULT nextval('test_fk_order.public.s':::STRING::REGCLASS),
-  v INT8 NULL,
-  CONSTRAINT "primary" PRIMARY KEY (id ASC),
-  FAMILY f1 (id, v)
+    id INT8 NOT NULL DEFAULT nextval('test_fk_order.public.s':::STRING::REGCLASS),
+    v INT8 NULL,
+    CONSTRAINT "primary" PRIMARY KEY (id ASC),
+    FAMILY f1 (id, v)
 );
 ALTER TABLE public.a ADD CONSTRAINT fk_i_ref_b FOREIGN KEY (i) REFERENCES public.b(i);
 ALTER TABLE public.f ADD CONSTRAINT fk_g_ref_g FOREIGN KEY (g) REFERENCES public.g(i);
@@ -225,7 +218,6 @@ ALTER TABLE public.f VALIDATE CONSTRAINT fk_g_ref_g;
 ALTER TABLE public.d VALIDATE CONSTRAINT fk_e_ref_e;
 ALTER TABLE public.d VALIDATE CONSTRAINT fk_f_ref_f;
 ALTER TABLE public.c VALIDATE CONSTRAINT fk_i_ref_d;
-
 
 # Test that a cycle between two tables is handled correctly.
 statement ok
@@ -267,7 +259,6 @@ ALTER TABLE public.loop_a ADD CONSTRAINT b_id_delete_constraint FOREIGN KEY (b_i
 ALTER TABLE public.loop_b VALIDATE CONSTRAINT fk_a_id_ref_loop_a;
 ALTER TABLE public.loop_a VALIDATE CONSTRAINT b_id_delete_constraint;
 
-
 # Test that a primary key with a non-default name works.
 statement ok
 CREATE DATABASE test_primary_key;
@@ -304,7 +295,6 @@ CREATE TABLE public.t (
   FAMILY f1 (a, b)
 );
 
-
 # Test showing a table with a semicolon in the table, index, and
 # column names properly escapes.
 statement ok
@@ -322,7 +312,6 @@ CREATE TABLE public.";" (
   INDEX ";_;_idx" (";" ASC),
   FAMILY "primary" (";", rowid)
 );
-
 
 # Ensure quotes in comments are properly escaped, also that the object names
 # are properly escaped in the output of the COMMENT statements.
@@ -369,7 +358,6 @@ CREATE TABLE sc2.t (
   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
   FAMILY "primary" (x, rowid)
 );
-
 
 # Ensure sequences are shown correctly.
 statement ok

--- a/pkg/sql/opt/norm/project_set_funcs.go
+++ b/pkg/sql/opt/norm/project_set_funcs.go
@@ -141,7 +141,7 @@ func (c *CustomFuncs) ConstructValuesFromZips(zip memo.ZipExpr) memo.RelExpr {
 				val := c.f.ConstructConstVal(vals[0], vals[0].ResolvedType())
 				addValToOutRows(val, j, i)
 			}
-			generator.Close()
+			generator.Close(c.f.evalCtx.Context)
 
 		default:
 			panic(errors.AssertionFailedf("invalid parameter type"))

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -5052,21 +5052,6 @@ table's zone configuration this will return NULL.`,
 			tree.VolatilityStable,
 		),
 	),
-
-	"crdb_internal.show_create_all_tables": makeBuiltin(
-		tree.FunctionProperties{},
-		tree.Overload{
-			Types: tree.ArgTypes{
-				{"dbName", types.String},
-			},
-			ReturnType: tree.FixedReturnType(types.String),
-			Fn:         showCreateAllTablesBuiltin,
-			Info: `Returns a flat log of CREATE table statements followed by
-ALTER table statements that add table constraints. The flat log can be used
-to recreate a database.'`,
-			Volatility: tree.VolatilityStable,
-		},
-	),
 }
 
 var lengthImpls = func(incBitOverload bool) builtinDefinition {

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -13,6 +13,7 @@ package builtins
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -32,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	pbtypes "github.com/gogo/protobuf/types"
@@ -348,7 +350,6 @@ var generators = map[string]builtinDefinition{
 			tree.VolatilityVolatile,
 		),
 	),
-
 	"crdb_internal.payloads_for_trace": makeBuiltin(
 		tree.FunctionProperties{
 			Class:    tree.GeneratorClass,
@@ -361,6 +362,27 @@ var generators = map[string]builtinDefinition{
 			payloadsForTraceGeneratorType,
 			makePayloadsForTraceGenerator,
 			"Returns the payload(s) of the requested trace.",
+			tree.VolatilityVolatile,
+		),
+	),
+	"crdb_internal.show_create_all_tables": makeBuiltin(
+		tree.FunctionProperties{
+			Class: tree.GeneratorClass,
+		},
+		makeGeneratorOverload(
+			tree.ArgTypes{
+				{"dbName", types.String},
+			},
+			showCreateAllTablesGeneratorType,
+			makeShowCreateAllTablesGenerator,
+			`Returns a rows CREATE table statements followed by 
+ALTER table statements that add table constraints. The rows are ordered
+by dependencies. All foreign keys are added after the creation of the table
+in the alter statements.
+It is not recommended to perform this operation on a database with many 
+tables.
+The output can be used to recreate a database.'
+`,
 			tree.VolatilityVolatile,
 		),
 	),
@@ -1613,4 +1635,159 @@ func (p *payloadsForTraceGenerator) Close() {
 		// TODO(angelapwen, yuzefovich): The iterator's error should be surfaced here.
 		return
 	}
+}
+
+var showCreateAllTablesGeneratorType = types.String
+
+// Phase is used to determine if CREATE statements or ALTER statements
+// are being generated for showCreateAllTables.
+type Phase int
+
+const (
+	create Phase = iota
+	alterAddFks
+	alterValidateFks
+)
+
+// showCreateAllTablesGenerator supports the execution of
+// crdb_internal.show_create_all_tables(dbName).
+type showCreateAllTablesGenerator struct {
+	ie        sqlutil.InternalExecutor
+	txn       *kv.Txn
+	timestamp string
+	ids       []int64
+	dbName    string
+
+	// The following variables are updated during
+	// calls to Next() and change throughout the lifecycle of
+	// showCreateAllTablesGenerator.
+	curr           tree.Datum
+	idx            int
+	shouldValidate bool
+	alterArr       tree.Datums
+	alterArrIdx    int
+	phase          Phase
+}
+
+// ResolvedType implements the tree.ValueGenerator interface.
+func (s *showCreateAllTablesGenerator) ResolvedType() *types.T {
+	return showCreateAllTablesGeneratorType
+}
+
+// Start implements the tree.ValueGenerator interface.
+func (s *showCreateAllTablesGenerator) Start(ctx context.Context, txn *kv.Txn) error {
+	ids, err := getTopologicallySortedTableIDs(ctx, s.ie, txn, s.dbName, s.timestamp)
+	if err != nil {
+		return err
+	}
+
+	s.ids = ids
+
+	s.txn = txn
+	s.idx = -1
+	s.phase = create
+	return nil
+}
+
+func (s *showCreateAllTablesGenerator) Next(ctx context.Context) (bool, error) {
+	switch s.phase {
+	case create:
+		s.idx++
+		if s.idx >= len(s.ids) {
+			// Were done generating the create statements, start generating alters.
+			s.phase = alterAddFks
+			s.idx = -1
+			return s.Next(ctx)
+		}
+
+		createStmt, err := getCreateStatement(
+			ctx, s.ie, s.txn, s.ids[s.idx], s.timestamp, s.dbName,
+		)
+		if err != nil {
+			return false, err
+		}
+		createStmtStr := string(tree.MustBeDString(createStmt))
+		s.curr = tree.NewDString(fmt.Sprintf("%s;", createStmtStr))
+	case alterAddFks, alterValidateFks:
+		// We have existing alter statements to generate for the current
+		// table id.
+		s.alterArrIdx++
+		if s.alterArrIdx < len(s.alterArr) {
+			alterStmt := tree.MustBeDString(s.alterArr[s.alterArrIdx])
+			s.curr = tree.NewDString(
+				fmt.Sprintf("%s;", alterStmt),
+			)
+
+			// At least one FK was added, we must validate the FK.
+			s.shouldValidate = true
+			return true, nil
+		}
+		// We need to generate the alter statements for the next table.
+		s.idx++
+		if s.idx >= len(s.ids) {
+			if s.phase == alterAddFks {
+				// Were done generating the alter fk statements,
+				// start generating alter validate fk statements.
+				s.phase = alterValidateFks
+				s.idx = -1
+
+				if s.shouldValidate {
+					// Add a warning about the possibility of foreign key
+					// validation failing.
+					s.curr = tree.NewDString(foreignKeyValidationWarning)
+					return true, nil
+				}
+				return s.Next(ctx)
+			}
+			// We're done if were on phase alterValidateFks and we
+			// finish going through all the table ids.
+			return false, nil
+		}
+
+		statementType := alterAddFKStatements
+		if s.phase == alterValidateFks {
+			statementType = alterValidateFKStatements
+		}
+		alterStmt, err := getAlterStatements(
+			ctx, s.ie, s.txn, s.ids[s.idx], s.timestamp, s.dbName, statementType,
+		)
+		if err != nil {
+			return false, err
+		}
+		if alterStmt == nil {
+			// There can be no ALTER statements for a given id, in this case
+			// we go next.
+			return s.Next(ctx)
+		}
+		s.alterArr = tree.MustBeDArray(alterStmt).Array
+		s.alterArrIdx = -1
+		return s.Next(ctx)
+	}
+
+	return true, nil
+}
+
+// Values implements the tree.ValueGenerator interface.
+func (s *showCreateAllTablesGenerator) Values() (tree.Datums, error) {
+	return tree.Datums{s.curr}, nil
+}
+
+// Close implements the tree.ValueGenerator interface.
+func (s *showCreateAllTablesGenerator) Close() {}
+
+// makeShowCreateAllTablesGenerator creates a generator to support the
+// crdb_internal.show_create_all_tables(dbName) builtin.
+// We use the timestamp of when the generator is created as the
+// timestamp to pass to AS OF SYSTEM TIME for looking up the create table
+// and alter table statements.
+func makeShowCreateAllTablesGenerator(
+	ctx *tree.EvalContext, args tree.Datums,
+) (tree.ValueGenerator, error) {
+	dbName := string(tree.MustBeDString(args[0]))
+	tsI, err := tree.MakeDTimestamp(timeutil.Now(), time.Microsecond)
+	if err != nil {
+		return nil, err
+	}
+	ts := tsI.String()
+	return &showCreateAllTablesGenerator{timestamp: ts, dbName: dbName, ie: ctx.InternalExecutor.(sqlutil.InternalExecutor)}, nil
 }

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -13,7 +13,6 @@ package builtins
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -33,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
@@ -86,7 +86,7 @@ type aclexplodeGenerator struct{}
 
 func (aclexplodeGenerator) ResolvedType() *types.T                   { return aclexplodeGeneratorType }
 func (aclexplodeGenerator) Start(_ context.Context, _ *kv.Txn) error { return nil }
-func (aclexplodeGenerator) Close()                                   {}
+func (aclexplodeGenerator) Close(_ context.Context)                  {}
 func (aclexplodeGenerator) Next(_ context.Context) (bool, error)     { return false, nil }
 func (aclexplodeGenerator) Values() (tree.Datums, error)             { return nil, nil }
 
@@ -371,11 +371,11 @@ var generators = map[string]builtinDefinition{
 		},
 		makeGeneratorOverload(
 			tree.ArgTypes{
-				{"dbName", types.String},
+				{"database_name", types.String},
 			},
 			showCreateAllTablesGeneratorType,
 			makeShowCreateAllTablesGenerator,
-			`Returns a rows CREATE table statements followed by 
+			`Returns rows of CREATE table statements followed by 
 ALTER table statements that add table constraints. The rows are ordered
 by dependencies. All foreign keys are added after the creation of the table
 in the alter statements.
@@ -442,7 +442,7 @@ func makeRegexpSplitToTableGeneratorFactory(hasFlags bool) tree.GeneratorFactory
 func (*regexpSplitToTableGenerator) ResolvedType() *types.T { return types.String }
 
 // Close implements the tree.ValueGenerator interface.
-func (*regexpSplitToTableGenerator) Close() {}
+func (*regexpSplitToTableGenerator) Close(_ context.Context) {}
 
 // Start implements the tree.ValueGenerator interface.
 func (g *regexpSplitToTableGenerator) Start(_ context.Context, _ *kv.Txn) error {
@@ -479,7 +479,7 @@ func makeKeywordsGenerator(_ *tree.EvalContext, _ tree.Datums) (tree.ValueGenera
 func (*keywordsValueGenerator) ResolvedType() *types.T { return keywordsValueGeneratorType }
 
 // Close implements the tree.ValueGenerator interface.
-func (*keywordsValueGenerator) Close() {}
+func (*keywordsValueGenerator) Close(_ context.Context) {}
 
 // Start implements the tree.ValueGenerator interface.
 func (k *keywordsValueGenerator) Start(_ context.Context, _ *kv.Txn) error {
@@ -631,7 +631,7 @@ func (s *seriesValueGenerator) Start(_ context.Context, _ *kv.Txn) error {
 }
 
 // Close implements the tree.ValueGenerator interface.
-func (s *seriesValueGenerator) Close() {}
+func (s *seriesValueGenerator) Close(_ context.Context) {}
 
 // Next implements the tree.ValueGenerator interface.
 func (s *seriesValueGenerator) Next(_ context.Context) (bool, error) {
@@ -682,7 +682,7 @@ func (s *multipleArrayValueGenerator) Start(_ context.Context, _ *kv.Txn) error 
 }
 
 // Close implements the tree.ValueGenerator interface.
-func (s *multipleArrayValueGenerator) Close() {}
+func (s *multipleArrayValueGenerator) Close(_ context.Context) {}
 
 // Next implements the tree.ValueGenerator interface.
 func (s *multipleArrayValueGenerator) Next(_ context.Context) (bool, error) {
@@ -731,7 +731,7 @@ func (s *arrayValueGenerator) Start(_ context.Context, _ *kv.Txn) error {
 }
 
 // Close implements the tree.ValueGenerator interface.
-func (s *arrayValueGenerator) Close() {}
+func (s *arrayValueGenerator) Close(_ context.Context) {}
 
 // Next implements the tree.ValueGenerator interface.
 func (s *arrayValueGenerator) Next(_ context.Context) (bool, error) {
@@ -780,7 +780,7 @@ func (s *expandArrayValueGenerator) Start(_ context.Context, _ *kv.Txn) error {
 }
 
 // Close implements the tree.ValueGenerator interface.
-func (s *expandArrayValueGenerator) Close() {}
+func (s *expandArrayValueGenerator) Close(_ context.Context) {}
 
 // Next implements the tree.ValueGenerator interface.
 func (s *expandArrayValueGenerator) Next(_ context.Context) (bool, error) {
@@ -853,7 +853,7 @@ func (s *subscriptsValueGenerator) Start(_ context.Context, _ *kv.Txn) error {
 }
 
 // Close implements the tree.ValueGenerator interface.
-func (s *subscriptsValueGenerator) Close() {}
+func (s *subscriptsValueGenerator) Close(_ context.Context) {}
 
 // Next implements the tree.ValueGenerator interface.
 func (s *subscriptsValueGenerator) Next(_ context.Context) (bool, error) {
@@ -898,7 +898,7 @@ func (s *unaryValueGenerator) Start(_ context.Context, _ *kv.Txn) error {
 }
 
 // Close implements the tree.ValueGenerator interface.
-func (s *unaryValueGenerator) Close() {}
+func (s *unaryValueGenerator) Close(_ context.Context) {}
 
 // Next implements the tree.ValueGenerator interface.
 func (s *unaryValueGenerator) Next(_ context.Context) (bool, error) {
@@ -1003,7 +1003,7 @@ func (g *jsonArrayGenerator) Start(_ context.Context, _ *kv.Txn) error {
 }
 
 // Close implements the tree.ValueGenerator interface.
-func (g *jsonArrayGenerator) Close() {}
+func (g *jsonArrayGenerator) Close(_ context.Context) {}
 
 // Next implements the tree.ValueGenerator interface.
 func (g *jsonArrayGenerator) Next(_ context.Context) (bool, error) {
@@ -1072,7 +1072,7 @@ func (g *jsonObjectKeysGenerator) ResolvedType() *types.T {
 func (g *jsonObjectKeysGenerator) Start(_ context.Context, _ *kv.Txn) error { return nil }
 
 // Close implements the tree.ValueGenerator interface.
-func (g *jsonObjectKeysGenerator) Close() {}
+func (g *jsonObjectKeysGenerator) Close(_ context.Context) {}
 
 // Next implements the tree.ValueGenerator interface.
 func (g *jsonObjectKeysGenerator) Next(_ context.Context) (bool, error) {
@@ -1168,7 +1168,7 @@ func (g *jsonEachGenerator) Start(_ context.Context, _ *kv.Txn) error {
 }
 
 // Close implements the tree.ValueGenerator interface.
-func (g *jsonEachGenerator) Close() {}
+func (g *jsonEachGenerator) Close(_ context.Context) {}
 
 // Next implements the tree.ValueGenerator interface.
 func (g *jsonEachGenerator) Next(_ context.Context) (bool, error) {
@@ -1300,7 +1300,7 @@ func (c *checkConsistencyGenerator) Values() (tree.Datums, error) {
 }
 
 // Close is part of the tree.ValueGenerator interface.
-func (c *checkConsistencyGenerator) Close() {}
+func (c *checkConsistencyGenerator) Close(_ context.Context) {}
 
 // rangeKeyIteratorChunkSize is the number of K/V pairs that the
 // rangeKeyIterator requests at a time. If this changes, make sure
@@ -1422,7 +1422,7 @@ func (rk *rangeKeyIterator) Values() (tree.Datums, error) {
 }
 
 // Close implements the tree.ValueGenerator interface.
-func (rk *rangeKeyIterator) Close() {}
+func (rk *rangeKeyIterator) Close(_ context.Context) {}
 
 var payloadsForSpanGeneratorLabels = []string{"payload_type", "payload_jsonb"}
 
@@ -1552,7 +1552,7 @@ func (p *payloadsForSpanGenerator) Values() (tree.Datums, error) {
 }
 
 // Close implements the tree.ValueGenerator interface.
-func (p *payloadsForSpanGenerator) Close() {}
+func (p *payloadsForSpanGenerator) Close(_ context.Context) {}
 
 var payloadsForTraceGeneratorLabels = []string{"span_id", "payload_type", "payload_jsonb"}
 
@@ -1629,7 +1629,7 @@ func (p *payloadsForTraceGenerator) Values() (tree.Datums, error) {
 }
 
 // Close implements the tree.ValueGenerator interface.
-func (p *payloadsForTraceGenerator) Close() {
+func (p *payloadsForTraceGenerator) Close(_ context.Context) {
 	err := p.it.Close()
 	if err != nil {
 		// TODO(angelapwen, yuzefovich): The iterator's error should be surfaced here.
@@ -1657,6 +1657,7 @@ type showCreateAllTablesGenerator struct {
 	timestamp string
 	ids       []int64
 	dbName    string
+	acc       mon.BoundAccount
 
 	// The following variables are updated during
 	// calls to Next() and change throughout the lifecycle of
@@ -1676,7 +1677,20 @@ func (s *showCreateAllTablesGenerator) ResolvedType() *types.T {
 
 // Start implements the tree.ValueGenerator interface.
 func (s *showCreateAllTablesGenerator) Start(ctx context.Context, txn *kv.Txn) error {
-	ids, err := getTopologicallySortedTableIDs(ctx, s.ie, txn, s.dbName, s.timestamp)
+	// Note: All the table ids are accumulated in ram before the generator
+	// starts generating values.
+	// This is reasonable under the assumption that:
+	// This uses approximately the same amount of memory as required when
+	// generating the vtable crdb_internal.show_create_statements. If generating
+	// and reading from the vtable succeeds which we do to retrieve the ids, then
+	// it is reasonable to use the same amount of memory to hold the ids in
+	// ram during the lifecycle of showCreateAllTablesGenerator.
+	//
+	// We also account for the memory in the BoundAccount memory monitor in
+	// showCreateAllTablesGenerator.
+	ids, err := getTopologicallySortedTableIDs(
+		ctx, s.ie, txn, s.dbName, s.timestamp, &s.acc,
+	)
 	if err != nil {
 		return err
 	}
@@ -1707,16 +1721,14 @@ func (s *showCreateAllTablesGenerator) Next(ctx context.Context) (bool, error) {
 			return false, err
 		}
 		createStmtStr := string(tree.MustBeDString(createStmt))
-		s.curr = tree.NewDString(fmt.Sprintf("%s;", createStmtStr))
+		s.curr = tree.NewDString(createStmtStr + ";")
 	case alterAddFks, alterValidateFks:
 		// We have existing alter statements to generate for the current
 		// table id.
 		s.alterArrIdx++
 		if s.alterArrIdx < len(s.alterArr) {
-			alterStmt := tree.MustBeDString(s.alterArr[s.alterArrIdx])
-			s.curr = tree.NewDString(
-				fmt.Sprintf("%s;", alterStmt),
-			)
+			alterStmtStr := string(tree.MustBeDString(s.alterArr[s.alterArrIdx]))
+			s.curr = tree.NewDString(alterStmtStr + ";")
 
 			// At least one FK was added, we must validate the FK.
 			s.shouldValidate = true
@@ -1773,7 +1785,9 @@ func (s *showCreateAllTablesGenerator) Values() (tree.Datums, error) {
 }
 
 // Close implements the tree.ValueGenerator interface.
-func (s *showCreateAllTablesGenerator) Close() {}
+func (s *showCreateAllTablesGenerator) Close(ctx context.Context) {
+	s.acc.Close(ctx)
+}
 
 // makeShowCreateAllTablesGenerator creates a generator to support the
 // crdb_internal.show_create_all_tables(dbName) builtin.
@@ -1789,5 +1803,10 @@ func makeShowCreateAllTablesGenerator(
 		return nil, err
 	}
 	ts := tsI.String()
-	return &showCreateAllTablesGenerator{timestamp: ts, dbName: dbName, ie: ctx.InternalExecutor.(sqlutil.InternalExecutor)}, nil
+	return &showCreateAllTablesGenerator{
+		timestamp: ts,
+		dbName:    dbName,
+		ie:        ctx.InternalExecutor.(sqlutil.InternalExecutor),
+		acc:       ctx.Mon.MakeBoundAccount(),
+	}, nil
 }

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -409,7 +409,7 @@ func (m *minimumBoundRadiusGen) Values() (tree.Datums, error) {
 		tree.NewDFloat(tree.DFloat(m.radius))}, nil
 }
 
-func (m *minimumBoundRadiusGen) Close() {}
+func (m *minimumBoundRadiusGen) Close(_ context.Context) {}
 
 func makeSubdividedGeometriesGeneratorFactory(expectMaxVerticesArg bool) tree.GeneratorFactory {
 	return func(
@@ -441,7 +441,7 @@ type subdividedGeometriesGen struct {
 
 func (s *subdividedGeometriesGen) ResolvedType() *types.T { return types.Geometry }
 
-func (s *subdividedGeometriesGen) Close() {}
+func (s *subdividedGeometriesGen) Close(_ context.Context) {}
 
 func (s *subdividedGeometriesGen) Start(_ context.Context, _ *kv.Txn) error {
 	s.curr = -1

--- a/pkg/sql/sem/builtins/show_create_all_tables_builtin.go
+++ b/pkg/sql/sem/builtins/show_create_all_tables_builtin.go
@@ -14,12 +14,23 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/errors"
 )
+
+const sizeOfInt64 = int64(unsafe.Sizeof(int64(0)))
+
+// mapEntryOverhead is a guess on how much space (in bytes)
+// each item added to a map takes.
+// More explanation in cockroach/pkg/sql/rowexec/aggregator.go variable
+// hashAggregatorSizeOfBucketsItem
+const mapEntryOverhead = 64
 
 // alterAddFKStatements represents the column name for alter_statements in
 // crdb_internal.create_statements.
@@ -39,26 +50,28 @@ const foreignKeyValidationWarning = "-- Validate foreign key constraints. These 
 // the table that uses the sequence).
 // The tables are sorted by table id first to guarantee stable ordering.
 func getTopologicallySortedTableIDs(
-	ctx context.Context, ie sqlutil.InternalExecutor, txn *kv.Txn, dbName string, ts string,
+	ctx context.Context,
+	ie sqlutil.InternalExecutor,
+	txn *kv.Txn,
+	dbName string,
+	ts string,
+	acc *mon.BoundAccount,
 ) ([]int64, error) {
-	tids, err := getTableIDs(ctx, ie, txn, ts, dbName)
+	ids, err := getTableIDs(ctx, ie, txn, ts, dbName, acc)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(tids) == 0 {
+	if len(ids) == 0 {
 		return nil, nil
 	}
 
-	var ids []int64
-
+	sizeOfMap := int64(0)
 	// dependsOnIDs maps an id of a table to the ids it depends on.
 	// We perform the topological sort on dependsOnIDs instead of on the
 	// byID map to reduce memory usage.
 	dependsOnIDs := make(map[int64][]int64)
-	for _, tid := range tids {
-		ids = append(ids, tid)
-
+	for _, tid := range ids {
 		query := fmt.Sprintf(`
 		SELECT dependson_id
 		FROM %s.crdb_internal.backward_dependencies
@@ -86,6 +99,14 @@ func getTopologicallySortedTableIDs(
 		if err != nil {
 			return nil, err
 		}
+
+		// Account for memory of map.
+		sizeOfKeyValue := int64(unsafe.Sizeof(tid)) + int64(len(refs))*sizeOfInt64
+		sizeOfMap += sizeOfKeyValue + mapEntryOverhead
+		if err = acc.Grow(ctx, sizeOfKeyValue+mapEntryOverhead); err != nil {
+			return nil, err
+		}
+
 		dependsOnIDs[tid] = refs
 	}
 
@@ -99,24 +120,56 @@ func getTopologicallySortedTableIDs(
 	// for views and sequences creation, hence simple alphabetical sort won't
 	// be enough.
 	var topologicallyOrderedIDs []int64
-	seen := make(map[int64]bool)
+
+	// The sort relies on creating a new array for the ids.
+	if err = acc.Grow(ctx, int64(len(ids))*sizeOfInt64); err != nil {
+		return nil, err
+	}
+	seen := make(map[int64]struct{})
 	for _, id := range ids {
-		topologicalSort(id, dependsOnIDs, seen, &topologicallyOrderedIDs)
+		if err := topologicalSort(
+			ctx, id, dependsOnIDs, seen, &topologicallyOrderedIDs, acc,
+		); err != nil {
+			return nil, err
+		}
 	}
 
+	// Clear memory used by the seen map.
+	sizeOfSeen := len(seen)
+	seen = nil
+	acc.Shrink(ctx, int64(sizeOfSeen)*(sizeOfInt64+mapEntryOverhead))
+
+	// The lengths should match. This is also important for memory accounting,
+	// the two arrays should have the same length.
+	if len(ids) != len(topologicallyOrderedIDs) {
+		return nil, errors.AssertionFailedf("show_create_all_tables_builtin failed. "+
+			"len(ids):% d not equal to len(topologicallySortedIDs): %d",
+			len(ids), len(topologicallyOrderedIDs))
+	}
+
+	// Shrink the memory we used for the original ids array.
+	acc.Shrink(ctx, int64(len(ids))*sizeOfInt64)
+	acc.Shrink(ctx, sizeOfMap)
 	return topologicallyOrderedIDs, nil
 }
 
 // getTableIDs returns the set of table ids from
 // crdb_internal.show_create_all_tables for a specified database.
 func getTableIDs(
-	ctx context.Context, ie sqlutil.InternalExecutor, txn *kv.Txn, ts string, dbName string,
+	ctx context.Context,
+	ie sqlutil.InternalExecutor,
+	txn *kv.Txn,
+	ts string,
+	dbName string,
+	acc *mon.BoundAccount,
 ) ([]int64, error) {
 	query := fmt.Sprintf(`
 		SELECT descriptor_id
 		FROM %s.crdb_internal.create_statements
 		AS OF SYSTEM TIME %s
-		WHERE database_name = $1 AND schema_name NOT LIKE $2
+		WHERE database_name = $1 
+		AND is_virtual = FALSE
+		AND is_temporary = FALSE
 		`, dbName, ts)
 	it, err := ie.QueryIteratorEx(
 		ctx,
@@ -125,7 +178,6 @@ func getTableIDs(
 		sessiondata.NoSessionDataOverride,
 		query,
 		dbName,
-		sessiondata.PgTempSchemaName+"%",
 	)
 	if err != nil {
 		return nil, err
@@ -138,6 +190,9 @@ func getTableIDs(
 		tid := tree.MustBeDInt(it.Cur()[0])
 
 		tableIDs = append(tableIDs, int64(tid))
+		if err = acc.Grow(ctx, int64(unsafe.Sizeof(tid))); err != nil {
+			return nil, err
+		}
 	}
 	if err != nil {
 		return tableIDs, err
@@ -152,23 +207,41 @@ func getTableIDs(
 // for views and sequences creation, hence simple alphabetical sort won't
 // be enough.
 func topologicalSort(
-	tid int64, dependsOnIDs map[int64][]int64, seen map[int64]bool, collected *[]int64,
-) {
+	ctx context.Context,
+	tid int64,
+	dependsOnIDs map[int64][]int64,
+	seen map[int64]struct{},
+	collected *[]int64,
+	acc *mon.BoundAccount,
+) error {
 	// has this table already been collected previously?
 	// We need this check because a table could be traversed to multiple times
 	// if it is referenced.
 	// For example, if a table references itself, without this check
 	// collect would infinitely recurse.
-	if seen[tid] {
-		return
+	if _, isPresent := seen[tid]; isPresent {
+		return nil
 	}
 
-	seen[tid] = true
+	// Account for memory of map.
+	// The key value entry into the map is only the memory of an int64 since
+	// the value stuct{}{} uses no memory.
+	if err := acc.Grow(ctx, sizeOfInt64+mapEntryOverhead); err != nil {
+		return err
+	}
+	seen[tid] = struct{}{}
 	for _, dep := range dependsOnIDs[tid] {
-		topologicalSort(dep, dependsOnIDs, seen, collected)
+		if err := topologicalSort(ctx, dep, dependsOnIDs, seen, collected, acc); err != nil {
+			return err
+		}
 	}
 
+	if err := acc.Grow(ctx, int64(unsafe.Sizeof(tid))); err != nil {
+		return err
+	}
 	*collected = append(*collected, tid)
+
+	return nil
 }
 
 // getCreateStatement gets the create statement to recreate a table (ignoring fks)

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -5408,7 +5408,7 @@ func (c *CallbackValueGenerator) Values() (Datums, error) {
 }
 
 // Close is part of the ValueGenerator interface.
-func (c *CallbackValueGenerator) Close() {}
+func (c *CallbackValueGenerator) Close(_ context.Context) {}
 
 // Sqrt returns the square root of x.
 func Sqrt(x float64) (*DFloat, error) {

--- a/pkg/sql/sem/tree/generators.go
+++ b/pkg/sql/sem/tree/generators.go
@@ -59,7 +59,7 @@ type ValueGenerator interface {
 	// Close must be called after Start() before disposing of the
 	// ValueGenerator. It does not need to be called if Start() has not
 	// been called yet. It must not be called in-between restarts.
-	Close()
+	Close(ctx context.Context)
 }
 
 // GeneratorFactory is the type of constructor functions for


### PR DESCRIPTION
crdb_internal.show_create_all_tables is now a generator that returns
create / alter statements row by row.

The id sort is now done on only the table ids.
The topological sort is done using a map of int64 -> int64
meaning the tableMetadata is no longer kept in ram during the sort.

Memory is now proportional to the number of tables in the database.
The amount of memory used in this builtin for storing table ids is
the same as the amount of memory needed when generating the underlying
crdb_internal.create_statements. This is technically still not constrained
so we should make it clear that the command should not be run on dbs with
an excessive number of tables.

Release justification: fix for inefficient memory usage, low risk, builtin
currently not in release version of crdb

Release note (sql change): SHOW CREATE ALL TABLES is updated to be more
memory efficient, however this should still not be run on a database with
an excessive number of tables. Users should not run this on a
database with more than 10000 tables (arbitrary but tested number)