### PR TITLE
release-20.1: lease: fix lease retention bug for tables taken offline

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -391,7 +391,7 @@ CREATE TABLE crdb_internal.leases (
 				ts.mu.Lock()
 				defer ts.mu.Unlock()
 
-				dropped := tree.MakeDBool(tree.DBool(ts.mu.dropped))
+				takenOffline := tree.MakeDBool(tree.DBool(ts.mu.takenOffline))
 
 				for _, state := range ts.mu.active.data {
 					if p.CheckAnyPrivilege(ctx, &state.TableDescriptor) != nil {
@@ -410,7 +410,7 @@ CREATE TABLE crdb_internal.leases (
 						tree.NewDString(state.Name),
 						tree.NewDInt(tree.DInt(int64(state.GetParentID()))),
 						&lease.expiration,
-						dropped,
+						takenOffline,
 					); err != nil {
 						return err
 					}


### PR DESCRIPTION
Tables can temporarily be taken offline, either permanently or
temporarily. For example, executing a DROP TABLE statement will take
a table offline permanently, and an IMPORT INTO will take a table
offline only for the duration of the import and will bring it online
again afterward.

Previously, the lease manager would not distinguish between those two
cases and would behave as if the table was gone forever. As a result any
lease acquired after the table came back online would always be dropped
upon dereferencing. Although this behavior is valid, it is inefficient,
hence this patch.

Fixes #57834.

Release note: None