### PR TITLE
sql: do not set tag about an implicit txn in the span

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -692,7 +692,6 @@ func (s *Server) newConnExecutorWithTxn(
 	)
 	ex.state.resetForNewSQLTxn(
 		ctx,
-		explicitTxn,
 		txn.ReadTimestamp().GoTime(),
 		nil, /* historicalTimestamp */
 		roachpb.UnspecifiedUserPriority,

--- a/pkg/sql/conn_fsm.go
+++ b/pkg/sql/conn_fsm.go
@@ -435,10 +435,8 @@ func noTxnToOpen(args fsm.Args) error {
 	payload := args.Payload.(eventTxnStartPayload)
 	ts := args.Extended.(*txnState)
 
-	txnTyp := explicitTxn
 	advCode := advanceOne
 	if ev.ImplicitTxn.Get() {
-		txnTyp = implicitTxn
 		// For an implicit txn, we want the statement that produced the event to be
 		// executed again (this time in state Open).
 		advCode = stayInPlace
@@ -446,7 +444,6 @@ func noTxnToOpen(args fsm.Args) error {
 
 	ts.resetForNewSQLTxn(
 		connCtx,
-		txnTyp,
 		payload.txnSQLTimestamp,
 		payload.historicalTimestamp,
 		payload.pri,

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -139,7 +139,6 @@ const (
 // tranCtx: A bag of extra execution context.
 func (ts *txnState) resetForNewSQLTxn(
 	connCtx context.Context,
-	txnType txnType,
 	sqlTimestamp time.Time,
 	historicalTimestamp *hlc.Timestamp,
 	priority roachpb.UserPriority,
@@ -164,9 +163,6 @@ func (ts *txnState) resetForNewSQLTxn(
 		traceOpts = append(traceOpts, tracing.WithBypassRegistry())
 	}
 	txnCtx, sp := createRootOrChildSpan(connCtx, opName, tranCtx.tracer, traceOpts...)
-	if txnType == implicitTxn {
-		sp.SetTag("implicit", "true")
-	}
 
 	alreadyRecording := tranCtx.sessionTracing.Enabled()
 	duration := traceTxnThreshold.Get(&tranCtx.settings.SV)


### PR DESCRIPTION
It seems to me that we don't use that tag anywhere(?).

It was added in #22946. This should not be merged (if ever)
until the branch is cut.

Release note: None