### PR TITLE
ui: change index columns in DbSummaryTables from 'Indices'->'Indexes'

### DIFF
--- a/pkg/ui/src/views/databases/containers/databaseTables/index.tsx
+++ b/pkg/ui/src/views/databases/containers/databaseTables/index.tsx
@@ -153,7 +153,7 @@ export class DatabaseSummaryTables extends DatabaseSummaryBase {
                   sort: (tableInfo) => tableInfo.numColumns,
                 },
                 {
-                  title: "# of Indices",
+                  title: "# of Indexes",
                   cell: (tableInfo) => tableInfo.numIndices,
                   sort: (tableInfo) => tableInfo.numIndices,
                 },


### PR DESCRIPTION
Small cosmetic change to make copy more consistent in the DB Console UI.

Resolves #56385

Release justification: None. Safe, low impact cosmetic change.
Release note: None