### PR TITLE
opt: remove unique checks for constraints used as arbiters

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -715,23 +715,6 @@ vectorized: true
 │                         table: t@primary
 │                         spans: FULL SCAN
 │
-├── • constraint-check
-│   │
-│   └── • error if rows
-│       │
-│       └── • hash join (right semi)
-│           │ equality: (pk) = (upsert_pk)
-│           │ right cols are key
-│           │ pred: column3 != partition_by
-│           │
-│           ├── • scan
-│           │     missing stats
-│           │     table: t@t_a_idx
-│           │     spans: FULL SCAN
-│           │
-│           └── • scan buffer
-│                 label: buffer 1
-│
 └── • constraint-check
     │
     └── • error if rows

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -759,26 +759,8 @@ vectorized: true
 │   └── • error if rows
 │       │
 │       └── • lookup join (semi)
-│           │ table: regional_by_row_table@primary
-│           │ equality: (lookup_join_const_col_@33, upsert_pk) = (crdb_region,pk)
-│           │ equality cols are key
-│           │ pred: column1 != crdb_region
-│           │
-│           └── • cross join
-│               │
-│               ├── • values
-│               │     size: 1 column, 3 rows
-│               │
-│               └── • scan buffer
-│                     label: buffer 1
-│
-├── • constraint-check
-│   │
-│   └── • error if rows
-│       │
-│       └── • lookup join (semi)
 │           │ table: regional_by_row_table@regional_by_row_table_b_key
-│           │ equality: (lookup_join_const_col_@48, column5) = (crdb_region,b)
+│           │ equality: (lookup_join_const_col_@33, column5) = (crdb_region,b)
 │           │ equality cols are key
 │           │ pred: (upsert_pk != pk) OR (column1 != crdb_region)
 │           │
@@ -796,7 +778,7 @@ vectorized: true
         │
         └── • lookup join (semi)
             │ table: regional_by_row_table@new_idx
-            │ equality: (lookup_join_const_col_@63, column4, column5) = (crdb_region,a,b)
+            │ equality: (lookup_join_const_col_@48, column4, column5) = (crdb_region,a,b)
             │ equality cols are key
             │ pred: (upsert_pk != pk) OR (column1 != crdb_region)
             │
@@ -842,26 +824,8 @@ vectorized: true
 │   └── • error if rows
 │       │
 │       └── • lookup join (semi)
-│           │ table: regional_by_row_table@primary
-│           │ equality: (lookup_join_const_col_@33, upsert_pk) = (crdb_region,pk)
-│           │ equality cols are key
-│           │ pred: column1 != crdb_region
-│           │
-│           └── • cross join
-│               │
-│               ├── • values
-│               │     size: 1 column, 3 rows
-│               │
-│               └── • scan buffer
-│                     label: buffer 1
-│
-├── • constraint-check
-│   │
-│   └── • error if rows
-│       │
-│       └── • lookup join (semi)
 │           │ table: regional_by_row_table@regional_by_row_table_b_key
-│           │ equality: (lookup_join_const_col_@48, column5) = (crdb_region,b)
+│           │ equality: (lookup_join_const_col_@33, column5) = (crdb_region,b)
 │           │ equality cols are key
 │           │ pred: (upsert_pk != pk) OR (column1 != crdb_region)
 │           │
@@ -879,7 +843,7 @@ vectorized: true
         │
         └── • lookup join (semi)
             │ table: regional_by_row_table@new_idx
-            │ equality: (lookup_join_const_col_@63, column4, column5) = (crdb_region,a,b)
+            │ equality: (lookup_join_const_col_@48, column4, column5) = (crdb_region,a,b)
             │ equality cols are key
             │ pred: (upsert_pk != pk) OR (column1 != crdb_region)
             │

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -326,123 +326,69 @@ vectorized: true
 
 # Use all the unique indexes and constraints as arbiters for DO NOTHING with no
 # conflict columns.
-# TODO(rytaft): we should be able to remove the unique checks in this case
-# (see #59119).
 query T
 EXPLAIN (VERBOSE) INSERT INTO uniq VALUES (1, 2, 3, 4, 5) ON CONFLICT DO NOTHING
 ----
 distribution: local
 vectorized: true
 ·
-• root
+• insert
 │ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: uniq(k, v, w, x, y)
+│ auto commit
+│ arbiter indexes: primary, uniq_v_key
+│ arbiter constraints: unique_w, unique_x_y
 │
-├── • insert
-│   │ columns: ()
-│   │ estimated row count: 0 (missing stats)
-│   │ into: uniq(k, v, w, x, y)
-│   │ arbiter indexes: primary, uniq_v_key
-│   │ arbiter constraints: unique_w, unique_x_y
-│   │
-│   └── • buffer
-│       │ columns: (column1, column2, column3, column4, column5)
-│       │ label: buffer 1
-│       │
-│       └── • cross join (right anti)
-│           │ columns: (column1, column2, column3, column4, column5)
-│           │ estimated row count: 0 (missing stats)
-│           │
-│           ├── • scan
-│           │     columns: (k)
-│           │     estimated row count: 1 (missing stats)
-│           │     table: uniq@primary
-│           │     spans: /1/0-/1/1
-│           │
-│           └── • hash join (right anti)
-│               │ columns: (column1, column2, column3, column4, column5)
-│               │ estimated row count: 0 (missing stats)
-│               │ equality: (w) = (column3)
-│               │ right cols are key
-│               │
-│               ├── • scan
-│               │     columns: (w)
-│               │     estimated row count: 1,000 (missing stats)
-│               │     table: uniq@primary
-│               │     spans: FULL SCAN
-│               │
-│               └── • lookup join (anti)
-│                   │ columns: (column1, column2, column3, column4, column5)
-│                   │ estimated row count: 0 (missing stats)
-│                   │ table: uniq@uniq_v_key
-│                   │ equality: (column2) = (v)
-│                   │ equality cols are key
-│                   │
-│                   └── • hash join (right anti)
-│                       │ columns: (column1, column2, column3, column4, column5)
-│                       │ estimated row count: 0 (missing stats)
-│                       │ equality: (x, y) = (column4, column5)
-│                       │ right cols are key
-│                       │
-│                       ├── • scan
-│                       │     columns: (x, y)
-│                       │     estimated row count: 1,000 (missing stats)
-│                       │     table: uniq@primary
-│                       │     spans: FULL SCAN
-│                       │
-│                       └── • values
-│                             columns: (column1, column2, column3, column4, column5)
-│                             size: 5 columns, 1 row
-│                             row 0, expr 0: 1
-│                             row 0, expr 1: 2
-│                             row 0, expr 2: 3
-│                             row 0, expr 3: 4
-│                             row 0, expr 4: 5
-│
-├── • constraint-check
-│   │
-│   └── • error if rows
-│       │ columns: ()
-│       │
-│       └── • hash join (right semi)
-│           │ columns: (column1, column2, column3, column4, column5)
-│           │ estimated row count: 0 (missing stats)
-│           │ equality: (w) = (column3)
-│           │ right cols are key
-│           │ pred: column1 != k
-│           │
-│           ├── • scan
-│           │     columns: (k, w)
-│           │     estimated row count: 1,000 (missing stats)
-│           │     table: uniq@primary
-│           │     spans: FULL SCAN
-│           │
-│           └── • scan buffer
-│                 columns: (column1, column2, column3, column4, column5)
-│                 estimated row count: 0 (missing stats)
-│                 label: buffer 1
-│
-└── • constraint-check
+└── • cross join (right anti)
+    │ columns: (column1, column2, column3, column4, column5)
+    │ estimated row count: 0 (missing stats)
     │
-    └── • error if rows
-        │ columns: ()
+    ├── • scan
+    │     columns: (k)
+    │     estimated row count: 1 (missing stats)
+    │     table: uniq@primary
+    │     spans: /1/0-/1/1
+    │
+    └── • hash join (right anti)
+        │ columns: (column1, column2, column3, column4, column5)
+        │ estimated row count: 0 (missing stats)
+        │ equality: (w) = (column3)
+        │ right cols are key
         │
-        └── • hash join (right semi)
+        ├── • scan
+        │     columns: (w)
+        │     estimated row count: 1,000 (missing stats)
+        │     table: uniq@primary
+        │     spans: FULL SCAN
+        │
+        └── • lookup join (anti)
             │ columns: (column1, column2, column3, column4, column5)
             │ estimated row count: 0 (missing stats)
-            │ equality: (x, y) = (column4, column5)
-            │ right cols are key
-            │ pred: column1 != k
+            │ table: uniq@uniq_v_key
+            │ equality: (column2) = (v)
+            │ equality cols are key
             │
-            ├── • scan
-            │     columns: (k, x, y)
-            │     estimated row count: 1,000 (missing stats)
-            │     table: uniq@primary
-            │     spans: FULL SCAN
-            │
-            └── • scan buffer
-                  columns: (column1, column2, column3, column4, column5)
-                  estimated row count: 0 (missing stats)
-                  label: buffer 1
+            └── • hash join (right anti)
+                │ columns: (column1, column2, column3, column4, column5)
+                │ estimated row count: 0 (missing stats)
+                │ equality: (x, y) = (column4, column5)
+                │ right cols are key
+                │
+                ├── • scan
+                │     columns: (x, y)
+                │     estimated row count: 1,000 (missing stats)
+                │     table: uniq@primary
+                │     spans: FULL SCAN
+                │
+                └── • values
+                      columns: (column1, column2, column3, column4, column5)
+                      size: 5 columns, 1 row
+                      row 0, expr 0: 1
+                      row 0, expr 1: 2
+                      row 0, expr 2: 3
+                      row 0, expr 3: 4
+                      row 0, expr 4: 5
 
 # Insert with non-constant input.
 query T
@@ -948,138 +894,62 @@ ON CONFLICT DO NOTHING
 distribution: local
 vectorized: true
 ·
-• root
+• insert
 │ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: uniq_enum(r, s, i, j)
+│ auto commit
+│ arbiter indexes: primary, uniq_enum_r_s_j_key
+│ arbiter constraints: unique_i, unique_s_j
 │
-├── • insert
-│   │ columns: ()
-│   │ estimated row count: 0 (missing stats)
-│   │ into: uniq_enum(r, s, i, j)
-│   │ arbiter indexes: primary, uniq_enum_r_s_j_key
-│   │ arbiter constraints: unique_i, unique_s_j
-│   │
-│   └── • buffer
-│       │ columns: (column1, column2, column3, column4, check1)
-│       │ label: buffer 1
-│       │
-│       └── • render
-│           │ columns: (column1, column2, column3, column4, check1)
-│           │ estimated row count: 0 (missing stats)
-│           │ render check1: column1 IN ('us-east', 'us-west', 'eu-west')
-│           │ render column1: column1
-│           │ render column2: column2
-│           │ render column3: column3
-│           │ render column4: column4
-│           │
-│           └── • lookup join (anti)
-│               │ columns: (column1, column2, column3, column4)
-│               │ estimated row count: 0 (missing stats)
-│               │ table: uniq_enum@uniq_enum_r_s_j_key
-│               │ equality cols are key
-│               │ lookup condition: ((column2 = s) AND (column4 = j)) AND (r IN ('us-east', 'us-west', 'eu-west'))
-│               │
-│               └── • lookup join (anti)
-│                   │ columns: (column1, column2, column3, column4)
-│                   │ estimated row count: 0 (missing stats)
-│                   │ table: uniq_enum@primary
-│                   │ equality cols are key
-│                   │ lookup condition: (column3 = i) AND (r IN ('us-east', 'us-west', 'eu-west'))
-│                   │
-│                   └── • lookup join (anti)
-│                       │ columns: (column1, column2, column3, column4)
-│                       │ estimated row count: 0 (missing stats)
-│                       │ table: uniq_enum@primary
-│                       │ equality: (column1, column3) = (r,i)
-│                       │ equality cols are key
-│                       │
-│                       └── • lookup join (anti)
-│                           │ columns: (column1, column2, column3, column4)
-│                           │ estimated row count: 0 (missing stats)
-│                           │ table: uniq_enum@uniq_enum_r_s_j_key
-│                           │ equality: (column1, column2, column4) = (r,s,j)
-│                           │ equality cols are key
-│                           │
-│                           └── • values
-│                                 columns: (column1, column2, column3, column4)
-│                                 size: 4 columns, 2 rows
-│                                 row 0, expr 0: 'us-west'
-│                                 row 0, expr 1: 'foo'
-│                                 row 0, expr 2: 1
-│                                 row 0, expr 3: 1
-│                                 row 1, expr 0: 'us-east'
-│                                 row 1, expr 1: 'bar'
-│                                 row 1, expr 2: 2
-│                                 row 1, expr 3: 2
-│
-├── • constraint-check
-│   │
-│   └── • error if rows
-│       │ columns: ()
-│       │
-│       └── • project
-│           │ columns: (column1, column2, column3, column4)
-│           │ estimated row count: 0 (missing stats)
-│           │
-│           └── • lookup join (semi)
-│               │ columns: ("lookup_join_const_col_@36", column1, column2, column3, column4)
-│               │ table: uniq_enum@primary
-│               │ equality: (lookup_join_const_col_@36, column3) = (r,i)
-│               │ equality cols are key
-│               │ pred: column1 != r
-│               │
-│               └── • cross join (inner)
-│                   │ columns: ("lookup_join_const_col_@36", column1, column2, column3, column4)
-│                   │ estimated row count: 0 (missing stats)
-│                   │
-│                   ├── • values
-│                   │     columns: ("lookup_join_const_col_@36")
-│                   │     size: 1 column, 3 rows
-│                   │     row 0, expr 0: 'us-east'
-│                   │     row 1, expr 0: 'us-west'
-│                   │     row 2, expr 0: 'eu-west'
-│                   │
-│                   └── • project
-│                       │ columns: (column1, column2, column3, column4)
-│                       │ estimated row count: 0 (missing stats)
-│                       │
-│                       └── • scan buffer
-│                             columns: (column1, column2, column3, column4, check1)
-│                             label: buffer 1
-│
-└── • constraint-check
+└── • render
+    │ columns: (column1, column2, column3, column4, check1)
+    │ estimated row count: 0 (missing stats)
+    │ render check1: column1 IN ('us-east', 'us-west', 'eu-west')
+    │ render column1: column1
+    │ render column2: column2
+    │ render column3: column3
+    │ render column4: column4
     │
-    └── • error if rows
-        │ columns: ()
+    └── • lookup join (anti)
+        │ columns: (column1, column2, column3, column4)
+        │ estimated row count: 0 (missing stats)
+        │ table: uniq_enum@uniq_enum_r_s_j_key
+        │ equality cols are key
+        │ lookup condition: ((column2 = s) AND (column4 = j)) AND (r IN ('us-east', 'us-west', 'eu-west'))
         │
-        └── • project
+        └── • lookup join (anti)
             │ columns: (column1, column2, column3, column4)
             │ estimated row count: 0 (missing stats)
+            │ table: uniq_enum@primary
+            │ equality cols are key
+            │ lookup condition: (column3 = i) AND (r IN ('us-east', 'us-west', 'eu-west'))
             │
-            └── • lookup join (semi)
-                │ columns: ("lookup_join_const_col_@46", column1, column2, column3, column4)
-                │ table: uniq_enum@uniq_enum_r_s_j_key
-                │ equality: (lookup_join_const_col_@46, column2, column4) = (r,s,j)
+            └── • lookup join (anti)
+                │ columns: (column1, column2, column3, column4)
+                │ estimated row count: 0 (missing stats)
+                │ table: uniq_enum@primary
+                │ equality: (column1, column3) = (r,i)
                 │ equality cols are key
-                │ pred: (column1 != r) OR (column3 != i)
                 │
-                └── • cross join (inner)
-                    │ columns: ("lookup_join_const_col_@46", column1, column2, column3, column4)
+                └── • lookup join (anti)
+                    │ columns: (column1, column2, column3, column4)
                     │ estimated row count: 0 (missing stats)
+                    │ table: uniq_enum@uniq_enum_r_s_j_key
+                    │ equality: (column1, column2, column4) = (r,s,j)
+                    │ equality cols are key
                     │
-                    ├── • values
-                    │     columns: ("lookup_join_const_col_@46")
-                    │     size: 1 column, 3 rows
-                    │     row 0, expr 0: 'us-east'
-                    │     row 1, expr 0: 'us-west'
-                    │     row 2, expr 0: 'eu-west'
-                    │
-                    └── • project
-                        │ columns: (column1, column2, column3, column4)
-                        │ estimated row count: 0 (missing stats)
-                        │
-                        └── • scan buffer
-                              columns: (column1, column2, column3, column4, check1)
-                              label: buffer 1
+                    └── • values
+                          columns: (column1, column2, column3, column4)
+                          size: 4 columns, 2 rows
+                          row 0, expr 0: 'us-west'
+                          row 0, expr 1: 'foo'
+                          row 0, expr 2: 1
+                          row 0, expr 3: 1
+                          row 1, expr 0: 'us-east'
+                          row 1, expr 1: 'bar'
+                          row 1, expr 2: 2
+                          row 1, expr 3: 2
 
 # None of the inserted values have nulls.
 query T
@@ -1185,177 +1055,103 @@ vectorized: true
 
 # Use all the unique indexes and constraints as arbiters for DO NOTHING with no
 # conflict columns.
-# TODO(mgartner): we should be able to remove the unique checks in this case
-# (see #59119).
 query T
 EXPLAIN (VERBOSE) INSERT INTO uniq_partial VALUES (1, 2, 3) ON CONFLICT DO NOTHING
 ----
 distribution: local
 vectorized: true
 ·
-• root
+• insert
 │ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: uniq_partial(k, a, b)
+│ auto commit
+│ arbiter indexes: primary
+│ arbiter constraints: unique_a, unique_b
 │
-├── • insert
-│   │ columns: ()
-│   │ estimated row count: 0 (missing stats)
-│   │ into: uniq_partial(k, a, b)
-│   │ arbiter indexes: primary
-│   │ arbiter constraints: unique_a, unique_b
-│   │
-│   └── • buffer
-│       │ columns: (column1, column2, column3)
-│       │ label: buffer 1
-│       │
-│       └── • project
-│           │ columns: (column1, column2, column3)
-│           │ estimated row count: 0 (missing stats)
-│           │
-│           └── • distinct
-│               │ columns: (arbiter_unique_b_distinct, column1, column2, column3)
-│               │ estimated row count: 0 (missing stats)
-│               │ distinct on: arbiter_unique_b_distinct
-│               │ nulls are distinct
-│               │
-│               └── • render
-│                   │ columns: (arbiter_unique_b_distinct, column1, column2, column3)
-│                   │ estimated row count: 0 (missing stats)
-│                   │ render arbiter_unique_b_distinct: (column3 > 0) OR CAST(NULL AS BOOL)
-│                   │ render column1: column1
-│                   │ render column2: column2
-│                   │ render column3: column3
-│                   │
-│                   └── • distinct
-│                       │ columns: (arbiter_unique_a_distinct, column1, column2, column3)
-│                       │ estimated row count: 0 (missing stats)
-│                       │ distinct on: arbiter_unique_a_distinct
-│                       │ nulls are distinct
-│                       │
-│                       └── • render
-│                           │ columns: (arbiter_unique_a_distinct, column1, column2, column3)
-│                           │ estimated row count: 0 (missing stats)
-│                           │ render arbiter_unique_a_distinct: (column3 > 0) OR CAST(NULL AS BOOL)
-│                           │ render column1: column1
-│                           │ render column2: column2
-│                           │ render column3: column3
-│                           │
-│                           └── • hash join (right anti)
-│                               │ columns: (column1, column2, column3)
-│                               │ estimated row count: 0 (missing stats)
-│                               │ equality: (b) = (column3)
-│                               │ right cols are key
-│                               │
-│                               ├── • filter
-│                               │   │ columns: (b)
-│                               │   │ estimated row count: 333 (missing stats)
-│                               │   │ filter: b > 0
-│                               │   │
-│                               │   └── • scan
-│                               │         columns: (b)
-│                               │         estimated row count: 1,000 (missing stats)
-│                               │         table: uniq_partial@primary
-│                               │         spans: FULL SCAN
-│                               │
-│                               └── • hash join (right anti)
-│                                   │ columns: (column1, column2, column3)
-│                                   │ estimated row count: 0 (missing stats)
-│                                   │ equality: (a) = (column2)
-│                                   │ right cols are key
-│                                   │ pred: column3 > 0
-│                                   │
-│                                   ├── • filter
-│                                   │   │ columns: (a, b)
-│                                   │   │ estimated row count: 333 (missing stats)
-│                                   │   │ filter: b > 0
-│                                   │   │
-│                                   │   └── • scan
-│                                   │         columns: (a, b)
-│                                   │         estimated row count: 1,000 (missing stats)
-│                                   │         table: uniq_partial@primary
-│                                   │         spans: FULL SCAN
-│                                   │
-│                                   └── • cross join (anti)
-│                                       │ columns: (column1, column2, column3)
-│                                       │ estimated row count: 0 (missing stats)
-│                                       │
-│                                       ├── • values
-│                                       │     columns: (column1, column2, column3)
-│                                       │     size: 3 columns, 1 row
-│                                       │     row 0, expr 0: 1
-│                                       │     row 0, expr 1: 2
-│                                       │     row 0, expr 2: 3
-│                                       │
-│                                       └── • scan
-│                                             columns: (k)
-│                                             estimated row count: 1 (missing stats)
-│                                             table: uniq_partial@primary
-│                                             spans: /1/0-/1/1
-│
-├── • constraint-check
-│   │
-│   └── • error if rows
-│       │ columns: ()
-│       │
-│       └── • hash join (right semi)
-│           │ columns: (column1, column2, column3)
-│           │ estimated row count: 0 (missing stats)
-│           │ equality: (a) = (column2)
-│           │ right cols are key
-│           │ pred: column1 != k
-│           │
-│           ├── • filter
-│           │   │ columns: (k, a, b)
-│           │   │ estimated row count: 333 (missing stats)
-│           │   │ filter: b > 0
-│           │   │
-│           │   └── • scan
-│           │         columns: (k, a, b)
-│           │         estimated row count: 1,000 (missing stats)
-│           │         table: uniq_partial@primary
-│           │         spans: FULL SCAN
-│           │
-│           └── • filter
-│               │ columns: (column1, column2, column3)
-│               │ estimated row count: 0 (missing stats)
-│               │ filter: column3 > 0
-│               │
-│               └── • scan buffer
-│                     columns: (column1, column2, column3)
-│                     estimated row count: 0 (missing stats)
-│                     label: buffer 1
-│
-└── • constraint-check
+└── • project
+    │ columns: (column1, column2, column3)
+    │ estimated row count: 0 (missing stats)
     │
-    └── • error if rows
-        │ columns: ()
+    └── • distinct
+        │ columns: (arbiter_unique_b_distinct, column1, column2, column3)
+        │ estimated row count: 0 (missing stats)
+        │ distinct on: arbiter_unique_b_distinct
+        │ nulls are distinct
         │
-        └── • hash join (right semi)
-            │ columns: (column1, column2, column3)
+        └── • render
+            │ columns: (arbiter_unique_b_distinct, column1, column2, column3)
             │ estimated row count: 0 (missing stats)
-            │ equality: (b) = (column3)
-            │ right cols are key
-            │ pred: column1 != k
+            │ render arbiter_unique_b_distinct: (column3 > 0) OR CAST(NULL AS BOOL)
+            │ render column1: column1
+            │ render column2: column2
+            │ render column3: column3
             │
-            ├── • filter
-            │   │ columns: (k, b)
-            │   │ estimated row count: 333 (missing stats)
-            │   │ filter: b > 0
-            │   │
-            │   └── • scan
-            │         columns: (k, b)
-            │         estimated row count: 1,000 (missing stats)
-            │         table: uniq_partial@primary
-            │         spans: FULL SCAN
-            │
-            └── • filter
-                │ columns: (column1, column2, column3)
+            └── • distinct
+                │ columns: (arbiter_unique_a_distinct, column1, column2, column3)
                 │ estimated row count: 0 (missing stats)
-                │ filter: column3 > 0
+                │ distinct on: arbiter_unique_a_distinct
+                │ nulls are distinct
                 │
-                └── • scan buffer
-                      columns: (column1, column2, column3)
-                      estimated row count: 0 (missing stats)
-                      label: buffer 1
+                └── • render
+                    │ columns: (arbiter_unique_a_distinct, column1, column2, column3)
+                    │ estimated row count: 0 (missing stats)
+                    │ render arbiter_unique_a_distinct: (column3 > 0) OR CAST(NULL AS BOOL)
+                    │ render column1: column1
+                    │ render column2: column2
+                    │ render column3: column3
+                    │
+                    └── • hash join (right anti)
+                        │ columns: (column1, column2, column3)
+                        │ estimated row count: 0 (missing stats)
+                        │ equality: (b) = (column3)
+                        │ right cols are key
+                        │
+                        ├── • filter
+                        │   │ columns: (b)
+                        │   │ estimated row count: 333 (missing stats)
+                        │   │ filter: b > 0
+                        │   │
+                        │   └── • scan
+                        │         columns: (b)
+                        │         estimated row count: 1,000 (missing stats)
+                        │         table: uniq_partial@primary
+                        │         spans: FULL SCAN
+                        │
+                        └── • hash join (right anti)
+                            │ columns: (column1, column2, column3)
+                            │ estimated row count: 0 (missing stats)
+                            │ equality: (a) = (column2)
+                            │ right cols are key
+                            │ pred: column3 > 0
+                            │
+                            ├── • filter
+                            │   │ columns: (a, b)
+                            │   │ estimated row count: 333 (missing stats)
+                            │   │ filter: b > 0
+                            │   │
+                            │   └── • scan
+                            │         columns: (a, b)
+                            │         estimated row count: 1,000 (missing stats)
+                            │         table: uniq_partial@primary
+                            │         spans: FULL SCAN
+                            │
+                            └── • cross join (anti)
+                                │ columns: (column1, column2, column3)
+                                │ estimated row count: 0 (missing stats)
+                                │
+                                ├── • values
+                                │     columns: (column1, column2, column3)
+                                │     size: 3 columns, 1 row
+                                │     row 0, expr 0: 1
+                                │     row 0, expr 1: 2
+                                │     row 0, expr 2: 3
+                                │
+                                └── • scan
+                                      columns: (k)
+                                      estimated row count: 1 (missing stats)
+                                      table: uniq_partial@primary
+                                      spans: /1/0-/1/1
 
 # Insert with non-constant input.
 query T
@@ -1568,109 +1364,64 @@ ON CONFLICT DO NOTHING
 distribution: local
 vectorized: true
 ·
-• root
+• insert
 │ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: uniq_partial_enum(r, a, b, c)
+│ auto commit
+│ arbiter indexes: primary
+│ arbiter constraints: unique_b
 │
-├── • insert
-│   │ columns: ()
-│   │ estimated row count: 0 (missing stats)
-│   │ into: uniq_partial_enum(r, a, b, c)
-│   │ arbiter indexes: primary
-│   │ arbiter constraints: unique_b
-│   │
-│   └── • buffer
-│       │ columns: (column1, column2, column3, column4, check1, partial_index_put1)
-│       │ label: buffer 1
-│       │
-│       └── • render
-│           │ columns: (column1, column2, column3, column4, check1, partial_index_put1)
-│           │ estimated row count: 0
-│           │ render partial_index_put1: column4 IN ('bar', 'baz', 'foo')
-│           │ render check1: column1 IN ('us-east', 'us-west', 'eu-west')
-│           │ render column1: column1
-│           │ render column2: column2
-│           │ render column3: column3
-│           │ render column4: column4
-│           │
-│           └── • distinct
-│               │ columns: (arbiter_unique_b_distinct, column1, column2, column3, column4)
-│               │ estimated row count: 0
-│               │ distinct on: arbiter_unique_b_distinct, column3
-│               │ nulls are distinct
-│               │
-│               └── • render
-│                   │ columns: (arbiter_unique_b_distinct, column1, column2, column3, column4)
-│                   │ estimated row count: 0
-│                   │ render arbiter_unique_b_distinct: (column4 IN ('bar', 'baz', 'foo')) OR CAST(NULL AS BOOL)
-│                   │ render column1: column1
-│                   │ render column2: column2
-│                   │ render column3: column3
-│                   │ render column4: column4
-│                   │
-│                   └── • lookup join (anti)
-│                       │ columns: (column1, column2, column3, column4)
-│                       │ estimated row count: 0
-│                       │ table: uniq_partial_enum@uniq_partial_enum_r_b_idx (partial index)
-│                       │ lookup condition: (column3 = b) AND (r IN ('us-east', 'us-west', 'eu-west'))
-│                       │ pred: column4 IN ('bar', 'baz', 'foo')
-│                       │
-│                       └── • lookup join (anti)
-│                           │ columns: (column1, column2, column3, column4)
-│                           │ estimated row count: 0
-│                           │ table: uniq_partial_enum@primary
-│                           │ equality: (column1, column2) = (r,a)
-│                           │ equality cols are key
-│                           │
-│                           └── • values
-│                                 columns: (column1, column2, column3, column4)
-│                                 size: 4 columns, 2 rows
-│                                 row 0, expr 0: 'us-west'
-│                                 row 0, expr 1: 1
-│                                 row 0, expr 2: 1
-│                                 row 0, expr 3: 'foo'
-│                                 row 1, expr 0: 'us-east'
-│                                 row 1, expr 1: 2
-│                                 row 1, expr 2: 2
-│                                 row 1, expr 3: 'bar'
-│
-└── • constraint-check
+└── • render
+    │ columns: (column1, column2, column3, column4, check1, partial_index_put1)
+    │ estimated row count: 0
+    │ render partial_index_put1: column4 IN ('bar', 'baz', 'foo')
+    │ render check1: column1 IN ('us-east', 'us-west', 'eu-west')
+    │ render column1: column1
+    │ render column2: column2
+    │ render column3: column3
+    │ render column4: column4
     │
-    └── • error if rows
-        │ columns: ()
+    └── • distinct
+        │ columns: (arbiter_unique_b_distinct, column1, column2, column3, column4)
+        │ estimated row count: 0
+        │ distinct on: arbiter_unique_b_distinct, column3
+        │ nulls are distinct
         │
-        └── • project
-            │ columns: (column1, column2, column3, column4)
+        └── • render
+            │ columns: (arbiter_unique_b_distinct, column1, column2, column3, column4)
             │ estimated row count: 0
+            │ render arbiter_unique_b_distinct: (column4 IN ('bar', 'baz', 'foo')) OR CAST(NULL AS BOOL)
+            │ render column1: column1
+            │ render column2: column2
+            │ render column3: column3
+            │ render column4: column4
             │
-            └── • lookup join (semi)
-                │ columns: ("lookup_join_const_col_@26", column1, column2, column3, column4)
+            └── • lookup join (anti)
+                │ columns: (column1, column2, column3, column4)
+                │ estimated row count: 0
                 │ table: uniq_partial_enum@uniq_partial_enum_r_b_idx (partial index)
-                │ equality: (lookup_join_const_col_@26, column3) = (r,b)
-                │ pred: (column1 != r) OR (column2 != a)
+                │ lookup condition: (column3 = b) AND (r IN ('us-east', 'us-west', 'eu-west'))
+                │ pred: column4 IN ('bar', 'baz', 'foo')
                 │
-                └── • cross join (inner)
-                    │ columns: ("lookup_join_const_col_@26", column1, column2, column3, column4)
+                └── • lookup join (anti)
+                    │ columns: (column1, column2, column3, column4)
                     │ estimated row count: 0
+                    │ table: uniq_partial_enum@primary
+                    │ equality: (column1, column2) = (r,a)
+                    │ equality cols are key
                     │
-                    ├── • values
-                    │     columns: ("lookup_join_const_col_@26")
-                    │     size: 1 column, 3 rows
-                    │     row 0, expr 0: 'us-east'
-                    │     row 1, expr 0: 'us-west'
-                    │     row 2, expr 0: 'eu-west'
-                    │
-                    └── • filter
-                        │ columns: (column1, column2, column3, column4)
-                        │ estimated row count: 0
-                        │ filter: column4 IN ('bar', 'baz', 'foo')
-                        │
-                        └── • project
-                            │ columns: (column1, column2, column3, column4)
-                            │ estimated row count: 0
-                            │
-                            └── • scan buffer
-                                  columns: (column1, column2, column3, column4, check1, partial_index_put1)
-                                  label: buffer 1
+                    └── • values
+                          columns: (column1, column2, column3, column4)
+                          size: 4 columns, 2 rows
+                          row 0, expr 0: 'us-west'
+                          row 0, expr 1: 1
+                          row 0, expr 2: 1
+                          row 0, expr 3: 'foo'
+                          row 1, expr 0: 'us-east'
+                          row 1, expr 1: 2
+                          row 1, expr 2: 2
+                          row 1, expr 3: 'bar'
 
 # We can eliminate uniqueness checks for i and s due to functional dependencies.
 # We cannot eliminate checks for d, since functional dependencies could not be
@@ -3758,41 +3509,6 @@ vectorized: true
 │                             row 1, expr 2: 2
 │                             row 1, expr 3: 2
 │
-├── • constraint-check
-│   │
-│   └── • error if rows
-│       │ columns: ()
-│       │
-│       └── • project
-│           │ columns: (upsert_r, upsert_s, upsert_i, upsert_j)
-│           │ estimated row count: 1 (missing stats)
-│           │
-│           └── • lookup join (semi)
-│               │ columns: ("lookup_join_const_col_@23", upsert_r, upsert_s, upsert_i, upsert_j)
-│               │ table: uniq_enum@primary
-│               │ equality: (lookup_join_const_col_@23, upsert_i) = (r,i)
-│               │ equality cols are key
-│               │ pred: upsert_r != r
-│               │
-│               └── • cross join (inner)
-│                   │ columns: ("lookup_join_const_col_@23", upsert_r, upsert_s, upsert_i, upsert_j)
-│                   │ estimated row count: 6 (missing stats)
-│                   │
-│                   ├── • values
-│                   │     columns: ("lookup_join_const_col_@23")
-│                   │     size: 1 column, 3 rows
-│                   │     row 0, expr 0: 'us-east'
-│                   │     row 1, expr 0: 'us-west'
-│                   │     row 2, expr 0: 'eu-west'
-│                   │
-│                   └── • project
-│                       │ columns: (upsert_r, upsert_s, upsert_i, upsert_j)
-│                       │ estimated row count: 2 (missing stats)
-│                       │
-│                       └── • scan buffer
-│                             columns: (column1, column2, column3, column4, r, s, i, j, upsert_i, r, check1, upsert_r, upsert_s, upsert_j)
-│                             label: buffer 1
-│
 └── • constraint-check
     │
     └── • error if rows
@@ -3803,18 +3519,18 @@ vectorized: true
             │ estimated row count: 1 (missing stats)
             │
             └── • lookup join (semi)
-                │ columns: ("lookup_join_const_col_@33", upsert_r, upsert_s, upsert_i, upsert_j)
-                │ table: uniq_enum@uniq_enum_r_s_j_key
-                │ equality: (lookup_join_const_col_@33, upsert_s, upsert_j) = (r,s,j)
+                │ columns: ("lookup_join_const_col_@23", upsert_r, upsert_s, upsert_i, upsert_j)
+                │ table: uniq_enum@primary
+                │ equality: (lookup_join_const_col_@23, upsert_i) = (r,i)
                 │ equality cols are key
-                │ pred: (upsert_r != r) OR (upsert_i != i)
+                │ pred: upsert_r != r
                 │
                 └── • cross join (inner)
-                    │ columns: ("lookup_join_const_col_@33", upsert_r, upsert_s, upsert_i, upsert_j)
+                    │ columns: ("lookup_join_const_col_@23", upsert_r, upsert_s, upsert_i, upsert_j)
                     │ estimated row count: 6 (missing stats)
                     │
                     ├── • values
-                    │     columns: ("lookup_join_const_col_@33")
+                    │     columns: ("lookup_join_const_col_@23")
                     │     size: 1 column, 3 rows
                     │     row 0, expr 0: 'us-east'
                     │     row 1, expr 0: 'us-west'

--- a/pkg/sql/opt/optbuilder/arbiter_set.go
+++ b/pkg/sql/opt/optbuilder/arbiter_set.go
@@ -86,6 +86,12 @@ func (a *arbiterSet) UniqueConstraintOrdinals() []int {
 	return a.uniqueConstraints.Ordered()
 }
 
+// ContainsUniqueConstraint returns true if the set contains the given unique
+// constraint.
+func (a *arbiterSet) ContainsUniqueConstraint(uniq cat.UniqueOrdinal) bool {
+	return a.uniqueConstraints.Contains(uniq)
+}
+
 // ForEach calls a function for every arbiter in the set. The function is called
 // with the following arguments:
 //

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
@@ -239,8 +239,6 @@ insert uniq
 
 # Use all the unique indexes and constraints as arbiters for DO NOTHING with no
 # conflict columns.
-# TODO(rytaft): we should be able to remove the unique checks in this case
-# (see #59119).
 build
 INSERT INTO uniq VALUES (1, 2, 3, 4, 5) ON CONFLICT DO NOTHING
 ----
@@ -249,124 +247,87 @@ insert uniq
  ├── arbiter indexes: primary uniq_v_key
  ├── arbiter constraints: unique_w unique_x_y
  ├── insert-mapping:
- │    ├── column1:7 => uniq.k:1
- │    ├── column2:8 => uniq.v:2
- │    ├── column3:9 => uniq.w:3
- │    ├── column4:10 => uniq.x:4
- │    └── column5:11 => uniq.y:5
- ├── input binding: &1
- ├── upsert-distinct-on
- │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
- │    ├── grouping columns: column4:10!null column5:11!null
- │    ├── upsert-distinct-on
- │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
- │    │    ├── grouping columns: column3:9!null
- │    │    ├── upsert-distinct-on
- │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
- │    │    │    ├── grouping columns: column2:8!null
- │    │    │    ├── upsert-distinct-on
- │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
- │    │    │    │    ├── grouping columns: column1:7!null
- │    │    │    │    ├── anti-join (hash)
- │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
- │    │    │    │    │    ├── anti-join (hash)
- │    │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
- │    │    │    │    │    │    ├── anti-join (hash)
- │    │    │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
- │    │    │    │    │    │    │    ├── anti-join (hash)
- │    │    │    │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
- │    │    │    │    │    │    │    │    ├── values
- │    │    │    │    │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
- │    │    │    │    │    │    │    │    │    └── (1, 2, 3, 4, 5)
- │    │    │    │    │    │    │    │    ├── scan uniq
- │    │    │    │    │    │    │    │    │    └── columns: uniq.k:12!null uniq.v:13 uniq.w:14 uniq.x:15 uniq.y:16
- │    │    │    │    │    │    │    │    └── filters
- │    │    │    │    │    │    │    │         └── column1:7 = uniq.k:12
- │    │    │    │    │    │    │    ├── scan uniq
- │    │    │    │    │    │    │    │    └── columns: uniq.k:18!null uniq.v:19 uniq.w:20 uniq.x:21 uniq.y:22
- │    │    │    │    │    │    │    └── filters
- │    │    │    │    │    │    │         └── column2:8 = uniq.v:19
- │    │    │    │    │    │    ├── scan uniq
- │    │    │    │    │    │    │    └── columns: uniq.k:24!null uniq.v:25 uniq.w:26 uniq.x:27 uniq.y:28
- │    │    │    │    │    │    └── filters
- │    │    │    │    │    │         └── column3:9 = uniq.w:26
- │    │    │    │    │    ├── scan uniq
- │    │    │    │    │    │    └── columns: uniq.k:30!null uniq.v:31 uniq.w:32 uniq.x:33 uniq.y:34
- │    │    │    │    │    └── filters
- │    │    │    │    │         ├── column4:10 = uniq.x:33
- │    │    │    │    │         └── column5:11 = uniq.y:34
- │    │    │    │    └── aggregations
- │    │    │    │         ├── first-agg [as=column2:8]
- │    │    │    │         │    └── column2:8
- │    │    │    │         ├── first-agg [as=column3:9]
- │    │    │    │         │    └── column3:9
- │    │    │    │         ├── first-agg [as=column4:10]
- │    │    │    │         │    └── column4:10
- │    │    │    │         └── first-agg [as=column5:11]
- │    │    │    │              └── column5:11
- │    │    │    └── aggregations
- │    │    │         ├── first-agg [as=column1:7]
- │    │    │         │    └── column1:7
- │    │    │         ├── first-agg [as=column3:9]
- │    │    │         │    └── column3:9
- │    │    │         ├── first-agg [as=column4:10]
- │    │    │         │    └── column4:10
- │    │    │         └── first-agg [as=column5:11]
- │    │    │              └── column5:11
- │    │    └── aggregations
- │    │         ├── first-agg [as=column1:7]
- │    │         │    └── column1:7
- │    │         ├── first-agg [as=column2:8]
- │    │         │    └── column2:8
- │    │         ├── first-agg [as=column4:10]
- │    │         │    └── column4:10
- │    │         └── first-agg [as=column5:11]
- │    │              └── column5:11
- │    └── aggregations
- │         ├── first-agg [as=column1:7]
- │         │    └── column1:7
- │         ├── first-agg [as=column2:8]
- │         │    └── column2:8
- │         └── first-agg [as=column3:9]
- │              └── column3:9
- └── unique-checks
-      ├── unique-checks-item: uniq(w)
-      │    └── semi-join (hash)
-      │         ├── columns: k:42!null v:43!null w:44!null x:45!null y:46!null
-      │         ├── with-scan &1
-      │         │    ├── columns: k:42!null v:43!null w:44!null x:45!null y:46!null
-      │         │    └── mapping:
-      │         │         ├──  column1:7 => k:42
-      │         │         ├──  column2:8 => v:43
-      │         │         ├──  column3:9 => w:44
-      │         │         ├──  column4:10 => x:45
-      │         │         └──  column5:11 => y:46
-      │         ├── scan uniq
-      │         │    └── columns: uniq.k:36!null uniq.v:37 uniq.w:38 uniq.x:39 uniq.y:40
-      │         └── filters
-      │              ├── w:44 = uniq.w:38
-      │              └── k:42 != uniq.k:36
-      └── unique-checks-item: uniq(x,y)
-           └── semi-join (hash)
-                ├── columns: k:53!null v:54!null w:55!null x:56!null y:57!null
-                ├── with-scan &1
-                │    ├── columns: k:53!null v:54!null w:55!null x:56!null y:57!null
-                │    └── mapping:
-                │         ├──  column1:7 => k:53
-                │         ├──  column2:8 => v:54
-                │         ├──  column3:9 => w:55
-                │         ├──  column4:10 => x:56
-                │         └──  column5:11 => y:57
-                ├── scan uniq
-                │    └── columns: uniq.k:47!null uniq.v:48 uniq.w:49 uniq.x:50 uniq.y:51
-                └── filters
-                     ├── x:56 = uniq.x:50
-                     ├── y:57 = uniq.y:51
-                     └── k:53 != uniq.k:47
+ │    ├── column1:7 => k:1
+ │    ├── column2:8 => v:2
+ │    ├── column3:9 => w:3
+ │    ├── column4:10 => x:4
+ │    └── column5:11 => y:5
+ └── upsert-distinct-on
+      ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
+      ├── grouping columns: column4:10!null column5:11!null
+      ├── upsert-distinct-on
+      │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
+      │    ├── grouping columns: column3:9!null
+      │    ├── upsert-distinct-on
+      │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
+      │    │    ├── grouping columns: column2:8!null
+      │    │    ├── upsert-distinct-on
+      │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
+      │    │    │    ├── grouping columns: column1:7!null
+      │    │    │    ├── anti-join (hash)
+      │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
+      │    │    │    │    ├── anti-join (hash)
+      │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
+      │    │    │    │    │    ├── anti-join (hash)
+      │    │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
+      │    │    │    │    │    │    ├── anti-join (hash)
+      │    │    │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
+      │    │    │    │    │    │    │    ├── values
+      │    │    │    │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column5:11!null
+      │    │    │    │    │    │    │    │    └── (1, 2, 3, 4, 5)
+      │    │    │    │    │    │    │    ├── scan uniq
+      │    │    │    │    │    │    │    │    └── columns: k:12!null v:13 w:14 x:15 y:16
+      │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │         └── column1:7 = k:12
+      │    │    │    │    │    │    ├── scan uniq
+      │    │    │    │    │    │    │    └── columns: k:18!null v:19 w:20 x:21 y:22
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         └── column2:8 = v:19
+      │    │    │    │    │    ├── scan uniq
+      │    │    │    │    │    │    └── columns: k:24!null v:25 w:26 x:27 y:28
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         └── column3:9 = w:26
+      │    │    │    │    ├── scan uniq
+      │    │    │    │    │    └── columns: k:30!null v:31 w:32 x:33 y:34
+      │    │    │    │    └── filters
+      │    │    │    │         ├── column4:10 = x:33
+      │    │    │    │         └── column5:11 = y:34
+      │    │    │    └── aggregations
+      │    │    │         ├── first-agg [as=column2:8]
+      │    │    │         │    └── column2:8
+      │    │    │         ├── first-agg [as=column3:9]
+      │    │    │         │    └── column3:9
+      │    │    │         ├── first-agg [as=column4:10]
+      │    │    │         │    └── column4:10
+      │    │    │         └── first-agg [as=column5:11]
+      │    │    │              └── column5:11
+      │    │    └── aggregations
+      │    │         ├── first-agg [as=column1:7]
+      │    │         │    └── column1:7
+      │    │         ├── first-agg [as=column3:9]
+      │    │         │    └── column3:9
+      │    │         ├── first-agg [as=column4:10]
+      │    │         │    └── column4:10
+      │    │         └── first-agg [as=column5:11]
+      │    │              └── column5:11
+      │    └── aggregations
+      │         ├── first-agg [as=column1:7]
+      │         │    └── column1:7
+      │         ├── first-agg [as=column2:8]
+      │         │    └── column2:8
+      │         ├── first-agg [as=column4:10]
+      │         │    └── column4:10
+      │         └── first-agg [as=column5:11]
+      │              └── column5:11
+      └── aggregations
+           ├── first-agg [as=column1:7]
+           │    └── column1:7
+           ├── first-agg [as=column2:8]
+           │    └── column2:8
+           └── first-agg [as=column3:9]
+                └── column3:9
 
 # On conflict clause references unique without index constraint.
-# TODO(rytaft): we should be able to remove the unique check for w in this case
-# (see #59119).
 build
 INSERT INTO uniq VALUES (1, 2, 3, 4, 5) ON CONFLICT (w) DO NOTHING
 ----
@@ -402,39 +363,23 @@ insert uniq
  │         └── first-agg [as=column5:11]
  │              └── column5:11
  └── unique-checks
-      ├── unique-checks-item: uniq(w)
-      │    └── semi-join (hash)
-      │         ├── columns: k:24!null v:25!null w:26!null x:27!null y:28!null
-      │         ├── with-scan &1
-      │         │    ├── columns: k:24!null v:25!null w:26!null x:27!null y:28!null
-      │         │    └── mapping:
-      │         │         ├──  column1:7 => k:24
-      │         │         ├──  column2:8 => v:25
-      │         │         ├──  column3:9 => w:26
-      │         │         ├──  column4:10 => x:27
-      │         │         └──  column5:11 => y:28
-      │         ├── scan uniq
-      │         │    └── columns: uniq.k:18!null uniq.v:19 uniq.w:20 uniq.x:21 uniq.y:22
-      │         └── filters
-      │              ├── w:26 = uniq.w:20
-      │              └── k:24 != uniq.k:18
       └── unique-checks-item: uniq(x,y)
            └── semi-join (hash)
-                ├── columns: k:35!null v:36!null w:37!null x:38!null y:39!null
+                ├── columns: k:24!null v:25!null w:26!null x:27!null y:28!null
                 ├── with-scan &1
-                │    ├── columns: k:35!null v:36!null w:37!null x:38!null y:39!null
+                │    ├── columns: k:24!null v:25!null w:26!null x:27!null y:28!null
                 │    └── mapping:
-                │         ├──  column1:7 => k:35
-                │         ├──  column2:8 => v:36
-                │         ├──  column3:9 => w:37
-                │         ├──  column4:10 => x:38
-                │         └──  column5:11 => y:39
+                │         ├──  column1:7 => k:24
+                │         ├──  column2:8 => v:25
+                │         ├──  column3:9 => w:26
+                │         ├──  column4:10 => x:27
+                │         └──  column5:11 => y:28
                 ├── scan uniq
-                │    └── columns: uniq.k:29!null uniq.v:30 uniq.w:31 uniq.x:32 uniq.y:33
+                │    └── columns: uniq.k:18!null uniq.v:19 uniq.w:20 uniq.x:21 uniq.y:22
                 └── filters
-                     ├── x:38 = uniq.x:32
-                     ├── y:39 = uniq.y:33
-                     └── k:35 != uniq.k:29
+                     ├── x:27 = uniq.x:21
+                     ├── y:28 = uniq.y:22
+                     └── k:24 != uniq.k:18
 
 exec-ddl
 CREATE TABLE other (k INT, v INT, w INT NOT NULL, x INT, y INT)
@@ -895,8 +840,6 @@ insert uniq_partial
 
 # Use all the unique constraint as an arbiter for DO NOTHING with no conflict
 # columns.
-# TODO(rytaft/mgartner): we should be able to remove the unique checks in this
-# case (see #59119).
 build
 INSERT INTO uniq_partial VALUES (1, 2, 3), (2, 2, 3) ON CONFLICT DO NOTHING
 ----
@@ -905,70 +848,52 @@ insert uniq_partial
  ├── arbiter indexes: primary
  ├── arbiter constraints: unique_a
  ├── insert-mapping:
- │    ├── column1:5 => uniq_partial.k:1
- │    ├── column2:6 => uniq_partial.a:2
- │    └── column3:7 => uniq_partial.b:3
- ├── input binding: &1
- ├── project
- │    ├── columns: column1:5!null column2:6!null column3:7!null
- │    └── upsert-distinct-on
- │         ├── columns: column1:5!null column2:6!null column3:7!null arbiter_unique_a_distinct:16
- │         ├── grouping columns: column2:6!null arbiter_unique_a_distinct:16
- │         ├── project
- │         │    ├── columns: arbiter_unique_a_distinct:16 column1:5!null column2:6!null column3:7!null
- │         │    ├── upsert-distinct-on
- │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
- │         │    │    ├── grouping columns: column1:5!null
- │         │    │    ├── anti-join (hash)
- │         │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
- │         │    │    │    ├── anti-join (hash)
- │         │    │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
- │         │    │    │    │    ├── values
- │         │    │    │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
- │         │    │    │    │    │    ├── (1, 2, 3)
- │         │    │    │    │    │    └── (2, 2, 3)
- │         │    │    │    │    ├── scan uniq_partial
- │         │    │    │    │    │    └── columns: uniq_partial.k:8!null uniq_partial.a:9 uniq_partial.b:10
- │         │    │    │    │    └── filters
- │         │    │    │    │         └── column1:5 = uniq_partial.k:8
- │         │    │    │    ├── select
- │         │    │    │    │    ├── columns: uniq_partial.k:12!null uniq_partial.a:13 uniq_partial.b:14!null
- │         │    │    │    │    ├── scan uniq_partial
- │         │    │    │    │    │    └── columns: uniq_partial.k:12!null uniq_partial.a:13 uniq_partial.b:14
- │         │    │    │    │    └── filters
- │         │    │    │    │         └── uniq_partial.b:14 > 0
- │         │    │    │    └── filters
- │         │    │    │         ├── column2:6 = uniq_partial.a:13
- │         │    │    │         └── column3:7 > 0
- │         │    │    └── aggregations
- │         │    │         ├── first-agg [as=column2:6]
- │         │    │         │    └── column2:6
- │         │    │         └── first-agg [as=column3:7]
- │         │    │              └── column3:7
- │         │    └── projections
- │         │         └── (column3:7 > 0) OR NULL::BOOL [as=arbiter_unique_a_distinct:16]
- │         └── aggregations
- │              ├── first-agg [as=column1:5]
- │              │    └── column1:5
- │              └── first-agg [as=column3:7]
- │                   └── column3:7
- └── unique-checks
-      └── unique-checks-item: uniq_partial(a)
-           └── semi-join (hash)
-                ├── columns: k:21!null a:22!null b:23!null
-                ├── with-scan &1
-                │    ├── columns: k:21!null a:22!null b:23!null
-                │    └── mapping:
-                │         ├──  column1:5 => k:21
-                │         ├──  column2:6 => a:22
-                │         └──  column3:7 => b:23
-                ├── scan uniq_partial
-                │    └── columns: uniq_partial.k:17!null uniq_partial.a:18 uniq_partial.b:19
-                └── filters
-                     ├── a:22 = uniq_partial.a:18
-                     ├── b:23 > 0
-                     ├── uniq_partial.b:19 > 0
-                     └── k:21 != uniq_partial.k:17
+ │    ├── column1:5 => k:1
+ │    ├── column2:6 => a:2
+ │    └── column3:7 => b:3
+ └── project
+      ├── columns: column1:5!null column2:6!null column3:7!null
+      └── upsert-distinct-on
+           ├── columns: column1:5!null column2:6!null column3:7!null arbiter_unique_a_distinct:16
+           ├── grouping columns: column2:6!null arbiter_unique_a_distinct:16
+           ├── project
+           │    ├── columns: arbiter_unique_a_distinct:16 column1:5!null column2:6!null column3:7!null
+           │    ├── upsert-distinct-on
+           │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+           │    │    ├── grouping columns: column1:5!null
+           │    │    ├── anti-join (hash)
+           │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+           │    │    │    ├── anti-join (hash)
+           │    │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+           │    │    │    │    ├── values
+           │    │    │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+           │    │    │    │    │    ├── (1, 2, 3)
+           │    │    │    │    │    └── (2, 2, 3)
+           │    │    │    │    ├── scan uniq_partial
+           │    │    │    │    │    └── columns: k:8!null a:9 b:10
+           │    │    │    │    └── filters
+           │    │    │    │         └── column1:5 = k:8
+           │    │    │    ├── select
+           │    │    │    │    ├── columns: k:12!null a:13 b:14!null
+           │    │    │    │    ├── scan uniq_partial
+           │    │    │    │    │    └── columns: k:12!null a:13 b:14
+           │    │    │    │    └── filters
+           │    │    │    │         └── b:14 > 0
+           │    │    │    └── filters
+           │    │    │         ├── column2:6 = a:13
+           │    │    │         └── column3:7 > 0
+           │    │    └── aggregations
+           │    │         ├── first-agg [as=column2:6]
+           │    │         │    └── column2:6
+           │    │         └── first-agg [as=column3:7]
+           │    │              └── column3:7
+           │    └── projections
+           │         └── (column3:7 > 0) OR NULL::BOOL [as=arbiter_unique_a_distinct:16]
+           └── aggregations
+                ├── first-agg [as=column1:5]
+                │    └── column1:5
+                └── first-agg [as=column3:7]
+                     └── column3:7
 
 # Error when there is no arbiter predicate to match the partial unique
 # constraint predicate.
@@ -978,8 +903,6 @@ INSERT INTO uniq_partial VALUES (1, 2, 3) ON CONFLICT (a) DO NOTHING
 error (42P10): there is no unique or exclusion constraint matching the ON CONFLICT specification
 
 # On conflict clause references unique without index constraint.
-# TODO(rytaft/mgartner): we should be able to remove the unique check for a in
-# this case (see #59119).
 build
 INSERT INTO uniq_partial VALUES (1, 2, 3) ON CONFLICT (a) WHERE b > 0 DO NOTHING
 ----
@@ -987,55 +910,37 @@ insert uniq_partial
  ├── columns: <none>
  ├── arbiter constraints: unique_a
  ├── insert-mapping:
- │    ├── column1:5 => uniq_partial.k:1
- │    ├── column2:6 => uniq_partial.a:2
- │    └── column3:7 => uniq_partial.b:3
- ├── input binding: &1
- ├── project
- │    ├── columns: column1:5!null column2:6!null column3:7!null
- │    └── upsert-distinct-on
- │         ├── columns: column1:5!null column2:6!null column3:7!null arbiter_unique_a_distinct:12
- │         ├── grouping columns: column2:6!null arbiter_unique_a_distinct:12
- │         ├── project
- │         │    ├── columns: arbiter_unique_a_distinct:12 column1:5!null column2:6!null column3:7!null
- │         │    ├── anti-join (hash)
- │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
- │         │    │    ├── values
- │         │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
- │         │    │    │    └── (1, 2, 3)
- │         │    │    ├── select
- │         │    │    │    ├── columns: uniq_partial.k:8!null uniq_partial.a:9 uniq_partial.b:10!null
- │         │    │    │    ├── scan uniq_partial
- │         │    │    │    │    └── columns: uniq_partial.k:8!null uniq_partial.a:9 uniq_partial.b:10
- │         │    │    │    └── filters
- │         │    │    │         └── uniq_partial.b:10 > 0
- │         │    │    └── filters
- │         │    │         ├── column2:6 = uniq_partial.a:9
- │         │    │         └── column3:7 > 0
- │         │    └── projections
- │         │         └── (column3:7 > 0) OR NULL::BOOL [as=arbiter_unique_a_distinct:12]
- │         └── aggregations
- │              ├── first-agg [as=column1:5]
- │              │    └── column1:5
- │              └── first-agg [as=column3:7]
- │                   └── column3:7
- └── unique-checks
-      └── unique-checks-item: uniq_partial(a)
-           └── semi-join (hash)
-                ├── columns: k:17!null a:18!null b:19!null
-                ├── with-scan &1
-                │    ├── columns: k:17!null a:18!null b:19!null
-                │    └── mapping:
-                │         ├──  column1:5 => k:17
-                │         ├──  column2:6 => a:18
-                │         └──  column3:7 => b:19
-                ├── scan uniq_partial
-                │    └── columns: uniq_partial.k:13!null uniq_partial.a:14 uniq_partial.b:15
-                └── filters
-                     ├── a:18 = uniq_partial.a:14
-                     ├── b:19 > 0
-                     ├── uniq_partial.b:15 > 0
-                     └── k:17 != uniq_partial.k:13
+ │    ├── column1:5 => k:1
+ │    ├── column2:6 => a:2
+ │    └── column3:7 => b:3
+ └── project
+      ├── columns: column1:5!null column2:6!null column3:7!null
+      └── upsert-distinct-on
+           ├── columns: column1:5!null column2:6!null column3:7!null arbiter_unique_a_distinct:12
+           ├── grouping columns: column2:6!null arbiter_unique_a_distinct:12
+           ├── project
+           │    ├── columns: arbiter_unique_a_distinct:12 column1:5!null column2:6!null column3:7!null
+           │    ├── anti-join (hash)
+           │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+           │    │    ├── values
+           │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+           │    │    │    └── (1, 2, 3)
+           │    │    ├── select
+           │    │    │    ├── columns: k:8!null a:9 b:10!null
+           │    │    │    ├── scan uniq_partial
+           │    │    │    │    └── columns: k:8!null a:9 b:10
+           │    │    │    └── filters
+           │    │    │         └── b:10 > 0
+           │    │    └── filters
+           │    │         ├── column2:6 = a:9
+           │    │         └── column3:7 > 0
+           │    └── projections
+           │         └── (column3:7 > 0) OR NULL::BOOL [as=arbiter_unique_a_distinct:12]
+           └── aggregations
+                ├── first-agg [as=column1:5]
+                │    └── column1:5
+                └── first-agg [as=column3:7]
+                     └── column3:7
 
 # Insert with non-constant input.
 build
@@ -1410,48 +1315,29 @@ insert uniq_constraint_and_partial_index
  ├── columns: <none>
  ├── arbiter constraints: unique_a
  ├── insert-mapping:
- │    ├── column1:5 => uniq_constraint_and_partial_index.k:1
- │    ├── column2:6 => uniq_constraint_and_partial_index.a:2
- │    └── column3:7 => uniq_constraint_and_partial_index.b:3
+ │    ├── column1:5 => k:1
+ │    ├── column2:6 => a:2
+ │    └── column3:7 => b:3
  ├── partial index put columns: partial_index_put1:13
- ├── input binding: &1
- ├── project
- │    ├── columns: partial_index_put1:13!null column1:5!null column2:6!null column3:7!null
- │    ├── anti-join (cross)
- │    │    ├── columns: column1:5!null column2:6!null column3:7!null
- │    │    ├── values
- │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
- │    │    │    └── (1, 1, 1)
- │    │    ├── select
- │    │    │    ├── columns: uniq_constraint_and_partial_index.a:9!null
- │    │    │    ├── scan uniq_constraint_and_partial_index
- │    │    │    │    ├── columns: uniq_constraint_and_partial_index.a:9
- │    │    │    │    └── partial index predicates
- │    │    │    │         └── secondary: filters
- │    │    │    │              └── uniq_constraint_and_partial_index.b:10 > 0
- │    │    │    └── filters
- │    │    │         └── uniq_constraint_and_partial_index.a:9 = 1
- │    │    └── filters (true)
- │    └── projections
- │         └── column3:7 > 0 [as=partial_index_put1:13]
- └── unique-checks
-      └── unique-checks-item: uniq_constraint_and_partial_index(a)
-           └── semi-join (hash)
-                ├── columns: k:18!null a:19!null b:20!null
-                ├── with-scan &1
-                │    ├── columns: k:18!null a:19!null b:20!null
-                │    └── mapping:
-                │         ├──  column1:5 => k:18
-                │         ├──  column2:6 => a:19
-                │         └──  column3:7 => b:20
-                ├── scan uniq_constraint_and_partial_index
-                │    ├── columns: uniq_constraint_and_partial_index.k:14!null uniq_constraint_and_partial_index.a:15
-                │    └── partial index predicates
-                │         └── secondary: filters
-                │              └── uniq_constraint_and_partial_index.b:16 > 0
-                └── filters
-                     ├── a:19 = uniq_constraint_and_partial_index.a:15
-                     └── k:18 != uniq_constraint_and_partial_index.k:14
+ └── project
+      ├── columns: partial_index_put1:13!null column1:5!null column2:6!null column3:7!null
+      ├── anti-join (cross)
+      │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    ├── values
+      │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    │    └── (1, 1, 1)
+      │    ├── select
+      │    │    ├── columns: a:9!null
+      │    │    ├── scan uniq_constraint_and_partial_index
+      │    │    │    ├── columns: a:9
+      │    │    │    └── partial index predicates
+      │    │    │         └── secondary: filters
+      │    │    │              └── b:10 > 0
+      │    │    └── filters
+      │    │         └── a:9 = 1
+      │    └── filters (true)
+      └── projections
+           └── column3:7 > 0 [as=partial_index_put1:13]
 
 exec-ddl
 CREATE TABLE uniq_partial_constraint_and_partial_index (
@@ -1474,94 +1360,73 @@ insert uniq_partial_constraint_and_partial_index
  ├── arbiter indexes: secondary
  ├── arbiter constraints: unique_a
  ├── insert-mapping:
- │    ├── column1:5 => uniq_partial_constraint_and_partial_index.k:1
- │    ├── column2:6 => uniq_partial_constraint_and_partial_index.a:2
- │    └── column3:7 => uniq_partial_constraint_and_partial_index.b:3
+ │    ├── column1:5 => k:1
+ │    ├── column2:6 => a:2
+ │    └── column3:7 => b:3
  ├── partial index put columns: partial_index_put1:18
- ├── input binding: &1
- ├── project
- │    ├── columns: partial_index_put1:18!null column1:5!null column2:6!null column3:7!null
- │    ├── project
- │    │    ├── columns: column1:5!null column2:6!null column3:7!null
- │    │    └── upsert-distinct-on
- │    │         ├── columns: column1:5!null column2:6!null column3:7!null arbiter_unique_a_distinct:17
- │    │         ├── grouping columns: column2:6!null arbiter_unique_a_distinct:17
- │    │         ├── project
- │    │         │    ├── columns: arbiter_unique_a_distinct:17 column1:5!null column2:6!null column3:7!null
- │    │         │    ├── project
- │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
- │    │         │    │    └── upsert-distinct-on
- │    │         │    │         ├── columns: column1:5!null column2:6!null column3:7!null arbiter_secondary_distinct:16
- │    │         │    │         ├── grouping columns: column2:6!null arbiter_secondary_distinct:16
- │    │         │    │         ├── project
- │    │         │    │         │    ├── columns: arbiter_secondary_distinct:16 column1:5!null column2:6!null column3:7!null
- │    │         │    │         │    ├── anti-join (hash)
- │    │         │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
- │    │         │    │         │    │    ├── anti-join (hash)
- │    │         │    │         │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
- │    │         │    │         │    │    │    ├── values
- │    │         │    │         │    │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
- │    │         │    │         │    │    │    │    └── (1, 1, 1)
- │    │         │    │         │    │    │    ├── select
- │    │         │    │         │    │    │    │    ├── columns: uniq_partial_constraint_and_partial_index.k:8!null uniq_partial_constraint_and_partial_index.a:9 uniq_partial_constraint_and_partial_index.b:10!null
- │    │         │    │         │    │    │    │    ├── scan uniq_partial_constraint_and_partial_index
- │    │         │    │         │    │    │    │    │    ├── columns: uniq_partial_constraint_and_partial_index.k:8!null uniq_partial_constraint_and_partial_index.a:9 uniq_partial_constraint_and_partial_index.b:10
- │    │         │    │         │    │    │    │    │    └── partial index predicates
- │    │         │    │         │    │    │    │    │         └── secondary: filters
- │    │         │    │         │    │    │    │    │              └── uniq_partial_constraint_and_partial_index.b:10 > 0
- │    │         │    │         │    │    │    │    └── filters
- │    │         │    │         │    │    │    │         └── uniq_partial_constraint_and_partial_index.b:10 > 0
- │    │         │    │         │    │    │    └── filters
- │    │         │    │         │    │    │         ├── column2:6 = uniq_partial_constraint_and_partial_index.a:9
- │    │         │    │         │    │    │         └── column3:7 > 0
- │    │         │    │         │    │    ├── select
- │    │         │    │         │    │    │    ├── columns: uniq_partial_constraint_and_partial_index.k:12!null uniq_partial_constraint_and_partial_index.a:13 uniq_partial_constraint_and_partial_index.b:14!null
- │    │         │    │         │    │    │    ├── scan uniq_partial_constraint_and_partial_index
- │    │         │    │         │    │    │    │    ├── columns: uniq_partial_constraint_and_partial_index.k:12!null uniq_partial_constraint_and_partial_index.a:13 uniq_partial_constraint_and_partial_index.b:14
- │    │         │    │         │    │    │    │    └── partial index predicates
- │    │         │    │         │    │    │    │         └── secondary: filters
- │    │         │    │         │    │    │    │              └── uniq_partial_constraint_and_partial_index.b:14 > 0
- │    │         │    │         │    │    │    └── filters
- │    │         │    │         │    │    │         └── uniq_partial_constraint_and_partial_index.b:14 > 10
- │    │         │    │         │    │    └── filters
- │    │         │    │         │    │         ├── column2:6 = uniq_partial_constraint_and_partial_index.a:13
- │    │         │    │         │    │         └── column3:7 > 10
- │    │         │    │         │    └── projections
- │    │         │    │         │         └── (column3:7 > 0) OR NULL::BOOL [as=arbiter_secondary_distinct:16]
- │    │         │    │         └── aggregations
- │    │         │    │              ├── first-agg [as=column1:5]
- │    │         │    │              │    └── column1:5
- │    │         │    │              └── first-agg [as=column3:7]
- │    │         │    │                   └── column3:7
- │    │         │    └── projections
- │    │         │         └── (column3:7 > 10) OR NULL::BOOL [as=arbiter_unique_a_distinct:17]
- │    │         └── aggregations
- │    │              ├── first-agg [as=column1:5]
- │    │              │    └── column1:5
- │    │              └── first-agg [as=column3:7]
- │    │                   └── column3:7
- │    └── projections
- │         └── column3:7 > 0 [as=partial_index_put1:18]
- └── unique-checks
-      └── unique-checks-item: uniq_partial_constraint_and_partial_index(a)
-           └── semi-join (hash)
-                ├── columns: k:23!null a:24!null b:25!null
-                ├── with-scan &1
-                │    ├── columns: k:23!null a:24!null b:25!null
-                │    └── mapping:
-                │         ├──  column1:5 => k:23
-                │         ├──  column2:6 => a:24
-                │         └──  column3:7 => b:25
-                ├── scan uniq_partial_constraint_and_partial_index
-                │    ├── columns: uniq_partial_constraint_and_partial_index.k:19!null uniq_partial_constraint_and_partial_index.a:20 uniq_partial_constraint_and_partial_index.b:21
-                │    └── partial index predicates
-                │         └── secondary: filters
-                │              └── uniq_partial_constraint_and_partial_index.b:21 > 0
-                └── filters
-                     ├── a:24 = uniq_partial_constraint_and_partial_index.a:20
-                     ├── b:25 > 10
-                     ├── uniq_partial_constraint_and_partial_index.b:21 > 10
-                     └── k:23 != uniq_partial_constraint_and_partial_index.k:19
+ └── project
+      ├── columns: partial_index_put1:18!null column1:5!null column2:6!null column3:7!null
+      ├── project
+      │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │    └── upsert-distinct-on
+      │         ├── columns: column1:5!null column2:6!null column3:7!null arbiter_unique_a_distinct:17
+      │         ├── grouping columns: column2:6!null arbiter_unique_a_distinct:17
+      │         ├── project
+      │         │    ├── columns: arbiter_unique_a_distinct:17 column1:5!null column2:6!null column3:7!null
+      │         │    ├── project
+      │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │         │    │    └── upsert-distinct-on
+      │         │    │         ├── columns: column1:5!null column2:6!null column3:7!null arbiter_secondary_distinct:16
+      │         │    │         ├── grouping columns: column2:6!null arbiter_secondary_distinct:16
+      │         │    │         ├── project
+      │         │    │         │    ├── columns: arbiter_secondary_distinct:16 column1:5!null column2:6!null column3:7!null
+      │         │    │         │    ├── anti-join (hash)
+      │         │    │         │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │         │    │         │    │    ├── anti-join (hash)
+      │         │    │         │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │         │    │         │    │    │    ├── values
+      │         │    │         │    │    │    │    ├── columns: column1:5!null column2:6!null column3:7!null
+      │         │    │         │    │    │    │    └── (1, 1, 1)
+      │         │    │         │    │    │    ├── select
+      │         │    │         │    │    │    │    ├── columns: k:8!null a:9 b:10!null
+      │         │    │         │    │    │    │    ├── scan uniq_partial_constraint_and_partial_index
+      │         │    │         │    │    │    │    │    ├── columns: k:8!null a:9 b:10
+      │         │    │         │    │    │    │    │    └── partial index predicates
+      │         │    │         │    │    │    │    │         └── secondary: filters
+      │         │    │         │    │    │    │    │              └── b:10 > 0
+      │         │    │         │    │    │    │    └── filters
+      │         │    │         │    │    │    │         └── b:10 > 0
+      │         │    │         │    │    │    └── filters
+      │         │    │         │    │    │         ├── column2:6 = a:9
+      │         │    │         │    │    │         └── column3:7 > 0
+      │         │    │         │    │    ├── select
+      │         │    │         │    │    │    ├── columns: k:12!null a:13 b:14!null
+      │         │    │         │    │    │    ├── scan uniq_partial_constraint_and_partial_index
+      │         │    │         │    │    │    │    ├── columns: k:12!null a:13 b:14
+      │         │    │         │    │    │    │    └── partial index predicates
+      │         │    │         │    │    │    │         └── secondary: filters
+      │         │    │         │    │    │    │              └── b:14 > 0
+      │         │    │         │    │    │    └── filters
+      │         │    │         │    │    │         └── b:14 > 10
+      │         │    │         │    │    └── filters
+      │         │    │         │    │         ├── column2:6 = a:13
+      │         │    │         │    │         └── column3:7 > 10
+      │         │    │         │    └── projections
+      │         │    │         │         └── (column3:7 > 0) OR NULL::BOOL [as=arbiter_secondary_distinct:16]
+      │         │    │         └── aggregations
+      │         │    │              ├── first-agg [as=column1:5]
+      │         │    │              │    └── column1:5
+      │         │    │              └── first-agg [as=column3:7]
+      │         │    │                   └── column3:7
+      │         │    └── projections
+      │         │         └── (column3:7 > 10) OR NULL::BOOL [as=arbiter_unique_a_distinct:17]
+      │         └── aggregations
+      │              ├── first-agg [as=column1:5]
+      │              │    └── column1:5
+      │              └── first-agg [as=column3:7]
+      │                   └── column3:7
+      └── projections
+           └── column3:7 > 0 [as=partial_index_put1:18]
 
 exec-ddl
 CREATE TABLE uniq_computed_pk (

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-upsert
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-upsert
@@ -691,39 +691,22 @@ upsert uniq
  │         ├── CASE WHEN uniq.k:12 IS NULL THEN column4:10 ELSE uniq.x:15 END [as=upsert_x:22]
  │         └── CASE WHEN uniq.k:12 IS NULL THEN column5:11 ELSE uniq.y:16 END [as=upsert_y:23]
  └── unique-checks
-      ├── unique-checks-item: uniq(w)
-      │    └── semi-join (hash)
-      │         ├── columns: k:30 v:31!null w:32 x:33 y:34
-      │         ├── with-scan &1
-      │         │    ├── columns: k:30 v:31!null w:32 x:33 y:34
-      │         │    └── mapping:
-      │         │         ├──  upsert_k:19 => k:30
-      │         │         ├──  upsert_v:20 => v:31
-      │         │         ├──  upsert_w:21 => w:32
-      │         │         ├──  upsert_x:22 => x:33
-      │         │         └──  upsert_y:23 => y:34
-      │         ├── scan uniq
-      │         │    └── columns: uniq.k:24!null uniq.v:25 uniq.w:26 uniq.x:27 uniq.y:28
-      │         └── filters
-      │              ├── w:32 = uniq.w:26
-      │              └── k:30 != uniq.k:24
-      └── unique-checks-item: uniq(x,y)
+      └── unique-checks-item: uniq(w)
            └── semi-join (hash)
-                ├── columns: k:41 v:42!null w:43 x:44 y:45
+                ├── columns: k:30 v:31!null w:32 x:33 y:34
                 ├── with-scan &1
-                │    ├── columns: k:41 v:42!null w:43 x:44 y:45
+                │    ├── columns: k:30 v:31!null w:32 x:33 y:34
                 │    └── mapping:
-                │         ├──  upsert_k:19 => k:41
-                │         ├──  upsert_v:20 => v:42
-                │         ├──  upsert_w:21 => w:43
-                │         ├──  upsert_x:22 => x:44
-                │         └──  upsert_y:23 => y:45
+                │         ├──  upsert_k:19 => k:30
+                │         ├──  upsert_v:20 => v:31
+                │         ├──  upsert_w:21 => w:32
+                │         ├──  upsert_x:22 => x:33
+                │         └──  upsert_y:23 => y:34
                 ├── scan uniq
-                │    └── columns: uniq.k:35!null uniq.v:36 uniq.w:37 uniq.x:38 uniq.y:39
+                │    └── columns: uniq.k:24!null uniq.v:25 uniq.w:26 uniq.x:27 uniq.y:28
                 └── filters
-                     ├── x:44 = uniq.x:38
-                     ├── y:45 = uniq.y:39
-                     └── k:41 != uniq.k:35
+                     ├── w:32 = uniq.w:26
+                     └── k:30 != uniq.k:24
 
 # Cannot conflict on a subset of columns in a unique constraint.
 build
@@ -1036,37 +1019,21 @@ upsert uniq_overlaps_pk
       │              ├── b:26 = uniq_overlaps_pk.b:21
       │              ├── c:27 = uniq_overlaps_pk.c:22
       │              └── a:25 != uniq_overlaps_pk.a:20
-      ├── unique-checks-item: uniq_overlaps_pk(a)
-      │    └── semi-join (hash)
-      │         ├── columns: a:34 b:35!null c:36 d:37
-      │         ├── with-scan &1
-      │         │    ├── columns: a:34 b:35!null c:36 d:37
-      │         │    └── mapping:
-      │         │         ├──  upsert_a:16 => a:34
-      │         │         ├──  upsert_b:17 => b:35
-      │         │         ├──  upsert_c:18 => c:36
-      │         │         └──  upsert_d:19 => d:37
-      │         ├── scan uniq_overlaps_pk
-      │         │    └── columns: uniq_overlaps_pk.a:29!null uniq_overlaps_pk.b:30!null uniq_overlaps_pk.c:31 uniq_overlaps_pk.d:32
-      │         └── filters
-      │              ├── a:34 = uniq_overlaps_pk.a:29
-      │              └── b:35 != uniq_overlaps_pk.b:30
-      └── unique-checks-item: uniq_overlaps_pk(c,d)
+      └── unique-checks-item: uniq_overlaps_pk(a)
            └── semi-join (hash)
-                ├── columns: a:43 b:44!null c:45 d:46
+                ├── columns: a:34 b:35!null c:36 d:37
                 ├── with-scan &1
-                │    ├── columns: a:43 b:44!null c:45 d:46
+                │    ├── columns: a:34 b:35!null c:36 d:37
                 │    └── mapping:
-                │         ├──  upsert_a:16 => a:43
-                │         ├──  upsert_b:17 => b:44
-                │         ├──  upsert_c:18 => c:45
-                │         └──  upsert_d:19 => d:46
+                │         ├──  upsert_a:16 => a:34
+                │         ├──  upsert_b:17 => b:35
+                │         ├──  upsert_c:18 => c:36
+                │         └──  upsert_d:19 => d:37
                 ├── scan uniq_overlaps_pk
-                │    └── columns: uniq_overlaps_pk.a:38!null uniq_overlaps_pk.b:39!null uniq_overlaps_pk.c:40 uniq_overlaps_pk.d:41
+                │    └── columns: uniq_overlaps_pk.a:29!null uniq_overlaps_pk.b:30!null uniq_overlaps_pk.c:31 uniq_overlaps_pk.d:32
                 └── filters
-                     ├── c:45 = uniq_overlaps_pk.c:40
-                     ├── d:46 = uniq_overlaps_pk.d:41
-                     └── (a:43 != uniq_overlaps_pk.a:38) OR (b:44 != uniq_overlaps_pk.b:39)
+                     ├── a:34 = uniq_overlaps_pk.a:29
+                     └── b:35 != uniq_overlaps_pk.b:30
 
 exec-ddl
 CREATE TABLE uniq_hidden_pk (


### PR DESCRIPTION
This commit removes uniqueness checks for `UNIQUE WITHOUT INDEX`
constraints that are already used as arbiters to detect conflicts
in `INSERT ... ON CONFLICT` statements. Unique checks are not needed
in this case to enforce uniqueness.

Fixes #59119

Release justification: This commit is a low-risk update to new
functionality.

Release note (performance improvement): The optimizer no longer plans
uniqueness checks for columns in implicitly partitioned unique indexes
when those columns are used as the arbiters to detect conflicts
in INSERT ... ON CONFLICT statements. Unique checks are not needed
in this case to enforce uniqueness. Removing these checks results in
improved performance for INSERT ... ON CONFLICT statements.