### PR TITLE
release-20.2: sql: fix SHOW TABLES FROM db stats display

### DIFF
--- a/pkg/sql/delegate/show_tables.go
+++ b/pkg/sql/delegate/show_tables.go
@@ -88,9 +88,10 @@ SELECT ns.nspname AS schema_name,
 	}
 	if showEstimatedRowCountClusterSetting.Get(&d.evalCtx.Settings.SV) {
 		estimatedRowCount = ", s.estimated_row_count AS estimated_row_count"
-		estimatedRowCountJoin = `
-  LEFT
-  JOIN crdb_internal.table_row_statistics AS s on (s.table_id = pc.oid::INT8)`
+		estimatedRowCountJoin = fmt.Sprintf(
+			`LEFT JOIN %[1]s.crdb_internal.table_row_statistics AS s on (s.table_id = pc.oid::INT8)`,
+			&name.CatalogName,
+		)
 	}
 	query := fmt.Sprintf(
 		getTablesQuery,

--- a/pkg/sql/logictest/testdata/logic_test/namespace
+++ b/pkg/sql/logictest/testdata/logic_test/namespace
@@ -15,7 +15,7 @@ public  a  table  root  0
 query TTTTI
 SHOW TABLES FROM public.public
 ----
-public  t  table  root  NULL
+public  t  table  root  0
 
 # Of course one can also list the tables in "public" by making it the
 # current database.

--- a/pkg/sql/logictest/testdata/logic_test/rename_table
+++ b/pkg/sql/logictest/testdata/logic_test/rename_table
@@ -129,8 +129,8 @@ SHOW TABLES
 query TTTTI
 SHOW TABLES FROM test2
 ----
-public  t   table  root  NULL
-public  t2  table  root  NULL
+public  t   table  root  0
+public  t2  table  root  0
 
 user root
 

--- a/pkg/sql/logictest/testdata/logic_test/rename_view
+++ b/pkg/sql/logictest/testdata/logic_test/rename_view
@@ -146,8 +146,8 @@ SHOW TABLES FROM test
 query TTTTI
 SHOW TABLES FROM test2
 ----
-public  v   view  root  NULL
-public  v2  view  root  NULL
+public  v   view  root  0
+public  v2  view  root  0
 
 user root
 

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -1104,7 +1104,7 @@ publicdb   root
 query TTTTI
 SHOW TABLES FROM publicdb
 ----
-public  publictable  table  root  NULL
+public  publictable  table  root  0
 
 query TTTTI
 SHOW TABLES FROM privatedb

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -189,69 +189,69 @@ query TTTTI colnames,rowsort
 SELECT * FROM [SHOW TABLES FROM system]
 ----
 schema_name  table_name                       type   owner  estimated_row_count
-public       namespace                        table  NULL   NULL
-public       descriptor                       table  NULL   NULL
-public       users                            table  NULL   NULL
-public       zones                            table  NULL   NULL
-public       settings                         table  NULL   NULL
-public       tenants                          table  NULL   NULL
-public       lease                            table  NULL   NULL
-public       eventlog                         table  NULL   NULL
-public       rangelog                         table  NULL   NULL
-public       ui                               table  NULL   NULL
-public       jobs                             table  NULL   NULL
-public       web_sessions                     table  NULL   NULL
-public       table_statistics                 table  NULL   NULL
-public       locations                        table  NULL   NULL
-public       role_members                     table  NULL   NULL
-public       comments                         table  NULL   NULL
-public       replication_constraint_stats     table  NULL   NULL
-public       replication_critical_localities  table  NULL   NULL
-public       replication_stats                table  NULL   NULL
-public       reports_meta                     table  NULL   NULL
-public       namespace2                       table  NULL   NULL
-public       protected_ts_meta                table  NULL   NULL
-public       protected_ts_records             table  NULL   NULL
-public       role_options                     table  NULL   NULL
-public       statement_bundle_chunks          table  NULL   NULL
-public       statement_diagnostics_requests   table  NULL   NULL
-public       statement_diagnostics            table  NULL   NULL
-public       scheduled_jobs                   table  NULL   NULL
-public       sqlliveness                      table  NULL   NULL
+public       namespace                        table  NULL   0
+public       descriptor                       table  NULL   0
+public       users                            table  NULL   0
+public       zones                            table  NULL   0
+public       settings                         table  NULL   0
+public       tenants                          table  NULL   0
+public       lease                            table  NULL   0
+public       eventlog                         table  NULL   0
+public       rangelog                         table  NULL   0
+public       ui                               table  NULL   0
+public       jobs                             table  NULL   0
+public       web_sessions                     table  NULL   0
+public       table_statistics                 table  NULL   0
+public       locations                        table  NULL   0
+public       role_members                     table  NULL   0
+public       comments                         table  NULL   0
+public       replication_constraint_stats     table  NULL   0
+public       replication_critical_localities  table  NULL   0
+public       replication_stats                table  NULL   0
+public       reports_meta                     table  NULL   0
+public       namespace2                       table  NULL   0
+public       protected_ts_meta                table  NULL   0
+public       protected_ts_records             table  NULL   0
+public       role_options                     table  NULL   0
+public       statement_bundle_chunks          table  NULL   0
+public       statement_diagnostics_requests   table  NULL   0
+public       statement_diagnostics            table  NULL   0
+public       scheduled_jobs                   table  NULL   0
+public       sqlliveness                      table  NULL   0
 
-query TTTTTT colnames,rowsort
+query TTTTIT colnames,rowsort
 SELECT * FROM [SHOW TABLES FROM system WITH COMMENT]
 ----
 schema_name  table_name                       type   owner  estimated_row_count  comment
-public       namespace                        table  NULL   NULL                 ·
-public       descriptor                       table  NULL   NULL                 ·
-public       users                            table  NULL   NULL                 ·
-public       zones                            table  NULL   NULL                 ·
-public       settings                         table  NULL   NULL                 ·
-public       tenants                          table  NULL   NULL                 ·
-public       lease                            table  NULL   NULL                 ·
-public       eventlog                         table  NULL   NULL                 ·
-public       rangelog                         table  NULL   NULL                 ·
-public       ui                               table  NULL   NULL                 ·
-public       jobs                             table  NULL   NULL                 ·
-public       web_sessions                     table  NULL   NULL                 ·
-public       table_statistics                 table  NULL   NULL                 ·
-public       locations                        table  NULL   NULL                 ·
-public       role_members                     table  NULL   NULL                 ·
-public       comments                         table  NULL   NULL                 ·
-public       replication_constraint_stats     table  NULL   NULL                 ·
-public       replication_critical_localities  table  NULL   NULL                 ·
-public       replication_stats                table  NULL   NULL                 ·
-public       reports_meta                     table  NULL   NULL                 ·
-public       namespace2                       table  NULL   NULL                 ·
-public       protected_ts_meta                table  NULL   NULL                 ·
-public       protected_ts_records             table  NULL   NULL                 ·
-public       role_options                     table  NULL   NULL                 ·
-public       statement_bundle_chunks          table  NULL   NULL                 ·
-public       statement_diagnostics_requests   table  NULL   NULL                 ·
-public       statement_diagnostics            table  NULL   NULL                 ·
-public       scheduled_jobs                   table  NULL   NULL                 ·
-public       sqlliveness                      table  NULL   NULL                 ·
+public       namespace                        table  NULL   0                    ·
+public       descriptor                       table  NULL   0                    ·
+public       users                            table  NULL   0                    ·
+public       zones                            table  NULL   0                    ·
+public       settings                         table  NULL   0                    ·
+public       tenants                          table  NULL   0                    ·
+public       lease                            table  NULL   0                    ·
+public       eventlog                         table  NULL   0                    ·
+public       rangelog                         table  NULL   0                    ·
+public       ui                               table  NULL   0                    ·
+public       jobs                             table  NULL   0                    ·
+public       web_sessions                     table  NULL   0                    ·
+public       table_statistics                 table  NULL   0                    ·
+public       locations                        table  NULL   0                    ·
+public       role_members                     table  NULL   0                    ·
+public       comments                         table  NULL   0                    ·
+public       replication_constraint_stats     table  NULL   0                    ·
+public       replication_critical_localities  table  NULL   0                    ·
+public       replication_stats                table  NULL   0                    ·
+public       reports_meta                     table  NULL   0                    ·
+public       namespace2                       table  NULL   0                    ·
+public       protected_ts_meta                table  NULL   0                    ·
+public       protected_ts_records             table  NULL   0                    ·
+public       role_options                     table  NULL   0                    ·
+public       statement_bundle_chunks          table  NULL   0                    ·
+public       statement_diagnostics_requests   table  NULL   0                    ·
+public       statement_diagnostics            table  NULL   0                    ·
+public       scheduled_jobs                   table  NULL   0                    ·
+public       sqlliveness                      table  NULL   0                    ·
 
 query ITTT colnames
 SELECT node_id, user_name, application_name, active_queries

--- a/pkg/sql/logictest/testdata/logic_test/show_tables
+++ b/pkg/sql/logictest/testdata/logic_test/show_tables
@@ -1,10 +1,27 @@
 # LogicTest: local
 
 statement ok
-SET CLUSTER SETTING sql.show_tables.estimated_row_count.enabled = false
+CREATE TABLE show_this_table()
+
+query TTTTI
+SHOW TABLES
+----
+public  show_this_table  table  root  0
 
 statement ok
-CREATE TABLE show_this_table ()
+CREATE DATABASE other;
+SET DATABASE = 'other'
+
+query TTTTI
+SHOW TABLES FROM test
+----
+public  show_this_table  table  root  0
+
+statement ok
+SET DATABASE = 'test'
+
+statement ok
+SET CLUSTER SETTING sql.show_tables.estimated_row_count.enabled = false
 
 query TTTT
 SHOW TABLES

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -10,35 +10,35 @@ test       root
 query TTTTI
 SHOW TABLES FROM system
 ----
-public  comments                         table  NULL  NULL
-public  descriptor                       table  NULL  NULL
-public  eventlog                         table  NULL  NULL
-public  jobs                             table  NULL  NULL
-public  lease                            table  NULL  NULL
-public  locations                        table  NULL  NULL
-public  namespace                        table  NULL  NULL
-public  namespace2                       table  NULL  NULL
-public  protected_ts_meta                table  NULL  NULL
-public  protected_ts_records             table  NULL  NULL
-public  rangelog                         table  NULL  NULL
-public  replication_constraint_stats     table  NULL  NULL
-public  replication_critical_localities  table  NULL  NULL
-public  replication_stats                table  NULL  NULL
-public  reports_meta                     table  NULL  NULL
-public  role_members                     table  NULL  NULL
-public  role_options                     table  NULL  NULL
-public  scheduled_jobs                   table  NULL  NULL
-public  settings                         table  NULL  NULL
-public  sqlliveness                      table  NULL  NULL
-public  statement_bundle_chunks          table  NULL  NULL
-public  statement_diagnostics            table  NULL  NULL
-public  statement_diagnostics_requests   table  NULL  NULL
-public  table_statistics                 table  NULL  NULL
-public  tenants                          table  NULL  NULL
-public  ui                               table  NULL  NULL
-public  users                            table  NULL  NULL
-public  web_sessions                     table  NULL  NULL
-public  zones                            table  NULL  NULL
+public  comments                         table  NULL  0
+public  descriptor                       table  NULL  0
+public  eventlog                         table  NULL  0
+public  jobs                             table  NULL  0
+public  lease                            table  NULL  0
+public  locations                        table  NULL  0
+public  namespace                        table  NULL  0
+public  namespace2                       table  NULL  0
+public  protected_ts_meta                table  NULL  0
+public  protected_ts_records             table  NULL  0
+public  rangelog                         table  NULL  0
+public  replication_constraint_stats     table  NULL  0
+public  replication_critical_localities  table  NULL  0
+public  replication_stats                table  NULL  0
+public  reports_meta                     table  NULL  0
+public  role_members                     table  NULL  0
+public  role_options                     table  NULL  0
+public  scheduled_jobs                   table  NULL  0
+public  settings                         table  NULL  0
+public  sqlliveness                      table  NULL  0
+public  statement_bundle_chunks          table  NULL  0
+public  statement_diagnostics            table  NULL  0
+public  statement_diagnostics_requests   table  NULL  0
+public  table_statistics                 table  NULL  0
+public  tenants                          table  NULL  0
+public  ui                               table  NULL  0
+public  users                            table  NULL  0
+public  web_sessions                     table  NULL  0
+public  zones                            table  NULL  0
 
 query I rowsort
 SELECT id FROM system.descriptor

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -556,7 +556,7 @@ func TestPGPreparedQuery(t *testing.T) {
 			baseTest.Results("users", "primary", false, 1, "username", "ASC", false, false),
 		}},
 		{"SHOW TABLES FROM system", []preparedQueryTest{
-			baseTest.Results("public", "comments", "table", gosql.NullString{}, gosql.NullString{}).Others(28),
+			baseTest.Results("public", "comments", "table", gosql.NullString{}, 0).Others(28),
 		}},
 		{"SHOW SCHEMAS FROM system", []preparedQueryTest{
 			baseTest.Results("crdb_internal", gosql.NullString{}).Others(4),


### PR DESCRIPTION
Backport 1/1 commits from #61191.

/cc @cockroachdb/release

---

fixes #58652

Release justification: low-risk bug fix to existing functionality.

Release note (bug fix): The `SHOW TABLES FROM database` command would
always show a NULL estimated_row_count if inspecting a database that was
not the current database. This is now fixed.
