### PR TITLE
opt: remove uniqueness checks for gen_random_uuid()

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -81,6 +81,7 @@ sql.metrics.statement_details.plan_collection.period	duration	5m0s	the time unti
 sql.metrics.statement_details.threshold	duration	0s	minimum execution time to cause statement statistics to be collected. If configured, no transaction stats are collected.
 sql.metrics.transaction_details.enabled	boolean	true	collect per-application transaction statistics
 sql.notices.enabled	boolean	true	enable notices in the server/client protocol being sent
+sql.optimizer.uniqueness_checks_for_gen_random_uuid.enabled	boolean	false	if enabled, uniqueness checks may be planned for mutations of UUID columns updated with gen_random_uuid(); otherwise, uniqueness is assumed due to near-zero collision probability
 sql.spatial.experimental_box2d_comparison_operators.enabled	boolean	false	enables the use of certain experimental box2d comparison operators
 sql.stats.automatic_collection.enabled	boolean	true	automatic statistics collection mode
 sql.stats.automatic_collection.fraction_stale_rows	float	0.2	target fraction of stale rows per table that will trigger a statistics refresh

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -83,6 +83,7 @@
 <tr><td><code>sql.metrics.statement_details.threshold</code></td><td>duration</td><td><code>0s</code></td><td>minimum execution time to cause statement statistics to be collected. If configured, no transaction stats are collected.</td></tr>
 <tr><td><code>sql.metrics.transaction_details.enabled</code></td><td>boolean</td><td><code>true</code></td><td>collect per-application transaction statistics</td></tr>
 <tr><td><code>sql.notices.enabled</code></td><td>boolean</td><td><code>true</code></td><td>enable notices in the server/client protocol being sent</td></tr>
+<tr><td><code>sql.optimizer.uniqueness_checks_for_gen_random_uuid.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if enabled, uniqueness checks may be planned for mutations of UUID columns updated with gen_random_uuid(); otherwise, uniqueness is assumed due to near-zero collision probability</td></tr>
 <tr><td><code>sql.spatial.experimental_box2d_comparison_operators.enabled</code></td><td>boolean</td><td><code>false</code></td><td>enables the use of certain experimental box2d comparison operators</td></tr>
 <tr><td><code>sql.stats.automatic_collection.enabled</code></td><td>boolean</td><td><code>true</code></td><td>automatic statistics collection mode</td></tr>
 <tr><td><code>sql.stats.automatic_collection.fraction_stale_rows</code></td><td>float</td><td><code>0.2</code></td><td>target fraction of stale rows per table that will trigger a statistics refresh</td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/unique
+++ b/pkg/sql/logictest/testdata/logic_test/unique
@@ -104,11 +104,19 @@ CREATE TABLE uniq_computed_pk (
 )
 
 statement ok
-CREATE TABLE other (k INT, v INT, w INT NOT NULL, x INT, y INT)
+CREATE TABLE uniq_uuid (
+  id1 UUID,
+  id2 UUID,
+  UNIQUE WITHOUT INDEX (id1),
+  UNIQUE WITHOUT INDEX (id2)
+)
+
+statement ok
+CREATE TABLE other (k INT, v INT, w INT NOT NULL, x INT, y INT, u UUID)
 
 # Insert some data into the other table.
 statement ok
-INSERT INTO other VALUES (10, 10, 1, 1, 1)
+INSERT INTO other VALUES (10, 10, 1, 1, 1, '8597b0eb-7b89-4857-858a-fabf86f6a3ac')
 
 
 # -- Tests with INSERT --
@@ -360,6 +368,15 @@ SELECT * FROM uniq_computed_pk
 i  s  d    c_i_expr  c_s  c_d  c_d_expr
 1  a  1.0  bar       a    1.0  1.0
 2  b  2.0  bar       b    2.0  2.0
+
+# Insert a couple of rows into a table with UUID columns.
+statement ok
+INSERT INTO uniq_uuid (id1, id2) SELECT gen_random_uuid(), '8597b0eb-7b89-4857-858a-fabf86f6a3ac'
+
+# We can catch uniqueness violations on UUID columns set to a value other than
+# gen_random_uuid().
+statement error pgcode 23505 pq: duplicate key value violates unique constraint "unique_id2"\nDETAIL: Key \(id2\)=\('8597b0eb-7b89-4857-858a-fabf86f6a3ac'\) already exists\.
+INSERT INTO uniq_uuid (id1, id2) SELECT gen_random_uuid(), u FROM other
 
 
 # -- Tests with UPDATE --

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -224,7 +224,17 @@ CREATE TABLE uniq_computed_pk (
 )
 
 statement ok
-CREATE TABLE other (k INT, v INT, w INT NOT NULL, x INT, y INT)
+CREATE TABLE uniq_uuid (
+  id1 UUID DEFAULT gen_random_uuid(),
+  id2 UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+  UNIQUE WITHOUT INDEX (id1),
+  UNIQUE WITHOUT INDEX (id2),
+  FAMILY (id1),
+  FAMILY (id2)
+)
+
+statement ok
+CREATE TABLE other (k INT, v INT, w INT NOT NULL, x INT, y INT, u UUID)
 
 # -- Tests with INSERT --
 subtest Insert
@@ -578,7 +588,7 @@ vectorized: true
 │       │
 │       └── • hash join (semi)
 │           │ equality: (v, x) = (b, c)
-│           │ pred: column16 != rowid
+│           │ pred: column17 != rowid
 │           │
 │           ├── • scan buffer
 │           │     label: buffer 1
@@ -594,7 +604,7 @@ vectorized: true
 │       │
 │       └── • hash join (semi)
 │           │ equality: (k, v, y) = (a, b, d)
-│           │ pred: column16 != rowid
+│           │ pred: column17 != rowid
 │           │
 │           ├── • scan buffer
 │           │     label: buffer 1
@@ -610,7 +620,7 @@ vectorized: true
         │
         └── • hash join (semi)
             │ equality: (k) = (a)
-            │ pred: column16 != rowid
+            │ pred: column17 != rowid
             │
             ├── • scan buffer
             │     label: buffer 1
@@ -1453,7 +1463,7 @@ vectorized: true
         │
         └── • hash join (semi)
             │ equality: (v) = (b)
-            │ pred: column15 != rowid
+            │ pred: column16 != rowid
             │
             ├── • filter
             │   │ filter: x > 0
@@ -1699,6 +1709,175 @@ vectorized: true
             │
             └── • scan buffer
                   label: buffer 1
+
+# By default, we do not require checks on UUID columns set to gen_random_uuid(),
+# but we do for UUID columns set to other values.
+query T
+EXPLAIN INSERT INTO uniq_uuid (id1, id2) VALUES (gen_random_uuid(), '8597b0eb-7b89-4857-858a-fabf86f6a3ac')
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • insert
+│   │ into: uniq_uuid(id1, id2, rowid)
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • values
+│             size: 3 columns, 1 row
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • hash join (right semi)
+            │ equality: (id2) = (column2)
+            │ right cols are key
+            │ pred: column8 != rowid
+            │
+            ├── • scan
+            │     missing stats
+            │     table: uniq_uuid@primary
+            │     spans: FULL SCAN
+            │
+            └── • scan buffer
+                  label: buffer 1
+
+# The default value of id1 is gen_random_uuid(), so we don't need to plan checks
+# for it. But the default value of id2 is '00000000-0000-0000-0000-000000000000',
+# so we do need checks.
+query T
+EXPLAIN INSERT INTO uniq_uuid (id1, id2) VALUES (DEFAULT, DEFAULT)
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • insert
+│   │ into: uniq_uuid(id1, id2, rowid)
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • values
+│             size: 3 columns, 1 row
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • hash join (right semi)
+            │ equality: (id2) = (column2)
+            │ right cols are key
+            │ pred: column8 != rowid
+            │
+            ├── • scan
+            │     missing stats
+            │     table: uniq_uuid@primary
+            │     spans: FULL SCAN
+            │
+            └── • scan buffer
+                  label: buffer 1
+
+# We can also detect gen_random_uuid() when it is a projection.
+query T
+EXPLAIN INSERT INTO uniq_uuid (id1, id2) SELECT gen_random_uuid(), u FROM other
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • insert
+│   │ into: uniq_uuid(id1, id2, rowid)
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: other@primary
+│                 spans: FULL SCAN
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • hash join (semi)
+            │ equality: (u) = (id2)
+            │ pred: column16 != rowid
+            │
+            ├── • scan buffer
+            │     label: buffer 1
+            │
+            └── • scan
+                  missing stats
+                  table: uniq_uuid@primary
+                  spans: FULL SCAN
+
+statement ok
+SET CLUSTER SETTING sql.optimizer.uniqueness_checks_for_gen_random_uuid.enabled = true
+
+# After changing the cluster setting, checks are required for both columns.
+query T
+EXPLAIN INSERT INTO uniq_uuid (id1, id2) VALUES (gen_random_uuid(), '8597b0eb-7b89-4857-858a-fabf86f6a3ac')
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • insert
+│   │ into: uniq_uuid(id1, id2, rowid)
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • values
+│             size: 3 columns, 1 row
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • hash join (right semi)
+│           │ equality: (id1) = (column1)
+│           │ right cols are key
+│           │ pred: column8 != rowid
+│           │
+│           ├── • scan
+│           │     missing stats
+│           │     table: uniq_uuid@primary
+│           │     spans: FULL SCAN
+│           │
+│           └── • scan buffer
+│                 label: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • hash join (right semi)
+            │ equality: (id2) = (column2)
+            │ right cols are key
+            │ pred: column8 != rowid
+            │
+            ├── • scan
+            │     missing stats
+            │     table: uniq_uuid@primary
+            │     spans: FULL SCAN
+            │
+            └── • scan buffer
+                  label: buffer 1
+
+statement ok
+SET CLUSTER SETTING sql.optimizer.uniqueness_checks_for_gen_random_uuid.enabled = false
 
 
 # -- Tests with UPDATE --
@@ -2588,6 +2767,109 @@ vectorized: true
                                   columns: (r, a, b, b_new, partial_index_put1, partial_index_put1, c)
                                   label: buffer 1
 
+# By default, we do not require checks on UUID columns set to gen_random_uuid(),
+# but we do for UUID columns set to other values.
+query T
+EXPLAIN UPDATE uniq_uuid SET id1 = '8597b0eb-7b89-4857-858a-fabf86f6a3ac', id2 = gen_random_uuid()
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • update
+│   │ table: uniq_uuid
+│   │ set: id1, id2
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: uniq_uuid@primary
+│                 spans: FULL SCAN
+│                 locking strength: for update
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • hash join (semi)
+            │ equality: (id1_new) = (id1)
+            │ pred: rowid != rowid
+            │
+            ├── • scan buffer
+            │     label: buffer 1
+            │
+            └── • scan
+                  missing stats
+                  table: uniq_uuid@primary
+                  spans: FULL SCAN
+
+statement ok
+SET CLUSTER SETTING sql.optimizer.uniqueness_checks_for_gen_random_uuid.enabled = true
+
+# After changing the cluster setting, checks are required for both columns.
+query T
+EXPLAIN UPDATE uniq_uuid SET id1 = '8597b0eb-7b89-4857-858a-fabf86f6a3ac', id2 = gen_random_uuid()
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • update
+│   │ table: uniq_uuid
+│   │ set: id1, id2
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: uniq_uuid@primary
+│                 spans: FULL SCAN
+│                 locking strength: for update
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • hash join (semi)
+│           │ equality: (id1_new) = (id1)
+│           │ pred: rowid != rowid
+│           │
+│           ├── • scan buffer
+│           │     label: buffer 1
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: uniq_uuid@primary
+│                 spans: FULL SCAN
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • hash join (semi)
+            │ equality: (id2_new) = (id2)
+            │ pred: rowid != rowid
+            │
+            ├── • scan buffer
+            │     label: buffer 1
+            │
+            └── • scan
+                  missing stats
+                  table: uniq_uuid@primary
+                  spans: FULL SCAN
+
+statement ok
+SET CLUSTER SETTING sql.optimizer.uniqueness_checks_for_gen_random_uuid.enabled = false
+
 
 # -- Tests with UPSERT --
 subtest Upsert
@@ -3060,7 +3342,7 @@ vectorized: true
 │       │
 │       └── • hash join (semi)
 │           │ equality: (v, x) = (b, c)
-│           │ pred: column16 != rowid
+│           │ pred: column17 != rowid
 │           │
 │           ├── • scan buffer
 │           │     label: buffer 1
@@ -3076,7 +3358,7 @@ vectorized: true
 │       │
 │       └── • hash join (semi)
 │           │ equality: (k, v, y) = (a, b, d)
-│           │ pred: column16 != rowid
+│           │ pred: column17 != rowid
 │           │
 │           ├── • scan buffer
 │           │     label: buffer 1
@@ -3092,7 +3374,7 @@ vectorized: true
         │
         └── • hash join (semi)
             │ equality: (k) = (a)
-            │ pred: column16 != rowid
+            │ pred: column17 != rowid
             │
             ├── • scan buffer
             │     label: buffer 1
@@ -3545,3 +3827,97 @@ vectorized: true
                         └── • scan buffer
                               columns: (column1, column2, column3, column4, r, s, i, j, upsert_i, r, check1, upsert_r, upsert_s, upsert_j)
                               label: buffer 1
+
+# By default, we do not require checks on UUID columns set to gen_random_uuid(),
+# but we do for UUID columns set to other values.
+query T
+EXPLAIN UPSERT INTO uniq_uuid (id1, id2) VALUES (gen_random_uuid(), '8597b0eb-7b89-4857-858a-fabf86f6a3ac')
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • upsert
+│   │ into: uniq_uuid(id1, id2, rowid)
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • values
+│             size: 3 columns, 1 row
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • hash join (right semi)
+            │ equality: (id2) = (column2)
+            │ right cols are key
+            │ pred: column8 != rowid
+            │
+            ├── • scan
+            │     missing stats
+            │     table: uniq_uuid@primary
+            │     spans: FULL SCAN
+            │
+            └── • scan buffer
+                  label: buffer 1
+
+statement ok
+SET CLUSTER SETTING sql.optimizer.uniqueness_checks_for_gen_random_uuid.enabled = true
+
+# After changing the cluster setting, checks are required for both columns.
+query T
+EXPLAIN UPSERT INTO uniq_uuid (id1, id2) VALUES (gen_random_uuid(), '8597b0eb-7b89-4857-858a-fabf86f6a3ac')
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • upsert
+│   │ into: uniq_uuid(id1, id2, rowid)
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • values
+│             size: 3 columns, 1 row
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • hash join (right semi)
+│           │ equality: (id1) = (column1)
+│           │ right cols are key
+│           │ pred: column8 != rowid
+│           │
+│           ├── • scan
+│           │     missing stats
+│           │     table: uniq_uuid@primary
+│           │     spans: FULL SCAN
+│           │
+│           └── • scan buffer
+│                 label: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • hash join (right semi)
+            │ equality: (id2) = (column2)
+            │ right cols are key
+            │ pred: column8 != rowid
+            │
+            ├── • scan
+            │     missing stats
+            │     table: uniq_uuid@primary
+            │     spans: FULL SCAN
+            │
+            └── • scan buffer
+                  label: buffer 1
+
+statement ok
+SET CLUSTER SETTING sql.optimizer.uniqueness_checks_for_gen_random_uuid.enabled = false

--- a/pkg/sql/opt/optbuilder/BUILD.bazel
+++ b/pkg/sql/opt/optbuilder/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/server/telemetry",
+        "//pkg/settings",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/schemaexpr",

--- a/pkg/sql/opt/optbuilder/mutation_builder_unique.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_unique.go
@@ -12,6 +12,7 @@ package optbuilder
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
@@ -20,6 +21,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
+
+// UniquenessChecksForGenRandomUUIDClusterMode controls the cluster setting for
+// enabling uniqueness checks for UUID columns set to gen_random_uuid().
+var UniquenessChecksForGenRandomUUIDClusterMode = settings.RegisterBoolSetting(
+	"sql.optimizer.uniqueness_checks_for_gen_random_uuid.enabled",
+	"if enabled, uniqueness checks may be planned for mutations of UUID columns updated with"+
+		" gen_random_uuid(); otherwise, uniqueness is assumed due to near-zero collision probability",
+	false,
+).WithPublic()
 
 // buildUniqueChecksForInsert builds uniqueness check queries for an insert.
 // These check queries are used to enforce UNIQUE WITHOUT INDEX constraints.
@@ -196,20 +206,24 @@ func (h *uniqueCheckHelper) init(mb *mutationBuilder, uniqueOrdinal int) bool {
 	h.uniqueOrdinals = uniqueOrds
 	h.primaryKeyOrdinals = primaryOrds
 
-	// Check if we are setting NULL values for the unique columns, like when this
-	// mutation is the result of a SET NULL cascade action.
-	numNullCols := 0
 	for tabOrd, ok := h.uniqueOrdinals.Next(0); ok; tabOrd, ok = h.uniqueOrdinals.Next(tabOrd + 1) {
 		colID := mb.mapToReturnColID(tabOrd)
+		// Check if we are setting NULL values for the unique columns, like when
+		// this mutation is the result of a SET NULL cascade action. If at least one
+		// unique column is getting a NULL value, unique check not needed.
 		if memo.OutputColumnIsAlwaysNull(mb.outScope.expr, colID) {
-			numNullCols++
+			return false
 		}
-	}
 
-	// If at least one unique column is getting a NULL value, unique check not
-	// needed.
-	if numNullCols != 0 {
-		return false
+		// If one of the columns is a UUID set to gen_random_uuid() and we don't
+		// require uniqueness checks for gen_random_uuid(), unique check not needed.
+		if mb.md.ColumnMeta(colID).Type.Family() == types.UuidFamily &&
+			columnIsGenRandomUUID(mb.outScope.expr, colID) {
+			requireCheck := UniquenessChecksForGenRandomUUIDClusterMode.Get(&mb.b.evalCtx.Settings.SV)
+			if !requireCheck {
+				return false
+			}
+		}
 	}
 
 	// Build the scan that will serve as the right side of the semi join in the
@@ -355,4 +369,45 @@ func (h *uniqueCheckHelper) buildTableScan() (outScope *scope, ordinals []int) {
 		noRowLocking,
 		h.mb.b.allocScope(),
 	), ordinals
+}
+
+// columnIsGenRandomUUID returns true if the expression returns the function
+// gen_random_uuid() for the given column.
+func columnIsGenRandomUUID(e memo.RelExpr, col opt.ColumnID) bool {
+	isGenRandomUUIDFunction := func(scalar opt.ScalarExpr) bool {
+		if function, ok := scalar.(*memo.FunctionExpr); ok {
+			if function.Name == "gen_random_uuid" {
+				return true
+			}
+		}
+		return false
+	}
+
+	switch e.Op() {
+	case opt.ProjectOp:
+		p := e.(*memo.ProjectExpr)
+		if p.Passthrough.Contains(col) {
+			return columnIsGenRandomUUID(p.Input, col)
+		}
+		for i := range p.Projections {
+			if p.Projections[i].Col == col {
+				return isGenRandomUUIDFunction(p.Projections[i].Element)
+			}
+		}
+
+	case opt.ValuesOp:
+		v := e.(*memo.ValuesExpr)
+		colOrdinal, ok := v.Cols.Find(col)
+		if !ok {
+			return false
+		}
+		for i := range v.Rows {
+			if !isGenRandomUUIDFunction(v.Rows[i].(*memo.TupleExpr).Elems[colOrdinal]) {
+				return false
+			}
+		}
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
This commit removes uniqueness checks for UUID columns that are set
to `gen_random_uuid()`, because uniqueness can be sufficiently guaranteed
by randomness. The probability of collision when using `gen_random_uuid()`
is extremely low. If users still want the checks, however, they can set
`sql.optimizer.uniqueness_checks_for_gen_random_uuid.enabled`, a new cluster
setting, to true. By default the setting is false.

Fixes #57790

Release justification: This commit is a low-risk update to new functionality.

Release note (sql change): Added a new cluster setting
sql.optimizer.uniqueness_checks_for_gen_random_uuid.enabled, which controls
creation of uniqueness checks for UUID columns set to gen_random_uuid().
When enabled, uniqueness checks will be added for the UUID column if it
has a unique constraint that cannot be enforced by an index. When disabled,
no uniqueness checks are planned for these columns, and uniqueness is
assumed due to the near-zero collision probability of gen_random_uuid()