### PR TITLE
kvserver: remove `kv.atomic_replication_changes.enabled` setting

### DIFF
--- a/pkg/kv/kvserver/allocator_test.go
+++ b/pkg/kv/kvserver/allocator_test.go
@@ -1075,8 +1075,6 @@ func TestAllocatorRebalanceDeadNodes(t *testing.T) {
 	}{
 		// 3/3 live -> 3/4 live: ok
 		{replicas(1, 2, 3), 6},
-		// 2/3 live -> 2/4 live: nope
-		{replicas(1, 2, 7), 0},
 		// 4/4 live -> 4/5 live: ok
 		{replicas(1, 2, 3, 4), 6},
 		// 3/4 live -> 3/5 live: ok
@@ -1085,8 +1083,6 @@ func TestAllocatorRebalanceDeadNodes(t *testing.T) {
 		{replicas(1, 2, 3, 4, 5), 6},
 		// 4/5 live -> 4/6 live: ok
 		{replicas(1, 2, 3, 4, 7), 6},
-		// 3/5 live -> 3/6 live: nope
-		{replicas(1, 2, 3, 7, 8), 0},
 	}
 
 	for _, c := range testCases {

--- a/pkg/kv/kvserver/client_atomic_membership_change_test.go
+++ b/pkg/kv/kvserver/client_atomic_membership_change_test.go
@@ -48,9 +48,6 @@ func TestAtomicReplicationChange(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, 6, args)
 	defer tc.Stopper().Stop(ctx)
 
-	_, err := tc.ServerConn(0).Exec(`SET CLUSTER SETTING kv.atomic_replication_changes.enabled = true`)
-	require.NoError(t, err)
-
 	// Create a range and put it on n1, n2, n3. Intentionally do this one at a
 	// time so we're not using atomic replication changes yet.
 	k := tc.ScratchRange(t)

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -85,14 +85,6 @@ var disableSyncRaftLog = settings.RegisterBoolSetting(
 	false,
 )
 
-// UseAtomicReplicationChanges determines whether to issue atomic replication changes.
-// This has no effect until the cluster version is 19.2 or higher.
-var UseAtomicReplicationChanges = settings.RegisterBoolSetting(
-	"kv.atomic_replication_changes.enabled",
-	"use atomic replication changes",
-	true,
-)
-
 // MaxCommandSizeFloor is the minimum allowed value for the MaxCommandSize
 // cluster setting.
 const MaxCommandSizeFloor = 4 << 20 // 4MB

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -958,23 +958,6 @@ func (r *Replica) ChangeReplicas(
 			return nil, errors.New("must disable replicate queue to use ChangeReplicas manually")
 		}
 	}
-
-	// We execute the change serially if we're not allowed to run atomic
-	// replication changes or if that was explicitly disabled.
-	st := r.ClusterSettings()
-	unroll := !UseAtomicReplicationChanges.Get(&st.SV)
-	if unroll {
-		// Legacy behavior.
-		for i := range chgs {
-			var err error
-			desc, err = r.changeReplicasImpl(ctx, desc, priority, reason, details, chgs[i:i+1])
-			if err != nil {
-				return nil, err
-			}
-		}
-		return desc, nil
-	}
-	// Atomic replication change.
 	return r.changeReplicasImpl(ctx, desc, priority, reason, details, chgs)
 }
 

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -868,9 +868,6 @@ func TestLearnerOrJointConfigAdminRelocateRange(t *testing.T) {
 	})
 	defer tc.Stopper().Stop(ctx)
 
-	_, err := tc.Conns[0].Exec(`SET CLUSTER SETTING kv.atomic_replication_changes.enabled = true`)
-	require.NoError(t, err)
-
 	scratchStartKey := tc.ScratchRange(t)
 	ltk.withStopAfterLearnerAtomic(func() {
 		_ = tc.AddVotersOrFatal(t, scratchStartKey, tc.Target(1))

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -46,13 +46,6 @@ func TestReplicateQueueRebalance(t *testing.T) {
 
 	// This test was seen taking north of 20m under race.
 	skip.UnderRace(t)
-
-	testutils.RunTrueAndFalse(t, "atomic", func(t *testing.T, atomic bool) {
-		testReplicateQueueRebalanceInner(t, atomic)
-	})
-}
-
-func testReplicateQueueRebalanceInner(t *testing.T, atomic bool) {
 	skip.UnderShort(t)
 
 	const numNodes = 5
@@ -72,9 +65,6 @@ func testReplicateQueueRebalanceInner(t *testing.T, atomic bool) {
 		st := server.ClusterSettings()
 		st.Manual.Store(true)
 		kvserver.LoadBasedRebalancingMode.Override(&st.SV, int64(kvserver.LBRebalancingOff))
-		// NB: usually it's preferred to set the cluster settings, but this is less
-		// boilerplate than setting it and then waiting for all nodes to have it.
-		kvserver.UseAtomicReplicationChanges.Override(&st.SV, atomic)
 	}
 
 	const newRanges = 10
@@ -153,11 +143,7 @@ func testReplicateQueueRebalanceInner(t *testing.T, atomic bool) {
 		// If we have atomic changes enabled, we expect to never see four replicas
 		// on our tracked ranges. If we don't have atomic changes, we can't avoid
 		// it.
-		if atomic {
-			t.Error(info)
-		} else {
-			t.Log(info)
-		}
+		t.Error(info)
 	}
 }
 

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -76,6 +76,7 @@ var retiredSettings = map[string]struct{}{
 	"sql.testing.vectorize.batch_size":      {},
 	"sql.testing.mutations.max_batch_size":  {},
 	"sql.testing.mock_contention.enabled":   {},
+	"kv.atomic_replication_changes.enabled": {},
 }
 
 // register adds a setting to the registry.


### PR DESCRIPTION
This setting was added in 19.2 to provide a fallback against atomic
replication changes. They've now been a part of CockroachDB for over 3
releases. They're also a requirement for non-voting replicas.

Release note (backward-incompatible change): Removed the
`kv.atomic_replication_changes.enabled` cluster setting. All replication
changes on a range now use joint-consensus.