### PR TITLE
kv: disable race testing of kvserver package

### DIFF
--- a/pkg/kv/kvserver/main_test.go
+++ b/pkg/kv/kvserver/main_test.go
@@ -46,8 +46,11 @@ func TestMain(m *testing.M) {
 	// below-Raft proto tracking in non-race builds, so there is little benefit
 	// to also doing it in race builds.
 	if util.RaceEnabled {
-		os.Exit(m.Run())
-		return
+		// This package fails under race with "clock allocator overflow".
+		// Tracked by #61120.
+		//os.Exit(m.Run())
+		fmt.Println("SKIPPED (#61120)")
+		os.Exit(0)
 	}
 
 	// Create a set of all protos we believe to be marshaled downstream of raft.

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -369,7 +368,6 @@ func TestReplicaRangefeedExpiringLeaseError(t *testing.T) {
 func TestReplicaRangefeedRetryErrors(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderRaceWithIssue(t, 61120)
 
 	ctx := context.Background()
 	startKey := []byte("a")
@@ -775,7 +773,6 @@ func TestReplicaRangefeedRetryErrors(t *testing.T) {
 func TestReplicaRangefeedPushesTransactions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderRaceWithIssue(t, 61120)
 
 	ctx := context.Background()
 	tc, db, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration,
@@ -890,7 +887,6 @@ func TestReplicaRangefeedPushesTransactions(t *testing.T) {
 func TestReplicaRangefeedNudgeSlowClosedTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderRaceWithIssue(t, 61120)
 
 	ctx := context.Background()
 	tc, db, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration,


### PR DESCRIPTION
The thread sanitizer dies with a "clock allocator overflow" on this
package. The failure is not specific to a test; we have skipped the
tests that were running and it's now being hit during another test.

I tried splitting out the client tests, but they rely on a lot of
_test code from the `kvserver` package. It requires duplicating or
moving around a lot of code (and making many methods public from
non-test kvserver code).

Until we figure out a solution, I am skipping the entire package under
race.

Informs #61120.

Release justification: non-production code change.

Release note: None