### PR TITLE
sql/pgwire: fix decoding of enum arrays in binary format

### DIFF
--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -483,7 +483,7 @@ func DecodeDatum(
 			}
 			return tree.ParseDJSON(string(b))
 		}
-		if _, ok := types.ArrayOids[id]; ok {
+		if t.Family() == types.ArrayFamily {
 			// Arrays come in in their string form, so we parse them as such and later
 			// convert them to their actual datum form.
 			if err := validateStringBytes(b); err != nil {
@@ -756,8 +756,8 @@ func DecodeDatum(
 			ba, err := bitarray.FromEncodingParts(words, lastBitsUsed)
 			return &tree.DBitArray{BitArray: ba}, err
 		default:
-			if _, ok := types.ArrayOids[id]; ok {
-				return decodeBinaryArray(evalCtx, types.OidToType[id].ArrayContents(), b, code)
+			if t.Family() == types.ArrayFamily {
+				return decodeBinaryArray(evalCtx, t.ArrayContents(), b, code)
 			}
 		}
 	default:
@@ -917,7 +917,7 @@ func decodeBinaryArray(
 	if t.Oid() != oid.Oid(hdr.ElemOid) {
 		return nil, pgerror.Newf(pgcode.DatatypeMismatch, "wrong element type")
 	}
-	arr := tree.NewDArray(types.OidToType[t.Oid()])
+	arr := tree.NewDArray(t)
 	if hdr.Ndims == 0 {
 		return arr, nil
 	}

--- a/pkg/sql/pgwire/testdata/pgtest/enum
+++ b/pkg/sql/pgwire/testdata/pgtest/enum
@@ -116,3 +116,62 @@ ReadyForQuery
 {"Type":"BindComplete"}
 {"Type":"CommandComplete","CommandTag":"INSERT 0 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "DROP TABLE IF EXISTS tba"}
+----
+
+until ignore=NoticeResponse
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DROP TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "CREATE TABLE tba (x te[])"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Prepare a query and use the binary format (ParameterFormatCodes = [1])
+# This is crdb_only because the OID is part of the binary encoding, but
+# PG and CRDB assign different OIDs for custom types.
+send crdb_only
+Parse {"Name": "s3", "Query": "SELECT '{hi}'::te[]"}
+Bind {"DestinationPortal": "p3", "PreparedStatement": "s3", "ResultFormatCodes": [1]}
+Execute {"Portal": "p3"}
+Sync
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"binary":"0000000100000000000186d40000000100000001000000026869"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+
+# Prepare a query and use the binary format (ParameterFormatCodes = [1])
+# This is crdb_only because the OID is part of the binary encoding, but
+# PG and CRDB assign different OIDs for custom types.
+# The "Parameters" field is the byte array representation of the binary string above.
+send crdb_only
+Parse {"Name": "s4", "Query": "INSERT INTO tba VALUES ($1)"}
+Bind {"DestinationPortal": "p4", "PreparedStatement": "s4", "ParameterFormatCodes": [1], "Parameters": [[0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 134, 212, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 2, 104, 105]]}
+Execute {"Portal": "p4"}
+Sync
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"INSERT 0 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}


### PR DESCRIPTION
fixes #61046 

Release note (bug fix): Previously, CockroachDB could not decode arrays
of user-defined types when sent to the server in the binary format. Now
it can.

Release justification: low-risk, high-benefit bugfix to existing
functionality.