### PR TITLE
multiregionccl: gate ADD REGION under ccl / enterprise license

### DIFF
--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/sql",
         "//pkg/sql/catalog/catalogkv",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/typedesc",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/tree",

--- a/pkg/ccl/multiregionccl/multiregion_test.go
+++ b/pkg/ccl/multiregionccl/multiregion_test.go
@@ -68,13 +68,23 @@ CREATE TABLE t4 () LOCALITY REGIONAL BY ROW
 
 	// Test certain commands are no longer usable.
 	t.Run("no new multi-region items", func(t *testing.T) {
-		for _, errorStmt := range []string{
-			`CREATE DATABASE db WITH PRIMARY REGION "us-east1" REGIONS "us-east2"`,
+		for _, tc := range []struct {
+			stmt             string
+			expectedContains string
+		}{
+			{
+				stmt:             `CREATE DATABASE db WITH PRIMARY REGION "us-east1" REGIONS "us-east2"`,
+				expectedContains: multiRegionNoEnterpriseContains,
+			},
+			{
+				stmt:             `ALTER DATABASE test ADD REGION "us-east3"`,
+				expectedContains: "use of ADD REGION requires an enterprise license",
+			},
 		} {
-			t.Run(errorStmt, func(t *testing.T) {
-				_, err := sqlDB.Exec(errorStmt)
+			t.Run(tc.stmt, func(t *testing.T) {
+				_, err := sqlDB.Exec(tc.stmt)
 				require.Error(t, err)
-				require.Contains(t, err.Error(), multiRegionNoEnterpriseContains)
+				require.Contains(t, err.Error(), tc.expectedContains)
 			})
 		}
 	})


### PR DESCRIPTION
Release note (enterprise change): ALTER DATABASE ... ADD REGION ... now
requires an enterprise license.

Release justification: low risk fix for new functionality

