### PR TITLE
sql: fix reverting schema changes for databases and schemas

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -719,12 +719,19 @@ func (sc *SchemaChanger) handlePermanentSchemaChangeError(
 	ctx context.Context, err error, evalCtx *extendedEvalContext,
 ) error {
 
-	// Ensure that this mutation is first in line prior to reverting.
+	// Ensure that this is a table descriptor and that the mutation is first in
+	// line prior to reverting.
 	{
 		// Pull out the requested descriptor.
 		desc, descErr := sc.getTargetDescriptor(ctx)
 		if descErr != nil {
 			return descErr
+		}
+		// Currently we don't attempt to roll back schema changes for anything other
+		// than tables. For jobs intended to drop other types of descriptors, we do
+		// nothing.
+		if _, ok := desc.(catalog.TableDescriptor); !ok {
+			return errors.Newf("schema change jobs on databases and schemas cannot be reverted")
 		}
 
 		// Check that we aren't queued behind another schema changer.
@@ -2311,12 +2318,11 @@ func (r schemaChangeResumer) OnFailOrCancel(ctx context.Context, execCtx interfa
 	p := execCtx.(JobExecContext)
 	details := r.job.Details().(jobspb.SchemaChangeDetails)
 
-	if details.DroppedDatabaseID != descpb.InvalidID {
-		// TODO (lucy): Do we need to do anything here?
-		return nil
-	}
+	// If this is a schema change to drop a database or schema, DescID will be
+	// unset. We cannot revert such schema changes, so just exit early with an
+	// error.
 	if details.DescID == descpb.InvalidID {
-		return errors.AssertionFailedf("job has no database ID or table ID")
+		return errors.Newf("schema change jobs on databases and schemas cannot be reverted")
 	}
 	sc := SchemaChanger{
 		descID:               details.DescID,


### PR DESCRIPTION
Previously, we were failing to handle the case where a schema change job
to drop or rename a database or schema entered the reverting state. In
`OnFailOrCancel`, we were always trying to look up the descriptor
associated with the job assuming it was a table. This led to a panic in
20.2. On master we get return an internal error `relation [id] not
found`.

We also had the preexisting behavior that when dropping a database, we
would return nil from `OnFailOrCancel` without indicating anything was
wrong. This is undesirable, since it's abnormal for these jobs to enter
the reverting state, and we can't actually either revert the schema
change or clean up.

This PR adds checks at the top of `OnFailOrCancel` so that we now exit
early with an error if the descriptor is not a table, and makes the
behavior for all database and schema jobs consistent.

Fixes #59415.

Release justification: Fixes for high-priority or high-severity bugs in
existing functionality

Release note (bug fix): Fixed a bug where schema changes on databases
and schemas could return a `relation [<id>] does not exist` if they
failed or were canceled and entered the reverting state. These jobs are
not actually possible to revert. With this change, the correct error
causing the job to fail will be returned, and the job will enter the
failed state with an error indicating that the job could not be
reverted.