### PR TITLE
jobs: make sure we finish spans if canceled before starting job

### DIFF
--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -849,14 +849,16 @@ func (sj *StartableJob) Start(ctx context.Context) (err error) {
 	if !sj.txn.IsCommitted() {
 		return fmt.Errorf("cannot resume %T job which is not committed", sj.resumer)
 	}
-	if err := sj.started(ctx, nil /* txn */); err != nil {
-		return err
-	}
 
 	finishSpan := func() {
 		if sj.span != nil {
 			sj.span.Finish()
 		}
+	}
+
+	if err := sj.started(ctx, nil /* txn */); err != nil {
+		finishSpan()
+		return err
 	}
 
 	if err := sj.registry.stopper.RunAsyncTask(ctx, sj.taskName(), func(ctx context.Context) {


### PR DESCRIPTION
Was seeing:
```
    testcluster.go:135: condition failed to evaluate within 45s: unexpectedly found active spans:
             0.000ms      0.000ms    === operation:job _unfinished:1 intExec:create-stats
        goroutine 84 [running]:
        runtime/debug.Stack(0xc0086b1890, 0x792e940, 0xc009ac37e0)
        	/usr/local/go/src/runtime/debug/stack.go:24 +0xab
```

In roachprod stressrace with a big cluster. This seemed to fix it.

Release justification: bug fixes and low-risk updates to new functionality.

Release note: None