### PR TITLE
opt: fix inverted join logical prop output cols

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -332,18 +332,14 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 	// In test builds, assert that the exec plan output columns match the opt
 	// plan output columns.
 	if util.CrdbTestBuild {
-		// TODO(sumeer): paired inverted joins produce extra columns unknown to the
-		// optimizer.
-		if e.Op() != opt.InvertedJoinOp {
-			optCols := e.Relational().OutputCols
-			var execCols opt.ColSet
-			ep.outputCols.ForEach(func(key, val int) {
-				execCols.Add(opt.ColumnID(key))
-			})
-			if !execCols.Equals(optCols) {
-				return execPlan{}, errors.AssertionFailedf(
-					"exec columns do not match opt columns: expected %v, got %v. op: %T", optCols, execCols, e)
-			}
+		optCols := e.Relational().OutputCols
+		var execCols opt.ColSet
+		ep.outputCols.ForEach(func(key, val int) {
+			execCols.Add(opt.ColumnID(key))
+		})
+		if !execCols.Equals(optCols) {
+			return execPlan{}, errors.AssertionFailedf(
+				"exec columns do not match opt columns: expected %v, got %v. op: %T", optCols, execCols, e)
 		}
 	}
 

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -2171,6 +2171,7 @@ func (h *joinPropsHelper) outputCols() opt.ColSet {
 	//
 	//   1. semi and anti joins, which only project the left columns
 	//   2. lookup joins, which can project a subset of input columns
+	//   3. inverted joins, which can project a subset of input columns
 	//
 	var cols opt.ColSet
 	switch h.joinType {
@@ -2184,6 +2185,10 @@ func (h *joinPropsHelper) outputCols() opt.ColSet {
 	if lookup, ok := h.join.(*LookupJoinExpr); ok {
 		// Remove any columns that are not projected by the lookup join.
 		cols.IntersectionWith(lookup.Cols)
+	}
+	if inv, ok := h.join.(*InvertedJoinExpr); ok {
+		// Remove any columns that are not projected by the inverted join.
+		cols.IntersectionWith(inv.Cols)
 	}
 
 	return cols

--- a/pkg/sql/opt/memo/testdata/stats/inverted-join
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-join
@@ -270,12 +270,12 @@ project
       ├── stats: [rows=3]
       ├── fd: (1)-->(2,3)
       ├── inner-join (inverted json_multi_col@sj_idx [as=t1])
-      │    ├── columns: t2.j:8(jsonb) "inverted_join_const_col_@3":11(string!null) t1.k:12(int!null) s:14(string!null)
+      │    ├── columns: t2.j:8(jsonb) t1.k:12(int!null) s:14(string!null)
       │    ├── prefix key columns: [11] = [14]
       │    ├── inverted-expr
       │    │    └── t1.j:13 @> t2.j:8 [type=bool]
       │    ├── stats: [rows=3, distinct(11)=3, null(11)=0, distinct(12)=2.99565406, null(12)=0, distinct(14)=3, null(14)=0]
-      │    ├── fd: (12)-->(14), (11)==(14), (14)==(11)
+      │    ├── fd: (12)-->(14)
       │    ├── inner-join (cross)
       │    │    ├── columns: t2.j:8(jsonb) "inverted_join_const_col_@3":11(string!null)
       │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
@@ -321,12 +321,12 @@ project
       ├── stats: [rows=0.3]
       ├── fd: ()-->(4), (1)-->(2,3)
       ├── inner-join (inverted json_multi_col@sij_idx [as=t1])
-      │    ├── columns: t2.j:9(jsonb) "inverted_join_const_col_@3":12(string!null) "inverted_join_const_col_@4":13(int!null) t1.k:14(int!null) s:16(string!null) i:17(int!null)
+      │    ├── columns: t2.j:9(jsonb) t1.k:14(int!null) s:16(string!null) i:17(int!null)
       │    ├── prefix key columns: [12 13] = [16 17]
       │    ├── inverted-expr
       │    │    └── t1.j:15 @> t2.j:9 [type=bool]
       │    ├── stats: [rows=0.3, distinct(12)=0.3, null(12)=0, distinct(13)=0.3, null(13)=0, distinct(14)=0.299956504, null(14)=0, distinct(16)=0.3, null(16)=0, distinct(17)=0.3, null(17)=0, distinct(16,17)=0.3, null(16,17)=0]
-      │    ├── fd: ()-->(13,17), (14)-->(16), (12)==(16), (16)==(12), (13)==(17), (17)==(13)
+      │    ├── fd: ()-->(17), (14)-->(16)
       │    ├── project
       │    │    ├── columns: "inverted_join_const_col_@4":13(int!null) t2.j:9(jsonb) "inverted_join_const_col_@3":12(string!null)
       │    │    ├── stats: [rows=30, distinct(12)=3, null(12)=0, distinct(13)=1, null(13)=0]

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -5781,12 +5781,12 @@ project
       ├── immutable
       ├── fd: ()-->(14), (1)-->(10)
       ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
-      │    ├── columns: c.gid:1!null c.geom:10 "inverted_join_const_col_@14":20!null n.gid:21!null n.boroname:22!null
+      │    ├── columns: c.gid:1!null c.geom:10 n.gid:21!null n.boroname:22!null
       │    ├── prefix key columns: [20] = [22]
       │    ├── inverted-expr
       │    │    └── st_covers(c.geom:10, n.geom:24)
       │    ├── key: (1,21)
-      │    ├── fd: ()-->(20,22), (1)-->(10), (20)==(22), (22)==(20)
+      │    ├── fd: ()-->(22), (1)-->(10)
       │    ├── project
       │    │    ├── columns: "inverted_join_const_col_@14":20!null c.gid:1!null c.geom:10
       │    │    ├── key: (1)
@@ -5819,12 +5819,12 @@ project
       ├── immutable
       ├── fd: ()-->(6,9)
       ├── inner-join (inverted json_arr1@a_idx [as=t1])
-      │    ├── columns: t2.a:4 "inverted_join_const_col_@6":18!null t1.k:19!null
+      │    ├── columns: t2.a:4 t1.k:19!null
       │    ├── flags: force inverted join (into right side)
       │    ├── prefix key columns: [18] = [19]
       │    ├── inverted-expr
       │    │    └── t1.a:22 @> t2.a:4
-      │    ├── fd: ()-->(18,19), (18)==(19), (19)==(18)
+      │    ├── fd: ()-->(19)
       │    ├── project
       │    │    ├── columns: "inverted_join_const_col_@6":18!null t2.a:4
       │    │    ├── fd: ()-->(18)
@@ -5854,12 +5854,12 @@ project
       ├── immutable
       ├── fd: ()-->(6,8)
       ├── inner-join (inverted json_arr1@j_idx [as=t1])
-      │    ├── columns: t2.j:3 "inverted_join_const_col_@6":17!null t1.k:18!null
+      │    ├── columns: t2.j:3 t1.k:18!null
       │    ├── flags: force inverted join (into right side)
       │    ├── prefix key columns: [17] = [18]
       │    ├── inverted-expr
       │    │    └── t1.j:20 @> t2.j:3
-      │    ├── fd: ()-->(17,18), (17)==(18), (18)==(17)
+      │    ├── fd: ()-->(18)
       │    ├── project
       │    │    ├── columns: "inverted_join_const_col_@6":17!null t2.j:3
       │    │    ├── fd: ()-->(17)
@@ -5889,12 +5889,12 @@ project
       ├── immutable
       ├── fd: ()-->(6,8,9)
       ├── inner-join (inverted json_arr1@j_idx [as=t1])
-      │    ├── columns: t2.j:3 "inverted_join_const_col_@6":17!null t1.k:18!null
+      │    ├── columns: t2.j:3 t1.k:18!null
       │    ├── flags: force inverted join (into right side)
       │    ├── prefix key columns: [17] = [18]
       │    ├── inverted-expr
       │    │    └── t1.j:20 @> t2.j:3
-      │    ├── fd: ()-->(17,18), (17)==(18), (18)==(17)
+      │    ├── fd: ()-->(18)
       │    ├── project
       │    │    ├── columns: "inverted_join_const_col_@6":17!null t2.j:3
       │    │    ├── fd: ()-->(17)
@@ -5924,12 +5924,11 @@ project
       ├── immutable
       ├── fd: (6)-->(8)
       ├── inner-join (inverted json_arr1@j_idx [as=t1])
-      │    ├── columns: t2.j:3 "inverted_join_const_col_@6":17!null t1.k:18!null
+      │    ├── columns: t2.j:3 t1.k:18!null
       │    ├── flags: force inverted join (into right side)
       │    ├── prefix key columns: [17] = [18]
       │    ├── inverted-expr
       │    │    └── t1.j:20 @> t2.j:3
-      │    ├── fd: (17)==(18), (18)==(17)
       │    ├── inner-join (cross)
       │    │    ├── columns: t2.j:3 "inverted_join_const_col_@6":17!null
       │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
@@ -5997,12 +5996,12 @@ project
       ├── immutable
       ├── fd: (6)-->(8)
       ├── inner-join (inverted json_check@secondary [as=t1])
-      │    ├── columns: t2.j:3 "inverted_join_const_col_@7":11!null t1.k:12!null i:13!null
+      │    ├── columns: t2.j:3 t1.k:12!null i:13!null
       │    ├── flags: force inverted join (into right side)
       │    ├── prefix key columns: [11] = [13]
       │    ├── inverted-expr
       │    │    └── t1.j:14 @> t2.j:3
-      │    ├── fd: (12)-->(13), (11)==(13), (13)==(11)
+      │    ├── fd: (12)-->(13)
       │    ├── inner-join (cross)
       │    │    ├── columns: t2.j:3 "inverted_join_const_col_@7":11!null
       │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
@@ -6036,12 +6035,12 @@ project
       ├── immutable
       ├── fd: ()-->(7), (6)-->(9)
       ├── inner-join (inverted json_comp@bj_idx [as=t1])
-      │    ├── columns: t2.j:3 "inverted_join_const_col_@8":12!null t1.k:13!null b:15!null
+      │    ├── columns: t2.j:3 t1.k:13!null b:15!null
       │    ├── flags: force inverted join (into right side)
       │    ├── prefix key columns: [12] = [15]
       │    ├── inverted-expr
       │    │    └── t1.j:16 @> t2.j:3
-      │    ├── fd: ()-->(12,15), (12)==(15), (15)==(12)
+      │    ├── fd: ()-->(15)
       │    ├── project
       │    │    ├── columns: "inverted_join_const_col_@8":12!null t2.j:3
       │    │    ├── fd: ()-->(12)
@@ -6081,12 +6080,12 @@ project
       ├── immutable
       ├── fd: ()-->(7), (6)-->(9)
       ├── inner-join (inverted json_comp@bj_partial_idx,partial [as=t1])
-      │    ├── columns: t2.j:3 "inverted_join_const_col_@8":13!null t1.k:14!null b:16!null
+      │    ├── columns: t2.j:3 t1.k:14!null b:16!null
       │    ├── flags: force inverted join (into right side)
       │    ├── prefix key columns: [13] = [16]
       │    ├── inverted-expr
       │    │    └── t1.j:17 @> t2.j:3
-      │    ├── fd: ()-->(13,16), (13)==(16), (16)==(13)
+      │    ├── fd: ()-->(16)
       │    ├── project
       │    │    ├── columns: "inverted_join_const_col_@8":13!null t2.j:3
       │    │    ├── fd: ()-->(13)
@@ -6153,12 +6152,12 @@ project
       ├── immutable
       ├── fd: (6)-->(7,8)
       ├── inner-join (inverted json_arr1@j_idx [as=t1])
-      │    ├── columns: t2.j:3 "inverted_join_const_col_@6":19!null "inverted_join_const_col_@7":20!null t1.k:21!null i:22!null
+      │    ├── columns: t2.j:3 t1.k:21!null i:22!null
       │    ├── flags: force inverted join (into right side)
       │    ├── prefix key columns: [19 20] = [21 22]
       │    ├── inverted-expr
       │    │    └── t1.j:23 @> t2.j:3
-      │    ├── fd: (21)-->(22), (19)==(21), (21)==(19), (20)==(22), (22)==(20)
+      │    ├── fd: (21)-->(22)
       │    ├── inner-join (cross)
       │    │    ├── columns: t2.j:3 "inverted_join_const_col_@6":19!null "inverted_join_const_col_@7":20!null
       │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
@@ -6203,12 +6202,12 @@ project
       ├── key: (6)
       ├── fd: (1)-->(3), (6)-->(7,8), (1)==(6), (6)==(1)
       ├── inner-join (inverted json_arr1@j_idx [as=t1])
-      │    ├── columns: t2.k:1!null t2.j:3 "inverted_join_const_col_@7":18!null t1.k:19!null i:20!null
+      │    ├── columns: t2.k:1!null t2.j:3 t1.k:19!null i:20!null
       │    ├── flags: force inverted join (into right side)
       │    ├── prefix key columns: [1 18] = [19 20]
       │    ├── inverted-expr
       │    │    └── t1.j:21 @> t2.j:3
-      │    ├── fd: (1)-->(3), (19)-->(20), (1)==(19), (19)==(1), (18)==(20), (20)==(18)
+      │    ├── fd: (1)-->(3), (19)-->(20), (1)==(19), (19)==(1)
       │    ├── inner-join (cross)
       │    │    ├── columns: t2.k:1!null t2.j:3 "inverted_join_const_col_@7":18!null
       │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
@@ -6322,11 +6321,11 @@ semi-join (lookup json_arr1 [as=t1])
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  ├── inner-join (inverted json_arr1@j_idx [as=t1])
- │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 "inverted_join_const_col_@7":19!null t1.k:20!null i:21!null continuation:33
+ │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:20!null i:21!null continuation:33
  │    ├── prefix key columns: [19] = [21]
  │    ├── inverted-expr
  │    │    └── t1.j:22 @> t2.j:3
- │    ├── fd: (1)-->(2-4), (20)-->(21,33), (19)==(21), (21)==(19)
+ │    ├── fd: (1)-->(2-4), (20)-->(21,33)
  │    ├── inner-join (cross)
  │    │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 "inverted_join_const_col_@7":19!null
  │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)


### PR DESCRIPTION
An inverted join may project a subset of its input columns. This was not
accounted for when building logical properties, which led caused test
build assertions to fail. This commit corrects the issue.

Fixes #59285

Release justification: This is a low-risk bug fix for inverted joins.

Release note: None