### PR TITLE
sql: populate database_name when selecting from crdb_internal.create_statements

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1938,7 +1938,7 @@ CREATE TABLE crdb_internal.create_statements (
 	is_multi_region               BOOL NOT NULL,
   INDEX(descriptor_id)
 )
-`, virtualOnce, false, /* includesIndexEntries */
+`, virtualCurrentDB, false, /* includesIndexEntries */
 	func(ctx context.Context, p *planner, h oidHasher, db *dbdesc.Immutable, scName string,
 		table catalog.TableDescriptor, lookup simpleSchemaResolver, addRow func(...tree.Datum) error) error {
 		contextName := ""

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1957,8 +1957,8 @@ type virtualOpts int
 const (
 	// virtualMany iterates over virtual schemas in every catalog/database.
 	virtualMany virtualOpts = iota
-	// virtualOnce iterates over virtual schemas once, in the nil database.
-	virtualOnce
+	// virtualCurrentDB iterates over virtual schemas in the current database.
+	virtualCurrentDB
 	// hideVirtual completely hides virtual schemas during iteration.
 	hideVirtual
 )
@@ -2118,7 +2118,7 @@ func forEachTableDescWithTableLookupInternalFromDescriptors(
 	lCtx := newInternalLookupCtx(ctx, descs, dbContext,
 		catalogkv.NewOneLevelUncachedDescGetter(p.txn, p.execCfg.Codec))
 
-	if virtualOpts == virtualMany || virtualOpts == virtualOnce {
+	if virtualOpts == virtualMany || virtualOpts == virtualCurrentDB {
 		// Virtual descriptors first.
 		vt := p.getVirtualTabler()
 		vEntries := vt.getEntries()
@@ -2137,8 +2137,8 @@ func forEachTableDescWithTableLookupInternalFromDescriptors(
 		}
 
 		switch virtualOpts {
-		case virtualOnce:
-			if err := iterate(nil); err != nil {
+		case virtualCurrentDB:
+			if err := iterate(dbContext); err != nil {
 				return err
 			}
 		case virtualMany:

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -32,6 +32,4704 @@ query TTTT colnames
 SELECT create_statement, create_nofks, alter_statements, validate_statements FROM crdb_internal.create_statements WHERE database_name = 'test'
 ----
 create_statement  create_nofks  alter_statements  validate_statements
+CREATE TABLE crdb_internal.backward_dependencies (
+   descriptor_id INT8 NULL,
+   descriptor_name STRING NOT NULL,
+   index_id INT8 NULL,
+   column_id INT8 NULL,
+   dependson_id INT8 NOT NULL,
+   dependson_type STRING NOT NULL,
+   dependson_index_id INT8 NULL,
+   dependson_name STRING NULL,
+   dependson_details STRING NULL
+)  CREATE TABLE crdb_internal.backward_dependencies (
+   descriptor_id INT8 NULL,
+   descriptor_name STRING NOT NULL,
+   index_id INT8 NULL,
+   column_id INT8 NULL,
+   dependson_id INT8 NOT NULL,
+   dependson_type STRING NOT NULL,
+   dependson_index_id INT8 NULL,
+   dependson_name STRING NULL,
+   dependson_details STRING NULL
+)  {}  {}
+CREATE TABLE crdb_internal.builtin_functions (
+   function STRING NOT NULL,
+   signature STRING NOT NULL,
+   category STRING NOT NULL,
+   details STRING NOT NULL
+)  CREATE TABLE crdb_internal.builtin_functions (
+   function STRING NOT NULL,
+   signature STRING NOT NULL,
+   category STRING NOT NULL,
+   details STRING NOT NULL
+)  {}  {}
+CREATE TABLE crdb_internal.cluster_contention_events (
+   table_id INT8 NOT NULL,
+   index_id INT8 NOT NULL,
+   num_contention_events INT8 NOT NULL,
+   cumulative_contention_time INTERVAL NOT NULL,
+   key BYTES NOT NULL,
+   txn_id UUID NOT NULL,
+   count INT8 NOT NULL
+)  CREATE TABLE crdb_internal.cluster_contention_events (
+   table_id INT8 NOT NULL,
+   index_id INT8 NOT NULL,
+   num_contention_events INT8 NOT NULL,
+   cumulative_contention_time INTERVAL NOT NULL,
+   key BYTES NOT NULL,
+   txn_id UUID NOT NULL,
+   count INT8 NOT NULL
+)  {}  {}
+CREATE TABLE crdb_internal.cluster_database_privileges (
+   database_name STRING NOT NULL,
+   grantee STRING NOT NULL,
+   privilege_type STRING NOT NULL
+)  CREATE TABLE crdb_internal.cluster_database_privileges (
+   database_name STRING NOT NULL,
+   grantee STRING NOT NULL,
+   privilege_type STRING NOT NULL
+)  {}  {}
+CREATE TABLE crdb_internal.cluster_queries (
+   query_id STRING NULL,
+   txn_id UUID NULL,
+   node_id INT8 NOT NULL,
+   session_id STRING NULL,
+   user_name STRING NULL,
+   start TIMESTAMP NULL,
+   query STRING NULL,
+   client_address STRING NULL,
+   application_name STRING NULL,
+   distributed BOOL NULL,
+   phase STRING NULL
+)  CREATE TABLE crdb_internal.cluster_queries (
+   query_id STRING NULL,
+   txn_id UUID NULL,
+   node_id INT8 NOT NULL,
+   session_id STRING NULL,
+   user_name STRING NULL,
+   start TIMESTAMP NULL,
+   query STRING NULL,
+   client_address STRING NULL,
+   application_name STRING NULL,
+   distributed BOOL NULL,
+   phase STRING NULL
+)  {}  {}
+CREATE TABLE crdb_internal.cluster_sessions (
+   node_id INT8 NOT NULL,
+   session_id STRING NULL,
+   user_name STRING NULL,
+   client_address STRING NULL,
+   application_name STRING NULL,
+   active_queries STRING NULL,
+   last_active_query STRING NULL,
+   session_start TIMESTAMP NULL,
+   oldest_query_start TIMESTAMP NULL,
+   kv_txn STRING NULL,
+   alloc_bytes INT8 NULL,
+   max_alloc_bytes INT8 NULL
+)  CREATE TABLE crdb_internal.cluster_sessions (
+   node_id INT8 NOT NULL,
+   session_id STRING NULL,
+   user_name STRING NULL,
+   client_address STRING NULL,
+   application_name STRING NULL,
+   active_queries STRING NULL,
+   last_active_query STRING NULL,
+   session_start TIMESTAMP NULL,
+   oldest_query_start TIMESTAMP NULL,
+   kv_txn STRING NULL,
+   alloc_bytes INT8 NULL,
+   max_alloc_bytes INT8 NULL
+)  {}  {}
+CREATE TABLE crdb_internal.cluster_settings (
+   variable STRING NOT NULL,
+   value STRING NOT NULL,
+   type STRING NOT NULL,
+   public BOOL NOT NULL,
+   description STRING NOT NULL
+)  CREATE TABLE crdb_internal.cluster_settings (
+   variable STRING NOT NULL,
+   value STRING NOT NULL,
+   type STRING NOT NULL,
+   public BOOL NOT NULL,
+   description STRING NOT NULL
+)  {}  {}
+CREATE TABLE crdb_internal.cluster_transactions (
+   id UUID NULL,
+   node_id INT8 NULL,
+   session_id STRING NULL,
+   start TIMESTAMP NULL,
+   txn_string STRING NULL,
+   application_name STRING NULL,
+   num_stmts INT8 NULL,
+   num_retries INT8 NULL,
+   num_auto_retries INT8 NULL
+)  CREATE TABLE crdb_internal.cluster_transactions (
+   id UUID NULL,
+   node_id INT8 NULL,
+   session_id STRING NULL,
+   start TIMESTAMP NULL,
+   txn_string STRING NULL,
+   application_name STRING NULL,
+   num_stmts INT8 NULL,
+   num_retries INT8 NULL,
+   num_auto_retries INT8 NULL
+)  {}  {}
+CREATE TABLE crdb_internal.create_statements (
+   database_id INT8 NULL,
+   database_name STRING NULL,
+   schema_name STRING NOT NULL,
+   descriptor_id INT8 NULL,
+   descriptor_type STRING NOT NULL,
+   descriptor_name STRING NOT NULL,
+   create_statement STRING NOT NULL,
+   state STRING NOT NULL,
+   create_nofks STRING NOT NULL,
+   alter_statements STRING[] NOT NULL,
+   validate_statements STRING[] NOT NULL,
+   has_partitions BOOL NOT NULL,
+   is_multi_region BOOL NOT NULL,
+   INDEX create_statements_descriptor_id_idx (descriptor_id ASC) STORING (database_id, database_name, schema_name, descriptor_type, descriptor_name, create_statement, state, create_nofks, alter_statements, validate_statements, has_partitions, is_multi_region)
+)  CREATE TABLE crdb_internal.create_statements (
+   database_id INT8 NULL,
+   database_name STRING NULL,
+   schema_name STRING NOT NULL,
+   descriptor_id INT8 NULL,
+   descriptor_type STRING NOT NULL,
+   descriptor_name STRING NOT NULL,
+   create_statement STRING NOT NULL,
+   state STRING NOT NULL,
+   create_nofks STRING NOT NULL,
+   alter_statements STRING[] NOT NULL,
+   validate_statements STRING[] NOT NULL,
+   has_partitions BOOL NOT NULL,
+   is_multi_region BOOL NOT NULL,
+   INDEX create_statements_descriptor_id_idx (descriptor_id ASC) STORING (database_id, database_name, schema_name, descriptor_type, descriptor_name, create_statement, state, create_nofks, alter_statements, validate_statements, has_partitions, is_multi_region)
+)  {}  {}
+CREATE TABLE crdb_internal.create_type_statements (
+   database_id INT8 NULL,
+   database_name STRING NULL,
+   schema_name STRING NULL,
+   descriptor_id INT8 NULL,
+   descriptor_name STRING NULL,
+   create_statement STRING NULL,
+   enum_members STRING[] NULL,
+   INDEX create_type_statements_descriptor_id_idx (descriptor_id ASC) STORING (database_id, database_name, schema_name, descriptor_name, create_statement, enum_members)
+)  CREATE TABLE crdb_internal.create_type_statements (
+   database_id INT8 NULL,
+   database_name STRING NULL,
+   schema_name STRING NULL,
+   descriptor_id INT8 NULL,
+   descriptor_name STRING NULL,
+   create_statement STRING NULL,
+   enum_members STRING[] NULL,
+   INDEX create_type_statements_descriptor_id_idx (descriptor_id ASC) STORING (database_id, database_name, schema_name, descriptor_name, create_statement, enum_members)
+)  {}  {}
+CREATE TABLE crdb_internal.databases (
+   id INT8 NOT NULL,
+   name STRING NOT NULL,
+   owner NAME NOT NULL,
+   primary_region STRING NULL,
+   regions STRING[] NULL,
+   survival_goal STRING NULL
+)  CREATE TABLE crdb_internal.databases (
+   id INT8 NOT NULL,
+   name STRING NOT NULL,
+   owner NAME NOT NULL,
+   primary_region STRING NULL,
+   regions STRING[] NULL,
+   survival_goal STRING NULL
+)  {}  {}
+CREATE TABLE crdb_internal.feature_usage (
+   feature_name STRING NOT NULL,
+   usage_count INT8 NOT NULL
+)  CREATE TABLE crdb_internal.feature_usage (
+   feature_name STRING NOT NULL,
+   usage_count INT8 NOT NULL
+)  {}  {}
+CREATE TABLE crdb_internal.forward_dependencies (
+   descriptor_id INT8 NULL,
+   descriptor_name STRING NOT NULL,
+   index_id INT8 NULL,
+   dependedonby_id INT8 NOT NULL,
+   dependedonby_type STRING NOT NULL,
+   dependedonby_index_id INT8 NULL,
+   dependedonby_name STRING NULL,
+   dependedonby_details STRING NULL
+)  CREATE TABLE crdb_internal.forward_dependencies (
+   descriptor_id INT8 NULL,
+   descriptor_name STRING NOT NULL,
+   index_id INT8 NULL,
+   dependedonby_id INT8 NOT NULL,
+   dependedonby_type STRING NOT NULL,
+   dependedonby_index_id INT8 NULL,
+   dependedonby_name STRING NULL,
+   dependedonby_details STRING NULL
+)  {}  {}
+CREATE TABLE crdb_internal.gossip_alerts (
+   node_id INT8 NOT NULL,
+   store_id INT8 NULL,
+   category STRING NOT NULL,
+   description STRING NOT NULL,
+   value FLOAT8 NOT NULL
+)  CREATE TABLE crdb_internal.gossip_alerts (
+   node_id INT8 NOT NULL,
+   store_id INT8 NULL,
+   category STRING NOT NULL,
+   description STRING NOT NULL,
+   value FLOAT8 NOT NULL
+)  {}  {}
+CREATE TABLE crdb_internal.gossip_liveness (
+   node_id INT8 NOT NULL,
+   epoch INT8 NOT NULL,
+   expiration STRING NOT NULL,
+   draining BOOL NOT NULL,
+   decommissioning BOOL NOT NULL,
+   membership STRING NOT NULL,
+   updated_at TIMESTAMP NULL
+)  CREATE TABLE crdb_internal.gossip_liveness (
+   node_id INT8 NOT NULL,
+   epoch INT8 NOT NULL,
+   expiration STRING NOT NULL,
+   draining BOOL NOT NULL,
+   decommissioning BOOL NOT NULL,
+   membership STRING NOT NULL,
+   updated_at TIMESTAMP NULL
+)  {}  {}
+CREATE TABLE crdb_internal.gossip_network (
+   source_id INT8 NOT NULL,
+   target_id INT8 NOT NULL
+)  CREATE TABLE crdb_internal.gossip_network (
+   source_id INT8 NOT NULL,
+   target_id INT8 NOT NULL
+)  {}  {}
+CREATE TABLE crdb_internal.gossip_nodes (
+   node_id INT8 NOT NULL,
+   network STRING NOT NULL,
+   address STRING NOT NULL,
+   advertise_address STRING NOT NULL,
+   sql_network STRING NOT NULL,
+   sql_address STRING NOT NULL,
+   advertise_sql_address STRING NOT NULL,
+   attrs JSONB NOT NULL,
+   locality STRING NOT NULL,
+   cluster_name STRING NOT NULL,
+   server_version STRING NOT NULL,
+   build_tag STRING NOT NULL,
+   started_at TIMESTAMP NOT NULL,
+   is_live BOOL NOT NULL,
+   ranges INT8 NOT NULL,
+   leases INT8 NOT NULL
+)  CREATE TABLE crdb_internal.gossip_nodes (
+   node_id INT8 NOT NULL,
+   network STRING NOT NULL,
+   address STRING NOT NULL,
+   advertise_address STRING NOT NULL,
+   sql_network STRING NOT NULL,
+   sql_address STRING NOT NULL,
+   advertise_sql_address STRING NOT NULL,
+   attrs JSONB NOT NULL,
+   locality STRING NOT NULL,
+   cluster_name STRING NOT NULL,
+   server_version STRING NOT NULL,
+   build_tag STRING NOT NULL,
+   started_at TIMESTAMP NOT NULL,
+   is_live BOOL NOT NULL,
+   ranges INT8 NOT NULL,
+   leases INT8 NOT NULL
+)  {}  {}
+CREATE TABLE crdb_internal.index_columns (
+   descriptor_id INT8 NULL,
+   descriptor_name STRING NOT NULL,
+   index_id INT8 NOT NULL,
+   index_name STRING NOT NULL,
+   column_type STRING NOT NULL,
+   column_id INT8 NOT NULL,
+   column_name STRING NULL,
+   column_direction STRING NULL,
+   implicit BOOL NULL
+)  CREATE TABLE crdb_internal.index_columns (
+   descriptor_id INT8 NULL,
+   descriptor_name STRING NOT NULL,
+   index_id INT8 NOT NULL,
+   index_name STRING NOT NULL,
+   column_type STRING NOT NULL,
+   column_id INT8 NOT NULL,
+   column_name STRING NULL,
+   column_direction STRING NULL,
+   implicit BOOL NULL
+)  {}  {}
+CREATE TABLE crdb_internal.invalid_objects (
+   id INT8 NULL,
+   database_name STRING NULL,
+   schema_name STRING NULL,
+   obj_name STRING NULL,
+   error STRING NULL
+)  CREATE TABLE crdb_internal.invalid_objects (
+   id INT8 NULL,
+   database_name STRING NULL,
+   schema_name STRING NULL,
+   obj_name STRING NULL,
+   error STRING NULL
+)  {}  {}
+CREATE TABLE crdb_internal.jobs (
+   job_id INT8 NULL,
+   job_type STRING NULL,
+   description STRING NULL,
+   statement STRING NULL,
+   user_name STRING NULL,
+   descriptor_ids INT8[] NULL,
+   status STRING NULL,
+   running_status STRING NULL,
+   created TIMESTAMP NULL,
+   started TIMESTAMP NULL,
+   finished TIMESTAMP NULL,
+   modified TIMESTAMP NULL,
+   fraction_completed FLOAT8 NULL,
+   high_water_timestamp DECIMAL NULL,
+   error STRING NULL,
+   coordinator_id INT8 NULL
+)  CREATE TABLE crdb_internal.jobs (
+   job_id INT8 NULL,
+   job_type STRING NULL,
+   description STRING NULL,
+   statement STRING NULL,
+   user_name STRING NULL,
+   descriptor_ids INT8[] NULL,
+   status STRING NULL,
+   running_status STRING NULL,
+   created TIMESTAMP NULL,
+   started TIMESTAMP NULL,
+   finished TIMESTAMP NULL,
+   modified TIMESTAMP NULL,
+   fraction_completed FLOAT8 NULL,
+   high_water_timestamp DECIMAL NULL,
+   error STRING NULL,
+   coordinator_id INT8 NULL
+)  {}  {}
+CREATE TABLE crdb_internal.kv_node_status (
+   node_id INT8 NOT NULL,
+   network STRING NOT NULL,
+   address STRING NOT NULL,
+   attrs JSONB NOT NULL,
+   locality STRING NOT NULL,
+   server_version STRING NOT NULL,
+   go_version STRING NOT NULL,
+   tag STRING NOT NULL,
+   "time" STRING NOT NULL,
+   revision STRING NOT NULL,
+   cgo_compiler STRING NOT NULL,
+   platform STRING NOT NULL,
+   distribution STRING NOT NULL,
+   type STRING NOT NULL,
+   dependencies STRING NOT NULL,
+   started_at TIMESTAMP NOT NULL,
+   updated_at TIMESTAMP NOT NULL,
+   metrics JSONB NOT NULL,
+   args JSONB NOT NULL,
+   env JSONB NOT NULL,
+   activity JSONB NOT NULL
+)  CREATE TABLE crdb_internal.kv_node_status (
+   node_id INT8 NOT NULL,
+   network STRING NOT NULL,
+   address STRING NOT NULL,
+   attrs JSONB NOT NULL,
+   locality STRING NOT NULL,
+   server_version STRING NOT NULL,
+   go_version STRING NOT NULL,
+   tag STRING NOT NULL,
+   "time" STRING NOT NULL,
+   revision STRING NOT NULL,
+   cgo_compiler STRING NOT NULL,
+   platform STRING NOT NULL,
+   distribution STRING NOT NULL,
+   type STRING NOT NULL,
+   dependencies STRING NOT NULL,
+   started_at TIMESTAMP NOT NULL,
+   updated_at TIMESTAMP NOT NULL,
+   metrics JSONB NOT NULL,
+   args JSONB NOT NULL,
+   env JSONB NOT NULL,
+   activity JSONB NOT NULL
+)  {}  {}
+CREATE TABLE crdb_internal.kv_store_status (
+   node_id INT8 NOT NULL,
+   store_id INT8 NOT NULL,
+   attrs JSONB NOT NULL,
+   capacity INT8 NOT NULL,
+   available INT8 NOT NULL,
+   used INT8 NOT NULL,
+   logical_bytes INT8 NOT NULL,
+   range_count INT8 NOT NULL,
+   lease_count INT8 NOT NULL,
+   writes_per_second FLOAT8 NOT NULL,
+   bytes_per_replica JSONB NOT NULL,
+   writes_per_replica JSONB NOT NULL,
+   metrics JSONB NOT NULL
+)  CREATE TABLE crdb_internal.kv_store_status (
+   node_id INT8 NOT NULL,
+   store_id INT8 NOT NULL,
+   attrs JSONB NOT NULL,
+   capacity INT8 NOT NULL,
+   available INT8 NOT NULL,
+   used INT8 NOT NULL,
+   logical_bytes INT8 NOT NULL,
+   range_count INT8 NOT NULL,
+   lease_count INT8 NOT NULL,
+   writes_per_second FLOAT8 NOT NULL,
+   bytes_per_replica JSONB NOT NULL,
+   writes_per_replica JSONB NOT NULL,
+   metrics JSONB NOT NULL
+)  {}  {}
+CREATE TABLE crdb_internal.leases (
+   node_id INT8 NOT NULL,
+   table_id INT8 NOT NULL,
+   name STRING NOT NULL,
+   parent_id INT8 NOT NULL,
+   expiration TIMESTAMP NOT NULL,
+   deleted BOOL NOT NULL
+)  CREATE TABLE crdb_internal.leases (
+   node_id INT8 NOT NULL,
+   table_id INT8 NOT NULL,
+   name STRING NOT NULL,
+   parent_id INT8 NOT NULL,
+   expiration TIMESTAMP NOT NULL,
+   deleted BOOL NOT NULL
+)  {}  {}
+CREATE TABLE crdb_internal.node_build_info (
+   node_id INT8 NOT NULL,
+   field STRING NOT NULL,
+   value STRING NOT NULL
+)  CREATE TABLE crdb_internal.node_build_info (
+   node_id INT8 NOT NULL,
+   field STRING NOT NULL,
+   value STRING NOT NULL
+)  {}  {}
+CREATE TABLE crdb_internal.node_contention_events (
+   table_id INT8 NOT NULL,
+   index_id INT8 NOT NULL,
+   num_contention_events INT8 NOT NULL,
+   cumulative_contention_time INTERVAL NOT NULL,
+   key BYTES NOT NULL,
+   txn_id UUID NOT NULL,
+   count INT8 NOT NULL
+)  CREATE TABLE crdb_internal.node_contention_events (
+   table_id INT8 NOT NULL,
+   index_id INT8 NOT NULL,
+   num_contention_events INT8 NOT NULL,
+   cumulative_contention_time INTERVAL NOT NULL,
+   key BYTES NOT NULL,
+   txn_id UUID NOT NULL,
+   count INT8 NOT NULL
+)  {}  {}
+CREATE TABLE crdb_internal.node_inflight_trace_spans (
+   trace_id INT8 NOT NULL,
+   parent_span_id INT8 NOT NULL,
+   span_id INT8 NOT NULL,
+   goroutine_id INT8 NOT NULL,
+   finished BOOL NOT NULL,
+   start_time TIMESTAMPTZ NULL,
+   duration INTERVAL NULL,
+   operation STRING NULL
+)  CREATE TABLE crdb_internal.node_inflight_trace_spans (
+   trace_id INT8 NOT NULL,
+   parent_span_id INT8 NOT NULL,
+   span_id INT8 NOT NULL,
+   goroutine_id INT8 NOT NULL,
+   finished BOOL NOT NULL,
+   start_time TIMESTAMPTZ NULL,
+   duration INTERVAL NULL,
+   operation STRING NULL
+)  {}  {}
+CREATE TABLE crdb_internal.node_metrics (
+   store_id INT8 NULL,
+   name STRING NOT NULL,
+   value FLOAT8 NOT NULL
+)  CREATE TABLE crdb_internal.node_metrics (
+   store_id INT8 NULL,
+   name STRING NOT NULL,
+   value FLOAT8 NOT NULL
+)  {}  {}
+CREATE TABLE crdb_internal.node_queries (
+   query_id STRING NULL,
+   txn_id UUID NULL,
+   node_id INT8 NOT NULL,
+   session_id STRING NULL,
+   user_name STRING NULL,
+   start TIMESTAMP NULL,
+   query STRING NULL,
+   client_address STRING NULL,
+   application_name STRING NULL,
+   distributed BOOL NULL,
+   phase STRING NULL
+)  CREATE TABLE crdb_internal.node_queries (
+   query_id STRING NULL,
+   txn_id UUID NULL,
+   node_id INT8 NOT NULL,
+   session_id STRING NULL,
+   user_name STRING NULL,
+   start TIMESTAMP NULL,
+   query STRING NULL,
+   client_address STRING NULL,
+   application_name STRING NULL,
+   distributed BOOL NULL,
+   phase STRING NULL
+)  {}  {}
+CREATE TABLE crdb_internal.node_runtime_info (
+   node_id INT8 NOT NULL,
+   component STRING NOT NULL,
+   field STRING NOT NULL,
+   value STRING NOT NULL
+)  CREATE TABLE crdb_internal.node_runtime_info (
+   node_id INT8 NOT NULL,
+   component STRING NOT NULL,
+   field STRING NOT NULL,
+   value STRING NOT NULL
+)  {}  {}
+CREATE TABLE crdb_internal.node_sessions (
+   node_id INT8 NOT NULL,
+   session_id STRING NULL,
+   user_name STRING NULL,
+   client_address STRING NULL,
+   application_name STRING NULL,
+   active_queries STRING NULL,
+   last_active_query STRING NULL,
+   session_start TIMESTAMP NULL,
+   oldest_query_start TIMESTAMP NULL,
+   kv_txn STRING NULL,
+   alloc_bytes INT8 NULL,
+   max_alloc_bytes INT8 NULL
+)  CREATE TABLE crdb_internal.node_sessions (
+   node_id INT8 NOT NULL,
+   session_id STRING NULL,
+   user_name STRING NULL,
+   client_address STRING NULL,
+   application_name STRING NULL,
+   active_queries STRING NULL,
+   last_active_query STRING NULL,
+   session_start TIMESTAMP NULL,
+   oldest_query_start TIMESTAMP NULL,
+   kv_txn STRING NULL,
+   alloc_bytes INT8 NULL,
+   max_alloc_bytes INT8 NULL
+)  {}  {}
+CREATE TABLE crdb_internal.node_statement_statistics (
+   node_id INT8 NOT NULL,
+   application_name STRING NOT NULL,
+   flags STRING NOT NULL,
+   key STRING NOT NULL,
+   anonymized STRING NULL,
+   count INT8 NOT NULL,
+   first_attempt_count INT8 NOT NULL,
+   max_retries INT8 NOT NULL,
+   last_error STRING NULL,
+   rows_avg FLOAT8 NOT NULL,
+   rows_var FLOAT8 NOT NULL,
+   parse_lat_avg FLOAT8 NOT NULL,
+   parse_lat_var FLOAT8 NOT NULL,
+   plan_lat_avg FLOAT8 NOT NULL,
+   plan_lat_var FLOAT8 NOT NULL,
+   run_lat_avg FLOAT8 NOT NULL,
+   run_lat_var FLOAT8 NOT NULL,
+   service_lat_avg FLOAT8 NOT NULL,
+   service_lat_var FLOAT8 NOT NULL,
+   overhead_lat_avg FLOAT8 NOT NULL,
+   overhead_lat_var FLOAT8 NOT NULL,
+   bytes_read_avg FLOAT8 NOT NULL,
+   bytes_read_var FLOAT8 NOT NULL,
+   rows_read_avg FLOAT8 NOT NULL,
+   rows_read_var FLOAT8 NOT NULL,
+   implicit_txn BOOL NOT NULL
+)  CREATE TABLE crdb_internal.node_statement_statistics (
+   node_id INT8 NOT NULL,
+   application_name STRING NOT NULL,
+   flags STRING NOT NULL,
+   key STRING NOT NULL,
+   anonymized STRING NULL,
+   count INT8 NOT NULL,
+   first_attempt_count INT8 NOT NULL,
+   max_retries INT8 NOT NULL,
+   last_error STRING NULL,
+   rows_avg FLOAT8 NOT NULL,
+   rows_var FLOAT8 NOT NULL,
+   parse_lat_avg FLOAT8 NOT NULL,
+   parse_lat_var FLOAT8 NOT NULL,
+   plan_lat_avg FLOAT8 NOT NULL,
+   plan_lat_var FLOAT8 NOT NULL,
+   run_lat_avg FLOAT8 NOT NULL,
+   run_lat_var FLOAT8 NOT NULL,
+   service_lat_avg FLOAT8 NOT NULL,
+   service_lat_var FLOAT8 NOT NULL,
+   overhead_lat_avg FLOAT8 NOT NULL,
+   overhead_lat_var FLOAT8 NOT NULL,
+   bytes_read_avg FLOAT8 NOT NULL,
+   bytes_read_var FLOAT8 NOT NULL,
+   rows_read_avg FLOAT8 NOT NULL,
+   rows_read_var FLOAT8 NOT NULL,
+   implicit_txn BOOL NOT NULL
+)  {}  {}
+CREATE TABLE crdb_internal.node_transaction_statistics (
+   node_id INT8 NOT NULL,
+   application_name STRING NOT NULL,
+   key STRING NULL,
+   statement_ids STRING[] NULL,
+   count INT8 NULL,
+   max_retries INT8 NULL,
+   service_lat_avg FLOAT8 NOT NULL,
+   service_lat_var FLOAT8 NOT NULL,
+   retry_lat_avg FLOAT8 NOT NULL,
+   retry_lat_var FLOAT8 NOT NULL,
+   commit_lat_avg FLOAT8 NOT NULL,
+   commit_lat_var FLOAT8 NOT NULL,
+   rows_read_avg FLOAT8 NOT NULL,
+   rows_read_var FLOAT8 NOT NULL
+)  CREATE TABLE crdb_internal.node_transaction_statistics (
+   node_id INT8 NOT NULL,
+   application_name STRING NOT NULL,
+   key STRING NULL,
+   statement_ids STRING[] NULL,
+   count INT8 NULL,
+   max_retries INT8 NULL,
+   service_lat_avg FLOAT8 NOT NULL,
+   service_lat_var FLOAT8 NOT NULL,
+   retry_lat_avg FLOAT8 NOT NULL,
+   retry_lat_var FLOAT8 NOT NULL,
+   commit_lat_avg FLOAT8 NOT NULL,
+   commit_lat_var FLOAT8 NOT NULL,
+   rows_read_avg FLOAT8 NOT NULL,
+   rows_read_var FLOAT8 NOT NULL
+)  {}  {}
+CREATE TABLE crdb_internal.node_transactions (
+   id UUID NULL,
+   node_id INT8 NULL,
+   session_id STRING NULL,
+   start TIMESTAMP NULL,
+   txn_string STRING NULL,
+   application_name STRING NULL,
+   num_stmts INT8 NULL,
+   num_retries INT8 NULL,
+   num_auto_retries INT8 NULL
+)  CREATE TABLE crdb_internal.node_transactions (
+   id UUID NULL,
+   node_id INT8 NULL,
+   session_id STRING NULL,
+   start TIMESTAMP NULL,
+   txn_string STRING NULL,
+   application_name STRING NULL,
+   num_stmts INT8 NULL,
+   num_retries INT8 NULL,
+   num_auto_retries INT8 NULL
+)  {}  {}
+CREATE TABLE crdb_internal.node_txn_stats (
+   node_id INT8 NOT NULL,
+   application_name STRING NOT NULL,
+   txn_count INT8 NOT NULL,
+   txn_time_avg_sec FLOAT8 NOT NULL,
+   txn_time_var_sec FLOAT8 NOT NULL,
+   committed_count INT8 NOT NULL,
+   implicit_count INT8 NOT NULL
+)  CREATE TABLE crdb_internal.node_txn_stats (
+   node_id INT8 NOT NULL,
+   application_name STRING NOT NULL,
+   txn_count INT8 NOT NULL,
+   txn_time_avg_sec FLOAT8 NOT NULL,
+   txn_time_var_sec FLOAT8 NOT NULL,
+   committed_count INT8 NOT NULL,
+   implicit_count INT8 NOT NULL
+)  {}  {}
+CREATE TABLE crdb_internal.partitions (
+   table_id INT8 NOT NULL,
+   index_id INT8 NOT NULL,
+   parent_name STRING NULL,
+   name STRING NOT NULL,
+   columns INT8 NOT NULL,
+   column_names STRING NULL,
+   list_value STRING NULL,
+   range_value STRING NULL,
+   zone_id INT8 NULL,
+   subzone_id INT8 NULL
+)  CREATE TABLE crdb_internal.partitions (
+   table_id INT8 NOT NULL,
+   index_id INT8 NOT NULL,
+   parent_name STRING NULL,
+   name STRING NOT NULL,
+   columns INT8 NOT NULL,
+   column_names STRING NULL,
+   list_value STRING NULL,
+   range_value STRING NULL,
+   zone_id INT8 NULL,
+   subzone_id INT8 NULL
+)  {}  {}
+CREATE TABLE crdb_internal.predefined_comments (
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                type INT8 NULL,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                object_id INT8 NULL,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                sub_id INT8 NULL,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                comment STRING NULL
+)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               CREATE TABLE crdb_internal.predefined_comments (
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                type INT8 NULL,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                object_id INT8 NULL,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                sub_id INT8 NULL,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                comment STRING NULL
+)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               {}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              {}
+CREATE VIEW crdb_internal.ranges (range_id, start_key, start_pretty, end_key, end_pretty, table_id, database_name, schema_name, table_name, index_name, replicas, replica_localities, learner_replicas, split_enforced_until, lease_holder, range_size) AS SELECT range_id, start_key, start_pretty, end_key, end_pretty, table_id, database_name, schema_name, table_name, index_name, replicas, replica_localities, learner_replicas, split_enforced_until, crdb_internal.lease_holder(start_key) AS lease_holder, (crdb_internal.range_stats(start_key)->>'key_bytes')::INT8 + (crdb_internal.range_stats(start_key)->>'val_bytes')::INT8 AS range_size FROM crdb_internal.ranges_no_leases  CREATE VIEW crdb_internal.ranges (range_id, start_key, start_pretty, end_key, end_pretty, table_id, database_name, schema_name, table_name, index_name, replicas, replica_localities, learner_replicas, split_enforced_until, lease_holder, range_size) AS SELECT range_id, start_key, start_pretty, end_key, end_pretty, table_id, database_name, schema_name, table_name, index_name, replicas, replica_localities, learner_replicas, split_enforced_until, crdb_internal.lease_holder(start_key) AS lease_holder, (crdb_internal.range_stats(start_key)->>'key_bytes')::INT8 + (crdb_internal.range_stats(start_key)->>'val_bytes')::INT8 AS range_size FROM crdb_internal.ranges_no_leases  {}  {}
+CREATE TABLE crdb_internal.ranges_no_leases (
+   range_id INT8 NOT NULL,
+   start_key BYTES NOT NULL,
+   start_pretty STRING NOT NULL,
+   end_key BYTES NOT NULL,
+   end_pretty STRING NOT NULL,
+   table_id INT8 NOT NULL,
+   database_name STRING NOT NULL,
+   schema_name STRING NOT NULL,
+   table_name STRING NOT NULL,
+   index_name STRING NOT NULL,
+   replicas INT8[] NOT NULL,
+   replica_localities STRING[] NOT NULL,
+   learner_replicas INT8[] NOT NULL,
+   split_enforced_until TIMESTAMP NULL
+)  CREATE TABLE crdb_internal.ranges_no_leases (
+   range_id INT8 NOT NULL,
+   start_key BYTES NOT NULL,
+   start_pretty STRING NOT NULL,
+   end_key BYTES NOT NULL,
+   end_pretty STRING NOT NULL,
+   table_id INT8 NOT NULL,
+   database_name STRING NOT NULL,
+   schema_name STRING NOT NULL,
+   table_name STRING NOT NULL,
+   index_name STRING NOT NULL,
+   replicas INT8[] NOT NULL,
+   replica_localities STRING[] NOT NULL,
+   learner_replicas INT8[] NOT NULL,
+   split_enforced_until TIMESTAMP NULL
+)  {}  {}
+CREATE TABLE crdb_internal.schema_changes (
+   table_id INT8 NOT NULL,
+   parent_id INT8 NOT NULL,
+   name STRING NOT NULL,
+   type STRING NOT NULL,
+   target_id INT8 NULL,
+   target_name STRING NULL,
+   state STRING NOT NULL,
+   direction STRING NOT NULL
+)  CREATE TABLE crdb_internal.schema_changes (
+   table_id INT8 NOT NULL,
+   parent_id INT8 NOT NULL,
+   name STRING NOT NULL,
+   type STRING NOT NULL,
+   target_id INT8 NULL,
+   target_name STRING NULL,
+   state STRING NOT NULL,
+   direction STRING NOT NULL
+)  {}  {}
+CREATE TABLE crdb_internal.session_trace (
+   span_idx INT8 NOT NULL,
+   message_idx INT8 NOT NULL,
+   "timestamp" TIMESTAMPTZ NOT NULL,
+   duration INTERVAL NULL,
+   operation STRING NULL,
+   loc STRING NOT NULL,
+   tag STRING NOT NULL,
+   message STRING NOT NULL,
+   age INTERVAL NOT NULL
+)  CREATE TABLE crdb_internal.session_trace (
+   span_idx INT8 NOT NULL,
+   message_idx INT8 NOT NULL,
+   "timestamp" TIMESTAMPTZ NOT NULL,
+   duration INTERVAL NULL,
+   operation STRING NULL,
+   loc STRING NOT NULL,
+   tag STRING NOT NULL,
+   message STRING NOT NULL,
+   age INTERVAL NOT NULL
+)  {}  {}
+CREATE TABLE crdb_internal.session_variables (
+   variable STRING NOT NULL,
+   value STRING NOT NULL,
+   hidden BOOL NOT NULL
+)  CREATE TABLE crdb_internal.session_variables (
+   variable STRING NOT NULL,
+   value STRING NOT NULL,
+   hidden BOOL NOT NULL
+)  {}  {}
+CREATE TABLE crdb_internal.table_columns (
+   descriptor_id INT8 NULL,
+   descriptor_name STRING NOT NULL,
+   column_id INT8 NOT NULL,
+   column_name STRING NOT NULL,
+   column_type STRING NOT NULL,
+   nullable BOOL NOT NULL,
+   default_expr STRING NULL,
+   hidden BOOL NOT NULL
+)  CREATE TABLE crdb_internal.table_columns (
+   descriptor_id INT8 NULL,
+   descriptor_name STRING NOT NULL,
+   column_id INT8 NOT NULL,
+   column_name STRING NOT NULL,
+   column_type STRING NOT NULL,
+   nullable BOOL NOT NULL,
+   default_expr STRING NULL,
+   hidden BOOL NOT NULL
+)  {}  {}
+CREATE TABLE crdb_internal.table_indexes (
+   descriptor_id INT8 NULL,
+   descriptor_name STRING NOT NULL,
+   index_id INT8 NOT NULL,
+   index_name STRING NOT NULL,
+   index_type STRING NOT NULL,
+   is_unique BOOL NOT NULL,
+   is_inverted BOOL NOT NULL
+)  CREATE TABLE crdb_internal.table_indexes (
+   descriptor_id INT8 NULL,
+   descriptor_name STRING NOT NULL,
+   index_id INT8 NOT NULL,
+   index_name STRING NOT NULL,
+   index_type STRING NOT NULL,
+   is_unique BOOL NOT NULL,
+   is_inverted BOOL NOT NULL
+)  {}  {}
+CREATE TABLE crdb_internal.table_row_statistics (
+   table_id INT8 NOT NULL,
+   table_name STRING NOT NULL,
+   estimated_row_count INT8 NULL
+)  CREATE TABLE crdb_internal.table_row_statistics (
+   table_id INT8 NOT NULL,
+   table_name STRING NOT NULL,
+   estimated_row_count INT8 NULL
+)  {}  {}
+CREATE TABLE crdb_internal.tables (
+   table_id INT8 NOT NULL,
+   parent_id INT8 NOT NULL,
+   name STRING NOT NULL,
+   database_name STRING NULL,
+   version INT8 NOT NULL,
+   mod_time TIMESTAMP NOT NULL,
+   mod_time_logical DECIMAL NOT NULL,
+   format_version STRING NOT NULL,
+   state STRING NOT NULL,
+   sc_lease_node_id INT8 NULL,
+   sc_lease_expiration_time TIMESTAMP NULL,
+   drop_time TIMESTAMP NULL,
+   audit_mode STRING NOT NULL,
+   schema_name STRING NOT NULL,
+   parent_schema_id INT8 NOT NULL,
+   locality STRING NULL
+)  CREATE TABLE crdb_internal.tables (
+   table_id INT8 NOT NULL,
+   parent_id INT8 NOT NULL,
+   name STRING NOT NULL,
+   database_name STRING NULL,
+   version INT8 NOT NULL,
+   mod_time TIMESTAMP NOT NULL,
+   mod_time_logical DECIMAL NOT NULL,
+   format_version STRING NOT NULL,
+   state STRING NOT NULL,
+   sc_lease_node_id INT8 NULL,
+   sc_lease_expiration_time TIMESTAMP NULL,
+   drop_time TIMESTAMP NULL,
+   audit_mode STRING NOT NULL,
+   schema_name STRING NOT NULL,
+   parent_schema_id INT8 NOT NULL,
+   locality STRING NULL
+)  {}  {}
+CREATE TABLE crdb_internal.zones (
+   zone_id INT8 NOT NULL,
+   subzone_id INT8 NOT NULL,
+   target STRING NULL,
+   range_name STRING NULL,
+   database_name STRING NULL,
+   table_name STRING NULL,
+   index_name STRING NULL,
+   partition_name STRING NULL,
+   raw_config_yaml STRING NOT NULL,
+   raw_config_sql STRING NULL,
+   raw_config_protobuf BYTES NOT NULL,
+   full_config_yaml STRING NOT NULL,
+   full_config_sql STRING NULL
+)  CREATE TABLE crdb_internal.zones (
+   zone_id INT8 NOT NULL,
+   subzone_id INT8 NOT NULL,
+   target STRING NULL,
+   range_name STRING NULL,
+   database_name STRING NULL,
+   table_name STRING NULL,
+   index_name STRING NULL,
+   partition_name STRING NULL,
+   raw_config_yaml STRING NOT NULL,
+   raw_config_sql STRING NULL,
+   raw_config_protobuf BYTES NOT NULL,
+   full_config_yaml STRING NOT NULL,
+   full_config_sql STRING NULL
+)  {}  {}
+CREATE TABLE information_schema.administrable_role_authorizations (
+   grantee STRING NOT NULL,
+   role_name STRING NOT NULL,
+   is_grantable STRING NOT NULL
+)  CREATE TABLE information_schema.administrable_role_authorizations (
+   grantee STRING NOT NULL,
+   role_name STRING NOT NULL,
+   is_grantable STRING NOT NULL
+)  {}  {}
+CREATE TABLE information_schema.applicable_roles (
+   grantee STRING NOT NULL,
+   role_name STRING NOT NULL,
+   is_grantable STRING NOT NULL
+)  CREATE TABLE information_schema.applicable_roles (
+   grantee STRING NOT NULL,
+   role_name STRING NOT NULL,
+   is_grantable STRING NOT NULL
+)  {}  {}
+CREATE TABLE information_schema.character_sets (
+   character_set_catalog STRING NULL,
+   character_set_schema STRING NULL,
+   character_set_name STRING NOT NULL,
+   character_repertoire STRING NOT NULL,
+   form_of_use STRING NOT NULL,
+   default_collate_catalog STRING NULL,
+   default_collate_schema STRING NULL,
+   default_collate_name STRING NULL
+)  CREATE TABLE information_schema.character_sets (
+   character_set_catalog STRING NULL,
+   character_set_schema STRING NULL,
+   character_set_name STRING NOT NULL,
+   character_repertoire STRING NOT NULL,
+   form_of_use STRING NOT NULL,
+   default_collate_catalog STRING NULL,
+   default_collate_schema STRING NULL,
+   default_collate_name STRING NULL
+)  {}  {}
+CREATE TABLE information_schema.check_constraints (
+   constraint_catalog STRING NOT NULL,
+   constraint_schema STRING NOT NULL,
+   constraint_name STRING NOT NULL,
+   check_clause STRING NOT NULL
+)  CREATE TABLE information_schema.check_constraints (
+   constraint_catalog STRING NOT NULL,
+   constraint_schema STRING NOT NULL,
+   constraint_name STRING NOT NULL,
+   check_clause STRING NOT NULL
+)  {}  {}
+CREATE TABLE information_schema.collation_character_set_applicability (
+   collation_catalog STRING NOT NULL,
+   collation_schema STRING NOT NULL,
+   collation_name STRING NOT NULL,
+   character_set_catalog STRING NULL,
+   character_set_schema STRING NULL,
+   character_set_name STRING NOT NULL
+)  CREATE TABLE information_schema.collation_character_set_applicability (
+   collation_catalog STRING NOT NULL,
+   collation_schema STRING NOT NULL,
+   collation_name STRING NOT NULL,
+   character_set_catalog STRING NULL,
+   character_set_schema STRING NULL,
+   character_set_name STRING NOT NULL
+)  {}  {}
+CREATE TABLE information_schema.collations (
+   collation_catalog STRING NOT NULL,
+   collation_schema STRING NOT NULL,
+   collation_name STRING NOT NULL,
+   pad_attribute STRING NOT NULL
+)  CREATE TABLE information_schema.collations (
+   collation_catalog STRING NOT NULL,
+   collation_schema STRING NOT NULL,
+   collation_name STRING NOT NULL,
+   pad_attribute STRING NOT NULL
+)  {}  {}
+CREATE TABLE information_schema.column_privileges (
+   grantor STRING NULL,
+   grantee STRING NOT NULL,
+   table_catalog STRING NOT NULL,
+   table_schema STRING NOT NULL,
+   table_name STRING NOT NULL,
+   column_name STRING NOT NULL,
+   privilege_type STRING NOT NULL,
+   is_grantable STRING NULL
+)  CREATE TABLE information_schema.column_privileges (
+   grantor STRING NULL,
+   grantee STRING NOT NULL,
+   table_catalog STRING NOT NULL,
+   table_schema STRING NOT NULL,
+   table_name STRING NOT NULL,
+   column_name STRING NOT NULL,
+   privilege_type STRING NOT NULL,
+   is_grantable STRING NULL
+)  {}  {}
+CREATE TABLE information_schema.column_udt_usage (
+   udt_catalog STRING NOT NULL,
+   udt_schema STRING NOT NULL,
+   udt_name STRING NOT NULL,
+   table_catalog STRING NOT NULL,
+   table_schema STRING NOT NULL,
+   table_name STRING NOT NULL,
+   column_name STRING NOT NULL
+)  CREATE TABLE information_schema.column_udt_usage (
+   udt_catalog STRING NOT NULL,
+   udt_schema STRING NOT NULL,
+   udt_name STRING NOT NULL,
+   table_catalog STRING NOT NULL,
+   table_schema STRING NOT NULL,
+   table_name STRING NOT NULL,
+   column_name STRING NOT NULL
+)  {}  {}
+CREATE TABLE information_schema.columns (
+   table_catalog STRING NOT NULL,
+   table_schema STRING NOT NULL,
+   table_name STRING NOT NULL,
+   column_name STRING NOT NULL,
+   column_comment STRING NULL,
+   ordinal_position INT8 NOT NULL,
+   column_default STRING NULL,
+   is_nullable STRING NOT NULL,
+   data_type STRING NOT NULL,
+   character_maximum_length INT8 NULL,
+   character_octet_length INT8 NULL,
+   numeric_precision INT8 NULL,
+   numeric_precision_radix INT8 NULL,
+   numeric_scale INT8 NULL,
+   datetime_precision INT8 NULL,
+   interval_type STRING NULL,
+   interval_precision INT8 NULL,
+   character_set_catalog STRING NULL,
+   character_set_schema STRING NULL,
+   character_set_name STRING NULL,
+   collation_catalog STRING NULL,
+   collation_schema STRING NULL,
+   collation_name STRING NULL,
+   domain_catalog STRING NULL,
+   domain_schema STRING NULL,
+   domain_name STRING NULL,
+   udt_catalog STRING NULL,
+   udt_schema STRING NULL,
+   udt_name STRING NULL,
+   scope_catalog STRING NULL,
+   scope_schema STRING NULL,
+   scope_name STRING NULL,
+   maximum_cardinality INT8 NULL,
+   dtd_identifier STRING NULL,
+   is_self_referencing STRING NULL,
+   is_identity STRING NULL,
+   identity_generation STRING NULL,
+   identity_start STRING NULL,
+   identity_increment STRING NULL,
+   identity_maximum STRING NULL,
+   identity_minimum STRING NULL,
+   identity_cycle STRING NULL,
+   is_generated STRING NULL,
+   generation_expression STRING NULL,
+   is_updatable STRING NULL,
+   is_hidden STRING NOT NULL,
+   crdb_sql_type STRING NOT NULL
+)  CREATE TABLE information_schema.columns (
+   table_catalog STRING NOT NULL,
+   table_schema STRING NOT NULL,
+   table_name STRING NOT NULL,
+   column_name STRING NOT NULL,
+   column_comment STRING NULL,
+   ordinal_position INT8 NOT NULL,
+   column_default STRING NULL,
+   is_nullable STRING NOT NULL,
+   data_type STRING NOT NULL,
+   character_maximum_length INT8 NULL,
+   character_octet_length INT8 NULL,
+   numeric_precision INT8 NULL,
+   numeric_precision_radix INT8 NULL,
+   numeric_scale INT8 NULL,
+   datetime_precision INT8 NULL,
+   interval_type STRING NULL,
+   interval_precision INT8 NULL,
+   character_set_catalog STRING NULL,
+   character_set_schema STRING NULL,
+   character_set_name STRING NULL,
+   collation_catalog STRING NULL,
+   collation_schema STRING NULL,
+   collation_name STRING NULL,
+   domain_catalog STRING NULL,
+   domain_schema STRING NULL,
+   domain_name STRING NULL,
+   udt_catalog STRING NULL,
+   udt_schema STRING NULL,
+   udt_name STRING NULL,
+   scope_catalog STRING NULL,
+   scope_schema STRING NULL,
+   scope_name STRING NULL,
+   maximum_cardinality INT8 NULL,
+   dtd_identifier STRING NULL,
+   is_self_referencing STRING NULL,
+   is_identity STRING NULL,
+   identity_generation STRING NULL,
+   identity_start STRING NULL,
+   identity_increment STRING NULL,
+   identity_maximum STRING NULL,
+   identity_minimum STRING NULL,
+   identity_cycle STRING NULL,
+   is_generated STRING NULL,
+   generation_expression STRING NULL,
+   is_updatable STRING NULL,
+   is_hidden STRING NOT NULL,
+   crdb_sql_type STRING NOT NULL
+)  {}  {}
+CREATE TABLE information_schema.constraint_column_usage (
+   table_catalog STRING NOT NULL,
+   table_schema STRING NOT NULL,
+   table_name STRING NOT NULL,
+   column_name STRING NOT NULL,
+   constraint_catalog STRING NOT NULL,
+   constraint_schema STRING NOT NULL,
+   constraint_name STRING NOT NULL
+)  CREATE TABLE information_schema.constraint_column_usage (
+   table_catalog STRING NOT NULL,
+   table_schema STRING NOT NULL,
+   table_name STRING NOT NULL,
+   column_name STRING NOT NULL,
+   constraint_catalog STRING NOT NULL,
+   constraint_schema STRING NOT NULL,
+   constraint_name STRING NOT NULL
+)  {}  {}
+CREATE TABLE information_schema.enabled_roles (
+   role_name STRING NOT NULL
+)  CREATE TABLE information_schema.enabled_roles (
+   role_name STRING NOT NULL
+)  {}  {}
+CREATE TABLE information_schema.key_column_usage (
+   constraint_catalog STRING NOT NULL,
+   constraint_schema STRING NOT NULL,
+   constraint_name STRING NOT NULL,
+   table_catalog STRING NOT NULL,
+   table_schema STRING NOT NULL,
+   table_name STRING NOT NULL,
+   column_name STRING NOT NULL,
+   ordinal_position INT8 NOT NULL,
+   position_in_unique_constraint INT8 NULL
+)  CREATE TABLE information_schema.key_column_usage (
+   constraint_catalog STRING NOT NULL,
+   constraint_schema STRING NOT NULL,
+   constraint_name STRING NOT NULL,
+   table_catalog STRING NOT NULL,
+   table_schema STRING NOT NULL,
+   table_name STRING NOT NULL,
+   column_name STRING NOT NULL,
+   ordinal_position INT8 NOT NULL,
+   position_in_unique_constraint INT8 NULL
+)  {}  {}
+CREATE TABLE information_schema.parameters (
+   specific_catalog STRING NULL,
+   specific_schema STRING NULL,
+   specific_name STRING NULL,
+   ordinal_position INT8 NULL,
+   parameter_mode STRING NULL,
+   is_result STRING NULL,
+   as_locator STRING NULL,
+   parameter_name STRING NULL,
+   data_type STRING NULL,
+   character_maximum_length INT8 NULL,
+   character_octet_length INT8 NULL,
+   character_set_catalog STRING NULL,
+   character_set_schema STRING NULL,
+   character_set_name STRING NULL,
+   collation_catalog STRING NULL,
+   collation_schema STRING NULL,
+   collation_name STRING NULL,
+   numeric_precision INT8 NULL,
+   numeric_precision_radix INT8 NULL,
+   numeric_scale INT8 NULL,
+   datetime_precision INT8 NULL,
+   interval_type STRING NULL,
+   interval_precision INT8 NULL,
+   udt_catalog STRING NULL,
+   udt_schema STRING NULL,
+   udt_name STRING NULL,
+   scope_catalog STRING NULL,
+   scope_schema STRING NULL,
+   scope_name STRING NULL,
+   maximum_cardinality INT8 NULL,
+   dtd_identifier STRING NULL,
+   parameter_default STRING NULL
+)  CREATE TABLE information_schema.parameters (
+   specific_catalog STRING NULL,
+   specific_schema STRING NULL,
+   specific_name STRING NULL,
+   ordinal_position INT8 NULL,
+   parameter_mode STRING NULL,
+   is_result STRING NULL,
+   as_locator STRING NULL,
+   parameter_name STRING NULL,
+   data_type STRING NULL,
+   character_maximum_length INT8 NULL,
+   character_octet_length INT8 NULL,
+   character_set_catalog STRING NULL,
+   character_set_schema STRING NULL,
+   character_set_name STRING NULL,
+   collation_catalog STRING NULL,
+   collation_schema STRING NULL,
+   collation_name STRING NULL,
+   numeric_precision INT8 NULL,
+   numeric_precision_radix INT8 NULL,
+   numeric_scale INT8 NULL,
+   datetime_precision INT8 NULL,
+   interval_type STRING NULL,
+   interval_precision INT8 NULL,
+   udt_catalog STRING NULL,
+   udt_schema STRING NULL,
+   udt_name STRING NULL,
+   scope_catalog STRING NULL,
+   scope_schema STRING NULL,
+   scope_name STRING NULL,
+   maximum_cardinality INT8 NULL,
+   dtd_identifier STRING NULL,
+   parameter_default STRING NULL
+)  {}  {}
+CREATE TABLE information_schema.referential_constraints (
+   constraint_catalog STRING NOT NULL,
+   constraint_schema STRING NOT NULL,
+   constraint_name STRING NOT NULL,
+   unique_constraint_catalog STRING NOT NULL,
+   unique_constraint_schema STRING NOT NULL,
+   unique_constraint_name STRING NULL,
+   match_option STRING NOT NULL,
+   update_rule STRING NOT NULL,
+   delete_rule STRING NOT NULL,
+   table_name STRING NOT NULL,
+   referenced_table_name STRING NOT NULL
+)  CREATE TABLE information_schema.referential_constraints (
+   constraint_catalog STRING NOT NULL,
+   constraint_schema STRING NOT NULL,
+   constraint_name STRING NOT NULL,
+   unique_constraint_catalog STRING NOT NULL,
+   unique_constraint_schema STRING NOT NULL,
+   unique_constraint_name STRING NULL,
+   match_option STRING NOT NULL,
+   update_rule STRING NOT NULL,
+   delete_rule STRING NOT NULL,
+   table_name STRING NOT NULL,
+   referenced_table_name STRING NOT NULL
+)  {}  {}
+CREATE TABLE information_schema.role_table_grants (
+   grantor STRING NULL,
+   grantee STRING NOT NULL,
+   table_catalog STRING NOT NULL,
+   table_schema STRING NOT NULL,
+   table_name STRING NOT NULL,
+   privilege_type STRING NOT NULL,
+   is_grantable STRING NULL,
+   with_hierarchy STRING NULL
+)  CREATE TABLE information_schema.role_table_grants (
+   grantor STRING NULL,
+   grantee STRING NOT NULL,
+   table_catalog STRING NOT NULL,
+   table_schema STRING NOT NULL,
+   table_name STRING NOT NULL,
+   privilege_type STRING NOT NULL,
+   is_grantable STRING NULL,
+   with_hierarchy STRING NULL
+)  {}  {}
+CREATE TABLE information_schema.routines (
+   specific_catalog STRING NULL,
+   specific_schema STRING NULL,
+   specific_name STRING NULL,
+   routine_catalog STRING NULL,
+   routine_schema STRING NULL,
+   routine_name STRING NULL,
+   routine_type STRING NULL,
+   module_catalog STRING NULL,
+   module_schema STRING NULL,
+   module_name STRING NULL,
+   udt_catalog STRING NULL,
+   udt_schema STRING NULL,
+   udt_name STRING NULL,
+   data_type STRING NULL,
+   character_maximum_length INT8 NULL,
+   character_octet_length INT8 NULL,
+   character_set_catalog STRING NULL,
+   character_set_schema STRING NULL,
+   character_set_name STRING NULL,
+   collation_catalog STRING NULL,
+   collation_schema STRING NULL,
+   collation_name STRING NULL,
+   numeric_precision INT8 NULL,
+   numeric_precision_radix INT8 NULL,
+   numeric_scale INT8 NULL,
+   datetime_precision INT8 NULL,
+   interval_type STRING NULL,
+   interval_precision STRING NULL,
+   type_udt_catalog STRING NULL,
+   type_udt_schema STRING NULL,
+   type_udt_name STRING NULL,
+   scope_catalog STRING NULL,
+   scope_name STRING NULL,
+   maximum_cardinality INT8 NULL,
+   dtd_identifier STRING NULL,
+   routine_body STRING NULL,
+   routine_definition STRING NULL,
+   external_name STRING NULL,
+   external_language STRING NULL,
+   parameter_style STRING NULL,
+   is_deterministic STRING NULL,
+   sql_data_access STRING NULL,
+   is_null_call STRING NULL,
+   sql_path STRING NULL,
+   schema_level_routine STRING NULL,
+   max_dynamic_result_sets INT8 NULL,
+   is_user_defined_cast STRING NULL,
+   is_implicitly_invocable STRING NULL,
+   security_type STRING NULL,
+   to_sql_specific_catalog STRING NULL,
+   to_sql_specific_schema STRING NULL,
+   to_sql_specific_name STRING NULL,
+   as_locator STRING NULL,
+   created TIMESTAMPTZ NULL,
+   last_altered TIMESTAMPTZ NULL,
+   new_savepoint_level STRING NULL,
+   is_udt_dependent STRING NULL,
+   result_cast_from_data_type STRING NULL,
+   result_cast_as_locator STRING NULL,
+   result_cast_char_max_length INT8 NULL,
+   result_cast_char_octet_length STRING NULL,
+   result_cast_char_set_catalog STRING NULL,
+   result_cast_char_set_schema STRING NULL,
+   result_cast_char_set_name STRING NULL,
+   result_cast_collation_catalog STRING NULL,
+   result_cast_collation_schema STRING NULL,
+   result_cast_collation_name STRING NULL,
+   result_cast_numeric_precision INT8 NULL,
+   result_cast_numeric_precision_radix INT8 NULL,
+   result_cast_numeric_scale INT8 NULL,
+   result_cast_datetime_precision STRING NULL,
+   result_cast_interval_type STRING NULL,
+   result_cast_interval_precision INT8 NULL,
+   result_cast_type_udt_catalog STRING NULL,
+   result_cast_type_udt_schema STRING NULL,
+   result_cast_type_udt_name STRING NULL,
+   result_cast_scope_catalog STRING NULL,
+   result_cast_scope_schema STRING NULL,
+   result_cast_scope_name STRING NULL,
+   result_cast_maximum_cardinality INT8 NULL,
+   result_cast_dtd_identifier STRING NULL
+)  CREATE TABLE information_schema.routines (
+   specific_catalog STRING NULL,
+   specific_schema STRING NULL,
+   specific_name STRING NULL,
+   routine_catalog STRING NULL,
+   routine_schema STRING NULL,
+   routine_name STRING NULL,
+   routine_type STRING NULL,
+   module_catalog STRING NULL,
+   module_schema STRING NULL,
+   module_name STRING NULL,
+   udt_catalog STRING NULL,
+   udt_schema STRING NULL,
+   udt_name STRING NULL,
+   data_type STRING NULL,
+   character_maximum_length INT8 NULL,
+   character_octet_length INT8 NULL,
+   character_set_catalog STRING NULL,
+   character_set_schema STRING NULL,
+   character_set_name STRING NULL,
+   collation_catalog STRING NULL,
+   collation_schema STRING NULL,
+   collation_name STRING NULL,
+   numeric_precision INT8 NULL,
+   numeric_precision_radix INT8 NULL,
+   numeric_scale INT8 NULL,
+   datetime_precision INT8 NULL,
+   interval_type STRING NULL,
+   interval_precision STRING NULL,
+   type_udt_catalog STRING NULL,
+   type_udt_schema STRING NULL,
+   type_udt_name STRING NULL,
+   scope_catalog STRING NULL,
+   scope_name STRING NULL,
+   maximum_cardinality INT8 NULL,
+   dtd_identifier STRING NULL,
+   routine_body STRING NULL,
+   routine_definition STRING NULL,
+   external_name STRING NULL,
+   external_language STRING NULL,
+   parameter_style STRING NULL,
+   is_deterministic STRING NULL,
+   sql_data_access STRING NULL,
+   is_null_call STRING NULL,
+   sql_path STRING NULL,
+   schema_level_routine STRING NULL,
+   max_dynamic_result_sets INT8 NULL,
+   is_user_defined_cast STRING NULL,
+   is_implicitly_invocable STRING NULL,
+   security_type STRING NULL,
+   to_sql_specific_catalog STRING NULL,
+   to_sql_specific_schema STRING NULL,
+   to_sql_specific_name STRING NULL,
+   as_locator STRING NULL,
+   created TIMESTAMPTZ NULL,
+   last_altered TIMESTAMPTZ NULL,
+   new_savepoint_level STRING NULL,
+   is_udt_dependent STRING NULL,
+   result_cast_from_data_type STRING NULL,
+   result_cast_as_locator STRING NULL,
+   result_cast_char_max_length INT8 NULL,
+   result_cast_char_octet_length STRING NULL,
+   result_cast_char_set_catalog STRING NULL,
+   result_cast_char_set_schema STRING NULL,
+   result_cast_char_set_name STRING NULL,
+   result_cast_collation_catalog STRING NULL,
+   result_cast_collation_schema STRING NULL,
+   result_cast_collation_name STRING NULL,
+   result_cast_numeric_precision INT8 NULL,
+   result_cast_numeric_precision_radix INT8 NULL,
+   result_cast_numeric_scale INT8 NULL,
+   result_cast_datetime_precision STRING NULL,
+   result_cast_interval_type STRING NULL,
+   result_cast_interval_precision INT8 NULL,
+   result_cast_type_udt_catalog STRING NULL,
+   result_cast_type_udt_schema STRING NULL,
+   result_cast_type_udt_name STRING NULL,
+   result_cast_scope_catalog STRING NULL,
+   result_cast_scope_schema STRING NULL,
+   result_cast_scope_name STRING NULL,
+   result_cast_maximum_cardinality INT8 NULL,
+   result_cast_dtd_identifier STRING NULL
+)  {}  {}
+CREATE TABLE information_schema.schema_privileges (
+   grantee STRING NOT NULL,
+   table_catalog STRING NOT NULL,
+   table_schema STRING NOT NULL,
+   privilege_type STRING NOT NULL,
+   is_grantable STRING NULL
+)  CREATE TABLE information_schema.schema_privileges (
+   grantee STRING NOT NULL,
+   table_catalog STRING NOT NULL,
+   table_schema STRING NOT NULL,
+   privilege_type STRING NOT NULL,
+   is_grantable STRING NULL
+)  {}  {}
+CREATE TABLE information_schema.schemata (
+   catalog_name STRING NOT NULL,
+   schema_name STRING NOT NULL,
+   default_character_set_name STRING NULL,
+   sql_path STRING NULL,
+   crdb_is_user_defined STRING NULL
+)  CREATE TABLE information_schema.schemata (
+   catalog_name STRING NOT NULL,
+   schema_name STRING NOT NULL,
+   default_character_set_name STRING NULL,
+   sql_path STRING NULL,
+   crdb_is_user_defined STRING NULL
+)  {}  {}
+CREATE TABLE information_schema.sequences (
+   sequence_catalog STRING NOT NULL,
+   sequence_schema STRING NOT NULL,
+   sequence_name STRING NOT NULL,
+   data_type STRING NOT NULL,
+   numeric_precision INT8 NOT NULL,
+   numeric_precision_radix INT8 NOT NULL,
+   numeric_scale INT8 NOT NULL,
+   start_value STRING NOT NULL,
+   minimum_value STRING NOT NULL,
+   maximum_value STRING NOT NULL,
+   increment STRING NOT NULL,
+   cycle_option STRING NOT NULL
+)  CREATE TABLE information_schema.sequences (
+   sequence_catalog STRING NOT NULL,
+   sequence_schema STRING NOT NULL,
+   sequence_name STRING NOT NULL,
+   data_type STRING NOT NULL,
+   numeric_precision INT8 NOT NULL,
+   numeric_precision_radix INT8 NOT NULL,
+   numeric_scale INT8 NOT NULL,
+   start_value STRING NOT NULL,
+   minimum_value STRING NOT NULL,
+   maximum_value STRING NOT NULL,
+   increment STRING NOT NULL,
+   cycle_option STRING NOT NULL
+)  {}  {}
+CREATE TABLE information_schema.session_variables (
+   variable STRING NOT NULL,
+   value STRING NOT NULL
+)  CREATE TABLE information_schema.session_variables (
+   variable STRING NOT NULL,
+   value STRING NOT NULL
+)  {}  {}
+CREATE TABLE information_schema.statistics (
+   table_catalog STRING NOT NULL,
+   table_schema STRING NOT NULL,
+   table_name STRING NOT NULL,
+   non_unique STRING NOT NULL,
+   index_schema STRING NOT NULL,
+   index_name STRING NOT NULL,
+   seq_in_index INT8 NOT NULL,
+   column_name STRING NOT NULL,
+   "COLLATION" STRING NULL,
+   cardinality INT8 NULL,
+   direction STRING NOT NULL,
+   storing STRING NOT NULL,
+   implicit STRING NOT NULL
+)  CREATE TABLE information_schema.statistics (
+   table_catalog STRING NOT NULL,
+   table_schema STRING NOT NULL,
+   table_name STRING NOT NULL,
+   non_unique STRING NOT NULL,
+   index_schema STRING NOT NULL,
+   index_name STRING NOT NULL,
+   seq_in_index INT8 NOT NULL,
+   column_name STRING NOT NULL,
+   "COLLATION" STRING NULL,
+   cardinality INT8 NULL,
+   direction STRING NOT NULL,
+   storing STRING NOT NULL,
+   implicit STRING NOT NULL
+)  {}  {}
+CREATE TABLE information_schema.table_constraints (
+   constraint_catalog STRING NOT NULL,
+   constraint_schema STRING NOT NULL,
+   constraint_name STRING NOT NULL,
+   table_catalog STRING NOT NULL,
+   table_schema STRING NOT NULL,
+   table_name STRING NOT NULL,
+   constraint_type STRING NOT NULL,
+   is_deferrable STRING NOT NULL,
+   initially_deferred STRING NOT NULL
+)  CREATE TABLE information_schema.table_constraints (
+   constraint_catalog STRING NOT NULL,
+   constraint_schema STRING NOT NULL,
+   constraint_name STRING NOT NULL,
+   table_catalog STRING NOT NULL,
+   table_schema STRING NOT NULL,
+   table_name STRING NOT NULL,
+   constraint_type STRING NOT NULL,
+   is_deferrable STRING NOT NULL,
+   initially_deferred STRING NOT NULL
+)  {}  {}
+CREATE TABLE information_schema.table_privileges (
+   grantor STRING NULL,
+   grantee STRING NOT NULL,
+   table_catalog STRING NOT NULL,
+   table_schema STRING NOT NULL,
+   table_name STRING NOT NULL,
+   privilege_type STRING NOT NULL,
+   is_grantable STRING NULL,
+   with_hierarchy STRING NOT NULL
+)  CREATE TABLE information_schema.table_privileges (
+   grantor STRING NULL,
+   grantee STRING NOT NULL,
+   table_catalog STRING NOT NULL,
+   table_schema STRING NOT NULL,
+   table_name STRING NOT NULL,
+   privilege_type STRING NOT NULL,
+   is_grantable STRING NULL,
+   with_hierarchy STRING NOT NULL
+)  {}  {}
+CREATE TABLE information_schema.tables (
+   table_catalog STRING NOT NULL,
+   table_schema STRING NOT NULL,
+   table_name STRING NOT NULL,
+   table_type STRING NOT NULL,
+   is_insertable_into STRING NOT NULL,
+   version INT8 NULL
+)  CREATE TABLE information_schema.tables (
+   table_catalog STRING NOT NULL,
+   table_schema STRING NOT NULL,
+   table_name STRING NOT NULL,
+   table_type STRING NOT NULL,
+   is_insertable_into STRING NOT NULL,
+   version INT8 NULL
+)  {}  {}
+CREATE TABLE information_schema.type_privileges (
+   grantee STRING NOT NULL,
+   type_catalog STRING NOT NULL,
+   type_schema STRING NOT NULL,
+   type_name STRING NOT NULL,
+   privilege_type STRING NOT NULL
+)  CREATE TABLE information_schema.type_privileges (
+   grantee STRING NOT NULL,
+   type_catalog STRING NOT NULL,
+   type_schema STRING NOT NULL,
+   type_name STRING NOT NULL,
+   privilege_type STRING NOT NULL
+)  {}  {}
+CREATE TABLE information_schema.user_privileges (
+   grantee STRING NOT NULL,
+   table_catalog STRING NOT NULL,
+   privilege_type STRING NOT NULL,
+   is_grantable STRING NULL
+)  CREATE TABLE information_schema.user_privileges (
+   grantee STRING NOT NULL,
+   table_catalog STRING NOT NULL,
+   privilege_type STRING NOT NULL,
+   is_grantable STRING NULL
+)  {}  {}
+CREATE TABLE information_schema.views (
+   table_catalog STRING NOT NULL,
+   table_schema STRING NOT NULL,
+   table_name STRING NOT NULL,
+   view_definition STRING NOT NULL,
+   check_option STRING NULL,
+   is_updatable STRING NOT NULL,
+   is_insertable_into STRING NOT NULL,
+   is_trigger_updatable STRING NOT NULL,
+   is_trigger_deletable STRING NOT NULL,
+   is_trigger_insertable_into STRING NOT NULL
+)  CREATE TABLE information_schema.views (
+   table_catalog STRING NOT NULL,
+   table_schema STRING NOT NULL,
+   table_name STRING NOT NULL,
+   view_definition STRING NOT NULL,
+   check_option STRING NULL,
+   is_updatable STRING NOT NULL,
+   is_insertable_into STRING NOT NULL,
+   is_trigger_updatable STRING NOT NULL,
+   is_trigger_deletable STRING NOT NULL,
+   is_trigger_insertable_into STRING NOT NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_aggregate (
+   aggfnoid REGPROC NULL,
+   aggkind "char" NULL,
+   aggnumdirectargs INT2 NULL,
+   aggtransfn REGPROC NULL,
+   aggfinalfn REGPROC NULL,
+   aggcombinefn REGPROC NULL,
+   aggserialfn REGPROC NULL,
+   aggdeserialfn REGPROC NULL,
+   aggmtransfn REGPROC NULL,
+   aggminvtransfn REGPROC NULL,
+   aggmfinalfn REGPROC NULL,
+   aggfinalextra BOOL NULL,
+   aggmfinalextra BOOL NULL,
+   aggsortop OID NULL,
+   aggtranstype OID NULL,
+   aggtransspace INT4 NULL,
+   aggmtranstype OID NULL,
+   aggmtransspace INT4 NULL,
+   agginitval STRING NULL,
+   aggminitval STRING NULL,
+   aggfinalmodify "char" NULL,
+   aggmfinalmodify "char" NULL
+)  CREATE TABLE pg_catalog.pg_aggregate (
+   aggfnoid REGPROC NULL,
+   aggkind "char" NULL,
+   aggnumdirectargs INT2 NULL,
+   aggtransfn REGPROC NULL,
+   aggfinalfn REGPROC NULL,
+   aggcombinefn REGPROC NULL,
+   aggserialfn REGPROC NULL,
+   aggdeserialfn REGPROC NULL,
+   aggmtransfn REGPROC NULL,
+   aggminvtransfn REGPROC NULL,
+   aggmfinalfn REGPROC NULL,
+   aggfinalextra BOOL NULL,
+   aggmfinalextra BOOL NULL,
+   aggsortop OID NULL,
+   aggtranstype OID NULL,
+   aggtransspace INT4 NULL,
+   aggmtranstype OID NULL,
+   aggmtransspace INT4 NULL,
+   agginitval STRING NULL,
+   aggminitval STRING NULL,
+   aggfinalmodify "char" NULL,
+   aggmfinalmodify "char" NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_aggregate_fnoid_index (
+   aggfnoid REGPROC NULL
+)  CREATE TABLE pg_catalog.pg_aggregate_fnoid_index (
+   aggfnoid REGPROC NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_am (
+   oid OID NULL,
+   amname NAME NULL,
+   amstrategies INT2 NULL,
+   amsupport INT2 NULL,
+   amcanorder BOOL NULL,
+   amcanorderbyop BOOL NULL,
+   amcanbackward BOOL NULL,
+   amcanunique BOOL NULL,
+   amcanmulticol BOOL NULL,
+   amoptionalkey BOOL NULL,
+   amsearcharray BOOL NULL,
+   amsearchnulls BOOL NULL,
+   amstorage BOOL NULL,
+   amclusterable BOOL NULL,
+   ampredlocks BOOL NULL,
+   amkeytype OID NULL,
+   aminsert OID NULL,
+   ambeginscan OID NULL,
+   amgettuple OID NULL,
+   amgetbitmap OID NULL,
+   amrescan OID NULL,
+   amendscan OID NULL,
+   ammarkpos OID NULL,
+   amrestrpos OID NULL,
+   ambuild OID NULL,
+   ambuildempty OID NULL,
+   ambulkdelete OID NULL,
+   amvacuumcleanup OID NULL,
+   amcanreturn OID NULL,
+   amcostestimate OID NULL,
+   amoptions OID NULL,
+   amhandler OID NULL,
+   amtype "char" NULL
+)  CREATE TABLE pg_catalog.pg_am (
+   oid OID NULL,
+   amname NAME NULL,
+   amstrategies INT2 NULL,
+   amsupport INT2 NULL,
+   amcanorder BOOL NULL,
+   amcanorderbyop BOOL NULL,
+   amcanbackward BOOL NULL,
+   amcanunique BOOL NULL,
+   amcanmulticol BOOL NULL,
+   amoptionalkey BOOL NULL,
+   amsearcharray BOOL NULL,
+   amsearchnulls BOOL NULL,
+   amstorage BOOL NULL,
+   amclusterable BOOL NULL,
+   ampredlocks BOOL NULL,
+   amkeytype OID NULL,
+   aminsert OID NULL,
+   ambeginscan OID NULL,
+   amgettuple OID NULL,
+   amgetbitmap OID NULL,
+   amrescan OID NULL,
+   amendscan OID NULL,
+   ammarkpos OID NULL,
+   amrestrpos OID NULL,
+   ambuild OID NULL,
+   ambuildempty OID NULL,
+   ambulkdelete OID NULL,
+   amvacuumcleanup OID NULL,
+   amcanreturn OID NULL,
+   amcostestimate OID NULL,
+   amoptions OID NULL,
+   amhandler OID NULL,
+   amtype "char" NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_am_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_am_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_amop (
+   amoplefttype OID NULL,
+   amopmethod OID NULL,
+   amopopr OID NULL,
+   amoppurpose "char" NULL,
+   amoprighttype OID NULL,
+   oid OID NULL,
+   amopfamily OID NULL,
+   amopsortfamily OID NULL,
+   amopstrategy INT2 NULL
+)  CREATE TABLE pg_catalog.pg_amop (
+   amoplefttype OID NULL,
+   amopmethod OID NULL,
+   amopopr OID NULL,
+   amoppurpose "char" NULL,
+   amoprighttype OID NULL,
+   oid OID NULL,
+   amopfamily OID NULL,
+   amopsortfamily OID NULL,
+   amopstrategy INT2 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_amop_fam_strat_index (
+   amoplefttype OID NULL,
+   amoprighttype OID NULL,
+   amopstrategy INT2 NULL,
+   amopfamily OID NULL
+)  CREATE TABLE pg_catalog.pg_amop_fam_strat_index (
+   amoplefttype OID NULL,
+   amoprighttype OID NULL,
+   amopstrategy INT2 NULL,
+   amopfamily OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_amop_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_amop_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_amop_opr_fam_index (
+   amoppurpose "char" NULL,
+   amopfamily OID NULL,
+   amopopr OID NULL
+)  CREATE TABLE pg_catalog.pg_amop_opr_fam_index (
+   amoppurpose "char" NULL,
+   amopfamily OID NULL,
+   amopopr OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_amproc (
+   amproc REGPROC NULL,
+   amprocfamily OID NULL,
+   amproclefttype OID NULL,
+   amprocnum INT2 NULL,
+   amprocrighttype OID NULL,
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_amproc (
+   amproc REGPROC NULL,
+   amprocfamily OID NULL,
+   amproclefttype OID NULL,
+   amprocnum INT2 NULL,
+   amprocrighttype OID NULL,
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_amproc_fam_proc_index (
+   amprocfamily OID NULL,
+   amproclefttype OID NULL,
+   amprocnum INT2 NULL,
+   amprocrighttype OID NULL
+)  CREATE TABLE pg_catalog.pg_amproc_fam_proc_index (
+   amprocfamily OID NULL,
+   amproclefttype OID NULL,
+   amprocnum INT2 NULL,
+   amprocrighttype OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_amproc_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_amproc_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_attrdef (
+   oid OID NULL,
+   adrelid OID NOT NULL,
+   adnum INT2 NULL,
+   adbin STRING NULL,
+   adsrc STRING NULL,
+   INDEX pg_attrdef_adrelid_idx (adrelid ASC) STORING (oid, adnum, adbin, adsrc)
+)  CREATE TABLE pg_catalog.pg_attrdef (
+   oid OID NULL,
+   adrelid OID NOT NULL,
+   adnum INT2 NULL,
+   adbin STRING NULL,
+   adsrc STRING NULL,
+   INDEX pg_attrdef_adrelid_idx (adrelid ASC) STORING (oid, adnum, adbin, adsrc)
+)  {}  {}
+CREATE TABLE pg_catalog.pg_attrdef_adrelid_adnum_index (
+   adnum INT2 NULL,
+   adrelid OID NULL
+)  CREATE TABLE pg_catalog.pg_attrdef_adrelid_adnum_index (
+   adnum INT2 NULL,
+   adrelid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_attrdef_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_attrdef_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_attribute (
+   attrelid OID NOT NULL,
+   attname NAME NULL,
+   atttypid OID NULL,
+   attstattarget INT4 NULL,
+   attlen INT2 NULL,
+   attnum INT2 NULL,
+   attndims INT4 NULL,
+   attcacheoff INT4 NULL,
+   atttypmod INT4 NULL,
+   attbyval BOOL NULL,
+   attstorage "char" NULL,
+   attalign "char" NULL,
+   attnotnull BOOL NULL,
+   atthasdef BOOL NULL,
+   attidentity "char" NULL,
+   attgenerated "char" NULL,
+   attisdropped BOOL NULL,
+   attislocal BOOL NULL,
+   attinhcount INT4 NULL,
+   attcollation OID NULL,
+   attacl STRING[] NULL,
+   attoptions STRING[] NULL,
+   attfdwoptions STRING[] NULL,
+   atthasmissing BOOL NULL,
+   INDEX pg_attribute_attrelid_idx (attrelid ASC) STORING (attname, atttypid, attstattarget, attlen, attnum, attndims, attcacheoff, atttypmod, attbyval, attstorage, attalign, attnotnull, atthasdef, attidentity, attgenerated, attisdropped, attislocal, attinhcount, attcollation, attacl, attoptions, attfdwoptions, atthasmissing)
+)  CREATE TABLE pg_catalog.pg_attribute (
+   attrelid OID NOT NULL,
+   attname NAME NULL,
+   atttypid OID NULL,
+   attstattarget INT4 NULL,
+   attlen INT2 NULL,
+   attnum INT2 NULL,
+   attndims INT4 NULL,
+   attcacheoff INT4 NULL,
+   atttypmod INT4 NULL,
+   attbyval BOOL NULL,
+   attstorage "char" NULL,
+   attalign "char" NULL,
+   attnotnull BOOL NULL,
+   atthasdef BOOL NULL,
+   attidentity "char" NULL,
+   attgenerated "char" NULL,
+   attisdropped BOOL NULL,
+   attislocal BOOL NULL,
+   attinhcount INT4 NULL,
+   attcollation OID NULL,
+   attacl STRING[] NULL,
+   attoptions STRING[] NULL,
+   attfdwoptions STRING[] NULL,
+   atthasmissing BOOL NULL,
+   INDEX pg_attribute_attrelid_idx (attrelid ASC) STORING (attname, atttypid, attstattarget, attlen, attnum, attndims, attcacheoff, atttypmod, attbyval, attstorage, attalign, attnotnull, atthasdef, attidentity, attgenerated, attisdropped, attislocal, attinhcount, attcollation, attacl, attoptions, attfdwoptions, atthasmissing)
+)  {}  {}
+CREATE TABLE pg_catalog.pg_attribute_relid_attnum_index (
+   attnum INT2 NULL,
+   attrelid OID NULL
+)  CREATE TABLE pg_catalog.pg_attribute_relid_attnum_index (
+   attnum INT2 NULL,
+   attrelid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_auth_members (
+   roleid OID NULL,
+   member OID NULL,
+   grantor OID NULL,
+   admin_option BOOL NULL
+)  CREATE TABLE pg_catalog.pg_auth_members (
+   roleid OID NULL,
+   member OID NULL,
+   grantor OID NULL,
+   admin_option BOOL NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_auth_members_member_role_index (
+   member OID NULL,
+   roleid OID NULL
+)  CREATE TABLE pg_catalog.pg_auth_members_member_role_index (
+   member OID NULL,
+   roleid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_auth_members_role_member_index (
+   member OID NULL,
+   roleid OID NULL
+)  CREATE TABLE pg_catalog.pg_auth_members_role_member_index (
+   member OID NULL,
+   roleid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_authid (
+   oid OID NULL,
+   rolname NAME NULL,
+   rolsuper BOOL NULL,
+   rolinherit BOOL NULL,
+   rolcreaterole BOOL NULL,
+   rolcreatedb BOOL NULL,
+   rolcanlogin BOOL NULL,
+   rolreplication BOOL NULL,
+   rolbypassrls BOOL NULL,
+   rolconnlimit INT4 NULL,
+   rolpassword STRING NULL,
+   rolvaliduntil TIMESTAMPTZ NULL
+)  CREATE TABLE pg_catalog.pg_authid (
+   oid OID NULL,
+   rolname NAME NULL,
+   rolsuper BOOL NULL,
+   rolinherit BOOL NULL,
+   rolcreaterole BOOL NULL,
+   rolcreatedb BOOL NULL,
+   rolcanlogin BOOL NULL,
+   rolreplication BOOL NULL,
+   rolbypassrls BOOL NULL,
+   rolconnlimit INT4 NULL,
+   rolpassword STRING NULL,
+   rolvaliduntil TIMESTAMPTZ NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_authid_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_authid_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_available_extension_versions (
+   trusted BOOL NULL,
+   comment STRING NULL,
+   relocatable BOOL NULL,
+   requires NAME[] NULL,
+   schema NAME NULL,
+   installed BOOL NULL,
+   name NAME NULL,
+   superuser BOOL NULL,
+   version STRING NULL
+)  CREATE TABLE pg_catalog.pg_available_extension_versions (
+   trusted BOOL NULL,
+   comment STRING NULL,
+   relocatable BOOL NULL,
+   requires NAME[] NULL,
+   schema NAME NULL,
+   installed BOOL NULL,
+   name NAME NULL,
+   superuser BOOL NULL,
+   version STRING NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_available_extensions (
+   name NAME NULL,
+   default_version STRING NULL,
+   installed_version STRING NULL,
+   comment STRING NULL
+)  CREATE TABLE pg_catalog.pg_available_extensions (
+   name NAME NULL,
+   default_version STRING NULL,
+   installed_version STRING NULL,
+   comment STRING NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_cast (
+   oid OID NULL,
+   castsource OID NULL,
+   casttarget OID NULL,
+   castfunc OID NULL,
+   castcontext "char" NULL,
+   castmethod "char" NULL
+)  CREATE TABLE pg_catalog.pg_cast (
+   oid OID NULL,
+   castsource OID NULL,
+   casttarget OID NULL,
+   castfunc OID NULL,
+   castcontext "char" NULL,
+   castmethod "char" NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_cast_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_cast_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_cast_source_target_index (
+   castsource OID NULL,
+   casttarget OID NULL
+)  CREATE TABLE pg_catalog.pg_cast_source_target_index (
+   castsource OID NULL,
+   casttarget OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_class (
+   oid OID NOT NULL,
+   relname NAME NOT NULL,
+   relnamespace OID NULL,
+   reltype OID NULL,
+   reloftype OID NULL,
+   relowner OID NULL,
+   relam OID NULL,
+   relfilenode OID NULL,
+   reltablespace OID NULL,
+   relpages INT4 NULL,
+   reltuples FLOAT4 NULL,
+   relallvisible INT4 NULL,
+   reltoastrelid OID NULL,
+   relhasindex BOOL NULL,
+   relisshared BOOL NULL,
+   relpersistence "char" NULL,
+   relistemp BOOL NULL,
+   relkind "char" NULL,
+   relnatts INT2 NULL,
+   relchecks INT2 NULL,
+   relhasoids BOOL NULL,
+   relhaspkey BOOL NULL,
+   relhasrules BOOL NULL,
+   relhastriggers BOOL NULL,
+   relhassubclass BOOL NULL,
+   relfrozenxid INT8 NULL,
+   relacl STRING[] NULL,
+   reloptions STRING[] NULL,
+   relforcerowsecurity BOOL NULL,
+   relispartition BOOL NULL,
+   relispopulated BOOL NULL,
+   relreplident "char" NULL,
+   relrewrite OID NULL,
+   relrowsecurity BOOL NULL,
+   relpartbound STRING NULL,
+   INDEX pg_class_oid_idx (oid ASC) STORING (relname, relnamespace, reltype, reloftype, relowner, relam, relfilenode, reltablespace, relpages, reltuples, relallvisible, reltoastrelid, relhasindex, relisshared, relpersistence, relistemp, relkind, relnatts, relchecks, relhasoids, relhaspkey, relhasrules, relhastriggers, relhassubclass, relfrozenxid, relacl, reloptions, relforcerowsecurity, relispartition, relispopulated, relreplident, relrewrite, relrowsecurity, relpartbound)
+)  CREATE TABLE pg_catalog.pg_class (
+   oid OID NOT NULL,
+   relname NAME NOT NULL,
+   relnamespace OID NULL,
+   reltype OID NULL,
+   reloftype OID NULL,
+   relowner OID NULL,
+   relam OID NULL,
+   relfilenode OID NULL,
+   reltablespace OID NULL,
+   relpages INT4 NULL,
+   reltuples FLOAT4 NULL,
+   relallvisible INT4 NULL,
+   reltoastrelid OID NULL,
+   relhasindex BOOL NULL,
+   relisshared BOOL NULL,
+   relpersistence "char" NULL,
+   relistemp BOOL NULL,
+   relkind "char" NULL,
+   relnatts INT2 NULL,
+   relchecks INT2 NULL,
+   relhasoids BOOL NULL,
+   relhaspkey BOOL NULL,
+   relhasrules BOOL NULL,
+   relhastriggers BOOL NULL,
+   relhassubclass BOOL NULL,
+   relfrozenxid INT8 NULL,
+   relacl STRING[] NULL,
+   reloptions STRING[] NULL,
+   relforcerowsecurity BOOL NULL,
+   relispartition BOOL NULL,
+   relispopulated BOOL NULL,
+   relreplident "char" NULL,
+   relrewrite OID NULL,
+   relrowsecurity BOOL NULL,
+   relpartbound STRING NULL,
+   INDEX pg_class_oid_idx (oid ASC) STORING (relname, relnamespace, reltype, reloftype, relowner, relam, relfilenode, reltablespace, relpages, reltuples, relallvisible, reltoastrelid, relhasindex, relisshared, relpersistence, relistemp, relkind, relnatts, relchecks, relhasoids, relhaspkey, relhasrules, relhastriggers, relhassubclass, relfrozenxid, relacl, reloptions, relforcerowsecurity, relispartition, relispopulated, relreplident, relrewrite, relrowsecurity, relpartbound)
+)  {}  {}
+CREATE TABLE pg_catalog.pg_class_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_class_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_class_tblspc_relfilenode_index (
+   relfilenode OID NULL,
+   reltablespace OID NULL
+)  CREATE TABLE pg_catalog.pg_class_tblspc_relfilenode_index (
+   relfilenode OID NULL,
+   reltablespace OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_collation (
+   oid OID NULL,
+   collname STRING NULL,
+   collnamespace OID NULL,
+   collowner OID NULL,
+   collencoding INT4 NULL,
+   collcollate STRING NULL,
+   collctype STRING NULL,
+   collprovider "char" NULL,
+   collversion STRING NULL,
+   collisdeterministic BOOL NULL
+)  CREATE TABLE pg_catalog.pg_collation (
+   oid OID NULL,
+   collname STRING NULL,
+   collnamespace OID NULL,
+   collowner OID NULL,
+   collencoding INT4 NULL,
+   collcollate STRING NULL,
+   collctype STRING NULL,
+   collprovider "char" NULL,
+   collversion STRING NULL,
+   collisdeterministic BOOL NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_collation_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_collation_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_config (
+   name STRING NULL,
+   setting STRING NULL
+)  CREATE TABLE pg_catalog.pg_config (
+   name STRING NULL,
+   setting STRING NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_constraint (
+   oid OID NULL,
+   conname NAME NULL,
+   connamespace OID NULL,
+   contype STRING NULL,
+   condeferrable BOOL NULL,
+   condeferred BOOL NULL,
+   convalidated BOOL NULL,
+   conrelid OID NOT NULL,
+   contypid OID NULL,
+   conindid OID NULL,
+   confrelid OID NULL,
+   confupdtype STRING NULL,
+   confdeltype STRING NULL,
+   confmatchtype STRING NULL,
+   conislocal BOOL NULL,
+   coninhcount INT4 NULL,
+   connoinherit BOOL NULL,
+   conkey INT2[] NULL,
+   confkey INT2[] NULL,
+   conpfeqop OID[] NULL,
+   conppeqop OID[] NULL,
+   conffeqop OID[] NULL,
+   conexclop OID[] NULL,
+   conbin STRING NULL,
+   consrc STRING NULL,
+   condef STRING NULL,
+   INDEX pg_constraint_conrelid_idx (conrelid ASC) STORING (oid, conname, connamespace, contype, condeferrable, condeferred, convalidated, contypid, conindid, confrelid, confupdtype, confdeltype, confmatchtype, conislocal, coninhcount, connoinherit, conkey, confkey, conpfeqop, conppeqop, conffeqop, conexclop, conbin, consrc, condef)
+)  CREATE TABLE pg_catalog.pg_constraint (
+   oid OID NULL,
+   conname NAME NULL,
+   connamespace OID NULL,
+   contype STRING NULL,
+   condeferrable BOOL NULL,
+   condeferred BOOL NULL,
+   convalidated BOOL NULL,
+   conrelid OID NOT NULL,
+   contypid OID NULL,
+   conindid OID NULL,
+   confrelid OID NULL,
+   confupdtype STRING NULL,
+   confdeltype STRING NULL,
+   confmatchtype STRING NULL,
+   conislocal BOOL NULL,
+   coninhcount INT4 NULL,
+   connoinherit BOOL NULL,
+   conkey INT2[] NULL,
+   confkey INT2[] NULL,
+   conpfeqop OID[] NULL,
+   conppeqop OID[] NULL,
+   conffeqop OID[] NULL,
+   conexclop OID[] NULL,
+   conbin STRING NULL,
+   consrc STRING NULL,
+   condef STRING NULL,
+   INDEX pg_constraint_conrelid_idx (conrelid ASC) STORING (oid, conname, connamespace, contype, condeferrable, condeferred, convalidated, contypid, conindid, confrelid, confupdtype, confdeltype, confmatchtype, conislocal, coninhcount, connoinherit, conkey, confkey, conpfeqop, conppeqop, conffeqop, conexclop, conbin, consrc, condef)
+)  {}  {}
+CREATE TABLE pg_catalog.pg_constraint_conparentid_index (
+   conparentid OID NULL
+)  CREATE TABLE pg_catalog.pg_constraint_conparentid_index (
+   conparentid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_constraint_contypid_index (
+   contypid OID NULL
+)  CREATE TABLE pg_catalog.pg_constraint_contypid_index (
+   contypid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_constraint_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_constraint_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_conversion (
+   oid OID NULL,
+   conname NAME NULL,
+   connamespace OID NULL,
+   conowner OID NULL,
+   conforencoding INT4 NULL,
+   contoencoding INT4 NULL,
+   conproc OID NULL,
+   condefault BOOL NULL
+)  CREATE TABLE pg_catalog.pg_conversion (
+   oid OID NULL,
+   conname NAME NULL,
+   connamespace OID NULL,
+   conowner OID NULL,
+   conforencoding INT4 NULL,
+   contoencoding INT4 NULL,
+   conproc OID NULL,
+   condefault BOOL NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_conversion_default_index (
+   oid OID NULL,
+   conforencoding INT4 NULL,
+   connamespace OID NULL,
+   contoencoding INT4 NULL
+)  CREATE TABLE pg_catalog.pg_conversion_default_index (
+   oid OID NULL,
+   conforencoding INT4 NULL,
+   connamespace OID NULL,
+   contoencoding INT4 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_conversion_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_conversion_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_cursors (
+   is_scrollable BOOL NULL,
+   name STRING NULL,
+   statement STRING NULL,
+   creation_time TIMESTAMPTZ NULL,
+   is_binary BOOL NULL,
+   is_holdable BOOL NULL
+)  CREATE TABLE pg_catalog.pg_cursors (
+   is_scrollable BOOL NULL,
+   name STRING NULL,
+   statement STRING NULL,
+   creation_time TIMESTAMPTZ NULL,
+   is_binary BOOL NULL,
+   is_holdable BOOL NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_database (
+   oid OID NULL,
+   datname NAME NULL,
+   datdba OID NULL,
+   encoding INT4 NULL,
+   datcollate STRING NULL,
+   datctype STRING NULL,
+   datistemplate BOOL NULL,
+   datallowconn BOOL NULL,
+   datconnlimit INT4 NULL,
+   datlastsysoid OID NULL,
+   datfrozenxid INT8 NULL,
+   datminmxid INT8 NULL,
+   dattablespace OID NULL,
+   datacl STRING[] NULL
+)  CREATE TABLE pg_catalog.pg_database (
+   oid OID NULL,
+   datname NAME NULL,
+   datdba OID NULL,
+   encoding INT4 NULL,
+   datcollate STRING NULL,
+   datctype STRING NULL,
+   datistemplate BOOL NULL,
+   datallowconn BOOL NULL,
+   datconnlimit INT4 NULL,
+   datlastsysoid OID NULL,
+   datfrozenxid INT8 NULL,
+   datminmxid INT8 NULL,
+   dattablespace OID NULL,
+   datacl STRING[] NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_database_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_database_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_db_role_setting (
+   setconfig STRING[] NULL,
+   setdatabase OID NULL,
+   setrole OID NULL
+)  CREATE TABLE pg_catalog.pg_db_role_setting (
+   setconfig STRING[] NULL,
+   setdatabase OID NULL,
+   setrole OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_db_role_setting_databaseid_rol_index (
+   setdatabase OID NULL,
+   setrole OID NULL
+)  CREATE TABLE pg_catalog.pg_db_role_setting_databaseid_rol_index (
+   setdatabase OID NULL,
+   setrole OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_default_acl (
+   oid OID NULL,
+   defaclrole OID NULL,
+   defaclnamespace OID NULL,
+   defaclobjtype "char" NULL,
+   defaclacl STRING[] NULL
+)  CREATE TABLE pg_catalog.pg_default_acl (
+   oid OID NULL,
+   defaclrole OID NULL,
+   defaclnamespace OID NULL,
+   defaclobjtype "char" NULL,
+   defaclacl STRING[] NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_default_acl_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_default_acl_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_default_acl_role_nsp_obj_index (
+   defaclnamespace OID NULL,
+   defaclobjtype "char" NULL,
+   defaclrole OID NULL
+)  CREATE TABLE pg_catalog.pg_default_acl_role_nsp_obj_index (
+   defaclnamespace OID NULL,
+   defaclobjtype "char" NULL,
+   defaclrole OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_depend (
+   classid OID NULL,
+   objid OID NULL,
+   objsubid INT4 NULL,
+   refclassid OID NULL,
+   refobjid OID NULL,
+   refobjsubid INT4 NULL,
+   deptype "char" NULL
+)  CREATE TABLE pg_catalog.pg_depend (
+   classid OID NULL,
+   objid OID NULL,
+   objsubid INT4 NULL,
+   refclassid OID NULL,
+   refobjid OID NULL,
+   refobjsubid INT4 NULL,
+   deptype "char" NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_depend_depender_index (
+   classid OID NULL,
+   objid OID NULL,
+   objsubid INT4 NULL
+)  CREATE TABLE pg_catalog.pg_depend_depender_index (
+   classid OID NULL,
+   objid OID NULL,
+   objsubid INT4 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_depend_reference_index (
+   refclassid OID NULL,
+   refobjid OID NULL,
+   refobjsubid INT4 NULL
+)  CREATE TABLE pg_catalog.pg_depend_reference_index (
+   refclassid OID NULL,
+   refobjid OID NULL,
+   refobjsubid INT4 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_description (
+   objoid OID NULL,
+   classoid OID NULL,
+   objsubid INT4 NULL,
+   description STRING NULL
+)  CREATE TABLE pg_catalog.pg_description (
+   objoid OID NULL,
+   classoid OID NULL,
+   objsubid INT4 NULL,
+   description STRING NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_description_o_c_o_index (
+   classoid OID NULL,
+   objoid OID NULL,
+   objsubid INT4 NULL
+)  CREATE TABLE pg_catalog.pg_description_o_c_o_index (
+   classoid OID NULL,
+   objoid OID NULL,
+   objsubid INT4 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_enum (
+   oid OID NULL,
+   enumtypid OID NULL,
+   enumsortorder FLOAT4 NULL,
+   enumlabel STRING NULL
+)  CREATE TABLE pg_catalog.pg_enum (
+   oid OID NULL,
+   enumtypid OID NULL,
+   enumsortorder FLOAT4 NULL,
+   enumlabel STRING NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_enum_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_enum_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_enum_typid_sortorder_index (
+   enumsortorder FLOAT4 NULL,
+   enumtypid OID NULL
+)  CREATE TABLE pg_catalog.pg_enum_typid_sortorder_index (
+   enumsortorder FLOAT4 NULL,
+   enumtypid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_event_trigger (
+   evtname NAME NULL,
+   evtevent NAME NULL,
+   evtowner OID NULL,
+   evtfoid OID NULL,
+   evtenabled "char" NULL,
+   evttags STRING[] NULL,
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_event_trigger (
+   evtname NAME NULL,
+   evtevent NAME NULL,
+   evtowner OID NULL,
+   evtfoid OID NULL,
+   evtenabled "char" NULL,
+   evttags STRING[] NULL,
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_event_trigger_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_event_trigger_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_extension (
+   oid OID NULL,
+   extname NAME NULL,
+   extowner OID NULL,
+   extnamespace OID NULL,
+   extrelocatable BOOL NULL,
+   extversion STRING NULL,
+   extconfig STRING NULL,
+   extcondition STRING NULL
+)  CREATE TABLE pg_catalog.pg_extension (
+   oid OID NULL,
+   extname NAME NULL,
+   extowner OID NULL,
+   extnamespace OID NULL,
+   extrelocatable BOOL NULL,
+   extversion STRING NULL,
+   extconfig STRING NULL,
+   extcondition STRING NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_extension_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_extension_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_file_settings (
+   error STRING NULL,
+   name STRING NULL,
+   seqno INT4 NULL,
+   setting STRING NULL,
+   sourcefile STRING NULL,
+   sourceline INT4 NULL,
+   applied BOOL NULL
+)  CREATE TABLE pg_catalog.pg_file_settings (
+   error STRING NULL,
+   name STRING NULL,
+   seqno INT4 NULL,
+   setting STRING NULL,
+   sourcefile STRING NULL,
+   sourceline INT4 NULL,
+   applied BOOL NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_foreign_data_wrapper (
+   oid OID NULL,
+   fdwname NAME NULL,
+   fdwowner OID NULL,
+   fdwhandler OID NULL,
+   fdwvalidator OID NULL,
+   fdwacl STRING[] NULL,
+   fdwoptions STRING[] NULL
+)  CREATE TABLE pg_catalog.pg_foreign_data_wrapper (
+   oid OID NULL,
+   fdwname NAME NULL,
+   fdwowner OID NULL,
+   fdwhandler OID NULL,
+   fdwvalidator OID NULL,
+   fdwacl STRING[] NULL,
+   fdwoptions STRING[] NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_foreign_data_wrapper_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_foreign_data_wrapper_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_foreign_server (
+   oid OID NULL,
+   srvname NAME NULL,
+   srvowner OID NULL,
+   srvfdw OID NULL,
+   srvtype STRING NULL,
+   srvversion STRING NULL,
+   srvacl STRING[] NULL,
+   srvoptions STRING[] NULL
+)  CREATE TABLE pg_catalog.pg_foreign_server (
+   oid OID NULL,
+   srvname NAME NULL,
+   srvowner OID NULL,
+   srvfdw OID NULL,
+   srvtype STRING NULL,
+   srvversion STRING NULL,
+   srvacl STRING[] NULL,
+   srvoptions STRING[] NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_foreign_server_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_foreign_server_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_foreign_table (
+   ftrelid OID NULL,
+   ftserver OID NULL,
+   ftoptions STRING[] NULL
+)  CREATE TABLE pg_catalog.pg_foreign_table (
+   ftrelid OID NULL,
+   ftserver OID NULL,
+   ftoptions STRING[] NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_foreign_table_relid_index (
+   ftrelid OID NULL
+)  CREATE TABLE pg_catalog.pg_foreign_table_relid_index (
+   ftrelid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_group (
+   grolist OID[] NULL,
+   groname NAME NULL,
+   grosysid OID NULL
+)  CREATE TABLE pg_catalog.pg_group (
+   grolist OID[] NULL,
+   groname NAME NULL,
+   grosysid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_hba_file_rules (
+   address STRING NULL,
+   database STRING[] NULL,
+   line_number INT4 NULL,
+   netmask STRING NULL,
+   type STRING NULL,
+   user_name STRING[] NULL,
+   auth_method STRING NULL,
+   error STRING NULL,
+   options STRING[] NULL
+)  CREATE TABLE pg_catalog.pg_hba_file_rules (
+   address STRING NULL,
+   database STRING[] NULL,
+   line_number INT4 NULL,
+   netmask STRING NULL,
+   type STRING NULL,
+   user_name STRING[] NULL,
+   auth_method STRING NULL,
+   error STRING NULL,
+   options STRING[] NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_index (
+   indexrelid OID NULL,
+   indrelid OID NULL,
+   indnatts INT2 NULL,
+   indisunique BOOL NULL,
+   indisprimary BOOL NULL,
+   indisexclusion BOOL NULL,
+   indimmediate BOOL NULL,
+   indisclustered BOOL NULL,
+   indisvalid BOOL NULL,
+   indcheckxmin BOOL NULL,
+   indisready BOOL NULL,
+   indislive BOOL NULL,
+   indisreplident BOOL NULL,
+   indkey INT2VECTOR NULL,
+   indcollation OIDVECTOR NULL,
+   indclass OIDVECTOR NULL,
+   indoption INT2VECTOR NULL,
+   indexprs STRING NULL,
+   indpred STRING NULL,
+   indnkeyatts INT2 NULL
+)  CREATE TABLE pg_catalog.pg_index (
+   indexrelid OID NULL,
+   indrelid OID NULL,
+   indnatts INT2 NULL,
+   indisunique BOOL NULL,
+   indisprimary BOOL NULL,
+   indisexclusion BOOL NULL,
+   indimmediate BOOL NULL,
+   indisclustered BOOL NULL,
+   indisvalid BOOL NULL,
+   indcheckxmin BOOL NULL,
+   indisready BOOL NULL,
+   indislive BOOL NULL,
+   indisreplident BOOL NULL,
+   indkey INT2VECTOR NULL,
+   indcollation OIDVECTOR NULL,
+   indclass OIDVECTOR NULL,
+   indoption INT2VECTOR NULL,
+   indexprs STRING NULL,
+   indpred STRING NULL,
+   indnkeyatts INT2 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_index_indexrelid_index (
+   indexrelid OID NULL
+)  CREATE TABLE pg_catalog.pg_index_indexrelid_index (
+   indexrelid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_index_indrelid_index (
+   indrelid OID NULL
+)  CREATE TABLE pg_catalog.pg_index_indrelid_index (
+   indrelid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_indexes (
+   crdb_oid OID NULL,
+   schemaname NAME NULL,
+   tablename NAME NULL,
+   indexname NAME NULL,
+   tablespace NAME NULL,
+   indexdef STRING NULL
+)  CREATE TABLE pg_catalog.pg_indexes (
+   crdb_oid OID NULL,
+   schemaname NAME NULL,
+   tablename NAME NULL,
+   indexname NAME NULL,
+   tablespace NAME NULL,
+   indexdef STRING NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_inherits (
+   inhrelid OID NULL,
+   inhparent OID NULL,
+   inhseqno INT4 NULL
+)  CREATE TABLE pg_catalog.pg_inherits (
+   inhrelid OID NULL,
+   inhparent OID NULL,
+   inhseqno INT4 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_inherits_parent_index (
+   inhparent OID NULL
+)  CREATE TABLE pg_catalog.pg_inherits_parent_index (
+   inhparent OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_inherits_relid_seqno_index (
+   inhrelid OID NULL,
+   inhseqno INT4 NULL
+)  CREATE TABLE pg_catalog.pg_inherits_relid_seqno_index (
+   inhrelid OID NULL,
+   inhseqno INT4 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_init_privs_o_c_o_index (
+   classoid OID NULL,
+   objoid OID NULL,
+   objsubid INT4 NULL
+)  CREATE TABLE pg_catalog.pg_init_privs_o_c_o_index (
+   classoid OID NULL,
+   objoid OID NULL,
+   objsubid INT4 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_language (
+   oid OID NULL,
+   lanname NAME NULL,
+   lanowner OID NULL,
+   lanispl BOOL NULL,
+   lanpltrusted BOOL NULL,
+   lanplcallfoid OID NULL,
+   laninline OID NULL,
+   lanvalidator OID NULL,
+   lanacl STRING[] NULL
+)  CREATE TABLE pg_catalog.pg_language (
+   oid OID NULL,
+   lanname NAME NULL,
+   lanowner OID NULL,
+   lanispl BOOL NULL,
+   lanpltrusted BOOL NULL,
+   lanplcallfoid OID NULL,
+   laninline OID NULL,
+   lanvalidator OID NULL,
+   lanacl STRING[] NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_language_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_language_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_largeobject (
+   data BYTES NULL,
+   loid OID NULL,
+   pageno INT4 NULL
+)  CREATE TABLE pg_catalog.pg_largeobject (
+   data BYTES NULL,
+   loid OID NULL,
+   pageno INT4 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_largeobject_loid_pn_index (
+   loid OID NULL,
+   pageno INT4 NULL
+)  CREATE TABLE pg_catalog.pg_largeobject_loid_pn_index (
+   loid OID NULL,
+   pageno INT4 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_largeobject_metadata_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_largeobject_metadata_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_locks (
+   locktype STRING NULL,
+   database OID NULL,
+   relation OID NULL,
+   page INT4 NULL,
+   tuple INT2 NULL,
+   virtualxid STRING NULL,
+   transactionid INT8 NULL,
+   classid OID NULL,
+   objid OID NULL,
+   objsubid INT2 NULL,
+   virtualtransaction STRING NULL,
+   pid INT4 NULL,
+   mode STRING NULL,
+   granted BOOL NULL,
+   fastpath BOOL NULL
+)  CREATE TABLE pg_catalog.pg_locks (
+   locktype STRING NULL,
+   database OID NULL,
+   relation OID NULL,
+   page INT4 NULL,
+   tuple INT2 NULL,
+   virtualxid STRING NULL,
+   transactionid INT8 NULL,
+   classid OID NULL,
+   objid OID NULL,
+   objsubid INT2 NULL,
+   virtualtransaction STRING NULL,
+   pid INT4 NULL,
+   mode STRING NULL,
+   granted BOOL NULL,
+   fastpath BOOL NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_matviews (
+   schemaname NAME NULL,
+   matviewname NAME NULL,
+   matviewowner NAME NULL,
+   tablespace NAME NULL,
+   hasindexes BOOL NULL,
+   ispopulated BOOL NULL,
+   definition STRING NULL
+)  CREATE TABLE pg_catalog.pg_matviews (
+   schemaname NAME NULL,
+   matviewname NAME NULL,
+   matviewowner NAME NULL,
+   tablespace NAME NULL,
+   hasindexes BOOL NULL,
+   ispopulated BOOL NULL,
+   definition STRING NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_namespace (
+   oid OID NULL,
+   nspname NAME NOT NULL,
+   nspowner OID NULL,
+   nspacl STRING[] NULL
+)  CREATE TABLE pg_catalog.pg_namespace (
+   oid OID NULL,
+   nspname NAME NOT NULL,
+   nspowner OID NULL,
+   nspacl STRING[] NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_namespace_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_namespace_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_opclass (
+   oid OID NULL,
+   opcmethod OID NULL,
+   opcname NAME NULL,
+   opcnamespace OID NULL,
+   opcowner OID NULL,
+   opcfamily OID NULL,
+   opcintype OID NULL,
+   opcdefault BOOL NULL,
+   opckeytype OID NULL
+)  CREATE TABLE pg_catalog.pg_opclass (
+   oid OID NULL,
+   opcmethod OID NULL,
+   opcname NAME NULL,
+   opcnamespace OID NULL,
+   opcowner OID NULL,
+   opcfamily OID NULL,
+   opcintype OID NULL,
+   opcdefault BOOL NULL,
+   opckeytype OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_opclass_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_opclass_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_operator (
+   oid OID NULL,
+   oprname NAME NULL,
+   oprnamespace OID NULL,
+   oprowner OID NULL,
+   oprkind STRING NULL,
+   oprcanmerge BOOL NULL,
+   oprcanhash BOOL NULL,
+   oprleft OID NULL,
+   oprright OID NULL,
+   oprresult OID NULL,
+   oprcom OID NULL,
+   oprnegate OID NULL,
+   oprcode OID NULL,
+   oprrest OID NULL,
+   oprjoin OID NULL
+)  CREATE TABLE pg_catalog.pg_operator (
+   oid OID NULL,
+   oprname NAME NULL,
+   oprnamespace OID NULL,
+   oprowner OID NULL,
+   oprkind STRING NULL,
+   oprcanmerge BOOL NULL,
+   oprcanhash BOOL NULL,
+   oprleft OID NULL,
+   oprright OID NULL,
+   oprresult OID NULL,
+   oprcom OID NULL,
+   oprnegate OID NULL,
+   oprcode OID NULL,
+   oprrest OID NULL,
+   oprjoin OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_operator_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_operator_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_opfamily (
+   opfname NAME NULL,
+   opfnamespace OID NULL,
+   opfowner OID NULL,
+   oid OID NULL,
+   opfmethod OID NULL
+)  CREATE TABLE pg_catalog.pg_opfamily (
+   opfname NAME NULL,
+   opfnamespace OID NULL,
+   opfowner OID NULL,
+   oid OID NULL,
+   opfmethod OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_opfamily_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_opfamily_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_partitioned_table_partrelid_index (
+   partrelid OID NULL
+)  CREATE TABLE pg_catalog.pg_partitioned_table_partrelid_index (
+   partrelid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_policies (
+   with_check STRING NULL,
+   cmd STRING NULL,
+   permissive STRING NULL,
+   policyname NAME NULL,
+   qual STRING NULL,
+   roles NAME[] NULL,
+   schemaname NAME NULL,
+   tablename NAME NULL
+)  CREATE TABLE pg_catalog.pg_policies (
+   with_check STRING NULL,
+   cmd STRING NULL,
+   permissive STRING NULL,
+   policyname NAME NULL,
+   qual STRING NULL,
+   roles NAME[] NULL,
+   schemaname NAME NULL,
+   tablename NAME NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_policy_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_policy_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_prepared_statements (
+   name STRING NULL,
+   statement STRING NULL,
+   prepare_time TIMESTAMPTZ NULL,
+   parameter_types REGTYPE[] NULL,
+   from_sql BOOL NULL
+)  CREATE TABLE pg_catalog.pg_prepared_statements (
+   name STRING NULL,
+   statement STRING NULL,
+   prepare_time TIMESTAMPTZ NULL,
+   parameter_types REGTYPE[] NULL,
+   from_sql BOOL NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_prepared_xacts (
+   transaction INT8 NULL,
+   gid STRING NULL,
+   prepared TIMESTAMPTZ NULL,
+   owner NAME NULL,
+   database NAME NULL
+)  CREATE TABLE pg_catalog.pg_prepared_xacts (
+   transaction INT8 NULL,
+   gid STRING NULL,
+   prepared TIMESTAMPTZ NULL,
+   owner NAME NULL,
+   database NAME NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_proc (
+   oid OID NULL,
+   proname NAME NULL,
+   pronamespace OID NULL,
+   proowner OID NULL,
+   prolang OID NULL,
+   procost FLOAT4 NULL,
+   prorows FLOAT4 NULL,
+   provariadic OID NULL,
+   protransform STRING NULL,
+   proisagg BOOL NULL,
+   proiswindow BOOL NULL,
+   prosecdef BOOL NULL,
+   proleakproof BOOL NULL,
+   proisstrict BOOL NULL,
+   proretset BOOL NULL,
+   provolatile "char" NULL,
+   proparallel "char" NULL,
+   pronargs INT2 NULL,
+   pronargdefaults INT2 NULL,
+   prorettype OID NULL,
+   proargtypes OIDVECTOR NULL,
+   proallargtypes OID[] NULL,
+   proargmodes STRING[] NULL,
+   proargnames STRING[] NULL,
+   proargdefaults STRING NULL,
+   protrftypes OID[] NULL,
+   prosrc STRING NULL,
+   probin STRING NULL,
+   proconfig STRING[] NULL,
+   proacl STRING[] NULL,
+   prokind "char" NULL,
+   prosupport REGPROC NULL
+)  CREATE TABLE pg_catalog.pg_proc (
+   oid OID NULL,
+   proname NAME NULL,
+   pronamespace OID NULL,
+   proowner OID NULL,
+   prolang OID NULL,
+   procost FLOAT4 NULL,
+   prorows FLOAT4 NULL,
+   provariadic OID NULL,
+   protransform STRING NULL,
+   proisagg BOOL NULL,
+   proiswindow BOOL NULL,
+   prosecdef BOOL NULL,
+   proleakproof BOOL NULL,
+   proisstrict BOOL NULL,
+   proretset BOOL NULL,
+   provolatile "char" NULL,
+   proparallel "char" NULL,
+   pronargs INT2 NULL,
+   pronargdefaults INT2 NULL,
+   prorettype OID NULL,
+   proargtypes OIDVECTOR NULL,
+   proallargtypes OID[] NULL,
+   proargmodes STRING[] NULL,
+   proargnames STRING[] NULL,
+   proargdefaults STRING NULL,
+   protrftypes OID[] NULL,
+   prosrc STRING NULL,
+   probin STRING NULL,
+   proconfig STRING[] NULL,
+   proacl STRING[] NULL,
+   prokind "char" NULL,
+   prosupport REGPROC NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_proc_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_proc_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_publication (
+   pubupdate BOOL NULL,
+   oid OID NULL,
+   puballtables BOOL NULL,
+   pubdelete BOOL NULL,
+   pubinsert BOOL NULL,
+   pubname NAME NULL,
+   pubowner OID NULL,
+   pubtruncate BOOL NULL,
+   pubviaroot BOOL NULL
+)  CREATE TABLE pg_catalog.pg_publication (
+   pubupdate BOOL NULL,
+   oid OID NULL,
+   puballtables BOOL NULL,
+   pubdelete BOOL NULL,
+   pubinsert BOOL NULL,
+   pubname NAME NULL,
+   pubowner OID NULL,
+   pubtruncate BOOL NULL,
+   pubviaroot BOOL NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_publication_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_publication_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_publication_rel (
+   oid OID NULL,
+   prpubid OID NULL,
+   prrelid OID NULL
+)  CREATE TABLE pg_catalog.pg_publication_rel (
+   oid OID NULL,
+   prpubid OID NULL,
+   prrelid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_publication_rel_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_publication_rel_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_publication_rel_prrelid_prpubid_index (
+   prpubid OID NULL,
+   prrelid OID NULL
+)  CREATE TABLE pg_catalog.pg_publication_rel_prrelid_prpubid_index (
+   prpubid OID NULL,
+   prrelid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_publication_tables (
+   pubname NAME NULL,
+   schemaname NAME NULL,
+   tablename NAME NULL
+)  CREATE TABLE pg_catalog.pg_publication_tables (
+   pubname NAME NULL,
+   schemaname NAME NULL,
+   tablename NAME NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_range (
+   rngtypid OID NULL,
+   rngsubtype OID NULL,
+   rngcollation OID NULL,
+   rngsubopc OID NULL,
+   rngcanonical OID NULL,
+   rngsubdiff OID NULL
+)  CREATE TABLE pg_catalog.pg_range (
+   rngtypid OID NULL,
+   rngsubtype OID NULL,
+   rngcollation OID NULL,
+   rngsubopc OID NULL,
+   rngcanonical OID NULL,
+   rngsubdiff OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_range_rngtypid_index (
+   rngtypid OID NULL
+)  CREATE TABLE pg_catalog.pg_range_rngtypid_index (
+   rngtypid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_replication_origin (
+   roident OID NULL,
+   roname STRING NULL
+)  CREATE TABLE pg_catalog.pg_replication_origin (
+   roident OID NULL,
+   roname STRING NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_replication_origin_roiident_index (
+   roident OID NULL
+)  CREATE TABLE pg_catalog.pg_replication_origin_roiident_index (
+   roident OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_replication_origin_roname_index (
+   roname STRING NULL
+)  CREATE TABLE pg_catalog.pg_replication_origin_roname_index (
+   roname STRING NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_rewrite (
+   oid OID NULL,
+   rulename NAME NULL,
+   ev_class OID NULL,
+   ev_type STRING NULL,
+   ev_enabled STRING NULL,
+   is_instead BOOL NULL,
+   ev_qual STRING NULL,
+   ev_action STRING NULL
+)  CREATE TABLE pg_catalog.pg_rewrite (
+   oid OID NULL,
+   rulename NAME NULL,
+   ev_class OID NULL,
+   ev_type STRING NULL,
+   ev_enabled STRING NULL,
+   is_instead BOOL NULL,
+   ev_qual STRING NULL,
+   ev_action STRING NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_rewrite_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_rewrite_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_roles (
+   oid OID NULL,
+   rolname NAME NULL,
+   rolsuper BOOL NULL,
+   rolinherit BOOL NULL,
+   rolcreaterole BOOL NULL,
+   rolcreatedb BOOL NULL,
+   rolcatupdate BOOL NULL,
+   rolcanlogin BOOL NULL,
+   rolreplication BOOL NULL,
+   rolconnlimit INT4 NULL,
+   rolpassword STRING NULL,
+   rolvaliduntil TIMESTAMPTZ NULL,
+   rolbypassrls BOOL NULL,
+   rolconfig STRING[] NULL
+)  CREATE TABLE pg_catalog.pg_roles (
+   oid OID NULL,
+   rolname NAME NULL,
+   rolsuper BOOL NULL,
+   rolinherit BOOL NULL,
+   rolcreaterole BOOL NULL,
+   rolcreatedb BOOL NULL,
+   rolcatupdate BOOL NULL,
+   rolcanlogin BOOL NULL,
+   rolreplication BOOL NULL,
+   rolconnlimit INT4 NULL,
+   rolpassword STRING NULL,
+   rolvaliduntil TIMESTAMPTZ NULL,
+   rolbypassrls BOOL NULL,
+   rolconfig STRING[] NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_rules (
+   definition STRING NULL,
+   rulename NAME NULL,
+   schemaname NAME NULL,
+   tablename NAME NULL
+)  CREATE TABLE pg_catalog.pg_rules (
+   definition STRING NULL,
+   rulename NAME NULL,
+   schemaname NAME NULL,
+   tablename NAME NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_seclabel (
+   objoid OID NULL,
+   classoid OID NULL,
+   objsubid INT8 NULL,
+   provider STRING NULL,
+   label STRING NULL
+)  CREATE TABLE pg_catalog.pg_seclabel (
+   objoid OID NULL,
+   classoid OID NULL,
+   objsubid INT8 NULL,
+   provider STRING NULL,
+   label STRING NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_seclabel_object_index (
+   objoid OID NULL,
+   objsubid INT4 NULL,
+   provider STRING NULL,
+   classoid OID NULL
+)  CREATE TABLE pg_catalog.pg_seclabel_object_index (
+   objoid OID NULL,
+   objsubid INT4 NULL,
+   provider STRING NULL,
+   classoid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_seclabels (
+   objoid OID NULL,
+   classoid OID NULL,
+   objsubid INT4 NULL,
+   objtype STRING NULL,
+   objnamespace OID NULL,
+   objname STRING NULL,
+   provider STRING NULL,
+   label STRING NULL
+)  CREATE TABLE pg_catalog.pg_seclabels (
+   objoid OID NULL,
+   classoid OID NULL,
+   objsubid INT4 NULL,
+   objtype STRING NULL,
+   objnamespace OID NULL,
+   objname STRING NULL,
+   provider STRING NULL,
+   label STRING NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_sequence (
+   seqrelid OID NULL,
+   seqtypid OID NULL,
+   seqstart INT8 NULL,
+   seqincrement INT8 NULL,
+   seqmax INT8 NULL,
+   seqmin INT8 NULL,
+   seqcache INT8 NULL,
+   seqcycle BOOL NULL
+)  CREATE TABLE pg_catalog.pg_sequence (
+   seqrelid OID NULL,
+   seqtypid OID NULL,
+   seqstart INT8 NULL,
+   seqincrement INT8 NULL,
+   seqmax INT8 NULL,
+   seqmin INT8 NULL,
+   seqcache INT8 NULL,
+   seqcycle BOOL NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_sequence_seqrelid_index (
+   seqrelid OID NULL
+)  CREATE TABLE pg_catalog.pg_sequence_seqrelid_index (
+   seqrelid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_settings (
+   name STRING NULL,
+   setting STRING NULL,
+   unit STRING NULL,
+   category STRING NULL,
+   short_desc STRING NULL,
+   extra_desc STRING NULL,
+   context STRING NULL,
+   vartype STRING NULL,
+   source STRING NULL,
+   min_val STRING NULL,
+   max_val STRING NULL,
+   enumvals STRING NULL,
+   boot_val STRING NULL,
+   reset_val STRING NULL,
+   sourcefile STRING NULL,
+   sourceline INT4 NULL,
+   pending_restart BOOL NULL
+)  CREATE TABLE pg_catalog.pg_settings (
+   name STRING NULL,
+   setting STRING NULL,
+   unit STRING NULL,
+   category STRING NULL,
+   short_desc STRING NULL,
+   extra_desc STRING NULL,
+   context STRING NULL,
+   vartype STRING NULL,
+   source STRING NULL,
+   min_val STRING NULL,
+   max_val STRING NULL,
+   enumvals STRING NULL,
+   boot_val STRING NULL,
+   reset_val STRING NULL,
+   sourcefile STRING NULL,
+   sourceline INT4 NULL,
+   pending_restart BOOL NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_shadow (
+   useconfig STRING[] NULL,
+   usecreatedb BOOL NULL,
+   userepl BOOL NULL,
+   usesuper BOOL NULL,
+   usesysid OID NULL,
+   valuntil TIMESTAMPTZ NULL,
+   passwd STRING NULL,
+   usename NAME NULL,
+   usebypassrls BOOL NULL
+)  CREATE TABLE pg_catalog.pg_shadow (
+   useconfig STRING[] NULL,
+   usecreatedb BOOL NULL,
+   userepl BOOL NULL,
+   usesuper BOOL NULL,
+   usesysid OID NULL,
+   valuntil TIMESTAMPTZ NULL,
+   passwd STRING NULL,
+   usename NAME NULL,
+   usebypassrls BOOL NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_shdepend (
+   dbid OID NULL,
+   classid OID NULL,
+   objid OID NULL,
+   objsubid INT4 NULL,
+   refclassid OID NULL,
+   refobjid OID NULL,
+   deptype "char" NULL
+)  CREATE TABLE pg_catalog.pg_shdepend (
+   dbid OID NULL,
+   classid OID NULL,
+   objid OID NULL,
+   objsubid INT4 NULL,
+   refclassid OID NULL,
+   refobjid OID NULL,
+   deptype "char" NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_shdepend_depender_index (
+   objsubid INT4 NULL,
+   classid OID NULL,
+   dbid OID NULL,
+   objid OID NULL
+)  CREATE TABLE pg_catalog.pg_shdepend_depender_index (
+   objsubid INT4 NULL,
+   classid OID NULL,
+   dbid OID NULL,
+   objid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_shdepend_reference_index (
+   refclassid OID NULL,
+   refobjid OID NULL
+)  CREATE TABLE pg_catalog.pg_shdepend_reference_index (
+   refclassid OID NULL,
+   refobjid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_shdescription (
+   objoid OID NULL,
+   classoid OID NULL,
+   description STRING NULL
+)  CREATE TABLE pg_catalog.pg_shdescription (
+   objoid OID NULL,
+   classoid OID NULL,
+   description STRING NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_shdescription_o_c_index (
+   classoid OID NULL,
+   objoid OID NULL
+)  CREATE TABLE pg_catalog.pg_shdescription_o_c_index (
+   classoid OID NULL,
+   objoid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_shmem_allocations (
+   name STRING NULL,
+   off INT8 NULL,
+   size INT8 NULL,
+   allocated_size INT8 NULL
+)  CREATE TABLE pg_catalog.pg_shmem_allocations (
+   name STRING NULL,
+   off INT8 NULL,
+   size INT8 NULL,
+   allocated_size INT8 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_shseclabel (
+   objoid OID NULL,
+   classoid OID NULL,
+   provider STRING NULL,
+   label STRING NULL
+)  CREATE TABLE pg_catalog.pg_shseclabel (
+   objoid OID NULL,
+   classoid OID NULL,
+   provider STRING NULL,
+   label STRING NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_shseclabel_object_index (
+   classoid OID NULL,
+   objoid OID NULL,
+   provider STRING NULL
+)  CREATE TABLE pg_catalog.pg_shseclabel_object_index (
+   classoid OID NULL,
+   objoid OID NULL,
+   provider STRING NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_stat_activity (
+   datid OID NULL,
+   datname NAME NULL,
+   pid INT8 NULL,
+   usesysid OID NULL,
+   usename NAME NULL,
+   application_name STRING NULL,
+   client_addr INET NULL,
+   client_hostname STRING NULL,
+   client_port INT8 NULL,
+   backend_start TIMESTAMPTZ NULL,
+   xact_start TIMESTAMPTZ NULL,
+   query_start TIMESTAMPTZ NULL,
+   state_change TIMESTAMPTZ NULL,
+   wait_event_type STRING NULL,
+   wait_event STRING NULL,
+   state STRING NULL,
+   backend_xid INT8 NULL,
+   backend_xmin INT8 NULL,
+   query STRING NULL,
+   backend_type STRING NULL,
+   leader_pid INT4 NULL
+)  CREATE TABLE pg_catalog.pg_stat_activity (
+   datid OID NULL,
+   datname NAME NULL,
+   pid INT8 NULL,
+   usesysid OID NULL,
+   usename NAME NULL,
+   application_name STRING NULL,
+   client_addr INET NULL,
+   client_hostname STRING NULL,
+   client_port INT8 NULL,
+   backend_start TIMESTAMPTZ NULL,
+   xact_start TIMESTAMPTZ NULL,
+   query_start TIMESTAMPTZ NULL,
+   state_change TIMESTAMPTZ NULL,
+   wait_event_type STRING NULL,
+   wait_event STRING NULL,
+   state STRING NULL,
+   backend_xid INT8 NULL,
+   backend_xmin INT8 NULL,
+   query STRING NULL,
+   backend_type STRING NULL,
+   leader_pid INT4 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_stat_all_indexes (
+   schemaname NAME NULL,
+   idx_scan INT8 NULL,
+   idx_tup_fetch INT8 NULL,
+   idx_tup_read INT8 NULL,
+   indexrelid OID NULL,
+   indexrelname NAME NULL,
+   relid OID NULL,
+   relname NAME NULL
+)  CREATE TABLE pg_catalog.pg_stat_all_indexes (
+   schemaname NAME NULL,
+   idx_scan INT8 NULL,
+   idx_tup_fetch INT8 NULL,
+   idx_tup_read INT8 NULL,
+   indexrelid OID NULL,
+   indexrelname NAME NULL,
+   relid OID NULL,
+   relname NAME NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_stat_all_tables (
+   n_tup_ins INT8 NULL,
+   schemaname NAME NULL,
+   analyze_count INT8 NULL,
+   autovacuum_count INT8 NULL,
+   last_autovacuum TIMESTAMPTZ NULL,
+   seq_tup_read INT8 NULL,
+   vacuum_count INT8 NULL,
+   last_vacuum TIMESTAMPTZ NULL,
+   n_ins_since_vacuum INT8 NULL,
+   n_tup_del INT8 NULL,
+   n_live_tup INT8 NULL,
+   relid OID NULL,
+   seq_scan INT8 NULL,
+   autoanalyze_count INT8 NULL,
+   idx_scan INT8 NULL,
+   idx_tup_fetch INT8 NULL,
+   n_mod_since_analyze INT8 NULL,
+   n_tup_hot_upd INT8 NULL,
+   n_tup_upd INT8 NULL,
+   relname NAME NULL,
+   last_analyze TIMESTAMPTZ NULL,
+   last_autoanalyze TIMESTAMPTZ NULL,
+   n_dead_tup INT8 NULL
+)  CREATE TABLE pg_catalog.pg_stat_all_tables (
+   n_tup_ins INT8 NULL,
+   schemaname NAME NULL,
+   analyze_count INT8 NULL,
+   autovacuum_count INT8 NULL,
+   last_autovacuum TIMESTAMPTZ NULL,
+   seq_tup_read INT8 NULL,
+   vacuum_count INT8 NULL,
+   last_vacuum TIMESTAMPTZ NULL,
+   n_ins_since_vacuum INT8 NULL,
+   n_tup_del INT8 NULL,
+   n_live_tup INT8 NULL,
+   relid OID NULL,
+   seq_scan INT8 NULL,
+   autoanalyze_count INT8 NULL,
+   idx_scan INT8 NULL,
+   idx_tup_fetch INT8 NULL,
+   n_mod_since_analyze INT8 NULL,
+   n_tup_hot_upd INT8 NULL,
+   n_tup_upd INT8 NULL,
+   relname NAME NULL,
+   last_analyze TIMESTAMPTZ NULL,
+   last_autoanalyze TIMESTAMPTZ NULL,
+   n_dead_tup INT8 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_stat_archiver (
+   last_archived_time TIMESTAMPTZ NULL,
+   last_archived_wal STRING NULL,
+   last_failed_time TIMESTAMPTZ NULL,
+   last_failed_wal STRING NULL,
+   stats_reset TIMESTAMPTZ NULL,
+   archived_count INT8 NULL,
+   failed_count INT8 NULL
+)  CREATE TABLE pg_catalog.pg_stat_archiver (
+   last_archived_time TIMESTAMPTZ NULL,
+   last_archived_wal STRING NULL,
+   last_failed_time TIMESTAMPTZ NULL,
+   last_failed_wal STRING NULL,
+   stats_reset TIMESTAMPTZ NULL,
+   archived_count INT8 NULL,
+   failed_count INT8 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_stat_bgwriter (
+   buffers_backend_fsync INT8 NULL,
+   buffers_clean INT8 NULL,
+   checkpoint_sync_time FLOAT8 NULL,
+   checkpoints_req INT8 NULL,
+   checkpoints_timed INT8 NULL,
+   maxwritten_clean INT8 NULL,
+   buffers_alloc INT8 NULL,
+   buffers_backend INT8 NULL,
+   buffers_checkpoint INT8 NULL,
+   checkpoint_write_time FLOAT8 NULL,
+   stats_reset TIMESTAMPTZ NULL
+)  CREATE TABLE pg_catalog.pg_stat_bgwriter (
+   buffers_backend_fsync INT8 NULL,
+   buffers_clean INT8 NULL,
+   checkpoint_sync_time FLOAT8 NULL,
+   checkpoints_req INT8 NULL,
+   checkpoints_timed INT8 NULL,
+   maxwritten_clean INT8 NULL,
+   buffers_alloc INT8 NULL,
+   buffers_backend INT8 NULL,
+   buffers_checkpoint INT8 NULL,
+   checkpoint_write_time FLOAT8 NULL,
+   stats_reset TIMESTAMPTZ NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_stat_database (
+   blks_read INT8 NULL,
+   datid OID NULL,
+   deadlocks INT8 NULL,
+   temp_files INT8 NULL,
+   tup_updated INT8 NULL,
+   conflicts INT8 NULL,
+   temp_bytes INT8 NULL,
+   tup_returned INT8 NULL,
+   xact_rollback INT8 NULL,
+   blk_read_time FLOAT8 NULL,
+   blks_hit INT8 NULL,
+   checksum_failures INT8 NULL,
+   tup_deleted INT8 NULL,
+   xact_commit INT8 NULL,
+   blk_write_time FLOAT8 NULL,
+   checksum_last_failure TIMESTAMPTZ NULL,
+   datname NAME NULL,
+   numbackends INT4 NULL,
+   stats_reset TIMESTAMPTZ NULL,
+   tup_fetched INT8 NULL,
+   tup_inserted INT8 NULL
+)  CREATE TABLE pg_catalog.pg_stat_database (
+   blks_read INT8 NULL,
+   datid OID NULL,
+   deadlocks INT8 NULL,
+   temp_files INT8 NULL,
+   tup_updated INT8 NULL,
+   conflicts INT8 NULL,
+   temp_bytes INT8 NULL,
+   tup_returned INT8 NULL,
+   xact_rollback INT8 NULL,
+   blk_read_time FLOAT8 NULL,
+   blks_hit INT8 NULL,
+   checksum_failures INT8 NULL,
+   tup_deleted INT8 NULL,
+   xact_commit INT8 NULL,
+   blk_write_time FLOAT8 NULL,
+   checksum_last_failure TIMESTAMPTZ NULL,
+   datname NAME NULL,
+   numbackends INT4 NULL,
+   stats_reset TIMESTAMPTZ NULL,
+   tup_fetched INT8 NULL,
+   tup_inserted INT8 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_stat_database_conflicts (
+   confl_lock INT8 NULL,
+   confl_snapshot INT8 NULL,
+   confl_tablespace INT8 NULL,
+   datid OID NULL,
+   datname NAME NULL,
+   confl_bufferpin INT8 NULL,
+   confl_deadlock INT8 NULL
+)  CREATE TABLE pg_catalog.pg_stat_database_conflicts (
+   confl_lock INT8 NULL,
+   confl_snapshot INT8 NULL,
+   confl_tablespace INT8 NULL,
+   datid OID NULL,
+   datname NAME NULL,
+   confl_bufferpin INT8 NULL,
+   confl_deadlock INT8 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_stat_gssapi (
+   encrypted BOOL NULL,
+   gss_authenticated BOOL NULL,
+   pid INT4 NULL,
+   principal STRING NULL
+)  CREATE TABLE pg_catalog.pg_stat_gssapi (
+   encrypted BOOL NULL,
+   gss_authenticated BOOL NULL,
+   pid INT4 NULL,
+   principal STRING NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_stat_progress_analyze (
+   sample_blks_scanned INT8 NULL,
+   datname NAME NULL,
+   ext_stats_computed INT8 NULL,
+   relid OID NULL,
+   datid OID NULL,
+   ext_stats_total INT8 NULL,
+   phase STRING NULL,
+   pid INT4 NULL,
+   sample_blks_total INT8 NULL,
+   child_tables_done INT8 NULL,
+   child_tables_total INT8 NULL,
+   current_child_table_relid OID NULL
+)  CREATE TABLE pg_catalog.pg_stat_progress_analyze (
+   sample_blks_scanned INT8 NULL,
+   datname NAME NULL,
+   ext_stats_computed INT8 NULL,
+   relid OID NULL,
+   datid OID NULL,
+   ext_stats_total INT8 NULL,
+   phase STRING NULL,
+   pid INT4 NULL,
+   sample_blks_total INT8 NULL,
+   child_tables_done INT8 NULL,
+   child_tables_total INT8 NULL,
+   current_child_table_relid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_stat_progress_basebackup (
+   backup_streamed INT8 NULL,
+   backup_total INT8 NULL,
+   phase STRING NULL,
+   pid INT4 NULL,
+   tablespaces_streamed INT8 NULL,
+   tablespaces_total INT8 NULL
+)  CREATE TABLE pg_catalog.pg_stat_progress_basebackup (
+   backup_streamed INT8 NULL,
+   backup_total INT8 NULL,
+   phase STRING NULL,
+   pid INT4 NULL,
+   tablespaces_streamed INT8 NULL,
+   tablespaces_total INT8 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_stat_progress_cluster (
+   heap_blks_scanned INT8 NULL,
+   heap_tuples_scanned INT8 NULL,
+   index_rebuild_count INT8 NULL,
+   phase STRING NULL,
+   relid OID NULL,
+   cluster_index_relid OID NULL,
+   command STRING NULL,
+   datname NAME NULL,
+   pid INT4 NULL,
+   datid OID NULL,
+   heap_blks_total INT8 NULL,
+   heap_tuples_written INT8 NULL
+)  CREATE TABLE pg_catalog.pg_stat_progress_cluster (
+   heap_blks_scanned INT8 NULL,
+   heap_tuples_scanned INT8 NULL,
+   index_rebuild_count INT8 NULL,
+   phase STRING NULL,
+   relid OID NULL,
+   cluster_index_relid OID NULL,
+   command STRING NULL,
+   datname NAME NULL,
+   pid INT4 NULL,
+   datid OID NULL,
+   heap_blks_total INT8 NULL,
+   heap_tuples_written INT8 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_stat_progress_create_index (
+   blocks_total INT8 NULL,
+   partitions_total INT8 NULL,
+   relid OID NULL,
+   tuples_done INT8 NULL,
+   current_locker_pid INT8 NULL,
+   datid OID NULL,
+   index_relid OID NULL,
+   partitions_done INT8 NULL,
+   blocks_done INT8 NULL,
+   datname NAME NULL,
+   lockers_total INT8 NULL,
+   phase STRING NULL,
+   command STRING NULL,
+   lockers_done INT8 NULL,
+   pid INT4 NULL,
+   tuples_total INT8 NULL
+)  CREATE TABLE pg_catalog.pg_stat_progress_create_index (
+   blocks_total INT8 NULL,
+   partitions_total INT8 NULL,
+   relid OID NULL,
+   tuples_done INT8 NULL,
+   current_locker_pid INT8 NULL,
+   datid OID NULL,
+   index_relid OID NULL,
+   partitions_done INT8 NULL,
+   blocks_done INT8 NULL,
+   datname NAME NULL,
+   lockers_total INT8 NULL,
+   phase STRING NULL,
+   command STRING NULL,
+   lockers_done INT8 NULL,
+   pid INT4 NULL,
+   tuples_total INT8 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_stat_progress_vacuum (
+   index_vacuum_count INT8 NULL,
+   num_dead_tuples INT8 NULL,
+   relid OID NULL,
+   datid OID NULL,
+   datname NAME NULL,
+   heap_blks_vacuumed INT8 NULL,
+   max_dead_tuples INT8 NULL,
+   phase STRING NULL,
+   pid INT4 NULL,
+   heap_blks_scanned INT8 NULL,
+   heap_blks_total INT8 NULL
+)  CREATE TABLE pg_catalog.pg_stat_progress_vacuum (
+   index_vacuum_count INT8 NULL,
+   num_dead_tuples INT8 NULL,
+   relid OID NULL,
+   datid OID NULL,
+   datname NAME NULL,
+   heap_blks_vacuumed INT8 NULL,
+   max_dead_tuples INT8 NULL,
+   phase STRING NULL,
+   pid INT4 NULL,
+   heap_blks_scanned INT8 NULL,
+   heap_blks_total INT8 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_stat_slru (
+   blks_exists INT8 NULL,
+   blks_hit INT8 NULL,
+   blks_written INT8 NULL,
+   flushes INT8 NULL,
+   name STRING NULL,
+   truncates INT8 NULL,
+   blks_read INT8 NULL,
+   blks_zeroed INT8 NULL,
+   stats_reset TIMESTAMPTZ NULL
+)  CREATE TABLE pg_catalog.pg_stat_slru (
+   blks_exists INT8 NULL,
+   blks_hit INT8 NULL,
+   blks_written INT8 NULL,
+   flushes INT8 NULL,
+   name STRING NULL,
+   truncates INT8 NULL,
+   blks_read INT8 NULL,
+   blks_zeroed INT8 NULL,
+   stats_reset TIMESTAMPTZ NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_stat_ssl (
+   pid INT4 NULL,
+   ssl BOOL NULL,
+   client_dn STRING NULL,
+   client_serial DECIMAL NULL,
+   compression BOOL NULL,
+   issuer_dn STRING NULL,
+   version STRING NULL,
+   bits INT4 NULL,
+   cipher STRING NULL
+)  CREATE TABLE pg_catalog.pg_stat_ssl (
+   pid INT4 NULL,
+   ssl BOOL NULL,
+   client_dn STRING NULL,
+   client_serial DECIMAL NULL,
+   compression BOOL NULL,
+   issuer_dn STRING NULL,
+   version STRING NULL,
+   bits INT4 NULL,
+   cipher STRING NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_stat_sys_indexes (
+   idx_tup_fetch INT8 NULL,
+   idx_tup_read INT8 NULL,
+   indexrelid OID NULL,
+   indexrelname NAME NULL,
+   relid OID NULL,
+   relname NAME NULL,
+   schemaname NAME NULL,
+   idx_scan INT8 NULL
+)  CREATE TABLE pg_catalog.pg_stat_sys_indexes (
+   idx_tup_fetch INT8 NULL,
+   idx_tup_read INT8 NULL,
+   indexrelid OID NULL,
+   indexrelname NAME NULL,
+   relid OID NULL,
+   relname NAME NULL,
+   schemaname NAME NULL,
+   idx_scan INT8 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_stat_sys_tables (
+   relid OID NULL,
+   relname NAME NULL,
+   vacuum_count INT8 NULL,
+   n_ins_since_vacuum INT8 NULL,
+   n_tup_ins INT8 NULL,
+   schemaname NAME NULL,
+   seq_tup_read INT8 NULL,
+   autovacuum_count INT8 NULL,
+   idx_scan INT8 NULL,
+   last_vacuum TIMESTAMPTZ NULL,
+   n_dead_tup INT8 NULL,
+   n_mod_since_analyze INT8 NULL,
+   n_tup_del INT8 NULL,
+   n_tup_upd INT8 NULL,
+   seq_scan INT8 NULL,
+   autoanalyze_count INT8 NULL,
+   idx_tup_fetch INT8 NULL,
+   last_autoanalyze TIMESTAMPTZ NULL,
+   n_live_tup INT8 NULL,
+   analyze_count INT8 NULL,
+   last_analyze TIMESTAMPTZ NULL,
+   last_autovacuum TIMESTAMPTZ NULL,
+   n_tup_hot_upd INT8 NULL
+)  CREATE TABLE pg_catalog.pg_stat_sys_tables (
+   relid OID NULL,
+   relname NAME NULL,
+   vacuum_count INT8 NULL,
+   n_ins_since_vacuum INT8 NULL,
+   n_tup_ins INT8 NULL,
+   schemaname NAME NULL,
+   seq_tup_read INT8 NULL,
+   autovacuum_count INT8 NULL,
+   idx_scan INT8 NULL,
+   last_vacuum TIMESTAMPTZ NULL,
+   n_dead_tup INT8 NULL,
+   n_mod_since_analyze INT8 NULL,
+   n_tup_del INT8 NULL,
+   n_tup_upd INT8 NULL,
+   seq_scan INT8 NULL,
+   autoanalyze_count INT8 NULL,
+   idx_tup_fetch INT8 NULL,
+   last_autoanalyze TIMESTAMPTZ NULL,
+   n_live_tup INT8 NULL,
+   analyze_count INT8 NULL,
+   last_analyze TIMESTAMPTZ NULL,
+   last_autovacuum TIMESTAMPTZ NULL,
+   n_tup_hot_upd INT8 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_stat_user_functions (
+   funcname NAME NULL,
+   schemaname NAME NULL,
+   self_time FLOAT8 NULL,
+   total_time FLOAT8 NULL,
+   calls INT8 NULL,
+   funcid OID NULL
+)  CREATE TABLE pg_catalog.pg_stat_user_functions (
+   funcname NAME NULL,
+   schemaname NAME NULL,
+   self_time FLOAT8 NULL,
+   total_time FLOAT8 NULL,
+   calls INT8 NULL,
+   funcid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_stat_user_indexes (
+   relname NAME NULL,
+   schemaname NAME NULL,
+   idx_scan INT8 NULL,
+   idx_tup_fetch INT8 NULL,
+   idx_tup_read INT8 NULL,
+   indexrelid OID NULL,
+   indexrelname NAME NULL,
+   relid OID NULL
+)  CREATE TABLE pg_catalog.pg_stat_user_indexes (
+   relname NAME NULL,
+   schemaname NAME NULL,
+   idx_scan INT8 NULL,
+   idx_tup_fetch INT8 NULL,
+   idx_tup_read INT8 NULL,
+   indexrelid OID NULL,
+   indexrelname NAME NULL,
+   relid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_stat_user_tables (
+   last_analyze TIMESTAMPTZ NULL,
+   n_dead_tup INT8 NULL,
+   n_ins_since_vacuum INT8 NULL,
+   n_live_tup INT8 NULL,
+   n_tup_ins INT8 NULL,
+   seq_tup_read INT8 NULL,
+   autovacuum_count INT8 NULL,
+   last_autovacuum TIMESTAMPTZ NULL,
+   last_vacuum TIMESTAMPTZ NULL,
+   n_mod_since_analyze INT8 NULL,
+   n_tup_del INT8 NULL,
+   n_tup_hot_upd INT8 NULL,
+   relid OID NULL,
+   last_autoanalyze TIMESTAMPTZ NULL,
+   n_tup_upd INT8 NULL,
+   relname NAME NULL,
+   analyze_count INT8 NULL,
+   autoanalyze_count INT8 NULL,
+   idx_scan INT8 NULL,
+   idx_tup_fetch INT8 NULL,
+   schemaname NAME NULL,
+   seq_scan INT8 NULL,
+   vacuum_count INT8 NULL
+)  CREATE TABLE pg_catalog.pg_stat_user_tables (
+   last_analyze TIMESTAMPTZ NULL,
+   n_dead_tup INT8 NULL,
+   n_ins_since_vacuum INT8 NULL,
+   n_live_tup INT8 NULL,
+   n_tup_ins INT8 NULL,
+   seq_tup_read INT8 NULL,
+   autovacuum_count INT8 NULL,
+   last_autovacuum TIMESTAMPTZ NULL,
+   last_vacuum TIMESTAMPTZ NULL,
+   n_mod_since_analyze INT8 NULL,
+   n_tup_del INT8 NULL,
+   n_tup_hot_upd INT8 NULL,
+   relid OID NULL,
+   last_autoanalyze TIMESTAMPTZ NULL,
+   n_tup_upd INT8 NULL,
+   relname NAME NULL,
+   analyze_count INT8 NULL,
+   autoanalyze_count INT8 NULL,
+   idx_scan INT8 NULL,
+   idx_tup_fetch INT8 NULL,
+   schemaname NAME NULL,
+   seq_scan INT8 NULL,
+   vacuum_count INT8 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_stat_xact_all_tables (
+   n_tup_del INT8 NULL,
+   n_tup_hot_upd INT8 NULL,
+   n_tup_ins INT8 NULL,
+   schemaname NAME NULL,
+   seq_scan INT8 NULL,
+   seq_tup_read INT8 NULL,
+   idx_scan INT8 NULL,
+   idx_tup_fetch INT8 NULL,
+   n_tup_upd INT8 NULL,
+   relid OID NULL,
+   relname NAME NULL
+)  CREATE TABLE pg_catalog.pg_stat_xact_all_tables (
+   n_tup_del INT8 NULL,
+   n_tup_hot_upd INT8 NULL,
+   n_tup_ins INT8 NULL,
+   schemaname NAME NULL,
+   seq_scan INT8 NULL,
+   seq_tup_read INT8 NULL,
+   idx_scan INT8 NULL,
+   idx_tup_fetch INT8 NULL,
+   n_tup_upd INT8 NULL,
+   relid OID NULL,
+   relname NAME NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_stat_xact_sys_tables (
+   n_tup_del INT8 NULL,
+   n_tup_hot_upd INT8 NULL,
+   n_tup_upd INT8 NULL,
+   relname NAME NULL,
+   schemaname NAME NULL,
+   seq_scan INT8 NULL,
+   idx_scan INT8 NULL,
+   idx_tup_fetch INT8 NULL,
+   seq_tup_read INT8 NULL,
+   n_tup_ins INT8 NULL,
+   relid OID NULL
+)  CREATE TABLE pg_catalog.pg_stat_xact_sys_tables (
+   n_tup_del INT8 NULL,
+   n_tup_hot_upd INT8 NULL,
+   n_tup_upd INT8 NULL,
+   relname NAME NULL,
+   schemaname NAME NULL,
+   seq_scan INT8 NULL,
+   idx_scan INT8 NULL,
+   idx_tup_fetch INT8 NULL,
+   seq_tup_read INT8 NULL,
+   n_tup_ins INT8 NULL,
+   relid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_stat_xact_user_functions (
+   total_time FLOAT8 NULL,
+   calls INT8 NULL,
+   funcid OID NULL,
+   funcname NAME NULL,
+   schemaname NAME NULL,
+   self_time FLOAT8 NULL
+)  CREATE TABLE pg_catalog.pg_stat_xact_user_functions (
+   total_time FLOAT8 NULL,
+   calls INT8 NULL,
+   funcid OID NULL,
+   funcname NAME NULL,
+   schemaname NAME NULL,
+   self_time FLOAT8 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_stat_xact_user_tables (
+   n_tup_hot_upd INT8 NULL,
+   n_tup_ins INT8 NULL,
+   relid OID NULL,
+   seq_scan INT8 NULL,
+   n_tup_del INT8 NULL,
+   idx_tup_fetch INT8 NULL,
+   n_tup_upd INT8 NULL,
+   relname NAME NULL,
+   schemaname NAME NULL,
+   seq_tup_read INT8 NULL,
+   idx_scan INT8 NULL
+)  CREATE TABLE pg_catalog.pg_stat_xact_user_tables (
+   n_tup_hot_upd INT8 NULL,
+   n_tup_ins INT8 NULL,
+   relid OID NULL,
+   seq_scan INT8 NULL,
+   n_tup_del INT8 NULL,
+   idx_tup_fetch INT8 NULL,
+   n_tup_upd INT8 NULL,
+   relname NAME NULL,
+   schemaname NAME NULL,
+   seq_tup_read INT8 NULL,
+   idx_scan INT8 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_statio_all_indexes (
+   idx_blks_hit INT8 NULL,
+   idx_blks_read INT8 NULL,
+   indexrelid OID NULL,
+   indexrelname NAME NULL,
+   relid OID NULL,
+   relname NAME NULL,
+   schemaname NAME NULL
+)  CREATE TABLE pg_catalog.pg_statio_all_indexes (
+   idx_blks_hit INT8 NULL,
+   idx_blks_read INT8 NULL,
+   indexrelid OID NULL,
+   indexrelname NAME NULL,
+   relid OID NULL,
+   relname NAME NULL,
+   schemaname NAME NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_statio_all_sequences (
+   relid OID NULL,
+   relname NAME NULL,
+   schemaname NAME NULL,
+   blks_hit INT8 NULL,
+   blks_read INT8 NULL
+)  CREATE TABLE pg_catalog.pg_statio_all_sequences (
+   relid OID NULL,
+   relname NAME NULL,
+   schemaname NAME NULL,
+   blks_hit INT8 NULL,
+   blks_read INT8 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_statio_all_tables (
+   schemaname NAME NULL,
+   tidx_blks_hit INT8 NULL,
+   tidx_blks_read INT8 NULL,
+   toast_blks_read INT8 NULL,
+   heap_blks_read INT8 NULL,
+   idx_blks_read INT8 NULL,
+   relid OID NULL,
+   relname NAME NULL,
+   heap_blks_hit INT8 NULL,
+   idx_blks_hit INT8 NULL,
+   toast_blks_hit INT8 NULL
+)  CREATE TABLE pg_catalog.pg_statio_all_tables (
+   schemaname NAME NULL,
+   tidx_blks_hit INT8 NULL,
+   tidx_blks_read INT8 NULL,
+   toast_blks_read INT8 NULL,
+   heap_blks_read INT8 NULL,
+   idx_blks_read INT8 NULL,
+   relid OID NULL,
+   relname NAME NULL,
+   heap_blks_hit INT8 NULL,
+   idx_blks_hit INT8 NULL,
+   toast_blks_hit INT8 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_statio_sys_indexes (
+   indexrelname NAME NULL,
+   relid OID NULL,
+   relname NAME NULL,
+   schemaname NAME NULL,
+   idx_blks_hit INT8 NULL,
+   idx_blks_read INT8 NULL,
+   indexrelid OID NULL
+)  CREATE TABLE pg_catalog.pg_statio_sys_indexes (
+   indexrelname NAME NULL,
+   relid OID NULL,
+   relname NAME NULL,
+   schemaname NAME NULL,
+   idx_blks_hit INT8 NULL,
+   idx_blks_read INT8 NULL,
+   indexrelid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_statio_sys_sequences (
+   relname NAME NULL,
+   schemaname NAME NULL,
+   blks_hit INT8 NULL,
+   blks_read INT8 NULL,
+   relid OID NULL
+)  CREATE TABLE pg_catalog.pg_statio_sys_sequences (
+   relname NAME NULL,
+   schemaname NAME NULL,
+   blks_hit INT8 NULL,
+   blks_read INT8 NULL,
+   relid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_statio_sys_tables (
+   idx_blks_hit INT8 NULL,
+   relid OID NULL,
+   relname NAME NULL,
+   tidx_blks_hit INT8 NULL,
+   tidx_blks_read INT8 NULL,
+   toast_blks_read INT8 NULL,
+   heap_blks_read INT8 NULL,
+   idx_blks_read INT8 NULL,
+   schemaname NAME NULL,
+   toast_blks_hit INT8 NULL,
+   heap_blks_hit INT8 NULL
+)  CREATE TABLE pg_catalog.pg_statio_sys_tables (
+   idx_blks_hit INT8 NULL,
+   relid OID NULL,
+   relname NAME NULL,
+   tidx_blks_hit INT8 NULL,
+   tidx_blks_read INT8 NULL,
+   toast_blks_read INT8 NULL,
+   heap_blks_read INT8 NULL,
+   idx_blks_read INT8 NULL,
+   schemaname NAME NULL,
+   toast_blks_hit INT8 NULL,
+   heap_blks_hit INT8 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_statio_user_indexes (
+   idx_blks_read INT8 NULL,
+   indexrelid OID NULL,
+   indexrelname NAME NULL,
+   relid OID NULL,
+   relname NAME NULL,
+   schemaname NAME NULL,
+   idx_blks_hit INT8 NULL
+)  CREATE TABLE pg_catalog.pg_statio_user_indexes (
+   idx_blks_read INT8 NULL,
+   indexrelid OID NULL,
+   indexrelname NAME NULL,
+   relid OID NULL,
+   relname NAME NULL,
+   schemaname NAME NULL,
+   idx_blks_hit INT8 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_statio_user_sequences (
+   relname NAME NULL,
+   schemaname NAME NULL,
+   blks_hit INT8 NULL,
+   blks_read INT8 NULL,
+   relid OID NULL
+)  CREATE TABLE pg_catalog.pg_statio_user_sequences (
+   relname NAME NULL,
+   schemaname NAME NULL,
+   blks_hit INT8 NULL,
+   blks_read INT8 NULL,
+   relid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_statio_user_tables (
+   idx_blks_read INT8 NULL,
+   relid OID NULL,
+   tidx_blks_read INT8 NULL,
+   toast_blks_read INT8 NULL,
+   heap_blks_hit INT8 NULL,
+   heap_blks_read INT8 NULL,
+   idx_blks_hit INT8 NULL,
+   relname NAME NULL,
+   schemaname NAME NULL,
+   tidx_blks_hit INT8 NULL,
+   toast_blks_hit INT8 NULL
+)  CREATE TABLE pg_catalog.pg_statio_user_tables (
+   idx_blks_read INT8 NULL,
+   relid OID NULL,
+   tidx_blks_read INT8 NULL,
+   toast_blks_read INT8 NULL,
+   heap_blks_hit INT8 NULL,
+   heap_blks_read INT8 NULL,
+   idx_blks_hit INT8 NULL,
+   relname NAME NULL,
+   schemaname NAME NULL,
+   tidx_blks_hit INT8 NULL,
+   toast_blks_hit INT8 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_statistic_ext (
+   stxrelid OID NULL,
+   stxstattarget INT4 NULL,
+   oid OID NULL,
+   stxkeys INT2VECTOR NULL,
+   stxkind "char"[] NULL,
+   stxname NAME NULL,
+   stxnamespace OID NULL,
+   stxowner OID NULL
+)  CREATE TABLE pg_catalog.pg_statistic_ext (
+   stxrelid OID NULL,
+   stxstattarget INT4 NULL,
+   oid OID NULL,
+   stxkeys INT2VECTOR NULL,
+   stxkind "char"[] NULL,
+   stxname NAME NULL,
+   stxnamespace OID NULL,
+   stxowner OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_statistic_ext_data_stxoid_index (
+   stxoid OID NULL
+)  CREATE TABLE pg_catalog.pg_statistic_ext_data_stxoid_index (
+   stxoid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_statistic_ext_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_statistic_ext_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_statistic_ext_relid_index (
+   stxrelid OID NULL
+)  CREATE TABLE pg_catalog.pg_statistic_ext_relid_index (
+   stxrelid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_statistic_relid_att_inh_index (
+   staattnum INT2 NULL,
+   stainherit BOOL NULL,
+   starelid OID NULL
+)  CREATE TABLE pg_catalog.pg_statistic_relid_att_inh_index (
+   staattnum INT2 NULL,
+   stainherit BOOL NULL,
+   starelid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_subscription (
+   subname NAME NULL,
+   subpublications STRING[] NULL,
+   subslotname NAME NULL,
+   subsynccommit STRING NULL,
+   oid OID NULL,
+   subconninfo STRING NULL,
+   subdbid OID NULL,
+   subenabled BOOL NULL,
+   subowner OID NULL
+)  CREATE TABLE pg_catalog.pg_subscription (
+   subname NAME NULL,
+   subpublications STRING[] NULL,
+   subslotname NAME NULL,
+   subsynccommit STRING NULL,
+   oid OID NULL,
+   subconninfo STRING NULL,
+   subdbid OID NULL,
+   subenabled BOOL NULL,
+   subowner OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_subscription_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_subscription_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_subscription_rel_srrelid_srsubid_index (
+   srrelid OID NULL,
+   srsubid OID NULL
+)  CREATE TABLE pg_catalog.pg_subscription_rel_srrelid_srsubid_index (
+   srrelid OID NULL,
+   srsubid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_tables (
+   schemaname NAME NULL,
+   tablename NAME NULL,
+   tableowner NAME NULL,
+   tablespace NAME NULL,
+   hasindexes BOOL NULL,
+   hasrules BOOL NULL,
+   hastriggers BOOL NULL,
+   rowsecurity BOOL NULL
+)  CREATE TABLE pg_catalog.pg_tables (
+   schemaname NAME NULL,
+   tablename NAME NULL,
+   tableowner NAME NULL,
+   tablespace NAME NULL,
+   hasindexes BOOL NULL,
+   hasrules BOOL NULL,
+   hastriggers BOOL NULL,
+   rowsecurity BOOL NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_tablespace (
+   oid OID NULL,
+   spcname NAME NULL,
+   spcowner OID NULL,
+   spclocation STRING NULL,
+   spcacl STRING[] NULL,
+   spcoptions STRING[] NULL
+)  CREATE TABLE pg_catalog.pg_tablespace (
+   oid OID NULL,
+   spcname NAME NULL,
+   spcowner OID NULL,
+   spclocation STRING NULL,
+   spcacl STRING[] NULL,
+   spcoptions STRING[] NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_tablespace_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_tablespace_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_timezone_abbrevs (
+   abbrev STRING NULL,
+   is_dst BOOL NULL,
+   utc_offset INTERVAL NULL
+)  CREATE TABLE pg_catalog.pg_timezone_abbrevs (
+   abbrev STRING NULL,
+   is_dst BOOL NULL,
+   utc_offset INTERVAL NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_timezone_names (
+   abbrev STRING NULL,
+   is_dst BOOL NULL,
+   name STRING NULL,
+   utc_offset INTERVAL NULL
+)  CREATE TABLE pg_catalog.pg_timezone_names (
+   abbrev STRING NULL,
+   is_dst BOOL NULL,
+   name STRING NULL,
+   utc_offset INTERVAL NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_transform (
+   trffromsql REGPROC NULL,
+   trflang OID NULL,
+   trftosql REGPROC NULL,
+   trftype OID NULL,
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_transform (
+   trffromsql REGPROC NULL,
+   trflang OID NULL,
+   trftosql REGPROC NULL,
+   trftype OID NULL,
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_transform_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_transform_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_transform_type_lang_index (
+   trflang OID NULL,
+   trftype OID NULL
+)  CREATE TABLE pg_catalog.pg_transform_type_lang_index (
+   trflang OID NULL,
+   trftype OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_trigger (
+   oid OID NULL,
+   tgrelid OID NULL,
+   tgname NAME NULL,
+   tgfoid OID NULL,
+   tgtype INT2 NULL,
+   tgenabled STRING NULL,
+   tgisinternal BOOL NULL,
+   tgconstrrelid OID NULL,
+   tgconstrindid OID NULL,
+   tgconstraint OID NULL,
+   tgdeferrable BOOL NULL,
+   tginitdeferred BOOL NULL,
+   tgnargs INT2 NULL,
+   tgattr INT2VECTOR NULL,
+   tgargs BYTES NULL,
+   tgqual STRING NULL,
+   tgoldtable NAME NULL,
+   tgnewtable NAME NULL,
+   tgparentid OID NULL
+)  CREATE TABLE pg_catalog.pg_trigger (
+   oid OID NULL,
+   tgrelid OID NULL,
+   tgname NAME NULL,
+   tgfoid OID NULL,
+   tgtype INT2 NULL,
+   tgenabled STRING NULL,
+   tgisinternal BOOL NULL,
+   tgconstrrelid OID NULL,
+   tgconstrindid OID NULL,
+   tgconstraint OID NULL,
+   tgdeferrable BOOL NULL,
+   tginitdeferred BOOL NULL,
+   tgnargs INT2 NULL,
+   tgattr INT2VECTOR NULL,
+   tgargs BYTES NULL,
+   tgqual STRING NULL,
+   tgoldtable NAME NULL,
+   tgnewtable NAME NULL,
+   tgparentid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_trigger_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_trigger_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_trigger_tgconstraint_index (
+   tgconstraint OID NULL
+)  CREATE TABLE pg_catalog.pg_trigger_tgconstraint_index (
+   tgconstraint OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_ts_config (
+   cfgname NAME NULL,
+   cfgnamespace OID NULL,
+   cfgowner OID NULL,
+   cfgparser OID NULL,
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_ts_config (
+   cfgname NAME NULL,
+   cfgnamespace OID NULL,
+   cfgowner OID NULL,
+   cfgparser OID NULL,
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_ts_config_map (
+   mapcfg OID NULL,
+   mapdict OID NULL,
+   mapseqno INT4 NULL,
+   maptokentype INT4 NULL
+)  CREATE TABLE pg_catalog.pg_ts_config_map (
+   mapcfg OID NULL,
+   mapdict OID NULL,
+   mapseqno INT4 NULL,
+   maptokentype INT4 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_ts_config_map_index (
+   mapcfg OID NULL,
+   mapseqno INT4 NULL,
+   maptokentype INT4 NULL
+)  CREATE TABLE pg_catalog.pg_ts_config_map_index (
+   mapcfg OID NULL,
+   mapseqno INT4 NULL,
+   maptokentype INT4 NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_ts_config_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_ts_config_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_ts_dict (
+   dictinitoption STRING NULL,
+   dictname NAME NULL,
+   dictnamespace OID NULL,
+   dictowner OID NULL,
+   dicttemplate OID NULL,
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_ts_dict (
+   dictinitoption STRING NULL,
+   dictname NAME NULL,
+   dictnamespace OID NULL,
+   dictowner OID NULL,
+   dicttemplate OID NULL,
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_ts_dict_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_ts_dict_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_ts_parser (
+   prslextype REGPROC NULL,
+   prsname NAME NULL,
+   prsnamespace OID NULL,
+   prsstart REGPROC NULL,
+   prstoken REGPROC NULL,
+   oid OID NULL,
+   prsend REGPROC NULL,
+   prsheadline REGPROC NULL
+)  CREATE TABLE pg_catalog.pg_ts_parser (
+   prslextype REGPROC NULL,
+   prsname NAME NULL,
+   prsnamespace OID NULL,
+   prsstart REGPROC NULL,
+   prstoken REGPROC NULL,
+   oid OID NULL,
+   prsend REGPROC NULL,
+   prsheadline REGPROC NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_ts_parser_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_ts_parser_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_ts_template (
+   oid OID NULL,
+   tmplinit REGPROC NULL,
+   tmpllexize REGPROC NULL,
+   tmplname NAME NULL,
+   tmplnamespace OID NULL
+)  CREATE TABLE pg_catalog.pg_ts_template (
+   oid OID NULL,
+   tmplinit REGPROC NULL,
+   tmpllexize REGPROC NULL,
+   tmplname NAME NULL,
+   tmplnamespace OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_ts_template_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_ts_template_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_type (
+   oid OID NOT NULL,
+   typname NAME NOT NULL,
+   typnamespace OID NULL,
+   typowner OID NULL,
+   typlen INT2 NULL,
+   typbyval BOOL NULL,
+   typtype "char" NULL,
+   typcategory "char" NULL,
+   typispreferred BOOL NULL,
+   typisdefined BOOL NULL,
+   typdelim "char" NULL,
+   typrelid OID NULL,
+   typelem OID NULL,
+   typarray OID NULL,
+   typinput REGPROC NULL,
+   typoutput REGPROC NULL,
+   typreceive REGPROC NULL,
+   typsend REGPROC NULL,
+   typmodin REGPROC NULL,
+   typmodout REGPROC NULL,
+   typanalyze REGPROC NULL,
+   typalign "char" NULL,
+   typstorage "char" NULL,
+   typnotnull BOOL NULL,
+   typbasetype OID NULL,
+   typtypmod INT4 NULL,
+   typndims INT4 NULL,
+   typcollation OID NULL,
+   typdefaultbin STRING NULL,
+   typdefault STRING NULL,
+   typacl STRING[] NULL,
+   INDEX pg_type_oid_idx (oid ASC) STORING (typname, typnamespace, typowner, typlen, typbyval, typtype, typcategory, typispreferred, typisdefined, typdelim, typrelid, typelem, typarray, typinput, typoutput, typreceive, typsend, typmodin, typmodout, typanalyze, typalign, typstorage, typnotnull, typbasetype, typtypmod, typndims, typcollation, typdefaultbin, typdefault, typacl)
+)  CREATE TABLE pg_catalog.pg_type (
+   oid OID NOT NULL,
+   typname NAME NOT NULL,
+   typnamespace OID NULL,
+   typowner OID NULL,
+   typlen INT2 NULL,
+   typbyval BOOL NULL,
+   typtype "char" NULL,
+   typcategory "char" NULL,
+   typispreferred BOOL NULL,
+   typisdefined BOOL NULL,
+   typdelim "char" NULL,
+   typrelid OID NULL,
+   typelem OID NULL,
+   typarray OID NULL,
+   typinput REGPROC NULL,
+   typoutput REGPROC NULL,
+   typreceive REGPROC NULL,
+   typsend REGPROC NULL,
+   typmodin REGPROC NULL,
+   typmodout REGPROC NULL,
+   typanalyze REGPROC NULL,
+   typalign "char" NULL,
+   typstorage "char" NULL,
+   typnotnull BOOL NULL,
+   typbasetype OID NULL,
+   typtypmod INT4 NULL,
+   typndims INT4 NULL,
+   typcollation OID NULL,
+   typdefaultbin STRING NULL,
+   typdefault STRING NULL,
+   typacl STRING[] NULL,
+   INDEX pg_type_oid_idx (oid ASC) STORING (typname, typnamespace, typowner, typlen, typbyval, typtype, typcategory, typispreferred, typisdefined, typdelim, typrelid, typelem, typarray, typinput, typoutput, typreceive, typsend, typmodin, typmodout, typanalyze, typalign, typstorage, typnotnull, typbasetype, typtypmod, typndims, typcollation, typdefaultbin, typdefault, typacl)
+)  {}  {}
+CREATE TABLE pg_catalog.pg_type_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_type_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_user (
+   usename NAME NULL,
+   usesysid OID NULL,
+   usecreatedb BOOL NULL,
+   usesuper BOOL NULL,
+   userepl BOOL NULL,
+   usebypassrls BOOL NULL,
+   passwd STRING NULL,
+   valuntil TIMESTAMP NULL,
+   useconfig STRING[] NULL
+)  CREATE TABLE pg_catalog.pg_user (
+   usename NAME NULL,
+   usesysid OID NULL,
+   usecreatedb BOOL NULL,
+   usesuper BOOL NULL,
+   userepl BOOL NULL,
+   usebypassrls BOOL NULL,
+   passwd STRING NULL,
+   valuntil TIMESTAMP NULL,
+   useconfig STRING[] NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_user_mapping (
+   oid OID NULL,
+   umuser OID NULL,
+   umserver OID NULL,
+   umoptions STRING[] NULL
+)  CREATE TABLE pg_catalog.pg_user_mapping (
+   oid OID NULL,
+   umuser OID NULL,
+   umserver OID NULL,
+   umoptions STRING[] NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_user_mapping_oid_index (
+   oid OID NULL
+)  CREATE TABLE pg_catalog.pg_user_mapping_oid_index (
+   oid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_user_mapping_user_server_index (
+   umserver OID NULL,
+   umuser OID NULL
+)  CREATE TABLE pg_catalog.pg_user_mapping_user_server_index (
+   umserver OID NULL,
+   umuser OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_user_mappings (
+   srvname NAME NULL,
+   umid OID NULL,
+   umoptions STRING[] NULL,
+   umuser OID NULL,
+   usename NAME NULL,
+   srvid OID NULL
+)  CREATE TABLE pg_catalog.pg_user_mappings (
+   srvname NAME NULL,
+   umid OID NULL,
+   umoptions STRING[] NULL,
+   umuser OID NULL,
+   usename NAME NULL,
+   srvid OID NULL
+)  {}  {}
+CREATE TABLE pg_catalog.pg_views (
+   schemaname NAME NULL,
+   viewname NAME NULL,
+   viewowner NAME NULL,
+   definition STRING NULL
+)  CREATE TABLE pg_catalog.pg_views (
+   schemaname NAME NULL,
+   viewname NAME NULL,
+   viewowner NAME NULL,
+   definition STRING NULL
+)  {}  {}
+CREATE TABLE pg_extension.geography_columns (
+   f_table_catalog NAME NULL,
+   f_table_schema NAME NULL,
+   f_table_name NAME NULL,
+   f_geography_column NAME NULL,
+   coord_dimension INT8 NULL,
+   srid INT8 NULL,
+   type STRING NULL
+)  CREATE TABLE pg_extension.geography_columns (
+   f_table_catalog NAME NULL,
+   f_table_schema NAME NULL,
+   f_table_name NAME NULL,
+   f_geography_column NAME NULL,
+   coord_dimension INT8 NULL,
+   srid INT8 NULL,
+   type STRING NULL
+)  {}  {}
+CREATE TABLE pg_extension.geometry_columns (
+   f_table_catalog NAME NULL,
+   f_table_schema NAME NULL,
+   f_table_name NAME NULL,
+   f_geometry_column NAME NULL,
+   coord_dimension INT8 NULL,
+   srid INT8 NULL,
+   type STRING NULL
+)  CREATE TABLE pg_extension.geometry_columns (
+   f_table_catalog NAME NULL,
+   f_table_schema NAME NULL,
+   f_table_name NAME NULL,
+   f_geometry_column NAME NULL,
+   coord_dimension INT8 NULL,
+   srid INT8 NULL,
+   type STRING NULL
+)  {}  {}
+CREATE TABLE pg_extension.spatial_ref_sys (
+   srid INT8 NULL,
+   auth_name VARCHAR(256) NULL,
+   auth_srid INT8 NULL,
+   srtext VARCHAR(2048) NULL,
+   proj4text VARCHAR(2048) NULL
+)  CREATE TABLE pg_extension.spatial_ref_sys (
+   srid INT8 NULL,
+   auth_name VARCHAR(256) NULL,
+   auth_srid INT8 NULL,
+   srtext VARCHAR(2048) NULL,
+   proj4text VARCHAR(2048) NULL
+)  {}  {}
 CREATE TABLE public.t (
    a INT8 NULL,
    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3510,3 +3510,10 @@ WHERE indexrelid IN (SELECT crdb_oid FROM pg_catalog.pg_indexes WHERE indexname 
 ----
 indoption
 1
+
+# Regression #59561.
+# database_name would not be populated even when the SELECT does not use the virtual index.
+query TTI
+SELECT database_name, descriptor_name, descriptor_id from test.crdb_internal.create_statements where descriptor_name = 'pg_views'
+----
+test  pg_views  4294967022


### PR DESCRIPTION
Previously, SELECTING from crdb_internal.create_statements and not
using the virtual index would result in database_name being nil.
This was because we did not pass the db descriptor into populate.

Release justification: Low risk, bug fix, internal table
Release note (sql change): selecting from crdb_internal.create_statements
will now correctly populate the database_name when the virtual index is
not used. Internal table.

Fixes #59561