### PR TITLE
release-20.2: sql: fix reverting schema changes for databases and schemas

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -6496,3 +6496,99 @@ AND descriptor_ids[1] = 'db.t2'::regclass::int`,
 	require.Equal(t, status, jobs.StatusCanceled)
 	require.Equal(t, error, "job canceled by user")
 }
+
+// TestRevertingJobsOnDatabasesAndSchemas tests that schema change jobs on
+// databases and schemas return an error from the OnFailOrCancel hook.
+// Regression test for #59415.
+func TestRevertingJobsOnDatabasesAndSchemas(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer setTestJobsAdoptInterval()()
+	ctx := context.Background()
+
+	var s serverutils.TestServerInterface
+	params, _ := tests.CreateTestServerParams()
+	params.Knobs = base.TestingKnobs{
+		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+			RunBeforeResume: func(jobID int64) error {
+				scJob, err := s.JobRegistry().(*jobs.Registry).LoadJob(ctx, jobID)
+				if err != nil {
+					return err
+				}
+				pl := scJob.Payload()
+				// This is a hacky way to only inject errors in the rename/drop/grant jobs.
+				if strings.Contains(pl.Description, "updating parent database") {
+					return nil
+				}
+				for _, s := range []string{"DROP", "RENAME", "updating privileges"} {
+					if strings.Contains(pl.Description, s) {
+						return errors.New("injected permanent error")
+					}
+				}
+				return nil
+			},
+		},
+	}
+	var db *gosql.DB
+	s, db, _ = serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+	sqlDB := sqlutils.MakeSQLRunner(db)
+
+	for _, tc := range []struct {
+		name       string
+		setupStmts string
+		scStmt     string
+		jobRegex   string
+	}{
+		{
+			name:       "drop schema",
+			setupStmts: `CREATE DATABASE db_drop_schema; USE db_drop_schema; CREATE SCHEMA sc;`,
+			scStmt:     `DROP SCHEMA sc`,
+			jobRegex:   `^DROP SCHEMA sc$`,
+		},
+		{
+			name:       "rename schema",
+			setupStmts: `CREATE DATABASE db_rename_schema; USE db_rename_schema; CREATE SCHEMA sc;`,
+			scStmt:     `ALTER SCHEMA sc RENAME TO new_name`,
+			jobRegex:   `^ALTER SCHEMA sc RENAME TO new_name$`,
+		},
+		{
+			name:       "grant on schema",
+			setupStmts: `CREATE DATABASE db_grant_on_schema; USE db_grant_on_schema; CREATE SCHEMA sc;`,
+			scStmt:     `GRANT ALL ON SCHEMA sc TO PUBLIC`,
+			jobRegex:   `updating privileges for schema`,
+		},
+		{
+			name:       "drop database cascade",
+			setupStmts: `CREATE DATABASE db_drop; USE db_drop; CREATE SCHEMA sc; CREATE TABLE db_drop.sc.tbl(); USE defaultdb;`,
+			scStmt:     `DROP DATABASE db_drop CASCADE`,
+			jobRegex:   `^DROP DATABASE db_drop CASCADE$`,
+		},
+		{
+			name:       "rename database",
+			setupStmts: `CREATE DATABASE db_rename;`,
+			scStmt:     `ALTER DATABASE db_rename RENAME TO db_new_name`,
+			jobRegex:   `^ALTER DATABASE db_rename RENAME TO db_new_name$`,
+		},
+		{
+			name:       "grant on database",
+			setupStmts: `CREATE DATABASE db_grant`,
+			scStmt:     `GRANT ALL ON DATABASE db_grant TO PUBLIC`,
+			jobRegex:   `updating privileges for database`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sqlDB.Exec(t, tc.setupStmts)
+			sqlDB.ExpectErr(t, "injected permanent error", tc.scStmt)
+			result := sqlDB.QueryStr(t,
+				`SELECT status, error FROM crdb_internal.jobs WHERE description ~ $1`,
+				tc.jobRegex)
+			require.Len(t, result, 1)
+			status, jobError := result[0][0], result[0][1]
+			require.Equal(t, string(jobs.StatusFailed), status)
+			require.Regexp(t,
+				"cannot be reverted, manual cleanup may be required: "+
+					"schema change jobs on databases and schemas cannot be reverted",
+				jobError)
+		})
+	}
+}


### PR DESCRIPTION
Backport 1/1 commits from #61159.

/cc @cockroachdb/release

---

Previously, we were failing to handle the case where a schema change job
to drop or rename a database or schema entered the reverting state. In
`OnFailOrCancel`, we were always trying to look up the descriptor
associated with the job assuming it was a table. This led to a panic in
20.2. On master we get return an internal error `relation [id] not
found`.

We also had the preexisting behavior that when dropping a database, we
would return nil from `OnFailOrCancel` without indicating anything was
wrong. This is undesirable, since it's abnormal for these jobs to enter
the reverting state, and we can't actually either revert the schema
change or clean up.

This PR adds checks at the top of `OnFailOrCancel` so that we now exit
early with an error if the descriptor is not a table, and makes the
behavior for all database and schema jobs consistent.

Fixes #59415.

Release note (bug fix): Fixed a bug where schema changes on databases
and schemas could panic in 20.2 if they failed or were canceled and
entered the reverting state. These jobs are not actually possible to
revert. With this change, the correct error causing the job to fail will
be returned, and the job will enter the failed state with an error
indicating that the job could not be reverted.