### PR TITLE
sql: fix TestParallel flakes due to auto stats

### DIFF
--- a/pkg/sql/logictest/BUILD.bazel
+++ b/pkg/sql/logictest/BUILD.bazel
@@ -63,6 +63,7 @@ go_test(
         "//pkg/server",
         "//pkg/sql",
         "//pkg/sql/sessiondata",
+        "//pkg/sql/stats",
         "//pkg/sql/tests",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",

--- a/pkg/sql/logictest/parallel_test.go
+++ b/pkg/sql/logictest/parallel_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -191,6 +192,8 @@ func (t *parallelTest) setup(spec *parTestSpec) {
 		st := server.ClusterSettings()
 		st.Manual.Store(true)
 		sql.DistSQLClusterExecMode.Override(&st.SV, int64(mode))
+		// Disable automatic stats - they can interfere with the test shutdown.
+		stats.AutomaticStatisticsClusterMode.Override(&st.SV, false)
 	}
 
 	t.clients = make([][]*gosql.DB, spec.ClusterSize)


### PR DESCRIPTION
Fixes #61057.

Release justification: test fix

Release note: None