### PR TITLE
Revert "sql: fix SHOW TABLES FROM db stats display"

### DIFF
--- a/pkg/sql/delegate/show_tables.go
+++ b/pkg/sql/delegate/show_tables.go
@@ -85,10 +85,8 @@ ORDER BY schema_name, table_name
 	var estimatedRowCountJoin string
 	if showEstimatedRowCountClusterSetting.Get(&d.evalCtx.Settings.SV) {
 		estimatedRowCount = "s.estimated_row_count AS estimated_row_count, "
-		estimatedRowCountJoin = fmt.Sprintf(
-			`LEFT JOIN %[1]s.crdb_internal.table_row_statistics AS s on (s.table_id = pc.oid::INT8)`,
-			&name.CatalogName,
-		)
+		estimatedRowCountJoin = `
+  LEFT JOIN crdb_internal.table_row_statistics AS s on (s.table_id = pc.oid::INT8)`
 	}
 	var descJoin string
 	var comment string

--- a/pkg/sql/logictest/testdata/logic_test/namespace
+++ b/pkg/sql/logictest/testdata/logic_test/namespace
@@ -15,7 +15,7 @@ public  a  table  root  0  NULL
 query TTTTIT
 SHOW TABLES FROM public.public
 ----
-public  t  table  root  0  NULL
+public  t  table  root  NULL  NULL
 
 # Of course one can also list the tables in "public" by making it the
 # current database.

--- a/pkg/sql/logictest/testdata/logic_test/rename_table
+++ b/pkg/sql/logictest/testdata/logic_test/rename_table
@@ -131,8 +131,8 @@ SHOW TABLES
 query TTTTIT
 SHOW TABLES FROM test2
 ----
-public  t   table  root  0  NULL
-public  t2  table  root  0  NULL
+public  t   table  root  NULL  NULL
+public  t2  table  root  NULL  NULL
 
 user root
 

--- a/pkg/sql/logictest/testdata/logic_test/rename_view
+++ b/pkg/sql/logictest/testdata/logic_test/rename_view
@@ -146,8 +146,8 @@ SHOW TABLES FROM test
 query TTTTIT
 SHOW TABLES FROM test2
 ----
-public  v   view  root  0  NULL
-public  v2  view  root  0  NULL
+public  v   view  root  NULL  NULL
+public  v2  view  root  NULL  NULL
 
 user root
 

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -1104,7 +1104,7 @@ publicdb  root  NULL  {}  NULL
 query TTTTIT
 SHOW TABLES FROM publicdb
 ----
-public  publictable  table  root  0  NULL
+public  publictable  table  root  NULL  NULL
 
 query TTTTIT
 SHOW TABLES FROM privatedb

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -196,71 +196,71 @@ query TTTTIT colnames,rowsort
 SELECT * FROM [SHOW TABLES FROM system]
 ----
 schema_name  table_name                       type   owner  estimated_row_count  locality
-public       namespace                        table  NULL   0                    NULL
-public       migrations                       table  NULL   0                    NULL
-public       sqlliveness                      table  NULL   0                    NULL
-public       scheduled_jobs                   table  NULL   0                    NULL
-public       statement_diagnostics            table  NULL   0                    NULL
-public       statement_diagnostics_requests   table  NULL   0                    NULL
-public       statement_bundle_chunks          table  NULL   0                    NULL
-public       role_options                     table  NULL   0                    NULL
-public       protected_ts_records             table  NULL   0                    NULL
-public       protected_ts_meta                table  NULL   0                    NULL
-public       namespace2                       table  NULL   0                    NULL
-public       reports_meta                     table  NULL   0                    NULL
-public       replication_stats                table  NULL   0                    NULL
-public       replication_critical_localities  table  NULL   0                    NULL
-public       replication_constraint_stats     table  NULL   0                    NULL
-public       comments                         table  NULL   0                    NULL
-public       role_members                     table  NULL   0                    NULL
-public       locations                        table  NULL   0                    NULL
-public       table_statistics                 table  NULL   0                    NULL
-public       web_sessions                     table  NULL   0                    NULL
-public       jobs                             table  NULL   0                    NULL
-public       ui                               table  NULL   0                    NULL
-public       rangelog                         table  NULL   0                    NULL
-public       eventlog                         table  NULL   0                    NULL
-public       lease                            table  NULL   0                    NULL
-public       tenants                          table  NULL   0                    NULL
-public       settings                         table  NULL   0                    NULL
-public       zones                            table  NULL   0                    NULL
-public       users                            table  NULL   0                    NULL
-public       descriptor                       table  NULL   0                    NULL
+public       namespace                        table  NULL   NULL                 NULL
+public       migrations                       table  NULL   NULL                 NULL
+public       sqlliveness                      table  NULL   NULL                 NULL
+public       scheduled_jobs                   table  NULL   NULL                 NULL
+public       statement_diagnostics            table  NULL   NULL                 NULL
+public       statement_diagnostics_requests   table  NULL   NULL                 NULL
+public       statement_bundle_chunks          table  NULL   NULL                 NULL
+public       role_options                     table  NULL   NULL                 NULL
+public       protected_ts_records             table  NULL   NULL                 NULL
+public       protected_ts_meta                table  NULL   NULL                 NULL
+public       namespace2                       table  NULL   NULL                 NULL
+public       reports_meta                     table  NULL   NULL                 NULL
+public       replication_stats                table  NULL   NULL                 NULL
+public       replication_critical_localities  table  NULL   NULL                 NULL
+public       replication_constraint_stats     table  NULL   NULL                 NULL
+public       comments                         table  NULL   NULL                 NULL
+public       role_members                     table  NULL   NULL                 NULL
+public       locations                        table  NULL   NULL                 NULL
+public       table_statistics                 table  NULL   NULL                 NULL
+public       web_sessions                     table  NULL   NULL                 NULL
+public       jobs                             table  NULL   NULL                 NULL
+public       ui                               table  NULL   NULL                 NULL
+public       rangelog                         table  NULL   NULL                 NULL
+public       eventlog                         table  NULL   NULL                 NULL
+public       lease                            table  NULL   NULL                 NULL
+public       tenants                          table  NULL   NULL                 NULL
+public       settings                         table  NULL   NULL                 NULL
+public       zones                            table  NULL   NULL                 NULL
+public       users                            table  NULL   NULL                 NULL
+public       descriptor                       table  NULL   NULL                 NULL
 
-query TTTTITT colnames,rowsort
+query TTTTTTT colnames,rowsort
 SELECT * FROM [SHOW TABLES FROM system WITH COMMENT]
 ----
 schema_name  table_name                       type   owner  estimated_row_count  locality  comment
-public       namespace                        table  NULL   0                    NULL      ·
-public       migrations                       table  NULL   0                    NULL      ·
-public       sqlliveness                      table  NULL   0                    NULL      ·
-public       scheduled_jobs                   table  NULL   0                    NULL      ·
-public       statement_diagnostics            table  NULL   0                    NULL      ·
-public       statement_diagnostics_requests   table  NULL   0                    NULL      ·
-public       statement_bundle_chunks          table  NULL   0                    NULL      ·
-public       role_options                     table  NULL   0                    NULL      ·
-public       protected_ts_records             table  NULL   0                    NULL      ·
-public       protected_ts_meta                table  NULL   0                    NULL      ·
-public       namespace2                       table  NULL   0                    NULL      ·
-public       reports_meta                     table  NULL   0                    NULL      ·
-public       replication_stats                table  NULL   0                    NULL      ·
-public       replication_critical_localities  table  NULL   0                    NULL      ·
-public       replication_constraint_stats     table  NULL   0                    NULL      ·
-public       comments                         table  NULL   0                    NULL      ·
-public       role_members                     table  NULL   0                    NULL      ·
-public       locations                        table  NULL   0                    NULL      ·
-public       table_statistics                 table  NULL   0                    NULL      ·
-public       web_sessions                     table  NULL   0                    NULL      ·
-public       jobs                             table  NULL   0                    NULL      ·
-public       ui                               table  NULL   0                    NULL      ·
-public       rangelog                         table  NULL   0                    NULL      ·
-public       eventlog                         table  NULL   0                    NULL      ·
-public       lease                            table  NULL   0                    NULL      ·
-public       tenants                          table  NULL   0                    NULL      ·
-public       settings                         table  NULL   0                    NULL      ·
-public       zones                            table  NULL   0                    NULL      ·
-public       users                            table  NULL   0                    NULL      ·
-public       descriptor                       table  NULL   0                    NULL      ·
+public       namespace                        table  NULL   NULL                 NULL      ·
+public       migrations                       table  NULL   NULL                 NULL      ·
+public       sqlliveness                      table  NULL   NULL                 NULL      ·
+public       scheduled_jobs                   table  NULL   NULL                 NULL      ·
+public       statement_diagnostics            table  NULL   NULL                 NULL      ·
+public       statement_diagnostics_requests   table  NULL   NULL                 NULL      ·
+public       statement_bundle_chunks          table  NULL   NULL                 NULL      ·
+public       role_options                     table  NULL   NULL                 NULL      ·
+public       protected_ts_records             table  NULL   NULL                 NULL      ·
+public       protected_ts_meta                table  NULL   NULL                 NULL      ·
+public       namespace2                       table  NULL   NULL                 NULL      ·
+public       reports_meta                     table  NULL   NULL                 NULL      ·
+public       replication_stats                table  NULL   NULL                 NULL      ·
+public       replication_critical_localities  table  NULL   NULL                 NULL      ·
+public       replication_constraint_stats     table  NULL   NULL                 NULL      ·
+public       comments                         table  NULL   NULL                 NULL      ·
+public       role_members                     table  NULL   NULL                 NULL      ·
+public       locations                        table  NULL   NULL                 NULL      ·
+public       table_statistics                 table  NULL   NULL                 NULL      ·
+public       web_sessions                     table  NULL   NULL                 NULL      ·
+public       jobs                             table  NULL   NULL                 NULL      ·
+public       ui                               table  NULL   NULL                 NULL      ·
+public       rangelog                         table  NULL   NULL                 NULL      ·
+public       eventlog                         table  NULL   NULL                 NULL      ·
+public       lease                            table  NULL   NULL                 NULL      ·
+public       tenants                          table  NULL   NULL                 NULL      ·
+public       settings                         table  NULL   NULL                 NULL      ·
+public       zones                            table  NULL   NULL                 NULL      ·
+public       users                            table  NULL   NULL                 NULL      ·
+public       descriptor                       table  NULL   NULL                 NULL      ·
 
 query ITTT colnames
 SELECT node_id, user_name, application_name, active_queries

--- a/pkg/sql/logictest/testdata/logic_test/show_tables
+++ b/pkg/sql/logictest/testdata/logic_test/show_tables
@@ -1,27 +1,10 @@
 # LogicTest: local
 
 statement ok
-CREATE TABLE show_this_table()
-
-query TTTTIT
-SHOW TABLES
-----
-public  show_this_table  table  root  0  NULL
-
-statement ok
-CREATE DATABASE other;
-SET DATABASE = 'other'
-
-query TTTTIT
-SHOW TABLES FROM test
-----
-public  show_this_table  table  root  0  NULL
-
-statement ok
-SET DATABASE = 'test'
-
-statement ok
 SET CLUSTER SETTING sql.show_tables.estimated_row_count.enabled = false
+
+statement ok
+CREATE TABLE show_this_table()
 
 query TTTTT
 SHOW TABLES

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -10,36 +10,36 @@ test       root  NULL  {}  NULL
 query TTTTIT
 SHOW TABLES FROM system
 ----
-public  comments                         table  NULL  0  NULL
-public  descriptor                       table  NULL  0  NULL
-public  eventlog                         table  NULL  0  NULL
-public  jobs                             table  NULL  0  NULL
-public  lease                            table  NULL  0  NULL
-public  locations                        table  NULL  0  NULL
-public  migrations                       table  NULL  0  NULL
-public  namespace                        table  NULL  0  NULL
-public  namespace2                       table  NULL  0  NULL
-public  protected_ts_meta                table  NULL  0  NULL
-public  protected_ts_records             table  NULL  0  NULL
-public  rangelog                         table  NULL  0  NULL
-public  replication_constraint_stats     table  NULL  0  NULL
-public  replication_critical_localities  table  NULL  0  NULL
-public  replication_stats                table  NULL  0  NULL
-public  reports_meta                     table  NULL  0  NULL
-public  role_members                     table  NULL  0  NULL
-public  role_options                     table  NULL  0  NULL
-public  scheduled_jobs                   table  NULL  0  NULL
-public  settings                         table  NULL  0  NULL
-public  sqlliveness                      table  NULL  0  NULL
-public  statement_bundle_chunks          table  NULL  0  NULL
-public  statement_diagnostics            table  NULL  0  NULL
-public  statement_diagnostics_requests   table  NULL  0  NULL
-public  table_statistics                 table  NULL  0  NULL
-public  tenants                          table  NULL  0  NULL
-public  ui                               table  NULL  0  NULL
-public  users                            table  NULL  0  NULL
-public  web_sessions                     table  NULL  0  NULL
-public  zones                            table  NULL  0  NULL
+public  comments                         table  NULL  NULL  NULL
+public  descriptor                       table  NULL  NULL  NULL
+public  eventlog                         table  NULL  NULL  NULL
+public  jobs                             table  NULL  NULL  NULL
+public  lease                            table  NULL  NULL  NULL
+public  locations                        table  NULL  NULL  NULL
+public  migrations                       table  NULL  NULL  NULL
+public  namespace                        table  NULL  NULL  NULL
+public  namespace2                       table  NULL  NULL  NULL
+public  protected_ts_meta                table  NULL  NULL  NULL
+public  protected_ts_records             table  NULL  NULL  NULL
+public  rangelog                         table  NULL  NULL  NULL
+public  replication_constraint_stats     table  NULL  NULL  NULL
+public  replication_critical_localities  table  NULL  NULL  NULL
+public  replication_stats                table  NULL  NULL  NULL
+public  reports_meta                     table  NULL  NULL  NULL
+public  role_members                     table  NULL  NULL  NULL
+public  role_options                     table  NULL  NULL  NULL
+public  scheduled_jobs                   table  NULL  NULL  NULL
+public  settings                         table  NULL  NULL  NULL
+public  sqlliveness                      table  NULL  NULL  NULL
+public  statement_bundle_chunks          table  NULL  NULL  NULL
+public  statement_diagnostics            table  NULL  NULL  NULL
+public  statement_diagnostics_requests   table  NULL  NULL  NULL
+public  table_statistics                 table  NULL  NULL  NULL
+public  tenants                          table  NULL  NULL  NULL
+public  ui                               table  NULL  NULL  NULL
+public  users                            table  NULL  NULL  NULL
+public  web_sessions                     table  NULL  NULL  NULL
+public  zones                            table  NULL  NULL  NULL
 
 query I rowsort
 SELECT id FROM system.descriptor


### PR DESCRIPTION
This reverts commit fe801c777d68b3ef0f9c691995a33b1843c5487f.
fixes #61209 

Release justification: low-risk revert to a commit that made a test
flaky.

Release note (bug fix): This reverts `sql: fix SHOW TABLES FROM db stats
display`