### PR TITLE
jobs: do not emit an error when resuming already completed job

### DIFF
--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -164,6 +164,10 @@ FROM system.jobs WHERE id = $1 AND claim_session_id = $2`,
 	}
 
 	status := Status(*row[0].(*tree.DString))
+	if status == StatusSucceeded {
+		// A concurrent registry could have already executed the job.
+		return nil
+	}
 	if status != StatusRunning && status != StatusReverting {
 		// A concurrent registry could have requested the job to be paused or canceled.
 		return errors.Errorf("job %d: status changed to %s which is not resumable`", jobID, status)


### PR DESCRIPTION
It is expected that when querying the status of a job to be resumed we
might see that it is already in `Succeeded` status, and in such scenario
we should not be returning an error (which would get logged and be
annoying).

Release justification: bug fix.

Release note: None