### PR TITLE
sql: fixed information_schema.columns.udt_schema for enum types

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -458,6 +458,15 @@ https://www.postgresql.org/docs/9.5/infoschema-columns.html`,
 				columnID := tree.DInt(column.GetID())
 				description := commentMap[tableID][columnID]
 
+				// udt_schema is set to pg_catalog for builtin types. If, however, the
+				// type is a user defined type, then we should fill this value based on
+				// the schema it is under.
+				udtSchema := pgCatalogNameDString
+				typeMetaName := column.GetType().TypeMeta.Name
+				if typeMetaName != nil {
+					udtSchema = tree.NewDString(typeMetaName.Schema)
+				}
+
 				err := addRow(
 					dbNameStr,                         // table_catalog
 					scNameStr,                         // table_schema
@@ -486,23 +495,23 @@ https://www.postgresql.org/docs/9.5/infoschema-columns.html`,
 					tree.DNull,                                                // domain_schema
 					tree.DNull,                                                // domain_name
 					dbNameStr,                                                 // udt_catalog
-					pgCatalogNameDString,                                      // udt_schema
-					tree.NewDString(column.GetType().PGName()),                // udt_name
-					tree.DNull,                                                // scope_catalog
-					tree.DNull,                                                // scope_schema
-					tree.DNull,                                                // scope_name
-					tree.DNull,                                                // maximum_cardinality
-					tree.DNull,                                                // dtd_identifier
-					tree.DNull,                                                // is_self_referencing
-					tree.DNull,                                                // is_identity
-					tree.DNull,                                                // identity_generation
-					tree.DNull,                                                // identity_start
-					tree.DNull,                                                // identity_increment
-					tree.DNull,                                                // identity_maximum
-					tree.DNull,                                                // identity_minimum
-					tree.DNull,                                                // identity_cycle
-					yesOrNoDatum(column.IsComputed()),                         // is_generated
-					colComputed,                                               // generation_expression
+					udtSchema,                                                 // udt_schema
+					tree.NewDString(column.GetType().PGName()), // udt_name
+					tree.DNull,                        // scope_catalog
+					tree.DNull,                        // scope_schema
+					tree.DNull,                        // scope_name
+					tree.DNull,                        // maximum_cardinality
+					tree.DNull,                        // dtd_identifier
+					tree.DNull,                        // is_self_referencing
+					tree.DNull,                        // is_identity
+					tree.DNull,                        // identity_generation
+					tree.DNull,                        // identity_start
+					tree.DNull,                        // identity_increment
+					tree.DNull,                        // identity_maximum
+					tree.DNull,                        // identity_minimum
+					tree.DNull,                        // identity_cycle
+					yesOrNoDatum(column.IsComputed()), // is_generated
+					colComputed,                       // generation_expression
 					yesOrNoDatum(table.IsTable() &&
 						!table.IsVirtualTable() &&
 						!column.IsComputed(),

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4281,3 +4281,23 @@ other_db       public        t2          d            2
 
 statement ok
 SET DATABASE = test
+
+# Testing udt_type at information_schema.columns
+statement ok
+CREATE DATABASE enum_db;
+SET DATABASE = enum_db;
+CREATE SCHEMA sh;
+CREATE TYPE e AS ENUM ('a', 'b');
+CREATE TYPE sh.d AS ENUM('x', 'y');
+CREATE TABLE t (e e, d sh.d);
+
+query TT colnames
+select udt_schema, udt_name
+from information_schema.columns
+where table_name = 't'
+ORDER BY udt_name
+----
+udt_schema  udt_name
+sh          d
+public      e
+pg_catalog  int8


### PR DESCRIPTION
Previously, udt_schema displayed pg_catalog for any data type
This was inadequate because user defined types may have a different schema
To address this, this patch uses pg_catalog as default but checks for
user defined type's schema if any.

Release justification: bug fixes and low-risk updates to new functionality
Release note (sql change): Fixed information_schema.columns.udt_schema for enum or
user defined types

Fixes #60145