### PR TITLE
tracing: do not set tags when setting stats

### DIFF
--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -960,7 +960,6 @@ func (s *vectorizedFlowCreator) setupOutput(
 							// At the last outbox, we can accurately retrieve stats for the
 							// whole flow from parent monitors. These stats are added to a
 							// flow-level span.
-							span.SetTag(execinfrapb.FlowIDTagKey, flowCtx.ID)
 							span.SetSpanStats(&execinfrapb.ComponentStats{
 								Component: execinfrapb.FlowComponentID(base.SQLInstanceID(outputStream.OriginNodeID), flowCtx.ID),
 								FlowStats: execinfrapb.FlowStats{

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -15,31 +15,29 @@ SET vectorize=off; SET tracing = on; BEGIN; SELECT 1; COMMIT; SELECT 2; SET trac
 # how many commands we ran in the session.
 query ITT
 SELECT
-  span, regexp_replace(regexp_replace(message, 'pos:[0-9]*', 'pos:?'), 'flowid: [0-9A-Fa-f-]*', 'flowid: ?'), operation
+  span, regexp_replace(message, 'pos:[0-9]*', 'pos:?'), operation
 FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%SPAN START%' OR message LIKE '%pos%executing%';
 ----
-0                    === SPAN START: session recording ===                session recording
-1                    === SPAN START: exec stmt ===                        exec stmt
-1                    [NoTxn pos:?] executing ExecStmt: BEGIN TRANSACTION  exec stmt
-2                    === SPAN START: sql txn ===                          sql txn
-3                    === SPAN START: exec stmt ===                        exec stmt
-3                    [Open pos:?] executing ExecStmt: SELECT 1            exec stmt
-4                    === SPAN START: consuming rows ===                   consuming rows
-5                    === SPAN START: flow ===
-cockroach.flowid: ?  flow
-6                    === SPAN START: exec stmt ===                        exec stmt
-6                    [Open pos:?] executing ExecStmt: COMMIT TRANSACTION  exec stmt
-7                    === SPAN START: exec stmt ===                        exec stmt
-7                    [NoTxn pos:?] executing ExecStmt: SELECT 2           exec stmt
-8                    === SPAN START: sql txn ===                          sql txn
-9                    === SPAN START: exec stmt ===                        exec stmt
-9                    [Open pos:?] executing ExecStmt: SELECT 2            exec stmt
-10                   === SPAN START: consuming rows ===                   consuming rows
-11                   === SPAN START: flow ===
-cockroach.flowid: ?  flow
-12                   === SPAN START: exec stmt ===                        exec stmt
-12                   [NoTxn pos:?] executing ExecStmt: SET TRACING = off  exec stmt
+0   === SPAN START: session recording ===                session recording
+1   === SPAN START: exec stmt ===                        exec stmt
+1   [NoTxn pos:?] executing ExecStmt: BEGIN TRANSACTION  exec stmt
+2   === SPAN START: sql txn ===                          sql txn
+3   === SPAN START: exec stmt ===                        exec stmt
+3   [Open pos:?] executing ExecStmt: SELECT 1            exec stmt
+4   === SPAN START: consuming rows ===                   consuming rows
+5   === SPAN START: flow ===                             flow
+6   === SPAN START: exec stmt ===                        exec stmt
+6   [Open pos:?] executing ExecStmt: COMMIT TRANSACTION  exec stmt
+7   === SPAN START: exec stmt ===                        exec stmt
+7   [NoTxn pos:?] executing ExecStmt: SELECT 2           exec stmt
+8   === SPAN START: sql txn ===                          sql txn
+9   === SPAN START: exec stmt ===                        exec stmt
+9   [Open pos:?] executing ExecStmt: SELECT 2            exec stmt
+10  === SPAN START: consuming rows ===                   consuming rows
+11  === SPAN START: flow ===                             flow
+12  === SPAN START: exec stmt ===                        exec stmt
+12  [NoTxn pos:?] executing ExecStmt: SET TRACING = off  exec stmt
 
 # ------------------------------------------------------------------------------
 # Numeric References Tests.

--- a/pkg/sql/rowflow/BUILD.bazel
+++ b/pkg/sql/rowflow/BUILD.bazel
@@ -58,5 +58,7 @@ go_test(
         "//pkg/util/randutil",
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_gogo_protobuf//types",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -107,10 +107,10 @@ func TestTrace(t *testing.T) {
 
 				// Check that stat collection from the above SELECT statement is output
 				// to trace. We don't insert any rows in this test, thus the expected
-				// stat value is 0.
+				// num tuples value plus one is 1.
 				rows, err := sqlDB.Query(
 					"SELECT count(message) FROM crdb_internal.session_trace " +
-						"WHERE message LIKE '%cockroach.stat.kv.tuples.read: 0%'",
+						"WHERE message LIKE '%component%num_tuples%value_plus_one:1%'",
 				)
 				if err != nil {
 					t.Fatal(err)

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -314,9 +314,6 @@ func (s *spanInner) SetSpanStats(stats SpanStats) {
 	s.RecordStructured(stats)
 	s.crdb.mu.Lock()
 	s.crdb.mu.stats = stats
-	for name, value := range stats.StatsTags() {
-		s.setTagInner(name, value, true /* locked */)
-	}
 	s.crdb.mu.Unlock()
 }
 


### PR DESCRIPTION
**colflow: do not set redundant tag on the tracing span**

This is unnecessary given that we're setting the componentID below that
includes the flowID.

Release justification: low-risk update to new functionality.

Release note: None

**tracing: do not set tags when setting stats**

We no longer need to set tags on the tracing span in order to propagate
stats since we now propagate that info as a whole object (at the moment,
twice - as a Structured payload and as DeprecatedStats protobuf; the
latter will be removed after 21.1 branch is cut).

Addresses: #59379.

Release justification: low-risk update to new functionality.

Release note: None