### PR TITLE
sql: disable comparison of negative int to oid

### DIFF
--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -523,6 +523,9 @@ func AsDBitArray(e Expr) (*DBitArray, bool) {
 var errCannotCastNegativeIntToBitArray = pgerror.Newf(pgcode.CannotCoerce,
 	"cannot cast negative integer to bit varying with unbounded width")
 
+var errCannotCompareNegativeIntToOid = pgerror.Newf(pgcode.CannotCoerce,
+	"cannot compare negative integer to oid")
+
 // NewDBitArrayFromInt creates a bit array from the specified integer
 // at the specified width.
 // If the width is zero, only positive integers can be converted.

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2129,14 +2129,37 @@ var CmpOps = cmpOpFixups(map[ComparisonOperator]cmpOpOverload{
 		makeEqFn(types.Float, types.Int, VolatilityLeakProof),
 		makeEqFn(types.Int, types.Decimal, VolatilityLeakProof),
 		makeEqFn(types.Int, types.Float, VolatilityLeakProof),
-		makeEqFn(types.Int, types.Oid, VolatilityLeakProof),
-		makeEqFn(types.Oid, types.Int, VolatilityLeakProof),
 		makeEqFn(types.Timestamp, types.Date, VolatilityImmutable),
 		makeEqFn(types.Timestamp, types.TimestampTZ, VolatilityStable),
 		makeEqFn(types.TimestampTZ, types.Date, VolatilityStable),
 		makeEqFn(types.TimestampTZ, types.Timestamp, VolatilityStable),
 		makeEqFn(types.Time, types.TimeTZ, VolatilityStable),
 		makeEqFn(types.TimeTZ, types.Time, VolatilityStable),
+
+		&CmpOp{
+			LeftType:  types.Int,
+			RightType: types.Oid,
+			Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
+				i := MustBeDInt(left)
+				if i < 0 {
+					return nil, errCannotCompareNegativeIntToOid
+				}
+				return cmpOpScalarEQFn(ctx, left, right)
+			},
+			Volatility: VolatilityLeakProof,
+		},
+		&CmpOp{
+			LeftType:  types.Oid,
+			RightType: types.Int,
+			Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
+				i := MustBeDInt(right)
+				if i < 0 {
+					return nil, errCannotCompareNegativeIntToOid
+				}
+				return cmpOpScalarEQFn(ctx, left, right)
+			},
+			Volatility: VolatilityLeakProof,
+		},
 
 		// Tuple comparison.
 		&CmpOp{
@@ -2185,14 +2208,37 @@ var CmpOps = cmpOpFixups(map[ComparisonOperator]cmpOpOverload{
 		makeLtFn(types.Float, types.Int, VolatilityLeakProof),
 		makeLtFn(types.Int, types.Decimal, VolatilityLeakProof),
 		makeLtFn(types.Int, types.Float, VolatilityLeakProof),
-		makeLtFn(types.Int, types.Oid, VolatilityLeakProof),
-		makeLtFn(types.Oid, types.Int, VolatilityLeakProof),
 		makeLtFn(types.Timestamp, types.Date, VolatilityImmutable),
 		makeLtFn(types.Timestamp, types.TimestampTZ, VolatilityStable),
 		makeLtFn(types.TimestampTZ, types.Date, VolatilityStable),
 		makeLtFn(types.TimestampTZ, types.Timestamp, VolatilityStable),
 		makeLtFn(types.Time, types.TimeTZ, VolatilityStable),
 		makeLtFn(types.TimeTZ, types.Time, VolatilityStable),
+
+		&CmpOp{
+			LeftType:  types.Int,
+			RightType: types.Oid,
+			Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
+				i := MustBeDInt(left)
+				if i < 0 {
+					return nil, errCannotCompareNegativeIntToOid
+				}
+				return cmpOpScalarLTFn(ctx, left, right)
+			},
+			Volatility: VolatilityLeakProof,
+		},
+		&CmpOp{
+			LeftType:  types.Oid,
+			RightType: types.Int,
+			Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
+				i := MustBeDInt(right)
+				if i < 0 {
+					return nil, errCannotCompareNegativeIntToOid
+				}
+				return cmpOpScalarLTFn(ctx, left, right)
+			},
+			Volatility: VolatilityLeakProof,
+		},
 
 		// Tuple comparison.
 		&CmpOp{
@@ -2241,14 +2287,37 @@ var CmpOps = cmpOpFixups(map[ComparisonOperator]cmpOpOverload{
 		makeLeFn(types.Float, types.Int, VolatilityLeakProof),
 		makeLeFn(types.Int, types.Decimal, VolatilityLeakProof),
 		makeLeFn(types.Int, types.Float, VolatilityLeakProof),
-		makeLeFn(types.Int, types.Oid, VolatilityLeakProof),
-		makeLeFn(types.Oid, types.Int, VolatilityLeakProof),
 		makeLeFn(types.Timestamp, types.Date, VolatilityImmutable),
 		makeLeFn(types.Timestamp, types.TimestampTZ, VolatilityStable),
 		makeLeFn(types.TimestampTZ, types.Date, VolatilityStable),
 		makeLeFn(types.TimestampTZ, types.Timestamp, VolatilityStable),
 		makeLeFn(types.Time, types.TimeTZ, VolatilityStable),
 		makeLeFn(types.TimeTZ, types.Time, VolatilityStable),
+
+		&CmpOp{
+			LeftType:  types.Int,
+			RightType: types.Oid,
+			Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
+				i := MustBeDInt(left)
+				if i < 0 {
+					return nil, errCannotCompareNegativeIntToOid
+				}
+				return cmpOpScalarLEFn(ctx, left, right)
+			},
+			Volatility: VolatilityLeakProof,
+		},
+		&CmpOp{
+			LeftType:  types.Oid,
+			RightType: types.Int,
+			Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
+				i := MustBeDInt(right)
+				if i < 0 {
+					return nil, errCannotCompareNegativeIntToOid
+				}
+				return cmpOpScalarLEFn(ctx, left, right)
+			},
+			Volatility: VolatilityLeakProof,
+		},
 
 		// Tuple comparison.
 		&CmpOp{

--- a/pkg/sql/sem/tree/testdata/eval/oid
+++ b/pkg/sql/sem/tree/testdata/eval/oid
@@ -27,3 +27,33 @@ eval
 1:::OID >= 3:::INT
 ----
 false
+
+eval
+1:::OID = -3:::INT
+----
+cannot compare negative integer to oid
+
+eval
+-1:::INT4 = -1:::OID
+----
+cannot compare negative integer to oid
+
+eval
+1:::OID < -3:::INT
+----
+cannot compare negative integer to oid
+
+eval
+-1:::INT4 < -1:::OID
+----
+cannot compare negative integer to oid
+
+eval
+1:::OID <= -3:::INT
+----
+cannot compare negative integer to oid
+
+eval
+-1:::INT4 <= -1:::OID
+----
+cannot compare negative integer to oid


### PR DESCRIPTION
fixes #60533 

Future work here is to treat OIDs as unsigned 32-bit integers, and to
match the PG semantics of comparing signed integers to unsigned OIDs.

Release note (bug fix): The previous implementation of integer-oid
comparison is incorrect when the integer is negative. This
incorrectness is now fixed by explicitly disallowing negative int
comparison with oids.

Release justification: fix for high-priority bug, which is also
low-risk.