### PR TITLE
opt: index accelerate <@ (contained by) expressions for array inverted indexes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -994,3 +994,113 @@ query ITT
 SELECT * FROM c WHERE foo @> '{1, 2}' ORDER BY id
 ----
 4  {1,2,3}  {b,NULL,c}
+
+subtest contained_by_arrays
+
+statement ok
+CREATE TABLE cb (
+  id INT PRIMARY KEY,
+  numbers INT[],
+  words STRING[],
+  INVERTED INDEX n (numbers),
+  INVERTED INDEX w (words)
+)
+
+statement ok
+INSERT INTO cb VALUES
+  (0, ARRAY[], ARRAY[]),
+  (1, ARRAY[0], ARRAY[NULL]),
+  (2, ARRAY[1], ARRAY['cat']),
+  (3, ARRAY[0,1], ARRAY['mouse']),
+  (4, ARRAY[NULL], ARRAY['cat', 'mouse']),
+  (5, ARRAY[0,1,2], ARRAY['cat', NULL, 'mouse']),
+  (6, ARRAY[3,4,5], ARRAY['rat']),
+  (7, ARRAY[1,2,1], ARRAY['rat', NULL]),
+  (8, ARRAY[0,1,NULL], ARRAY[''])
+
+query T
+SELECT numbers FROM cb@n WHERE numbers <@ ARRAY[]::INT[]
+----
+{}
+
+query T
+SELECT numbers FROM cb@n WHERE numbers <@ ARRAY[1]
+----
+{}
+{1}
+
+query T
+SELECT numbers FROM cb@n WHERE numbers <@ ARRAY[0,1,2]
+----
+{}
+{0}
+{1}
+{0,1}
+{0,1,2}
+{1,2,1}
+
+query T
+SELECT numbers FROM cb@n WHERE numbers <@ ARRAY[1,2,3]
+----
+{}
+{1}
+{1,2,1}
+
+query T
+SELECT numbers FROM cb@n WHERE numbers <@ ARRAY[0,1,NULL]
+----
+{}
+{0}
+{1}
+{0,1}
+
+query T
+SELECT numbers FROM cb@n WHERE numbers <@ ARRAY[NULL]::INT[]
+----
+{}
+
+query T
+SELECT words FROM cb@w WHERE words <@ ARRAY[]::STRING[]
+----
+{}
+
+query T
+SELECT words FROM cb@w WHERE words <@ ARRAY['']::STRING[]
+----
+{}
+{""}
+
+query T
+SELECT words FROM cb@w WHERE words <@ ARRAY[NULL]::STRING[]
+----
+{}
+
+
+query T
+SELECT words FROM cb@w WHERE words <@ ARRAY['cat']
+----
+{}
+{cat}
+
+
+query T
+SELECT words FROM cb@w WHERE words <@ ARRAY['cat', 'mouse']
+----
+{}
+{cat}
+{mouse}
+{cat,mouse}
+
+query T
+SELECT words FROM cb@w WHERE words <@ ARRAY['cat', 'mouse', NULL]
+----
+{}
+{cat}
+{mouse}
+{cat,mouse}
+
+query T
+SELECT words FROM cb@w WHERE words <@ ARRAY[NULL, 'rat']
+----
+{}
+{rat}

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -866,6 +866,118 @@ vectorized: true
       right columns: ()
       right fixed values: 1 column
 
+# Test that queries with the contained by <@ operator use the inverted index.
+query T
+EXPLAIN (VERBOSE) SELECT * FROM e WHERE b <@ ARRAY[]::INT[]
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b)
+│ estimated row count: 333 (missing stats)
+│ filter: ARRAY[] @> b
+│
+└── • index join
+    │ columns: (a, b)
+    │ estimated row count: 111 (missing stats)
+    │ table: e@primary
+    │ key columns: a
+    │
+    └── • scan
+          columns: (a)
+          estimated row count: 111 (missing stats)
+          table: e@e_b_idx
+          spans: /[]-/"D"
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM e WHERE b <@ ARRAY[0,1,2]
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b)
+│ estimated row count: 333 (missing stats)
+│ filter: ARRAY[0,1,2] @> b
+│
+└── • index join
+    │ columns: (a, b)
+    │ estimated row count: 111 (missing stats)
+    │ table: e@primary
+    │ key columns: a
+    │
+    └── • project
+        │ columns: (a)
+        │ estimated row count: 111 (missing stats)
+        │
+        └── • inverted filter
+            │ columns: (a, b_inverted_key)
+            │ inverted column: b_inverted_key
+            │ num spans: 2
+            │
+            └── • scan
+                  columns: (a, b_inverted_key)
+                  estimated row count: 111 (missing stats)
+                  table: e@e_b_idx
+                  spans: /[]-/"D" /0-/3
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM e WHERE b <@ ARRAY[NULL]::INT[]
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b)
+│ estimated row count: 333 (missing stats)
+│ filter: ARRAY[NULL] @> b
+│
+└── • index join
+    │ columns: (a, b)
+    │ estimated row count: 111 (missing stats)
+    │ table: e@primary
+    │ key columns: a
+    │
+    └── • scan
+          columns: (a)
+          estimated row count: 111 (missing stats)
+          table: e@e_b_idx
+          spans: /[]-/"D"
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM e WHERE b <@ ARRAY[0,1,NULL]
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b)
+│ estimated row count: 333 (missing stats)
+│ filter: ARRAY[0,1,NULL] @> b
+│
+└── • index join
+    │ columns: (a, b)
+    │ estimated row count: 111 (missing stats)
+    │ table: e@primary
+    │ key columns: a
+    │
+    └── • project
+        │ columns: (a)
+        │ estimated row count: 111 (missing stats)
+        │
+        └── • inverted filter
+            │ columns: (a, b_inverted_key)
+            │ inverted column: b_inverted_key
+            │ num spans: 2
+            │
+            └── • scan
+                  columns: (a, b_inverted_key)
+                  estimated row count: 111 (missing stats)
+                  table: e@e_b_idx
+                  spans: /[]-/"D" /0-/2
+
+
 # Ensure that an inverted index with a composite primary key still encodes
 # the primary key data in the composite value.
 statement ok

--- a/pkg/sql/opt/invertedidx/json_array_test.go
+++ b/pkg/sql/opt/invertedidx/json_array_test.go
@@ -251,7 +251,7 @@ func TestTryFilterJsonOrArrayIndex(t *testing.T) {
 			unique:   true,
 		},
 		{
-			// Contained by is not yet supported.
+			// Contained by is not yet supported for JSON.
 			filters:  "j <@ '1'",
 			indexOrd: jsonOrd,
 			ok:       false,
@@ -264,10 +264,21 @@ func TestTryFilterJsonOrArrayIndex(t *testing.T) {
 			unique:   true,
 		},
 		{
-			// Contained by is not yet supported.
-			filters:  "a <@ '{1}'",
-			indexOrd: arrayOrd,
-			ok:       false,
+			// Contained by is supported for arrays.
+			filters:          "a <@ '{1}'",
+			indexOrd:         arrayOrd,
+			ok:               true,
+			tight:            false,
+			unique:           false,
+			remainingFilters: "a <@ '{1}'",
+		},
+		{
+			filters:          "a <@ '{}'",
+			indexOrd:         arrayOrd,
+			ok:               true,
+			tight:            false,
+			unique:           true,
+			remainingFilters: "a <@ '{}'",
 		},
 		{
 			// Wrong index ordinal.
@@ -289,6 +300,20 @@ func TestTryFilterJsonOrArrayIndex(t *testing.T) {
 			ok:       false,
 		},
 		{
+			// When operations affecting two different variables are OR-ed, we cannot
+			// constrain either index.
+			filters:  "j <@ '1' OR a <@ '{1}'",
+			indexOrd: jsonOrd,
+			ok:       false,
+		},
+		{
+			// When operations affecting two different variables are OR-ed, we cannot
+			// constrain either index.
+			filters:  "j <@ '1' OR a <@ '{1}'",
+			indexOrd: arrayOrd,
+			ok:       false,
+		},
+		{
 			// We can constrain either index when the functions are AND-ed.
 			filters:          "j @> '1' AND a @> '{1}'",
 			indexOrd:         jsonOrd,
@@ -305,6 +330,22 @@ func TestTryFilterJsonOrArrayIndex(t *testing.T) {
 			tight:            false,
 			unique:           true,
 			remainingFilters: "j @> '1'",
+		},
+		{
+			// We can constrain the array index when the functions are AND-ed.
+			filters:          "j <@ '1' AND a <@ '{1}'",
+			indexOrd:         arrayOrd,
+			ok:               true,
+			tight:            false,
+			unique:           false,
+			remainingFilters: "j <@ '1' AND a <@ '{1}'",
+		},
+		{
+			// We can constrain the JSON index when the functions are AND-ed.
+			// This will work once JSON is supported for <@.
+			filters:  "j <@ '1' AND a <@ '{1}'",
+			indexOrd: jsonOrd,
+			ok:       false,
 		},
 		{
 			// We can guarantee unique primary keys when there are multiple paths

--- a/pkg/sql/opt/memo/testdata/stats/inverted-array
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-array
@@ -128,3 +128,155 @@ index-join t
            │                <--- '\x8a' --- '\x8b'
            ├── key: (1)
            └── fd: (1)-->(4)
+
+# The inverted index is used when checking if an array column is contained by
+# an empty array. An additional filter is required.
+opt
+SELECT * FROM t@a_idx WHERE a <@ '{}'
+----
+select
+ ├── columns: k:1(int!null) a:2(int[])
+ ├── immutable
+ ├── stats: [rows=333.333333]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── index-join t
+ │    ├── columns: k:1(int!null) a:2(int[])
+ │    ├── stats: [rows=10]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    └── scan t@a_idx
+ │         ├── columns: k:1(int!null)
+ │         ├── inverted constraint: /4/1
+ │         │    └── spans: ["C", "C"]
+ │         ├── flags: force-index=a_idx
+ │         ├── stats: [rows=10, distinct(4)=1, null(4)=0]
+ │         │   histogram(4)=  0    10    0    0
+ │         │                <--- '\x43' --- '\x44'
+ │         └── key: (1)
+ └── filters
+      └── ARRAY[] @> a:2 [type=bool, outer=(2), immutable]
+
+# The inverted index is used when checking if an array column is contained by a
+# constant. An additional filter is required.
+opt
+SELECT * FROM t WHERE a <@ '{2}'
+----
+select
+ ├── columns: k:1(int!null) a:2(int[])
+ ├── immutable
+ ├── stats: [rows=333.333333]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── index-join t
+ │    ├── columns: k:1(int!null) a:2(int[])
+ │    ├── stats: [rows=20]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    └── inverted-filter
+ │         ├── columns: k:1(int!null)
+ │         ├── inverted expression: /4
+ │         │    ├── tight: false, unique: false
+ │         │    └── union spans
+ │         │         ├── ["C", "C"]
+ │         │         └── ["\x8a", "\x8a"]
+ │         ├── stats: [rows=20]
+ │         ├── key: (1)
+ │         └── scan t@a_idx
+ │              ├── columns: k:1(int!null) a_inverted_key:4(int[]!null)
+ │              ├── inverted constraint: /4/1
+ │              │    └── spans
+ │              │         ├── ["C", "C"]
+ │              │         └── ["\x8a", "\x8a"]
+ │              ├── stats: [rows=20, distinct(1)=19.6078431, null(1)=0, distinct(4)=2, null(4)=0]
+ │              │   histogram(4)=  0    10    0    10    0    0
+ │              │                <--- '\x43' --- '\x8a' --- '\x8b'
+ │              ├── key: (1)
+ │              └── fd: (1)-->(4)
+ └── filters
+      └── ARRAY[2] @> a:2 [type=bool, outer=(2), immutable]
+
+# A disjunction requires scanning all entries that match either the left or the
+# right. An additional filter is required.
+opt
+SELECT * FROM t WHERE a <@ '{2}' OR a <@ '{3}'
+----
+select
+ ├── columns: k:1(int!null) a:2(int[])
+ ├── immutable
+ ├── stats: [rows=333.333333]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── index-join t
+ │    ├── columns: k:1(int!null) a:2(int[])
+ │    ├── stats: [rows=30]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    └── inverted-filter
+ │         ├── columns: k:1(int!null)
+ │         ├── inverted expression: /4
+ │         │    ├── tight: false, unique: false
+ │         │    └── union spans
+ │         │         ├── ["C", "C"]
+ │         │         └── ["\x8a", "\x8c")
+ │         ├── stats: [rows=30]
+ │         ├── key: (1)
+ │         └── scan t@a_idx
+ │              ├── columns: k:1(int!null) a_inverted_key:4(int[]!null)
+ │              ├── inverted constraint: /4/1
+ │              │    └── spans
+ │              │         ├── ["C", "C"]
+ │              │         └── ["\x8a", "\x8c")
+ │              ├── stats: [rows=30, distinct(1)=29.4117647, null(1)=0, distinct(4)=3, null(4)=0]
+ │              │   histogram(4)=  0    10    0    10    0    10
+ │              │                <--- '\x43' --- '\x8a' --- '\x8b'
+ │              ├── key: (1)
+ │              └── fd: (1)-->(4)
+ └── filters
+      └── (ARRAY[2] @> a:2) OR (ARRAY[3] @> a:2) [type=bool, outer=(2), immutable]
+
+
+# A conjunction requires scanning all entries that match both the left and
+# the right. An additional filter is required.
+opt
+SELECT * FROM t WHERE a <@ '{2}' AND a <@ '{3}'
+----
+select
+ ├── columns: k:1(int!null) a:2(int[])
+ ├── immutable
+ ├── stats: [rows=111.111111]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── index-join t
+ │    ├── columns: k:1(int!null) a:2(int[])
+ │    ├── stats: [rows=30]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    └── inverted-filter
+ │         ├── columns: k:1(int!null)
+ │         ├── inverted expression: /4
+ │         │    ├── tight: false, unique: false
+ │         │    ├── union spans: ["C", "C"]
+ │         │    └── INTERSECTION
+ │         │         ├── span expression
+ │         │         │    ├── tight: false, unique: false
+ │         │         │    └── union spans: ["\x8a", "\x8a"]
+ │         │         └── span expression
+ │         │              ├── tight: false, unique: false
+ │         │              └── union spans: ["\x8b", "\x8b"]
+ │         ├── stats: [rows=30]
+ │         ├── key: (1)
+ │         └── scan t@a_idx
+ │              ├── columns: k:1(int!null) a_inverted_key:4(int[]!null)
+ │              ├── inverted constraint: /4/1
+ │              │    └── spans
+ │              │         ├── ["C", "C"]
+ │              │         └── ["\x8a", "\x8c")
+ │              ├── stats: [rows=30, distinct(1)=29.4117647, null(1)=0, distinct(4)=3, null(4)=0]
+ │              │   histogram(4)=  0    10    0    10    0    10
+ │              │                <--- '\x43' --- '\x8a' --- '\x8b'
+ │              ├── key: (1)
+ │              └── fd: (1)-->(4)
+ └── filters
+      ├── ARRAY[2] @> a:2 [type=bool, outer=(2), immutable]
+      └── ARRAY[3] @> a:2 [type=bool, outer=(2), immutable]

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -688,7 +688,7 @@ func (b *Builder) constructComparison(
 	case tree.Contains:
 		return b.factory.ConstructContains(left, right)
 	case tree.ContainedBy:
-		// This is just syntatic sugar that reverses the operands.
+		// This is just syntactic sugar that reverses the operands.
 		return b.factory.ConstructContains(right, left)
 	case tree.JSONExists:
 		return b.factory.ConstructJsonExists(left, right)

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -2384,6 +2384,145 @@ project
       └── filters
            └── a:2 IS NULL [outer=(2), constraints=(/2: [/NULL - /NULL]; tight), fd=()-->(2)]
 
+opt expect=GenerateInvertedIndexScans
+SELECT * FROM c WHERE a <@ ARRAY[1]
+----
+select
+ ├── columns: k:1!null a:2 u:3
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── index-join c
+ │    ├── columns: k:1!null a:2 u:3
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    └── inverted-filter
+ │         ├── columns: k:1!null
+ │         ├── inverted expression: /5
+ │         │    ├── tight: false, unique: false
+ │         │    └── union spans
+ │         │         ├── ["C", "C"]
+ │         │         └── ["\x89", "\x89"]
+ │         ├── key: (1)
+ │         └── scan c@a_inv_idx
+ │              ├── columns: k:1!null a_inverted_key:5!null
+ │              ├── inverted constraint: /5/1
+ │              │    └── spans
+ │              │         ├── ["C", "C"]
+ │              │         └── ["\x89", "\x89"]
+ │              ├── key: (1)
+ │              └── fd: (1)-->(5)
+ └── filters
+      └── ARRAY[1] @> a:2 [outer=(2), immutable]
+
+opt expect=GenerateInvertedIndexScans
+SELECT * FROM c WHERE a <@ ARRAY[]::INT[]
+----
+select
+ ├── columns: k:1!null a:2 u:3
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── index-join c
+ │    ├── columns: k:1!null a:2 u:3
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    └── scan c@a_inv_idx
+ │         ├── columns: k:1!null
+ │         ├── inverted constraint: /5/1
+ │         │    └── spans: ["C", "C"]
+ │         └── key: (1)
+ └── filters
+      └── ARRAY[] @> a:2 [outer=(2), immutable]
+
+opt expect=GenerateInvertedIndexScans
+SELECT * FROM c WHERE a <@ ARRAY[NULL]::INT[]
+----
+select
+ ├── columns: k:1!null a:2 u:3
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── index-join c
+ │    ├── columns: k:1!null a:2 u:3
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    └── scan c@a_inv_idx
+ │         ├── columns: k:1!null
+ │         ├── inverted constraint: /5/1
+ │         │    └── spans: ["C", "C"]
+ │         └── key: (1)
+ └── filters
+      └── ARRAY[NULL] @> a:2 [outer=(2), immutable]
+
+opt expect=GenerateInvertedIndexScans
+SELECT * FROM c WHERE a <@ ARRAY[1] OR a <@ ARRAY[2]
+----
+select
+ ├── columns: k:1!null a:2 u:3
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── index-join c
+ │    ├── columns: k:1!null a:2 u:3
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    └── inverted-filter
+ │         ├── columns: k:1!null
+ │         ├── inverted expression: /5
+ │         │    ├── tight: false, unique: false
+ │         │    └── union spans
+ │         │         ├── ["C", "C"]
+ │         │         └── ["\x89", "\x8b")
+ │         ├── key: (1)
+ │         └── scan c@a_inv_idx
+ │              ├── columns: k:1!null a_inverted_key:5!null
+ │              ├── inverted constraint: /5/1
+ │              │    └── spans
+ │              │         ├── ["C", "C"]
+ │              │         └── ["\x89", "\x8b")
+ │              ├── key: (1)
+ │              └── fd: (1)-->(5)
+ └── filters
+      └── (ARRAY[1] @> a:2) OR (ARRAY[2] @> a:2) [outer=(2), immutable]
+
+opt expect=GenerateInvertedIndexScans
+SELECT * FROM c WHERE a <@ ARRAY[1] AND a <@ ARRAY[2]
+----
+select
+ ├── columns: k:1!null a:2 u:3
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── index-join c
+ │    ├── columns: k:1!null a:2 u:3
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    └── inverted-filter
+ │         ├── columns: k:1!null
+ │         ├── inverted expression: /5
+ │         │    ├── tight: false, unique: false
+ │         │    ├── union spans: ["C", "C"]
+ │         │    └── INTERSECTION
+ │         │         ├── span expression
+ │         │         │    ├── tight: false, unique: false
+ │         │         │    └── union spans: ["\x89", "\x89"]
+ │         │         └── span expression
+ │         │              ├── tight: false, unique: false
+ │         │              └── union spans: ["\x8a", "\x8a"]
+ │         ├── key: (1)
+ │         └── scan c@a_inv_idx
+ │              ├── columns: k:1!null a_inverted_key:5!null
+ │              ├── inverted constraint: /5/1
+ │              │    └── spans
+ │              │         ├── ["C", "C"]
+ │              │         └── ["\x89", "\x8b")
+ │              ├── key: (1)
+ │              └── fd: (1)-->(5)
+ └── filters
+      ├── ARRAY[1] @> a:2 [outer=(2), immutable]
+      └── ARRAY[2] @> a:2 [outer=(2), immutable]
+
 # Tests for indexes with older descriptor versions.
 
 exec-ddl
@@ -2462,6 +2601,23 @@ index-join b
            │         └── ["7\x00\x03", "7\x00\x03"]
            ├── key: (1)
            └── fd: (1)-->(7)
+
+# The inverted index will never be used for <@ expressions if the index version
+# does not have empty arrays in the inverted index.
+opt expect-not=GenerateInvertedIndexScans
+SELECT * FROM c WHERE a <@ '{2}'
+----
+select
+ ├── columns: k:1!null a:2 u:3
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── scan c
+ │    ├── columns: k:1!null a:2 u:3
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── ARRAY[2] @> a:2 [outer=(2), immutable]
 
 exec-ddl
 DROP INDEX j_inv_idx

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -827,26 +827,24 @@ func EncodeInvertedIndexTableKeys(
 		// arrays.
 		return json.EncodeInvertedIndexKeys(inKey, val.(*tree.DJSON).JSON)
 	case types.ArrayFamily:
-		return encodeArrayInvertedIndexTableKeys(val.(*tree.DArray), inKey, version)
+		return encodeArrayInvertedIndexTableKeys(val.(*tree.DArray), inKey, version, false /* excludeNulls */)
 	}
 	return nil, errors.AssertionFailedf("trying to apply inverted index to unsupported type %s", datum.ResolvedType())
 }
 
-// EncodeContainingInvertedIndexSpans takes in a key prefix and returns the
-// spans that must be scanned in the inverted index to evaluate a contains (@>)
-// predicate with the given datum, which should be a container (either JSON
-// or Array). These spans should be used to find the objects in the index that
-// contain the given json or array. In other words, if we have a predicate
-// x @> y, this function should use the value of y to find the spans to scan
-// in an inverted index on x.
+// EncodeContainingInvertedIndexSpans returns the spans that must be scanned in
+// the inverted index to evaluate a contains (@>) predicate with the given
+// datum, which should be a container (either JSON or Array). These spans
+// should be used to find the objects in the index that contain the given json
+// or array. In other words, if we have a predicate x @> y, this function
+// should use the value of y to find the spans to scan in an inverted index on
+// x.
 //
 // The spans are returned in an inverted.SpanExpression, which represents the
 // set operations that must be applied on the spans read during execution. See
 // comments in the SpanExpression definition for details.
-//
-// The input inKey is prefixed to the keys in all returned spans.
 func EncodeContainingInvertedIndexSpans(
-	evalCtx *tree.EvalContext, val tree.Datum, inKey []byte, version descpb.IndexDescriptorVersion,
+	evalCtx *tree.EvalContext, val tree.Datum,
 ) (invertedExpr inverted.Expression, err error) {
 	if val == tree.DNull {
 		return nil, nil
@@ -854,13 +852,45 @@ func EncodeContainingInvertedIndexSpans(
 	datum := tree.UnwrapDatum(evalCtx, val)
 	switch val.ResolvedType().Family() {
 	case types.JsonFamily:
-		return json.EncodeContainingInvertedIndexSpans(inKey, val.(*tree.DJSON).JSON)
+		return json.EncodeContainingInvertedIndexSpans(nil /* inKey */, val.(*tree.DJSON).JSON)
 	case types.ArrayFamily:
-		return encodeContainingArrayInvertedIndexSpans(val.(*tree.DArray), inKey, version)
+		return encodeContainingArrayInvertedIndexSpans(val.(*tree.DArray), nil /* inKey */)
+	default:
+		return nil, errors.AssertionFailedf(
+			"trying to apply inverted index to unsupported type %s", datum.ResolvedType(),
+		)
 	}
-	return nil, errors.AssertionFailedf(
-		"trying to apply inverted index to unsupported type %s", datum.ResolvedType(),
-	)
+}
+
+// EncodeContainedInvertedIndexSpans returns the spans that must be scanned in
+// the inverted index to evaluate a contained by (<@) predicate with the given
+// datum, which should be a container (currently only Arrays, not JSON). These
+// spans should be used to find the objects in the index that could be
+// contained by the given json or array. In other words, if we have a predicate
+// x <@ y, this function should use the value of y to find the spans to scan in
+// an inverted index on x.
+//
+// The spans are returned in an inverted.SpanExpression, which represents the
+// set operations that must be applied on the spans read during execution. The
+// span expression returned will never be tight. See comments in the
+// SpanExpression definition for details.
+func EncodeContainedInvertedIndexSpans(
+	evalCtx *tree.EvalContext, val tree.Datum,
+) (invertedExpr inverted.Expression, err error) {
+	if val == tree.DNull {
+		return nil, nil
+	}
+	datum := tree.UnwrapDatum(evalCtx, val)
+	switch val.ResolvedType().Family() {
+	case types.ArrayFamily:
+		return encodeContainedArrayInvertedIndexSpans(val.(*tree.DArray), nil /* inKey */)
+	case types.JsonFamily:
+		return inverted.NonInvertedColExpression{}, nil
+	default:
+		return nil, errors.AssertionFailedf(
+			"trying to apply inverted index to unsupported type %s", datum.ResolvedType(),
+		)
+	}
 }
 
 // encodeArrayInvertedIndexTableKeys returns a list of inverted index keys for
@@ -869,8 +899,11 @@ func EncodeContainingInvertedIndexSpans(
 //
 // This function does not return keys for empty arrays or for NULL array elements
 // unless the version is at least descpb.EmptyArraysInInvertedIndexesVersion.
+// It also does not return keys for NULL array elements if excludeNulls is
+// true. This option is used by encodeContainedArrayInvertedIndexSpans, which
+// builds index spans to evaluate <@ (contained by) expressions.
 func encodeArrayInvertedIndexTableKeys(
-	val *tree.DArray, inKey []byte, version descpb.IndexDescriptorVersion,
+	val *tree.DArray, inKey []byte, version descpb.IndexDescriptorVersion, excludeNulls bool,
 ) (key [][]byte, err error) {
 	if val.Array.Len() == 0 {
 		if version >= descpb.EmptyArraysInInvertedIndexesVersion {
@@ -881,7 +914,7 @@ func encodeArrayInvertedIndexTableKeys(
 	outKeys := make([][]byte, 0, len(val.Array))
 	for i := range val.Array {
 		d := val.Array[i]
-		if d == tree.DNull && version < descpb.EmptyArraysInInvertedIndexesVersion {
+		if d == tree.DNull && (version < descpb.EmptyArraysInInvertedIndexesVersion || excludeNulls) {
 			// Older versions did not include null elements, but we must include them
 			// going forward since `SELECT ARRAY[NULL] @> ARRAY[]` returns true.
 			continue
@@ -906,7 +939,7 @@ func encodeArrayInvertedIndexTableKeys(
 // Returns unique=true if the spans are guaranteed not to produce
 // duplicate primary keys. Otherwise, returns unique=false.
 func encodeContainingArrayInvertedIndexSpans(
-	val *tree.DArray, inKey []byte, version descpb.IndexDescriptorVersion,
+	val *tree.DArray, inKey []byte,
 ) (invertedExpr inverted.Expression, err error) {
 	if val.Array.Len() == 0 {
 		// All arrays contain the empty array. Return a SpanExpression that
@@ -923,7 +956,7 @@ func encodeContainingArrayInvertedIndexSpans(
 		return &inverted.SpanExpression{Tight: true, Unique: true}, nil
 	}
 
-	keys, err := encodeArrayInvertedIndexTableKeys(val, inKey, version)
+	keys, err := encodeArrayInvertedIndexTableKeys(val, inKey, descpb.EmptyArraysInInvertedIndexesVersion, false /* excludeNulls */)
 	if err != nil {
 		return nil, err
 	}
@@ -938,6 +971,54 @@ func encodeContainingArrayInvertedIndexSpans(
 			invertedExpr = inverted.And(invertedExpr, spanExpr)
 		}
 	}
+	return invertedExpr, nil
+}
+
+// encodeContainedArrayInvertedIndexSpans returns the spans that must be
+// scanned in the inverted index to evaluate a contained by (<@) predicate with
+// the given array, one slice of spans per entry in the array. The input
+// inKey is prefixed to all returned keys.
+//
+// Returns unique=true if the spans are guaranteed not to produce
+// duplicate primary keys. Otherwise, returns unique=false.
+func encodeContainedArrayInvertedIndexSpans(
+	val *tree.DArray, inKey []byte,
+) (invertedExpr inverted.Expression, err error) {
+	// The empty array should always be added to the spans, since it is contained
+	// by everything.
+	emptyArrSpanExpr := inverted.ExprForSpan(
+		inverted.MakeSingleValSpan(encoding.EncodeEmptyArray(inKey)), false, /* tight */
+	)
+	emptyArrSpanExpr.Unique = true
+
+	// If the given array is empty, we return the SpanExpression.
+	if val.Array.Len() == 0 {
+		return emptyArrSpanExpr, nil
+	}
+
+	// We always exclude nulls from the list of keys when evaluating <@.
+	// This is because an expression like ARRAY[NULL] <@ ARRAY[NULL] is false,
+	// since NULL in SQL represents an unknown value.
+	keys, err := encodeArrayInvertedIndexTableKeys(val, inKey, descpb.EmptyArraysInInvertedIndexesVersion, true /* excludeNulls */)
+	if err != nil {
+		return nil, err
+	}
+	invertedExpr = emptyArrSpanExpr
+	for _, key := range keys {
+		spanExpr := inverted.ExprForSpan(
+			inverted.MakeSingleValSpan(key), false, /* tight */
+		)
+		invertedExpr = inverted.Or(invertedExpr, spanExpr)
+	}
+
+	// The inverted expression produced for <@ will never be tight.
+	// For example, if we are evaluating if indexed column x <@ ARRAY[1], the
+	// inverted expression would scan for all arrays in x that contain the
+	// empty array or ARRAY[1]. The resulting arrays could contain other values
+	// and would need to be passed through an additional filter. For example,
+	// ARRAY[1, 2, 3] would be returned by the scan, but it should be filtered
+	// out since ARRAY[1, 2, 3] <@ ARRAY[1] is false.
+	invertedExpr.SetNotTight()
 	return invertedExpr, nil
 }
 

--- a/pkg/sql/sem/tree/parse_array.go
+++ b/pkg/sql/sem/tree/parse_array.go
@@ -163,7 +163,7 @@ func ParseDArrayFromString(
 	return ret, dependsOnContext, nil
 }
 
-// doParseDArraryFromString does most of the work of ParseDArrayFromString,
+// doParseDArrayFromString does most of the work of ParseDArrayFromString,
 // except the error it returns isn't prettified as a parsing error.
 //
 // The dependsOnContext return value indicates if we had to consult the


### PR DESCRIPTION
Previously, we did not support index acceleration when checking if an indexed
column is <@ (contained by) a constant, or in other words, when the indexed
column is on the right side of a @> (contains) expression. We already perform
index acceleration for @> (contains) expressions where an indexed JSON or Array
column is on the left side of the expression.

This change adds support for using the inverted index with <@ expressions on
Array columns. When there is an inverted index available, a scan will be done on
the Array column using the spans found from the constant value. An additional
filter will then be applied, as the span expression will never be tight.
Support for JSON columns will be added later.

Informs: #59763

Release note (performance improvement): Some additional expressions using the <@ (contained by) and @> (contains) operators now support index-acceleration with the indexed column on either side of the expression.