### PR TITLE
sql: make schema change jobs for databases and schemas non-cancelable

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -1251,7 +1251,8 @@ func createNonDropDatabaseChangeJob(
 			DescID:        databaseID,
 			FormatVersion: jobspb.DatabaseJobFormatVersion,
 		},
-		Progress: jobspb.SchemaChangeProgress{},
+		Progress:      jobspb.SchemaChangeProgress{},
+		NonCancelable: true,
 	}
 
 	jobID := p.ExecCfg().JobRegistry.MakeJobID()
@@ -2282,7 +2283,8 @@ func (r *importResumer) dropSchemas(
 			DroppedDatabaseID: descpb.InvalidID,
 			FormatVersion:     jobspb.DatabaseJobFormatVersion,
 		},
-		Progress: jobspb.SchemaChangeProgress{},
+		Progress:      jobspb.SchemaChangeProgress{},
+		NonCancelable: true,
 	}
 	jobID := p.ExecCfg().JobRegistry.MakeJobID()
 	job, err := execCfg.JobRegistry.CreateJobWithTxn(ctx, dropSchemaJobRecord, jobID, txn)

--- a/pkg/sql/drop_schema.go
+++ b/pkg/sql/drop_schema.go
@@ -233,7 +233,8 @@ func (p *planner) createDropSchemaJob(
 			// drop schemas.
 			FormatVersion: jobspb.DatabaseJobFormatVersion,
 		},
-		Progress: jobspb.SchemaChangeProgress{},
+		Progress:      jobspb.SchemaChangeProgress{},
+		NonCancelable: true,
 	})
 	return err
 }

--- a/pkg/sql/schema.go
+++ b/pkg/sql/schema.go
@@ -80,7 +80,8 @@ func (p *planner) writeSchemaDescChange(
 				// jobs.
 				FormatVersion: jobspb.DatabaseJobFormatVersion,
 			},
-			Progress: jobspb.SchemaChangeProgress{},
+			Progress:      jobspb.SchemaChangeProgress{},
+			NonCancelable: true,
 		}
 		newJob, err := p.extendedEvalCtx.QueueJob(ctx, jobRecord)
 		if err != nil {

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -6852,42 +6852,13 @@ AND descriptor_ids[1] = 'db.t2'::regclass::int`,
 }
 
 // TestRevertingJobsOnDatabasesAndSchemas tests that schema change jobs on
-// databases and schemas return an error from the OnFailOrCancel hook.
-// Regression test for #59415.
+// databases and schemas return an error from the OnFailOrCancel hook. It also
+// tests that such jobs are not cancelable. Regression test for #59415.
 func TestRevertingJobsOnDatabasesAndSchemas(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer sqltestutils.SetTestJobsAdoptInterval()()
-	ctx := context.Background()
 
-	var s serverutils.TestServerInterface
-	params, _ := tests.CreateTestServerParams()
-	params.Knobs = base.TestingKnobs{
-		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
-			RunBeforeResume: func(jobID jobspb.JobID) error {
-				scJob, err := s.JobRegistry().(*jobs.Registry).LoadJob(ctx, jobID)
-				if err != nil {
-					return err
-				}
-				pl := scJob.Payload()
-				// This is a hacky way to only inject errors in the rename/drop/grant jobs.
-				if strings.Contains(pl.Description, "updating parent database") {
-					return nil
-				}
-				for _, s := range []string{"DROP", "RENAME", "updating privileges"} {
-					if strings.Contains(pl.Description, s) {
-						return errors.New("injected permanent error")
-					}
-				}
-				return nil
-			},
-		},
-	}
-	var db *gosql.DB
-	s, db, _ = serverutils.StartServer(t, params)
-	defer s.Stopper().Stop(ctx)
-	sqlDB := sqlutils.MakeSQLRunner(db)
-
-	for _, tc := range []struct {
+	testCases := []struct {
 		name       string
 		setupStmts string
 		scStmt     string
@@ -6929,20 +6900,132 @@ func TestRevertingJobsOnDatabasesAndSchemas(t *testing.T) {
 			scStmt:     `GRANT ALL ON DATABASE db_grant TO PUBLIC`,
 			jobRegex:   `updating privileges for database`,
 		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			sqlDB.Exec(t, tc.setupStmts)
-			sqlDB.ExpectErr(t, "injected permanent error", tc.scStmt)
-			result := sqlDB.QueryStr(t,
-				`SELECT status, error FROM crdb_internal.jobs WHERE description ~ $1`,
-				tc.jobRegex)
-			require.Len(t, result, 1)
-			status, jobError := result[0][0], result[0][1]
-			require.Equal(t, string(jobs.StatusFailed), status)
-			require.Regexp(t,
-				"cannot be reverted, manual cleanup may be required: "+
-					"schema change jobs on databases and schemas cannot be reverted",
-				jobError)
-		})
 	}
+
+	ctx := context.Background()
+
+	t.Run("failed due to injected error", func(t *testing.T) {
+		var s serverutils.TestServerInterface
+		params, _ := tests.CreateTestServerParams()
+		params.Knobs = base.TestingKnobs{
+			SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+				RunBeforeResume: func(jobID jobspb.JobID) error {
+					scJob, err := s.JobRegistry().(*jobs.Registry).LoadJob(ctx, jobID)
+					if err != nil {
+						return err
+					}
+					pl := scJob.Payload()
+					// This is a hacky way to only inject errors in the rename/drop/grant jobs.
+					if strings.Contains(pl.Description, "updating parent database") {
+						return nil
+					}
+					for _, s := range []string{"DROP", "RENAME", "updating privileges"} {
+						if strings.Contains(pl.Description, s) {
+							return errors.New("injected permanent error")
+						}
+					}
+					return nil
+				},
+			},
+		}
+		var db *gosql.DB
+		s, db, _ = serverutils.StartServer(t, params)
+		defer s.Stopper().Stop(ctx)
+		sqlDB := sqlutils.MakeSQLRunner(db)
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				sqlDB.Exec(t, tc.setupStmts)
+				sqlDB.ExpectErr(t, "injected permanent error", tc.scStmt)
+				result := sqlDB.QueryStr(t,
+					`SELECT status, error FROM crdb_internal.jobs WHERE description ~ $1`,
+					tc.jobRegex)
+				require.Len(t, result, 1)
+				status, jobError := result[0][0], result[0][1]
+				require.Equal(t, string(jobs.StatusFailed), status)
+				require.Regexp(t,
+					"cannot be reverted, manual cleanup may be required: "+
+						"schema change jobs on databases and schemas cannot be reverted",
+					jobError)
+			})
+		}
+	})
+
+	t.Run("canceling not allowed", func(t *testing.T) {
+		var state = struct {
+			mu    syncutil.Mutex
+			jobID jobspb.JobID
+			// Closed in the RunBeforeResume testing knob.
+			beforeResumeNotification chan struct{}
+			// Closed when we're ready to resume the schema change.
+			continueNotification chan struct{}
+		}{}
+		initNotification := func() (chan struct{}, chan struct{}) {
+			state.mu.Lock()
+			defer state.mu.Unlock()
+			state.beforeResumeNotification = make(chan struct{})
+			state.continueNotification = make(chan struct{})
+			return state.beforeResumeNotification, state.continueNotification
+		}
+		notifyBeforeResume := func(jobID jobspb.JobID) {
+			state.mu.Lock()
+			defer state.mu.Unlock()
+			state.jobID = jobID
+			if state.beforeResumeNotification != nil {
+				close(state.beforeResumeNotification)
+				state.beforeResumeNotification = nil
+			}
+			if state.continueNotification != nil {
+				<-state.continueNotification
+			}
+		}
+
+		var s serverutils.TestServerInterface
+		params, _ := tests.CreateTestServerParams()
+		params.Knobs = base.TestingKnobs{
+			SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+				RunBeforeResume: func(jobID jobspb.JobID) error {
+					scJob, err := s.JobRegistry().(*jobs.Registry).LoadJob(ctx, jobID)
+					if err != nil {
+						return err
+					}
+					pl := scJob.Payload()
+					// This is a hacky way to only block in the rename/drop/grant jobs.
+					if strings.Contains(pl.Description, "updating parent database") {
+						return nil
+					}
+					for _, s := range []string{"DROP", "RENAME", "updating privileges"} {
+						if strings.Contains(pl.Description, s) {
+							notifyBeforeResume(jobID)
+						}
+					}
+					return nil
+				},
+			},
+		}
+		var db *gosql.DB
+		s, db, _ = serverutils.StartServer(t, params)
+		defer s.Stopper().Stop(ctx)
+		sqlDB := sqlutils.MakeSQLRunner(db)
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				beforeResumeNotification, continueNotification := initNotification()
+				sqlDB.Exec(t, tc.setupStmts)
+
+				g := ctxgroup.WithContext(ctx)
+				g.GoCtx(func(ctx context.Context) error {
+					_, err := db.ExecContext(ctx, tc.scStmt)
+					assert.NoError(t, err)
+					return nil
+				})
+
+				<-beforeResumeNotification
+				sqlDB.ExpectErr(t, "not cancelable", "CANCEL JOB $1", state.jobID)
+
+				close(continueNotification)
+				require.NoError(t, g.Wait())
+			})
+		}
+	})
 }

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -61,7 +61,8 @@ func (p *planner) createDropDatabaseJob(
 			DroppedDatabaseID: databaseID,
 			FormatVersion:     jobspb.DatabaseJobFormatVersion,
 		},
-		Progress: jobspb.SchemaChangeProgress{},
+		Progress:      jobspb.SchemaChangeProgress{},
+		NonCancelable: true,
 	}
 	newJob, err := p.extendedEvalCtx.QueueJob(ctx, jobRecord)
 	if err != nil {
@@ -85,7 +86,8 @@ func (p *planner) createNonDropDatabaseChangeJob(
 			DescID:        databaseID,
 			FormatVersion: jobspb.DatabaseJobFormatVersion,
 		},
-		Progress: jobspb.SchemaChangeProgress{},
+		Progress:      jobspb.SchemaChangeProgress{},
+		NonCancelable: true,
 	}
 	newJob, err := p.extendedEvalCtx.QueueJob(ctx, jobRecord)
 	if err != nil {


### PR DESCRIPTION
Schema change jobs to drop, rename, or change privileges on databases
and schemas cannot be meaningfully reverted, because they just wait for
leases to drain, or handle draining names when applicable. Currently, if
we ever enter `OnFailOrCancel` for a schema change job on a database or
schema, we return with an error. This PR reduces the risk of this
happening by disallowing cancelation of these jobs.

Partially addresses #59545.

Release justification: Low risk, high benefit changes to existing
functionality

Release note (bug fix): Schema change jobs associated with databases and
schemas can no longer be canceled. Such jobs cannot actually be reverted
successfully, so cancelation had no benefit and could have caused
namespace corruption.