### PR TITLE
sql: tolerate decoding errors in the stats cache

### DIFF
--- a/pkg/sql/stats/stats_cache_test.go
+++ b/pkg/sql/stats/stats_cache_test.go
@@ -335,7 +335,7 @@ func TestCacheUserDefinedTypes(t *testing.T) {
 CREATE DATABASE t;
 USE t;
 CREATE TYPE t AS ENUM ('hello');
-CREATE TABLE tt (x t PRIMARY KEY);
+CREATE TABLE tt (x t PRIMARY KEY, y INT, INDEX(y));
 INSERT INTO tt VALUES ('hello');
 CREATE STATISTICS s FROM tt;
 `); err != nil {
@@ -355,9 +355,28 @@ CREATE STATISTICS s FROM tt;
 	tbl := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "tt")
 	// Get stats for our table. We are ensuring here that the access to the stats
 	// for tt properly hydrates the user defined type t before access.
-	_, err := sc.GetTableStats(ctx, tbl.GetID())
+	stats, err := sc.GetTableStats(ctx, tbl.GetID())
 	if err != nil {
 		t.Fatal(err)
+	}
+	if len(stats) != 2 {
+		t.Errorf("expected two statistics (for x and y), got %d", len(stats))
+	}
+
+	// Drop the table and the type.
+	if _, err := sqlDB.Exec(`DROP TABLE tt; DROP TYPE t;`); err != nil {
+		t.Fatal(err)
+	}
+	// Purge the cache.
+	sc.InvalidateTableStats(ctx, tbl.GetID())
+	// Verify that GetTableStats ignores the statistic on the now unknown type and
+	// returns the rest.
+	stats, err = sc.GetTableStats(ctx, tbl.GetID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stats) != 1 {
+		t.Errorf("expected one statistic (for y), got %d", len(stats))
 	}
 }
 


### PR DESCRIPTION
We saw an issue related to backup where `GetTableStats` failed
because one of the statistics was on a user-defined type that does not
exist anymore.

This change makes `GetTableStats` more robust by ignoring statistics
that cannot be decoded (and returning the rest) instead of erroring
out. It now only returns errors if we could not query the system
table.

Release justification: low risk, high benefit change to existing
functionality.

Release note: None