### PR TITLE
storage: add noop behavior for bounds setting in pebbleIterator

### DIFF
--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -229,18 +229,18 @@ func (p *pebbleBatch) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions) M
 	if iter.inuse {
 		panic("iterator already in use")
 	}
+	// Ensures no timestamp hints etc.
+	checkOptionsForIterReuse(opts)
 
 	if iter.iter != nil {
-		iter.setOptions(opts)
+		iter.setBounds(opts.LowerBound, opts.UpperBound)
 	} else {
 		if p.batch.Indexed() {
 			iter.init(p.batch, p.iter, opts)
 		} else {
 			iter.init(p.db, p.iter, opts)
 		}
-		// The timestamp hints should be empty given the earlier code, but we are
-		// being defensive.
-		if p.iter == nil && opts.MaxTimestampHint.IsEmpty() && opts.MinTimestampHint.IsEmpty() {
+		if p.iter == nil {
 			// For future cloning.
 			p.iter = iter.iter
 		}
@@ -271,18 +271,18 @@ func (p *pebbleBatch) NewEngineIterator(opts IterOptions) EngineIterator {
 	if iter.inuse {
 		panic("iterator already in use")
 	}
+	// Ensures no timestamp hints etc.
+	checkOptionsForIterReuse(opts)
 
 	if iter.iter != nil {
-		iter.setOptions(opts)
+		iter.setBounds(opts.LowerBound, opts.UpperBound)
 	} else {
 		if p.batch.Indexed() {
 			iter.init(p.batch, p.iter, opts)
 		} else {
 			iter.init(p.db, p.iter, opts)
 		}
-		// The timestamp hints should be empty given this is an EngineIterator,
-		// but we are being defensive.
-		if p.iter == nil && opts.MaxTimestampHint.IsEmpty() && opts.MinTimestampHint.IsEmpty() {
+		if p.iter == nil {
 			// For future cloning.
 			p.iter = iter.iter
 		}

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -186,6 +186,140 @@ func TestPebbleIterReuse(t *testing.T) {
 	iter2.Close()
 }
 
+type iterBoundsChecker struct {
+	t                  *testing.T
+	expectSetBounds    bool
+	boundsSlices       [2][]byte
+	boundsSlicesCopied [2][]byte
+}
+
+func (ibc *iterBoundsChecker) postSetBounds(lower, upper []byte) {
+	require.True(ibc.t, ibc.expectSetBounds)
+	ibc.expectSetBounds = false
+	// The slices passed in the second from last SetBounds call
+	// must still be the same.
+	for i := range ibc.boundsSlices {
+		if ibc.boundsSlices[i] != nil {
+			if !bytes.Equal(ibc.boundsSlices[i], ibc.boundsSlicesCopied[i]) {
+				ibc.t.Fatalf("bound slice changed: expected: %x, actual: %x",
+					ibc.boundsSlicesCopied[i], ibc.boundsSlices[i])
+			}
+		}
+	}
+	// Stash the bounds for later checking.
+	for i, bound := range [][]byte{lower, upper} {
+		ibc.boundsSlices[i] = bound
+		if bound != nil {
+			ibc.boundsSlicesCopied[i] = append(ibc.boundsSlicesCopied[i][:0], bound...)
+		} else {
+			ibc.boundsSlicesCopied[i] = nil
+		}
+	}
+}
+
+func TestPebbleIterBoundSliceStabilityAndNoop(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	eng := createTestPebbleEngine().(*Pebble)
+	defer eng.Close()
+	iter := newPebbleIterator(eng.db, nil, IterOptions{UpperBound: roachpb.Key("foo")})
+	defer iter.Close()
+	checker := &iterBoundsChecker{t: t}
+	iter.testingSetBoundsListener = checker
+
+	tc := []struct {
+		expectSetBounds bool
+		setUpperOnly    bool
+		lb              roachpb.Key
+		ub              roachpb.Key
+	}{
+		{
+			// [nil, www)
+			expectSetBounds: true,
+			ub:              roachpb.Key("www"),
+		},
+		{
+			// [nil, www)
+			expectSetBounds: false,
+			ub:              roachpb.Key("www"),
+		},
+		{
+			// [nil, www)
+			expectSetBounds: false,
+			setUpperOnly:    true,
+			ub:              roachpb.Key("www"),
+		},
+		{
+			// [ddd, www)
+			expectSetBounds: true,
+			lb:              roachpb.Key("ddd"),
+			ub:              roachpb.Key("www"),
+		},
+		{
+			// [ddd, www)
+			expectSetBounds: false,
+			setUpperOnly:    true,
+			ub:              roachpb.Key("www"),
+		},
+		{
+			// [ddd, xxx)
+			expectSetBounds: true,
+			setUpperOnly:    true,
+			ub:              roachpb.Key("xxx"),
+		},
+		{
+			// [aaa, bbb)
+			expectSetBounds: true,
+			lb:              roachpb.Key("aaa"),
+			ub:              roachpb.Key("bbb"),
+		},
+		{
+			// [ccc, ddd)
+			expectSetBounds: true,
+			lb:              roachpb.Key("ccc"),
+			ub:              roachpb.Key("ddd"),
+		},
+		{
+			// [ccc, nil)
+			expectSetBounds: true,
+			lb:              roachpb.Key("ccc"),
+		},
+		{
+			// [ccc, nil)
+			expectSetBounds: false,
+			lb:              roachpb.Key("ccc"),
+		},
+	}
+	var lb, ub roachpb.Key
+	for _, c := range tc {
+		t.Run(fmt.Sprintf("%v", c), func(t *testing.T) {
+			checker.expectSetBounds = c.expectSetBounds
+			checker.t = t
+			if c.setUpperOnly {
+				iter.SetUpperBound(c.ub)
+				ub = c.ub
+			} else {
+				iter.setBounds(c.lb, c.ub)
+				lb, ub = c.lb, c.ub
+			}
+			require.False(t, checker.expectSetBounds)
+			for i, bound := range [][]byte{lb, ub} {
+				if (bound == nil) != (checker.boundsSlicesCopied[i] == nil) {
+					t.Fatalf("inconsistent nil %d", i)
+				}
+				if bound != nil {
+					expected := append([]byte(nil), bound...)
+					expected = append(expected, 0x00)
+					if !bytes.Equal(expected, checker.boundsSlicesCopied[i]) {
+						t.Fatalf("expected: %x, actual: %x", expected, checker.boundsSlicesCopied[i])
+					}
+				}
+			}
+		})
+	}
+}
+
 func makeMVCCKey(a string) MVCCKey {
 	return MVCCKey{Key: []byte(a)}
 }


### PR DESCRIPTION
This is to compensate for the bug fix in Pebble which removes
the noop behavior from Pebble
https://github.com/cockroachdb/pebble/pull/1073

Added a test that checks that the noop behavior is working,
the contract regarding slice stability is followed, and that
the bounds are correct.

Additionally, there are some minor tweaks involving removal
and addition of some defensive code. The additions are
related to the pebbleIterator.reusable field.

Release justification: Fix for high-severity bug in existing
functionality. The Pebble bug fix that needs to be compensated
here could lead to incorrect results from iterators, even prior
to the latest seek optimization in Pebble (though our existing
tests were not failing prior to that latest seek optimization).

Release note: None