### PR TITLE
sql: remove unique constraint on rowid for implicitly partitioned table

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -681,6 +681,40 @@ INSERT INTO t VALUES (1, 1, 1, 1, 1, 1, 1), (2, 2, 2, 2, 2, 2, 2)
 statement error pq: duplicate key value violates unique constraint "t_b_key"\nDETAIL: Key \(b\)=\(1\) already exists\.
 UPDATE t SET b = 1 WHERE pk = 2
 
+# Create a table without an explicit primary key.
+statement ok
+CREATE TABLE no_pk (
+  i INT NOT NULL
+) PARTITION ALL BY LIST (i) (
+  PARTITION one VALUES IN ((1)),
+  PARTITION two VALUES IN ((2))
+)
+
+# We don't require the rowid to be unique in implicitly partitioned tables, so
+# there should be no uniqueness check.
+query T
+EXPLAIN INSERT INTO no_pk (rowid, i) VALUES (1, 1)
+----
+distribution: local
+vectorized: true
+·
+• insert
+│ into: no_pk(i, rowid)
+│ auto commit
+│
+└── • values
+      size: 2 columns, 1 row
+
+statement ok
+INSERT INTO no_pk (rowid, i) VALUES (1, 1), (1, 2)
+
+query II
+SELECT rowid, i FROM no_pk
+----
+1  1
+1  2
+
+
 subtest upsert
 
 # The conflict columns in an upsert should only include the primary key,

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -1039,6 +1039,59 @@ CREATE TABLE public.regional_by_row_table_pk_defined_separately (
                             FAMILY "primary" (pk, crdb_region)
 ) LOCALITY REGIONAL BY ROW
 
+
+# Tests using a table without an explicit primary key.
+statement ok
+CREATE TABLE regional_by_row_no_pk (
+  i INT
+) LOCALITY REGIONAL BY ROW
+
+# We don't require the rowid to be unique in REGIONAL BY ROW tables, so there
+# should be no uniqueness check.
+query T
+EXPLAIN INSERT INTO regional_by_row_no_pk (rowid, i) VALUES (1, 1)
+----
+distribution: local
+vectorized: true
+·
+• insert
+│ into: regional_by_row_no_pk(i, crdb_region, rowid)
+│ auto commit
+│
+└── • values
+      size: 4 columns, 1 row
+
+statement ok
+INSERT INTO regional_by_row_no_pk (crdb_region, rowid, i) VALUES ('us-east-1', 1, 1), ('ca-central-1', 1, 1)
+
+query TII
+SELECT crdb_region, rowid, i FROM regional_by_row_no_pk
+----
+ca-central-1  1  1
+us-east-1     1  1
+
+# Trying to change locality should fail since the new primary key will not be
+# unique.
+statement error pq: failed to ingest index entries during backfill: duplicate key value violates unique constraint "primary"\nDETAIL: Key \(rowid\)=\(1\) already exists\.
+ALTER TABLE regional_by_row_no_pk SET LOCALITY REGIONAL BY TABLE
+
+statement error pq: failed to ingest index entries during backfill: duplicate key value violates unique constraint "primary"\nDETAIL: Key \(rowid\)=\(1\) already exists\.
+ALTER TABLE regional_by_row_no_pk SET LOCALITY GLOBAL
+
+query T
+SELECT
+  create_statement
+FROM [SHOW CREATE TABLE regional_by_row_no_pk]
+----
+CREATE TABLE public.regional_by_row_no_pk (
+                            i INT8 NULL,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                            CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+                            FAMILY "primary" (i, crdb_region, rowid)
+) LOCALITY REGIONAL BY ROW
+
+
 # Tests for REGIONAL BY TABLE AS
 statement error cannot use column crdb_region_col which has type INT8 in REGIONAL BY ROW\nDETAIL: REGIONAL BY ROW AS must reference a column of type crdb_internal_region
 CREATE TABLE regional_by_row_table_as (


### PR DESCRIPTION
This commit removes the optimizer's unique without index constraint on the
automatically generated `rowid` column created for implicitly partitioned
and `REGIONAL BY ROW` tables that do not have an explicit primary
index. As a result, the optimizer does not treat the `rowid` column as a
key, and no uniqueness checks are planned for the `rowid` column when the
table is mutated.

There is no need for this column to be unique, since its only purpose is
to help create a key for the primary index. The combination of
`rowid` + partitioning column(s) is that key, and it is guaranteed to be
unique by the index itself. We don't need to enforce additional uniqueness
on part of that key.

Fixes #61030

Release justification: This commit is a low-risk update to new
functionality.

Release note (sql change): The optimizer no longer plans uniqueness checks
for implicitly partitioned and REGIONAL BY ROW tables on the automatically
generated rowid column that is created when a table has no explicit
primary key. As a result, this column is not guaranteed to be unique. The
primary key for the table is the combination of the implicit partitioning
columns and the rowid, which is guaranteed to be unique by the primary
index.

Release note (performance improvement): The optimizer no longer plans
uniqueness checks for implicitly partitioned and REGIONAL BY ROW tables
on the automatically generated rowid column that is created when a table
has no explicit primary key. As a result, INSERTs, UPDATEs and UPSERTs
on these tables are more efficient.