### PR TITLE
sql: deflake TestPGPreparedQuery

### DIFF
--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -556,7 +556,7 @@ func TestPGPreparedQuery(t *testing.T) {
 			baseTest.Results("users", "primary", false, 1, "username", "ASC", false, false),
 		}},
 		{"SHOW TABLES FROM system", []preparedQueryTest{
-			baseTest.Results("public", "comments", "table", gosql.NullString{}, gosql.NullString{}, gosql.NullString{}).Others(29),
+			baseTest.Results("public", "comments", "table", gosql.NullString{}, 0, gosql.NullString{}).Others(29),
 		}},
 		{"SHOW SCHEMAS FROM system", []preparedQueryTest{
 			baseTest.Results("crdb_internal", gosql.NullString{}).Others(4),
@@ -836,6 +836,14 @@ func TestPGPreparedQuery(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
+
+	// Update the default AS OF time for querying the system.table_statistics
+	// table to create the crdb_internal.table_row_statistics table.
+	if _, err := db.Exec(
+		"SET CLUSTER SETTING sql.crdb_internal.table_row_statistics.as_of_time = '-1µs'",
+	); err != nil {
+		t.Fatal(err)
+	}
 
 	runTests := func(
 		t *testing.T,


### PR DESCRIPTION
A recent change to stats in SHOW TABLES made this test flaky. Stats are
now read with AOST -10s by default, but for tests like this we need to
modify this. See #60953 and https://github.com/cockroachdb/cockroach/pull/61191

Release justification: test-only change

Release note: None