### PR TITLE
release-20.2: sql: fix negative int to oid comparison

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -355,3 +355,18 @@ FROM
       (d.adrelid = a.attrelid AND d.adnum = a.attnum)
   JOIN (SELECT 1 AS oid, 1 AS attnum) AS vals ON
       (c.oid = vals.oid AND a.attnum = vals.attnum);
+
+query O
+SELECT (-1)::OID
+----
+4294967295
+
+query O
+SELECT (-1)::REGPROC
+----
+4294967295
+
+query O
+SELECT (-1)::REGCLASS
+----
+4294967295

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2619,11 +2619,13 @@ https://www.postgresql.org/docs/9.6/catalog-pg-aggregate.html`,
 // pg_catalog tables, allowing for reliable joins across tables.
 //
 // In Postgres, oids are physical properties of database objects which are
-// sequentially generated and naturally unique across all objects. See:
-// https://www.postgresql.org/docs/9.6/static/datatype-oid.html.
+// sequentially generated. Postgres does not guarantee database-wide uniqueness
+// of OIDs, especially in large databases, but they are frequently used as the
+// key of unique indexes for pg_catalog tables.
+// See: https://www.postgresql.org/docs/9.6/static/datatype-oid.html.
 // Because Cockroach does not have an equivalent concept, we generate arbitrary
 // fingerprints for database objects with the only requirements being that they
-// are unique across all objects and that they are stable across accesses.
+// are 32 bits and that they are stable across accesses.
 //
 // The type has a few layers of methods:
 // - write<go_type> methods write concrete types to the underlying running hash.

--- a/pkg/sql/sem/tree/casts.go
+++ b/pkg/sql/sem/tree/casts.go
@@ -1062,11 +1062,15 @@ func PerformCast(ctx *EvalContext, d Datum, t *types.T) (Datum, error) {
 				return oid, nil
 			}
 		case *DInt:
+			// OIDs are always unsigned 32-bit integers. Some languages, like Java,
+			// store OIDs as signed 32-bit integers, so we implement the cast
+			// by converting to a uint32 first. This matches Postgres behavior.
+			i := DInt(uint32(*v))
 			switch t.Oid() {
 			case oid.T_oid:
-				return &DOid{semanticType: t, DInt: *v}, nil
+				return &DOid{semanticType: t, DInt: i}, nil
 			default:
-				tmpOid := NewDOid(*v)
+				tmpOid := NewDOid(i)
 				oid, err := queryOid(ctx, t, tmpOid)
 				if err != nil {
 					oid = tmpOid

--- a/pkg/sql/sem/tree/testdata/eval/oid
+++ b/pkg/sql/sem/tree/testdata/eval/oid
@@ -27,3 +27,58 @@ eval
 1:::OID >= 3:::INT
 ----
 false
+
+eval
+4294967295:::OID = -1:::INT4
+----
+true
+
+eval
+4294967293:::OID = -3:::INT2
+----
+true
+
+eval
+4294967196:::OID = -100:::INT8
+----
+true
+
+eval
+-1:::INT4 = 4294967295:::OID
+----
+true
+
+eval
+-3:::INT2 = 4294967293:::OID
+----
+true
+
+eval
+-100:::INT8 = 4294967196:::OID
+----
+true
+
+eval
+-429496719:::INT4 = 3865470577:::OID
+----
+true
+
+eval
+1:::OID < -2:::INT2
+----
+true
+
+eval
+1:::OID >= -3:::INT
+----
+false
+
+eval
+1:::OID > -2:::INT2
+----
+false
+
+eval
+1:::OID <= -3:::INT
+----
+true


### PR DESCRIPTION
Backport 1/1 commits from #61148.
This was a clean backport.

/cc @cockroachdb/release

---

fixes #60533 
full fix in place of #61138 

Release note (bug fix): Previously, comparing a negative integer to an
OID would fail to compare correctly because the integer was not
converted to an unsigned representation first. This is now fixed for
both comparisons and casts.

Release justification: High-priority bug fix in existing functionality.
