### PR TITLE
sql: fix negative int to oid comparison

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -400,3 +400,18 @@ PREPARE regression_56193 AS SELECT $1::regclass;
 EXECUTE regression_56193('regression_53686"'::regclass)
 ----
 "regression_53686"""
+
+query O
+SELECT (-1)::OID
+----
+4294967295
+
+query O
+SELECT (-1)::REGPROC
+----
+4294967295
+
+query O
+SELECT (-1)::REGCLASS
+----
+4294967295

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -4160,11 +4160,13 @@ https://www.postgresql.org/docs/9.6/catalog-pg-aggregate.html`,
 // pg_catalog tables, allowing for reliable joins across tables.
 //
 // In Postgres, oids are physical properties of database objects which are
-// sequentially generated and naturally unique across all objects. See:
-// https://www.postgresql.org/docs/9.6/static/datatype-oid.html.
+// sequentially generated. Postgres does not guarantee database-wide uniqueness
+// of OIDs, especially in large databases, but they are frequently used as the
+// key of unique indexes for pg_catalog tables.
+// See: https://www.postgresql.org/docs/9.6/static/datatype-oid.html.
 // Because Cockroach does not have an equivalent concept, we generate arbitrary
 // fingerprints for database objects with the only requirements being that they
-// are unique across all objects and that they are stable across accesses.
+// are 32 bits and that they are stable across accesses.
 //
 // The type has a few layers of methods:
 // - write<go_type> methods write concrete types to the underlying running hash.

--- a/pkg/sql/sem/tree/casts.go
+++ b/pkg/sql/sem/tree/casts.go
@@ -1292,11 +1292,15 @@ func performCastWithoutPrecisionTruncation(ctx *EvalContext, d Datum, t *types.T
 				return oid, nil
 			}
 		case *DInt:
+			// OIDs are always unsigned 32-bit integers. Some languages, like Java,
+			// store OIDs as signed 32-bit integers, so we implement the cast
+			// by converting to a uint32 first. This matches Postgres behavior.
+			i := DInt(uint32(*v))
 			switch t.Oid() {
 			case oid.T_oid:
-				return &DOid{semanticType: t, DInt: *v}, nil
+				return &DOid{semanticType: t, DInt: i}, nil
 			default:
-				tmpOid := NewDOid(*v)
+				tmpOid := NewDOid(i)
 				oid, err := queryOid(ctx, t, tmpOid)
 				if err != nil {
 					oid = tmpOid

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -679,6 +679,7 @@ func (d *DInt) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
+	thisInt := *d
 	var v DInt
 	switch t := UnwrapDatum(ctx, other).(type) {
 	case *DInt:
@@ -686,14 +687,18 @@ func (d *DInt) Compare(ctx *EvalContext, other Datum) int {
 	case *DFloat, *DDecimal:
 		return -t.Compare(ctx, d)
 	case *DOid:
+		// OIDs are always unsigned 32-bit integers. Some languages, like Java,
+		// compare OIDs to signed 32-bit integers, so we implement the comparison
+		// by converting to a uint32 first. This matches Postgres behavior.
+		thisInt = DInt(uint32(thisInt))
 		v = t.DInt
 	default:
 		panic(makeUnsupportedComparisonMessage(d, other))
 	}
-	if *d < v {
+	if thisInt < v {
 		return -1
 	}
-	if *d > v {
+	if thisInt > v {
 		return 1
 	}
 	return 0
@@ -4200,7 +4205,10 @@ func (d *DEnum) MinWriteable() (Datum, bool) {
 }
 
 // DOid is the Postgres OID datum. It can represent either an OID type or any
-// of the reg* types, such as regproc or regclass.
+// of the reg* types, such as regproc or regclass. An OID must only be
+// 32 bits, since this width encoding is enforced in the pgwire protocol.
+// OIDs are not guaranteed to be globally unique.
+// TODO(rafi): make this use a uint32 instead of a DInt.
 type DOid struct {
 	// A DOid embeds a DInt, the underlying integer OID for this OID datum.
 	DInt
@@ -4501,7 +4509,10 @@ func (d *DOid) Compare(ctx *EvalContext, other Datum) int {
 	case *DOid:
 		v = t.DInt
 	case *DInt:
-		v = *t
+		// OIDs are always unsigned 32-bit integers. Some languages, like Java,
+		// compare OIDs to signed 32-bit integers, so we implement the comparison
+		// by converting to a uint32 first. This matches Postgres behavior.
+		v = DInt(uint32(*t))
 	default:
 		panic(makeUnsupportedComparisonMessage(d, other))
 	}

--- a/pkg/sql/sem/tree/testdata/eval/oid
+++ b/pkg/sql/sem/tree/testdata/eval/oid
@@ -27,3 +27,58 @@ eval
 1:::OID >= 3:::INT
 ----
 false
+
+eval
+4294967295:::OID = -1:::INT4
+----
+true
+
+eval
+4294967293:::OID = -3:::INT2
+----
+true
+
+eval
+4294967196:::OID = -100:::INT8
+----
+true
+
+eval
+-1:::INT4 = 4294967295:::OID
+----
+true
+
+eval
+-3:::INT2 = 4294967293:::OID
+----
+true
+
+eval
+-100:::INT8 = 4294967196:::OID
+----
+true
+
+eval
+-429496719:::INT4 = 3865470577:::OID
+----
+true
+
+eval
+1:::OID < -2:::INT2
+----
+true
+
+eval
+1:::OID >= -3:::INT
+----
+false
+
+eval
+1:::OID > -2:::INT2
+----
+false
+
+eval
+1:::OID <= -3:::INT
+----
+true


### PR DESCRIPTION
fixes #60533 
full fix in place of #61138 

Release note (bug fix): Previously, comparing a negative integer to an
OID would fail to compare correctly because the integer was not
converted to an unsigned representation first. this is now fixed for
both comparisons and casts.

Release justification: High-priority bug fix in existign functionality.