### PR TITLE
cli: don't refresh prompt on line continuations

### DIFF
--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -746,6 +746,20 @@ func (c *cliState) doRefreshPrompts(nextState cliStateEnum) cliStateEnum {
 		return nextState
 	}
 
+	if c.useContinuePrompt {
+		if len(c.fullPrompt) < 3 {
+			c.continuePrompt = "> "
+		} else {
+			// continued statement prompt is: "        -> ".
+			c.continuePrompt = strings.Repeat(" ", len(c.fullPrompt)-3) + "-> "
+		}
+
+		c.ins.SetLeftPrompt(c.continuePrompt)
+		return nextState
+	}
+
+	// Configure the editor to use the new prompt.
+
 	parsedURL, err := url.Parse(c.conn.url)
 	if err != nil {
 		// If parsing fails, we'll keep the entire URL. The Open call succeeded, and that
@@ -800,20 +814,7 @@ func (c *cliState) doRefreshPrompts(nextState cliStateEnum) cliStateEnum {
 	}
 
 	c.fullPrompt += " "
-
-	if len(c.fullPrompt) < 3 {
-		c.continuePrompt = "> "
-	} else {
-		// continued statement prompt is: "        -> ".
-		c.continuePrompt = strings.Repeat(" ", len(c.fullPrompt)-3) + "-> "
-	}
-
-	switch c.useContinuePrompt {
-	case true:
-		c.currentPrompt = c.continuePrompt
-	case false:
-		c.currentPrompt = c.fullPrompt
-	}
+	c.currentPrompt = c.fullPrompt
 
 	// Configure the editor to use the new prompt.
 	c.ins.SetLeftPrompt(c.currentPrompt)


### PR DESCRIPTION
Previously, the CLI would recalculate its prompt (including any required
network roundtrips to determine transaction status and current database)
on every newline, even if the newline came in the middle of a SQL
statement. This was wasteful, of course, but it's also very confusing
for users when entering a large multi-line statement via paste: the
prompt refreshes defer until enter is pressed for the first time, and
there is a lot of unexplained latency during the statement that doesn't
reflect the actual SQL being executed. It also doesn't match the
reported execution time, leading to mass confusion and sadness.

Now, we don't bother refreshing the prompt during line continuations.

Closes #61095

Release note (cli change): optimize handling of multi-line SQL strings
to avoid unwanted extra server roundtrips.

Release justification: bug fixes and low-risk updates to new functionality