### PR TITLE
sql: full table scan metric no longer counts limit scans

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/limit
+++ b/pkg/sql/logictest/testdata/logic_test/limit
@@ -319,3 +319,15 @@ SELECT a FROM probe ORDER BY a LIMIT (SELECT v FROM vals WHERE k = 'large') OFFS
 query I
 SELECT a FROM probe ORDER BY a LIMIT (SELECT v FROM vals WHERE k = 'maxint64') OFFSET (SELECT v FROM vals WHERE k = 'maxint64');
 ----
+
+# Regression test for incorrectly treating LIMIT query as containing full scan (Issue #60751).
+statement ok
+SET disallow_full_table_scans = true;
+
+query I
+SELECT w FROM t ORDER BY k LIMIT 1;
+----
+1
+
+statement ok
+SET disallow_full_table_scans = false;

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -598,7 +598,7 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 
 	// Save if we planned a full table/index scan on the builder so that the
 	// planner can be made aware later. We only do this for non-virtual tables.
-	if !tab.IsVirtualTable() && scan.Constraint == nil && scan.InvertedConstraint == nil {
+	if !tab.IsVirtualTable() && scan.Constraint == nil && scan.InvertedConstraint == nil && !scan.HardLimit.IsSet() {
 		if scan.Index == cat.PrimaryIndex {
 			b.ContainsFullTableScan = true
 		} else {


### PR DESCRIPTION
Previous full table / index scan queries were counted
as limit scans, now limit scans are no longer counted.

Fixes: #60751

Release justification: bug fix and low-risk update

Release note (bug fix): limit scans are no longer counted
as full scans