### PR TITLE
colexecop: change Operator interface

### DIFF
--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -81,7 +81,7 @@ func (b *Bytes) AssertOffsetsAreNonDecreasing(n int) {
 
 // UpdateOffsetsToBeNonDecreasing makes sure that b.offsets[:n+1] are
 // non-decreasing which is an invariant that we need to maintain. It must be
-// called by the colexec.Operator that is modifying this Bytes before
+// called by the colexecop.Operator that is modifying this Bytes before
 // returning it as an output. A convenient place for this is Batch.SetLength()
 // method - we assume that *always*, before returning a batch, the length is
 // set on it.

--- a/pkg/col/coldatatestutils/random_testutils.go
+++ b/pkg/col/coldatatestutils/random_testutils.go
@@ -372,11 +372,11 @@ func NewRandomDataOp(
 	}
 }
 
-// Init is part of the colexec.Operator interface.
-func (o *RandomDataOp) Init() {}
+// Init is part of the colexecop.Operator interface.
+func (o *RandomDataOp) Init(context.Context) {}
 
-// Next is part of the colexec.Operator interface.
-func (o *RandomDataOp) Next(context.Context) coldata.Batch {
+// Next is part of the colexecop.Operator interface.
+func (o *RandomDataOp) Next() coldata.Batch {
 	if o.numReturned == o.numBatches {
 		// Done.
 		b := coldata.ZeroBatch

--- a/pkg/sql/colcontainer/diskqueue_test.go
+++ b/pkg/sql/colcontainer/diskqueue_test.go
@@ -76,6 +76,7 @@ func TestDiskQueue(t *testing.T) {
 							batches = append(batches, coldatatestutils.CopyBatch(b, typs, testColumnFactory))
 						},
 					})
+					op.Init(ctx)
 					typs := op.Typs()
 
 					queueCfg.CacheMode = diskQueueCacheMode
@@ -109,7 +110,7 @@ func TestDiskQueue(t *testing.T) {
 					// since that is the common pattern.
 					dest := coldata.NewMemBatch(typs, testColumnFactory)
 					for {
-						src := op.Next(ctx)
+						src := op.Next()
 						require.NoError(t, q.Enqueue(ctx, src))
 						if src.Length() == 0 {
 							break
@@ -241,7 +242,7 @@ func BenchmarkDiskQueue(b *testing.B) {
 		q, err := colcontainer.NewDiskQueue(ctx, typs, queueCfg, testDiskAcc)
 		require.NoError(b, err)
 		for {
-			batchToEnqueue := op.Next(ctx)
+			batchToEnqueue := op.Next()
 			if err := q.Enqueue(ctx, batchToEnqueue); err != nil {
 				b.Fatal(err)
 			}

--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -908,7 +908,7 @@ func TestAggregatorRandom(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					a.Init()
+					a.Init(context.Background())
 
 					testOutput := colexectestutils.NewOpTestOutput(a, expectedTuples)
 					if strings.Contains(agg.name, "hash") {
@@ -1067,9 +1067,9 @@ func benchmarkAggregateFunction(
 				if err != nil {
 					b.Fatal(err)
 				}
-				a.Init()
+				a.Init(ctx)
 				// Exhaust aggregator until all batches have been read.
-				for b := a.Next(ctx); b.Length() != 0; b = a.Next(ctx) {
+				for b := a.Next(); b.Length() != 0; b = a.Next() {
 				}
 				if err = a.(colexecop.Closer).Close(ctx); err != nil {
 					b.Fatal(err)

--- a/pkg/sql/colexec/aggregators_util.go
+++ b/pkg/sql/colexec/aggregators_util.go
@@ -189,7 +189,10 @@ func (h *filteringSingleFunctionHashHelper) applyFilter(
 		return vecs, inputLen, sel, false
 	}
 	h.filterInput.reset(vecs, inputLen, sel)
-	newBatch := h.filter.Next(ctx)
+	// Note that it is ok that we call Init on every iteration - it is a noop
+	// every time except for the first one.
+	h.filter.Init(ctx)
+	newBatch := h.filter.Next()
 	return newBatch.ColVecs(), newBatch.Length(), newBatch.Selection(), true
 }
 
@@ -514,9 +517,9 @@ func newSingleBatchOperator(
 	}
 }
 
-func (o *singleBatchOperator) Init() {}
+func (o *singleBatchOperator) Init(context.Context) {}
 
-func (o *singleBatchOperator) Next(context.Context) coldata.Batch {
+func (o *singleBatchOperator) Next() coldata.Batch {
 	if o.nexted {
 		return coldata.ZeroBatch
 	}

--- a/pkg/sql/colexec/and_or_projection.eg.go
+++ b/pkg/sql/colexec/and_or_projection.eg.go
@@ -107,6 +107,8 @@ func NewOrProjOp(
 }
 
 type andProjOp struct {
+	colexecop.InitHelper
+
 	allocator *colmem.Allocator
 	input     colexecop.Operator
 
@@ -166,11 +168,15 @@ func (o *andProjOp) Child(nth int, verbose bool) execinfra.OpNode {
 	}
 }
 
-func (o *andProjOp) Init() {
-	o.input.Init()
+// Init is part of the colexecop.Operator interface.
+func (o *andProjOp) Init(ctx context.Context) {
+	if !o.InitHelper.Init(ctx) {
+		return
+	}
+	o.input.Init(o.Ctx)
 }
 
-// Next is part of the Operator interface.
+// Next is part of the colexecop.Operator interface.
 // The idea to handle the short-circuiting logic is similar to what caseOp
 // does: a logical operator has an input and two projection chains. First,
 // it runs the left chain on the input batch. Then, it "subtracts" the
@@ -180,8 +186,8 @@ func (o *andProjOp) Init() {
 // side projection only on the remaining tuples (i.e. those that were not
 // "subtracted"). Next, it restores the original selection vector and
 // populates the result of the logical operation.
-func (o *andProjOp) Next(ctx context.Context) coldata.Batch {
-	batch := o.input.Next(ctx)
+func (o *andProjOp) Next() coldata.Batch {
+	batch := o.input.Next()
 	origLen := batch.Length()
 	if origLen == 0 {
 		return coldata.ZeroBatch
@@ -197,7 +203,7 @@ func (o *andProjOp) Next(ctx context.Context) coldata.Batch {
 	// here. First, we set the input batch for the left projection to run and
 	// actually run the projection.
 	o.leftFeedOp.SetBatch(batch)
-	batch = o.leftProjOpChain.Next(ctx)
+	batch = o.leftProjOpChain.Next()
 
 	// Now we need to populate a selection vector on the batch in such a way that
 	// those tuples that we already know the result of logical operation for do
@@ -272,7 +278,7 @@ func (o *andProjOp) Next(ctx context.Context) coldata.Batch {
 		// remaining tuples.
 		batch.SetLength(curIdx)
 		o.rightFeedOp.SetBatch(batch)
-		batch = o.rightProjOpChain.Next(ctx)
+		batch = o.rightProjOpChain.Next()
 		rightVec = batch.ColVec(o.rightIdx)
 		rightVals = rightVec.Bool()
 	}
@@ -545,6 +551,8 @@ func (o *andProjOp) Next(ctx context.Context) coldata.Batch {
 }
 
 type andRightNullProjOp struct {
+	colexecop.InitHelper
+
 	allocator *colmem.Allocator
 	input     colexecop.Operator
 
@@ -604,11 +612,15 @@ func (o *andRightNullProjOp) Child(nth int, verbose bool) execinfra.OpNode {
 	}
 }
 
-func (o *andRightNullProjOp) Init() {
-	o.input.Init()
+// Init is part of the colexecop.Operator interface.
+func (o *andRightNullProjOp) Init(ctx context.Context) {
+	if !o.InitHelper.Init(ctx) {
+		return
+	}
+	o.input.Init(o.Ctx)
 }
 
-// Next is part of the Operator interface.
+// Next is part of the colexecop.Operator interface.
 // The idea to handle the short-circuiting logic is similar to what caseOp
 // does: a logical operator has an input and two projection chains. First,
 // it runs the left chain on the input batch. Then, it "subtracts" the
@@ -618,8 +630,8 @@ func (o *andRightNullProjOp) Init() {
 // side projection only on the remaining tuples (i.e. those that were not
 // "subtracted"). Next, it restores the original selection vector and
 // populates the result of the logical operation.
-func (o *andRightNullProjOp) Next(ctx context.Context) coldata.Batch {
-	batch := o.input.Next(ctx)
+func (o *andRightNullProjOp) Next() coldata.Batch {
+	batch := o.input.Next()
 	origLen := batch.Length()
 	if origLen == 0 {
 		return coldata.ZeroBatch
@@ -635,7 +647,7 @@ func (o *andRightNullProjOp) Next(ctx context.Context) coldata.Batch {
 	// here. First, we set the input batch for the left projection to run and
 	// actually run the projection.
 	o.leftFeedOp.SetBatch(batch)
-	batch = o.leftProjOpChain.Next(ctx)
+	batch = o.leftProjOpChain.Next()
 
 	// Now we need to populate a selection vector on the batch in such a way that
 	// those tuples that we already know the result of logical operation for do
@@ -950,6 +962,8 @@ func (o *andRightNullProjOp) Next(ctx context.Context) coldata.Batch {
 }
 
 type andLeftNullProjOp struct {
+	colexecop.InitHelper
+
 	allocator *colmem.Allocator
 	input     colexecop.Operator
 
@@ -1009,11 +1023,15 @@ func (o *andLeftNullProjOp) Child(nth int, verbose bool) execinfra.OpNode {
 	}
 }
 
-func (o *andLeftNullProjOp) Init() {
-	o.input.Init()
+// Init is part of the colexecop.Operator interface.
+func (o *andLeftNullProjOp) Init(ctx context.Context) {
+	if !o.InitHelper.Init(ctx) {
+		return
+	}
+	o.input.Init(o.Ctx)
 }
 
-// Next is part of the Operator interface.
+// Next is part of the colexecop.Operator interface.
 // The idea to handle the short-circuiting logic is similar to what caseOp
 // does: a logical operator has an input and two projection chains. First,
 // it runs the left chain on the input batch. Then, it "subtracts" the
@@ -1023,8 +1041,8 @@ func (o *andLeftNullProjOp) Init() {
 // side projection only on the remaining tuples (i.e. those that were not
 // "subtracted"). Next, it restores the original selection vector and
 // populates the result of the logical operation.
-func (o *andLeftNullProjOp) Next(ctx context.Context) coldata.Batch {
-	batch := o.input.Next(ctx)
+func (o *andLeftNullProjOp) Next() coldata.Batch {
+	batch := o.input.Next()
 	origLen := batch.Length()
 	if origLen == 0 {
 		return coldata.ZeroBatch
@@ -1040,7 +1058,7 @@ func (o *andLeftNullProjOp) Next(ctx context.Context) coldata.Batch {
 	// here. First, we set the input batch for the left projection to run and
 	// actually run the projection.
 	o.leftFeedOp.SetBatch(batch)
-	batch = o.leftProjOpChain.Next(ctx)
+	batch = o.leftProjOpChain.Next()
 
 	// Now we need to populate a selection vector on the batch in such a way that
 	// those tuples that we already know the result of logical operation for do
@@ -1076,7 +1094,7 @@ func (o *andLeftNullProjOp) Next(ctx context.Context) coldata.Batch {
 		// remaining tuples.
 		batch.SetLength(curIdx)
 		o.rightFeedOp.SetBatch(batch)
-		batch = o.rightProjOpChain.Next(ctx)
+		batch = o.rightProjOpChain.Next()
 		rightVec = batch.ColVec(o.rightIdx)
 		rightVals = rightVec.Bool()
 	}
@@ -1336,6 +1354,8 @@ func (o *andLeftNullProjOp) Next(ctx context.Context) coldata.Batch {
 }
 
 type orProjOp struct {
+	colexecop.InitHelper
+
 	allocator *colmem.Allocator
 	input     colexecop.Operator
 
@@ -1395,11 +1415,15 @@ func (o *orProjOp) Child(nth int, verbose bool) execinfra.OpNode {
 	}
 }
 
-func (o *orProjOp) Init() {
-	o.input.Init()
+// Init is part of the colexecop.Operator interface.
+func (o *orProjOp) Init(ctx context.Context) {
+	if !o.InitHelper.Init(ctx) {
+		return
+	}
+	o.input.Init(o.Ctx)
 }
 
-// Next is part of the Operator interface.
+// Next is part of the colexecop.Operator interface.
 // The idea to handle the short-circuiting logic is similar to what caseOp
 // does: a logical operator has an input and two projection chains. First,
 // it runs the left chain on the input batch. Then, it "subtracts" the
@@ -1409,8 +1433,8 @@ func (o *orProjOp) Init() {
 // side projection only on the remaining tuples (i.e. those that were not
 // "subtracted"). Next, it restores the original selection vector and
 // populates the result of the logical operation.
-func (o *orProjOp) Next(ctx context.Context) coldata.Batch {
-	batch := o.input.Next(ctx)
+func (o *orProjOp) Next() coldata.Batch {
+	batch := o.input.Next()
 	origLen := batch.Length()
 	if origLen == 0 {
 		return coldata.ZeroBatch
@@ -1426,7 +1450,7 @@ func (o *orProjOp) Next(ctx context.Context) coldata.Batch {
 	// here. First, we set the input batch for the left projection to run and
 	// actually run the projection.
 	o.leftFeedOp.SetBatch(batch)
-	batch = o.leftProjOpChain.Next(ctx)
+	batch = o.leftProjOpChain.Next()
 
 	// Now we need to populate a selection vector on the batch in such a way that
 	// those tuples that we already know the result of logical operation for do
@@ -1502,7 +1526,7 @@ func (o *orProjOp) Next(ctx context.Context) coldata.Batch {
 		// remaining tuples.
 		batch.SetLength(curIdx)
 		o.rightFeedOp.SetBatch(batch)
-		batch = o.rightProjOpChain.Next(ctx)
+		batch = o.rightProjOpChain.Next()
 		rightVec = batch.ColVec(o.rightIdx)
 		rightVals = rightVec.Bool()
 	}
@@ -1775,6 +1799,8 @@ func (o *orProjOp) Next(ctx context.Context) coldata.Batch {
 }
 
 type orRightNullProjOp struct {
+	colexecop.InitHelper
+
 	allocator *colmem.Allocator
 	input     colexecop.Operator
 
@@ -1834,11 +1860,15 @@ func (o *orRightNullProjOp) Child(nth int, verbose bool) execinfra.OpNode {
 	}
 }
 
-func (o *orRightNullProjOp) Init() {
-	o.input.Init()
+// Init is part of the colexecop.Operator interface.
+func (o *orRightNullProjOp) Init(ctx context.Context) {
+	if !o.InitHelper.Init(ctx) {
+		return
+	}
+	o.input.Init(o.Ctx)
 }
 
-// Next is part of the Operator interface.
+// Next is part of the colexecop.Operator interface.
 // The idea to handle the short-circuiting logic is similar to what caseOp
 // does: a logical operator has an input and two projection chains. First,
 // it runs the left chain on the input batch. Then, it "subtracts" the
@@ -1848,8 +1878,8 @@ func (o *orRightNullProjOp) Init() {
 // side projection only on the remaining tuples (i.e. those that were not
 // "subtracted"). Next, it restores the original selection vector and
 // populates the result of the logical operation.
-func (o *orRightNullProjOp) Next(ctx context.Context) coldata.Batch {
-	batch := o.input.Next(ctx)
+func (o *orRightNullProjOp) Next() coldata.Batch {
+	batch := o.input.Next()
 	origLen := batch.Length()
 	if origLen == 0 {
 		return coldata.ZeroBatch
@@ -1865,7 +1895,7 @@ func (o *orRightNullProjOp) Next(ctx context.Context) coldata.Batch {
 	// here. First, we set the input batch for the left projection to run and
 	// actually run the projection.
 	o.leftFeedOp.SetBatch(batch)
-	batch = o.leftProjOpChain.Next(ctx)
+	batch = o.leftProjOpChain.Next()
 
 	// Now we need to populate a selection vector on the batch in such a way that
 	// those tuples that we already know the result of logical operation for do
@@ -2181,6 +2211,8 @@ func (o *orRightNullProjOp) Next(ctx context.Context) coldata.Batch {
 }
 
 type orLeftNullProjOp struct {
+	colexecop.InitHelper
+
 	allocator *colmem.Allocator
 	input     colexecop.Operator
 
@@ -2240,11 +2272,15 @@ func (o *orLeftNullProjOp) Child(nth int, verbose bool) execinfra.OpNode {
 	}
 }
 
-func (o *orLeftNullProjOp) Init() {
-	o.input.Init()
+// Init is part of the colexecop.Operator interface.
+func (o *orLeftNullProjOp) Init(ctx context.Context) {
+	if !o.InitHelper.Init(ctx) {
+		return
+	}
+	o.input.Init(o.Ctx)
 }
 
-// Next is part of the Operator interface.
+// Next is part of the colexecop.Operator interface.
 // The idea to handle the short-circuiting logic is similar to what caseOp
 // does: a logical operator has an input and two projection chains. First,
 // it runs the left chain on the input batch. Then, it "subtracts" the
@@ -2254,8 +2290,8 @@ func (o *orLeftNullProjOp) Init() {
 // side projection only on the remaining tuples (i.e. those that were not
 // "subtracted"). Next, it restores the original selection vector and
 // populates the result of the logical operation.
-func (o *orLeftNullProjOp) Next(ctx context.Context) coldata.Batch {
-	batch := o.input.Next(ctx)
+func (o *orLeftNullProjOp) Next() coldata.Batch {
+	batch := o.input.Next()
 	origLen := batch.Length()
 	if origLen == 0 {
 		return coldata.ZeroBatch
@@ -2271,7 +2307,7 @@ func (o *orLeftNullProjOp) Next(ctx context.Context) coldata.Batch {
 	// here. First, we set the input batch for the left projection to run and
 	// actually run the projection.
 	o.leftFeedOp.SetBatch(batch)
-	batch = o.leftProjOpChain.Next(ctx)
+	batch = o.leftProjOpChain.Next()
 
 	// Now we need to populate a selection vector on the batch in such a way that
 	// those tuples that we already know the result of logical operation for do
@@ -2308,7 +2344,7 @@ func (o *orLeftNullProjOp) Next(ctx context.Context) coldata.Batch {
 		// remaining tuples.
 		batch.SetLength(curIdx)
 		o.rightFeedOp.SetBatch(batch)
-		batch = o.rightProjOpChain.Next(ctx)
+		batch = o.rightProjOpChain.Next()
 		rightVec = batch.ColVec(o.rightIdx)
 		rightVals = rightVec.Bool()
 	}

--- a/pkg/sql/colexec/and_or_projection_test.go
+++ b/pkg/sql/colexec/and_or_projection_test.go
@@ -269,11 +269,11 @@ func benchmarkLogicalProjOp(
 		fmt.Sprintf("@1 %s @2", operation), false /* canFallbackToRowexec */, testMemAcc,
 	)
 	require.NoError(b, err)
-	logicalProjOp.Init()
+	logicalProjOp.Init(ctx)
 
 	b.SetBytes(int64(8 * coldata.BatchSize()))
 	for i := 0; i < b.N; i++ {
-		logicalProjOp.Next(ctx)
+		logicalProjOp.Next()
 	}
 }
 

--- a/pkg/sql/colexec/and_or_projection_tmpl.go
+++ b/pkg/sql/colexec/and_or_projection_tmpl.go
@@ -82,6 +82,8 @@ func New_OPERATIONProjOp(
 // {{range .Overloads}}
 
 type _OP_LOWERProjOp struct {
+	colexecop.InitHelper
+
 	allocator *colmem.Allocator
 	input     colexecop.Operator
 
@@ -141,11 +143,15 @@ func (o *_OP_LOWERProjOp) Child(nth int, verbose bool) execinfra.OpNode {
 	}
 }
 
-func (o *_OP_LOWERProjOp) Init() {
-	o.input.Init()
+// Init is part of the colexecop.Operator interface.
+func (o *_OP_LOWERProjOp) Init(ctx context.Context) {
+	if !o.InitHelper.Init(ctx) {
+		return
+	}
+	o.input.Init(o.Ctx)
 }
 
-// Next is part of the Operator interface.
+// Next is part of the colexecop.Operator interface.
 // The idea to handle the short-circuiting logic is similar to what caseOp
 // does: a logical operator has an input and two projection chains. First,
 // it runs the left chain on the input batch. Then, it "subtracts" the
@@ -155,8 +161,8 @@ func (o *_OP_LOWERProjOp) Init() {
 // side projection only on the remaining tuples (i.e. those that were not
 // "subtracted"). Next, it restores the original selection vector and
 // populates the result of the logical operation.
-func (o *_OP_LOWERProjOp) Next(ctx context.Context) coldata.Batch {
-	batch := o.input.Next(ctx)
+func (o *_OP_LOWERProjOp) Next() coldata.Batch {
+	batch := o.input.Next()
 	origLen := batch.Length()
 	if origLen == 0 {
 		return coldata.ZeroBatch
@@ -172,7 +178,7 @@ func (o *_OP_LOWERProjOp) Next(ctx context.Context) coldata.Batch {
 	// here. First, we set the input batch for the left projection to run and
 	// actually run the projection.
 	o.leftFeedOp.SetBatch(batch)
-	batch = o.leftProjOpChain.Next(ctx)
+	batch = o.leftProjOpChain.Next()
 
 	// Now we need to populate a selection vector on the batch in such a way that
 	// those tuples that we already know the result of logical operation for do
@@ -245,7 +251,7 @@ func (o *_OP_LOWERProjOp) Next(ctx context.Context) coldata.Batch {
 		// remaining tuples.
 		batch.SetLength(curIdx)
 		o.rightFeedOp.SetBatch(batch)
-		batch = o.rightProjOpChain.Next(ctx)
+		batch = o.rightProjOpChain.Next()
 		rightVec = batch.ColVec(o.rightIdx)
 		rightVals = rightVec.Bool()
 	}

--- a/pkg/sql/colexec/buffer_test.go
+++ b/pkg/sql/colexec/buffer_test.go
@@ -26,15 +26,14 @@ func TestBufferOp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
 	inputTuples := colexectestutils.Tuples{{int64(1)}, {int64(2)}, {int64(3)}}
 	input := colexectestutils.NewOpTestInput(testAllocator, coldata.BatchSize(), inputTuples, []*types.T{types.Int})
 	buffer := NewBufferOp(input).(*bufferOp)
-	buffer.Init()
+	buffer.Init(context.Background())
 
 	t.Run("TestBufferReturnsInputCorrectly", func(t *testing.T) {
-		buffer.advance(ctx)
-		b := buffer.Next(ctx)
+		buffer.advance()
+		b := buffer.Next()
 		require.Nil(t, b.Selection())
 		require.Equal(t, len(inputTuples), b.Length())
 		for i, val := range inputTuples {
@@ -42,7 +41,7 @@ func TestBufferOp(t *testing.T) {
 		}
 
 		// We've read over the batch, so we now should get a zero-length batch.
-		b = buffer.Next(ctx)
+		b = buffer.Next()
 		require.Nil(t, b.Selection())
 		require.Equal(t, 0, b.Length())
 	})

--- a/pkg/sql/colexec/builtin_funcs.go
+++ b/pkg/sql/colexec/builtin_funcs.go
@@ -11,8 +11,6 @@
 package colexec
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
@@ -24,7 +22,7 @@ import (
 )
 
 type defaultBuiltinFuncOperator struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	allocator           *colmem.Allocator
 	evalCtx             *tree.EvalContext
 	funcExpr            *tree.FuncExpr
@@ -40,12 +38,8 @@ type defaultBuiltinFuncOperator struct {
 
 var _ colexecop.Operator = &defaultBuiltinFuncOperator{}
 
-func (b *defaultBuiltinFuncOperator) Init() {
-	b.Input.Init()
-}
-
-func (b *defaultBuiltinFuncOperator) Next(ctx context.Context) coldata.Batch {
-	batch := b.Input.Next(ctx)
+func (b *defaultBuiltinFuncOperator) Next() coldata.Batch {
+	batch := b.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -127,7 +121,7 @@ func NewBuiltinFunctionOperator(
 		outputType := funcExpr.ResolvedType()
 		input = colexecutils.NewVectorTypeEnforcer(allocator, input, outputType, outputIdx)
 		return &defaultBuiltinFuncOperator{
-			OneInputNode:        colexecop.NewOneInputNode(input),
+			OneInputHelper:      colexecop.MakeOneInputHelper(input),
 			allocator:           allocator,
 			evalCtx:             evalCtx,
 			funcExpr:            funcExpr,

--- a/pkg/sql/colexec/builtin_funcs_test.go
+++ b/pkg/sql/colexec/builtin_funcs_test.go
@@ -135,12 +135,12 @@ func benchmarkBuiltinFunctions(b *testing.B, useSelectionVector bool, hasNulls b
 		"abs(@1)" /* projectingExpr */, false /* canFallbackToRowexec */, testMemAcc,
 	)
 	require.NoError(b, err)
-	op.Init()
+	op.Init(ctx)
 
 	b.SetBytes(int64(8 * coldata.BatchSize()))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		op.Next(ctx)
+		op.Next()
 	}
 }
 
@@ -193,7 +193,7 @@ func BenchmarkCompareSpecializedOperators(b *testing.B) {
 		b.Fatal(err)
 	}
 	defaultOp := &defaultBuiltinFuncOperator{
-		OneInputNode:        colexecop.NewOneInputNode(source),
+		OneInputHelper:      colexecop.MakeOneInputHelper(source),
 		allocator:           testAllocator,
 		evalCtx:             evalCtx,
 		funcExpr:            typedExpr.(*tree.FuncExpr),
@@ -205,19 +205,19 @@ func BenchmarkCompareSpecializedOperators(b *testing.B) {
 		row:                 make(tree.Datums, outputIdx),
 		argumentCols:        inputCols,
 	}
-	defaultOp.Init()
+	defaultOp.Init(ctx)
 
 	// Set up the specialized substring operator.
 	specOp := newSubstringOperator(
 		testAllocator, typs, inputCols, outputIdx, source,
 	)
-	specOp.Init()
+	specOp.Init(ctx)
 
 	b.Run("DefaultBuiltinOperator", func(b *testing.B) {
 		b.SetBytes(int64(len("hello there") * coldata.BatchSize()))
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			b := defaultOp.Next(ctx)
+			b := defaultOp.Next()
 			// Due to the flat byte updates, we have to reset the output
 			// bytes col after each next call.
 			b.ColVec(outputIdx).Bytes().Reset()
@@ -228,7 +228,7 @@ func BenchmarkCompareSpecializedOperators(b *testing.B) {
 		b.SetBytes(int64(len("hello there") * coldata.BatchSize()))
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			b := specOp.Next(ctx)
+			b := specOp.Next()
 			// Due to the flat byte updates, we have to reset the output
 			// bytes col after each next call.
 			b.ColVec(outputIdx).Bytes().Reset()

--- a/pkg/sql/colexec/case.go
+++ b/pkg/sql/colexec/case.go
@@ -24,6 +24,8 @@ import (
 )
 
 type caseOp struct {
+	colexecop.InitHelper
+
 	allocator *colmem.Allocator
 	buffer    *bufferOp
 
@@ -98,15 +100,18 @@ func NewCaseOp(
 	}
 }
 
-func (c *caseOp) Init() {
-	for i := range c.caseOps {
-		c.caseOps[i].Init()
+func (c *caseOp) Init(ctx context.Context) {
+	if !c.InitHelper.Init(ctx) {
+		return
 	}
-	c.elseOp.Init()
+	for i := range c.caseOps {
+		c.caseOps[i].Init(c.Ctx)
+	}
+	c.elseOp.Init(c.Ctx)
 }
 
-func (c *caseOp) Next(ctx context.Context) coldata.Batch {
-	c.buffer.advance(ctx)
+func (c *caseOp) Next() coldata.Batch {
+	c.buffer.advance()
 	origLen := c.buffer.batch.Length()
 	if origLen == 0 {
 		return coldata.ZeroBatch
@@ -140,7 +145,7 @@ func (c *caseOp) Next(ctx context.Context) coldata.Batch {
 			// Run the next case operator chain. It will project its THEN expression
 			// for all tuples that matched its WHEN expression and that were not
 			// already matched.
-			batch := c.caseOps[i].Next(ctx)
+			batch := c.caseOps[i].Next()
 			// The batch's projection column now additionally contains results for all
 			// of the tuples that passed the ith WHEN clause. The batch's selection
 			// vector is set to the same selection of tuples.
@@ -237,7 +242,7 @@ func (c *caseOp) Next(ctx context.Context) coldata.Batch {
 		// Finally, run the else operator, which will project into all tuples that
 		// are remaining in the selection vector (didn't match any case arms). Once
 		// that's done, restore the original selection vector and return the batch.
-		batch := c.elseOp.Next(ctx)
+		batch := c.elseOp.Next()
 		if batch.Length() > 0 {
 			inputCol := batch.ColVec(c.thenIdxs[len(c.thenIdxs)-1])
 			outputCol.Copy(

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -129,11 +129,11 @@ func wrapRowSources(
 	var c *colexec.Columnarizer
 	if proc.MustBeStreaming() {
 		c, err = colexec.NewStreamingColumnarizer(
-			ctx, colmem.NewAllocator(ctx, streamingMemAccount, factory), flowCtx, processorID, toWrap,
+			colmem.NewAllocator(ctx, streamingMemAccount, factory), flowCtx, processorID, toWrap,
 		)
 	} else {
 		c, err = colexec.NewBufferingColumnarizer(
-			ctx, colmem.NewAllocator(ctx, streamingMemAccount, factory), flowCtx, processorID, toWrap,
+			colmem.NewAllocator(ctx, streamingMemAccount, factory), flowCtx, processorID, toWrap,
 		)
 	}
 	return c, releasables, err

--- a/pkg/sql/colexec/colexecbase/cast.eg.go
+++ b/pkg/sql/colexec/colexecbase/cast.eg.go
@@ -42,10 +42,10 @@ func GetCastOperator(
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, toType, resultIdx)
 	if fromType.Family() == types.UnknownFamily {
 		return &castOpNullAny{
-			OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-			allocator:            allocator,
-			colIdx:               colIdx,
-			outputIdx:            resultIdx,
+			OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+			allocator:                allocator,
+			colIdx:                   colIdx,
+			outputIdx:                resultIdx,
 		}, nil
 	}
 	leftType, rightType := fromType, toType
@@ -60,11 +60,11 @@ func GetCastOperator(
 				case -1:
 				default:
 					return &castBoolBoolOp{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				}
 			case types.FloatFamily:
@@ -72,39 +72,39 @@ func GetCastOperator(
 				case -1:
 				default:
 					return &castBoolFloat64Op{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				}
 			case types.IntFamily:
 				switch rightType.Width() {
 				case 16:
 					return &castBoolInt16Op{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				case 32:
 					return &castBoolInt32Op{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				case -1:
 				default:
 					return &castBoolInt64Op{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				}
 			}
@@ -119,11 +119,11 @@ func GetCastOperator(
 				case -1:
 				default:
 					return &castDecimalBoolOp{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				}
 			case types.DecimalFamily:
@@ -131,11 +131,11 @@ func GetCastOperator(
 				case -1:
 				default:
 					return &castDecimalDecimalOp{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				}
 			}
@@ -148,28 +148,28 @@ func GetCastOperator(
 				switch rightType.Width() {
 				case 16:
 					return &castInt16Int16Op{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				case 32:
 					return &castInt16Int32Op{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				case -1:
 				default:
 					return &castInt16Int64Op{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				}
 			case types.BoolFamily:
@@ -177,11 +177,11 @@ func GetCastOperator(
 				case -1:
 				default:
 					return &castInt16BoolOp{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				}
 			case types.DecimalFamily:
@@ -189,11 +189,11 @@ func GetCastOperator(
 				case -1:
 				default:
 					return &castInt16DecimalOp{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				}
 			case types.FloatFamily:
@@ -201,11 +201,11 @@ func GetCastOperator(
 				case -1:
 				default:
 					return &castInt16Float64Op{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				}
 			}
@@ -215,28 +215,28 @@ func GetCastOperator(
 				switch rightType.Width() {
 				case 16:
 					return &castInt32Int16Op{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				case 32:
 					return &castInt32Int32Op{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				case -1:
 				default:
 					return &castInt32Int64Op{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				}
 			case types.BoolFamily:
@@ -244,11 +244,11 @@ func GetCastOperator(
 				case -1:
 				default:
 					return &castInt32BoolOp{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				}
 			case types.DecimalFamily:
@@ -256,11 +256,11 @@ func GetCastOperator(
 				case -1:
 				default:
 					return &castInt32DecimalOp{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				}
 			case types.FloatFamily:
@@ -268,11 +268,11 @@ func GetCastOperator(
 				case -1:
 				default:
 					return &castInt32Float64Op{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				}
 			}
@@ -283,28 +283,28 @@ func GetCastOperator(
 				switch rightType.Width() {
 				case 16:
 					return &castInt64Int16Op{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				case 32:
 					return &castInt64Int32Op{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				case -1:
 				default:
 					return &castInt64Int64Op{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				}
 			case types.BoolFamily:
@@ -312,11 +312,11 @@ func GetCastOperator(
 				case -1:
 				default:
 					return &castInt64BoolOp{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				}
 			case types.DecimalFamily:
@@ -324,11 +324,11 @@ func GetCastOperator(
 				case -1:
 				default:
 					return &castInt64DecimalOp{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				}
 			case types.FloatFamily:
@@ -336,11 +336,11 @@ func GetCastOperator(
 				case -1:
 				default:
 					return &castInt64Float64Op{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				}
 			}
@@ -355,11 +355,11 @@ func GetCastOperator(
 				case -1:
 				default:
 					return &castFloat64Float64Op{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				}
 			case types.BoolFamily:
@@ -367,11 +367,11 @@ func GetCastOperator(
 				case -1:
 				default:
 					return &castFloat64BoolOp{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				}
 			case types.DecimalFamily:
@@ -379,39 +379,39 @@ func GetCastOperator(
 				case -1:
 				default:
 					return &castFloat64DecimalOp{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				}
 			case types.IntFamily:
 				switch rightType.Width() {
 				case 16:
 					return &castFloat64Int16Op{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				case 32:
 					return &castFloat64Int32Op{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				case -1:
 				default:
 					return &castFloat64Int64Op{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				}
 			}
@@ -426,11 +426,11 @@ func GetCastOperator(
 				case -1:
 				default:
 					return &castDatumBoolOp{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				}
 			case typeconv.DatumVecCanonicalTypeFamily:
@@ -438,11 +438,11 @@ func GetCastOperator(
 				case -1:
 				default:
 					return &castDatumDatumOp{
-						OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-						allocator:            allocator,
-						colIdx:               colIdx,
-						outputIdx:            resultIdx,
-						toType:               toType,
+						OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+						allocator:                allocator,
+						colIdx:                   colIdx,
+						outputIdx:                resultIdx,
+						toType:                   toType,
 					}, nil
 				}
 			}
@@ -452,7 +452,7 @@ func GetCastOperator(
 }
 
 type castOpNullAny struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -461,12 +461,8 @@ type castOpNullAny struct {
 
 var _ colexecop.ClosableOperator = &castOpNullAny{}
 
-func (c *castOpNullAny) Init() {
-	c.Input.Init()
-}
-
-func (c *castOpNullAny) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castOpNullAny) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -506,7 +502,7 @@ func (c *castOpNullAny) Next(ctx context.Context) coldata.Batch {
 // probably require changing the way we handle cast overloads as well.
 
 type castBoolBoolOp struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -517,18 +513,14 @@ type castBoolBoolOp struct {
 var _ colexecop.ResettableOperator = &castBoolBoolOp{}
 var _ colexecop.ClosableOperator = &castBoolBoolOp{}
 
-func (c *castBoolBoolOp) Init() {
-	c.Input.Init()
-}
-
 func (c *castBoolBoolOp) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castBoolBoolOp) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castBoolBoolOp) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -611,7 +603,7 @@ func (c *castBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 }
 
 type castBoolFloat64Op struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -622,18 +614,14 @@ type castBoolFloat64Op struct {
 var _ colexecop.ResettableOperator = &castBoolFloat64Op{}
 var _ colexecop.ClosableOperator = &castBoolFloat64Op{}
 
-func (c *castBoolFloat64Op) Init() {
-	c.Input.Init()
-}
-
 func (c *castBoolFloat64Op) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castBoolFloat64Op) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castBoolFloat64Op) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -736,7 +724,7 @@ func (c *castBoolFloat64Op) Next(ctx context.Context) coldata.Batch {
 }
 
 type castBoolInt16Op struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -747,18 +735,14 @@ type castBoolInt16Op struct {
 var _ colexecop.ResettableOperator = &castBoolInt16Op{}
 var _ colexecop.ClosableOperator = &castBoolInt16Op{}
 
-func (c *castBoolInt16Op) Init() {
-	c.Input.Init()
-}
-
 func (c *castBoolInt16Op) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castBoolInt16Op) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castBoolInt16Op) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -861,7 +845,7 @@ func (c *castBoolInt16Op) Next(ctx context.Context) coldata.Batch {
 }
 
 type castBoolInt32Op struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -872,18 +856,14 @@ type castBoolInt32Op struct {
 var _ colexecop.ResettableOperator = &castBoolInt32Op{}
 var _ colexecop.ClosableOperator = &castBoolInt32Op{}
 
-func (c *castBoolInt32Op) Init() {
-	c.Input.Init()
-}
-
 func (c *castBoolInt32Op) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castBoolInt32Op) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castBoolInt32Op) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -986,7 +966,7 @@ func (c *castBoolInt32Op) Next(ctx context.Context) coldata.Batch {
 }
 
 type castBoolInt64Op struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -997,18 +977,14 @@ type castBoolInt64Op struct {
 var _ colexecop.ResettableOperator = &castBoolInt64Op{}
 var _ colexecop.ClosableOperator = &castBoolInt64Op{}
 
-func (c *castBoolInt64Op) Init() {
-	c.Input.Init()
-}
-
 func (c *castBoolInt64Op) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castBoolInt64Op) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castBoolInt64Op) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1111,7 +1087,7 @@ func (c *castBoolInt64Op) Next(ctx context.Context) coldata.Batch {
 }
 
 type castDecimalBoolOp struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -1122,18 +1098,14 @@ type castDecimalBoolOp struct {
 var _ colexecop.ResettableOperator = &castDecimalBoolOp{}
 var _ colexecop.ClosableOperator = &castDecimalBoolOp{}
 
-func (c *castDecimalBoolOp) Init() {
-	c.Input.Init()
-}
-
 func (c *castDecimalBoolOp) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castDecimalBoolOp) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castDecimalBoolOp) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1216,7 +1188,7 @@ func (c *castDecimalBoolOp) Next(ctx context.Context) coldata.Batch {
 }
 
 type castDecimalDecimalOp struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -1227,18 +1199,14 @@ type castDecimalDecimalOp struct {
 var _ colexecop.ResettableOperator = &castDecimalDecimalOp{}
 var _ colexecop.ClosableOperator = &castDecimalDecimalOp{}
 
-func (c *castDecimalDecimalOp) Init() {
-	c.Input.Init()
-}
-
 func (c *castDecimalDecimalOp) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castDecimalDecimalOp) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1341,7 +1309,7 @@ func (c *castDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 }
 
 type castInt16Int16Op struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -1352,18 +1320,14 @@ type castInt16Int16Op struct {
 var _ colexecop.ResettableOperator = &castInt16Int16Op{}
 var _ colexecop.ClosableOperator = &castInt16Int16Op{}
 
-func (c *castInt16Int16Op) Init() {
-	c.Input.Init()
-}
-
 func (c *castInt16Int16Op) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castInt16Int16Op) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castInt16Int16Op) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1446,7 +1410,7 @@ func (c *castInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 }
 
 type castInt16Int32Op struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -1457,18 +1421,14 @@ type castInt16Int32Op struct {
 var _ colexecop.ResettableOperator = &castInt16Int32Op{}
 var _ colexecop.ClosableOperator = &castInt16Int32Op{}
 
-func (c *castInt16Int32Op) Init() {
-	c.Input.Init()
-}
-
 func (c *castInt16Int32Op) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castInt16Int32Op) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castInt16Int32Op) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1559,7 +1519,7 @@ func (c *castInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 }
 
 type castInt16Int64Op struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -1570,18 +1530,14 @@ type castInt16Int64Op struct {
 var _ colexecop.ResettableOperator = &castInt16Int64Op{}
 var _ colexecop.ClosableOperator = &castInt16Int64Op{}
 
-func (c *castInt16Int64Op) Init() {
-	c.Input.Init()
-}
-
 func (c *castInt16Int64Op) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castInt16Int64Op) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castInt16Int64Op) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1672,7 +1628,7 @@ func (c *castInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 }
 
 type castInt16BoolOp struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -1683,18 +1639,14 @@ type castInt16BoolOp struct {
 var _ colexecop.ResettableOperator = &castInt16BoolOp{}
 var _ colexecop.ClosableOperator = &castInt16BoolOp{}
 
-func (c *castInt16BoolOp) Init() {
-	c.Input.Init()
-}
-
 func (c *castInt16BoolOp) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castInt16BoolOp) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castInt16BoolOp) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1785,7 +1737,7 @@ func (c *castInt16BoolOp) Next(ctx context.Context) coldata.Batch {
 }
 
 type castInt16DecimalOp struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -1796,18 +1748,14 @@ type castInt16DecimalOp struct {
 var _ colexecop.ResettableOperator = &castInt16DecimalOp{}
 var _ colexecop.ClosableOperator = &castInt16DecimalOp{}
 
-func (c *castInt16DecimalOp) Init() {
-	c.Input.Init()
-}
-
 func (c *castInt16DecimalOp) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castInt16DecimalOp) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1914,7 +1862,7 @@ func (c *castInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 }
 
 type castInt16Float64Op struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -1925,18 +1873,14 @@ type castInt16Float64Op struct {
 var _ colexecop.ResettableOperator = &castInt16Float64Op{}
 var _ colexecop.ClosableOperator = &castInt16Float64Op{}
 
-func (c *castInt16Float64Op) Init() {
-	c.Input.Init()
-}
-
 func (c *castInt16Float64Op) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castInt16Float64Op) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castInt16Float64Op) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2027,7 +1971,7 @@ func (c *castInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 }
 
 type castInt32Int16Op struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -2038,18 +1982,14 @@ type castInt32Int16Op struct {
 var _ colexecop.ResettableOperator = &castInt32Int16Op{}
 var _ colexecop.ClosableOperator = &castInt32Int16Op{}
 
-func (c *castInt32Int16Op) Init() {
-	c.Input.Init()
-}
-
 func (c *castInt32Int16Op) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castInt32Int16Op) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castInt32Int16Op) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2140,7 +2080,7 @@ func (c *castInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 }
 
 type castInt32Int32Op struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -2151,18 +2091,14 @@ type castInt32Int32Op struct {
 var _ colexecop.ResettableOperator = &castInt32Int32Op{}
 var _ colexecop.ClosableOperator = &castInt32Int32Op{}
 
-func (c *castInt32Int32Op) Init() {
-	c.Input.Init()
-}
-
 func (c *castInt32Int32Op) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castInt32Int32Op) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castInt32Int32Op) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2245,7 +2181,7 @@ func (c *castInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 }
 
 type castInt32Int64Op struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -2256,18 +2192,14 @@ type castInt32Int64Op struct {
 var _ colexecop.ResettableOperator = &castInt32Int64Op{}
 var _ colexecop.ClosableOperator = &castInt32Int64Op{}
 
-func (c *castInt32Int64Op) Init() {
-	c.Input.Init()
-}
-
 func (c *castInt32Int64Op) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castInt32Int64Op) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castInt32Int64Op) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2358,7 +2290,7 @@ func (c *castInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 }
 
 type castInt32BoolOp struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -2369,18 +2301,14 @@ type castInt32BoolOp struct {
 var _ colexecop.ResettableOperator = &castInt32BoolOp{}
 var _ colexecop.ClosableOperator = &castInt32BoolOp{}
 
-func (c *castInt32BoolOp) Init() {
-	c.Input.Init()
-}
-
 func (c *castInt32BoolOp) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castInt32BoolOp) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castInt32BoolOp) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2471,7 +2399,7 @@ func (c *castInt32BoolOp) Next(ctx context.Context) coldata.Batch {
 }
 
 type castInt32DecimalOp struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -2482,18 +2410,14 @@ type castInt32DecimalOp struct {
 var _ colexecop.ResettableOperator = &castInt32DecimalOp{}
 var _ colexecop.ClosableOperator = &castInt32DecimalOp{}
 
-func (c *castInt32DecimalOp) Init() {
-	c.Input.Init()
-}
-
 func (c *castInt32DecimalOp) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castInt32DecimalOp) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2600,7 +2524,7 @@ func (c *castInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 }
 
 type castInt32Float64Op struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -2611,18 +2535,14 @@ type castInt32Float64Op struct {
 var _ colexecop.ResettableOperator = &castInt32Float64Op{}
 var _ colexecop.ClosableOperator = &castInt32Float64Op{}
 
-func (c *castInt32Float64Op) Init() {
-	c.Input.Init()
-}
-
 func (c *castInt32Float64Op) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castInt32Float64Op) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castInt32Float64Op) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2713,7 +2633,7 @@ func (c *castInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 }
 
 type castInt64Int16Op struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -2724,18 +2644,14 @@ type castInt64Int16Op struct {
 var _ colexecop.ResettableOperator = &castInt64Int16Op{}
 var _ colexecop.ClosableOperator = &castInt64Int16Op{}
 
-func (c *castInt64Int16Op) Init() {
-	c.Input.Init()
-}
-
 func (c *castInt64Int16Op) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castInt64Int16Op) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castInt64Int16Op) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2826,7 +2742,7 @@ func (c *castInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 }
 
 type castInt64Int32Op struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -2837,18 +2753,14 @@ type castInt64Int32Op struct {
 var _ colexecop.ResettableOperator = &castInt64Int32Op{}
 var _ colexecop.ClosableOperator = &castInt64Int32Op{}
 
-func (c *castInt64Int32Op) Init() {
-	c.Input.Init()
-}
-
 func (c *castInt64Int32Op) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castInt64Int32Op) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castInt64Int32Op) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2939,7 +2851,7 @@ func (c *castInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 }
 
 type castInt64Int64Op struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -2950,18 +2862,14 @@ type castInt64Int64Op struct {
 var _ colexecop.ResettableOperator = &castInt64Int64Op{}
 var _ colexecop.ClosableOperator = &castInt64Int64Op{}
 
-func (c *castInt64Int64Op) Init() {
-	c.Input.Init()
-}
-
 func (c *castInt64Int64Op) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castInt64Int64Op) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castInt64Int64Op) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3044,7 +2952,7 @@ func (c *castInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 }
 
 type castInt64BoolOp struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -3055,18 +2963,14 @@ type castInt64BoolOp struct {
 var _ colexecop.ResettableOperator = &castInt64BoolOp{}
 var _ colexecop.ClosableOperator = &castInt64BoolOp{}
 
-func (c *castInt64BoolOp) Init() {
-	c.Input.Init()
-}
-
 func (c *castInt64BoolOp) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castInt64BoolOp) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castInt64BoolOp) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3157,7 +3061,7 @@ func (c *castInt64BoolOp) Next(ctx context.Context) coldata.Batch {
 }
 
 type castInt64DecimalOp struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -3168,18 +3072,14 @@ type castInt64DecimalOp struct {
 var _ colexecop.ResettableOperator = &castInt64DecimalOp{}
 var _ colexecop.ClosableOperator = &castInt64DecimalOp{}
 
-func (c *castInt64DecimalOp) Init() {
-	c.Input.Init()
-}
-
 func (c *castInt64DecimalOp) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castInt64DecimalOp) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3286,7 +3186,7 @@ func (c *castInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 }
 
 type castInt64Float64Op struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -3297,18 +3197,14 @@ type castInt64Float64Op struct {
 var _ colexecop.ResettableOperator = &castInt64Float64Op{}
 var _ colexecop.ClosableOperator = &castInt64Float64Op{}
 
-func (c *castInt64Float64Op) Init() {
-	c.Input.Init()
-}
-
 func (c *castInt64Float64Op) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castInt64Float64Op) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castInt64Float64Op) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3399,7 +3295,7 @@ func (c *castInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 }
 
 type castFloat64Float64Op struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -3410,18 +3306,14 @@ type castFloat64Float64Op struct {
 var _ colexecop.ResettableOperator = &castFloat64Float64Op{}
 var _ colexecop.ClosableOperator = &castFloat64Float64Op{}
 
-func (c *castFloat64Float64Op) Init() {
-	c.Input.Init()
-}
-
 func (c *castFloat64Float64Op) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castFloat64Float64Op) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3504,7 +3396,7 @@ func (c *castFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 }
 
 type castFloat64BoolOp struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -3515,18 +3407,14 @@ type castFloat64BoolOp struct {
 var _ colexecop.ResettableOperator = &castFloat64BoolOp{}
 var _ colexecop.ClosableOperator = &castFloat64BoolOp{}
 
-func (c *castFloat64BoolOp) Init() {
-	c.Input.Init()
-}
-
 func (c *castFloat64BoolOp) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castFloat64BoolOp) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castFloat64BoolOp) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3617,7 +3505,7 @@ func (c *castFloat64BoolOp) Next(ctx context.Context) coldata.Batch {
 }
 
 type castFloat64DecimalOp struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -3628,18 +3516,14 @@ type castFloat64DecimalOp struct {
 var _ colexecop.ResettableOperator = &castFloat64DecimalOp{}
 var _ colexecop.ClosableOperator = &castFloat64DecimalOp{}
 
-func (c *castFloat64DecimalOp) Init() {
-	c.Input.Init()
-}
-
 func (c *castFloat64DecimalOp) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castFloat64DecimalOp) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3754,7 +3638,7 @@ func (c *castFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 }
 
 type castFloat64Int16Op struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -3765,18 +3649,14 @@ type castFloat64Int16Op struct {
 var _ colexecop.ResettableOperator = &castFloat64Int16Op{}
 var _ colexecop.ClosableOperator = &castFloat64Int16Op{}
 
-func (c *castFloat64Int16Op) Init() {
-	c.Input.Init()
-}
-
 func (c *castFloat64Int16Op) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castFloat64Int16Op) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3879,7 +3759,7 @@ func (c *castFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 }
 
 type castFloat64Int32Op struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -3890,18 +3770,14 @@ type castFloat64Int32Op struct {
 var _ colexecop.ResettableOperator = &castFloat64Int32Op{}
 var _ colexecop.ClosableOperator = &castFloat64Int32Op{}
 
-func (c *castFloat64Int32Op) Init() {
-	c.Input.Init()
-}
-
 func (c *castFloat64Int32Op) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castFloat64Int32Op) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -4004,7 +3880,7 @@ func (c *castFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 }
 
 type castFloat64Int64Op struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -4015,18 +3891,14 @@ type castFloat64Int64Op struct {
 var _ colexecop.ResettableOperator = &castFloat64Int64Op{}
 var _ colexecop.ClosableOperator = &castFloat64Int64Op{}
 
-func (c *castFloat64Int64Op) Init() {
-	c.Input.Init()
-}
-
 func (c *castFloat64Int64Op) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castFloat64Int64Op) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -4129,7 +4001,7 @@ func (c *castFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 }
 
 type castDatumBoolOp struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -4140,18 +4012,14 @@ type castDatumBoolOp struct {
 var _ colexecop.ResettableOperator = &castDatumBoolOp{}
 var _ colexecop.ClosableOperator = &castDatumBoolOp{}
 
-func (c *castDatumBoolOp) Init() {
-	c.Input.Init()
-}
-
 func (c *castDatumBoolOp) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castDatumBoolOp) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castDatumBoolOp) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -4266,7 +4134,7 @@ func (c *castDatumBoolOp) Next(ctx context.Context) coldata.Batch {
 }
 
 type castDatumDatumOp struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	allocator *colmem.Allocator
 	colIdx    int
@@ -4277,18 +4145,14 @@ type castDatumDatumOp struct {
 var _ colexecop.ResettableOperator = &castDatumDatumOp{}
 var _ colexecop.ClosableOperator = &castDatumDatumOp{}
 
-func (c *castDatumDatumOp) Init() {
-	c.Input.Init()
-}
-
 func (c *castDatumDatumOp) Reset(ctx context.Context) {
 	if r, ok := c.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
 	}
 }
 
-func (c *castDatumDatumOp) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c *castDatumDatumOp) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch

--- a/pkg/sql/colexec/colexecbase/cast_test.go
+++ b/pkg/sql/colexec/colexecbase/cast_test.go
@@ -199,9 +199,9 @@ func BenchmarkCastOp(b *testing.B) {
 						require.NoError(b, err)
 						b.SetBytes(int64(8 * coldata.BatchSize()))
 						b.ResetTimer()
-						op.Init()
+						op.Init(ctx)
 						for i := 0; i < b.N; i++ {
-							op.Next(ctx)
+							op.Next()
 						}
 					})
 			}

--- a/pkg/sql/colexec/colexecbase/const.eg.go
+++ b/pkg/sql/colexec/colexecbase/const.eg.go
@@ -10,7 +10,6 @@
 package colexecbase
 
 import (
-	"context"
 	"time"
 
 	"github.com/cockroachdb/apd/v2"
@@ -49,10 +48,10 @@ func NewConstOp(
 		case -1:
 		default:
 			return &constBoolOp{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				allocator:    allocator,
-				outputIdx:    outputIdx,
-				constVal:     constVal.(bool),
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				allocator:      allocator,
+				outputIdx:      outputIdx,
+				constVal:       constVal.(bool),
 			}, nil
 		}
 	case types.BytesFamily:
@@ -60,10 +59,10 @@ func NewConstOp(
 		case -1:
 		default:
 			return &constBytesOp{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				allocator:    allocator,
-				outputIdx:    outputIdx,
-				constVal:     constVal.([]byte),
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				allocator:      allocator,
+				outputIdx:      outputIdx,
+				constVal:       constVal.([]byte),
 			}, nil
 		}
 	case types.DecimalFamily:
@@ -71,35 +70,35 @@ func NewConstOp(
 		case -1:
 		default:
 			return &constDecimalOp{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				allocator:    allocator,
-				outputIdx:    outputIdx,
-				constVal:     constVal.(apd.Decimal),
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				allocator:      allocator,
+				outputIdx:      outputIdx,
+				constVal:       constVal.(apd.Decimal),
 			}, nil
 		}
 	case types.IntFamily:
 		switch t.Width() {
 		case 16:
 			return &constInt16Op{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				allocator:    allocator,
-				outputIdx:    outputIdx,
-				constVal:     constVal.(int16),
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				allocator:      allocator,
+				outputIdx:      outputIdx,
+				constVal:       constVal.(int16),
 			}, nil
 		case 32:
 			return &constInt32Op{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				allocator:    allocator,
-				outputIdx:    outputIdx,
-				constVal:     constVal.(int32),
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				allocator:      allocator,
+				outputIdx:      outputIdx,
+				constVal:       constVal.(int32),
 			}, nil
 		case -1:
 		default:
 			return &constInt64Op{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				allocator:    allocator,
-				outputIdx:    outputIdx,
-				constVal:     constVal.(int64),
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				allocator:      allocator,
+				outputIdx:      outputIdx,
+				constVal:       constVal.(int64),
 			}, nil
 		}
 	case types.FloatFamily:
@@ -107,10 +106,10 @@ func NewConstOp(
 		case -1:
 		default:
 			return &constFloat64Op{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				allocator:    allocator,
-				outputIdx:    outputIdx,
-				constVal:     constVal.(float64),
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				allocator:      allocator,
+				outputIdx:      outputIdx,
+				constVal:       constVal.(float64),
 			}, nil
 		}
 	case types.TimestampTZFamily:
@@ -118,10 +117,10 @@ func NewConstOp(
 		case -1:
 		default:
 			return &constTimestampOp{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				allocator:    allocator,
-				outputIdx:    outputIdx,
-				constVal:     constVal.(time.Time),
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				allocator:      allocator,
+				outputIdx:      outputIdx,
+				constVal:       constVal.(time.Time),
 			}, nil
 		}
 	case types.IntervalFamily:
@@ -129,10 +128,10 @@ func NewConstOp(
 		case -1:
 		default:
 			return &constIntervalOp{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				allocator:    allocator,
-				outputIdx:    outputIdx,
-				constVal:     constVal.(duration.Duration),
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				allocator:      allocator,
+				outputIdx:      outputIdx,
+				constVal:       constVal.(duration.Duration),
 			}, nil
 		}
 	case types.JsonFamily:
@@ -140,10 +139,10 @@ func NewConstOp(
 		case -1:
 		default:
 			return &constJSONOp{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				allocator:    allocator,
-				outputIdx:    outputIdx,
-				constVal:     constVal.(json.JSON),
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				allocator:      allocator,
+				outputIdx:      outputIdx,
+				constVal:       constVal.(json.JSON),
 			}, nil
 		}
 	case typeconv.DatumVecCanonicalTypeFamily:
@@ -151,10 +150,10 @@ func NewConstOp(
 		case -1:
 		default:
 			return &constDatumOp{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				allocator:    allocator,
-				outputIdx:    outputIdx,
-				constVal:     constVal.(interface{}),
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				allocator:      allocator,
+				outputIdx:      outputIdx,
+				constVal:       constVal.(interface{}),
 			}, nil
 		}
 	}
@@ -162,19 +161,15 @@ func NewConstOp(
 }
 
 type constBoolOp struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	allocator *colmem.Allocator
 	outputIdx int
 	constVal  bool
 }
 
-func (c constBoolOp) Init() {
-	c.Input.Init()
-}
-
-func (c constBoolOp) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c constBoolOp) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -210,19 +205,15 @@ func (c constBoolOp) Next(ctx context.Context) coldata.Batch {
 }
 
 type constBytesOp struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	allocator *colmem.Allocator
 	outputIdx int
 	constVal  []byte
 }
 
-func (c constBytesOp) Init() {
-	c.Input.Init()
-}
-
-func (c constBytesOp) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c constBytesOp) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -257,19 +248,15 @@ func (c constBytesOp) Next(ctx context.Context) coldata.Batch {
 }
 
 type constDecimalOp struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	allocator *colmem.Allocator
 	outputIdx int
 	constVal  apd.Decimal
 }
 
-func (c constDecimalOp) Init() {
-	c.Input.Init()
-}
-
-func (c constDecimalOp) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c constDecimalOp) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -305,19 +292,15 @@ func (c constDecimalOp) Next(ctx context.Context) coldata.Batch {
 }
 
 type constInt16Op struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	allocator *colmem.Allocator
 	outputIdx int
 	constVal  int16
 }
 
-func (c constInt16Op) Init() {
-	c.Input.Init()
-}
-
-func (c constInt16Op) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c constInt16Op) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -353,19 +336,15 @@ func (c constInt16Op) Next(ctx context.Context) coldata.Batch {
 }
 
 type constInt32Op struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	allocator *colmem.Allocator
 	outputIdx int
 	constVal  int32
 }
 
-func (c constInt32Op) Init() {
-	c.Input.Init()
-}
-
-func (c constInt32Op) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c constInt32Op) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -401,19 +380,15 @@ func (c constInt32Op) Next(ctx context.Context) coldata.Batch {
 }
 
 type constInt64Op struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	allocator *colmem.Allocator
 	outputIdx int
 	constVal  int64
 }
 
-func (c constInt64Op) Init() {
-	c.Input.Init()
-}
-
-func (c constInt64Op) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c constInt64Op) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -449,19 +424,15 @@ func (c constInt64Op) Next(ctx context.Context) coldata.Batch {
 }
 
 type constFloat64Op struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	allocator *colmem.Allocator
 	outputIdx int
 	constVal  float64
 }
 
-func (c constFloat64Op) Init() {
-	c.Input.Init()
-}
-
-func (c constFloat64Op) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c constFloat64Op) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -497,19 +468,15 @@ func (c constFloat64Op) Next(ctx context.Context) coldata.Batch {
 }
 
 type constTimestampOp struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	allocator *colmem.Allocator
 	outputIdx int
 	constVal  time.Time
 }
 
-func (c constTimestampOp) Init() {
-	c.Input.Init()
-}
-
-func (c constTimestampOp) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c constTimestampOp) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -545,19 +512,15 @@ func (c constTimestampOp) Next(ctx context.Context) coldata.Batch {
 }
 
 type constIntervalOp struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	allocator *colmem.Allocator
 	outputIdx int
 	constVal  duration.Duration
 }
 
-func (c constIntervalOp) Init() {
-	c.Input.Init()
-}
-
-func (c constIntervalOp) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c constIntervalOp) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -593,19 +556,15 @@ func (c constIntervalOp) Next(ctx context.Context) coldata.Batch {
 }
 
 type constJSONOp struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	allocator *colmem.Allocator
 	outputIdx int
 	constVal  json.JSON
 }
 
-func (c constJSONOp) Init() {
-	c.Input.Init()
-}
-
-func (c constJSONOp) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c constJSONOp) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -640,19 +599,15 @@ func (c constJSONOp) Next(ctx context.Context) coldata.Batch {
 }
 
 type constDatumOp struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	allocator *colmem.Allocator
 	outputIdx int
 	constVal  interface{}
 }
 
-func (c constDatumOp) Init() {
-	c.Input.Init()
-}
-
-func (c constDatumOp) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c constDatumOp) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -693,24 +648,20 @@ func NewConstNullOp(
 ) colexecop.Operator {
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, types.Unknown, outputIdx)
 	return &constNullOp{
-		OneInputNode: colexecop.NewOneInputNode(input),
-		outputIdx:    outputIdx,
+		OneInputHelper: colexecop.MakeOneInputHelper(input),
+		outputIdx:      outputIdx,
 	}
 }
 
 type constNullOp struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	outputIdx int
 }
 
 var _ colexecop.Operator = &constNullOp{}
 
-func (c constNullOp) Init() {
-	c.Input.Init()
-}
-
-func (c constNullOp) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c constNullOp) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch

--- a/pkg/sql/colexec/colexecbase/const_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/const_tmpl.go
@@ -20,8 +20,6 @@
 package colexecbase
 
 import (
-	"context"
-
 	"github.com/cockroachdb/apd/v2"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
@@ -75,10 +73,10 @@ func NewConstOp(
 		// {{range .WidthOverloads}}
 		case _TYPE_WIDTH:
 			return &const_TYPEOp{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				allocator:    allocator,
-				outputIdx:    outputIdx,
-				constVal:     constVal.(_GOTYPE),
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				allocator:      allocator,
+				outputIdx:      outputIdx,
+				constVal:       constVal.(_GOTYPE),
 			}, nil
 			// {{end}}
 		}
@@ -91,19 +89,15 @@ func NewConstOp(
 // {{range .WidthOverloads}}
 
 type const_TYPEOp struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	allocator *colmem.Allocator
 	outputIdx int
 	constVal  _GOTYPE
 }
 
-func (c const_TYPEOp) Init() {
-	c.Input.Init()
-}
-
-func (c const_TYPEOp) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c const_TYPEOp) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -150,24 +144,20 @@ func NewConstNullOp(
 ) colexecop.Operator {
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, types.Unknown, outputIdx)
 	return &constNullOp{
-		OneInputNode: colexecop.NewOneInputNode(input),
-		outputIdx:    outputIdx,
+		OneInputHelper: colexecop.MakeOneInputHelper(input),
+		outputIdx:      outputIdx,
 	}
 }
 
 type constNullOp struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	outputIdx int
 }
 
 var _ colexecop.Operator = &constNullOp{}
 
-func (c constNullOp) Init() {
-	c.Input.Init()
-}
-
-func (c constNullOp) Next(ctx context.Context) coldata.Batch {
-	batch := c.Input.Next(ctx)
+func (c constNullOp) Next() coldata.Batch {
+	batch := c.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch

--- a/pkg/sql/colexec/colexecbase/distinct.eg.go
+++ b/pkg/sql/colexec/colexecbase/distinct.eg.go
@@ -38,7 +38,7 @@ func newSingleDistinct(
 		case -1:
 		default:
 			return &distinctBoolOp{
-				OneInputNode:   colexecop.NewOneInputNode(input),
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
 				distinctColIdx: distinctColIdx,
 				outputCol:      outputCol,
 			}, nil
@@ -48,7 +48,7 @@ func newSingleDistinct(
 		case -1:
 		default:
 			return &distinctBytesOp{
-				OneInputNode:   colexecop.NewOneInputNode(input),
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
 				distinctColIdx: distinctColIdx,
 				outputCol:      outputCol,
 			}, nil
@@ -58,7 +58,7 @@ func newSingleDistinct(
 		case -1:
 		default:
 			return &distinctDecimalOp{
-				OneInputNode:   colexecop.NewOneInputNode(input),
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
 				distinctColIdx: distinctColIdx,
 				outputCol:      outputCol,
 			}, nil
@@ -67,20 +67,20 @@ func newSingleDistinct(
 		switch t.Width() {
 		case 16:
 			return &distinctInt16Op{
-				OneInputNode:   colexecop.NewOneInputNode(input),
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
 				distinctColIdx: distinctColIdx,
 				outputCol:      outputCol,
 			}, nil
 		case 32:
 			return &distinctInt32Op{
-				OneInputNode:   colexecop.NewOneInputNode(input),
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
 				distinctColIdx: distinctColIdx,
 				outputCol:      outputCol,
 			}, nil
 		case -1:
 		default:
 			return &distinctInt64Op{
-				OneInputNode:   colexecop.NewOneInputNode(input),
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
 				distinctColIdx: distinctColIdx,
 				outputCol:      outputCol,
 			}, nil
@@ -90,7 +90,7 @@ func newSingleDistinct(
 		case -1:
 		default:
 			return &distinctFloat64Op{
-				OneInputNode:   colexecop.NewOneInputNode(input),
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
 				distinctColIdx: distinctColIdx,
 				outputCol:      outputCol,
 			}, nil
@@ -100,7 +100,7 @@ func newSingleDistinct(
 		case -1:
 		default:
 			return &distinctTimestampOp{
-				OneInputNode:   colexecop.NewOneInputNode(input),
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
 				distinctColIdx: distinctColIdx,
 				outputCol:      outputCol,
 			}, nil
@@ -110,7 +110,7 @@ func newSingleDistinct(
 		case -1:
 		default:
 			return &distinctIntervalOp{
-				OneInputNode:   colexecop.NewOneInputNode(input),
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
 				distinctColIdx: distinctColIdx,
 				outputCol:      outputCol,
 			}, nil
@@ -120,7 +120,7 @@ func newSingleDistinct(
 		case -1:
 		default:
 			return &distinctJSONOp{
-				OneInputNode:   colexecop.NewOneInputNode(input),
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
 				distinctColIdx: distinctColIdx,
 				outputCol:      outputCol,
 			}, nil
@@ -130,7 +130,7 @@ func newSingleDistinct(
 		case -1:
 		default:
 			return &distinctDatumOp{
-				OneInputNode:   colexecop.NewOneInputNode(input),
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
 				distinctColIdx: distinctColIdx,
 				outputCol:      outputCol,
 			}, nil
@@ -151,7 +151,7 @@ type distinctBoolOp struct {
 	// still works across batch boundaries.
 	lastVal bool
 
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	// distinctColIdx is the index of the column to distinct upon.
 	distinctColIdx int
@@ -165,10 +165,6 @@ type distinctBoolOp struct {
 
 var _ colexecop.ResettableOperator = &distinctBoolOp{}
 
-func (p *distinctBoolOp) Init() {
-	p.Input.Init()
-}
-
 func (p *distinctBoolOp) Reset(ctx context.Context) {
 	p.foundFirstRow = false
 	p.lastValNull = false
@@ -177,8 +173,8 @@ func (p *distinctBoolOp) Reset(ctx context.Context) {
 	}
 }
 
-func (p *distinctBoolOp) Next(ctx context.Context) coldata.Batch {
-	batch := p.Input.Next(ctx)
+func (p *distinctBoolOp) Next() coldata.Batch {
+	batch := p.Input.Next()
 	if batch.Length() == 0 {
 		return batch
 	}
@@ -417,7 +413,7 @@ type distinctBytesOp struct {
 	// still works across batch boundaries.
 	lastVal []byte
 
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	// distinctColIdx is the index of the column to distinct upon.
 	distinctColIdx int
@@ -431,10 +427,6 @@ type distinctBytesOp struct {
 
 var _ colexecop.ResettableOperator = &distinctBytesOp{}
 
-func (p *distinctBytesOp) Init() {
-	p.Input.Init()
-}
-
 func (p *distinctBytesOp) Reset(ctx context.Context) {
 	p.foundFirstRow = false
 	p.lastValNull = false
@@ -443,8 +435,8 @@ func (p *distinctBytesOp) Reset(ctx context.Context) {
 	}
 }
 
-func (p *distinctBytesOp) Next(ctx context.Context) coldata.Batch {
-	batch := p.Input.Next(ctx)
+func (p *distinctBytesOp) Next() coldata.Batch {
+	batch := p.Input.Next()
 	if batch.Length() == 0 {
 		return batch
 	}
@@ -651,7 +643,7 @@ type distinctDecimalOp struct {
 	// still works across batch boundaries.
 	lastVal apd.Decimal
 
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	// distinctColIdx is the index of the column to distinct upon.
 	distinctColIdx int
@@ -665,10 +657,6 @@ type distinctDecimalOp struct {
 
 var _ colexecop.ResettableOperator = &distinctDecimalOp{}
 
-func (p *distinctDecimalOp) Init() {
-	p.Input.Init()
-}
-
 func (p *distinctDecimalOp) Reset(ctx context.Context) {
 	p.foundFirstRow = false
 	p.lastValNull = false
@@ -677,8 +665,8 @@ func (p *distinctDecimalOp) Reset(ctx context.Context) {
 	}
 }
 
-func (p *distinctDecimalOp) Next(ctx context.Context) coldata.Batch {
-	batch := p.Input.Next(ctx)
+func (p *distinctDecimalOp) Next() coldata.Batch {
+	batch := p.Input.Next()
 	if batch.Length() == 0 {
 		return batch
 	}
@@ -885,7 +873,7 @@ type distinctInt16Op struct {
 	// still works across batch boundaries.
 	lastVal int16
 
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	// distinctColIdx is the index of the column to distinct upon.
 	distinctColIdx int
@@ -899,10 +887,6 @@ type distinctInt16Op struct {
 
 var _ colexecop.ResettableOperator = &distinctInt16Op{}
 
-func (p *distinctInt16Op) Init() {
-	p.Input.Init()
-}
-
 func (p *distinctInt16Op) Reset(ctx context.Context) {
 	p.foundFirstRow = false
 	p.lastValNull = false
@@ -911,8 +895,8 @@ func (p *distinctInt16Op) Reset(ctx context.Context) {
 	}
 }
 
-func (p *distinctInt16Op) Next(ctx context.Context) coldata.Batch {
-	batch := p.Input.Next(ctx)
+func (p *distinctInt16Op) Next() coldata.Batch {
+	batch := p.Input.Next()
 	if batch.Length() == 0 {
 		return batch
 	}
@@ -1163,7 +1147,7 @@ type distinctInt32Op struct {
 	// still works across batch boundaries.
 	lastVal int32
 
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	// distinctColIdx is the index of the column to distinct upon.
 	distinctColIdx int
@@ -1177,10 +1161,6 @@ type distinctInt32Op struct {
 
 var _ colexecop.ResettableOperator = &distinctInt32Op{}
 
-func (p *distinctInt32Op) Init() {
-	p.Input.Init()
-}
-
 func (p *distinctInt32Op) Reset(ctx context.Context) {
 	p.foundFirstRow = false
 	p.lastValNull = false
@@ -1189,8 +1169,8 @@ func (p *distinctInt32Op) Reset(ctx context.Context) {
 	}
 }
 
-func (p *distinctInt32Op) Next(ctx context.Context) coldata.Batch {
-	batch := p.Input.Next(ctx)
+func (p *distinctInt32Op) Next() coldata.Batch {
+	batch := p.Input.Next()
 	if batch.Length() == 0 {
 		return batch
 	}
@@ -1441,7 +1421,7 @@ type distinctInt64Op struct {
 	// still works across batch boundaries.
 	lastVal int64
 
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	// distinctColIdx is the index of the column to distinct upon.
 	distinctColIdx int
@@ -1455,10 +1435,6 @@ type distinctInt64Op struct {
 
 var _ colexecop.ResettableOperator = &distinctInt64Op{}
 
-func (p *distinctInt64Op) Init() {
-	p.Input.Init()
-}
-
 func (p *distinctInt64Op) Reset(ctx context.Context) {
 	p.foundFirstRow = false
 	p.lastValNull = false
@@ -1467,8 +1443,8 @@ func (p *distinctInt64Op) Reset(ctx context.Context) {
 	}
 }
 
-func (p *distinctInt64Op) Next(ctx context.Context) coldata.Batch {
-	batch := p.Input.Next(ctx)
+func (p *distinctInt64Op) Next() coldata.Batch {
+	batch := p.Input.Next()
 	if batch.Length() == 0 {
 		return batch
 	}
@@ -1719,7 +1695,7 @@ type distinctFloat64Op struct {
 	// still works across batch boundaries.
 	lastVal float64
 
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	// distinctColIdx is the index of the column to distinct upon.
 	distinctColIdx int
@@ -1733,10 +1709,6 @@ type distinctFloat64Op struct {
 
 var _ colexecop.ResettableOperator = &distinctFloat64Op{}
 
-func (p *distinctFloat64Op) Init() {
-	p.Input.Init()
-}
-
 func (p *distinctFloat64Op) Reset(ctx context.Context) {
 	p.foundFirstRow = false
 	p.lastValNull = false
@@ -1745,8 +1717,8 @@ func (p *distinctFloat64Op) Reset(ctx context.Context) {
 	}
 }
 
-func (p *distinctFloat64Op) Next(ctx context.Context) coldata.Batch {
-	batch := p.Input.Next(ctx)
+func (p *distinctFloat64Op) Next() coldata.Batch {
+	batch := p.Input.Next()
 	if batch.Length() == 0 {
 		return batch
 	}
@@ -2029,7 +2001,7 @@ type distinctTimestampOp struct {
 	// still works across batch boundaries.
 	lastVal time.Time
 
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	// distinctColIdx is the index of the column to distinct upon.
 	distinctColIdx int
@@ -2043,10 +2015,6 @@ type distinctTimestampOp struct {
 
 var _ colexecop.ResettableOperator = &distinctTimestampOp{}
 
-func (p *distinctTimestampOp) Init() {
-	p.Input.Init()
-}
-
 func (p *distinctTimestampOp) Reset(ctx context.Context) {
 	p.foundFirstRow = false
 	p.lastValNull = false
@@ -2055,8 +2023,8 @@ func (p *distinctTimestampOp) Reset(ctx context.Context) {
 	}
 }
 
-func (p *distinctTimestampOp) Next(ctx context.Context) coldata.Batch {
-	batch := p.Input.Next(ctx)
+func (p *distinctTimestampOp) Next() coldata.Batch {
+	batch := p.Input.Next()
 	if batch.Length() == 0 {
 		return batch
 	}
@@ -2291,7 +2259,7 @@ type distinctIntervalOp struct {
 	// still works across batch boundaries.
 	lastVal duration.Duration
 
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	// distinctColIdx is the index of the column to distinct upon.
 	distinctColIdx int
@@ -2305,10 +2273,6 @@ type distinctIntervalOp struct {
 
 var _ colexecop.ResettableOperator = &distinctIntervalOp{}
 
-func (p *distinctIntervalOp) Init() {
-	p.Input.Init()
-}
-
 func (p *distinctIntervalOp) Reset(ctx context.Context) {
 	p.foundFirstRow = false
 	p.lastValNull = false
@@ -2317,8 +2281,8 @@ func (p *distinctIntervalOp) Reset(ctx context.Context) {
 	}
 }
 
-func (p *distinctIntervalOp) Next(ctx context.Context) coldata.Batch {
-	batch := p.Input.Next(ctx)
+func (p *distinctIntervalOp) Next() coldata.Batch {
+	batch := p.Input.Next()
 	if batch.Length() == 0 {
 		return batch
 	}
@@ -2525,7 +2489,7 @@ type distinctJSONOp struct {
 	// still works across batch boundaries.
 	lastVal json.JSON
 
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	// distinctColIdx is the index of the column to distinct upon.
 	distinctColIdx int
@@ -2539,10 +2503,6 @@ type distinctJSONOp struct {
 
 var _ colexecop.ResettableOperator = &distinctJSONOp{}
 
-func (p *distinctJSONOp) Init() {
-	p.Input.Init()
-}
-
 func (p *distinctJSONOp) Reset(ctx context.Context) {
 	p.foundFirstRow = false
 	p.lastValNull = false
@@ -2551,8 +2511,8 @@ func (p *distinctJSONOp) Reset(ctx context.Context) {
 	}
 }
 
-func (p *distinctJSONOp) Next(ctx context.Context) coldata.Batch {
-	batch := p.Input.Next(ctx)
+func (p *distinctJSONOp) Next() coldata.Batch {
+	batch := p.Input.Next()
 	if batch.Length() == 0 {
 		return batch
 	}
@@ -2794,7 +2754,7 @@ type distinctDatumOp struct {
 	// still works across batch boundaries.
 	lastVal interface{}
 
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	// distinctColIdx is the index of the column to distinct upon.
 	distinctColIdx int
@@ -2808,10 +2768,6 @@ type distinctDatumOp struct {
 
 var _ colexecop.ResettableOperator = &distinctDatumOp{}
 
-func (p *distinctDatumOp) Init() {
-	p.Input.Init()
-}
-
 func (p *distinctDatumOp) Reset(ctx context.Context) {
 	p.foundFirstRow = false
 	p.lastValNull = false
@@ -2820,8 +2776,8 @@ func (p *distinctDatumOp) Reset(ctx context.Context) {
 	}
 }
 
-func (p *distinctDatumOp) Next(ctx context.Context) coldata.Batch {
-	batch := p.Input.Next(ctx)
+func (p *distinctDatumOp) Next() coldata.Batch {
+	batch := p.Input.Next()
 	if batch.Length() == 0 {
 		return batch
 	}

--- a/pkg/sql/colexec/colexecbase/distinct.go
+++ b/pkg/sql/colexec/colexecbase/distinct.go
@@ -27,9 +27,9 @@ func OrderedDistinctColsToOperators(
 ) (colexecop.ResettableOperator, []bool, error) {
 	distinctCol := make([]bool, coldata.BatchSize())
 	// zero the boolean column on every iteration.
-	input = fnOp{
-		OneInputNode: colexecop.NewOneInputNode(input),
-		fn:           func() { copy(distinctCol, colexecutils.ZeroBoolColumn) },
+	input = &fnOp{
+		OneInputHelper: colexecop.MakeOneInputHelper(input),
+		fn:             func() { copy(distinctCol, colexecutils.ZeroBoolColumn) },
 	}
 	var (
 		err error
@@ -67,7 +67,7 @@ func NewOrderedDistinct(
 		return nil, err
 	}
 	return &colexecutils.BoolVecToSelOp{
-		OneInputNode: colexecop.NewOneInputNode(op),
-		OutputCol:    outputCol,
+		OneInputHelper: colexecop.MakeOneInputHelper(op),
+		OutputCol:      outputCol,
 	}, nil
 }

--- a/pkg/sql/colexec/colexecbase/distinct_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/distinct_tmpl.go
@@ -76,7 +76,7 @@ func newSingleDistinct(
 		// {{range .WidthOverloads}}
 		case _TYPE_WIDTH:
 			return &distinct_TYPEOp{
-				OneInputNode:   colexecop.NewOneInputNode(input),
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
 				distinctColIdx: distinctColIdx,
 				outputCol:      outputCol,
 			}, nil
@@ -140,7 +140,7 @@ type distinct_TYPEOp struct {
 	// still works across batch boundaries.
 	lastVal _GOTYPE
 
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	// distinctColIdx is the index of the column to distinct upon.
 	distinctColIdx int
@@ -154,10 +154,6 @@ type distinct_TYPEOp struct {
 
 var _ colexecop.ResettableOperator = &distinct_TYPEOp{}
 
-func (p *distinct_TYPEOp) Init() {
-	p.Input.Init()
-}
-
 func (p *distinct_TYPEOp) Reset(ctx context.Context) {
 	p.foundFirstRow = false
 	p.lastValNull = false
@@ -166,8 +162,8 @@ func (p *distinct_TYPEOp) Reset(ctx context.Context) {
 	}
 }
 
-func (p *distinct_TYPEOp) Next(ctx context.Context) coldata.Batch {
-	batch := p.Input.Next(ctx)
+func (p *distinct_TYPEOp) Next() coldata.Batch {
+	batch := p.Input.Next()
 	if batch.Length() == 0 {
 		return batch
 	}

--- a/pkg/sql/colexec/colexecbase/fn_op.go
+++ b/pkg/sql/colexec/colexecbase/fn_op.go
@@ -20,25 +20,21 @@ import (
 // fnOp is an operator that executes an arbitrary function for its side-effects,
 // once per input batch, passing the input batch unmodified along.
 type fnOp struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	colexecop.NonExplainable
 
 	fn func()
 }
 
-var _ colexecop.ResettableOperator = fnOp{}
+var _ colexecop.ResettableOperator = &fnOp{}
 
-func (f fnOp) Init() {
-	f.Input.Init()
-}
-
-func (f fnOp) Next(ctx context.Context) coldata.Batch {
-	batch := f.Input.Next(ctx)
+func (f *fnOp) Next() coldata.Batch {
+	batch := f.Input.Next()
 	f.fn()
 	return batch
 }
 
-func (f fnOp) Reset(ctx context.Context) {
+func (f *fnOp) Reset(ctx context.Context) {
 	if resettableOp, ok := f.Input.(colexecop.Resetter); ok {
 		resettableOp.Reset(ctx)
 	}

--- a/pkg/sql/colexec/colexecbase/ordinality.go
+++ b/pkg/sql/colexec/colexecbase/ordinality.go
@@ -11,8 +11,6 @@
 package colexecbase
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
@@ -23,7 +21,7 @@ import (
 // ordinalityOp is an operator that implements WITH ORDINALITY, which adds
 // an additional column to the result with an ordinal number.
 type ordinalityOp struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	allocator *colmem.Allocator
 	// outputIdx is the index of the column in which ordinalityOp will write the
@@ -41,20 +39,16 @@ func NewOrdinalityOp(
 ) colexecop.Operator {
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, types.Int, outputIdx)
 	c := &ordinalityOp{
-		OneInputNode: colexecop.NewOneInputNode(input),
-		allocator:    allocator,
-		outputIdx:    outputIdx,
-		counter:      1,
+		OneInputHelper: colexecop.MakeOneInputHelper(input),
+		allocator:      allocator,
+		outputIdx:      outputIdx,
+		counter:        1,
 	}
 	return c
 }
 
-func (c *ordinalityOp) Init() {
-	c.Input.Init()
-}
-
-func (c *ordinalityOp) Next(ctx context.Context) coldata.Batch {
-	bat := c.Input.Next(ctx)
+func (c *ordinalityOp) Next() coldata.Batch {
+	bat := c.Input.Next()
 	if bat.Length() == 0 {
 		return coldata.ZeroBatch
 	}

--- a/pkg/sql/colexec/colexecbase/ordinality_test.go
+++ b/pkg/sql/colexec/colexecbase/ordinality_test.go
@@ -95,11 +95,11 @@ func BenchmarkOrdinality(b *testing.B) {
 	source := colexecop.NewRepeatableBatchSource(testAllocator, batch, typs)
 	ordinality, err := createTestOrdinalityOperator(ctx, flowCtx, source, []*types.T{types.Int, types.Int, types.Int})
 	require.NoError(b, err)
-	ordinality.Init()
+	ordinality.Init(ctx)
 
 	b.SetBytes(int64(8 * coldata.BatchSize()))
 	for i := 0; i < b.N; i++ {
-		ordinality.Next(ctx)
+		ordinality.Next()
 	}
 }
 

--- a/pkg/sql/colexec/colexechash/hash_utils.eg.go
+++ b/pkg/sql/colexec/colexechash/hash_utils.eg.go
@@ -10,7 +10,6 @@
 package colexechash
 
 import (
-	"context"
 	"math"
 	"reflect"
 	"unsafe"
@@ -39,7 +38,6 @@ var (
 // column values) at a given column and computes a new hash by applying a
 // transformation to the existing hash.
 func rehash(
-	ctx context.Context,
 	buckets []uint64,
 	col coldata.Vec,
 	nKeys int,
@@ -82,7 +80,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
@@ -105,7 +103,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				}
 			} else {
 				if sel != nil {
@@ -129,7 +127,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
@@ -149,7 +147,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				}
 			}
 		}
@@ -180,7 +178,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
@@ -200,7 +198,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				}
 			} else {
 				if sel != nil {
@@ -221,7 +219,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
@@ -238,7 +236,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				}
 			}
 		}
@@ -274,7 +272,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
@@ -299,7 +297,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				}
 			} else {
 				if sel != nil {
@@ -325,7 +323,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
@@ -347,7 +345,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				}
 			}
 		}
@@ -378,7 +376,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
@@ -399,7 +397,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				}
 			} else {
 				if sel != nil {
@@ -421,7 +419,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
@@ -439,7 +437,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				}
 			}
 		case 32:
@@ -467,7 +465,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
@@ -488,7 +486,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				}
 			} else {
 				if sel != nil {
@@ -510,7 +508,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
@@ -528,7 +526,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				}
 			}
 		case -1:
@@ -557,7 +555,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
@@ -578,7 +576,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				}
 			} else {
 				if sel != nil {
@@ -600,7 +598,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
@@ -618,7 +616,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				}
 			}
 		}
@@ -652,7 +650,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
@@ -675,7 +673,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				}
 			} else {
 				if sel != nil {
@@ -699,7 +697,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
@@ -719,7 +717,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				}
 			}
 		}
@@ -750,7 +748,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
@@ -770,7 +768,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				}
 			} else {
 				if sel != nil {
@@ -791,7 +789,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
@@ -808,7 +806,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				}
 			}
 		}
@@ -841,7 +839,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
@@ -863,7 +861,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				}
 			} else {
 				if sel != nil {
@@ -886,7 +884,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
@@ -905,7 +903,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				}
 			}
 		}
@@ -943,7 +941,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
@@ -970,7 +968,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				}
 			} else {
 				if sel != nil {
@@ -998,7 +996,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
@@ -1022,7 +1020,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				}
 			}
 		}
@@ -1053,7 +1051,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
@@ -1073,7 +1071,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				}
 			} else {
 				if sel != nil {
@@ -1094,7 +1092,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
@@ -1111,7 +1109,7 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall(ctx)
+					cancelChecker.CheckEveryCall()
 				}
 			}
 		}

--- a/pkg/sql/colexec/colexechash/hash_utils_test.go
+++ b/pkg/sql/colexec/colexechash/hash_utils_test.go
@@ -32,7 +32,6 @@ func TestHashFunctionFamily(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
 	bucketsA, bucketsB := make([]uint64, coldata.BatchSize()), make([]uint64, coldata.BatchSize())
 	nKeys := coldata.BatchSize()
 	keyTypes := []*types.T{types.Int}
@@ -46,12 +45,13 @@ func TestHashFunctionFamily(t *testing.T) {
 		overloadHelperVar execgen.OverloadHelper
 		datumAlloc        rowenc.DatumAlloc
 	)
+	cancelChecker.Init(context.Background())
 
 	for initHashValue, buckets := range [][]uint64{bucketsA, bucketsB} {
 		// We need +1 here because 0 is not a valid initial hash value.
 		initHash(buckets, nKeys, uint64(initHashValue+1))
 		for _, keysCol := range keys {
-			rehash(ctx, buckets, keysCol, nKeys, nil /* sel */, cancelChecker, &overloadHelperVar, &datumAlloc)
+			rehash(buckets, keysCol, nKeys, nil /* sel */, cancelChecker, &overloadHelperVar, &datumAlloc)
 		}
 		finalizeHash(buckets, nKeys, numBuckets)
 	}

--- a/pkg/sql/colexec/colexechash/hash_utils_tmpl.go
+++ b/pkg/sql/colexec/colexechash/hash_utils_tmpl.go
@@ -20,8 +20,6 @@
 package colexechash
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
@@ -63,7 +61,6 @@ func _ASSIGN_HASH(_, _, _, _ interface{}) uint64 {
 
 // {{/*
 func _REHASH_BODY(
-	ctx context.Context,
 	buckets []uint64,
 	keys _GOTYPESLICE,
 	nulls *coldata.Nulls,
@@ -103,7 +100,7 @@ func _REHASH_BODY(
 		//gcassert:bce
 		buckets[i] = uint64(p)
 	}
-	cancelChecker.CheckEveryCall(ctx)
+	cancelChecker.CheckEveryCall()
 	// {{end}}
 
 	// {{/*
@@ -115,7 +112,6 @@ func _REHASH_BODY(
 // column values) at a given column and computes a new hash by applying a
 // transformation to the existing hash.
 func rehash(
-	ctx context.Context,
 	buckets []uint64,
 	col coldata.Vec,
 	nKeys int,
@@ -136,15 +132,15 @@ func rehash(
 			keys, nulls := col.TemplateType(), col.Nulls()
 			if col.MaybeHasNulls() {
 				if sel != nil {
-					_REHASH_BODY(ctx, buckets, keys, nulls, nKeys, sel, true, true)
+					_REHASH_BODY(buckets, keys, nulls, nKeys, sel, true, true)
 				} else {
-					_REHASH_BODY(ctx, buckets, keys, nulls, nKeys, sel, false, true)
+					_REHASH_BODY(buckets, keys, nulls, nKeys, sel, false, true)
 				}
 			} else {
 				if sel != nil {
-					_REHASH_BODY(ctx, buckets, keys, nulls, nKeys, sel, true, false)
+					_REHASH_BODY(buckets, keys, nulls, nKeys, sel, true, false)
 				} else {
-					_REHASH_BODY(ctx, buckets, keys, nulls, nKeys, sel, false, false)
+					_REHASH_BODY(buckets, keys, nulls, nKeys, sel, false, false)
 				}
 			}
 			// {{end}}

--- a/pkg/sql/colexec/colexecjoin/crossjoiner.go
+++ b/pkg/sql/colexec/colexecjoin/crossjoiner.go
@@ -51,7 +51,7 @@ func NewCrossJoiner(
 			fdSemaphore,
 			diskAcc,
 		),
-		twoInputNode:          newTwoInputNode(left, right),
+		joinHelper:            newJoinHelper(left, right),
 		unlimitedAllocator:    unlimitedAllocator,
 		outputTypes:           joinType.MakeOutputTypes(leftTypes, rightTypes),
 		maxOutputBatchMemSize: memoryLimit,
@@ -60,7 +60,7 @@ func NewCrossJoiner(
 
 type crossJoiner struct {
 	*crossJoinerBase
-	twoInputNode
+	*joinHelper
 
 	unlimitedAllocator    *colmem.Allocator
 	inputsConsumed        bool
@@ -78,18 +78,17 @@ type crossJoiner struct {
 var _ colexecop.ClosableOperator = &crossJoiner{}
 var _ colexecop.ResettableOperator = &crossJoiner{}
 
-func (c *crossJoiner) Init() {
-	c.inputOne.Init()
-	c.inputTwo.Init()
+func (c *crossJoiner) Init(ctx context.Context) {
+	c.init(ctx)
 }
 
-func (c *crossJoiner) Next(ctx context.Context) coldata.Batch {
+func (c *crossJoiner) Next() coldata.Batch {
 	if !c.inputsConsumed {
-		c.consumeInputs(ctx)
+		c.consumeInputs(c.Ctx)
 		c.setupForBuilding()
 	}
 	if c.numTotalOutputTuples == c.numAlreadyEmitted {
-		if err := c.Close(ctx); err != nil {
+		if err := c.Close(c.Ctx); err != nil {
 			colexecerror.InternalError(err)
 		}
 		return coldata.ZeroBatch
@@ -107,14 +106,14 @@ func (c *crossJoiner) Next(ctx context.Context) coldata.Batch {
 		if c.isLeftAllNulls {
 			setAllNulls(c.output.ColVecs()[:len(c.left.types)], willEmit)
 		} else {
-			c.buildFromLeftInput(ctx, 0 /* destStartIdx */)
+			c.buildFromLeftInput(c.Ctx, 0 /* destStartIdx */)
 		}
 	}
 	if c.joinType.ShouldIncludeRightColsInOutput() {
 		if c.isRightAllNulls {
 			setAllNulls(c.output.ColVecs()[c.builderState.rightColOffset:], willEmit)
 		} else {
-			c.buildFromRightInput(ctx, 0 /* destStartIdx */)
+			c.buildFromRightInput(c.Ctx, 0 /* destStartIdx */)
 		}
 	}
 	c.output.SetLength(willEmit)
@@ -136,22 +135,22 @@ func (c *crossJoiner) consumeInputs(ctx context.Context) {
 	case descpb.LeftSemiJoin:
 		// With LEFT SEMI join we only need to know whether the right input is
 		// empty or not.
-		c.right.numTuples = c.inputTwo.Next(ctx).Length()
+		c.right.numTuples = c.inputTwo.Next().Length()
 		needLeftTuples = c.right.numTuples != 0
 	case descpb.RightSemiJoin:
 		// With RIGHT SEMI join we only need to know whether the left input is
 		// empty or not.
-		c.left.numTuples = c.inputOne.Next(ctx).Length()
+		c.left.numTuples = c.inputOne.Next().Length()
 		needRightTuples = c.left.numTuples != 0
 	case descpb.LeftAntiJoin:
 		// With LEFT ANTI join we only need to know whether the right input is
 		// empty or not.
-		c.right.numTuples = c.inputTwo.Next(ctx).Length()
+		c.right.numTuples = c.inputTwo.Next().Length()
 		needLeftTuples = c.right.numTuples == 0
 	case descpb.RightAntiJoin:
 		// With RIGHT ANTI join we only need to know whether the left input is
 		// empty or not.
-		c.left.numTuples = c.inputOne.Next(ctx).Length()
+		c.left.numTuples = c.inputOne.Next().Length()
 		needRightTuples = c.left.numTuples == 0
 	case descpb.IntersectAllJoin, descpb.ExceptAllJoin:
 		// With set-operation joins we only need the number of tuples from the
@@ -167,7 +166,7 @@ func (c *crossJoiner) consumeInputs(ctx context.Context) {
 
 	if needLeftTuples {
 		for {
-			batch := c.inputOne.Next(ctx)
+			batch := c.inputOne.Next()
 			c.left.tuples.Enqueue(ctx, batch)
 			if batch.Length() == 0 {
 				break
@@ -177,7 +176,7 @@ func (c *crossJoiner) consumeInputs(ctx context.Context) {
 	}
 	if needRightTuples {
 		for {
-			batch := c.inputTwo.Next(ctx)
+			batch := c.inputTwo.Next()
 			c.right.tuples.Enqueue(ctx, batch)
 			if batch.Length() == 0 {
 				break
@@ -187,7 +186,7 @@ func (c *crossJoiner) consumeInputs(ctx context.Context) {
 	}
 	if needOnlyNumRightTuples {
 		for {
-			batch := c.inputTwo.Next(ctx)
+			batch := c.inputTwo.Next()
 			if batch.Length() == 0 {
 				break
 			}

--- a/pkg/sql/colexec/colexecjoin/joiner_utils.go
+++ b/pkg/sql/colexec/colexecjoin/joiner_utils.go
@@ -11,32 +11,46 @@
 package colexecjoin
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/errors"
 )
 
-// newTwoInputNode returns an execinfra.OpNode with two Operator inputs.
-func newTwoInputNode(inputOne, inputTwo colexecop.Operator) twoInputNode {
-	return twoInputNode{inputOne: inputOne, inputTwo: inputTwo}
+// newJoinHelper returns an execinfra.OpNode with two Operator inputs.
+func newJoinHelper(inputOne, inputTwo colexecop.Operator) *joinHelper {
+	return &joinHelper{inputOne: inputOne, inputTwo: inputTwo}
 }
 
-type twoInputNode struct {
+type joinHelper struct {
+	colexecop.InitHelper
 	inputOne colexecop.Operator
 	inputTwo colexecop.Operator
 }
 
-func (twoInputNode) ChildCount(verbose bool) int {
+// init initializes both inputs and returns true if this is the first time init
+// was called.
+func (h *joinHelper) init(ctx context.Context) bool {
+	if !h.Init(ctx) {
+		return false
+	}
+	h.inputOne.Init(h.Ctx)
+	h.inputTwo.Init(h.Ctx)
+	return true
+}
+
+func (h *joinHelper) ChildCount(verbose bool) int {
 	return 2
 }
 
-func (n *twoInputNode) Child(nth int, verbose bool) execinfra.OpNode {
+func (h *joinHelper) Child(nth int, verbose bool) execinfra.OpNode {
 	switch nth {
 	case 0:
-		return n.inputOne
+		return h.inputOne
 	case 1:
-		return n.inputTwo
+		return h.inputTwo
 	}
 	colexecerror.InternalError(errors.AssertionFailedf("invalid idx %d", nth))
 	// This code is unreachable, but the compiler cannot infer that.

--- a/pkg/sql/colexec/colexecjoin/mergejoiner.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner.go
@@ -418,7 +418,7 @@ func newMergeJoinBase(
 	diskQueueCfg.CacheMode = colcontainer.DiskQueueCacheModeReuseCache
 	diskQueueCfg.SetDefaultBufferSizeBytesForCacheMode()
 	base := &mergeJoinBase{
-		twoInputNode:       newTwoInputNode(left, right),
+		joinHelper:         newJoinHelper(left, right),
 		unlimitedAllocator: unlimitedAllocator,
 		memoryLimit:        memoryLimit,
 		diskQueueCfg:       diskQueueCfg,
@@ -458,7 +458,7 @@ func newMergeJoinBase(
 
 // mergeJoinBase extracts the common logic between all merge join operators.
 type mergeJoinBase struct {
-	twoInputNode
+	*joinHelper
 	colexecop.CloserHelper
 
 	unlimitedAllocator *colmem.Allocator
@@ -506,10 +506,11 @@ func (o *mergeJoinBase) Reset(ctx context.Context) {
 	o.resetBuilderCrossProductState()
 }
 
-func (o *mergeJoinBase) Init() {
+func (o *mergeJoinBase) Init(ctx context.Context) {
+	if !o.init(ctx) {
+		return
+	}
 	o.outputTypes = o.joinType.MakeOutputTypes(o.left.sourceTypes, o.right.sourceTypes)
-	o.left.source.Init()
-	o.right.source.Init()
 	o.bufferedGroup.left.firstTuple = o.unlimitedAllocator.NewMemBatchWithFixedCapacity(
 		o.left.sourceTypes, 1, /* capacity */
 	).ColVecs()
@@ -542,12 +543,7 @@ func (o *mergeJoinBase) resetBuilderCrossProductState() {
 // A zero-length batch needs to be appended when no more batches will be
 // appended to the buffered group.
 func (o *mergeJoinBase) appendToBufferedGroup(
-	ctx context.Context,
-	input *mergeJoinInput,
-	batch coldata.Batch,
-	sel []int,
-	groupStartIdx int,
-	groupLength int,
+	input *mergeJoinInput, batch coldata.Batch, sel []int, groupStartIdx int, groupLength int,
 ) {
 	var (
 		bufferedGroup     *mjBufferedGroup
@@ -571,7 +567,7 @@ func (o *mergeJoinBase) appendToBufferedGroup(
 	if batch.Length() == 0 || groupLength == 0 {
 		// We have finished appending to this buffered group, so we need to
 		// Enqueue a zero-length batch per the contract of the spilling queue.
-		bufferedTuples.Enqueue(ctx, coldata.ZeroBatch)
+		bufferedTuples.Enqueue(o.Ctx, coldata.ZeroBatch)
 		return
 	}
 	// TODO(yuzefovich): for LEFT/RIGHT ANTI joins we only need to store the
@@ -622,7 +618,7 @@ func (o *mergeJoinBase) appendToBufferedGroup(
 		}
 		bufferedGroup.scratchBatch.SetLength(groupLength)
 	})
-	bufferedTuples.Enqueue(ctx, bufferedGroup.scratchBatch)
+	bufferedTuples.Enqueue(o.Ctx, bufferedGroup.scratchBatch)
 }
 
 // setBuilderSourceToBatch sets the builder state to use groups from the
@@ -636,19 +632,19 @@ func (o *mergeJoinBase) setBuilderSourceToBatch() {
 
 // initProberState sets the batches, lengths, and current indices to the right
 // locations given the last iteration of the operator.
-func (o *mergeJoinBase) initProberState(ctx context.Context) {
+func (o *mergeJoinBase) initProberState() {
 	// If this is the first batch or we're done with the current batch, get the
 	// next batch.
 	if o.proberState.lBatch == nil || (o.proberState.lLength != 0 && o.proberState.lIdx == o.proberState.lLength) {
-		o.proberState.lIdx, o.proberState.lBatch = 0, o.left.source.Next(ctx)
+		o.proberState.lIdx, o.proberState.lBatch = 0, o.left.source.Next()
 		o.proberState.lLength = o.proberState.lBatch.Length()
 	}
 	if o.proberState.rBatch == nil || (o.proberState.rLength != 0 && o.proberState.rIdx == o.proberState.rLength) {
-		o.proberState.rIdx, o.proberState.rBatch = 0, o.right.source.Next(ctx)
+		o.proberState.rIdx, o.proberState.rBatch = 0, o.right.source.Next()
 		o.proberState.rLength = o.proberState.rBatch.Length()
 	}
 	if o.bufferedGroup.needToReset {
-		o.bufferedGroup.helper.Reset(ctx)
+		o.bufferedGroup.helper.Reset(o.Ctx)
 		o.bufferedGroup.needToReset = false
 	}
 }
@@ -666,9 +662,9 @@ func (o *mergeJoinBase) sourceFinished() bool {
 
 // finishBufferedGroup appends a zero-length batch to the buffered group which
 // is required by the contract of the spilling queue.
-func (o *mergeJoinBase) finishBufferedGroup(ctx context.Context, input *mergeJoinInput) {
+func (o *mergeJoinBase) finishBufferedGroup(input *mergeJoinInput) {
 	o.appendToBufferedGroup(
-		ctx, input, coldata.ZeroBatch, nil, /* sel */
+		input, coldata.ZeroBatch, nil, /* sel */
 		0 /* groupStartIdx */, 0, /* groupLength */
 	)
 }
@@ -684,16 +680,19 @@ func (o *mergeJoinBase) finishBufferedGroup(ctx context.Context, input *mergeJoi
 // unbounded buffering.
 // SIDE EFFECT: can append to the buffered group corresponding to the source.
 func (o *mergeJoinBase) completeBufferedGroup(
-	ctx context.Context, input *mergeJoinInput, batch coldata.Batch, rowIdx int,
+	input *mergeJoinInput, batch coldata.Batch, rowIdx int,
 ) (_ coldata.Batch, idx int, batchLength int) {
 	batchLength = batch.Length()
 	if o.isBufferedGroupFinished(input, batch, rowIdx) {
-		o.finishBufferedGroup(ctx, input)
+		o.finishBufferedGroup(input)
 		return batch, rowIdx, batchLength
 	}
 
 	isBufferedGroupComplete := false
-	input.distincter.(colexecop.Resetter).Reset(ctx)
+	// It is ok that we might call Init() multiple times - it'll be a noop after
+	// the first one.
+	input.distincter.Init(o.Ctx)
+	input.distincter.(colexecop.Resetter).Reset(o.Ctx)
 	// Ignore the first row of the distincter in the first pass since we already
 	// know that we are in the same group and, thus, the row is not distinct,
 	// regardless of what the distincter outputs.
@@ -706,7 +705,7 @@ func (o *mergeJoinBase) completeBufferedGroup(
 		// so the distincter - in a sense - compares the incoming tuples to the
 		// first tuple of the first iteration (which we know is the same group).
 		input.distincterInput.SetBatch(batch)
-		input.distincter.Next(ctx)
+		input.distincter.Next()
 
 		sel = batch.Selection()
 		var groupLength int
@@ -733,19 +732,19 @@ func (o *mergeJoinBase) completeBufferedGroup(
 		loopStartIndex = 0
 
 		// Buffer all the tuples that are part of the buffered group.
-		o.appendToBufferedGroup(ctx, input, batch, sel, rowIdx, groupLength)
+		o.appendToBufferedGroup(input, batch, sel, rowIdx, groupLength)
 		rowIdx += groupLength
 
 		if !isBufferedGroupComplete {
 			// The buffered group is still not complete which means that we have
 			// just appended all the tuples from batch to it, so we need to get a
 			// fresh batch from the input.
-			rowIdx, batch = 0, input.source.Next(ctx)
+			rowIdx, batch = 0, input.source.Next()
 			batchLength = batch.Length()
 			if batchLength == 0 {
 				// The input has been exhausted, so the buffered group is now complete.
 				isBufferedGroupComplete = true
-				o.finishBufferedGroup(ctx, input)
+				o.finishBufferedGroup(input)
 			}
 		}
 	}
@@ -754,15 +753,13 @@ func (o *mergeJoinBase) completeBufferedGroup(
 }
 
 // finishProbe completes the buffered groups on both sides of the input.
-func (o *mergeJoinBase) finishProbe(ctx context.Context) {
+func (o *mergeJoinBase) finishProbe() {
 	o.proberState.lBatch, o.proberState.lIdx, o.proberState.lLength = o.completeBufferedGroup(
-		ctx,
 		&o.left,
 		o.proberState.lBatch,
 		o.proberState.lIdx,
 	)
 	o.proberState.rBatch, o.proberState.rIdx, o.proberState.rLength = o.completeBufferedGroup(
-		ctx,
 		&o.right,
 		o.proberState.rBatch,
 		o.proberState.rIdx,

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
@@ -11,7 +11,6 @@ package colexecjoin
 
 import (
 	"bytes"
-	"context"
 	"math"
 	"time"
 
@@ -46,7 +45,7 @@ type mergeJoinExceptAllOp struct {
 
 var _ colexecop.Operator = &mergeJoinExceptAllOp{}
 
-func (o *mergeJoinExceptAllOp) probeBodyLSeltrueRSeltrue(ctx context.Context) {
+func (o *mergeJoinExceptAllOp) probeBodyLSeltrueRSeltrue() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -218,9 +217,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -441,9 +440,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -656,9 +655,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -903,9 +902,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1158,9 +1157,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1414,9 +1413,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1697,9 +1696,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1952,9 +1951,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2174,9 +2173,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2407,9 +2406,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2634,9 +2633,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2725,7 +2724,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinExceptAllOp) probeBodyLSeltrueRSelfalse(ctx context.Context) {
+func (o *mergeJoinExceptAllOp) probeBodyLSeltrueRSelfalse() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -2897,9 +2896,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3120,9 +3119,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3335,9 +3334,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3582,9 +3581,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3837,9 +3836,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4093,9 +4092,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4376,9 +4375,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4631,9 +4630,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4853,9 +4852,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5086,9 +5085,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5313,9 +5312,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5404,7 +5403,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinExceptAllOp) probeBodyLSelfalseRSeltrue(ctx context.Context) {
+func (o *mergeJoinExceptAllOp) probeBodyLSelfalseRSeltrue() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -5576,9 +5575,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5799,9 +5798,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6014,9 +6013,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6261,9 +6260,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6516,9 +6515,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6772,9 +6771,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7055,9 +7054,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7310,9 +7309,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7532,9 +7531,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7765,9 +7764,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7992,9 +7991,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -8083,7 +8082,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinExceptAllOp) probeBodyLSelfalseRSelfalse(ctx context.Context) {
+func (o *mergeJoinExceptAllOp) probeBodyLSelfalseRSelfalse() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -8255,9 +8254,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -8478,9 +8477,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -8693,9 +8692,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -8940,9 +8939,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -9195,9 +9194,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -9451,9 +9450,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -9734,9 +9733,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -9989,9 +9988,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -10211,9 +10210,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -10444,9 +10443,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -10671,9 +10670,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -13804,28 +13803,28 @@ func (o *mergeJoinExceptAllOp) buildRightGroupsFromBatch(
 // and set the correct cardinality.
 // Note that in this phase, we do this for every group, except the last group
 // in the batch.
-func (o *mergeJoinExceptAllOp) probe(ctx context.Context) {
+func (o *mergeJoinExceptAllOp) probe() {
 	o.groups.reset(o.proberState.lIdx, o.proberState.lLength, o.proberState.rIdx, o.proberState.rLength)
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 	if lSel != nil {
 		if rSel != nil {
-			o.probeBodyLSeltrueRSeltrue(ctx)
+			o.probeBodyLSeltrueRSeltrue()
 		} else {
-			o.probeBodyLSeltrueRSelfalse(ctx)
+			o.probeBodyLSeltrueRSelfalse()
 		}
 	} else {
 		if rSel != nil {
-			o.probeBodyLSelfalseRSeltrue(ctx)
+			o.probeBodyLSelfalseRSeltrue()
 		} else {
-			o.probeBodyLSelfalseRSelfalse(ctx)
+			o.probeBodyLSelfalseRSelfalse()
 		}
 	}
 }
 
 // setBuilderSourceToBufferedGroup sets up the builder state to use the
 // buffered group.
-func (o *mergeJoinExceptAllOp) setBuilderSourceToBufferedGroup(ctx context.Context) {
+func (o *mergeJoinExceptAllOp) setBuilderSourceToBufferedGroup() {
 	o.builderState.buildFrom = mjBuildFromBufferedGroup
 	o.bufferedGroup.helper.setupBuilder()
 	o.builderState.totalOutCountFromBufferedGroup = o.bufferedGroup.helper.calculateOutputCount()
@@ -13840,7 +13839,7 @@ func (o *mergeJoinExceptAllOp) setBuilderSourceToBufferedGroup(ctx context.Conte
 // exhaustLeftSource sets up the builder to process any remaining tuples from
 // the left source. It should only be called when the right source has been
 // exhausted.
-func (o *mergeJoinExceptAllOp) exhaustLeftSource(ctx context.Context) {
+func (o *mergeJoinExceptAllOp) exhaustLeftSource() {
 	// The capacity of builder state lGroups and rGroups is always at least 1
 	// given the init.
 	o.builderState.lGroups = o.builderState.lGroups[:1]
@@ -13890,7 +13889,7 @@ func (o *mergeJoinExceptAllOp) calculateOutputCount(groups []group) int {
 }
 
 // build creates the cross product, and writes it to the output member.
-func (o *mergeJoinExceptAllOp) build(ctx context.Context) {
+func (o *mergeJoinExceptAllOp) build() {
 	outStartIdx := o.builderState.outCount
 	switch o.builderState.buildFrom {
 	case mjBuildFromBatch:
@@ -13916,7 +13915,7 @@ func (o *mergeJoinExceptAllOp) build(ctx context.Context) {
 		o.builderState.outCount += willEmit
 		o.builderState.alreadyEmittedFromBufferedGroup += willEmit
 		if o.output.Width() != 0 && willEmit > 0 {
-			o.bufferedGroup.helper.buildFromLeftInput(ctx, outStartIdx)
+			o.bufferedGroup.helper.buildFromLeftInput(o.Ctx, outStartIdx)
 		}
 
 	default:
@@ -13925,7 +13924,7 @@ func (o *mergeJoinExceptAllOp) build(ctx context.Context) {
 	}
 }
 
-func (o *mergeJoinExceptAllOp) Next(ctx context.Context) coldata.Batch {
+func (o *mergeJoinExceptAllOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
 	)
@@ -13933,7 +13932,7 @@ func (o *mergeJoinExceptAllOp) Next(ctx context.Context) coldata.Batch {
 	for {
 		switch o.state {
 		case mjEntry:
-			o.initProberState(ctx)
+			o.initProberState()
 
 			if o.nonEmptyBufferedGroup() {
 				o.state = mjFinishBufferedGroup
@@ -13960,7 +13959,7 @@ func (o *mergeJoinExceptAllOp) Next(ctx context.Context) coldata.Batch {
 			// nulls corresponding to the right one. But if the left source is
 			// finished, then there is nothing left to do.
 			if o.proberState.lIdx < o.proberState.lLength {
-				o.exhaustLeftSource(ctx)
+				o.exhaustLeftSource()
 				// We unset o.outputReady here because we want to put as many unmatched
 				// tuples from the left into the output batch. Once outCount reaches the
 				// desired output batch size, the output will be returned.
@@ -13968,15 +13967,15 @@ func (o *mergeJoinExceptAllOp) Next(ctx context.Context) coldata.Batch {
 			}
 			o.state = mjBuild
 		case mjFinishBufferedGroup:
-			o.finishProbe(ctx)
-			o.setBuilderSourceToBufferedGroup(ctx)
+			o.finishProbe()
+			o.setBuilderSourceToBufferedGroup()
 			o.state = mjBuild
 		case mjProbe:
-			o.probe(ctx)
+			o.probe()
 			o.setBuilderSourceToBatch()
 			o.state = mjBuild
 		case mjBuild:
-			o.build(ctx)
+			o.build()
 
 			if o.builderState.outFinished {
 				o.state = mjEntry
@@ -14000,7 +13999,7 @@ func (o *mergeJoinExceptAllOp) Next(ctx context.Context) coldata.Batch {
 			// Note that resetting of buffered group will close disk queues
 			// (if there are any).
 			if o.bufferedGroup.needToReset {
-				o.bufferedGroup.helper.Reset(ctx)
+				o.bufferedGroup.helper.Reset(o.Ctx)
 				o.bufferedGroup.needToReset = false
 			}
 			return coldata.ZeroBatch

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
@@ -11,7 +11,6 @@ package colexecjoin
 
 import (
 	"bytes"
-	"context"
 	"math"
 	"time"
 
@@ -46,7 +45,7 @@ type mergeJoinFullOuterOp struct {
 
 var _ colexecop.Operator = &mergeJoinFullOuterOp{}
 
-func (o *mergeJoinFullOuterOp) probeBodyLSeltrueRSeltrue(ctx context.Context) {
+func (o *mergeJoinFullOuterOp) probeBodyLSeltrueRSeltrue() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -215,9 +214,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -463,9 +462,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -695,9 +694,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -959,9 +958,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1242,9 +1241,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1526,9 +1525,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1837,9 +1836,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2128,9 +2127,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2374,9 +2373,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2624,9 +2623,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2874,9 +2873,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2987,7 +2986,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinFullOuterOp) probeBodyLSeltrueRSelfalse(ctx context.Context) {
+func (o *mergeJoinFullOuterOp) probeBodyLSeltrueRSelfalse() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -3156,9 +3155,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3404,9 +3403,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3636,9 +3635,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3900,9 +3899,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4183,9 +4182,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4467,9 +4466,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4778,9 +4777,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5069,9 +5068,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5315,9 +5314,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5565,9 +5564,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5815,9 +5814,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5928,7 +5927,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinFullOuterOp) probeBodyLSelfalseRSeltrue(ctx context.Context) {
+func (o *mergeJoinFullOuterOp) probeBodyLSelfalseRSeltrue() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -6097,9 +6096,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6345,9 +6344,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6577,9 +6576,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6841,9 +6840,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7124,9 +7123,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7408,9 +7407,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7719,9 +7718,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -8010,9 +8009,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -8256,9 +8255,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -8506,9 +8505,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -8756,9 +8755,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -8869,7 +8868,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinFullOuterOp) probeBodyLSelfalseRSelfalse(ctx context.Context) {
+func (o *mergeJoinFullOuterOp) probeBodyLSelfalseRSelfalse() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -9038,9 +9037,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -9286,9 +9285,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -9518,9 +9517,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -9782,9 +9781,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -10065,9 +10064,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -10349,9 +10348,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -10660,9 +10659,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -10951,9 +10950,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -11197,9 +11196,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -11447,9 +11446,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -11697,9 +11696,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -14896,28 +14895,28 @@ func (o *mergeJoinFullOuterOp) buildRightGroupsFromBatch(
 // and set the correct cardinality.
 // Note that in this phase, we do this for every group, except the last group
 // in the batch.
-func (o *mergeJoinFullOuterOp) probe(ctx context.Context) {
+func (o *mergeJoinFullOuterOp) probe() {
 	o.groups.reset(o.proberState.lIdx, o.proberState.lLength, o.proberState.rIdx, o.proberState.rLength)
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 	if lSel != nil {
 		if rSel != nil {
-			o.probeBodyLSeltrueRSeltrue(ctx)
+			o.probeBodyLSeltrueRSeltrue()
 		} else {
-			o.probeBodyLSeltrueRSelfalse(ctx)
+			o.probeBodyLSeltrueRSelfalse()
 		}
 	} else {
 		if rSel != nil {
-			o.probeBodyLSelfalseRSeltrue(ctx)
+			o.probeBodyLSelfalseRSeltrue()
 		} else {
-			o.probeBodyLSelfalseRSelfalse(ctx)
+			o.probeBodyLSelfalseRSelfalse()
 		}
 	}
 }
 
 // setBuilderSourceToBufferedGroup sets up the builder state to use the
 // buffered group.
-func (o *mergeJoinFullOuterOp) setBuilderSourceToBufferedGroup(ctx context.Context) {
+func (o *mergeJoinFullOuterOp) setBuilderSourceToBufferedGroup() {
 	o.builderState.buildFrom = mjBuildFromBufferedGroup
 	o.bufferedGroup.helper.setupBuilder()
 	o.builderState.totalOutCountFromBufferedGroup = o.bufferedGroup.helper.calculateOutputCount()
@@ -14932,7 +14931,7 @@ func (o *mergeJoinFullOuterOp) setBuilderSourceToBufferedGroup(ctx context.Conte
 // exhaustLeftSource sets up the builder to process any remaining tuples from
 // the left source. It should only be called when the right source has been
 // exhausted.
-func (o *mergeJoinFullOuterOp) exhaustLeftSource(ctx context.Context) {
+func (o *mergeJoinFullOuterOp) exhaustLeftSource() {
 	// The capacity of builder state lGroups and rGroups is always at least 1
 	// given the init.
 	o.builderState.lGroups = o.builderState.lGroups[:1]
@@ -15002,7 +15001,7 @@ func (o *mergeJoinFullOuterOp) calculateOutputCount(groups []group) int {
 }
 
 // build creates the cross product, and writes it to the output member.
-func (o *mergeJoinFullOuterOp) build(ctx context.Context) {
+func (o *mergeJoinFullOuterOp) build() {
 	outStartIdx := o.builderState.outCount
 	switch o.builderState.buildFrom {
 	case mjBuildFromBatch:
@@ -15029,8 +15028,8 @@ func (o *mergeJoinFullOuterOp) build(ctx context.Context) {
 		o.builderState.outCount += willEmit
 		o.builderState.alreadyEmittedFromBufferedGroup += willEmit
 		if o.output.Width() != 0 && willEmit > 0 {
-			o.bufferedGroup.helper.buildFromLeftInput(ctx, outStartIdx)
-			o.bufferedGroup.helper.buildFromRightInput(ctx, outStartIdx)
+			o.bufferedGroup.helper.buildFromLeftInput(o.Ctx, outStartIdx)
+			o.bufferedGroup.helper.buildFromRightInput(o.Ctx, outStartIdx)
 		}
 
 	default:
@@ -15039,7 +15038,7 @@ func (o *mergeJoinFullOuterOp) build(ctx context.Context) {
 	}
 }
 
-func (o *mergeJoinFullOuterOp) Next(ctx context.Context) coldata.Batch {
+func (o *mergeJoinFullOuterOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
 	)
@@ -15047,7 +15046,7 @@ func (o *mergeJoinFullOuterOp) Next(ctx context.Context) coldata.Batch {
 	for {
 		switch o.state {
 		case mjEntry:
-			o.initProberState(ctx)
+			o.initProberState()
 
 			if o.nonEmptyBufferedGroup() {
 				o.state = mjFinishBufferedGroup
@@ -15074,7 +15073,7 @@ func (o *mergeJoinFullOuterOp) Next(ctx context.Context) coldata.Batch {
 			// nulls corresponding to the right one. But if the left source is
 			// finished, then there is nothing left to do.
 			if o.proberState.lIdx < o.proberState.lLength {
-				o.exhaustLeftSource(ctx)
+				o.exhaustLeftSource()
 				// We unset o.outputReady here because we want to put as many unmatched
 				// tuples from the left into the output batch. Once outCount reaches the
 				// desired output batch size, the output will be returned.
@@ -15093,15 +15092,15 @@ func (o *mergeJoinFullOuterOp) Next(ctx context.Context) coldata.Batch {
 			}
 			o.state = mjBuild
 		case mjFinishBufferedGroup:
-			o.finishProbe(ctx)
-			o.setBuilderSourceToBufferedGroup(ctx)
+			o.finishProbe()
+			o.setBuilderSourceToBufferedGroup()
 			o.state = mjBuild
 		case mjProbe:
-			o.probe(ctx)
+			o.probe()
 			o.setBuilderSourceToBatch()
 			o.state = mjBuild
 		case mjBuild:
-			o.build(ctx)
+			o.build()
 
 			if o.builderState.outFinished {
 				o.state = mjEntry
@@ -15125,7 +15124,7 @@ func (o *mergeJoinFullOuterOp) Next(ctx context.Context) coldata.Batch {
 			// Note that resetting of buffered group will close disk queues
 			// (if there are any).
 			if o.bufferedGroup.needToReset {
-				o.bufferedGroup.helper.Reset(ctx)
+				o.bufferedGroup.helper.Reset(o.Ctx)
 				o.bufferedGroup.needToReset = false
 			}
 			return coldata.ZeroBatch

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
@@ -11,7 +11,6 @@ package colexecjoin
 
 import (
 	"bytes"
-	"context"
 	"math"
 	"time"
 
@@ -46,7 +45,7 @@ type mergeJoinInnerOp struct {
 
 var _ colexecop.Operator = &mergeJoinInnerOp{}
 
-func (o *mergeJoinInnerOp) probeBodyLSeltrueRSeltrue(ctx context.Context) {
+func (o *mergeJoinInnerOp) probeBodyLSeltrueRSeltrue() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -193,9 +192,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -338,9 +337,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -483,9 +482,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -660,9 +659,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -834,9 +833,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1009,9 +1008,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1211,9 +1210,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1377,9 +1376,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1522,9 +1521,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1685,9 +1684,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1836,9 +1835,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1880,7 +1879,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinInnerOp) probeBodyLSeltrueRSelfalse(ctx context.Context) {
+func (o *mergeJoinInnerOp) probeBodyLSeltrueRSelfalse() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -2027,9 +2026,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2172,9 +2171,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2317,9 +2316,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2494,9 +2493,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2668,9 +2667,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2843,9 +2842,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3045,9 +3044,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3211,9 +3210,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3356,9 +3355,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3519,9 +3518,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3670,9 +3669,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3714,7 +3713,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinInnerOp) probeBodyLSelfalseRSeltrue(ctx context.Context) {
+func (o *mergeJoinInnerOp) probeBodyLSelfalseRSeltrue() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -3861,9 +3860,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4006,9 +4005,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4151,9 +4150,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4328,9 +4327,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4502,9 +4501,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4677,9 +4676,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4879,9 +4878,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5045,9 +5044,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5190,9 +5189,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5353,9 +5352,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5504,9 +5503,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5548,7 +5547,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinInnerOp) probeBodyLSelfalseRSelfalse(ctx context.Context) {
+func (o *mergeJoinInnerOp) probeBodyLSelfalseRSelfalse() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -5695,9 +5694,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5840,9 +5839,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5985,9 +5984,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6162,9 +6161,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6336,9 +6335,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6511,9 +6510,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6713,9 +6712,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6879,9 +6878,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7024,9 +7023,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7187,9 +7186,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7338,9 +7337,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -10358,28 +10357,28 @@ func (o *mergeJoinInnerOp) buildRightGroupsFromBatch(
 // and set the correct cardinality.
 // Note that in this phase, we do this for every group, except the last group
 // in the batch.
-func (o *mergeJoinInnerOp) probe(ctx context.Context) {
+func (o *mergeJoinInnerOp) probe() {
 	o.groups.reset(o.proberState.lIdx, o.proberState.lLength, o.proberState.rIdx, o.proberState.rLength)
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 	if lSel != nil {
 		if rSel != nil {
-			o.probeBodyLSeltrueRSeltrue(ctx)
+			o.probeBodyLSeltrueRSeltrue()
 		} else {
-			o.probeBodyLSeltrueRSelfalse(ctx)
+			o.probeBodyLSeltrueRSelfalse()
 		}
 	} else {
 		if rSel != nil {
-			o.probeBodyLSelfalseRSeltrue(ctx)
+			o.probeBodyLSelfalseRSeltrue()
 		} else {
-			o.probeBodyLSelfalseRSelfalse(ctx)
+			o.probeBodyLSelfalseRSelfalse()
 		}
 	}
 }
 
 // setBuilderSourceToBufferedGroup sets up the builder state to use the
 // buffered group.
-func (o *mergeJoinInnerOp) setBuilderSourceToBufferedGroup(ctx context.Context) {
+func (o *mergeJoinInnerOp) setBuilderSourceToBufferedGroup() {
 	o.builderState.buildFrom = mjBuildFromBufferedGroup
 	o.bufferedGroup.helper.setupBuilder()
 	o.builderState.totalOutCountFromBufferedGroup = o.bufferedGroup.helper.calculateOutputCount()
@@ -10394,7 +10393,7 @@ func (o *mergeJoinInnerOp) setBuilderSourceToBufferedGroup(ctx context.Context) 
 // exhaustLeftSource sets up the builder to process any remaining tuples from
 // the left source. It should only be called when the right source has been
 // exhausted.
-func (o *mergeJoinInnerOp) exhaustLeftSource(ctx context.Context) {
+func (o *mergeJoinInnerOp) exhaustLeftSource() {
 }
 
 // exhaustRightSource sets up the builder to process any remaining tuples from
@@ -10426,7 +10425,7 @@ func (o *mergeJoinInnerOp) calculateOutputCount(groups []group) int {
 }
 
 // build creates the cross product, and writes it to the output member.
-func (o *mergeJoinInnerOp) build(ctx context.Context) {
+func (o *mergeJoinInnerOp) build() {
 	outStartIdx := o.builderState.outCount
 	switch o.builderState.buildFrom {
 	case mjBuildFromBatch:
@@ -10453,8 +10452,8 @@ func (o *mergeJoinInnerOp) build(ctx context.Context) {
 		o.builderState.outCount += willEmit
 		o.builderState.alreadyEmittedFromBufferedGroup += willEmit
 		if o.output.Width() != 0 && willEmit > 0 {
-			o.bufferedGroup.helper.buildFromLeftInput(ctx, outStartIdx)
-			o.bufferedGroup.helper.buildFromRightInput(ctx, outStartIdx)
+			o.bufferedGroup.helper.buildFromLeftInput(o.Ctx, outStartIdx)
+			o.bufferedGroup.helper.buildFromRightInput(o.Ctx, outStartIdx)
 		}
 
 	default:
@@ -10463,7 +10462,7 @@ func (o *mergeJoinInnerOp) build(ctx context.Context) {
 	}
 }
 
-func (o *mergeJoinInnerOp) Next(ctx context.Context) coldata.Batch {
+func (o *mergeJoinInnerOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
 	)
@@ -10471,7 +10470,7 @@ func (o *mergeJoinInnerOp) Next(ctx context.Context) coldata.Batch {
 	for {
 		switch o.state {
 		case mjEntry:
-			o.initProberState(ctx)
+			o.initProberState()
 
 			if o.nonEmptyBufferedGroup() {
 				o.state = mjFinishBufferedGroup
@@ -10487,18 +10486,18 @@ func (o *mergeJoinInnerOp) Next(ctx context.Context) coldata.Batch {
 		case mjSourceFinished:
 			o.outputReady = true
 			o.builderState.buildFrom = mjBuildFromBatch
-			o.setBuilderSourceToBufferedGroup(ctx)
+			o.setBuilderSourceToBufferedGroup()
 			o.state = mjBuild
 		case mjFinishBufferedGroup:
-			o.finishProbe(ctx)
-			o.setBuilderSourceToBufferedGroup(ctx)
+			o.finishProbe()
+			o.setBuilderSourceToBufferedGroup()
 			o.state = mjBuild
 		case mjProbe:
-			o.probe(ctx)
+			o.probe()
 			o.setBuilderSourceToBatch()
 			o.state = mjBuild
 		case mjBuild:
-			o.build(ctx)
+			o.build()
 
 			if o.builderState.outFinished {
 				o.state = mjEntry
@@ -10522,7 +10521,7 @@ func (o *mergeJoinInnerOp) Next(ctx context.Context) coldata.Batch {
 			// Note that resetting of buffered group will close disk queues
 			// (if there are any).
 			if o.bufferedGroup.needToReset {
-				o.bufferedGroup.helper.Reset(ctx)
+				o.bufferedGroup.helper.Reset(o.Ctx)
 				o.bufferedGroup.needToReset = false
 			}
 			return coldata.ZeroBatch

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
@@ -11,7 +11,6 @@ package colexecjoin
 
 import (
 	"bytes"
-	"context"
 	"math"
 	"time"
 
@@ -46,7 +45,7 @@ type mergeJoinIntersectAllOp struct {
 
 var _ colexecop.Operator = &mergeJoinIntersectAllOp{}
 
-func (o *mergeJoinIntersectAllOp) probeBodyLSeltrueRSeltrue(ctx context.Context) {
+func (o *mergeJoinIntersectAllOp) probeBodyLSeltrueRSeltrue() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -208,9 +207,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -372,9 +371,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -536,9 +535,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -732,9 +731,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -925,9 +924,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1119,9 +1118,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1340,9 +1339,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1525,9 +1524,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1689,9 +1688,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1871,9 +1870,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2041,9 +2040,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2089,7 +2088,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinIntersectAllOp) probeBodyLSeltrueRSelfalse(ctx context.Context) {
+func (o *mergeJoinIntersectAllOp) probeBodyLSeltrueRSelfalse() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -2251,9 +2250,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2415,9 +2414,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2579,9 +2578,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2775,9 +2774,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2968,9 +2967,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3162,9 +3161,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3383,9 +3382,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3568,9 +3567,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3732,9 +3731,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3914,9 +3913,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4084,9 +4083,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4132,7 +4131,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinIntersectAllOp) probeBodyLSelfalseRSeltrue(ctx context.Context) {
+func (o *mergeJoinIntersectAllOp) probeBodyLSelfalseRSeltrue() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -4294,9 +4293,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4458,9 +4457,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4622,9 +4621,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4818,9 +4817,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5011,9 +5010,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5205,9 +5204,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5426,9 +5425,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5611,9 +5610,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5775,9 +5774,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5957,9 +5956,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6127,9 +6126,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6175,7 +6174,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinIntersectAllOp) probeBodyLSelfalseRSelfalse(ctx context.Context) {
+func (o *mergeJoinIntersectAllOp) probeBodyLSelfalseRSelfalse() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -6337,9 +6336,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6501,9 +6500,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6665,9 +6664,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6861,9 +6860,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7054,9 +7053,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7248,9 +7247,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7469,9 +7468,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7654,9 +7653,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7818,9 +7817,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -8000,9 +7999,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -8170,9 +8169,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -11194,28 +11193,28 @@ func (o *mergeJoinIntersectAllOp) buildRightGroupsFromBatch(
 // and set the correct cardinality.
 // Note that in this phase, we do this for every group, except the last group
 // in the batch.
-func (o *mergeJoinIntersectAllOp) probe(ctx context.Context) {
+func (o *mergeJoinIntersectAllOp) probe() {
 	o.groups.reset(o.proberState.lIdx, o.proberState.lLength, o.proberState.rIdx, o.proberState.rLength)
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 	if lSel != nil {
 		if rSel != nil {
-			o.probeBodyLSeltrueRSeltrue(ctx)
+			o.probeBodyLSeltrueRSeltrue()
 		} else {
-			o.probeBodyLSeltrueRSelfalse(ctx)
+			o.probeBodyLSeltrueRSelfalse()
 		}
 	} else {
 		if rSel != nil {
-			o.probeBodyLSelfalseRSeltrue(ctx)
+			o.probeBodyLSelfalseRSeltrue()
 		} else {
-			o.probeBodyLSelfalseRSelfalse(ctx)
+			o.probeBodyLSelfalseRSelfalse()
 		}
 	}
 }
 
 // setBuilderSourceToBufferedGroup sets up the builder state to use the
 // buffered group.
-func (o *mergeJoinIntersectAllOp) setBuilderSourceToBufferedGroup(ctx context.Context) {
+func (o *mergeJoinIntersectAllOp) setBuilderSourceToBufferedGroup() {
 	o.builderState.buildFrom = mjBuildFromBufferedGroup
 	o.bufferedGroup.helper.setupBuilder()
 	o.builderState.totalOutCountFromBufferedGroup = o.bufferedGroup.helper.calculateOutputCount()
@@ -11230,7 +11229,7 @@ func (o *mergeJoinIntersectAllOp) setBuilderSourceToBufferedGroup(ctx context.Co
 // exhaustLeftSource sets up the builder to process any remaining tuples from
 // the left source. It should only be called when the right source has been
 // exhausted.
-func (o *mergeJoinIntersectAllOp) exhaustLeftSource(ctx context.Context) {
+func (o *mergeJoinIntersectAllOp) exhaustLeftSource() {
 }
 
 // exhaustRightSource sets up the builder to process any remaining tuples from
@@ -11262,7 +11261,7 @@ func (o *mergeJoinIntersectAllOp) calculateOutputCount(groups []group) int {
 }
 
 // build creates the cross product, and writes it to the output member.
-func (o *mergeJoinIntersectAllOp) build(ctx context.Context) {
+func (o *mergeJoinIntersectAllOp) build() {
 	outStartIdx := o.builderState.outCount
 	switch o.builderState.buildFrom {
 	case mjBuildFromBatch:
@@ -11288,7 +11287,7 @@ func (o *mergeJoinIntersectAllOp) build(ctx context.Context) {
 		o.builderState.outCount += willEmit
 		o.builderState.alreadyEmittedFromBufferedGroup += willEmit
 		if o.output.Width() != 0 && willEmit > 0 {
-			o.bufferedGroup.helper.buildFromLeftInput(ctx, outStartIdx)
+			o.bufferedGroup.helper.buildFromLeftInput(o.Ctx, outStartIdx)
 		}
 
 	default:
@@ -11297,7 +11296,7 @@ func (o *mergeJoinIntersectAllOp) build(ctx context.Context) {
 	}
 }
 
-func (o *mergeJoinIntersectAllOp) Next(ctx context.Context) coldata.Batch {
+func (o *mergeJoinIntersectAllOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
 	)
@@ -11305,7 +11304,7 @@ func (o *mergeJoinIntersectAllOp) Next(ctx context.Context) coldata.Batch {
 	for {
 		switch o.state {
 		case mjEntry:
-			o.initProberState(ctx)
+			o.initProberState()
 
 			if o.nonEmptyBufferedGroup() {
 				o.state = mjFinishBufferedGroup
@@ -11321,18 +11320,18 @@ func (o *mergeJoinIntersectAllOp) Next(ctx context.Context) coldata.Batch {
 		case mjSourceFinished:
 			o.outputReady = true
 			o.builderState.buildFrom = mjBuildFromBatch
-			o.setBuilderSourceToBufferedGroup(ctx)
+			o.setBuilderSourceToBufferedGroup()
 			o.state = mjBuild
 		case mjFinishBufferedGroup:
-			o.finishProbe(ctx)
-			o.setBuilderSourceToBufferedGroup(ctx)
+			o.finishProbe()
+			o.setBuilderSourceToBufferedGroup()
 			o.state = mjBuild
 		case mjProbe:
-			o.probe(ctx)
+			o.probe()
 			o.setBuilderSourceToBatch()
 			o.state = mjBuild
 		case mjBuild:
-			o.build(ctx)
+			o.build()
 
 			if o.builderState.outFinished {
 				o.state = mjEntry
@@ -11356,7 +11355,7 @@ func (o *mergeJoinIntersectAllOp) Next(ctx context.Context) coldata.Batch {
 			// Note that resetting of buffered group will close disk queues
 			// (if there are any).
 			if o.bufferedGroup.needToReset {
-				o.bufferedGroup.helper.Reset(ctx)
+				o.bufferedGroup.helper.Reset(o.Ctx)
 				o.bufferedGroup.needToReset = false
 			}
 			return coldata.ZeroBatch

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftanti.eg.go
@@ -11,7 +11,6 @@ package colexecjoin
 
 import (
 	"bytes"
-	"context"
 	"math"
 	"time"
 
@@ -46,7 +45,7 @@ type mergeJoinLeftAntiOp struct {
 
 var _ colexecop.Operator = &mergeJoinLeftAntiOp{}
 
-func (o *mergeJoinLeftAntiOp) probeBodyLSeltrueRSeltrue(ctx context.Context) {
+func (o *mergeJoinLeftAntiOp) probeBodyLSeltrueRSeltrue() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -204,9 +203,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -400,9 +399,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -588,9 +587,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -808,9 +807,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1036,9 +1035,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1265,9 +1264,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1521,9 +1520,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1749,9 +1748,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1944,9 +1943,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2150,9 +2149,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2350,9 +2349,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2428,7 +2427,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinLeftAntiOp) probeBodyLSeltrueRSelfalse(ctx context.Context) {
+func (o *mergeJoinLeftAntiOp) probeBodyLSeltrueRSelfalse() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -2586,9 +2585,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2782,9 +2781,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2970,9 +2969,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3190,9 +3189,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3418,9 +3417,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3647,9 +3646,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3903,9 +3902,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4131,9 +4130,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4326,9 +4325,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4532,9 +4531,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4732,9 +4731,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4810,7 +4809,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinLeftAntiOp) probeBodyLSelfalseRSeltrue(ctx context.Context) {
+func (o *mergeJoinLeftAntiOp) probeBodyLSelfalseRSeltrue() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -4968,9 +4967,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5164,9 +5163,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5352,9 +5351,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5572,9 +5571,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5800,9 +5799,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6029,9 +6028,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6285,9 +6284,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6513,9 +6512,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6708,9 +6707,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6914,9 +6913,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7114,9 +7113,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7192,7 +7191,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinLeftAntiOp) probeBodyLSelfalseRSelfalse(ctx context.Context) {
+func (o *mergeJoinLeftAntiOp) probeBodyLSelfalseRSelfalse() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -7350,9 +7349,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7546,9 +7545,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7734,9 +7733,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7954,9 +7953,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -8182,9 +8181,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -8411,9 +8410,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -8667,9 +8666,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -8895,9 +8894,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -9090,9 +9089,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -9296,9 +9295,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -9496,9 +9495,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -12616,28 +12615,28 @@ func (o *mergeJoinLeftAntiOp) buildRightGroupsFromBatch(
 // and set the correct cardinality.
 // Note that in this phase, we do this for every group, except the last group
 // in the batch.
-func (o *mergeJoinLeftAntiOp) probe(ctx context.Context) {
+func (o *mergeJoinLeftAntiOp) probe() {
 	o.groups.reset(o.proberState.lIdx, o.proberState.lLength, o.proberState.rIdx, o.proberState.rLength)
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 	if lSel != nil {
 		if rSel != nil {
-			o.probeBodyLSeltrueRSeltrue(ctx)
+			o.probeBodyLSeltrueRSeltrue()
 		} else {
-			o.probeBodyLSeltrueRSelfalse(ctx)
+			o.probeBodyLSeltrueRSelfalse()
 		}
 	} else {
 		if rSel != nil {
-			o.probeBodyLSelfalseRSeltrue(ctx)
+			o.probeBodyLSelfalseRSeltrue()
 		} else {
-			o.probeBodyLSelfalseRSelfalse(ctx)
+			o.probeBodyLSelfalseRSelfalse()
 		}
 	}
 }
 
 // setBuilderSourceToBufferedGroup sets up the builder state to use the
 // buffered group.
-func (o *mergeJoinLeftAntiOp) setBuilderSourceToBufferedGroup(ctx context.Context) {
+func (o *mergeJoinLeftAntiOp) setBuilderSourceToBufferedGroup() {
 	o.builderState.buildFrom = mjBuildFromBufferedGroup
 	o.bufferedGroup.helper.setupBuilder()
 	o.builderState.totalOutCountFromBufferedGroup = o.bufferedGroup.helper.calculateOutputCount()
@@ -12652,7 +12651,7 @@ func (o *mergeJoinLeftAntiOp) setBuilderSourceToBufferedGroup(ctx context.Contex
 // exhaustLeftSource sets up the builder to process any remaining tuples from
 // the left source. It should only be called when the right source has been
 // exhausted.
-func (o *mergeJoinLeftAntiOp) exhaustLeftSource(ctx context.Context) {
+func (o *mergeJoinLeftAntiOp) exhaustLeftSource() {
 	// The capacity of builder state lGroups and rGroups is always at least 1
 	// given the init.
 	o.builderState.lGroups = o.builderState.lGroups[:1]
@@ -12702,7 +12701,7 @@ func (o *mergeJoinLeftAntiOp) calculateOutputCount(groups []group) int {
 }
 
 // build creates the cross product, and writes it to the output member.
-func (o *mergeJoinLeftAntiOp) build(ctx context.Context) {
+func (o *mergeJoinLeftAntiOp) build() {
 	outStartIdx := o.builderState.outCount
 	switch o.builderState.buildFrom {
 	case mjBuildFromBatch:
@@ -12728,7 +12727,7 @@ func (o *mergeJoinLeftAntiOp) build(ctx context.Context) {
 		o.builderState.outCount += willEmit
 		o.builderState.alreadyEmittedFromBufferedGroup += willEmit
 		if o.output.Width() != 0 && willEmit > 0 {
-			o.bufferedGroup.helper.buildFromLeftInput(ctx, outStartIdx)
+			o.bufferedGroup.helper.buildFromLeftInput(o.Ctx, outStartIdx)
 		}
 
 	default:
@@ -12737,7 +12736,7 @@ func (o *mergeJoinLeftAntiOp) build(ctx context.Context) {
 	}
 }
 
-func (o *mergeJoinLeftAntiOp) Next(ctx context.Context) coldata.Batch {
+func (o *mergeJoinLeftAntiOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
 	)
@@ -12745,7 +12744,7 @@ func (o *mergeJoinLeftAntiOp) Next(ctx context.Context) coldata.Batch {
 	for {
 		switch o.state {
 		case mjEntry:
-			o.initProberState(ctx)
+			o.initProberState()
 
 			if o.nonEmptyBufferedGroup() {
 				o.state = mjFinishBufferedGroup
@@ -12772,7 +12771,7 @@ func (o *mergeJoinLeftAntiOp) Next(ctx context.Context) coldata.Batch {
 			// nulls corresponding to the right one. But if the left source is
 			// finished, then there is nothing left to do.
 			if o.proberState.lIdx < o.proberState.lLength {
-				o.exhaustLeftSource(ctx)
+				o.exhaustLeftSource()
 				// We unset o.outputReady here because we want to put as many unmatched
 				// tuples from the left into the output batch. Once outCount reaches the
 				// desired output batch size, the output will be returned.
@@ -12780,15 +12779,15 @@ func (o *mergeJoinLeftAntiOp) Next(ctx context.Context) coldata.Batch {
 			}
 			o.state = mjBuild
 		case mjFinishBufferedGroup:
-			o.finishProbe(ctx)
-			o.setBuilderSourceToBufferedGroup(ctx)
+			o.finishProbe()
+			o.setBuilderSourceToBufferedGroup()
 			o.state = mjBuild
 		case mjProbe:
-			o.probe(ctx)
+			o.probe()
 			o.setBuilderSourceToBatch()
 			o.state = mjBuild
 		case mjBuild:
-			o.build(ctx)
+			o.build()
 
 			if o.builderState.outFinished {
 				o.state = mjEntry
@@ -12812,7 +12811,7 @@ func (o *mergeJoinLeftAntiOp) Next(ctx context.Context) coldata.Batch {
 			// Note that resetting of buffered group will close disk queues
 			// (if there are any).
 			if o.bufferedGroup.needToReset {
-				o.bufferedGroup.helper.Reset(ctx)
+				o.bufferedGroup.helper.Reset(o.Ctx)
 				o.bufferedGroup.needToReset = false
 			}
 			return coldata.ZeroBatch

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
@@ -11,7 +11,6 @@ package colexecjoin
 
 import (
 	"bytes"
-	"context"
 	"math"
 	"time"
 
@@ -46,7 +45,7 @@ type mergeJoinLeftOuterOp struct {
 
 var _ colexecop.Operator = &mergeJoinLeftOuterOp{}
 
-func (o *mergeJoinLeftOuterOp) probeBodyLSeltrueRSeltrue(ctx context.Context) {
+func (o *mergeJoinLeftOuterOp) probeBodyLSeltrueRSeltrue() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -204,9 +203,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -401,9 +400,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -590,9 +589,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -811,9 +810,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1040,9 +1039,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1270,9 +1269,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1527,9 +1526,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1756,9 +1755,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1952,9 +1951,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2159,9 +2158,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2360,9 +2359,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2439,7 +2438,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinLeftOuterOp) probeBodyLSeltrueRSelfalse(ctx context.Context) {
+func (o *mergeJoinLeftOuterOp) probeBodyLSeltrueRSelfalse() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -2597,9 +2596,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2794,9 +2793,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2983,9 +2982,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3204,9 +3203,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3433,9 +3432,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3663,9 +3662,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3920,9 +3919,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4149,9 +4148,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4345,9 +4344,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4552,9 +4551,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4753,9 +4752,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4832,7 +4831,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinLeftOuterOp) probeBodyLSelfalseRSeltrue(ctx context.Context) {
+func (o *mergeJoinLeftOuterOp) probeBodyLSelfalseRSeltrue() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -4990,9 +4989,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5187,9 +5186,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5376,9 +5375,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5597,9 +5596,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5826,9 +5825,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6056,9 +6055,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6313,9 +6312,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6542,9 +6541,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6738,9 +6737,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6945,9 +6944,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7146,9 +7145,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7225,7 +7224,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinLeftOuterOp) probeBodyLSelfalseRSelfalse(ctx context.Context) {
+func (o *mergeJoinLeftOuterOp) probeBodyLSelfalseRSelfalse() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -7383,9 +7382,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7580,9 +7579,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7769,9 +7768,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7990,9 +7989,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -8219,9 +8218,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -8449,9 +8448,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -8706,9 +8705,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -8935,9 +8934,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -9131,9 +9130,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -9338,9 +9337,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -9539,9 +9538,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -12638,28 +12637,28 @@ func (o *mergeJoinLeftOuterOp) buildRightGroupsFromBatch(
 // and set the correct cardinality.
 // Note that in this phase, we do this for every group, except the last group
 // in the batch.
-func (o *mergeJoinLeftOuterOp) probe(ctx context.Context) {
+func (o *mergeJoinLeftOuterOp) probe() {
 	o.groups.reset(o.proberState.lIdx, o.proberState.lLength, o.proberState.rIdx, o.proberState.rLength)
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 	if lSel != nil {
 		if rSel != nil {
-			o.probeBodyLSeltrueRSeltrue(ctx)
+			o.probeBodyLSeltrueRSeltrue()
 		} else {
-			o.probeBodyLSeltrueRSelfalse(ctx)
+			o.probeBodyLSeltrueRSelfalse()
 		}
 	} else {
 		if rSel != nil {
-			o.probeBodyLSelfalseRSeltrue(ctx)
+			o.probeBodyLSelfalseRSeltrue()
 		} else {
-			o.probeBodyLSelfalseRSelfalse(ctx)
+			o.probeBodyLSelfalseRSelfalse()
 		}
 	}
 }
 
 // setBuilderSourceToBufferedGroup sets up the builder state to use the
 // buffered group.
-func (o *mergeJoinLeftOuterOp) setBuilderSourceToBufferedGroup(ctx context.Context) {
+func (o *mergeJoinLeftOuterOp) setBuilderSourceToBufferedGroup() {
 	o.builderState.buildFrom = mjBuildFromBufferedGroup
 	o.bufferedGroup.helper.setupBuilder()
 	o.builderState.totalOutCountFromBufferedGroup = o.bufferedGroup.helper.calculateOutputCount()
@@ -12674,7 +12673,7 @@ func (o *mergeJoinLeftOuterOp) setBuilderSourceToBufferedGroup(ctx context.Conte
 // exhaustLeftSource sets up the builder to process any remaining tuples from
 // the left source. It should only be called when the right source has been
 // exhausted.
-func (o *mergeJoinLeftOuterOp) exhaustLeftSource(ctx context.Context) {
+func (o *mergeJoinLeftOuterOp) exhaustLeftSource() {
 	// The capacity of builder state lGroups and rGroups is always at least 1
 	// given the init.
 	o.builderState.lGroups = o.builderState.lGroups[:1]
@@ -12726,7 +12725,7 @@ func (o *mergeJoinLeftOuterOp) calculateOutputCount(groups []group) int {
 }
 
 // build creates the cross product, and writes it to the output member.
-func (o *mergeJoinLeftOuterOp) build(ctx context.Context) {
+func (o *mergeJoinLeftOuterOp) build() {
 	outStartIdx := o.builderState.outCount
 	switch o.builderState.buildFrom {
 	case mjBuildFromBatch:
@@ -12753,8 +12752,8 @@ func (o *mergeJoinLeftOuterOp) build(ctx context.Context) {
 		o.builderState.outCount += willEmit
 		o.builderState.alreadyEmittedFromBufferedGroup += willEmit
 		if o.output.Width() != 0 && willEmit > 0 {
-			o.bufferedGroup.helper.buildFromLeftInput(ctx, outStartIdx)
-			o.bufferedGroup.helper.buildFromRightInput(ctx, outStartIdx)
+			o.bufferedGroup.helper.buildFromLeftInput(o.Ctx, outStartIdx)
+			o.bufferedGroup.helper.buildFromRightInput(o.Ctx, outStartIdx)
 		}
 
 	default:
@@ -12763,7 +12762,7 @@ func (o *mergeJoinLeftOuterOp) build(ctx context.Context) {
 	}
 }
 
-func (o *mergeJoinLeftOuterOp) Next(ctx context.Context) coldata.Batch {
+func (o *mergeJoinLeftOuterOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
 	)
@@ -12771,7 +12770,7 @@ func (o *mergeJoinLeftOuterOp) Next(ctx context.Context) coldata.Batch {
 	for {
 		switch o.state {
 		case mjEntry:
-			o.initProberState(ctx)
+			o.initProberState()
 
 			if o.nonEmptyBufferedGroup() {
 				o.state = mjFinishBufferedGroup
@@ -12798,7 +12797,7 @@ func (o *mergeJoinLeftOuterOp) Next(ctx context.Context) coldata.Batch {
 			// nulls corresponding to the right one. But if the left source is
 			// finished, then there is nothing left to do.
 			if o.proberState.lIdx < o.proberState.lLength {
-				o.exhaustLeftSource(ctx)
+				o.exhaustLeftSource()
 				// We unset o.outputReady here because we want to put as many unmatched
 				// tuples from the left into the output batch. Once outCount reaches the
 				// desired output batch size, the output will be returned.
@@ -12806,15 +12805,15 @@ func (o *mergeJoinLeftOuterOp) Next(ctx context.Context) coldata.Batch {
 			}
 			o.state = mjBuild
 		case mjFinishBufferedGroup:
-			o.finishProbe(ctx)
-			o.setBuilderSourceToBufferedGroup(ctx)
+			o.finishProbe()
+			o.setBuilderSourceToBufferedGroup()
 			o.state = mjBuild
 		case mjProbe:
-			o.probe(ctx)
+			o.probe()
 			o.setBuilderSourceToBatch()
 			o.state = mjBuild
 		case mjBuild:
-			o.build(ctx)
+			o.build()
 
 			if o.builderState.outFinished {
 				o.state = mjEntry
@@ -12838,7 +12837,7 @@ func (o *mergeJoinLeftOuterOp) Next(ctx context.Context) coldata.Batch {
 			// Note that resetting of buffered group will close disk queues
 			// (if there are any).
 			if o.bufferedGroup.needToReset {
-				o.bufferedGroup.helper.Reset(ctx)
+				o.bufferedGroup.helper.Reset(o.Ctx)
 				o.bufferedGroup.needToReset = false
 			}
 			return coldata.ZeroBatch

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
@@ -11,7 +11,6 @@ package colexecjoin
 
 import (
 	"bytes"
-	"context"
 	"math"
 	"time"
 
@@ -46,7 +45,7 @@ type mergeJoinLeftSemiOp struct {
 
 var _ colexecop.Operator = &mergeJoinLeftSemiOp{}
 
-func (o *mergeJoinLeftSemiOp) probeBodyLSeltrueRSeltrue(ctx context.Context) {
+func (o *mergeJoinLeftSemiOp) probeBodyLSeltrueRSeltrue() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -193,9 +192,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -337,9 +336,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -481,9 +480,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -657,9 +656,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -830,9 +829,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1004,9 +1003,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1205,9 +1204,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1370,9 +1369,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1514,9 +1513,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1676,9 +1675,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1826,9 +1825,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1869,7 +1868,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinLeftSemiOp) probeBodyLSeltrueRSelfalse(ctx context.Context) {
+func (o *mergeJoinLeftSemiOp) probeBodyLSeltrueRSelfalse() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -2016,9 +2015,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2160,9 +2159,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2304,9 +2303,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2480,9 +2479,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2653,9 +2652,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2827,9 +2826,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3028,9 +3027,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3193,9 +3192,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3337,9 +3336,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3499,9 +3498,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3649,9 +3648,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3692,7 +3691,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinLeftSemiOp) probeBodyLSelfalseRSeltrue(ctx context.Context) {
+func (o *mergeJoinLeftSemiOp) probeBodyLSelfalseRSeltrue() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -3839,9 +3838,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3983,9 +3982,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4127,9 +4126,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4303,9 +4302,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4476,9 +4475,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4650,9 +4649,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4851,9 +4850,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5016,9 +5015,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5160,9 +5159,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5322,9 +5321,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5472,9 +5471,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5515,7 +5514,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinLeftSemiOp) probeBodyLSelfalseRSelfalse(ctx context.Context) {
+func (o *mergeJoinLeftSemiOp) probeBodyLSelfalseRSelfalse() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -5662,9 +5661,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5806,9 +5805,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5950,9 +5949,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6126,9 +6125,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6299,9 +6298,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6473,9 +6472,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6674,9 +6673,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6839,9 +6838,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6983,9 +6982,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7145,9 +7144,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7295,9 +7294,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -10314,28 +10313,28 @@ func (o *mergeJoinLeftSemiOp) buildRightGroupsFromBatch(
 // and set the correct cardinality.
 // Note that in this phase, we do this for every group, except the last group
 // in the batch.
-func (o *mergeJoinLeftSemiOp) probe(ctx context.Context) {
+func (o *mergeJoinLeftSemiOp) probe() {
 	o.groups.reset(o.proberState.lIdx, o.proberState.lLength, o.proberState.rIdx, o.proberState.rLength)
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 	if lSel != nil {
 		if rSel != nil {
-			o.probeBodyLSeltrueRSeltrue(ctx)
+			o.probeBodyLSeltrueRSeltrue()
 		} else {
-			o.probeBodyLSeltrueRSelfalse(ctx)
+			o.probeBodyLSeltrueRSelfalse()
 		}
 	} else {
 		if rSel != nil {
-			o.probeBodyLSelfalseRSeltrue(ctx)
+			o.probeBodyLSelfalseRSeltrue()
 		} else {
-			o.probeBodyLSelfalseRSelfalse(ctx)
+			o.probeBodyLSelfalseRSelfalse()
 		}
 	}
 }
 
 // setBuilderSourceToBufferedGroup sets up the builder state to use the
 // buffered group.
-func (o *mergeJoinLeftSemiOp) setBuilderSourceToBufferedGroup(ctx context.Context) {
+func (o *mergeJoinLeftSemiOp) setBuilderSourceToBufferedGroup() {
 	o.builderState.buildFrom = mjBuildFromBufferedGroup
 	o.bufferedGroup.helper.setupBuilder()
 	o.builderState.totalOutCountFromBufferedGroup = o.bufferedGroup.helper.calculateOutputCount()
@@ -10350,7 +10349,7 @@ func (o *mergeJoinLeftSemiOp) setBuilderSourceToBufferedGroup(ctx context.Contex
 // exhaustLeftSource sets up the builder to process any remaining tuples from
 // the left source. It should only be called when the right source has been
 // exhausted.
-func (o *mergeJoinLeftSemiOp) exhaustLeftSource(ctx context.Context) {
+func (o *mergeJoinLeftSemiOp) exhaustLeftSource() {
 }
 
 // exhaustRightSource sets up the builder to process any remaining tuples from
@@ -10382,7 +10381,7 @@ func (o *mergeJoinLeftSemiOp) calculateOutputCount(groups []group) int {
 }
 
 // build creates the cross product, and writes it to the output member.
-func (o *mergeJoinLeftSemiOp) build(ctx context.Context) {
+func (o *mergeJoinLeftSemiOp) build() {
 	outStartIdx := o.builderState.outCount
 	switch o.builderState.buildFrom {
 	case mjBuildFromBatch:
@@ -10408,7 +10407,7 @@ func (o *mergeJoinLeftSemiOp) build(ctx context.Context) {
 		o.builderState.outCount += willEmit
 		o.builderState.alreadyEmittedFromBufferedGroup += willEmit
 		if o.output.Width() != 0 && willEmit > 0 {
-			o.bufferedGroup.helper.buildFromLeftInput(ctx, outStartIdx)
+			o.bufferedGroup.helper.buildFromLeftInput(o.Ctx, outStartIdx)
 		}
 
 	default:
@@ -10417,7 +10416,7 @@ func (o *mergeJoinLeftSemiOp) build(ctx context.Context) {
 	}
 }
 
-func (o *mergeJoinLeftSemiOp) Next(ctx context.Context) coldata.Batch {
+func (o *mergeJoinLeftSemiOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
 	)
@@ -10425,7 +10424,7 @@ func (o *mergeJoinLeftSemiOp) Next(ctx context.Context) coldata.Batch {
 	for {
 		switch o.state {
 		case mjEntry:
-			o.initProberState(ctx)
+			o.initProberState()
 
 			if o.nonEmptyBufferedGroup() {
 				o.state = mjFinishBufferedGroup
@@ -10441,18 +10440,18 @@ func (o *mergeJoinLeftSemiOp) Next(ctx context.Context) coldata.Batch {
 		case mjSourceFinished:
 			o.outputReady = true
 			o.builderState.buildFrom = mjBuildFromBatch
-			o.setBuilderSourceToBufferedGroup(ctx)
+			o.setBuilderSourceToBufferedGroup()
 			o.state = mjBuild
 		case mjFinishBufferedGroup:
-			o.finishProbe(ctx)
-			o.setBuilderSourceToBufferedGroup(ctx)
+			o.finishProbe()
+			o.setBuilderSourceToBufferedGroup()
 			o.state = mjBuild
 		case mjProbe:
-			o.probe(ctx)
+			o.probe()
 			o.setBuilderSourceToBatch()
 			o.state = mjBuild
 		case mjBuild:
-			o.build(ctx)
+			o.build()
 
 			if o.builderState.outFinished {
 				o.state = mjEntry
@@ -10476,7 +10475,7 @@ func (o *mergeJoinLeftSemiOp) Next(ctx context.Context) coldata.Batch {
 			// Note that resetting of buffered group will close disk queues
 			// (if there are any).
 			if o.bufferedGroup.needToReset {
-				o.bufferedGroup.helper.Reset(ctx)
+				o.bufferedGroup.helper.Reset(o.Ctx)
 				o.bufferedGroup.needToReset = false
 			}
 			return coldata.ZeroBatch

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
@@ -11,7 +11,6 @@ package colexecjoin
 
 import (
 	"bytes"
-	"context"
 	"math"
 	"time"
 
@@ -46,7 +45,7 @@ type mergeJoinRightAntiOp struct {
 
 var _ colexecop.Operator = &mergeJoinRightAntiOp{}
 
-func (o *mergeJoinRightAntiOp) probeBodyLSeltrueRSeltrue(ctx context.Context) {
+func (o *mergeJoinRightAntiOp) probeBodyLSeltrueRSeltrue() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -204,9 +203,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -399,9 +398,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -586,9 +585,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -805,9 +804,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1032,9 +1031,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1260,9 +1259,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1515,9 +1514,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1742,9 +1741,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1936,9 +1935,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2141,9 +2140,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2340,9 +2339,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2417,7 +2416,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinRightAntiOp) probeBodyLSeltrueRSelfalse(ctx context.Context) {
+func (o *mergeJoinRightAntiOp) probeBodyLSeltrueRSelfalse() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -2575,9 +2574,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2770,9 +2769,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2957,9 +2956,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3176,9 +3175,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3403,9 +3402,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3631,9 +3630,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3886,9 +3885,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4113,9 +4112,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4307,9 +4306,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4512,9 +4511,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4711,9 +4710,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4788,7 +4787,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinRightAntiOp) probeBodyLSelfalseRSeltrue(ctx context.Context) {
+func (o *mergeJoinRightAntiOp) probeBodyLSelfalseRSeltrue() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -4946,9 +4945,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5141,9 +5140,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5328,9 +5327,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5547,9 +5546,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5774,9 +5773,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6002,9 +6001,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6257,9 +6256,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6484,9 +6483,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6678,9 +6677,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6883,9 +6882,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7082,9 +7081,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7159,7 +7158,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinRightAntiOp) probeBodyLSelfalseRSelfalse(ctx context.Context) {
+func (o *mergeJoinRightAntiOp) probeBodyLSelfalseRSelfalse() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -7317,9 +7316,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7512,9 +7511,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7699,9 +7698,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7918,9 +7917,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -8145,9 +8144,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -8373,9 +8372,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -8628,9 +8627,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -8855,9 +8854,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -9049,9 +9048,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -9254,9 +9253,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -9453,9 +9452,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -12572,28 +12571,28 @@ func (o *mergeJoinRightAntiOp) buildRightGroupsFromBatch(
 // and set the correct cardinality.
 // Note that in this phase, we do this for every group, except the last group
 // in the batch.
-func (o *mergeJoinRightAntiOp) probe(ctx context.Context) {
+func (o *mergeJoinRightAntiOp) probe() {
 	o.groups.reset(o.proberState.lIdx, o.proberState.lLength, o.proberState.rIdx, o.proberState.rLength)
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 	if lSel != nil {
 		if rSel != nil {
-			o.probeBodyLSeltrueRSeltrue(ctx)
+			o.probeBodyLSeltrueRSeltrue()
 		} else {
-			o.probeBodyLSeltrueRSelfalse(ctx)
+			o.probeBodyLSeltrueRSelfalse()
 		}
 	} else {
 		if rSel != nil {
-			o.probeBodyLSelfalseRSeltrue(ctx)
+			o.probeBodyLSelfalseRSeltrue()
 		} else {
-			o.probeBodyLSelfalseRSelfalse(ctx)
+			o.probeBodyLSelfalseRSelfalse()
 		}
 	}
 }
 
 // setBuilderSourceToBufferedGroup sets up the builder state to use the
 // buffered group.
-func (o *mergeJoinRightAntiOp) setBuilderSourceToBufferedGroup(ctx context.Context) {
+func (o *mergeJoinRightAntiOp) setBuilderSourceToBufferedGroup() {
 	o.builderState.buildFrom = mjBuildFromBufferedGroup
 	o.bufferedGroup.helper.setupBuilder()
 	o.builderState.totalOutCountFromBufferedGroup = o.bufferedGroup.helper.calculateOutputCount()
@@ -12608,7 +12607,7 @@ func (o *mergeJoinRightAntiOp) setBuilderSourceToBufferedGroup(ctx context.Conte
 // exhaustLeftSource sets up the builder to process any remaining tuples from
 // the left source. It should only be called when the right source has been
 // exhausted.
-func (o *mergeJoinRightAntiOp) exhaustLeftSource(ctx context.Context) {
+func (o *mergeJoinRightAntiOp) exhaustLeftSource() {
 }
 
 // exhaustRightSource sets up the builder to process any remaining tuples from
@@ -12656,7 +12655,7 @@ func (o *mergeJoinRightAntiOp) calculateOutputCount(groups []group) int {
 }
 
 // build creates the cross product, and writes it to the output member.
-func (o *mergeJoinRightAntiOp) build(ctx context.Context) {
+func (o *mergeJoinRightAntiOp) build() {
 	outStartIdx := o.builderState.outCount
 	switch o.builderState.buildFrom {
 	case mjBuildFromBatch:
@@ -12680,7 +12679,7 @@ func (o *mergeJoinRightAntiOp) build(ctx context.Context) {
 		o.builderState.outCount += willEmit
 		o.builderState.alreadyEmittedFromBufferedGroup += willEmit
 		if o.output.Width() != 0 && willEmit > 0 {
-			o.bufferedGroup.helper.buildFromRightInput(ctx, outStartIdx)
+			o.bufferedGroup.helper.buildFromRightInput(o.Ctx, outStartIdx)
 		}
 
 	default:
@@ -12689,7 +12688,7 @@ func (o *mergeJoinRightAntiOp) build(ctx context.Context) {
 	}
 }
 
-func (o *mergeJoinRightAntiOp) Next(ctx context.Context) coldata.Batch {
+func (o *mergeJoinRightAntiOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
 	)
@@ -12697,7 +12696,7 @@ func (o *mergeJoinRightAntiOp) Next(ctx context.Context) coldata.Batch {
 	for {
 		switch o.state {
 		case mjEntry:
-			o.initProberState(ctx)
+			o.initProberState()
 
 			if o.nonEmptyBufferedGroup() {
 				o.state = mjFinishBufferedGroup
@@ -12732,15 +12731,15 @@ func (o *mergeJoinRightAntiOp) Next(ctx context.Context) coldata.Batch {
 			}
 			o.state = mjBuild
 		case mjFinishBufferedGroup:
-			o.finishProbe(ctx)
-			o.setBuilderSourceToBufferedGroup(ctx)
+			o.finishProbe()
+			o.setBuilderSourceToBufferedGroup()
 			o.state = mjBuild
 		case mjProbe:
-			o.probe(ctx)
+			o.probe()
 			o.setBuilderSourceToBatch()
 			o.state = mjBuild
 		case mjBuild:
-			o.build(ctx)
+			o.build()
 
 			if o.builderState.outFinished {
 				o.state = mjEntry
@@ -12764,7 +12763,7 @@ func (o *mergeJoinRightAntiOp) Next(ctx context.Context) coldata.Batch {
 			// Note that resetting of buffered group will close disk queues
 			// (if there are any).
 			if o.bufferedGroup.needToReset {
-				o.bufferedGroup.helper.Reset(ctx)
+				o.bufferedGroup.helper.Reset(o.Ctx)
 				o.bufferedGroup.needToReset = false
 			}
 			return coldata.ZeroBatch

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
@@ -11,7 +11,6 @@ package colexecjoin
 
 import (
 	"bytes"
-	"context"
 	"math"
 	"time"
 
@@ -46,7 +45,7 @@ type mergeJoinRightOuterOp struct {
 
 var _ colexecop.Operator = &mergeJoinRightOuterOp{}
 
-func (o *mergeJoinRightOuterOp) probeBodyLSeltrueRSeltrue(ctx context.Context) {
+func (o *mergeJoinRightOuterOp) probeBodyLSeltrueRSeltrue() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -204,9 +203,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -400,9 +399,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -588,9 +587,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -808,9 +807,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1036,9 +1035,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1265,9 +1264,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1521,9 +1520,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1749,9 +1748,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1944,9 +1943,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2150,9 +2149,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2350,9 +2349,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2428,7 +2427,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinRightOuterOp) probeBodyLSeltrueRSelfalse(ctx context.Context) {
+func (o *mergeJoinRightOuterOp) probeBodyLSeltrueRSelfalse() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -2586,9 +2585,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2782,9 +2781,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2970,9 +2969,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3190,9 +3189,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3418,9 +3417,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3647,9 +3646,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3903,9 +3902,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4131,9 +4130,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4326,9 +4325,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4532,9 +4531,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4732,9 +4731,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4810,7 +4809,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinRightOuterOp) probeBodyLSelfalseRSeltrue(ctx context.Context) {
+func (o *mergeJoinRightOuterOp) probeBodyLSelfalseRSeltrue() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -4968,9 +4967,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5164,9 +5163,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5352,9 +5351,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5572,9 +5571,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5800,9 +5799,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6029,9 +6028,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6285,9 +6284,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6513,9 +6512,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6708,9 +6707,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6914,9 +6913,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7114,9 +7113,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7192,7 +7191,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinRightOuterOp) probeBodyLSelfalseRSelfalse(ctx context.Context) {
+func (o *mergeJoinRightOuterOp) probeBodyLSelfalseRSelfalse() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -7350,9 +7349,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7546,9 +7545,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7734,9 +7733,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7954,9 +7953,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -8182,9 +8181,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -8411,9 +8410,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -8667,9 +8666,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -8895,9 +8894,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -9090,9 +9089,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -9296,9 +9295,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -9496,9 +9495,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -12616,28 +12615,28 @@ func (o *mergeJoinRightOuterOp) buildRightGroupsFromBatch(
 // and set the correct cardinality.
 // Note that in this phase, we do this for every group, except the last group
 // in the batch.
-func (o *mergeJoinRightOuterOp) probe(ctx context.Context) {
+func (o *mergeJoinRightOuterOp) probe() {
 	o.groups.reset(o.proberState.lIdx, o.proberState.lLength, o.proberState.rIdx, o.proberState.rLength)
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 	if lSel != nil {
 		if rSel != nil {
-			o.probeBodyLSeltrueRSeltrue(ctx)
+			o.probeBodyLSeltrueRSeltrue()
 		} else {
-			o.probeBodyLSeltrueRSelfalse(ctx)
+			o.probeBodyLSeltrueRSelfalse()
 		}
 	} else {
 		if rSel != nil {
-			o.probeBodyLSelfalseRSeltrue(ctx)
+			o.probeBodyLSelfalseRSeltrue()
 		} else {
-			o.probeBodyLSelfalseRSelfalse(ctx)
+			o.probeBodyLSelfalseRSelfalse()
 		}
 	}
 }
 
 // setBuilderSourceToBufferedGroup sets up the builder state to use the
 // buffered group.
-func (o *mergeJoinRightOuterOp) setBuilderSourceToBufferedGroup(ctx context.Context) {
+func (o *mergeJoinRightOuterOp) setBuilderSourceToBufferedGroup() {
 	o.builderState.buildFrom = mjBuildFromBufferedGroup
 	o.bufferedGroup.helper.setupBuilder()
 	o.builderState.totalOutCountFromBufferedGroup = o.bufferedGroup.helper.calculateOutputCount()
@@ -12652,7 +12651,7 @@ func (o *mergeJoinRightOuterOp) setBuilderSourceToBufferedGroup(ctx context.Cont
 // exhaustLeftSource sets up the builder to process any remaining tuples from
 // the left source. It should only be called when the right source has been
 // exhausted.
-func (o *mergeJoinRightOuterOp) exhaustLeftSource(ctx context.Context) {
+func (o *mergeJoinRightOuterOp) exhaustLeftSource() {
 }
 
 // exhaustRightSource sets up the builder to process any remaining tuples from
@@ -12702,7 +12701,7 @@ func (o *mergeJoinRightOuterOp) calculateOutputCount(groups []group) int {
 }
 
 // build creates the cross product, and writes it to the output member.
-func (o *mergeJoinRightOuterOp) build(ctx context.Context) {
+func (o *mergeJoinRightOuterOp) build() {
 	outStartIdx := o.builderState.outCount
 	switch o.builderState.buildFrom {
 	case mjBuildFromBatch:
@@ -12729,8 +12728,8 @@ func (o *mergeJoinRightOuterOp) build(ctx context.Context) {
 		o.builderState.outCount += willEmit
 		o.builderState.alreadyEmittedFromBufferedGroup += willEmit
 		if o.output.Width() != 0 && willEmit > 0 {
-			o.bufferedGroup.helper.buildFromLeftInput(ctx, outStartIdx)
-			o.bufferedGroup.helper.buildFromRightInput(ctx, outStartIdx)
+			o.bufferedGroup.helper.buildFromLeftInput(o.Ctx, outStartIdx)
+			o.bufferedGroup.helper.buildFromRightInput(o.Ctx, outStartIdx)
 		}
 
 	default:
@@ -12739,7 +12738,7 @@ func (o *mergeJoinRightOuterOp) build(ctx context.Context) {
 	}
 }
 
-func (o *mergeJoinRightOuterOp) Next(ctx context.Context) coldata.Batch {
+func (o *mergeJoinRightOuterOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
 	)
@@ -12747,7 +12746,7 @@ func (o *mergeJoinRightOuterOp) Next(ctx context.Context) coldata.Batch {
 	for {
 		switch o.state {
 		case mjEntry:
-			o.initProberState(ctx)
+			o.initProberState()
 
 			if o.nonEmptyBufferedGroup() {
 				o.state = mjFinishBufferedGroup
@@ -12782,15 +12781,15 @@ func (o *mergeJoinRightOuterOp) Next(ctx context.Context) coldata.Batch {
 			}
 			o.state = mjBuild
 		case mjFinishBufferedGroup:
-			o.finishProbe(ctx)
-			o.setBuilderSourceToBufferedGroup(ctx)
+			o.finishProbe()
+			o.setBuilderSourceToBufferedGroup()
 			o.state = mjBuild
 		case mjProbe:
-			o.probe(ctx)
+			o.probe()
 			o.setBuilderSourceToBatch()
 			o.state = mjBuild
 		case mjBuild:
-			o.build(ctx)
+			o.build()
 
 			if o.builderState.outFinished {
 				o.state = mjEntry
@@ -12814,7 +12813,7 @@ func (o *mergeJoinRightOuterOp) Next(ctx context.Context) coldata.Batch {
 			// Note that resetting of buffered group will close disk queues
 			// (if there are any).
 			if o.bufferedGroup.needToReset {
-				o.bufferedGroup.helper.Reset(ctx)
+				o.bufferedGroup.helper.Reset(o.Ctx)
 				o.bufferedGroup.needToReset = false
 			}
 			return coldata.ZeroBatch

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
@@ -11,7 +11,6 @@ package colexecjoin
 
 import (
 	"bytes"
-	"context"
 	"math"
 	"time"
 
@@ -46,7 +45,7 @@ type mergeJoinRightSemiOp struct {
 
 var _ colexecop.Operator = &mergeJoinRightSemiOp{}
 
-func (o *mergeJoinRightSemiOp) probeBodyLSeltrueRSeltrue(ctx context.Context) {
+func (o *mergeJoinRightSemiOp) probeBodyLSeltrueRSeltrue() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -193,9 +192,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -336,9 +335,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -479,9 +478,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -654,9 +653,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -826,9 +825,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -999,9 +998,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1199,9 +1198,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1363,9 +1362,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1506,9 +1505,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1667,9 +1666,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1816,9 +1815,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -1858,7 +1857,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinRightSemiOp) probeBodyLSeltrueRSelfalse(ctx context.Context) {
+func (o *mergeJoinRightSemiOp) probeBodyLSeltrueRSelfalse() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -2005,9 +2004,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2148,9 +2147,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2291,9 +2290,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2466,9 +2465,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2638,9 +2637,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -2811,9 +2810,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3011,9 +3010,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3175,9 +3174,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3318,9 +3317,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3479,9 +3478,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3628,9 +3627,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3670,7 +3669,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinRightSemiOp) probeBodyLSelfalseRSeltrue(ctx context.Context) {
+func (o *mergeJoinRightSemiOp) probeBodyLSelfalseRSeltrue() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -3817,9 +3816,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -3960,9 +3959,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4103,9 +4102,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4278,9 +4277,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4450,9 +4449,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4623,9 +4622,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4823,9 +4822,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -4987,9 +4986,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5130,9 +5129,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5291,9 +5290,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5440,9 +5439,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5482,7 +5481,7 @@ EqLoop:
 	}
 }
 
-func (o *mergeJoinRightSemiOp) probeBodyLSelfalseRSelfalse(ctx context.Context) {
+func (o *mergeJoinRightSemiOp) probeBodyLSelfalseRSelfalse() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -5629,9 +5628,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5772,9 +5771,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -5915,9 +5914,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6090,9 +6089,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6262,9 +6261,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6435,9 +6434,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6635,9 +6634,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6799,9 +6798,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -6942,9 +6941,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7103,9 +7102,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -7252,9 +7251,9 @@ EqLoop:
 							// Last equality column and either group is incomplete. Save state
 							// and have it handled in the next iteration.
 							if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-								o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+								o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 								o.proberState.lIdx = lGroupLength + beginLIdx
-								o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+								o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 								o.proberState.rIdx = rGroupLength + beginRIdx
 
 								o.groups.finishedCol()
@@ -10270,28 +10269,28 @@ func (o *mergeJoinRightSemiOp) buildRightGroupsFromBatch(
 // and set the correct cardinality.
 // Note that in this phase, we do this for every group, except the last group
 // in the batch.
-func (o *mergeJoinRightSemiOp) probe(ctx context.Context) {
+func (o *mergeJoinRightSemiOp) probe() {
 	o.groups.reset(o.proberState.lIdx, o.proberState.lLength, o.proberState.rIdx, o.proberState.rLength)
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 	if lSel != nil {
 		if rSel != nil {
-			o.probeBodyLSeltrueRSeltrue(ctx)
+			o.probeBodyLSeltrueRSeltrue()
 		} else {
-			o.probeBodyLSeltrueRSelfalse(ctx)
+			o.probeBodyLSeltrueRSelfalse()
 		}
 	} else {
 		if rSel != nil {
-			o.probeBodyLSelfalseRSeltrue(ctx)
+			o.probeBodyLSelfalseRSeltrue()
 		} else {
-			o.probeBodyLSelfalseRSelfalse(ctx)
+			o.probeBodyLSelfalseRSelfalse()
 		}
 	}
 }
 
 // setBuilderSourceToBufferedGroup sets up the builder state to use the
 // buffered group.
-func (o *mergeJoinRightSemiOp) setBuilderSourceToBufferedGroup(ctx context.Context) {
+func (o *mergeJoinRightSemiOp) setBuilderSourceToBufferedGroup() {
 	o.builderState.buildFrom = mjBuildFromBufferedGroup
 	o.bufferedGroup.helper.setupBuilder()
 	o.builderState.totalOutCountFromBufferedGroup = o.bufferedGroup.helper.calculateOutputCount()
@@ -10306,7 +10305,7 @@ func (o *mergeJoinRightSemiOp) setBuilderSourceToBufferedGroup(ctx context.Conte
 // exhaustLeftSource sets up the builder to process any remaining tuples from
 // the left source. It should only be called when the right source has been
 // exhausted.
-func (o *mergeJoinRightSemiOp) exhaustLeftSource(ctx context.Context) {
+func (o *mergeJoinRightSemiOp) exhaustLeftSource() {
 }
 
 // exhaustRightSource sets up the builder to process any remaining tuples from
@@ -10338,7 +10337,7 @@ func (o *mergeJoinRightSemiOp) calculateOutputCount(groups []group) int {
 }
 
 // build creates the cross product, and writes it to the output member.
-func (o *mergeJoinRightSemiOp) build(ctx context.Context) {
+func (o *mergeJoinRightSemiOp) build() {
 	outStartIdx := o.builderState.outCount
 	switch o.builderState.buildFrom {
 	case mjBuildFromBatch:
@@ -10362,7 +10361,7 @@ func (o *mergeJoinRightSemiOp) build(ctx context.Context) {
 		o.builderState.outCount += willEmit
 		o.builderState.alreadyEmittedFromBufferedGroup += willEmit
 		if o.output.Width() != 0 && willEmit > 0 {
-			o.bufferedGroup.helper.buildFromRightInput(ctx, outStartIdx)
+			o.bufferedGroup.helper.buildFromRightInput(o.Ctx, outStartIdx)
 		}
 
 	default:
@@ -10371,7 +10370,7 @@ func (o *mergeJoinRightSemiOp) build(ctx context.Context) {
 	}
 }
 
-func (o *mergeJoinRightSemiOp) Next(ctx context.Context) coldata.Batch {
+func (o *mergeJoinRightSemiOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
 	)
@@ -10379,7 +10378,7 @@ func (o *mergeJoinRightSemiOp) Next(ctx context.Context) coldata.Batch {
 	for {
 		switch o.state {
 		case mjEntry:
-			o.initProberState(ctx)
+			o.initProberState()
 
 			if o.nonEmptyBufferedGroup() {
 				o.state = mjFinishBufferedGroup
@@ -10395,18 +10394,18 @@ func (o *mergeJoinRightSemiOp) Next(ctx context.Context) coldata.Batch {
 		case mjSourceFinished:
 			o.outputReady = true
 			o.builderState.buildFrom = mjBuildFromBatch
-			o.setBuilderSourceToBufferedGroup(ctx)
+			o.setBuilderSourceToBufferedGroup()
 			o.state = mjBuild
 		case mjFinishBufferedGroup:
-			o.finishProbe(ctx)
-			o.setBuilderSourceToBufferedGroup(ctx)
+			o.finishProbe()
+			o.setBuilderSourceToBufferedGroup()
 			o.state = mjBuild
 		case mjProbe:
-			o.probe(ctx)
+			o.probe()
 			o.setBuilderSourceToBatch()
 			o.state = mjBuild
 		case mjBuild:
-			o.build(ctx)
+			o.build()
 
 			if o.builderState.outFinished {
 				o.state = mjEntry
@@ -10430,7 +10429,7 @@ func (o *mergeJoinRightSemiOp) Next(ctx context.Context) coldata.Batch {
 			// Note that resetting of buffered group will close disk queues
 			// (if there are any).
 			if o.bufferedGroup.needToReset {
-				o.bufferedGroup.helper.Reset(ctx)
+				o.bufferedGroup.helper.Reset(o.Ctx)
 				o.bufferedGroup.needToReset = false
 			}
 			return coldata.ZeroBatch

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_test.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_test.go
@@ -106,7 +106,7 @@ func TestMergeJoinCrossProduct(t *testing.T) {
 	if err != nil {
 		t.Fatal("error in merge join op constructor", err)
 	}
-	mj.Init()
+	mj.Init(ctx)
 	hj := NewHashJoiner(
 		testAllocator, testAllocator, HashJoinerSpec{
 			JoinType: descpb.InnerJoin,
@@ -118,15 +118,15 @@ func TestMergeJoinCrossProduct(t *testing.T) {
 			},
 		}, leftHJSource, rightHJSource, HashJoinerInitialNumBuckets, execinfra.DefaultMemoryLimit,
 	)
-	hj.Init()
+	hj.Init(ctx)
 
 	var mjOutputTuples, hjOutputTuples colexectestutils.Tuples
-	for b := mj.Next(ctx); b.Length() != 0; b = mj.Next(ctx) {
+	for b := mj.Next(); b.Length() != 0; b = mj.Next() {
 		for i := 0; i < b.Length(); i++ {
 			mjOutputTuples = append(mjOutputTuples, colexectestutils.GetTupleFromBatch(b, i))
 		}
 	}
-	for b := hj.Next(ctx); b.Length() != 0; b = hj.Next(ctx) {
+	for b := hj.Next(); b.Length() != 0; b = hj.Next() {
 		for i := 0; i < b.Length(); i++ {
 			hjOutputTuples = append(hjOutputTuples, colexectestutils.GetTupleFromBatch(b, i))
 		}
@@ -263,10 +263,10 @@ func BenchmarkMergeJoiner(b *testing.B) {
 					leftSource := colexectestutils.NewFiniteChunksSource(testAllocator, leftBatch, sourceTypes, nBatches, 1)
 					rightSource := colexectestutils.NewFiniteChunksSource(testAllocator, rightBatch, sourceTypes, nBatches, 1)
 					s := getNewMergeJoiner(leftSource, rightSource)
-					s.Init()
+					s.Init(ctx)
 
 					b.StartTimer()
-					for b := s.Next(ctx); b.Length() != 0; b = s.Next(ctx) {
+					for b := s.Next(); b.Length() != 0; b = s.Next() {
 					}
 					b.StopTimer()
 				}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
@@ -20,8 +20,6 @@
 package colexecjoin
 
 import (
-	"context"
-
 	"github.com/cockroachdb/apd/v2"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
@@ -271,9 +269,9 @@ func _PROBE_SWITCH(_JOIN_TYPE joinTypeInfo, _SEL_PERMUTATION selPermutation) { /
 						// Last equality column and either group is incomplete. Save state
 						// and have it handled in the next iteration.
 						if eqColIdx == len(o.left.eqCols)-1 && (!lComplete || !rComplete) {
-							o.appendToBufferedGroup(ctx, &o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
+							o.appendToBufferedGroup(&o.left, o.proberState.lBatch, lSel, beginLIdx, lGroupLength)
 							o.proberState.lIdx = lGroupLength + beginLIdx
-							o.appendToBufferedGroup(ctx, &o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
+							o.appendToBufferedGroup(&o.right, o.proberState.rBatch, rSel, beginRIdx, rGroupLength)
 							o.proberState.rIdx = rGroupLength + beginRIdx
 
 							o.groups.finishedCol()
@@ -636,7 +634,7 @@ func _PROCESS_NOT_LAST_GROUP_IN_COLUMN_SWITCH(_JOIN_TYPE joinTypeInfo) { // */}}
 // */}}
 
 // {{range $sel := $.SelPermutations}}
-func (o *mergeJoin_JOIN_TYPE_STRINGOp) probeBodyLSel_IS_L_SELRSel_IS_R_SEL(ctx context.Context) {
+func (o *mergeJoin_JOIN_TYPE_STRINGOp) probeBodyLSel_IS_L_SELRSel_IS_R_SEL() {
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 EqLoop:
@@ -974,28 +972,28 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) buildRightGroupsFromBatch(
 // and set the correct cardinality.
 // Note that in this phase, we do this for every group, except the last group
 // in the batch.
-func (o *mergeJoin_JOIN_TYPE_STRINGOp) probe(ctx context.Context) {
+func (o *mergeJoin_JOIN_TYPE_STRINGOp) probe() {
 	o.groups.reset(o.proberState.lIdx, o.proberState.lLength, o.proberState.rIdx, o.proberState.rLength)
 	lSel := o.proberState.lBatch.Selection()
 	rSel := o.proberState.rBatch.Selection()
 	if lSel != nil {
 		if rSel != nil {
-			o.probeBodyLSeltrueRSeltrue(ctx)
+			o.probeBodyLSeltrueRSeltrue()
 		} else {
-			o.probeBodyLSeltrueRSelfalse(ctx)
+			o.probeBodyLSeltrueRSelfalse()
 		}
 	} else {
 		if rSel != nil {
-			o.probeBodyLSelfalseRSeltrue(ctx)
+			o.probeBodyLSelfalseRSeltrue()
 		} else {
-			o.probeBodyLSelfalseRSelfalse(ctx)
+			o.probeBodyLSelfalseRSelfalse()
 		}
 	}
 }
 
 // setBuilderSourceToBufferedGroup sets up the builder state to use the
 // buffered group.
-func (o *mergeJoin_JOIN_TYPE_STRINGOp) setBuilderSourceToBufferedGroup(ctx context.Context) {
+func (o *mergeJoin_JOIN_TYPE_STRINGOp) setBuilderSourceToBufferedGroup() {
 	o.builderState.buildFrom = mjBuildFromBufferedGroup
 	o.bufferedGroup.helper.setupBuilder()
 	o.builderState.totalOutCountFromBufferedGroup = o.bufferedGroup.helper.calculateOutputCount()
@@ -1010,7 +1008,7 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) setBuilderSourceToBufferedGroup(ctx conte
 // exhaustLeftSource sets up the builder to process any remaining tuples from
 // the left source. It should only be called when the right source has been
 // exhausted.
-func (o *mergeJoin_JOIN_TYPE_STRINGOp) exhaustLeftSource(ctx context.Context) {
+func (o *mergeJoin_JOIN_TYPE_STRINGOp) exhaustLeftSource() {
 	// {{if or _JOIN_TYPE.IsInner (or _JOIN_TYPE.IsLeftSemi _JOIN_TYPE.IsRightSemi)}}
 	// {{/*
 	// Remaining tuples from the left source do not have a match, so they are
@@ -1112,7 +1110,7 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) calculateOutputCount(groups []group) int 
 }
 
 // build creates the cross product, and writes it to the output member.
-func (o *mergeJoin_JOIN_TYPE_STRINGOp) build(ctx context.Context) {
+func (o *mergeJoin_JOIN_TYPE_STRINGOp) build() {
 	outStartIdx := o.builderState.outCount
 	switch o.builderState.buildFrom {
 	case mjBuildFromBatch:
@@ -1148,10 +1146,10 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) build(ctx context.Context) {
 		o.builderState.alreadyEmittedFromBufferedGroup += willEmit
 		if o.output.Width() != 0 && willEmit > 0 {
 			// {{if not (or _JOIN_TYPE.IsRightSemi _JOIN_TYPE.IsRightAnti)}}
-			o.bufferedGroup.helper.buildFromLeftInput(ctx, outStartIdx)
+			o.bufferedGroup.helper.buildFromLeftInput(o.Ctx, outStartIdx)
 			// {{end}}
 			// {{if not (or _JOIN_TYPE.IsLeftSemi _JOIN_TYPE.IsLeftAnti)}}
-			o.bufferedGroup.helper.buildFromRightInput(ctx, outStartIdx)
+			o.bufferedGroup.helper.buildFromRightInput(o.Ctx, outStartIdx)
 			// {{end}}
 		}
 
@@ -1170,7 +1168,7 @@ func _SOURCE_FINISHED_SWITCH(_JOIN_TYPE joinTypeInfo) { // */}}
 	o.outputReady = true
 	o.builderState.buildFrom = mjBuildFromBatch
 	// {{if or $.JoinType.IsInner (or $.JoinType.IsLeftSemi $.JoinType.IsRightSemi)}}
-	o.setBuilderSourceToBufferedGroup(ctx)
+	o.setBuilderSourceToBufferedGroup()
 	// {{else}}
 	// Next, we need to make sure that builder state is set up for a case when
 	// neither exhaustLeftSource nor exhaustRightSource is called below. In such
@@ -1185,7 +1183,7 @@ func _SOURCE_FINISHED_SWITCH(_JOIN_TYPE joinTypeInfo) { // */}}
 	// nulls corresponding to the right one. But if the left source is
 	// finished, then there is nothing left to do.
 	if o.proberState.lIdx < o.proberState.lLength {
-		o.exhaustLeftSource(ctx)
+		o.exhaustLeftSource()
 		// We unset o.outputReady here because we want to put as many unmatched
 		// tuples from the left into the output batch. Once outCount reaches the
 		// desired output batch size, the output will be returned.
@@ -1211,7 +1209,7 @@ func _SOURCE_FINISHED_SWITCH(_JOIN_TYPE joinTypeInfo) { // */}}
 
 // */}}
 
-func (o *mergeJoin_JOIN_TYPE_STRINGOp) Next(ctx context.Context) coldata.Batch {
+func (o *mergeJoin_JOIN_TYPE_STRINGOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minCapacity */, o.memoryLimit,
 	)
@@ -1219,7 +1217,7 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) Next(ctx context.Context) coldata.Batch {
 	for {
 		switch o.state {
 		case mjEntry:
-			o.initProberState(ctx)
+			o.initProberState()
 
 			if o.nonEmptyBufferedGroup() {
 				o.state = mjFinishBufferedGroup
@@ -1236,15 +1234,15 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) Next(ctx context.Context) coldata.Batch {
 			_SOURCE_FINISHED_SWITCH(_JOIN_TYPE)
 			o.state = mjBuild
 		case mjFinishBufferedGroup:
-			o.finishProbe(ctx)
-			o.setBuilderSourceToBufferedGroup(ctx)
+			o.finishProbe()
+			o.setBuilderSourceToBufferedGroup()
 			o.state = mjBuild
 		case mjProbe:
-			o.probe(ctx)
+			o.probe()
 			o.setBuilderSourceToBatch()
 			o.state = mjBuild
 		case mjBuild:
-			o.build(ctx)
+			o.build()
 
 			if o.builderState.outFinished {
 				o.state = mjEntry
@@ -1268,7 +1266,7 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) Next(ctx context.Context) coldata.Batch {
 			// Note that resetting of buffered group will close disk queues
 			// (if there are any).
 			if o.bufferedGroup.needToReset {
-				o.bufferedGroup.helper.Reset(ctx)
+				o.bufferedGroup.helper.Reset(o.Ctx)
 				o.bufferedGroup.needToReset = false
 			}
 			return coldata.ZeroBatch

--- a/pkg/sql/colexec/colexecproj/default_cmp_proj_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/default_cmp_proj_ops.eg.go
@@ -10,8 +10,6 @@
 package colexecproj
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexeccmp"
@@ -30,12 +28,8 @@ type defaultCmpProjOp struct {
 
 var _ colexecop.Operator = &defaultCmpProjOp{}
 
-func (d *defaultCmpProjOp) Init() {
-	d.Input.Init()
-}
-
-func (d *defaultCmpProjOp) Next(ctx context.Context) coldata.Batch {
-	batch := d.Input.Next(ctx)
+func (d *defaultCmpProjOp) Next() coldata.Batch {
+	batch := d.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -91,12 +85,8 @@ type defaultCmpRConstProjOp struct {
 
 var _ colexecop.Operator = &defaultCmpRConstProjOp{}
 
-func (d *defaultCmpRConstProjOp) Init() {
-	d.Input.Init()
-}
-
-func (d *defaultCmpRConstProjOp) Next(ctx context.Context) coldata.Batch {
-	batch := d.Input.Next(ctx)
+func (d *defaultCmpRConstProjOp) Next() coldata.Batch {
+	batch := d.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch

--- a/pkg/sql/colexec/colexecproj/default_cmp_proj_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/default_cmp_proj_ops_tmpl.go
@@ -20,8 +20,6 @@
 package colexecproj
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexeccmp"
@@ -47,12 +45,8 @@ type defaultCmp_KINDProjOp struct {
 
 var _ colexecop.Operator = &defaultCmp_KINDProjOp{}
 
-func (d *defaultCmp_KINDProjOp) Init() {
-	d.Input.Init()
-}
-
-func (d *defaultCmp_KINDProjOp) Next(ctx context.Context) coldata.Batch {
-	batch := d.Input.Next(ctx)
+func (d *defaultCmp_KINDProjOp) Next() coldata.Batch {
+	batch := d.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch

--- a/pkg/sql/colexec/colexecproj/like_ops.go
+++ b/pkg/sql/colexec/colexecproj/like_ops.go
@@ -39,10 +39,10 @@ func GetLikeProjectionOperator(
 	pat := []byte(pattern)
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, types.Bool, resultIdx)
 	base := projConstOpBase{
-		OneInputNode: colexecop.NewOneInputNode(input),
-		allocator:    allocator,
-		colIdx:       colIdx,
-		outputIdx:    resultIdx,
+		OneInputHelper: colexecop.MakeOneInputHelper(input),
+		allocator:      allocator,
+		colIdx:         colIdx,
+		outputIdx:      resultIdx,
 	}
 	switch likeOpType {
 	case colexeccmp.LikeConstant:

--- a/pkg/sql/colexec/colexecproj/proj_const_left_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_const_left_ops.eg.go
@@ -10,7 +10,6 @@
 package colexecproj
 
 import (
-	"context"
 	"math"
 	"time"
 	"unsafe"
@@ -49,14 +48,14 @@ type projBitandInt16ConstInt16Op struct {
 	constArg int16
 }
 
-func (p projBitandInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitandInt16ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -144,10 +143,6 @@ func (p projBitandInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandInt16ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projBitandInt16ConstInt32Op struct {
@@ -155,14 +150,14 @@ type projBitandInt16ConstInt32Op struct {
 	constArg int16
 }
 
-func (p projBitandInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitandInt16ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -250,10 +245,6 @@ func (p projBitandInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandInt16ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projBitandInt16ConstInt64Op struct {
@@ -261,14 +252,14 @@ type projBitandInt16ConstInt64Op struct {
 	constArg int16
 }
 
-func (p projBitandInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitandInt16ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -356,10 +347,6 @@ func (p projBitandInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandInt16ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projBitandInt32ConstInt16Op struct {
@@ -367,14 +354,14 @@ type projBitandInt32ConstInt16Op struct {
 	constArg int32
 }
 
-func (p projBitandInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitandInt32ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -462,10 +449,6 @@ func (p projBitandInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandInt32ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projBitandInt32ConstInt32Op struct {
@@ -473,14 +456,14 @@ type projBitandInt32ConstInt32Op struct {
 	constArg int32
 }
 
-func (p projBitandInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitandInt32ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -568,10 +551,6 @@ func (p projBitandInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandInt32ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projBitandInt32ConstInt64Op struct {
@@ -579,14 +558,14 @@ type projBitandInt32ConstInt64Op struct {
 	constArg int32
 }
 
-func (p projBitandInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitandInt32ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -674,10 +653,6 @@ func (p projBitandInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandInt32ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projBitandInt64ConstInt16Op struct {
@@ -685,14 +660,14 @@ type projBitandInt64ConstInt16Op struct {
 	constArg int64
 }
 
-func (p projBitandInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitandInt64ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -780,10 +755,6 @@ func (p projBitandInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandInt64ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projBitandInt64ConstInt32Op struct {
@@ -791,14 +762,14 @@ type projBitandInt64ConstInt32Op struct {
 	constArg int64
 }
 
-func (p projBitandInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitandInt64ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -886,10 +857,6 @@ func (p projBitandInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandInt64ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projBitandInt64ConstInt64Op struct {
@@ -897,14 +864,14 @@ type projBitandInt64ConstInt64Op struct {
 	constArg int64
 }
 
-func (p projBitandInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitandInt64ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -992,10 +959,6 @@ func (p projBitandInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandInt64ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projBitandDatumConstDatumOp struct {
@@ -1003,14 +966,14 @@ type projBitandDatumConstDatumOp struct {
 	constArg interface{}
 }
 
-func (p projBitandDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1124,10 +1087,6 @@ func (p projBitandDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandDatumConstDatumOp) Init() {
-	p.Input.Init()
 }
 
 type projBitorInt16ConstInt16Op struct {
@@ -1135,14 +1094,14 @@ type projBitorInt16ConstInt16Op struct {
 	constArg int16
 }
 
-func (p projBitorInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitorInt16ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1230,10 +1189,6 @@ func (p projBitorInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorInt16ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projBitorInt16ConstInt32Op struct {
@@ -1241,14 +1196,14 @@ type projBitorInt16ConstInt32Op struct {
 	constArg int16
 }
 
-func (p projBitorInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitorInt16ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1336,10 +1291,6 @@ func (p projBitorInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorInt16ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projBitorInt16ConstInt64Op struct {
@@ -1347,14 +1298,14 @@ type projBitorInt16ConstInt64Op struct {
 	constArg int16
 }
 
-func (p projBitorInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitorInt16ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1442,10 +1393,6 @@ func (p projBitorInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorInt16ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projBitorInt32ConstInt16Op struct {
@@ -1453,14 +1400,14 @@ type projBitorInt32ConstInt16Op struct {
 	constArg int32
 }
 
-func (p projBitorInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitorInt32ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1548,10 +1495,6 @@ func (p projBitorInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorInt32ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projBitorInt32ConstInt32Op struct {
@@ -1559,14 +1502,14 @@ type projBitorInt32ConstInt32Op struct {
 	constArg int32
 }
 
-func (p projBitorInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitorInt32ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1654,10 +1597,6 @@ func (p projBitorInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorInt32ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projBitorInt32ConstInt64Op struct {
@@ -1665,14 +1604,14 @@ type projBitorInt32ConstInt64Op struct {
 	constArg int32
 }
 
-func (p projBitorInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitorInt32ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1760,10 +1699,6 @@ func (p projBitorInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorInt32ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projBitorInt64ConstInt16Op struct {
@@ -1771,14 +1706,14 @@ type projBitorInt64ConstInt16Op struct {
 	constArg int64
 }
 
-func (p projBitorInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitorInt64ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1866,10 +1801,6 @@ func (p projBitorInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorInt64ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projBitorInt64ConstInt32Op struct {
@@ -1877,14 +1808,14 @@ type projBitorInt64ConstInt32Op struct {
 	constArg int64
 }
 
-func (p projBitorInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitorInt64ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1972,10 +1903,6 @@ func (p projBitorInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorInt64ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projBitorInt64ConstInt64Op struct {
@@ -1983,14 +1910,14 @@ type projBitorInt64ConstInt64Op struct {
 	constArg int64
 }
 
-func (p projBitorInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitorInt64ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2078,10 +2005,6 @@ func (p projBitorInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorInt64ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projBitorDatumConstDatumOp struct {
@@ -2089,14 +2012,14 @@ type projBitorDatumConstDatumOp struct {
 	constArg interface{}
 }
 
-func (p projBitorDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2210,10 +2133,6 @@ func (p projBitorDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorDatumConstDatumOp) Init() {
-	p.Input.Init()
 }
 
 type projBitxorInt16ConstInt16Op struct {
@@ -2221,14 +2140,14 @@ type projBitxorInt16ConstInt16Op struct {
 	constArg int16
 }
 
-func (p projBitxorInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorInt16ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2316,10 +2235,6 @@ func (p projBitxorInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorInt16ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projBitxorInt16ConstInt32Op struct {
@@ -2327,14 +2242,14 @@ type projBitxorInt16ConstInt32Op struct {
 	constArg int16
 }
 
-func (p projBitxorInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorInt16ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2422,10 +2337,6 @@ func (p projBitxorInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorInt16ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projBitxorInt16ConstInt64Op struct {
@@ -2433,14 +2344,14 @@ type projBitxorInt16ConstInt64Op struct {
 	constArg int16
 }
 
-func (p projBitxorInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorInt16ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2528,10 +2439,6 @@ func (p projBitxorInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorInt16ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projBitxorInt32ConstInt16Op struct {
@@ -2539,14 +2446,14 @@ type projBitxorInt32ConstInt16Op struct {
 	constArg int32
 }
 
-func (p projBitxorInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorInt32ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2634,10 +2541,6 @@ func (p projBitxorInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorInt32ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projBitxorInt32ConstInt32Op struct {
@@ -2645,14 +2548,14 @@ type projBitxorInt32ConstInt32Op struct {
 	constArg int32
 }
 
-func (p projBitxorInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorInt32ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2740,10 +2643,6 @@ func (p projBitxorInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorInt32ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projBitxorInt32ConstInt64Op struct {
@@ -2751,14 +2650,14 @@ type projBitxorInt32ConstInt64Op struct {
 	constArg int32
 }
 
-func (p projBitxorInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorInt32ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2846,10 +2745,6 @@ func (p projBitxorInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorInt32ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projBitxorInt64ConstInt16Op struct {
@@ -2857,14 +2752,14 @@ type projBitxorInt64ConstInt16Op struct {
 	constArg int64
 }
 
-func (p projBitxorInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorInt64ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2952,10 +2847,6 @@ func (p projBitxorInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorInt64ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projBitxorInt64ConstInt32Op struct {
@@ -2963,14 +2854,14 @@ type projBitxorInt64ConstInt32Op struct {
 	constArg int64
 }
 
-func (p projBitxorInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorInt64ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3058,10 +2949,6 @@ func (p projBitxorInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorInt64ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projBitxorInt64ConstInt64Op struct {
@@ -3069,14 +2956,14 @@ type projBitxorInt64ConstInt64Op struct {
 	constArg int64
 }
 
-func (p projBitxorInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorInt64ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3164,10 +3051,6 @@ func (p projBitxorInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorInt64ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projBitxorDatumConstDatumOp struct {
@@ -3175,14 +3058,14 @@ type projBitxorDatumConstDatumOp struct {
 	constArg interface{}
 }
 
-func (p projBitxorDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3296,10 +3179,6 @@ func (p projBitxorDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorDatumConstDatumOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusDecimalConstInt16Op struct {
@@ -3307,14 +3186,14 @@ type projPlusDecimalConstInt16Op struct {
 	constArg apd.Decimal
 }
 
-func (p projPlusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusDecimalConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3430,10 +3309,6 @@ func (p projPlusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusDecimalConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusDecimalConstInt32Op struct {
@@ -3441,14 +3316,14 @@ type projPlusDecimalConstInt32Op struct {
 	constArg apd.Decimal
 }
 
-func (p projPlusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusDecimalConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3564,10 +3439,6 @@ func (p projPlusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusDecimalConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusDecimalConstInt64Op struct {
@@ -3575,14 +3446,14 @@ type projPlusDecimalConstInt64Op struct {
 	constArg apd.Decimal
 }
 
-func (p projPlusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusDecimalConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3698,10 +3569,6 @@ func (p projPlusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusDecimalConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusDecimalConstDecimalOp struct {
@@ -3709,14 +3576,14 @@ type projPlusDecimalConstDecimalOp struct {
 	constArg apd.Decimal
 }
 
-func (p projPlusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusDecimalConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3828,10 +3695,6 @@ func (p projPlusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusDecimalConstDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt16ConstInt16Op struct {
@@ -3839,14 +3702,14 @@ type projPlusInt16ConstInt16Op struct {
 	constArg int16
 }
 
-func (p projPlusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt16ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3958,10 +3821,6 @@ func (p projPlusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt16ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt16ConstInt32Op struct {
@@ -3969,14 +3828,14 @@ type projPlusInt16ConstInt32Op struct {
 	constArg int16
 }
 
-func (p projPlusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt16ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -4088,10 +3947,6 @@ func (p projPlusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt16ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt16ConstInt64Op struct {
@@ -4099,14 +3954,14 @@ type projPlusInt16ConstInt64Op struct {
 	constArg int16
 }
 
-func (p projPlusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt16ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -4218,10 +4073,6 @@ func (p projPlusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt16ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt16ConstDecimalOp struct {
@@ -4229,14 +4080,14 @@ type projPlusInt16ConstDecimalOp struct {
 	constArg int16
 }
 
-func (p projPlusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt16ConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -4356,10 +4207,6 @@ func (p projPlusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt16ConstDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt16ConstDatumOp struct {
@@ -4367,14 +4214,14 @@ type projPlusInt16ConstDatumOp struct {
 	constArg int16
 }
 
-func (p projPlusInt16ConstDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt16ConstDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -4514,10 +4361,6 @@ func (p projPlusInt16ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt16ConstDatumOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt32ConstInt16Op struct {
@@ -4525,14 +4368,14 @@ type projPlusInt32ConstInt16Op struct {
 	constArg int32
 }
 
-func (p projPlusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt32ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -4644,10 +4487,6 @@ func (p projPlusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt32ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt32ConstInt32Op struct {
@@ -4655,14 +4494,14 @@ type projPlusInt32ConstInt32Op struct {
 	constArg int32
 }
 
-func (p projPlusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt32ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -4774,10 +4613,6 @@ func (p projPlusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt32ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt32ConstInt64Op struct {
@@ -4785,14 +4620,14 @@ type projPlusInt32ConstInt64Op struct {
 	constArg int32
 }
 
-func (p projPlusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt32ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -4904,10 +4739,6 @@ func (p projPlusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt32ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt32ConstDecimalOp struct {
@@ -4915,14 +4746,14 @@ type projPlusInt32ConstDecimalOp struct {
 	constArg int32
 }
 
-func (p projPlusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt32ConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -5042,10 +4873,6 @@ func (p projPlusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt32ConstDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt32ConstDatumOp struct {
@@ -5053,14 +4880,14 @@ type projPlusInt32ConstDatumOp struct {
 	constArg int32
 }
 
-func (p projPlusInt32ConstDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt32ConstDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -5200,10 +5027,6 @@ func (p projPlusInt32ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt32ConstDatumOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt64ConstInt16Op struct {
@@ -5211,14 +5034,14 @@ type projPlusInt64ConstInt16Op struct {
 	constArg int64
 }
 
-func (p projPlusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt64ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -5330,10 +5153,6 @@ func (p projPlusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt64ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt64ConstInt32Op struct {
@@ -5341,14 +5160,14 @@ type projPlusInt64ConstInt32Op struct {
 	constArg int64
 }
 
-func (p projPlusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt64ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -5460,10 +5279,6 @@ func (p projPlusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt64ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt64ConstInt64Op struct {
@@ -5471,14 +5286,14 @@ type projPlusInt64ConstInt64Op struct {
 	constArg int64
 }
 
-func (p projPlusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt64ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -5590,10 +5405,6 @@ func (p projPlusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt64ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt64ConstDecimalOp struct {
@@ -5601,14 +5412,14 @@ type projPlusInt64ConstDecimalOp struct {
 	constArg int64
 }
 
-func (p projPlusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt64ConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -5728,10 +5539,6 @@ func (p projPlusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt64ConstDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt64ConstDatumOp struct {
@@ -5739,14 +5546,14 @@ type projPlusInt64ConstDatumOp struct {
 	constArg int64
 }
 
-func (p projPlusInt64ConstDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt64ConstDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -5886,10 +5693,6 @@ func (p projPlusInt64ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt64ConstDatumOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusFloat64ConstFloat64Op struct {
@@ -5897,14 +5700,14 @@ type projPlusFloat64ConstFloat64Op struct {
 	constArg float64
 }
 
-func (p projPlusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusFloat64ConstFloat64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -6004,10 +5807,6 @@ func (p projPlusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusFloat64ConstFloat64Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusTimestampConstIntervalOp struct {
@@ -6015,14 +5814,14 @@ type projPlusTimestampConstIntervalOp struct {
 	constArg time.Time
 }
 
-func (p projPlusTimestampConstIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusTimestampConstIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -6102,10 +5901,6 @@ func (p projPlusTimestampConstIntervalOp) Next(ctx context.Context) coldata.Batc
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusTimestampConstIntervalOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusIntervalConstTimestampOp struct {
@@ -6113,14 +5908,14 @@ type projPlusIntervalConstTimestampOp struct {
 	constArg duration.Duration
 }
 
-func (p projPlusIntervalConstTimestampOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusIntervalConstTimestampOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -6200,10 +5995,6 @@ func (p projPlusIntervalConstTimestampOp) Next(ctx context.Context) coldata.Batc
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusIntervalConstTimestampOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusIntervalConstIntervalOp struct {
@@ -6211,14 +6002,14 @@ type projPlusIntervalConstIntervalOp struct {
 	constArg duration.Duration
 }
 
-func (p projPlusIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusIntervalConstIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -6300,23 +6091,19 @@ func (p projPlusIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batch
 	return batch
 }
 
-func (p projPlusIntervalConstIntervalOp) Init() {
-	p.Input.Init()
-}
-
 type projPlusIntervalConstDatumOp struct {
 	projConstOpBase
 	constArg duration.Duration
 }
 
-func (p projPlusIntervalConstDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusIntervalConstDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -6458,23 +6245,19 @@ func (p projPlusIntervalConstDatumOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPlusIntervalConstDatumOp) Init() {
-	p.Input.Init()
-}
-
 type projPlusDatumConstIntervalOp struct {
 	projConstOpBase
 	constArg interface{}
 }
 
-func (p projPlusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusDatumConstIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -6606,23 +6389,19 @@ func (p projPlusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPlusDatumConstIntervalOp) Init() {
-	p.Input.Init()
-}
-
 type projPlusDatumConstInt16Op struct {
 	projConstOpBase
 	constArg interface{}
 }
 
-func (p projPlusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusDatumConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -6752,10 +6531,6 @@ func (p projPlusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusDatumConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusDatumConstInt32Op struct {
@@ -6763,14 +6538,14 @@ type projPlusDatumConstInt32Op struct {
 	constArg interface{}
 }
 
-func (p projPlusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusDatumConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -6900,10 +6675,6 @@ func (p projPlusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusDatumConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusDatumConstInt64Op struct {
@@ -6911,14 +6682,14 @@ type projPlusDatumConstInt64Op struct {
 	constArg interface{}
 }
 
-func (p projPlusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusDatumConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -7048,10 +6819,6 @@ func (p projPlusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusDatumConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projMinusDecimalConstInt16Op struct {
@@ -7059,14 +6826,14 @@ type projMinusDecimalConstInt16Op struct {
 	constArg apd.Decimal
 }
 
-func (p projMinusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDecimalConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -7182,10 +6949,6 @@ func (p projMinusDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusDecimalConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projMinusDecimalConstInt32Op struct {
@@ -7193,14 +6956,14 @@ type projMinusDecimalConstInt32Op struct {
 	constArg apd.Decimal
 }
 
-func (p projMinusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDecimalConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -7316,10 +7079,6 @@ func (p projMinusDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusDecimalConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projMinusDecimalConstInt64Op struct {
@@ -7327,14 +7086,14 @@ type projMinusDecimalConstInt64Op struct {
 	constArg apd.Decimal
 }
 
-func (p projMinusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDecimalConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -7450,10 +7209,6 @@ func (p projMinusDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusDecimalConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projMinusDecimalConstDecimalOp struct {
@@ -7461,14 +7216,14 @@ type projMinusDecimalConstDecimalOp struct {
 	constArg apd.Decimal
 }
 
-func (p projMinusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDecimalConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -7580,10 +7335,6 @@ func (p projMinusDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusDecimalConstDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusInt16ConstInt16Op struct {
@@ -7591,14 +7342,14 @@ type projMinusInt16ConstInt16Op struct {
 	constArg int16
 }
 
-func (p projMinusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt16ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -7710,10 +7461,6 @@ func (p projMinusInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusInt16ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projMinusInt16ConstInt32Op struct {
@@ -7721,14 +7468,14 @@ type projMinusInt16ConstInt32Op struct {
 	constArg int16
 }
 
-func (p projMinusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt16ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -7840,10 +7587,6 @@ func (p projMinusInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusInt16ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projMinusInt16ConstInt64Op struct {
@@ -7851,14 +7594,14 @@ type projMinusInt16ConstInt64Op struct {
 	constArg int16
 }
 
-func (p projMinusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt16ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -7970,10 +7713,6 @@ func (p projMinusInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusInt16ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projMinusInt16ConstDecimalOp struct {
@@ -7981,14 +7720,14 @@ type projMinusInt16ConstDecimalOp struct {
 	constArg int16
 }
 
-func (p projMinusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt16ConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -8108,10 +7847,6 @@ func (p projMinusInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusInt16ConstDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusInt16ConstDatumOp struct {
@@ -8119,14 +7854,14 @@ type projMinusInt16ConstDatumOp struct {
 	constArg int16
 }
 
-func (p projMinusInt16ConstDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt16ConstDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -8266,10 +8001,6 @@ func (p projMinusInt16ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusInt16ConstDatumOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusInt32ConstInt16Op struct {
@@ -8277,14 +8008,14 @@ type projMinusInt32ConstInt16Op struct {
 	constArg int32
 }
 
-func (p projMinusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt32ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -8396,10 +8127,6 @@ func (p projMinusInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusInt32ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projMinusInt32ConstInt32Op struct {
@@ -8407,14 +8134,14 @@ type projMinusInt32ConstInt32Op struct {
 	constArg int32
 }
 
-func (p projMinusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt32ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -8528,23 +8255,19 @@ func (p projMinusInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusInt32ConstInt32Op) Init() {
-	p.Input.Init()
-}
-
 type projMinusInt32ConstInt64Op struct {
 	projConstOpBase
 	constArg int32
 }
 
-func (p projMinusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt32ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -8658,23 +8381,19 @@ func (p projMinusInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusInt32ConstInt64Op) Init() {
-	p.Input.Init()
-}
-
 type projMinusInt32ConstDecimalOp struct {
 	projConstOpBase
 	constArg int32
 }
 
-func (p projMinusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt32ConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -8796,23 +8515,19 @@ func (p projMinusInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusInt32ConstDecimalOp) Init() {
-	p.Input.Init()
-}
-
 type projMinusInt32ConstDatumOp struct {
 	projConstOpBase
 	constArg int32
 }
 
-func (p projMinusInt32ConstDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt32ConstDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -8954,23 +8669,19 @@ func (p projMinusInt32ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusInt32ConstDatumOp) Init() {
-	p.Input.Init()
-}
-
 type projMinusInt64ConstInt16Op struct {
 	projConstOpBase
 	constArg int64
 }
 
-func (p projMinusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt64ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -9084,23 +8795,19 @@ func (p projMinusInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusInt64ConstInt16Op) Init() {
-	p.Input.Init()
-}
-
 type projMinusInt64ConstInt32Op struct {
 	projConstOpBase
 	constArg int64
 }
 
-func (p projMinusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt64ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -9214,23 +8921,19 @@ func (p projMinusInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusInt64ConstInt32Op) Init() {
-	p.Input.Init()
-}
-
 type projMinusInt64ConstInt64Op struct {
 	projConstOpBase
 	constArg int64
 }
 
-func (p projMinusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt64ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -9344,23 +9047,19 @@ func (p projMinusInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusInt64ConstInt64Op) Init() {
-	p.Input.Init()
-}
-
 type projMinusInt64ConstDecimalOp struct {
 	projConstOpBase
 	constArg int64
 }
 
-func (p projMinusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt64ConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -9482,23 +9181,19 @@ func (p projMinusInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusInt64ConstDecimalOp) Init() {
-	p.Input.Init()
-}
-
 type projMinusInt64ConstDatumOp struct {
 	projConstOpBase
 	constArg int64
 }
 
-func (p projMinusInt64ConstDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt64ConstDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -9640,23 +9335,19 @@ func (p projMinusInt64ConstDatumOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusInt64ConstDatumOp) Init() {
-	p.Input.Init()
-}
-
 type projMinusFloat64ConstFloat64Op struct {
 	projConstOpBase
 	constArg float64
 }
 
-func (p projMinusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusFloat64ConstFloat64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -9758,23 +9449,19 @@ func (p projMinusFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch 
 	return batch
 }
 
-func (p projMinusFloat64ConstFloat64Op) Init() {
-	p.Input.Init()
-}
-
 type projMinusTimestampConstTimestampOp struct {
 	projConstOpBase
 	constArg time.Time
 }
 
-func (p projMinusTimestampConstTimestampOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -9868,23 +9555,19 @@ func (p projMinusTimestampConstTimestampOp) Next(ctx context.Context) coldata.Ba
 	return batch
 }
 
-func (p projMinusTimestampConstTimestampOp) Init() {
-	p.Input.Init()
-}
-
 type projMinusTimestampConstIntervalOp struct {
 	projConstOpBase
 	constArg time.Time
 }
 
-func (p projMinusTimestampConstIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusTimestampConstIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -9966,23 +9649,19 @@ func (p projMinusTimestampConstIntervalOp) Next(ctx context.Context) coldata.Bat
 	return batch
 }
 
-func (p projMinusTimestampConstIntervalOp) Init() {
-	p.Input.Init()
-}
-
 type projMinusIntervalConstIntervalOp struct {
 	projConstOpBase
 	constArg duration.Duration
 }
 
-func (p projMinusIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusIntervalConstIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -10062,10 +9741,6 @@ func (p projMinusIntervalConstIntervalOp) Next(ctx context.Context) coldata.Batc
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusIntervalConstIntervalOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusIntervalConstDatumOp struct {
@@ -10073,14 +9748,14 @@ type projMinusIntervalConstDatumOp struct {
 	constArg duration.Duration
 }
 
-func (p projMinusIntervalConstDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusIntervalConstDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -10220,10 +9895,6 @@ func (p projMinusIntervalConstDatumOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusIntervalConstDatumOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusJSONConstBytesOp struct {
@@ -10231,14 +9902,14 @@ type projMinusJSONConstBytesOp struct {
 	constArg json.JSON
 }
 
-func (p projMinusJSONConstBytesOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusJSONConstBytesOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -10354,23 +10025,19 @@ func (p projMinusJSONConstBytesOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusJSONConstBytesOp) Init() {
-	p.Input.Init()
-}
-
 type projMinusJSONConstInt16Op struct {
 	projConstOpBase
 	constArg json.JSON
 }
 
-func (p projMinusJSONConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusJSONConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -10470,23 +10137,19 @@ func (p projMinusJSONConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusJSONConstInt16Op) Init() {
-	p.Input.Init()
-}
-
 type projMinusJSONConstInt32Op struct {
 	projConstOpBase
 	constArg json.JSON
 }
 
-func (p projMinusJSONConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusJSONConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -10586,23 +10249,19 @@ func (p projMinusJSONConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusJSONConstInt32Op) Init() {
-	p.Input.Init()
-}
-
 type projMinusJSONConstInt64Op struct {
 	projConstOpBase
 	constArg json.JSON
 }
 
-func (p projMinusJSONConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusJSONConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -10702,23 +10361,19 @@ func (p projMinusJSONConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusJSONConstInt64Op) Init() {
-	p.Input.Init()
-}
-
 type projMinusDatumConstDatumOp struct {
 	projConstOpBase
 	constArg interface{}
 }
 
-func (p projMinusDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -10834,23 +10489,19 @@ func (p projMinusDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusDatumConstDatumOp) Init() {
-	p.Input.Init()
-}
-
 type projMinusDatumConstIntervalOp struct {
 	projConstOpBase
 	constArg interface{}
 }
 
-func (p projMinusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDatumConstIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -10982,23 +10633,19 @@ func (p projMinusDatumConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusDatumConstIntervalOp) Init() {
-	p.Input.Init()
-}
-
 type projMinusDatumConstBytesOp struct {
 	projConstOpBase
 	constArg interface{}
 }
 
-func (p projMinusDatumConstBytesOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDatumConstBytesOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -11130,23 +10777,19 @@ func (p projMinusDatumConstBytesOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusDatumConstBytesOp) Init() {
-	p.Input.Init()
-}
-
 type projMinusDatumConstInt16Op struct {
 	projConstOpBase
 	constArg interface{}
 }
 
-func (p projMinusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDatumConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -11276,10 +10919,6 @@ func (p projMinusDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusDatumConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projMinusDatumConstInt32Op struct {
@@ -11287,14 +10926,14 @@ type projMinusDatumConstInt32Op struct {
 	constArg interface{}
 }
 
-func (p projMinusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDatumConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -11424,10 +11063,6 @@ func (p projMinusDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusDatumConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projMinusDatumConstInt64Op struct {
@@ -11435,14 +11070,14 @@ type projMinusDatumConstInt64Op struct {
 	constArg interface{}
 }
 
-func (p projMinusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDatumConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -11574,23 +11209,19 @@ func (p projMinusDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusDatumConstInt64Op) Init() {
-	p.Input.Init()
-}
-
 type projMultDecimalConstInt16Op struct {
 	projConstOpBase
 	constArg apd.Decimal
 }
 
-func (p projMultDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultDecimalConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -11706,10 +11337,6 @@ func (p projMultDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultDecimalConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projMultDecimalConstInt32Op struct {
@@ -11717,14 +11344,14 @@ type projMultDecimalConstInt32Op struct {
 	constArg apd.Decimal
 }
 
-func (p projMultDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultDecimalConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -11840,10 +11467,6 @@ func (p projMultDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultDecimalConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projMultDecimalConstInt64Op struct {
@@ -11851,14 +11474,14 @@ type projMultDecimalConstInt64Op struct {
 	constArg apd.Decimal
 }
 
-func (p projMultDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultDecimalConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -11974,10 +11597,6 @@ func (p projMultDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultDecimalConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projMultDecimalConstDecimalOp struct {
@@ -11985,14 +11604,14 @@ type projMultDecimalConstDecimalOp struct {
 	constArg apd.Decimal
 }
 
-func (p projMultDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultDecimalConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -12104,10 +11723,6 @@ func (p projMultDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultDecimalConstDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projMultDecimalConstIntervalOp struct {
@@ -12115,14 +11730,14 @@ type projMultDecimalConstIntervalOp struct {
 	constArg apd.Decimal
 }
 
-func (p projMultDecimalConstIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultDecimalConstIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -12222,10 +11837,6 @@ func (p projMultDecimalConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultDecimalConstIntervalOp) Init() {
-	p.Input.Init()
 }
 
 type projMultInt16ConstInt16Op struct {
@@ -12233,14 +11844,14 @@ type projMultInt16ConstInt16Op struct {
 	constArg int16
 }
 
-func (p projMultInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt16ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -12384,10 +11995,6 @@ func (p projMultInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt16ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projMultInt16ConstInt32Op struct {
@@ -12395,14 +12002,14 @@ type projMultInt16ConstInt32Op struct {
 	constArg int16
 }
 
-func (p projMultInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt16ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -12546,10 +12153,6 @@ func (p projMultInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt16ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projMultInt16ConstInt64Op struct {
@@ -12557,14 +12160,14 @@ type projMultInt16ConstInt64Op struct {
 	constArg int16
 }
 
-func (p projMultInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt16ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -12708,10 +12311,6 @@ func (p projMultInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt16ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projMultInt16ConstDecimalOp struct {
@@ -12719,14 +12318,14 @@ type projMultInt16ConstDecimalOp struct {
 	constArg int16
 }
 
-func (p projMultInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt16ConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -12846,10 +12445,6 @@ func (p projMultInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt16ConstDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projMultInt16ConstIntervalOp struct {
@@ -12857,14 +12452,14 @@ type projMultInt16ConstIntervalOp struct {
 	constArg int16
 }
 
-func (p projMultInt16ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt16ConstIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -12944,10 +12539,6 @@ func (p projMultInt16ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt16ConstIntervalOp) Init() {
-	p.Input.Init()
 }
 
 type projMultInt32ConstInt16Op struct {
@@ -12955,14 +12546,14 @@ type projMultInt32ConstInt16Op struct {
 	constArg int32
 }
 
-func (p projMultInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt32ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -13106,10 +12697,6 @@ func (p projMultInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt32ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projMultInt32ConstInt32Op struct {
@@ -13117,14 +12704,14 @@ type projMultInt32ConstInt32Op struct {
 	constArg int32
 }
 
-func (p projMultInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt32ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -13268,10 +12855,6 @@ func (p projMultInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt32ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projMultInt32ConstInt64Op struct {
@@ -13279,14 +12862,14 @@ type projMultInt32ConstInt64Op struct {
 	constArg int32
 }
 
-func (p projMultInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt32ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -13430,10 +13013,6 @@ func (p projMultInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt32ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projMultInt32ConstDecimalOp struct {
@@ -13441,14 +13020,14 @@ type projMultInt32ConstDecimalOp struct {
 	constArg int32
 }
 
-func (p projMultInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt32ConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -13568,10 +13147,6 @@ func (p projMultInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt32ConstDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projMultInt32ConstIntervalOp struct {
@@ -13579,14 +13154,14 @@ type projMultInt32ConstIntervalOp struct {
 	constArg int32
 }
 
-func (p projMultInt32ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt32ConstIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -13666,10 +13241,6 @@ func (p projMultInt32ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt32ConstIntervalOp) Init() {
-	p.Input.Init()
 }
 
 type projMultInt64ConstInt16Op struct {
@@ -13677,14 +13248,14 @@ type projMultInt64ConstInt16Op struct {
 	constArg int64
 }
 
-func (p projMultInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt64ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -13828,10 +13399,6 @@ func (p projMultInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt64ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projMultInt64ConstInt32Op struct {
@@ -13839,14 +13406,14 @@ type projMultInt64ConstInt32Op struct {
 	constArg int64
 }
 
-func (p projMultInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt64ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -13990,10 +13557,6 @@ func (p projMultInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt64ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projMultInt64ConstInt64Op struct {
@@ -14001,14 +13564,14 @@ type projMultInt64ConstInt64Op struct {
 	constArg int64
 }
 
-func (p projMultInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt64ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -14152,10 +13715,6 @@ func (p projMultInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt64ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projMultInt64ConstDecimalOp struct {
@@ -14163,14 +13722,14 @@ type projMultInt64ConstDecimalOp struct {
 	constArg int64
 }
 
-func (p projMultInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt64ConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -14290,10 +13849,6 @@ func (p projMultInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt64ConstDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projMultInt64ConstIntervalOp struct {
@@ -14301,14 +13856,14 @@ type projMultInt64ConstIntervalOp struct {
 	constArg int64
 }
 
-func (p projMultInt64ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt64ConstIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -14388,10 +13943,6 @@ func (p projMultInt64ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt64ConstIntervalOp) Init() {
-	p.Input.Init()
 }
 
 type projMultFloat64ConstFloat64Op struct {
@@ -14399,14 +13950,14 @@ type projMultFloat64ConstFloat64Op struct {
 	constArg float64
 }
 
-func (p projMultFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultFloat64ConstFloat64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -14508,23 +14059,19 @@ func (p projMultFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMultFloat64ConstFloat64Op) Init() {
-	p.Input.Init()
-}
-
 type projMultFloat64ConstIntervalOp struct {
 	projConstOpBase
 	constArg float64
 }
 
-func (p projMultFloat64ConstIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultFloat64ConstIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -14606,23 +14153,19 @@ func (p projMultFloat64ConstIntervalOp) Next(ctx context.Context) coldata.Batch 
 	return batch
 }
 
-func (p projMultFloat64ConstIntervalOp) Init() {
-	p.Input.Init()
-}
-
 type projMultIntervalConstInt16Op struct {
 	projConstOpBase
 	constArg duration.Duration
 }
 
-func (p projMultIntervalConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultIntervalConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -14702,10 +14245,6 @@ func (p projMultIntervalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultIntervalConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projMultIntervalConstInt32Op struct {
@@ -14713,14 +14252,14 @@ type projMultIntervalConstInt32Op struct {
 	constArg duration.Duration
 }
 
-func (p projMultIntervalConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultIntervalConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -14800,10 +14339,6 @@ func (p projMultIntervalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultIntervalConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projMultIntervalConstInt64Op struct {
@@ -14811,14 +14346,14 @@ type projMultIntervalConstInt64Op struct {
 	constArg duration.Duration
 }
 
-func (p projMultIntervalConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultIntervalConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -14898,10 +14433,6 @@ func (p projMultIntervalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultIntervalConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projMultIntervalConstFloat64Op struct {
@@ -14909,14 +14440,14 @@ type projMultIntervalConstFloat64Op struct {
 	constArg duration.Duration
 }
 
-func (p projMultIntervalConstFloat64Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultIntervalConstFloat64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -14996,10 +14527,6 @@ func (p projMultIntervalConstFloat64Op) Next(ctx context.Context) coldata.Batch 
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultIntervalConstFloat64Op) Init() {
-	p.Input.Init()
 }
 
 type projMultIntervalConstDecimalOp struct {
@@ -15007,14 +14534,14 @@ type projMultIntervalConstDecimalOp struct {
 	constArg duration.Duration
 }
 
-func (p projMultIntervalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultIntervalConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -15114,10 +14641,6 @@ func (p projMultIntervalConstDecimalOp) Next(ctx context.Context) coldata.Batch 
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultIntervalConstDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projDivDecimalConstInt16Op struct {
@@ -15125,14 +14648,14 @@ type projDivDecimalConstInt16Op struct {
 	constArg apd.Decimal
 }
 
-func (p projDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivDecimalConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -15264,10 +14787,6 @@ func (p projDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivDecimalConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projDivDecimalConstInt32Op struct {
@@ -15275,14 +14794,14 @@ type projDivDecimalConstInt32Op struct {
 	constArg apd.Decimal
 }
 
-func (p projDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivDecimalConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -15414,10 +14933,6 @@ func (p projDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivDecimalConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projDivDecimalConstInt64Op struct {
@@ -15425,14 +14940,14 @@ type projDivDecimalConstInt64Op struct {
 	constArg apd.Decimal
 }
 
-func (p projDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivDecimalConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -15564,10 +15079,6 @@ func (p projDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivDecimalConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projDivDecimalConstDecimalOp struct {
@@ -15575,14 +15086,14 @@ type projDivDecimalConstDecimalOp struct {
 	constArg apd.Decimal
 }
 
-func (p projDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projDivDecimalConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -15710,10 +15221,6 @@ func (p projDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivDecimalConstDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projDivInt16ConstInt16Op struct {
@@ -15721,14 +15228,14 @@ type projDivInt16ConstInt16Op struct {
 	constArg int16
 }
 
-func (p projDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt16ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -15856,10 +15363,6 @@ func (p projDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt16ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projDivInt16ConstInt32Op struct {
@@ -15867,14 +15370,14 @@ type projDivInt16ConstInt32Op struct {
 	constArg int16
 }
 
-func (p projDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt16ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -16002,10 +15505,6 @@ func (p projDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt16ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projDivInt16ConstInt64Op struct {
@@ -16013,14 +15512,14 @@ type projDivInt16ConstInt64Op struct {
 	constArg int16
 }
 
-func (p projDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt16ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -16148,10 +15647,6 @@ func (p projDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt16ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projDivInt16ConstDecimalOp struct {
@@ -16159,14 +15654,14 @@ type projDivInt16ConstDecimalOp struct {
 	constArg int16
 }
 
-func (p projDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt16ConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -16302,10 +15797,6 @@ func (p projDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt16ConstDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projDivInt32ConstInt16Op struct {
@@ -16313,14 +15804,14 @@ type projDivInt32ConstInt16Op struct {
 	constArg int32
 }
 
-func (p projDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt32ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -16448,10 +15939,6 @@ func (p projDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt32ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projDivInt32ConstInt32Op struct {
@@ -16459,14 +15946,14 @@ type projDivInt32ConstInt32Op struct {
 	constArg int32
 }
 
-func (p projDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt32ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -16594,10 +16081,6 @@ func (p projDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt32ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projDivInt32ConstInt64Op struct {
@@ -16605,14 +16088,14 @@ type projDivInt32ConstInt64Op struct {
 	constArg int32
 }
 
-func (p projDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt32ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -16740,10 +16223,6 @@ func (p projDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt32ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projDivInt32ConstDecimalOp struct {
@@ -16751,14 +16230,14 @@ type projDivInt32ConstDecimalOp struct {
 	constArg int32
 }
 
-func (p projDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt32ConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -16894,10 +16373,6 @@ func (p projDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt32ConstDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projDivInt64ConstInt16Op struct {
@@ -16905,14 +16380,14 @@ type projDivInt64ConstInt16Op struct {
 	constArg int64
 }
 
-func (p projDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt64ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -17040,10 +16515,6 @@ func (p projDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt64ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projDivInt64ConstInt32Op struct {
@@ -17051,14 +16522,14 @@ type projDivInt64ConstInt32Op struct {
 	constArg int64
 }
 
-func (p projDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt64ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -17186,10 +16657,6 @@ func (p projDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt64ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projDivInt64ConstInt64Op struct {
@@ -17197,14 +16664,14 @@ type projDivInt64ConstInt64Op struct {
 	constArg int64
 }
 
-func (p projDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt64ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -17332,10 +16799,6 @@ func (p projDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt64ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projDivInt64ConstDecimalOp struct {
@@ -17343,14 +16806,14 @@ type projDivInt64ConstDecimalOp struct {
 	constArg int64
 }
 
-func (p projDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt64ConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -17486,10 +16949,6 @@ func (p projDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt64ConstDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projDivFloat64ConstFloat64Op struct {
@@ -17497,14 +16956,14 @@ type projDivFloat64ConstFloat64Op struct {
 	constArg float64
 }
 
-func (p projDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivFloat64ConstFloat64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -17620,10 +17079,6 @@ func (p projDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivFloat64ConstFloat64Op) Init() {
-	p.Input.Init()
 }
 
 type projDivIntervalConstInt64Op struct {
@@ -17631,14 +17086,14 @@ type projDivIntervalConstInt64Op struct {
 	constArg duration.Duration
 }
 
-func (p projDivIntervalConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivIntervalConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -17734,10 +17189,6 @@ func (p projDivIntervalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivIntervalConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projDivIntervalConstFloat64Op struct {
@@ -17745,14 +17196,14 @@ type projDivIntervalConstFloat64Op struct {
 	constArg duration.Duration
 }
 
-func (p projDivIntervalConstFloat64Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivIntervalConstFloat64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -17850,23 +17301,19 @@ func (p projDivIntervalConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projDivIntervalConstFloat64Op) Init() {
-	p.Input.Init()
-}
-
 type projFloorDivDecimalConstInt16Op struct {
 	projConstOpBase
 	constArg apd.Decimal
 }
 
-func (p projFloorDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivDecimalConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -17998,10 +17445,6 @@ func (p projFloorDivDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivDecimalConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivDecimalConstInt32Op struct {
@@ -18009,14 +17452,14 @@ type projFloorDivDecimalConstInt32Op struct {
 	constArg apd.Decimal
 }
 
-func (p projFloorDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivDecimalConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -18148,10 +17591,6 @@ func (p projFloorDivDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivDecimalConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivDecimalConstInt64Op struct {
@@ -18159,14 +17598,14 @@ type projFloorDivDecimalConstInt64Op struct {
 	constArg apd.Decimal
 }
 
-func (p projFloorDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivDecimalConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -18298,10 +17737,6 @@ func (p projFloorDivDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivDecimalConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivDecimalConstDecimalOp struct {
@@ -18309,14 +17744,14 @@ type projFloorDivDecimalConstDecimalOp struct {
 	constArg apd.Decimal
 }
 
-func (p projFloorDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivDecimalConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -18444,10 +17879,6 @@ func (p projFloorDivDecimalConstDecimalOp) Next(ctx context.Context) coldata.Bat
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivDecimalConstDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt16ConstInt16Op struct {
@@ -18455,14 +17886,14 @@ type projFloorDivInt16ConstInt16Op struct {
 	constArg int16
 }
 
-func (p projFloorDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt16ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -18570,10 +18001,6 @@ func (p projFloorDivInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt16ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt16ConstInt32Op struct {
@@ -18581,14 +18008,14 @@ type projFloorDivInt16ConstInt32Op struct {
 	constArg int16
 }
 
-func (p projFloorDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt16ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -18696,10 +18123,6 @@ func (p projFloorDivInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt16ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt16ConstInt64Op struct {
@@ -18707,14 +18130,14 @@ type projFloorDivInt16ConstInt64Op struct {
 	constArg int16
 }
 
-func (p projFloorDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt16ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -18822,10 +18245,6 @@ func (p projFloorDivInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt16ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt16ConstDecimalOp struct {
@@ -18833,14 +18252,14 @@ type projFloorDivInt16ConstDecimalOp struct {
 	constArg int16
 }
 
-func (p projFloorDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt16ConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -18976,10 +18395,6 @@ func (p projFloorDivInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt16ConstDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt32ConstInt16Op struct {
@@ -18987,14 +18402,14 @@ type projFloorDivInt32ConstInt16Op struct {
 	constArg int32
 }
 
-func (p projFloorDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt32ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -19102,10 +18517,6 @@ func (p projFloorDivInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt32ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt32ConstInt32Op struct {
@@ -19113,14 +18524,14 @@ type projFloorDivInt32ConstInt32Op struct {
 	constArg int32
 }
 
-func (p projFloorDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt32ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -19228,10 +18639,6 @@ func (p projFloorDivInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt32ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt32ConstInt64Op struct {
@@ -19239,14 +18646,14 @@ type projFloorDivInt32ConstInt64Op struct {
 	constArg int32
 }
 
-func (p projFloorDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt32ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -19354,10 +18761,6 @@ func (p projFloorDivInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt32ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt32ConstDecimalOp struct {
@@ -19365,14 +18768,14 @@ type projFloorDivInt32ConstDecimalOp struct {
 	constArg int32
 }
 
-func (p projFloorDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt32ConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -19508,10 +18911,6 @@ func (p projFloorDivInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt32ConstDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt64ConstInt16Op struct {
@@ -19519,14 +18918,14 @@ type projFloorDivInt64ConstInt16Op struct {
 	constArg int64
 }
 
-func (p projFloorDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt64ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -19634,10 +19033,6 @@ func (p projFloorDivInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt64ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt64ConstInt32Op struct {
@@ -19645,14 +19040,14 @@ type projFloorDivInt64ConstInt32Op struct {
 	constArg int64
 }
 
-func (p projFloorDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt64ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -19760,10 +19155,6 @@ func (p projFloorDivInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt64ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt64ConstInt64Op struct {
@@ -19771,14 +19162,14 @@ type projFloorDivInt64ConstInt64Op struct {
 	constArg int64
 }
 
-func (p projFloorDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt64ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -19886,10 +19277,6 @@ func (p projFloorDivInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt64ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt64ConstDecimalOp struct {
@@ -19897,14 +19284,14 @@ type projFloorDivInt64ConstDecimalOp struct {
 	constArg int64
 }
 
-func (p projFloorDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt64ConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -20040,10 +19427,6 @@ func (p projFloorDivInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt64ConstDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivFloat64ConstFloat64Op struct {
@@ -20051,14 +19434,14 @@ type projFloorDivFloat64ConstFloat64Op struct {
 	constArg float64
 }
 
-func (p projFloorDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivFloat64ConstFloat64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -20174,10 +19557,6 @@ func (p projFloorDivFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Bat
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivFloat64ConstFloat64Op) Init() {
-	p.Input.Init()
 }
 
 type projModDecimalConstInt16Op struct {
@@ -20185,14 +19564,14 @@ type projModDecimalConstInt16Op struct {
 	constArg apd.Decimal
 }
 
-func (p projModDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projModDecimalConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -20324,10 +19703,6 @@ func (p projModDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModDecimalConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projModDecimalConstInt32Op struct {
@@ -20335,14 +19710,14 @@ type projModDecimalConstInt32Op struct {
 	constArg apd.Decimal
 }
 
-func (p projModDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projModDecimalConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -20474,10 +19849,6 @@ func (p projModDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModDecimalConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projModDecimalConstInt64Op struct {
@@ -20485,14 +19856,14 @@ type projModDecimalConstInt64Op struct {
 	constArg apd.Decimal
 }
 
-func (p projModDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projModDecimalConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -20624,10 +19995,6 @@ func (p projModDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModDecimalConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projModDecimalConstDecimalOp struct {
@@ -20635,14 +20002,14 @@ type projModDecimalConstDecimalOp struct {
 	constArg apd.Decimal
 }
 
-func (p projModDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projModDecimalConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -20770,10 +20137,6 @@ func (p projModDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModDecimalConstDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projModInt16ConstInt16Op struct {
@@ -20781,14 +20144,14 @@ type projModInt16ConstInt16Op struct {
 	constArg int16
 }
 
-func (p projModInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projModInt16ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -20896,10 +20259,6 @@ func (p projModInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt16ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projModInt16ConstInt32Op struct {
@@ -20907,14 +20266,14 @@ type projModInt16ConstInt32Op struct {
 	constArg int16
 }
 
-func (p projModInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projModInt16ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -21022,10 +20381,6 @@ func (p projModInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt16ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projModInt16ConstInt64Op struct {
@@ -21033,14 +20388,14 @@ type projModInt16ConstInt64Op struct {
 	constArg int16
 }
 
-func (p projModInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projModInt16ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -21148,10 +20503,6 @@ func (p projModInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt16ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projModInt16ConstDecimalOp struct {
@@ -21159,14 +20510,14 @@ type projModInt16ConstDecimalOp struct {
 	constArg int16
 }
 
-func (p projModInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projModInt16ConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -21302,10 +20653,6 @@ func (p projModInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt16ConstDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projModInt32ConstInt16Op struct {
@@ -21313,14 +20660,14 @@ type projModInt32ConstInt16Op struct {
 	constArg int32
 }
 
-func (p projModInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projModInt32ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -21428,10 +20775,6 @@ func (p projModInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt32ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projModInt32ConstInt32Op struct {
@@ -21439,14 +20782,14 @@ type projModInt32ConstInt32Op struct {
 	constArg int32
 }
 
-func (p projModInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projModInt32ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -21554,10 +20897,6 @@ func (p projModInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt32ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projModInt32ConstInt64Op struct {
@@ -21565,14 +20904,14 @@ type projModInt32ConstInt64Op struct {
 	constArg int32
 }
 
-func (p projModInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projModInt32ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -21680,10 +21019,6 @@ func (p projModInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt32ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projModInt32ConstDecimalOp struct {
@@ -21691,14 +21026,14 @@ type projModInt32ConstDecimalOp struct {
 	constArg int32
 }
 
-func (p projModInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projModInt32ConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -21834,10 +21169,6 @@ func (p projModInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt32ConstDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projModInt64ConstInt16Op struct {
@@ -21845,14 +21176,14 @@ type projModInt64ConstInt16Op struct {
 	constArg int64
 }
 
-func (p projModInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projModInt64ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -21960,10 +21291,6 @@ func (p projModInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt64ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projModInt64ConstInt32Op struct {
@@ -21971,14 +21298,14 @@ type projModInt64ConstInt32Op struct {
 	constArg int64
 }
 
-func (p projModInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projModInt64ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -22086,10 +21413,6 @@ func (p projModInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt64ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projModInt64ConstInt64Op struct {
@@ -22097,14 +21420,14 @@ type projModInt64ConstInt64Op struct {
 	constArg int64
 }
 
-func (p projModInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projModInt64ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -22212,10 +21535,6 @@ func (p projModInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt64ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projModInt64ConstDecimalOp struct {
@@ -22223,14 +21542,14 @@ type projModInt64ConstDecimalOp struct {
 	constArg int64
 }
 
-func (p projModInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projModInt64ConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -22366,10 +21685,6 @@ func (p projModInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt64ConstDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projModFloat64ConstFloat64Op struct {
@@ -22377,14 +21692,14 @@ type projModFloat64ConstFloat64Op struct {
 	constArg float64
 }
 
-func (p projModFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
+func (p projModFloat64ConstFloat64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -22500,10 +21815,6 @@ func (p projModFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModFloat64ConstFloat64Op) Init() {
-	p.Input.Init()
 }
 
 type projPowDecimalConstInt16Op struct {
@@ -22511,14 +21822,14 @@ type projPowDecimalConstInt16Op struct {
 	constArg apd.Decimal
 }
 
-func (p projPowDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projPowDecimalConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -22634,10 +21945,6 @@ func (p projPowDecimalConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPowDecimalConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projPowDecimalConstInt32Op struct {
@@ -22645,14 +21952,14 @@ type projPowDecimalConstInt32Op struct {
 	constArg apd.Decimal
 }
 
-func (p projPowDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projPowDecimalConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -22768,10 +22075,6 @@ func (p projPowDecimalConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPowDecimalConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projPowDecimalConstInt64Op struct {
@@ -22779,14 +22082,14 @@ type projPowDecimalConstInt64Op struct {
 	constArg apd.Decimal
 }
 
-func (p projPowDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projPowDecimalConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -22902,10 +22205,6 @@ func (p projPowDecimalConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPowDecimalConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projPowDecimalConstDecimalOp struct {
@@ -22913,14 +22212,14 @@ type projPowDecimalConstDecimalOp struct {
 	constArg apd.Decimal
 }
 
-func (p projPowDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projPowDecimalConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -23032,10 +22331,6 @@ func (p projPowDecimalConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPowDecimalConstDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projPowInt16ConstInt16Op struct {
@@ -23043,14 +22338,14 @@ type projPowInt16ConstInt16Op struct {
 	constArg int16
 }
 
-func (p projPowInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt16ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -23186,10 +22481,6 @@ func (p projPowInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPowInt16ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projPowInt16ConstInt32Op struct {
@@ -23197,14 +22488,14 @@ type projPowInt16ConstInt32Op struct {
 	constArg int16
 }
 
-func (p projPowInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt16ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -23340,10 +22631,6 @@ func (p projPowInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPowInt16ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projPowInt16ConstInt64Op struct {
@@ -23351,14 +22638,14 @@ type projPowInt16ConstInt64Op struct {
 	constArg int16
 }
 
-func (p projPowInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt16ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -23494,10 +22781,6 @@ func (p projPowInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPowInt16ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projPowInt16ConstDecimalOp struct {
@@ -23505,14 +22788,14 @@ type projPowInt16ConstDecimalOp struct {
 	constArg int16
 }
 
-func (p projPowInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt16ConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -23632,10 +22915,6 @@ func (p projPowInt16ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPowInt16ConstDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projPowInt32ConstInt16Op struct {
@@ -23643,14 +22922,14 @@ type projPowInt32ConstInt16Op struct {
 	constArg int32
 }
 
-func (p projPowInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt32ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -23786,10 +23065,6 @@ func (p projPowInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPowInt32ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projPowInt32ConstInt32Op struct {
@@ -23797,14 +23072,14 @@ type projPowInt32ConstInt32Op struct {
 	constArg int32
 }
 
-func (p projPowInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt32ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -23942,23 +23217,19 @@ func (p projPowInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPowInt32ConstInt32Op) Init() {
-	p.Input.Init()
-}
-
 type projPowInt32ConstInt64Op struct {
 	projConstOpBase
 	constArg int32
 }
 
-func (p projPowInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt32ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -24096,23 +23367,19 @@ func (p projPowInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPowInt32ConstInt64Op) Init() {
-	p.Input.Init()
-}
-
 type projPowInt32ConstDecimalOp struct {
 	projConstOpBase
 	constArg int32
 }
 
-func (p projPowInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt32ConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -24234,23 +23501,19 @@ func (p projPowInt32ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPowInt32ConstDecimalOp) Init() {
-	p.Input.Init()
-}
-
 type projPowInt64ConstInt16Op struct {
 	projConstOpBase
 	constArg int64
 }
 
-func (p projPowInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt64ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -24388,23 +23651,19 @@ func (p projPowInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPowInt64ConstInt16Op) Init() {
-	p.Input.Init()
-}
-
 type projPowInt64ConstInt32Op struct {
 	projConstOpBase
 	constArg int64
 }
 
-func (p projPowInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt64ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -24542,23 +23801,19 @@ func (p projPowInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPowInt64ConstInt32Op) Init() {
-	p.Input.Init()
-}
-
 type projPowInt64ConstInt64Op struct {
 	projConstOpBase
 	constArg int64
 }
 
-func (p projPowInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt64ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -24696,23 +23951,19 @@ func (p projPowInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPowInt64ConstInt64Op) Init() {
-	p.Input.Init()
-}
-
 type projPowInt64ConstDecimalOp struct {
 	projConstOpBase
 	constArg int64
 }
 
-func (p projPowInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt64ConstDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -24834,23 +24085,19 @@ func (p projPowInt64ConstDecimalOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPowInt64ConstDecimalOp) Init() {
-	p.Input.Init()
-}
-
 type projPowFloat64ConstFloat64Op struct {
 	projConstOpBase
 	constArg float64
 }
 
-func (p projPowFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
+func (p projPowFloat64ConstFloat64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -24952,23 +24199,19 @@ func (p projPowFloat64ConstFloat64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPowFloat64ConstFloat64Op) Init() {
-	p.Input.Init()
-}
-
 type projConcatBytesConstBytesOp struct {
 	projConstOpBase
 	constArg []byte
 }
 
-func (p projConcatBytesConstBytesOp) Next(ctx context.Context) coldata.Batch {
+func (p projConcatBytesConstBytesOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -25076,23 +24319,19 @@ func (p projConcatBytesConstBytesOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projConcatBytesConstBytesOp) Init() {
-	p.Input.Init()
-}
-
 type projConcatJSONConstJSONOp struct {
 	projConstOpBase
 	constArg json.JSON
 }
 
-func (p projConcatJSONConstJSONOp) Next(ctx context.Context) coldata.Batch {
+func (p projConcatJSONConstJSONOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -25196,23 +24435,19 @@ func (p projConcatJSONConstJSONOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projConcatJSONConstJSONOp) Init() {
-	p.Input.Init()
-}
-
 type projConcatDatumConstDatumOp struct {
 	projConstOpBase
 	constArg interface{}
 }
 
-func (p projConcatDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -25326,10 +24561,6 @@ func (p projConcatDatumConstDatumOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projConcatDatumConstDatumOp) Init() {
-	p.Input.Init()
 }
 
 type projLShiftInt16ConstInt16Op struct {
@@ -25337,14 +24568,14 @@ type projLShiftInt16ConstInt16Op struct {
 	constArg int16
 }
 
-func (p projLShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftInt16ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -25456,10 +24687,6 @@ func (p projLShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftInt16ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projLShiftInt16ConstInt32Op struct {
@@ -25467,14 +24694,14 @@ type projLShiftInt16ConstInt32Op struct {
 	constArg int16
 }
 
-func (p projLShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftInt16ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -25586,10 +24813,6 @@ func (p projLShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftInt16ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projLShiftInt16ConstInt64Op struct {
@@ -25597,14 +24820,14 @@ type projLShiftInt16ConstInt64Op struct {
 	constArg int16
 }
 
-func (p projLShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftInt16ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -25716,10 +24939,6 @@ func (p projLShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftInt16ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projLShiftInt32ConstInt16Op struct {
@@ -25727,14 +24946,14 @@ type projLShiftInt32ConstInt16Op struct {
 	constArg int32
 }
 
-func (p projLShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftInt32ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -25846,10 +25065,6 @@ func (p projLShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftInt32ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projLShiftInt32ConstInt32Op struct {
@@ -25857,14 +25072,14 @@ type projLShiftInt32ConstInt32Op struct {
 	constArg int32
 }
 
-func (p projLShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftInt32ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -25976,10 +25191,6 @@ func (p projLShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftInt32ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projLShiftInt32ConstInt64Op struct {
@@ -25987,14 +25198,14 @@ type projLShiftInt32ConstInt64Op struct {
 	constArg int32
 }
 
-func (p projLShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftInt32ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -26106,10 +25317,6 @@ func (p projLShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftInt32ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projLShiftInt64ConstInt16Op struct {
@@ -26117,14 +25324,14 @@ type projLShiftInt64ConstInt16Op struct {
 	constArg int64
 }
 
-func (p projLShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftInt64ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -26236,10 +25443,6 @@ func (p projLShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftInt64ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projLShiftInt64ConstInt32Op struct {
@@ -26247,14 +25450,14 @@ type projLShiftInt64ConstInt32Op struct {
 	constArg int64
 }
 
-func (p projLShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftInt64ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -26366,10 +25569,6 @@ func (p projLShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftInt64ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projLShiftInt64ConstInt64Op struct {
@@ -26377,14 +25576,14 @@ type projLShiftInt64ConstInt64Op struct {
 	constArg int64
 }
 
-func (p projLShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftInt64ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -26496,10 +25695,6 @@ func (p projLShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftInt64ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projLShiftDatumConstInt16Op struct {
@@ -26507,14 +25702,14 @@ type projLShiftDatumConstInt16Op struct {
 	constArg interface{}
 }
 
-func (p projLShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftDatumConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -26644,10 +25839,6 @@ func (p projLShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftDatumConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projLShiftDatumConstInt32Op struct {
@@ -26655,14 +25846,14 @@ type projLShiftDatumConstInt32Op struct {
 	constArg interface{}
 }
 
-func (p projLShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftDatumConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -26792,10 +25983,6 @@ func (p projLShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftDatumConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projLShiftDatumConstInt64Op struct {
@@ -26803,14 +25990,14 @@ type projLShiftDatumConstInt64Op struct {
 	constArg interface{}
 }
 
-func (p projLShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftDatumConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -26940,10 +26127,6 @@ func (p projLShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftDatumConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projRShiftInt16ConstInt16Op struct {
@@ -26951,14 +26134,14 @@ type projRShiftInt16ConstInt16Op struct {
 	constArg int16
 }
 
-func (p projRShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftInt16ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -27070,10 +26253,6 @@ func (p projRShiftInt16ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftInt16ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projRShiftInt16ConstInt32Op struct {
@@ -27081,14 +26260,14 @@ type projRShiftInt16ConstInt32Op struct {
 	constArg int16
 }
 
-func (p projRShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftInt16ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -27200,10 +26379,6 @@ func (p projRShiftInt16ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftInt16ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projRShiftInt16ConstInt64Op struct {
@@ -27211,14 +26386,14 @@ type projRShiftInt16ConstInt64Op struct {
 	constArg int16
 }
 
-func (p projRShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftInt16ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -27330,10 +26505,6 @@ func (p projRShiftInt16ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftInt16ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projRShiftInt32ConstInt16Op struct {
@@ -27341,14 +26512,14 @@ type projRShiftInt32ConstInt16Op struct {
 	constArg int32
 }
 
-func (p projRShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftInt32ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -27460,10 +26631,6 @@ func (p projRShiftInt32ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftInt32ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projRShiftInt32ConstInt32Op struct {
@@ -27471,14 +26638,14 @@ type projRShiftInt32ConstInt32Op struct {
 	constArg int32
 }
 
-func (p projRShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftInt32ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -27590,10 +26757,6 @@ func (p projRShiftInt32ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftInt32ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projRShiftInt32ConstInt64Op struct {
@@ -27601,14 +26764,14 @@ type projRShiftInt32ConstInt64Op struct {
 	constArg int32
 }
 
-func (p projRShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftInt32ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -27720,10 +26883,6 @@ func (p projRShiftInt32ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftInt32ConstInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projRShiftInt64ConstInt16Op struct {
@@ -27731,14 +26890,14 @@ type projRShiftInt64ConstInt16Op struct {
 	constArg int64
 }
 
-func (p projRShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftInt64ConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -27850,10 +27009,6 @@ func (p projRShiftInt64ConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftInt64ConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projRShiftInt64ConstInt32Op struct {
@@ -27861,14 +27016,14 @@ type projRShiftInt64ConstInt32Op struct {
 	constArg int64
 }
 
-func (p projRShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftInt64ConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -27980,10 +27135,6 @@ func (p projRShiftInt64ConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftInt64ConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projRShiftInt64ConstInt64Op struct {
@@ -27991,14 +27142,14 @@ type projRShiftInt64ConstInt64Op struct {
 	constArg int64
 }
 
-func (p projRShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftInt64ConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -28112,23 +27263,19 @@ func (p projRShiftInt64ConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projRShiftInt64ConstInt64Op) Init() {
-	p.Input.Init()
-}
-
 type projRShiftDatumConstInt16Op struct {
 	projConstOpBase
 	constArg interface{}
 }
 
-func (p projRShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftDatumConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -28258,10 +27405,6 @@ func (p projRShiftDatumConstInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftDatumConstInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projRShiftDatumConstInt32Op struct {
@@ -28269,14 +27412,14 @@ type projRShiftDatumConstInt32Op struct {
 	constArg interface{}
 }
 
-func (p projRShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftDatumConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -28406,10 +27549,6 @@ func (p projRShiftDatumConstInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftDatumConstInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projRShiftDatumConstInt64Op struct {
@@ -28417,14 +27556,14 @@ type projRShiftDatumConstInt64Op struct {
 	constArg interface{}
 }
 
-func (p projRShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftDatumConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -28556,23 +27695,19 @@ func (p projRShiftDatumConstInt64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projRShiftDatumConstInt64Op) Init() {
-	p.Input.Init()
-}
-
 type projJSONFetchValJSONConstBytesOp struct {
 	projConstOpBase
 	constArg json.JSON
 }
 
-func (p projJSONFetchValJSONConstBytesOp) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchValJSONConstBytesOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -28698,10 +27833,6 @@ func (p projJSONFetchValJSONConstBytesOp) Next(ctx context.Context) coldata.Batc
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projJSONFetchValJSONConstBytesOp) Init() {
-	p.Input.Init()
 }
 
 type projJSONFetchValJSONConstInt16Op struct {
@@ -28709,14 +27840,14 @@ type projJSONFetchValJSONConstInt16Op struct {
 	constArg json.JSON
 }
 
-func (p projJSONFetchValJSONConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchValJSONConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -28832,23 +27963,19 @@ func (p projJSONFetchValJSONConstInt16Op) Next(ctx context.Context) coldata.Batc
 	return batch
 }
 
-func (p projJSONFetchValJSONConstInt16Op) Init() {
-	p.Input.Init()
-}
-
 type projJSONFetchValJSONConstInt32Op struct {
 	projConstOpBase
 	constArg json.JSON
 }
 
-func (p projJSONFetchValJSONConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchValJSONConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -28964,23 +28091,19 @@ func (p projJSONFetchValJSONConstInt32Op) Next(ctx context.Context) coldata.Batc
 	return batch
 }
 
-func (p projJSONFetchValJSONConstInt32Op) Init() {
-	p.Input.Init()
-}
-
 type projJSONFetchValJSONConstInt64Op struct {
 	projConstOpBase
 	constArg json.JSON
 }
 
-func (p projJSONFetchValJSONConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchValJSONConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -29096,23 +28219,19 @@ func (p projJSONFetchValJSONConstInt64Op) Next(ctx context.Context) coldata.Batc
 	return batch
 }
 
-func (p projJSONFetchValJSONConstInt64Op) Init() {
-	p.Input.Init()
-}
-
 type projJSONFetchTextJSONConstBytesOp struct {
 	projConstOpBase
 	constArg json.JSON
 }
 
-func (p projJSONFetchTextJSONConstBytesOp) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchTextJSONConstBytesOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -29276,23 +28395,19 @@ func (p projJSONFetchTextJSONConstBytesOp) Next(ctx context.Context) coldata.Bat
 	return batch
 }
 
-func (p projJSONFetchTextJSONConstBytesOp) Init() {
-	p.Input.Init()
-}
-
 type projJSONFetchTextJSONConstInt16Op struct {
 	projConstOpBase
 	constArg json.JSON
 }
 
-func (p projJSONFetchTextJSONConstInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchTextJSONConstInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -29444,23 +28559,19 @@ func (p projJSONFetchTextJSONConstInt16Op) Next(ctx context.Context) coldata.Bat
 	return batch
 }
 
-func (p projJSONFetchTextJSONConstInt16Op) Init() {
-	p.Input.Init()
-}
-
 type projJSONFetchTextJSONConstInt32Op struct {
 	projConstOpBase
 	constArg json.JSON
 }
 
-func (p projJSONFetchTextJSONConstInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchTextJSONConstInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -29612,23 +28723,19 @@ func (p projJSONFetchTextJSONConstInt32Op) Next(ctx context.Context) coldata.Bat
 	return batch
 }
 
-func (p projJSONFetchTextJSONConstInt32Op) Init() {
-	p.Input.Init()
-}
-
 type projJSONFetchTextJSONConstInt64Op struct {
 	projConstOpBase
 	constArg json.JSON
 }
 
-func (p projJSONFetchTextJSONConstInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchTextJSONConstInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -29780,23 +28887,19 @@ func (p projJSONFetchTextJSONConstInt64Op) Next(ctx context.Context) coldata.Bat
 	return batch
 }
 
-func (p projJSONFetchTextJSONConstInt64Op) Init() {
-	p.Input.Init()
-}
-
 type projJSONFetchValPathJSONConstDatumOp struct {
 	projConstOpBase
 	constArg json.JSON
 }
 
-func (p projJSONFetchValPathJSONConstDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchValPathJSONConstDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -29912,23 +29015,19 @@ func (p projJSONFetchValPathJSONConstDatumOp) Next(ctx context.Context) coldata.
 	return batch
 }
 
-func (p projJSONFetchValPathJSONConstDatumOp) Init() {
-	p.Input.Init()
-}
-
 type projJSONFetchTextPathJSONConstDatumOp struct {
 	projConstOpBase
 	constArg json.JSON
 }
 
-func (p projJSONFetchTextPathJSONConstDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchTextPathJSONConstDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -30082,10 +29181,6 @@ func (p projJSONFetchTextPathJSONConstDatumOp) Next(ctx context.Context) coldata
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projJSONFetchTextPathJSONConstDatumOp) Init() {
-	p.Input.Init()
 }
 
 // GetProjectionLConstOperator returns the appropriate constant
@@ -30106,7 +29201,7 @@ func GetProjectionLConstOperator(
 ) (colexecop.Operator, error) {
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, outputType, outputIdx)
 	projConstOpBase := projConstOpBase{
-		OneInputNode:   colexecop.NewOneInputNode(input),
+		OneInputHelper: colexecop.MakeOneInputHelper(input),
 		allocator:      allocator,
 		colIdx:         colIdx,
 		outputIdx:      outputIdx,

--- a/pkg/sql/colexec/colexecproj/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/proj_const_ops_tmpl.go
@@ -20,8 +20,6 @@
 package colexecproj
 
 import (
-	"context"
-
 	"github.com/cockroachdb/apd/v2"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
@@ -89,14 +87,14 @@ type _OP_CONST_NAME struct {
 	// {{end}}
 }
 
-func (p _OP_CONST_NAME) Next(ctx context.Context) coldata.Batch {
+func (p _OP_CONST_NAME) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -134,10 +132,6 @@ func (p _OP_CONST_NAME) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p _OP_CONST_NAME) Init() {
-	p.Input.Init()
 }
 
 // {{end}}
@@ -268,7 +262,7 @@ func GetProjection_CONST_SIDEConstOperator(
 ) (colexecop.Operator, error) {
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, outputType, outputIdx)
 	projConstOpBase := projConstOpBase{
-		OneInputNode:   colexecop.NewOneInputNode(input),
+		OneInputHelper: colexecop.MakeOneInputHelper(input),
 		allocator:      allocator,
 		colIdx:         colIdx,
 		outputIdx:      outputIdx,

--- a/pkg/sql/colexec/colexecproj/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_const_right_ops.eg.go
@@ -11,7 +11,6 @@ package colexecproj
 
 import (
 	"bytes"
-	"context"
 	"math"
 	"time"
 	"unsafe"
@@ -51,14 +50,14 @@ type projBitandInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projBitandInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitandInt16Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -146,10 +145,6 @@ func (p projBitandInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandInt16Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitandInt16Int32ConstOp struct {
@@ -157,14 +152,14 @@ type projBitandInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projBitandInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitandInt16Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -252,10 +247,6 @@ func (p projBitandInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandInt16Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitandInt16Int64ConstOp struct {
@@ -263,14 +254,14 @@ type projBitandInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projBitandInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitandInt16Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -358,10 +349,6 @@ func (p projBitandInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandInt16Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitandInt32Int16ConstOp struct {
@@ -369,14 +356,14 @@ type projBitandInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projBitandInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitandInt32Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -464,10 +451,6 @@ func (p projBitandInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandInt32Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitandInt32Int32ConstOp struct {
@@ -475,14 +458,14 @@ type projBitandInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projBitandInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitandInt32Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -570,10 +553,6 @@ func (p projBitandInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandInt32Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitandInt32Int64ConstOp struct {
@@ -581,14 +560,14 @@ type projBitandInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projBitandInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitandInt32Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -676,10 +655,6 @@ func (p projBitandInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandInt32Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitandInt64Int16ConstOp struct {
@@ -687,14 +662,14 @@ type projBitandInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projBitandInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitandInt64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -782,10 +757,6 @@ func (p projBitandInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandInt64Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitandInt64Int32ConstOp struct {
@@ -793,14 +764,14 @@ type projBitandInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projBitandInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitandInt64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -888,10 +859,6 @@ func (p projBitandInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandInt64Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitandInt64Int64ConstOp struct {
@@ -899,14 +866,14 @@ type projBitandInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projBitandInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitandInt64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -994,10 +961,6 @@ func (p projBitandInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandInt64Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitandDatumDatumConstOp struct {
@@ -1005,14 +968,14 @@ type projBitandDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projBitandDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1126,10 +1089,6 @@ func (p projBitandDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandDatumDatumConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitorInt16Int16ConstOp struct {
@@ -1137,14 +1096,14 @@ type projBitorInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projBitorInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitorInt16Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1232,10 +1191,6 @@ func (p projBitorInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorInt16Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitorInt16Int32ConstOp struct {
@@ -1243,14 +1198,14 @@ type projBitorInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projBitorInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitorInt16Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1338,10 +1293,6 @@ func (p projBitorInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorInt16Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitorInt16Int64ConstOp struct {
@@ -1349,14 +1300,14 @@ type projBitorInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projBitorInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitorInt16Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1444,10 +1395,6 @@ func (p projBitorInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorInt16Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitorInt32Int16ConstOp struct {
@@ -1455,14 +1402,14 @@ type projBitorInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projBitorInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitorInt32Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1550,10 +1497,6 @@ func (p projBitorInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorInt32Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitorInt32Int32ConstOp struct {
@@ -1561,14 +1504,14 @@ type projBitorInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projBitorInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitorInt32Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1656,10 +1599,6 @@ func (p projBitorInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorInt32Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitorInt32Int64ConstOp struct {
@@ -1667,14 +1606,14 @@ type projBitorInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projBitorInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitorInt32Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1762,10 +1701,6 @@ func (p projBitorInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorInt32Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitorInt64Int16ConstOp struct {
@@ -1773,14 +1708,14 @@ type projBitorInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projBitorInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitorInt64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1868,10 +1803,6 @@ func (p projBitorInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorInt64Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitorInt64Int32ConstOp struct {
@@ -1879,14 +1810,14 @@ type projBitorInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projBitorInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitorInt64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1974,10 +1905,6 @@ func (p projBitorInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorInt64Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitorInt64Int64ConstOp struct {
@@ -1985,14 +1912,14 @@ type projBitorInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projBitorInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitorInt64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2080,10 +2007,6 @@ func (p projBitorInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorInt64Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitorDatumDatumConstOp struct {
@@ -2091,14 +2014,14 @@ type projBitorDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projBitorDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2212,10 +2135,6 @@ func (p projBitorDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorDatumDatumConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitxorInt16Int16ConstOp struct {
@@ -2223,14 +2142,14 @@ type projBitxorInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projBitxorInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorInt16Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2318,10 +2237,6 @@ func (p projBitxorInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorInt16Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitxorInt16Int32ConstOp struct {
@@ -2329,14 +2244,14 @@ type projBitxorInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projBitxorInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorInt16Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2424,10 +2339,6 @@ func (p projBitxorInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorInt16Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitxorInt16Int64ConstOp struct {
@@ -2435,14 +2346,14 @@ type projBitxorInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projBitxorInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorInt16Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2530,10 +2441,6 @@ func (p projBitxorInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorInt16Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitxorInt32Int16ConstOp struct {
@@ -2541,14 +2448,14 @@ type projBitxorInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projBitxorInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorInt32Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2636,10 +2543,6 @@ func (p projBitxorInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorInt32Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitxorInt32Int32ConstOp struct {
@@ -2647,14 +2550,14 @@ type projBitxorInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projBitxorInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorInt32Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2742,10 +2645,6 @@ func (p projBitxorInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorInt32Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitxorInt32Int64ConstOp struct {
@@ -2753,14 +2652,14 @@ type projBitxorInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projBitxorInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorInt32Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2848,10 +2747,6 @@ func (p projBitxorInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorInt32Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitxorInt64Int16ConstOp struct {
@@ -2859,14 +2754,14 @@ type projBitxorInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projBitxorInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorInt64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2954,10 +2849,6 @@ func (p projBitxorInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorInt64Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitxorInt64Int32ConstOp struct {
@@ -2965,14 +2856,14 @@ type projBitxorInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projBitxorInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorInt64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3060,10 +2951,6 @@ func (p projBitxorInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorInt64Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitxorInt64Int64ConstOp struct {
@@ -3071,14 +2958,14 @@ type projBitxorInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projBitxorInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorInt64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3166,10 +3053,6 @@ func (p projBitxorInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorInt64Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projBitxorDatumDatumConstOp struct {
@@ -3177,14 +3060,14 @@ type projBitxorDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projBitxorDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3298,10 +3181,6 @@ func (p projBitxorDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorDatumDatumConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusDecimalInt16ConstOp struct {
@@ -3309,14 +3188,14 @@ type projPlusDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projPlusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusDecimalInt16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3432,10 +3311,6 @@ func (p projPlusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusDecimalInt16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusDecimalInt32ConstOp struct {
@@ -3443,14 +3318,14 @@ type projPlusDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projPlusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusDecimalInt32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3566,10 +3441,6 @@ func (p projPlusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusDecimalInt32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusDecimalInt64ConstOp struct {
@@ -3577,14 +3448,14 @@ type projPlusDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projPlusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusDecimalInt64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3700,10 +3571,6 @@ func (p projPlusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusDecimalInt64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusDecimalDecimalConstOp struct {
@@ -3711,14 +3578,14 @@ type projPlusDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projPlusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusDecimalDecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3830,10 +3697,6 @@ func (p projPlusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusDecimalDecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt16Int16ConstOp struct {
@@ -3841,14 +3704,14 @@ type projPlusInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projPlusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt16Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3960,10 +3823,6 @@ func (p projPlusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt16Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt16Int32ConstOp struct {
@@ -3971,14 +3830,14 @@ type projPlusInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projPlusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt16Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -4090,10 +3949,6 @@ func (p projPlusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt16Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt16Int64ConstOp struct {
@@ -4101,14 +3956,14 @@ type projPlusInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projPlusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt16Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -4220,10 +4075,6 @@ func (p projPlusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt16Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt16DecimalConstOp struct {
@@ -4231,14 +4082,14 @@ type projPlusInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projPlusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt16DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -4358,10 +4209,6 @@ func (p projPlusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt16DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt16DatumConstOp struct {
@@ -4369,14 +4216,14 @@ type projPlusInt16DatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projPlusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt16DatumConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -4514,10 +4361,6 @@ func (p projPlusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt16DatumConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt32Int16ConstOp struct {
@@ -4525,14 +4368,14 @@ type projPlusInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projPlusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt32Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -4644,10 +4487,6 @@ func (p projPlusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt32Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt32Int32ConstOp struct {
@@ -4655,14 +4494,14 @@ type projPlusInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projPlusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt32Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -4774,10 +4613,6 @@ func (p projPlusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt32Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt32Int64ConstOp struct {
@@ -4785,14 +4620,14 @@ type projPlusInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projPlusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt32Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -4904,10 +4739,6 @@ func (p projPlusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt32Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt32DecimalConstOp struct {
@@ -4915,14 +4746,14 @@ type projPlusInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projPlusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt32DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -5042,10 +4873,6 @@ func (p projPlusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt32DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt32DatumConstOp struct {
@@ -5053,14 +4880,14 @@ type projPlusInt32DatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projPlusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt32DatumConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -5198,10 +5025,6 @@ func (p projPlusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt32DatumConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt64Int16ConstOp struct {
@@ -5209,14 +5032,14 @@ type projPlusInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projPlusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -5328,10 +5151,6 @@ func (p projPlusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt64Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt64Int32ConstOp struct {
@@ -5339,14 +5158,14 @@ type projPlusInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projPlusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -5458,10 +5277,6 @@ func (p projPlusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt64Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt64Int64ConstOp struct {
@@ -5469,14 +5284,14 @@ type projPlusInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projPlusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -5588,10 +5403,6 @@ func (p projPlusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt64Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt64DecimalConstOp struct {
@@ -5599,14 +5410,14 @@ type projPlusInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projPlusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -5726,10 +5537,6 @@ func (p projPlusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt64DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt64DatumConstOp struct {
@@ -5737,14 +5544,14 @@ type projPlusInt64DatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projPlusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt64DatumConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -5882,10 +5689,6 @@ func (p projPlusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt64DatumConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusFloat64Float64ConstOp struct {
@@ -5893,14 +5696,14 @@ type projPlusFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projPlusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusFloat64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -6000,10 +5803,6 @@ func (p projPlusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusFloat64Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusTimestampIntervalConstOp struct {
@@ -6011,14 +5810,14 @@ type projPlusTimestampIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projPlusTimestampIntervalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusTimestampIntervalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -6098,10 +5897,6 @@ func (p projPlusTimestampIntervalConstOp) Next(ctx context.Context) coldata.Batc
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusTimestampIntervalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusIntervalTimestampConstOp struct {
@@ -6109,14 +5904,14 @@ type projPlusIntervalTimestampConstOp struct {
 	constArg time.Time
 }
 
-func (p projPlusIntervalTimestampConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusIntervalTimestampConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -6196,10 +5991,6 @@ func (p projPlusIntervalTimestampConstOp) Next(ctx context.Context) coldata.Batc
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusIntervalTimestampConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusIntervalIntervalConstOp struct {
@@ -6207,14 +5998,14 @@ type projPlusIntervalIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projPlusIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusIntervalIntervalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -6296,23 +6087,19 @@ func (p projPlusIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch
 	return batch
 }
 
-func (p projPlusIntervalIntervalConstOp) Init() {
-	p.Input.Init()
-}
-
 type projPlusIntervalDatumConstOp struct {
 	projConstOpBase
 	constArg interface{}
 }
 
-func (p projPlusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusIntervalDatumConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -6452,23 +6239,19 @@ func (p projPlusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPlusIntervalDatumConstOp) Init() {
-	p.Input.Init()
-}
-
 type projPlusDatumIntervalConstOp struct {
 	projConstOpBase
 	constArg duration.Duration
 }
 
-func (p projPlusDatumIntervalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusDatumIntervalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -6600,10 +6383,6 @@ func (p projPlusDatumIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusDatumIntervalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusDatumInt16ConstOp struct {
@@ -6611,14 +6390,14 @@ type projPlusDatumInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projPlusDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusDatumInt16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -6750,10 +6529,6 @@ func (p projPlusDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusDatumInt16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusDatumInt32ConstOp struct {
@@ -6761,14 +6536,14 @@ type projPlusDatumInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projPlusDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusDatumInt32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -6900,10 +6675,6 @@ func (p projPlusDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusDatumInt32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusDatumInt64ConstOp struct {
@@ -6911,14 +6682,14 @@ type projPlusDatumInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projPlusDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusDatumInt64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -7052,23 +6823,19 @@ func (p projPlusDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPlusDatumInt64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type projMinusDecimalInt16ConstOp struct {
 	projConstOpBase
 	constArg int16
 }
 
-func (p projMinusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDecimalInt16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -7184,10 +6951,6 @@ func (p projMinusDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusDecimalInt16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusDecimalInt32ConstOp struct {
@@ -7195,14 +6958,14 @@ type projMinusDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projMinusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDecimalInt32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -7318,10 +7081,6 @@ func (p projMinusDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusDecimalInt32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusDecimalInt64ConstOp struct {
@@ -7329,14 +7088,14 @@ type projMinusDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projMinusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDecimalInt64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -7452,10 +7211,6 @@ func (p projMinusDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusDecimalInt64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusDecimalDecimalConstOp struct {
@@ -7463,14 +7218,14 @@ type projMinusDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projMinusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDecimalDecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -7584,23 +7339,19 @@ func (p projMinusDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 	return batch
 }
 
-func (p projMinusDecimalDecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type projMinusInt16Int16ConstOp struct {
 	projConstOpBase
 	constArg int16
 }
 
-func (p projMinusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt16Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -7712,10 +7463,6 @@ func (p projMinusInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusInt16Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusInt16Int32ConstOp struct {
@@ -7723,14 +7470,14 @@ type projMinusInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projMinusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt16Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -7842,10 +7589,6 @@ func (p projMinusInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusInt16Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusInt16Int64ConstOp struct {
@@ -7853,14 +7596,14 @@ type projMinusInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projMinusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt16Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -7972,10 +7715,6 @@ func (p projMinusInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusInt16Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusInt16DecimalConstOp struct {
@@ -7983,14 +7722,14 @@ type projMinusInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projMinusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt16DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -8110,10 +7849,6 @@ func (p projMinusInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusInt16DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusInt16DatumConstOp struct {
@@ -8121,14 +7856,14 @@ type projMinusInt16DatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projMinusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt16DatumConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -8268,23 +8003,19 @@ func (p projMinusInt16DatumConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusInt16DatumConstOp) Init() {
-	p.Input.Init()
-}
-
 type projMinusInt32Int16ConstOp struct {
 	projConstOpBase
 	constArg int16
 }
 
-func (p projMinusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt32Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -8396,10 +8127,6 @@ func (p projMinusInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusInt32Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusInt32Int32ConstOp struct {
@@ -8407,14 +8134,14 @@ type projMinusInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projMinusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt32Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -8526,10 +8253,6 @@ func (p projMinusInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusInt32Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusInt32Int64ConstOp struct {
@@ -8537,14 +8260,14 @@ type projMinusInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projMinusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt32Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -8656,10 +8379,6 @@ func (p projMinusInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusInt32Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusInt32DecimalConstOp struct {
@@ -8667,14 +8386,14 @@ type projMinusInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projMinusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt32DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -8794,10 +8513,6 @@ func (p projMinusInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusInt32DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusInt32DatumConstOp struct {
@@ -8805,14 +8520,14 @@ type projMinusInt32DatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projMinusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt32DatumConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -8952,23 +8667,19 @@ func (p projMinusInt32DatumConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusInt32DatumConstOp) Init() {
-	p.Input.Init()
-}
-
 type projMinusInt64Int16ConstOp struct {
 	projConstOpBase
 	constArg int16
 }
 
-func (p projMinusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -9080,10 +8791,6 @@ func (p projMinusInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusInt64Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusInt64Int32ConstOp struct {
@@ -9091,14 +8798,14 @@ type projMinusInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projMinusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -9210,10 +8917,6 @@ func (p projMinusInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusInt64Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusInt64Int64ConstOp struct {
@@ -9221,14 +8924,14 @@ type projMinusInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projMinusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -9342,23 +9045,19 @@ func (p projMinusInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusInt64Int64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type projMinusInt64DecimalConstOp struct {
 	projConstOpBase
 	constArg apd.Decimal
 }
 
-func (p projMinusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -9480,23 +9179,19 @@ func (p projMinusInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusInt64DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type projMinusInt64DatumConstOp struct {
 	projConstOpBase
 	constArg interface{}
 }
 
-func (p projMinusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt64DatumConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -9636,23 +9331,19 @@ func (p projMinusInt64DatumConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusInt64DatumConstOp) Init() {
-	p.Input.Init()
-}
-
 type projMinusFloat64Float64ConstOp struct {
 	projConstOpBase
 	constArg float64
 }
 
-func (p projMinusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusFloat64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -9754,23 +9445,19 @@ func (p projMinusFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch 
 	return batch
 }
 
-func (p projMinusFloat64Float64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type projMinusTimestampTimestampConstOp struct {
 	projConstOpBase
 	constArg time.Time
 }
 
-func (p projMinusTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -9864,23 +9551,19 @@ func (p projMinusTimestampTimestampConstOp) Next(ctx context.Context) coldata.Ba
 	return batch
 }
 
-func (p projMinusTimestampTimestampConstOp) Init() {
-	p.Input.Init()
-}
-
 type projMinusTimestampIntervalConstOp struct {
 	projConstOpBase
 	constArg duration.Duration
 }
 
-func (p projMinusTimestampIntervalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusTimestampIntervalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -9962,23 +9645,19 @@ func (p projMinusTimestampIntervalConstOp) Next(ctx context.Context) coldata.Bat
 	return batch
 }
 
-func (p projMinusTimestampIntervalConstOp) Init() {
-	p.Input.Init()
-}
-
 type projMinusIntervalIntervalConstOp struct {
 	projConstOpBase
 	constArg duration.Duration
 }
 
-func (p projMinusIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusIntervalIntervalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -10058,10 +9737,6 @@ func (p projMinusIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batc
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusIntervalIntervalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusIntervalDatumConstOp struct {
@@ -10069,14 +9744,14 @@ type projMinusIntervalDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projMinusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusIntervalDatumConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -10214,10 +9889,6 @@ func (p projMinusIntervalDatumConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusIntervalDatumConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusJSONBytesConstOp struct {
@@ -10225,14 +9896,14 @@ type projMinusJSONBytesConstOp struct {
 	constArg []byte
 }
 
-func (p projMinusJSONBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusJSONBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -10346,10 +10017,6 @@ func (p projMinusJSONBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusJSONBytesConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusJSONInt16ConstOp struct {
@@ -10357,14 +10024,14 @@ type projMinusJSONInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projMinusJSONInt16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusJSONInt16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -10464,10 +10131,6 @@ func (p projMinusJSONInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusJSONInt16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusJSONInt32ConstOp struct {
@@ -10475,14 +10138,14 @@ type projMinusJSONInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projMinusJSONInt32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusJSONInt32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -10582,10 +10245,6 @@ func (p projMinusJSONInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusJSONInt32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusJSONInt64ConstOp struct {
@@ -10593,14 +10252,14 @@ type projMinusJSONInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projMinusJSONInt64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusJSONInt64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -10700,10 +10359,6 @@ func (p projMinusJSONInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusJSONInt64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusDatumDatumConstOp struct {
@@ -10711,14 +10366,14 @@ type projMinusDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projMinusDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -10832,10 +10487,6 @@ func (p projMinusDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusDatumDatumConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusDatumIntervalConstOp struct {
@@ -10843,14 +10494,14 @@ type projMinusDatumIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projMinusDatumIntervalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDatumIntervalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -10982,10 +10633,6 @@ func (p projMinusDatumIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusDatumIntervalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusDatumBytesConstOp struct {
@@ -10993,14 +10640,14 @@ type projMinusDatumBytesConstOp struct {
 	constArg []byte
 }
 
-func (p projMinusDatumBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDatumBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -11130,10 +10777,6 @@ func (p projMinusDatumBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusDatumBytesConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusDatumInt16ConstOp struct {
@@ -11141,14 +10784,14 @@ type projMinusDatumInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projMinusDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDatumInt16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -11280,10 +10923,6 @@ func (p projMinusDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusDatumInt16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusDatumInt32ConstOp struct {
@@ -11291,14 +10930,14 @@ type projMinusDatumInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projMinusDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDatumInt32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -11430,10 +11069,6 @@ func (p projMinusDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusDatumInt32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusDatumInt64ConstOp struct {
@@ -11441,14 +11076,14 @@ type projMinusDatumInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projMinusDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDatumInt64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -11580,10 +11215,6 @@ func (p projMinusDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusDatumInt64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMultDecimalInt16ConstOp struct {
@@ -11591,14 +11222,14 @@ type projMultDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projMultDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultDecimalInt16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -11714,10 +11345,6 @@ func (p projMultDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultDecimalInt16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMultDecimalInt32ConstOp struct {
@@ -11725,14 +11352,14 @@ type projMultDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projMultDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultDecimalInt32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -11848,10 +11475,6 @@ func (p projMultDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultDecimalInt32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMultDecimalInt64ConstOp struct {
@@ -11859,14 +11482,14 @@ type projMultDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projMultDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultDecimalInt64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -11982,10 +11605,6 @@ func (p projMultDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultDecimalInt64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMultDecimalDecimalConstOp struct {
@@ -11993,14 +11612,14 @@ type projMultDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projMultDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultDecimalDecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -12112,10 +11731,6 @@ func (p projMultDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultDecimalDecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMultDecimalIntervalConstOp struct {
@@ -12123,14 +11738,14 @@ type projMultDecimalIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projMultDecimalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultDecimalIntervalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -12230,10 +11845,6 @@ func (p projMultDecimalIntervalConstOp) Next(ctx context.Context) coldata.Batch 
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultDecimalIntervalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMultInt16Int16ConstOp struct {
@@ -12241,14 +11852,14 @@ type projMultInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projMultInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt16Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -12392,10 +12003,6 @@ func (p projMultInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt16Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMultInt16Int32ConstOp struct {
@@ -12403,14 +12010,14 @@ type projMultInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projMultInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt16Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -12554,10 +12161,6 @@ func (p projMultInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt16Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMultInt16Int64ConstOp struct {
@@ -12565,14 +12168,14 @@ type projMultInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projMultInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt16Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -12716,10 +12319,6 @@ func (p projMultInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt16Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMultInt16DecimalConstOp struct {
@@ -12727,14 +12326,14 @@ type projMultInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projMultInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt16DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -12854,10 +12453,6 @@ func (p projMultInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt16DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMultInt16IntervalConstOp struct {
@@ -12865,14 +12460,14 @@ type projMultInt16IntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projMultInt16IntervalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt16IntervalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -12952,10 +12547,6 @@ func (p projMultInt16IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt16IntervalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMultInt32Int16ConstOp struct {
@@ -12963,14 +12554,14 @@ type projMultInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projMultInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt32Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -13114,10 +12705,6 @@ func (p projMultInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt32Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMultInt32Int32ConstOp struct {
@@ -13125,14 +12712,14 @@ type projMultInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projMultInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt32Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -13276,10 +12863,6 @@ func (p projMultInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt32Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMultInt32Int64ConstOp struct {
@@ -13287,14 +12870,14 @@ type projMultInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projMultInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt32Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -13438,10 +13021,6 @@ func (p projMultInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt32Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMultInt32DecimalConstOp struct {
@@ -13449,14 +13028,14 @@ type projMultInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projMultInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt32DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -13576,10 +13155,6 @@ func (p projMultInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt32DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMultInt32IntervalConstOp struct {
@@ -13587,14 +13162,14 @@ type projMultInt32IntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projMultInt32IntervalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt32IntervalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -13674,10 +13249,6 @@ func (p projMultInt32IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt32IntervalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMultInt64Int16ConstOp struct {
@@ -13685,14 +13256,14 @@ type projMultInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projMultInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -13836,10 +13407,6 @@ func (p projMultInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt64Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMultInt64Int32ConstOp struct {
@@ -13847,14 +13414,14 @@ type projMultInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projMultInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -13998,10 +13565,6 @@ func (p projMultInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt64Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMultInt64Int64ConstOp struct {
@@ -14009,14 +13572,14 @@ type projMultInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projMultInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -14160,10 +13723,6 @@ func (p projMultInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt64Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMultInt64DecimalConstOp struct {
@@ -14171,14 +13730,14 @@ type projMultInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projMultInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -14298,10 +13857,6 @@ func (p projMultInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt64DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMultInt64IntervalConstOp struct {
@@ -14309,14 +13864,14 @@ type projMultInt64IntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projMultInt64IntervalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt64IntervalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -14396,10 +13951,6 @@ func (p projMultInt64IntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt64IntervalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMultFloat64Float64ConstOp struct {
@@ -14407,14 +13958,14 @@ type projMultFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projMultFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultFloat64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -14514,10 +14065,6 @@ func (p projMultFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultFloat64Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMultFloat64IntervalConstOp struct {
@@ -14525,14 +14072,14 @@ type projMultFloat64IntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projMultFloat64IntervalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultFloat64IntervalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -14612,10 +14159,6 @@ func (p projMultFloat64IntervalConstOp) Next(ctx context.Context) coldata.Batch 
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultFloat64IntervalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMultIntervalInt16ConstOp struct {
@@ -14623,14 +14166,14 @@ type projMultIntervalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projMultIntervalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultIntervalInt16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -14710,10 +14253,6 @@ func (p projMultIntervalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultIntervalInt16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMultIntervalInt32ConstOp struct {
@@ -14721,14 +14260,14 @@ type projMultIntervalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projMultIntervalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultIntervalInt32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -14808,10 +14347,6 @@ func (p projMultIntervalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultIntervalInt32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMultIntervalInt64ConstOp struct {
@@ -14819,14 +14354,14 @@ type projMultIntervalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projMultIntervalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultIntervalInt64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -14906,10 +14441,6 @@ func (p projMultIntervalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultIntervalInt64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMultIntervalFloat64ConstOp struct {
@@ -14917,14 +14448,14 @@ type projMultIntervalFloat64ConstOp struct {
 	constArg float64
 }
 
-func (p projMultIntervalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultIntervalFloat64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -15004,10 +14535,6 @@ func (p projMultIntervalFloat64ConstOp) Next(ctx context.Context) coldata.Batch 
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultIntervalFloat64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projMultIntervalDecimalConstOp struct {
@@ -15015,14 +14542,14 @@ type projMultIntervalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projMultIntervalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultIntervalDecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -15122,10 +14649,6 @@ func (p projMultIntervalDecimalConstOp) Next(ctx context.Context) coldata.Batch 
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultIntervalDecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projDivDecimalInt16ConstOp struct {
@@ -15133,14 +14656,14 @@ type projDivDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projDivDecimalInt16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -15272,10 +14795,6 @@ func (p projDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivDecimalInt16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projDivDecimalInt32ConstOp struct {
@@ -15283,14 +14802,14 @@ type projDivDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projDivDecimalInt32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -15422,10 +14941,6 @@ func (p projDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivDecimalInt32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projDivDecimalInt64ConstOp struct {
@@ -15433,14 +14948,14 @@ type projDivDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projDivDecimalInt64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -15572,10 +15087,6 @@ func (p projDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivDecimalInt64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projDivDecimalDecimalConstOp struct {
@@ -15583,14 +15094,14 @@ type projDivDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projDivDecimalDecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -15718,10 +15229,6 @@ func (p projDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivDecimalDecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projDivInt16Int16ConstOp struct {
@@ -15729,14 +15236,14 @@ type projDivInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt16Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -15864,10 +15371,6 @@ func (p projDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt16Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projDivInt16Int32ConstOp struct {
@@ -15875,14 +15378,14 @@ type projDivInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt16Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -16010,10 +15513,6 @@ func (p projDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt16Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projDivInt16Int64ConstOp struct {
@@ -16021,14 +15520,14 @@ type projDivInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt16Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -16156,10 +15655,6 @@ func (p projDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt16Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projDivInt16DecimalConstOp struct {
@@ -16167,14 +15662,14 @@ type projDivInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt16DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -16310,10 +15805,6 @@ func (p projDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt16DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projDivInt32Int16ConstOp struct {
@@ -16321,14 +15812,14 @@ type projDivInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt32Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -16456,10 +15947,6 @@ func (p projDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt32Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projDivInt32Int32ConstOp struct {
@@ -16467,14 +15954,14 @@ type projDivInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt32Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -16602,10 +16089,6 @@ func (p projDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt32Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projDivInt32Int64ConstOp struct {
@@ -16613,14 +16096,14 @@ type projDivInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt32Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -16748,10 +16231,6 @@ func (p projDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt32Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projDivInt32DecimalConstOp struct {
@@ -16759,14 +16238,14 @@ type projDivInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt32DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -16902,10 +16381,6 @@ func (p projDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt32DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projDivInt64Int16ConstOp struct {
@@ -16913,14 +16388,14 @@ type projDivInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -17048,10 +16523,6 @@ func (p projDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt64Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projDivInt64Int32ConstOp struct {
@@ -17059,14 +16530,14 @@ type projDivInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -17194,10 +16665,6 @@ func (p projDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt64Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projDivInt64Int64ConstOp struct {
@@ -17205,14 +16672,14 @@ type projDivInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -17340,10 +16807,6 @@ func (p projDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt64Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projDivInt64DecimalConstOp struct {
@@ -17351,14 +16814,14 @@ type projDivInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -17494,10 +16957,6 @@ func (p projDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt64DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projDivFloat64Float64ConstOp struct {
@@ -17505,14 +16964,14 @@ type projDivFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projDivFloat64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -17628,10 +17087,6 @@ func (p projDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivFloat64Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projDivIntervalInt64ConstOp struct {
@@ -17639,14 +17094,14 @@ type projDivIntervalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projDivIntervalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projDivIntervalInt64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -17742,10 +17197,6 @@ func (p projDivIntervalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivIntervalInt64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projDivIntervalFloat64ConstOp struct {
@@ -17753,14 +17204,14 @@ type projDivIntervalFloat64ConstOp struct {
 	constArg float64
 }
 
-func (p projDivIntervalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projDivIntervalFloat64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -17858,23 +17309,19 @@ func (p projDivIntervalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projDivIntervalFloat64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type projFloorDivDecimalInt16ConstOp struct {
 	projConstOpBase
 	constArg int16
 }
 
-func (p projFloorDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivDecimalInt16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -18006,10 +17453,6 @@ func (p projFloorDivDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivDecimalInt16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivDecimalInt32ConstOp struct {
@@ -18017,14 +17460,14 @@ type projFloorDivDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projFloorDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivDecimalInt32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -18156,10 +17599,6 @@ func (p projFloorDivDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivDecimalInt32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivDecimalInt64ConstOp struct {
@@ -18167,14 +17606,14 @@ type projFloorDivDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projFloorDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivDecimalInt64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -18306,10 +17745,6 @@ func (p projFloorDivDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivDecimalInt64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivDecimalDecimalConstOp struct {
@@ -18317,14 +17752,14 @@ type projFloorDivDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projFloorDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivDecimalDecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -18452,10 +17887,6 @@ func (p projFloorDivDecimalDecimalConstOp) Next(ctx context.Context) coldata.Bat
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivDecimalDecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt16Int16ConstOp struct {
@@ -18463,14 +17894,14 @@ type projFloorDivInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projFloorDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt16Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -18578,10 +18009,6 @@ func (p projFloorDivInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt16Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt16Int32ConstOp struct {
@@ -18589,14 +18016,14 @@ type projFloorDivInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projFloorDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt16Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -18704,10 +18131,6 @@ func (p projFloorDivInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt16Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt16Int64ConstOp struct {
@@ -18715,14 +18138,14 @@ type projFloorDivInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projFloorDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt16Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -18830,10 +18253,6 @@ func (p projFloorDivInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt16Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt16DecimalConstOp struct {
@@ -18841,14 +18260,14 @@ type projFloorDivInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projFloorDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt16DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -18984,10 +18403,6 @@ func (p projFloorDivInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt16DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt32Int16ConstOp struct {
@@ -18995,14 +18410,14 @@ type projFloorDivInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projFloorDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt32Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -19110,10 +18525,6 @@ func (p projFloorDivInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt32Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt32Int32ConstOp struct {
@@ -19121,14 +18532,14 @@ type projFloorDivInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projFloorDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt32Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -19236,10 +18647,6 @@ func (p projFloorDivInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt32Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt32Int64ConstOp struct {
@@ -19247,14 +18654,14 @@ type projFloorDivInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projFloorDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt32Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -19362,10 +18769,6 @@ func (p projFloorDivInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt32Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt32DecimalConstOp struct {
@@ -19373,14 +18776,14 @@ type projFloorDivInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projFloorDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt32DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -19516,10 +18919,6 @@ func (p projFloorDivInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt32DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt64Int16ConstOp struct {
@@ -19527,14 +18926,14 @@ type projFloorDivInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projFloorDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -19642,10 +19041,6 @@ func (p projFloorDivInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt64Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt64Int32ConstOp struct {
@@ -19653,14 +19048,14 @@ type projFloorDivInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projFloorDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -19768,10 +19163,6 @@ func (p projFloorDivInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt64Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt64Int64ConstOp struct {
@@ -19779,14 +19170,14 @@ type projFloorDivInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projFloorDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -19894,10 +19285,6 @@ func (p projFloorDivInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt64Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt64DecimalConstOp struct {
@@ -19905,14 +19292,14 @@ type projFloorDivInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projFloorDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -20048,10 +19435,6 @@ func (p projFloorDivInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt64DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivFloat64Float64ConstOp struct {
@@ -20059,14 +19442,14 @@ type projFloorDivFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projFloorDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivFloat64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -20182,10 +19565,6 @@ func (p projFloorDivFloat64Float64ConstOp) Next(ctx context.Context) coldata.Bat
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivFloat64Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projModDecimalInt16ConstOp struct {
@@ -20193,14 +19572,14 @@ type projModDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projModDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projModDecimalInt16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -20332,10 +19711,6 @@ func (p projModDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModDecimalInt16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projModDecimalInt32ConstOp struct {
@@ -20343,14 +19718,14 @@ type projModDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projModDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projModDecimalInt32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -20482,10 +19857,6 @@ func (p projModDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModDecimalInt32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projModDecimalInt64ConstOp struct {
@@ -20493,14 +19864,14 @@ type projModDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projModDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projModDecimalInt64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -20632,10 +20003,6 @@ func (p projModDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModDecimalInt64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projModDecimalDecimalConstOp struct {
@@ -20643,14 +20010,14 @@ type projModDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projModDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projModDecimalDecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -20778,10 +20145,6 @@ func (p projModDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModDecimalDecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projModInt16Int16ConstOp struct {
@@ -20789,14 +20152,14 @@ type projModInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projModInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projModInt16Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -20904,10 +20267,6 @@ func (p projModInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt16Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projModInt16Int32ConstOp struct {
@@ -20915,14 +20274,14 @@ type projModInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projModInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projModInt16Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -21030,10 +20389,6 @@ func (p projModInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt16Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projModInt16Int64ConstOp struct {
@@ -21041,14 +20396,14 @@ type projModInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projModInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projModInt16Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -21156,10 +20511,6 @@ func (p projModInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt16Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projModInt16DecimalConstOp struct {
@@ -21167,14 +20518,14 @@ type projModInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projModInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projModInt16DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -21310,10 +20661,6 @@ func (p projModInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt16DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projModInt32Int16ConstOp struct {
@@ -21321,14 +20668,14 @@ type projModInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projModInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projModInt32Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -21436,10 +20783,6 @@ func (p projModInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt32Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projModInt32Int32ConstOp struct {
@@ -21447,14 +20790,14 @@ type projModInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projModInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projModInt32Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -21562,10 +20905,6 @@ func (p projModInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt32Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projModInt32Int64ConstOp struct {
@@ -21573,14 +20912,14 @@ type projModInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projModInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projModInt32Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -21688,10 +21027,6 @@ func (p projModInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt32Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projModInt32DecimalConstOp struct {
@@ -21699,14 +21034,14 @@ type projModInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projModInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projModInt32DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -21842,10 +21177,6 @@ func (p projModInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt32DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projModInt64Int16ConstOp struct {
@@ -21853,14 +21184,14 @@ type projModInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projModInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projModInt64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -21968,10 +21299,6 @@ func (p projModInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt64Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projModInt64Int32ConstOp struct {
@@ -21979,14 +21306,14 @@ type projModInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projModInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projModInt64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -22094,10 +21421,6 @@ func (p projModInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt64Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projModInt64Int64ConstOp struct {
@@ -22105,14 +21428,14 @@ type projModInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projModInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projModInt64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -22220,10 +21543,6 @@ func (p projModInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt64Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projModInt64DecimalConstOp struct {
@@ -22231,14 +21550,14 @@ type projModInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projModInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projModInt64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -22374,10 +21693,6 @@ func (p projModInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt64DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projModFloat64Float64ConstOp struct {
@@ -22385,14 +21700,14 @@ type projModFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projModFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projModFloat64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -22508,10 +21823,6 @@ func (p projModFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModFloat64Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPowDecimalInt16ConstOp struct {
@@ -22519,14 +21830,14 @@ type projPowDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projPowDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPowDecimalInt16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -22642,10 +21953,6 @@ func (p projPowDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPowDecimalInt16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPowDecimalInt32ConstOp struct {
@@ -22653,14 +21960,14 @@ type projPowDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projPowDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPowDecimalInt32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -22776,10 +22083,6 @@ func (p projPowDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPowDecimalInt32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPowDecimalInt64ConstOp struct {
@@ -22787,14 +22090,14 @@ type projPowDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projPowDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPowDecimalInt64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -22910,10 +22213,6 @@ func (p projPowDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPowDecimalInt64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPowDecimalDecimalConstOp struct {
@@ -22921,14 +22220,14 @@ type projPowDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projPowDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPowDecimalDecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -23042,23 +22341,19 @@ func (p projPowDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPowDecimalDecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type projPowInt16Int16ConstOp struct {
 	projConstOpBase
 	constArg int16
 }
 
-func (p projPowInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt16Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -23194,10 +22489,6 @@ func (p projPowInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPowInt16Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPowInt16Int32ConstOp struct {
@@ -23205,14 +22496,14 @@ type projPowInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projPowInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt16Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -23348,10 +22639,6 @@ func (p projPowInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPowInt16Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPowInt16Int64ConstOp struct {
@@ -23359,14 +22646,14 @@ type projPowInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projPowInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt16Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -23502,10 +22789,6 @@ func (p projPowInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPowInt16Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPowInt16DecimalConstOp struct {
@@ -23513,14 +22796,14 @@ type projPowInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projPowInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt16DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -23642,23 +22925,19 @@ func (p projPowInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPowInt16DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type projPowInt32Int16ConstOp struct {
 	projConstOpBase
 	constArg int16
 }
 
-func (p projPowInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt32Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -23794,10 +23073,6 @@ func (p projPowInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPowInt32Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPowInt32Int32ConstOp struct {
@@ -23805,14 +23080,14 @@ type projPowInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projPowInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt32Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -23948,10 +23223,6 @@ func (p projPowInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPowInt32Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPowInt32Int64ConstOp struct {
@@ -23959,14 +23230,14 @@ type projPowInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projPowInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt32Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -24102,10 +23373,6 @@ func (p projPowInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPowInt32Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPowInt32DecimalConstOp struct {
@@ -24113,14 +23380,14 @@ type projPowInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projPowInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt32DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -24242,23 +23509,19 @@ func (p projPowInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPowInt32DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type projPowInt64Int16ConstOp struct {
 	projConstOpBase
 	constArg int16
 }
 
-func (p projPowInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -24394,10 +23657,6 @@ func (p projPowInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPowInt64Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPowInt64Int32ConstOp struct {
@@ -24405,14 +23664,14 @@ type projPowInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projPowInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -24548,10 +23807,6 @@ func (p projPowInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPowInt64Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projPowInt64Int64ConstOp struct {
@@ -24559,14 +23814,14 @@ type projPowInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projPowInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -24704,23 +23959,19 @@ func (p projPowInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPowInt64Int64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type projPowInt64DecimalConstOp struct {
 	projConstOpBase
 	constArg apd.Decimal
 }
 
-func (p projPowInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -24842,23 +24093,19 @@ func (p projPowInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPowInt64DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type projPowFloat64Float64ConstOp struct {
 	projConstOpBase
 	constArg float64
 }
 
-func (p projPowFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPowFloat64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -24960,23 +24207,19 @@ func (p projPowFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPowFloat64Float64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type projConcatBytesBytesConstOp struct {
 	projConstOpBase
 	constArg []byte
 }
 
-func (p projConcatBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projConcatBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -25082,10 +24325,6 @@ func (p projConcatBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projConcatBytesBytesConstOp) Init() {
-	p.Input.Init()
 }
 
 type projConcatJSONJSONConstOp struct {
@@ -25093,14 +24332,14 @@ type projConcatJSONJSONConstOp struct {
 	constArg json.JSON
 }
 
-func (p projConcatJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projConcatJSONJSONConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -25202,10 +24441,6 @@ func (p projConcatJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projConcatJSONJSONConstOp) Init() {
-	p.Input.Init()
 }
 
 type projConcatDatumDatumConstOp struct {
@@ -25213,14 +24448,14 @@ type projConcatDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projConcatDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -25334,10 +24569,6 @@ func (p projConcatDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projConcatDatumDatumConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLShiftInt16Int16ConstOp struct {
@@ -25345,14 +24576,14 @@ type projLShiftInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projLShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftInt16Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -25464,10 +24695,6 @@ func (p projLShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftInt16Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLShiftInt16Int32ConstOp struct {
@@ -25475,14 +24702,14 @@ type projLShiftInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projLShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftInt16Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -25594,10 +24821,6 @@ func (p projLShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftInt16Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLShiftInt16Int64ConstOp struct {
@@ -25605,14 +24828,14 @@ type projLShiftInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projLShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftInt16Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -25724,10 +24947,6 @@ func (p projLShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftInt16Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLShiftInt32Int16ConstOp struct {
@@ -25735,14 +24954,14 @@ type projLShiftInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projLShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftInt32Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -25854,10 +25073,6 @@ func (p projLShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftInt32Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLShiftInt32Int32ConstOp struct {
@@ -25865,14 +25080,14 @@ type projLShiftInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projLShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftInt32Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -25984,10 +25199,6 @@ func (p projLShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftInt32Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLShiftInt32Int64ConstOp struct {
@@ -25995,14 +25206,14 @@ type projLShiftInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projLShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftInt32Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -26114,10 +25325,6 @@ func (p projLShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftInt32Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLShiftInt64Int16ConstOp struct {
@@ -26125,14 +25332,14 @@ type projLShiftInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projLShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftInt64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -26244,10 +25451,6 @@ func (p projLShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftInt64Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLShiftInt64Int32ConstOp struct {
@@ -26255,14 +25458,14 @@ type projLShiftInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projLShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftInt64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -26374,10 +25577,6 @@ func (p projLShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftInt64Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLShiftInt64Int64ConstOp struct {
@@ -26385,14 +25584,14 @@ type projLShiftInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projLShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftInt64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -26504,10 +25703,6 @@ func (p projLShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftInt64Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLShiftDatumInt16ConstOp struct {
@@ -26515,14 +25710,14 @@ type projLShiftDatumInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projLShiftDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftDatumInt16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -26654,10 +25849,6 @@ func (p projLShiftDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftDatumInt16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLShiftDatumInt32ConstOp struct {
@@ -26665,14 +25856,14 @@ type projLShiftDatumInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projLShiftDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftDatumInt32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -26804,10 +25995,6 @@ func (p projLShiftDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftDatumInt32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLShiftDatumInt64ConstOp struct {
@@ -26815,14 +26002,14 @@ type projLShiftDatumInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projLShiftDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftDatumInt64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -26954,10 +26141,6 @@ func (p projLShiftDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftDatumInt64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projRShiftInt16Int16ConstOp struct {
@@ -26965,14 +26148,14 @@ type projRShiftInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projRShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftInt16Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -27084,10 +26267,6 @@ func (p projRShiftInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftInt16Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projRShiftInt16Int32ConstOp struct {
@@ -27095,14 +26274,14 @@ type projRShiftInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projRShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftInt16Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -27214,10 +26393,6 @@ func (p projRShiftInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftInt16Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projRShiftInt16Int64ConstOp struct {
@@ -27225,14 +26400,14 @@ type projRShiftInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projRShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftInt16Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -27344,10 +26519,6 @@ func (p projRShiftInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftInt16Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projRShiftInt32Int16ConstOp struct {
@@ -27355,14 +26526,14 @@ type projRShiftInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projRShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftInt32Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -27474,10 +26645,6 @@ func (p projRShiftInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftInt32Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projRShiftInt32Int32ConstOp struct {
@@ -27485,14 +26652,14 @@ type projRShiftInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projRShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftInt32Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -27604,10 +26771,6 @@ func (p projRShiftInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftInt32Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projRShiftInt32Int64ConstOp struct {
@@ -27615,14 +26778,14 @@ type projRShiftInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projRShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftInt32Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -27734,10 +26897,6 @@ func (p projRShiftInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftInt32Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projRShiftInt64Int16ConstOp struct {
@@ -27745,14 +26904,14 @@ type projRShiftInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projRShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftInt64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -27864,10 +27023,6 @@ func (p projRShiftInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftInt64Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projRShiftInt64Int32ConstOp struct {
@@ -27875,14 +27030,14 @@ type projRShiftInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projRShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftInt64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -27994,10 +27149,6 @@ func (p projRShiftInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftInt64Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projRShiftInt64Int64ConstOp struct {
@@ -28005,14 +27156,14 @@ type projRShiftInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projRShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftInt64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -28126,23 +27277,19 @@ func (p projRShiftInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projRShiftInt64Int64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type projRShiftDatumInt16ConstOp struct {
 	projConstOpBase
 	constArg int16
 }
 
-func (p projRShiftDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftDatumInt16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -28274,10 +27421,6 @@ func (p projRShiftDatumInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftDatumInt16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projRShiftDatumInt32ConstOp struct {
@@ -28285,14 +27428,14 @@ type projRShiftDatumInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projRShiftDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftDatumInt32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -28424,10 +27567,6 @@ func (p projRShiftDatumInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftDatumInt32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projRShiftDatumInt64ConstOp struct {
@@ -28435,14 +27574,14 @@ type projRShiftDatumInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projRShiftDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftDatumInt64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -28576,23 +27715,19 @@ func (p projRShiftDatumInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projRShiftDatumInt64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type projJSONFetchValJSONBytesConstOp struct {
 	projConstOpBase
 	constArg []byte
 }
 
-func (p projJSONFetchValJSONBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchValJSONBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -28718,10 +27853,6 @@ func (p projJSONFetchValJSONBytesConstOp) Next(ctx context.Context) coldata.Batc
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projJSONFetchValJSONBytesConstOp) Init() {
-	p.Input.Init()
 }
 
 type projJSONFetchValJSONInt16ConstOp struct {
@@ -28729,14 +27860,14 @@ type projJSONFetchValJSONInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projJSONFetchValJSONInt16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchValJSONInt16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -28852,10 +27983,6 @@ func (p projJSONFetchValJSONInt16ConstOp) Next(ctx context.Context) coldata.Batc
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projJSONFetchValJSONInt16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projJSONFetchValJSONInt32ConstOp struct {
@@ -28863,14 +27990,14 @@ type projJSONFetchValJSONInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projJSONFetchValJSONInt32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchValJSONInt32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -28986,10 +28113,6 @@ func (p projJSONFetchValJSONInt32ConstOp) Next(ctx context.Context) coldata.Batc
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projJSONFetchValJSONInt32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projJSONFetchValJSONInt64ConstOp struct {
@@ -28997,14 +28120,14 @@ type projJSONFetchValJSONInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projJSONFetchValJSONInt64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchValJSONInt64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -29120,10 +28243,6 @@ func (p projJSONFetchValJSONInt64ConstOp) Next(ctx context.Context) coldata.Batc
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projJSONFetchValJSONInt64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projJSONFetchTextJSONBytesConstOp struct {
@@ -29131,14 +28250,14 @@ type projJSONFetchTextJSONBytesConstOp struct {
 	constArg []byte
 }
 
-func (p projJSONFetchTextJSONBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchTextJSONBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -29300,10 +28419,6 @@ func (p projJSONFetchTextJSONBytesConstOp) Next(ctx context.Context) coldata.Bat
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projJSONFetchTextJSONBytesConstOp) Init() {
-	p.Input.Init()
 }
 
 type projJSONFetchTextJSONInt16ConstOp struct {
@@ -29311,14 +28426,14 @@ type projJSONFetchTextJSONInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projJSONFetchTextJSONInt16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchTextJSONInt16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -29470,10 +28585,6 @@ func (p projJSONFetchTextJSONInt16ConstOp) Next(ctx context.Context) coldata.Bat
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projJSONFetchTextJSONInt16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projJSONFetchTextJSONInt32ConstOp struct {
@@ -29481,14 +28592,14 @@ type projJSONFetchTextJSONInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projJSONFetchTextJSONInt32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchTextJSONInt32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -29640,10 +28751,6 @@ func (p projJSONFetchTextJSONInt32ConstOp) Next(ctx context.Context) coldata.Bat
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projJSONFetchTextJSONInt32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projJSONFetchTextJSONInt64ConstOp struct {
@@ -29651,14 +28758,14 @@ type projJSONFetchTextJSONInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projJSONFetchTextJSONInt64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchTextJSONInt64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -29812,23 +28919,19 @@ func (p projJSONFetchTextJSONInt64ConstOp) Next(ctx context.Context) coldata.Bat
 	return batch
 }
 
-func (p projJSONFetchTextJSONInt64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type projJSONFetchValPathJSONDatumConstOp struct {
 	projConstOpBase
 	constArg interface{}
 }
 
-func (p projJSONFetchValPathJSONDatumConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchValPathJSONDatumConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -29944,23 +29047,19 @@ func (p projJSONFetchValPathJSONDatumConstOp) Next(ctx context.Context) coldata.
 	return batch
 }
 
-func (p projJSONFetchValPathJSONDatumConstOp) Init() {
-	p.Input.Init()
-}
-
 type projJSONFetchTextPathJSONDatumConstOp struct {
 	projConstOpBase
 	constArg interface{}
 }
 
-func (p projJSONFetchTextPathJSONDatumConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchTextPathJSONDatumConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -30116,23 +29215,19 @@ func (p projJSONFetchTextPathJSONDatumConstOp) Next(ctx context.Context) coldata
 	return batch
 }
 
-func (p projJSONFetchTextPathJSONDatumConstOp) Init() {
-	p.Input.Init()
-}
-
 type projEQBoolBoolConstOp struct {
 	projConstOpBase
 	constArg bool
 }
 
-func (p projEQBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQBoolBoolConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -30268,10 +29363,6 @@ func (p projEQBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQBoolBoolConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQBytesBytesConstOp struct {
@@ -30279,14 +29370,14 @@ type projEQBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p projEQBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -30388,10 +29479,6 @@ func (p projEQBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQBytesBytesConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQDecimalInt16ConstOp struct {
@@ -30399,14 +29486,14 @@ type projEQDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projEQDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQDecimalInt16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -30534,10 +29621,6 @@ func (p projEQDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQDecimalInt16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQDecimalInt32ConstOp struct {
@@ -30545,14 +29628,14 @@ type projEQDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projEQDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQDecimalInt32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -30680,10 +29763,6 @@ func (p projEQDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQDecimalInt32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQDecimalInt64ConstOp struct {
@@ -30691,14 +29770,14 @@ type projEQDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projEQDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQDecimalInt64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -30826,10 +29905,6 @@ func (p projEQDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQDecimalInt64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQDecimalFloat64ConstOp struct {
@@ -30837,14 +29912,14 @@ type projEQDecimalFloat64ConstOp struct {
 	constArg float64
 }
 
-func (p projEQDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQDecimalFloat64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -30980,10 +30055,6 @@ func (p projEQDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQDecimalFloat64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQDecimalDecimalConstOp struct {
@@ -30991,14 +30062,14 @@ type projEQDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projEQDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQDecimalDecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -31102,10 +30173,6 @@ func (p projEQDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQDecimalDecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQInt16Int16ConstOp struct {
@@ -31113,14 +30180,14 @@ type projEQInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projEQInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt16Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -31268,10 +30335,6 @@ func (p projEQInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt16Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQInt16Int32ConstOp struct {
@@ -31279,14 +30342,14 @@ type projEQInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projEQInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt16Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -31434,10 +30497,6 @@ func (p projEQInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt16Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQInt16Int64ConstOp struct {
@@ -31445,14 +30504,14 @@ type projEQInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projEQInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt16Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -31600,10 +30659,6 @@ func (p projEQInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt16Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQInt16Float64ConstOp struct {
@@ -31611,14 +30666,14 @@ type projEQInt16Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projEQInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt16Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -31798,10 +30853,6 @@ func (p projEQInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt16Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQInt16DecimalConstOp struct {
@@ -31809,14 +30860,14 @@ type projEQInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projEQInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt16DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -31944,10 +30995,6 @@ func (p projEQInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt16DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQInt32Int16ConstOp struct {
@@ -31955,14 +31002,14 @@ type projEQInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projEQInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt32Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -32110,10 +31157,6 @@ func (p projEQInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt32Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQInt32Int32ConstOp struct {
@@ -32121,14 +31164,14 @@ type projEQInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projEQInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt32Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -32276,10 +31319,6 @@ func (p projEQInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt32Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQInt32Int64ConstOp struct {
@@ -32287,14 +31326,14 @@ type projEQInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projEQInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt32Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -32442,10 +31481,6 @@ func (p projEQInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt32Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQInt32Float64ConstOp struct {
@@ -32453,14 +31488,14 @@ type projEQInt32Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projEQInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt32Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -32640,10 +31675,6 @@ func (p projEQInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt32Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQInt32DecimalConstOp struct {
@@ -32651,14 +31682,14 @@ type projEQInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projEQInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt32DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -32786,10 +31817,6 @@ func (p projEQInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt32DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQInt64Int16ConstOp struct {
@@ -32797,14 +31824,14 @@ type projEQInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projEQInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -32952,10 +31979,6 @@ func (p projEQInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt64Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQInt64Int32ConstOp struct {
@@ -32963,14 +31986,14 @@ type projEQInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projEQInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -33118,10 +32141,6 @@ func (p projEQInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt64Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQInt64Int64ConstOp struct {
@@ -33129,14 +32148,14 @@ type projEQInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projEQInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -33284,10 +32303,6 @@ func (p projEQInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt64Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQInt64Float64ConstOp struct {
@@ -33295,14 +32310,14 @@ type projEQInt64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projEQInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -33482,10 +32497,6 @@ func (p projEQInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt64Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQInt64DecimalConstOp struct {
@@ -33493,14 +32504,14 @@ type projEQInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projEQInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -33628,10 +32639,6 @@ func (p projEQInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt64DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQFloat64Int16ConstOp struct {
@@ -33639,14 +32646,14 @@ type projEQFloat64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projEQFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQFloat64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -33826,10 +32833,6 @@ func (p projEQFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQFloat64Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQFloat64Int32ConstOp struct {
@@ -33837,14 +32840,14 @@ type projEQFloat64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projEQFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQFloat64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -34024,10 +33027,6 @@ func (p projEQFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQFloat64Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQFloat64Int64ConstOp struct {
@@ -34035,14 +33034,14 @@ type projEQFloat64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projEQFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQFloat64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -34222,10 +33221,6 @@ func (p projEQFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQFloat64Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQFloat64Float64ConstOp struct {
@@ -34233,14 +33228,14 @@ type projEQFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projEQFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQFloat64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -34420,10 +33415,6 @@ func (p projEQFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQFloat64Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQFloat64DecimalConstOp struct {
@@ -34431,14 +33422,14 @@ type projEQFloat64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projEQFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQFloat64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -34574,10 +33565,6 @@ func (p projEQFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQFloat64DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQTimestampTimestampConstOp struct {
@@ -34585,14 +33572,14 @@ type projEQTimestampTimestampConstOp struct {
 	constArg time.Time
 }
 
-func (p projEQTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQTimestampTimestampConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -34724,10 +33711,6 @@ func (p projEQTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQTimestampTimestampConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQIntervalIntervalConstOp struct {
@@ -34735,14 +33718,14 @@ type projEQIntervalIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projEQIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQIntervalIntervalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -34846,10 +33829,6 @@ func (p projEQIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQIntervalIntervalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQJSONJSONConstOp struct {
@@ -34857,14 +33836,14 @@ type projEQJSONJSONConstOp struct {
 	constArg json.JSON
 }
 
-func (p projEQJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQJSONJSONConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -34990,10 +33969,6 @@ func (p projEQJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQJSONJSONConstOp) Init() {
-	p.Input.Init()
 }
 
 type projEQDatumDatumConstOp struct {
@@ -35001,14 +33976,14 @@ type projEQDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projEQDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQDatumDatumConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -35118,10 +34093,6 @@ func (p projEQDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQDatumDatumConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEBoolBoolConstOp struct {
@@ -35129,14 +34100,14 @@ type projNEBoolBoolConstOp struct {
 	constArg bool
 }
 
-func (p projNEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEBoolBoolConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -35272,10 +34243,6 @@ func (p projNEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEBoolBoolConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEBytesBytesConstOp struct {
@@ -35283,14 +34250,14 @@ type projNEBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p projNEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -35392,10 +34359,6 @@ func (p projNEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEBytesBytesConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEDecimalInt16ConstOp struct {
@@ -35403,14 +34366,14 @@ type projNEDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projNEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEDecimalInt16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -35538,10 +34501,6 @@ func (p projNEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEDecimalInt16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEDecimalInt32ConstOp struct {
@@ -35549,14 +34508,14 @@ type projNEDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projNEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEDecimalInt32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -35684,10 +34643,6 @@ func (p projNEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEDecimalInt32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEDecimalInt64ConstOp struct {
@@ -35695,14 +34650,14 @@ type projNEDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projNEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEDecimalInt64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -35830,10 +34785,6 @@ func (p projNEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEDecimalInt64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEDecimalFloat64ConstOp struct {
@@ -35841,14 +34792,14 @@ type projNEDecimalFloat64ConstOp struct {
 	constArg float64
 }
 
-func (p projNEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEDecimalFloat64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -35984,10 +34935,6 @@ func (p projNEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEDecimalFloat64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEDecimalDecimalConstOp struct {
@@ -35995,14 +34942,14 @@ type projNEDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projNEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEDecimalDecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -36106,10 +35053,6 @@ func (p projNEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEDecimalDecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEInt16Int16ConstOp struct {
@@ -36117,14 +35060,14 @@ type projNEInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projNEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt16Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -36272,10 +35215,6 @@ func (p projNEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt16Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEInt16Int32ConstOp struct {
@@ -36283,14 +35222,14 @@ type projNEInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projNEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt16Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -36438,10 +35377,6 @@ func (p projNEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt16Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEInt16Int64ConstOp struct {
@@ -36449,14 +35384,14 @@ type projNEInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projNEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt16Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -36604,10 +35539,6 @@ func (p projNEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt16Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEInt16Float64ConstOp struct {
@@ -36615,14 +35546,14 @@ type projNEInt16Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projNEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt16Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -36802,10 +35733,6 @@ func (p projNEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt16Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEInt16DecimalConstOp struct {
@@ -36813,14 +35740,14 @@ type projNEInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projNEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt16DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -36948,10 +35875,6 @@ func (p projNEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt16DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEInt32Int16ConstOp struct {
@@ -36959,14 +35882,14 @@ type projNEInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projNEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt32Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -37114,10 +36037,6 @@ func (p projNEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt32Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEInt32Int32ConstOp struct {
@@ -37125,14 +36044,14 @@ type projNEInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projNEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt32Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -37280,10 +36199,6 @@ func (p projNEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt32Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEInt32Int64ConstOp struct {
@@ -37291,14 +36206,14 @@ type projNEInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projNEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt32Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -37446,10 +36361,6 @@ func (p projNEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt32Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEInt32Float64ConstOp struct {
@@ -37457,14 +36368,14 @@ type projNEInt32Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projNEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt32Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -37644,10 +36555,6 @@ func (p projNEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt32Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEInt32DecimalConstOp struct {
@@ -37655,14 +36562,14 @@ type projNEInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projNEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt32DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -37790,10 +36697,6 @@ func (p projNEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt32DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEInt64Int16ConstOp struct {
@@ -37801,14 +36704,14 @@ type projNEInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projNEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -37956,10 +36859,6 @@ func (p projNEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt64Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEInt64Int32ConstOp struct {
@@ -37967,14 +36866,14 @@ type projNEInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projNEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -38122,10 +37021,6 @@ func (p projNEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt64Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEInt64Int64ConstOp struct {
@@ -38133,14 +37028,14 @@ type projNEInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projNEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -38288,10 +37183,6 @@ func (p projNEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt64Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEInt64Float64ConstOp struct {
@@ -38299,14 +37190,14 @@ type projNEInt64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projNEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -38486,10 +37377,6 @@ func (p projNEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt64Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEInt64DecimalConstOp struct {
@@ -38497,14 +37384,14 @@ type projNEInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projNEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -38632,10 +37519,6 @@ func (p projNEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt64DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEFloat64Int16ConstOp struct {
@@ -38643,14 +37526,14 @@ type projNEFloat64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projNEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEFloat64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -38830,10 +37713,6 @@ func (p projNEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEFloat64Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEFloat64Int32ConstOp struct {
@@ -38841,14 +37720,14 @@ type projNEFloat64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projNEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEFloat64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -39028,10 +37907,6 @@ func (p projNEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEFloat64Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEFloat64Int64ConstOp struct {
@@ -39039,14 +37914,14 @@ type projNEFloat64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projNEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEFloat64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -39226,10 +38101,6 @@ func (p projNEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEFloat64Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEFloat64Float64ConstOp struct {
@@ -39237,14 +38108,14 @@ type projNEFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projNEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEFloat64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -39424,10 +38295,6 @@ func (p projNEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEFloat64Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEFloat64DecimalConstOp struct {
@@ -39435,14 +38302,14 @@ type projNEFloat64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projNEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEFloat64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -39578,10 +38445,6 @@ func (p projNEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEFloat64DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNETimestampTimestampConstOp struct {
@@ -39589,14 +38452,14 @@ type projNETimestampTimestampConstOp struct {
 	constArg time.Time
 }
 
-func (p projNETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNETimestampTimestampConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -39728,10 +38591,6 @@ func (p projNETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNETimestampTimestampConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEIntervalIntervalConstOp struct {
@@ -39739,14 +38598,14 @@ type projNEIntervalIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projNEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEIntervalIntervalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -39850,10 +38709,6 @@ func (p projNEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEIntervalIntervalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEJSONJSONConstOp struct {
@@ -39861,14 +38716,14 @@ type projNEJSONJSONConstOp struct {
 	constArg json.JSON
 }
 
-func (p projNEJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEJSONJSONConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -39994,10 +38849,6 @@ func (p projNEJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEJSONJSONConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNEDatumDatumConstOp struct {
@@ -40005,14 +38856,14 @@ type projNEDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projNEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEDatumDatumConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -40122,10 +38973,6 @@ func (p projNEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEDatumDatumConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTBoolBoolConstOp struct {
@@ -40133,14 +38980,14 @@ type projLTBoolBoolConstOp struct {
 	constArg bool
 }
 
-func (p projLTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTBoolBoolConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -40276,10 +39123,6 @@ func (p projLTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTBoolBoolConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTBytesBytesConstOp struct {
@@ -40287,14 +39130,14 @@ type projLTBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p projLTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -40396,10 +39239,6 @@ func (p projLTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTBytesBytesConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTDecimalInt16ConstOp struct {
@@ -40407,14 +39246,14 @@ type projLTDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projLTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTDecimalInt16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -40542,10 +39381,6 @@ func (p projLTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTDecimalInt16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTDecimalInt32ConstOp struct {
@@ -40553,14 +39388,14 @@ type projLTDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projLTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTDecimalInt32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -40688,10 +39523,6 @@ func (p projLTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTDecimalInt32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTDecimalInt64ConstOp struct {
@@ -40699,14 +39530,14 @@ type projLTDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projLTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTDecimalInt64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -40834,10 +39665,6 @@ func (p projLTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTDecimalInt64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTDecimalFloat64ConstOp struct {
@@ -40845,14 +39672,14 @@ type projLTDecimalFloat64ConstOp struct {
 	constArg float64
 }
 
-func (p projLTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTDecimalFloat64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -40988,10 +39815,6 @@ func (p projLTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTDecimalFloat64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTDecimalDecimalConstOp struct {
@@ -40999,14 +39822,14 @@ type projLTDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projLTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTDecimalDecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -41110,10 +39933,6 @@ func (p projLTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTDecimalDecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTInt16Int16ConstOp struct {
@@ -41121,14 +39940,14 @@ type projLTInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projLTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt16Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -41276,10 +40095,6 @@ func (p projLTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt16Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTInt16Int32ConstOp struct {
@@ -41287,14 +40102,14 @@ type projLTInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projLTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt16Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -41442,10 +40257,6 @@ func (p projLTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt16Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTInt16Int64ConstOp struct {
@@ -41453,14 +40264,14 @@ type projLTInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projLTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt16Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -41608,10 +40419,6 @@ func (p projLTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt16Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTInt16Float64ConstOp struct {
@@ -41619,14 +40426,14 @@ type projLTInt16Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projLTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt16Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -41806,10 +40613,6 @@ func (p projLTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt16Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTInt16DecimalConstOp struct {
@@ -41817,14 +40620,14 @@ type projLTInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projLTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt16DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -41952,10 +40755,6 @@ func (p projLTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt16DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTInt32Int16ConstOp struct {
@@ -41963,14 +40762,14 @@ type projLTInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projLTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt32Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -42118,10 +40917,6 @@ func (p projLTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt32Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTInt32Int32ConstOp struct {
@@ -42129,14 +40924,14 @@ type projLTInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projLTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt32Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -42284,10 +41079,6 @@ func (p projLTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt32Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTInt32Int64ConstOp struct {
@@ -42295,14 +41086,14 @@ type projLTInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projLTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt32Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -42450,10 +41241,6 @@ func (p projLTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt32Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTInt32Float64ConstOp struct {
@@ -42461,14 +41248,14 @@ type projLTInt32Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projLTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt32Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -42648,10 +41435,6 @@ func (p projLTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt32Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTInt32DecimalConstOp struct {
@@ -42659,14 +41442,14 @@ type projLTInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projLTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt32DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -42794,10 +41577,6 @@ func (p projLTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt32DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTInt64Int16ConstOp struct {
@@ -42805,14 +41584,14 @@ type projLTInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projLTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -42960,10 +41739,6 @@ func (p projLTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt64Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTInt64Int32ConstOp struct {
@@ -42971,14 +41746,14 @@ type projLTInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projLTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -43126,10 +41901,6 @@ func (p projLTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt64Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTInt64Int64ConstOp struct {
@@ -43137,14 +41908,14 @@ type projLTInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projLTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -43292,10 +42063,6 @@ func (p projLTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt64Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTInt64Float64ConstOp struct {
@@ -43303,14 +42070,14 @@ type projLTInt64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projLTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -43490,10 +42257,6 @@ func (p projLTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt64Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTInt64DecimalConstOp struct {
@@ -43501,14 +42264,14 @@ type projLTInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projLTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -43636,10 +42399,6 @@ func (p projLTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt64DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTFloat64Int16ConstOp struct {
@@ -43647,14 +42406,14 @@ type projLTFloat64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projLTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTFloat64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -43834,10 +42593,6 @@ func (p projLTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTFloat64Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTFloat64Int32ConstOp struct {
@@ -43845,14 +42600,14 @@ type projLTFloat64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projLTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTFloat64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -44032,10 +42787,6 @@ func (p projLTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTFloat64Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTFloat64Int64ConstOp struct {
@@ -44043,14 +42794,14 @@ type projLTFloat64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projLTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTFloat64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -44230,10 +42981,6 @@ func (p projLTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTFloat64Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTFloat64Float64ConstOp struct {
@@ -44241,14 +42988,14 @@ type projLTFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projLTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTFloat64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -44428,10 +43175,6 @@ func (p projLTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTFloat64Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTFloat64DecimalConstOp struct {
@@ -44439,14 +43182,14 @@ type projLTFloat64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projLTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTFloat64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -44582,10 +43325,6 @@ func (p projLTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTFloat64DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTTimestampTimestampConstOp struct {
@@ -44593,14 +43332,14 @@ type projLTTimestampTimestampConstOp struct {
 	constArg time.Time
 }
 
-func (p projLTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTTimestampTimestampConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -44732,10 +43471,6 @@ func (p projLTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTTimestampTimestampConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTIntervalIntervalConstOp struct {
@@ -44743,14 +43478,14 @@ type projLTIntervalIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projLTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTIntervalIntervalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -44854,10 +43589,6 @@ func (p projLTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTIntervalIntervalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTJSONJSONConstOp struct {
@@ -44865,14 +43596,14 @@ type projLTJSONJSONConstOp struct {
 	constArg json.JSON
 }
 
-func (p projLTJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTJSONJSONConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -44998,10 +43729,6 @@ func (p projLTJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTJSONJSONConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLTDatumDatumConstOp struct {
@@ -45009,14 +43736,14 @@ type projLTDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projLTDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTDatumDatumConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -45126,10 +43853,6 @@ func (p projLTDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTDatumDatumConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEBoolBoolConstOp struct {
@@ -45137,14 +43860,14 @@ type projLEBoolBoolConstOp struct {
 	constArg bool
 }
 
-func (p projLEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEBoolBoolConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -45280,10 +44003,6 @@ func (p projLEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEBoolBoolConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEBytesBytesConstOp struct {
@@ -45291,14 +44010,14 @@ type projLEBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p projLEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -45400,10 +44119,6 @@ func (p projLEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEBytesBytesConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEDecimalInt16ConstOp struct {
@@ -45411,14 +44126,14 @@ type projLEDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p projLEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEDecimalInt16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -45546,10 +44261,6 @@ func (p projLEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEDecimalInt16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEDecimalInt32ConstOp struct {
@@ -45557,14 +44268,14 @@ type projLEDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projLEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEDecimalInt32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -45692,10 +44403,6 @@ func (p projLEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEDecimalInt32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEDecimalInt64ConstOp struct {
@@ -45703,14 +44410,14 @@ type projLEDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projLEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEDecimalInt64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -45838,10 +44545,6 @@ func (p projLEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEDecimalInt64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEDecimalFloat64ConstOp struct {
@@ -45849,14 +44552,14 @@ type projLEDecimalFloat64ConstOp struct {
 	constArg float64
 }
 
-func (p projLEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEDecimalFloat64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -45992,10 +44695,6 @@ func (p projLEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEDecimalFloat64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEDecimalDecimalConstOp struct {
@@ -46003,14 +44702,14 @@ type projLEDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projLEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEDecimalDecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -46114,10 +44813,6 @@ func (p projLEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEDecimalDecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEInt16Int16ConstOp struct {
@@ -46125,14 +44820,14 @@ type projLEInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projLEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt16Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -46280,10 +44975,6 @@ func (p projLEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt16Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEInt16Int32ConstOp struct {
@@ -46291,14 +44982,14 @@ type projLEInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projLEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt16Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -46446,10 +45137,6 @@ func (p projLEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt16Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEInt16Int64ConstOp struct {
@@ -46457,14 +45144,14 @@ type projLEInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projLEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt16Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -46612,10 +45299,6 @@ func (p projLEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt16Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEInt16Float64ConstOp struct {
@@ -46623,14 +45306,14 @@ type projLEInt16Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projLEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt16Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -46810,10 +45493,6 @@ func (p projLEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt16Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEInt16DecimalConstOp struct {
@@ -46821,14 +45500,14 @@ type projLEInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projLEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt16DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -46956,10 +45635,6 @@ func (p projLEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt16DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEInt32Int16ConstOp struct {
@@ -46967,14 +45642,14 @@ type projLEInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projLEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt32Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -47122,10 +45797,6 @@ func (p projLEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt32Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEInt32Int32ConstOp struct {
@@ -47133,14 +45804,14 @@ type projLEInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projLEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt32Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -47288,10 +45959,6 @@ func (p projLEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt32Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEInt32Int64ConstOp struct {
@@ -47299,14 +45966,14 @@ type projLEInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projLEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt32Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -47454,10 +46121,6 @@ func (p projLEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt32Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEInt32Float64ConstOp struct {
@@ -47465,14 +46128,14 @@ type projLEInt32Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projLEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt32Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -47652,10 +46315,6 @@ func (p projLEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt32Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEInt32DecimalConstOp struct {
@@ -47663,14 +46322,14 @@ type projLEInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projLEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt32DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -47798,10 +46457,6 @@ func (p projLEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt32DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEInt64Int16ConstOp struct {
@@ -47809,14 +46464,14 @@ type projLEInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projLEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -47964,10 +46619,6 @@ func (p projLEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt64Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEInt64Int32ConstOp struct {
@@ -47975,14 +46626,14 @@ type projLEInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projLEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -48130,10 +46781,6 @@ func (p projLEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt64Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEInt64Int64ConstOp struct {
@@ -48141,14 +46788,14 @@ type projLEInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projLEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -48296,10 +46943,6 @@ func (p projLEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt64Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEInt64Float64ConstOp struct {
@@ -48307,14 +46950,14 @@ type projLEInt64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projLEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -48494,10 +47137,6 @@ func (p projLEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt64Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEInt64DecimalConstOp struct {
@@ -48505,14 +47144,14 @@ type projLEInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projLEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -48640,10 +47279,6 @@ func (p projLEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt64DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEFloat64Int16ConstOp struct {
@@ -48651,14 +47286,14 @@ type projLEFloat64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p projLEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEFloat64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -48838,10 +47473,6 @@ func (p projLEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEFloat64Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEFloat64Int32ConstOp struct {
@@ -48849,14 +47480,14 @@ type projLEFloat64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projLEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEFloat64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -49036,10 +47667,6 @@ func (p projLEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEFloat64Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEFloat64Int64ConstOp struct {
@@ -49047,14 +47674,14 @@ type projLEFloat64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projLEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEFloat64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -49234,10 +47861,6 @@ func (p projLEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEFloat64Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEFloat64Float64ConstOp struct {
@@ -49245,14 +47868,14 @@ type projLEFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projLEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEFloat64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -49432,10 +48055,6 @@ func (p projLEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEFloat64Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEFloat64DecimalConstOp struct {
@@ -49443,14 +48062,14 @@ type projLEFloat64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projLEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEFloat64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -49586,10 +48205,6 @@ func (p projLEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEFloat64DecimalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLETimestampTimestampConstOp struct {
@@ -49597,14 +48212,14 @@ type projLETimestampTimestampConstOp struct {
 	constArg time.Time
 }
 
-func (p projLETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLETimestampTimestampConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -49736,10 +48351,6 @@ func (p projLETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLETimestampTimestampConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEIntervalIntervalConstOp struct {
@@ -49747,14 +48358,14 @@ type projLEIntervalIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p projLEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEIntervalIntervalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -49858,10 +48469,6 @@ func (p projLEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEIntervalIntervalConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEJSONJSONConstOp struct {
@@ -49869,14 +48476,14 @@ type projLEJSONJSONConstOp struct {
 	constArg json.JSON
 }
 
-func (p projLEJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEJSONJSONConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -50002,10 +48609,6 @@ func (p projLEJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEJSONJSONConstOp) Init() {
-	p.Input.Init()
 }
 
 type projLEDatumDatumConstOp struct {
@@ -50013,14 +48616,14 @@ type projLEDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p projLEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEDatumDatumConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -50130,10 +48733,6 @@ func (p projLEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEDatumDatumConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGTBoolBoolConstOp struct {
@@ -50141,14 +48740,14 @@ type projGTBoolBoolConstOp struct {
 	constArg bool
 }
 
-func (p projGTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTBoolBoolConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -50284,10 +48883,6 @@ func (p projGTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTBoolBoolConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGTBytesBytesConstOp struct {
@@ -50295,14 +48890,14 @@ type projGTBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p projGTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -50406,23 +49001,19 @@ func (p projGTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGTBytesBytesConstOp) Init() {
-	p.Input.Init()
-}
-
 type projGTDecimalInt16ConstOp struct {
 	projConstOpBase
 	constArg int16
 }
 
-func (p projGTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTDecimalInt16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -50550,10 +49141,6 @@ func (p projGTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTDecimalInt16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGTDecimalInt32ConstOp struct {
@@ -50561,14 +49148,14 @@ type projGTDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projGTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTDecimalInt32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -50696,10 +49283,6 @@ func (p projGTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTDecimalInt32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGTDecimalInt64ConstOp struct {
@@ -50707,14 +49290,14 @@ type projGTDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projGTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTDecimalInt64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -50842,10 +49425,6 @@ func (p projGTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTDecimalInt64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGTDecimalFloat64ConstOp struct {
@@ -50853,14 +49432,14 @@ type projGTDecimalFloat64ConstOp struct {
 	constArg float64
 }
 
-func (p projGTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTDecimalFloat64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -50996,10 +49575,6 @@ func (p projGTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTDecimalFloat64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGTDecimalDecimalConstOp struct {
@@ -51007,14 +49582,14 @@ type projGTDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projGTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTDecimalDecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -51120,23 +49695,19 @@ func (p projGTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGTDecimalDecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type projGTInt16Int16ConstOp struct {
 	projConstOpBase
 	constArg int16
 }
 
-func (p projGTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt16Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -51284,10 +49855,6 @@ func (p projGTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTInt16Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGTInt16Int32ConstOp struct {
@@ -51295,14 +49862,14 @@ type projGTInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projGTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt16Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -51450,10 +50017,6 @@ func (p projGTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTInt16Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGTInt16Int64ConstOp struct {
@@ -51461,14 +50024,14 @@ type projGTInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projGTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt16Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -51616,10 +50179,6 @@ func (p projGTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTInt16Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGTInt16Float64ConstOp struct {
@@ -51627,14 +50186,14 @@ type projGTInt16Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projGTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt16Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -51814,10 +50373,6 @@ func (p projGTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTInt16Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGTInt16DecimalConstOp struct {
@@ -51825,14 +50380,14 @@ type projGTInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projGTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt16DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -51962,23 +50517,19 @@ func (p projGTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGTInt16DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type projGTInt32Int16ConstOp struct {
 	projConstOpBase
 	constArg int16
 }
 
-func (p projGTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt32Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -52126,10 +50677,6 @@ func (p projGTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTInt32Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGTInt32Int32ConstOp struct {
@@ -52137,14 +50684,14 @@ type projGTInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projGTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt32Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -52292,10 +50839,6 @@ func (p projGTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTInt32Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGTInt32Int64ConstOp struct {
@@ -52303,14 +50846,14 @@ type projGTInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projGTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt32Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -52458,10 +51001,6 @@ func (p projGTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTInt32Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGTInt32Float64ConstOp struct {
@@ -52469,14 +51008,14 @@ type projGTInt32Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projGTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt32Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -52656,10 +51195,6 @@ func (p projGTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTInt32Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGTInt32DecimalConstOp struct {
@@ -52667,14 +51202,14 @@ type projGTInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projGTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt32DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -52804,23 +51339,19 @@ func (p projGTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGTInt32DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type projGTInt64Int16ConstOp struct {
 	projConstOpBase
 	constArg int16
 }
 
-func (p projGTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -52968,10 +51499,6 @@ func (p projGTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTInt64Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGTInt64Int32ConstOp struct {
@@ -52979,14 +51506,14 @@ type projGTInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projGTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -53134,10 +51661,6 @@ func (p projGTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTInt64Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGTInt64Int64ConstOp struct {
@@ -53145,14 +51668,14 @@ type projGTInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projGTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -53300,10 +51823,6 @@ func (p projGTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTInt64Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGTInt64Float64ConstOp struct {
@@ -53311,14 +51830,14 @@ type projGTInt64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projGTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -53498,10 +52017,6 @@ func (p projGTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTInt64Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGTInt64DecimalConstOp struct {
@@ -53509,14 +52024,14 @@ type projGTInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projGTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -53646,23 +52161,19 @@ func (p projGTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGTInt64DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type projGTFloat64Int16ConstOp struct {
 	projConstOpBase
 	constArg int16
 }
 
-func (p projGTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTFloat64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -53842,10 +52353,6 @@ func (p projGTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTFloat64Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGTFloat64Int32ConstOp struct {
@@ -53853,14 +52360,14 @@ type projGTFloat64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projGTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTFloat64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -54040,10 +52547,6 @@ func (p projGTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTFloat64Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGTFloat64Int64ConstOp struct {
@@ -54051,14 +52554,14 @@ type projGTFloat64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projGTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTFloat64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -54238,10 +52741,6 @@ func (p projGTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTFloat64Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGTFloat64Float64ConstOp struct {
@@ -54249,14 +52748,14 @@ type projGTFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projGTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTFloat64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -54436,10 +52935,6 @@ func (p projGTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTFloat64Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGTFloat64DecimalConstOp struct {
@@ -54447,14 +52942,14 @@ type projGTFloat64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projGTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTFloat64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -54592,23 +53087,19 @@ func (p projGTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGTFloat64DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type projGTTimestampTimestampConstOp struct {
 	projConstOpBase
 	constArg time.Time
 }
 
-func (p projGTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTTimestampTimestampConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -54742,23 +53233,19 @@ func (p projGTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 	return batch
 }
 
-func (p projGTTimestampTimestampConstOp) Init() {
-	p.Input.Init()
-}
-
 type projGTIntervalIntervalConstOp struct {
 	projConstOpBase
 	constArg duration.Duration
 }
 
-func (p projGTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTIntervalIntervalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -54864,23 +53351,19 @@ func (p projGTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGTIntervalIntervalConstOp) Init() {
-	p.Input.Init()
-}
-
 type projGTJSONJSONConstOp struct {
 	projConstOpBase
 	constArg json.JSON
 }
 
-func (p projGTJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTJSONJSONConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -55008,23 +53491,19 @@ func (p projGTJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGTJSONJSONConstOp) Init() {
-	p.Input.Init()
-}
-
 type projGTDatumDatumConstOp struct {
 	projConstOpBase
 	constArg interface{}
 }
 
-func (p projGTDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTDatumDatumConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -55136,23 +53615,19 @@ func (p projGTDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGTDatumDatumConstOp) Init() {
-	p.Input.Init()
-}
-
 type projGEBoolBoolConstOp struct {
 	projConstOpBase
 	constArg bool
 }
 
-func (p projGEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEBoolBoolConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -55290,23 +53765,19 @@ func (p projGEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGEBoolBoolConstOp) Init() {
-	p.Input.Init()
-}
-
 type projGEBytesBytesConstOp struct {
 	projConstOpBase
 	constArg []byte
 }
 
-func (p projGEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -55410,23 +53881,19 @@ func (p projGEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGEBytesBytesConstOp) Init() {
-	p.Input.Init()
-}
-
 type projGEDecimalInt16ConstOp struct {
 	projConstOpBase
 	constArg int16
 }
 
-func (p projGEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEDecimalInt16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -55554,10 +54021,6 @@ func (p projGEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEDecimalInt16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGEDecimalInt32ConstOp struct {
@@ -55565,14 +54028,14 @@ type projGEDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p projGEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEDecimalInt32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -55700,10 +54163,6 @@ func (p projGEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEDecimalInt32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGEDecimalInt64ConstOp struct {
@@ -55711,14 +54170,14 @@ type projGEDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p projGEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEDecimalInt64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -55846,10 +54305,6 @@ func (p projGEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEDecimalInt64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGEDecimalFloat64ConstOp struct {
@@ -55857,14 +54312,14 @@ type projGEDecimalFloat64ConstOp struct {
 	constArg float64
 }
 
-func (p projGEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEDecimalFloat64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -56000,10 +54455,6 @@ func (p projGEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEDecimalFloat64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGEDecimalDecimalConstOp struct {
@@ -56011,14 +54462,14 @@ type projGEDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projGEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEDecimalDecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -56124,23 +54575,19 @@ func (p projGEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGEDecimalDecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type projGEInt16Int16ConstOp struct {
 	projConstOpBase
 	constArg int16
 }
 
-func (p projGEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt16Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -56288,10 +54735,6 @@ func (p projGEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEInt16Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGEInt16Int32ConstOp struct {
@@ -56299,14 +54742,14 @@ type projGEInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projGEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt16Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -56454,10 +54897,6 @@ func (p projGEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEInt16Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGEInt16Int64ConstOp struct {
@@ -56465,14 +54904,14 @@ type projGEInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projGEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt16Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -56620,10 +55059,6 @@ func (p projGEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEInt16Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGEInt16Float64ConstOp struct {
@@ -56631,14 +55066,14 @@ type projGEInt16Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projGEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt16Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -56818,10 +55253,6 @@ func (p projGEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEInt16Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGEInt16DecimalConstOp struct {
@@ -56829,14 +55260,14 @@ type projGEInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projGEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt16DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -56966,23 +55397,19 @@ func (p projGEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGEInt16DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type projGEInt32Int16ConstOp struct {
 	projConstOpBase
 	constArg int16
 }
 
-func (p projGEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt32Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -57130,10 +55557,6 @@ func (p projGEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEInt32Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGEInt32Int32ConstOp struct {
@@ -57141,14 +55564,14 @@ type projGEInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projGEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt32Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -57296,10 +55719,6 @@ func (p projGEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEInt32Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGEInt32Int64ConstOp struct {
@@ -57307,14 +55726,14 @@ type projGEInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projGEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt32Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -57462,10 +55881,6 @@ func (p projGEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEInt32Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGEInt32Float64ConstOp struct {
@@ -57473,14 +55888,14 @@ type projGEInt32Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projGEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt32Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -57660,10 +56075,6 @@ func (p projGEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEInt32Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGEInt32DecimalConstOp struct {
@@ -57671,14 +56082,14 @@ type projGEInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projGEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt32DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -57808,23 +56219,19 @@ func (p projGEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGEInt32DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type projGEInt64Int16ConstOp struct {
 	projConstOpBase
 	constArg int16
 }
 
-func (p projGEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -57972,10 +56379,6 @@ func (p projGEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEInt64Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGEInt64Int32ConstOp struct {
@@ -57983,14 +56386,14 @@ type projGEInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projGEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -58138,10 +56541,6 @@ func (p projGEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEInt64Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGEInt64Int64ConstOp struct {
@@ -58149,14 +56548,14 @@ type projGEInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projGEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -58304,10 +56703,6 @@ func (p projGEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEInt64Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGEInt64Float64ConstOp struct {
@@ -58315,14 +56710,14 @@ type projGEInt64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projGEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -58502,10 +56897,6 @@ func (p projGEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEInt64Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGEInt64DecimalConstOp struct {
@@ -58513,14 +56904,14 @@ type projGEInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projGEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -58650,23 +57041,19 @@ func (p projGEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGEInt64DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type projGEFloat64Int16ConstOp struct {
 	projConstOpBase
 	constArg int16
 }
 
-func (p projGEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEFloat64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -58846,10 +57233,6 @@ func (p projGEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEFloat64Int16ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGEFloat64Int32ConstOp struct {
@@ -58857,14 +57240,14 @@ type projGEFloat64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p projGEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEFloat64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -59044,10 +57427,6 @@ func (p projGEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEFloat64Int32ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGEFloat64Int64ConstOp struct {
@@ -59055,14 +57434,14 @@ type projGEFloat64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p projGEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEFloat64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -59242,10 +57621,6 @@ func (p projGEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEFloat64Int64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGEFloat64Float64ConstOp struct {
@@ -59253,14 +57628,14 @@ type projGEFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p projGEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEFloat64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -59440,10 +57815,6 @@ func (p projGEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEFloat64Float64ConstOp) Init() {
-	p.Input.Init()
 }
 
 type projGEFloat64DecimalConstOp struct {
@@ -59451,14 +57822,14 @@ type projGEFloat64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p projGEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEFloat64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -59596,23 +57967,19 @@ func (p projGEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGEFloat64DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type projGETimestampTimestampConstOp struct {
 	projConstOpBase
 	constArg time.Time
 }
 
-func (p projGETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGETimestampTimestampConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -59746,23 +58113,19 @@ func (p projGETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 	return batch
 }
 
-func (p projGETimestampTimestampConstOp) Init() {
-	p.Input.Init()
-}
-
 type projGEIntervalIntervalConstOp struct {
 	projConstOpBase
 	constArg duration.Duration
 }
 
-func (p projGEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEIntervalIntervalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -59868,23 +58231,19 @@ func (p projGEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGEIntervalIntervalConstOp) Init() {
-	p.Input.Init()
-}
-
 type projGEJSONJSONConstOp struct {
 	projConstOpBase
 	constArg json.JSON
 }
 
-func (p projGEJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEJSONJSONConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -60012,23 +58371,19 @@ func (p projGEJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGEJSONJSONConstOp) Init() {
-	p.Input.Init()
-}
-
 type projGEDatumDatumConstOp struct {
 	projConstOpBase
 	constArg interface{}
 }
 
-func (p projGEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEDatumDatumConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -60138,10 +58493,6 @@ func (p projGEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEDatumDatumConstOp) Init() {
-	p.Input.Init()
 }
 
 // GetProjectionRConstOperator returns the appropriate constant
@@ -60162,7 +58513,7 @@ func GetProjectionRConstOperator(
 ) (colexecop.Operator, error) {
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, outputType, outputIdx)
 	projConstOpBase := projConstOpBase{
-		OneInputNode:   colexecop.NewOneInputNode(input),
+		OneInputHelper: colexecop.MakeOneInputHelper(input),
 		allocator:      allocator,
 		colIdx:         colIdx,
 		outputIdx:      outputIdx,

--- a/pkg/sql/colexec/colexecproj/proj_like_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_like_ops.eg.go
@@ -12,7 +12,6 @@ package colexecproj
 
 import (
 	"bytes"
-	"context"
 	"regexp"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -23,14 +22,14 @@ type projPrefixBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p projPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -108,10 +107,6 @@ func (p projPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPrefixBytesBytesConstOp) Init() {
-	p.Input.Init()
 }
 
 type projSuffixBytesBytesConstOp struct {
@@ -119,14 +114,14 @@ type projSuffixBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p projSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -204,10 +199,6 @@ func (p projSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projSuffixBytesBytesConstOp) Init() {
-	p.Input.Init()
 }
 
 type projContainsBytesBytesConstOp struct {
@@ -215,14 +206,14 @@ type projContainsBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p projContainsBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -300,10 +291,6 @@ func (p projContainsBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projContainsBytesBytesConstOp) Init() {
-	p.Input.Init()
 }
 
 type projRegexpBytesBytesConstOp struct {
@@ -311,14 +298,14 @@ type projRegexpBytesBytesConstOp struct {
 	constArg *regexp.Regexp
 }
 
-func (p projRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projRegexpBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -396,10 +383,6 @@ func (p projRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRegexpBytesBytesConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNotPrefixBytesBytesConstOp struct {
@@ -407,14 +390,14 @@ type projNotPrefixBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p projNotPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNotPrefixBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -492,10 +475,6 @@ func (p projNotPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNotPrefixBytesBytesConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNotSuffixBytesBytesConstOp struct {
@@ -503,14 +482,14 @@ type projNotSuffixBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p projNotSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNotSuffixBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -588,10 +567,6 @@ func (p projNotSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNotSuffixBytesBytesConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNotContainsBytesBytesConstOp struct {
@@ -599,14 +574,14 @@ type projNotContainsBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p projNotContainsBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNotContainsBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -684,10 +659,6 @@ func (p projNotContainsBytesBytesConstOp) Next(ctx context.Context) coldata.Batc
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNotContainsBytesBytesConstOp) Init() {
-	p.Input.Init()
 }
 
 type projNotRegexpBytesBytesConstOp struct {
@@ -695,14 +666,14 @@ type projNotRegexpBytesBytesConstOp struct {
 	constArg *regexp.Regexp
 }
 
-func (p projNotRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p projNotRegexpBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -780,8 +751,4 @@ func (p projNotRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNotRegexpBytesBytesConstOp) Init() {
-	p.Input.Init()
 }

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
@@ -11,7 +11,6 @@ package colexecproj
 
 import (
 	"bytes"
-	"context"
 	"math"
 	"unsafe"
 
@@ -48,7 +47,7 @@ var (
 // so, it'll be redeclared because we execute that template twice. To go
 // around the problem we specify it here.
 type projConstOpBase struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	allocator      *colmem.Allocator
 	colIdx         int
 	outputIdx      int
@@ -57,7 +56,7 @@ type projConstOpBase struct {
 
 // projOpBase contains all of the fields for non-constant projections.
 type projOpBase struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	allocator      *colmem.Allocator
 	col1Idx        int
 	col2Idx        int
@@ -69,14 +68,14 @@ type projBitandInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projBitandInt16Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitandInt16Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -173,24 +172,20 @@ func (p projBitandInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandInt16Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projBitandInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projBitandInt16Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitandInt16Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -287,24 +282,20 @@ func (p projBitandInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandInt16Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projBitandInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projBitandInt16Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitandInt16Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -401,24 +392,20 @@ func (p projBitandInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandInt16Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projBitandInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projBitandInt32Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitandInt32Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -515,24 +502,20 @@ func (p projBitandInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandInt32Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projBitandInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projBitandInt32Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitandInt32Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -629,24 +612,20 @@ func (p projBitandInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandInt32Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projBitandInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projBitandInt32Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitandInt32Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -743,24 +722,20 @@ func (p projBitandInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandInt32Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projBitandInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projBitandInt64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitandInt64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -857,24 +832,20 @@ func (p projBitandInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandInt64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projBitandInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projBitandInt64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitandInt64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -971,24 +942,20 @@ func (p projBitandInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandInt64Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projBitandInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projBitandInt64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitandInt64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1085,24 +1052,20 @@ func (p projBitandInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandInt64Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projBitandDatumDatumOp struct {
 	projOpBase
 }
 
-func (p projBitandDatumDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitandDatumDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1223,24 +1186,20 @@ func (p projBitandDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitandDatumDatumOp) Init() {
-	p.Input.Init()
 }
 
 type projBitorInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projBitorInt16Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitorInt16Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1337,24 +1296,20 @@ func (p projBitorInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorInt16Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projBitorInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projBitorInt16Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitorInt16Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1451,24 +1406,20 @@ func (p projBitorInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorInt16Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projBitorInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projBitorInt16Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitorInt16Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1565,24 +1516,20 @@ func (p projBitorInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorInt16Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projBitorInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projBitorInt32Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitorInt32Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1679,24 +1626,20 @@ func (p projBitorInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorInt32Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projBitorInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projBitorInt32Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitorInt32Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1793,24 +1736,20 @@ func (p projBitorInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorInt32Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projBitorInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projBitorInt32Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitorInt32Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -1907,24 +1846,20 @@ func (p projBitorInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorInt32Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projBitorInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projBitorInt64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitorInt64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2021,24 +1956,20 @@ func (p projBitorInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorInt64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projBitorInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projBitorInt64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitorInt64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2135,24 +2066,20 @@ func (p projBitorInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorInt64Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projBitorInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projBitorInt64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitorInt64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2249,24 +2176,20 @@ func (p projBitorInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorInt64Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projBitorDatumDatumOp struct {
 	projOpBase
 }
 
-func (p projBitorDatumDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitorDatumDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2387,24 +2310,20 @@ func (p projBitorDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitorDatumDatumOp) Init() {
-	p.Input.Init()
 }
 
 type projBitxorInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projBitxorInt16Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorInt16Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2501,24 +2420,20 @@ func (p projBitxorInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorInt16Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projBitxorInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projBitxorInt16Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorInt16Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2615,24 +2530,20 @@ func (p projBitxorInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorInt16Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projBitxorInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projBitxorInt16Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorInt16Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2729,24 +2640,20 @@ func (p projBitxorInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorInt16Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projBitxorInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projBitxorInt32Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorInt32Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2843,24 +2750,20 @@ func (p projBitxorInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorInt32Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projBitxorInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projBitxorInt32Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorInt32Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -2957,24 +2860,20 @@ func (p projBitxorInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorInt32Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projBitxorInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projBitxorInt32Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorInt32Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3071,24 +2970,20 @@ func (p projBitxorInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorInt32Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projBitxorInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projBitxorInt64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorInt64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3185,24 +3080,20 @@ func (p projBitxorInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorInt64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projBitxorInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projBitxorInt64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorInt64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3299,24 +3190,20 @@ func (p projBitxorInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorInt64Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projBitxorInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projBitxorInt64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorInt64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3413,24 +3300,20 @@ func (p projBitxorInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorInt64Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projBitxorDatumDatumOp struct {
 	projOpBase
 }
 
-func (p projBitxorDatumDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projBitxorDatumDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3551,24 +3434,20 @@ func (p projBitxorDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projBitxorDatumDatumOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusDecimalInt16Op struct {
 	projOpBase
 }
 
-func (p projPlusDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusDecimalInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3693,24 +3572,20 @@ func (p projPlusDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusDecimalInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusDecimalInt32Op struct {
 	projOpBase
 }
 
-func (p projPlusDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusDecimalInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3835,24 +3710,20 @@ func (p projPlusDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusDecimalInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusDecimalInt64Op struct {
 	projOpBase
 }
 
-func (p projPlusDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusDecimalInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -3977,24 +3848,20 @@ func (p projPlusDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusDecimalInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusDecimalDecimalOp struct {
 	projOpBase
 }
 
-func (p projPlusDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusDecimalDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -4115,24 +3982,20 @@ func (p projPlusDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusDecimalDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projPlusInt16Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt16Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -4253,24 +4116,20 @@ func (p projPlusInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt16Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projPlusInt16Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt16Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -4391,24 +4250,20 @@ func (p projPlusInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt16Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projPlusInt16Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt16Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -4529,24 +4384,20 @@ func (p projPlusInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt16Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt16DecimalOp struct {
 	projOpBase
 }
 
-func (p projPlusInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt16DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -4675,24 +4526,20 @@ func (p projPlusInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt16DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt16DatumOp struct {
 	projOpBase
 }
 
-func (p projPlusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt16DatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -4839,24 +4686,20 @@ func (p projPlusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt16DatumOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projPlusInt32Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt32Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -4977,24 +4820,20 @@ func (p projPlusInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt32Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projPlusInt32Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt32Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -5115,24 +4954,20 @@ func (p projPlusInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt32Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projPlusInt32Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt32Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -5253,24 +5088,20 @@ func (p projPlusInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt32Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt32DecimalOp struct {
 	projOpBase
 }
 
-func (p projPlusInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt32DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -5399,24 +5230,20 @@ func (p projPlusInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt32DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt32DatumOp struct {
 	projOpBase
 }
 
-func (p projPlusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt32DatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -5563,24 +5390,20 @@ func (p projPlusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt32DatumOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projPlusInt64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -5701,24 +5524,20 @@ func (p projPlusInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projPlusInt64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -5839,24 +5658,20 @@ func (p projPlusInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt64Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projPlusInt64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -5977,24 +5792,20 @@ func (p projPlusInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt64Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt64DecimalOp struct {
 	projOpBase
 }
 
-func (p projPlusInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -6123,24 +5934,20 @@ func (p projPlusInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt64DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusInt64DatumOp struct {
 	projOpBase
 }
 
-func (p projPlusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusInt64DatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -6287,24 +6094,20 @@ func (p projPlusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusInt64DatumOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusFloat64Float64Op struct {
 	projOpBase
 }
 
-func (p projPlusFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusFloat64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -6413,24 +6216,20 @@ func (p projPlusFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusFloat64Float64Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusTimestampIntervalOp struct {
 	projOpBase
 }
 
-func (p projPlusTimestampIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusTimestampIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -6519,24 +6318,20 @@ func (p projPlusTimestampIntervalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusTimestampIntervalOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusIntervalTimestampOp struct {
 	projOpBase
 }
 
-func (p projPlusIntervalTimestampOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusIntervalTimestampOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -6625,24 +6420,20 @@ func (p projPlusIntervalTimestampOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusIntervalTimestampOp) Init() {
-	p.Input.Init()
 }
 
 type projPlusIntervalIntervalOp struct {
 	projOpBase
 }
 
-func (p projPlusIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusIntervalIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -6733,22 +6524,18 @@ func (p projPlusIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPlusIntervalIntervalOp) Init() {
-	p.Input.Init()
-}
-
 type projPlusIntervalDatumOp struct {
 	projOpBase
 }
 
-func (p projPlusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusIntervalDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -6897,22 +6684,18 @@ func (p projPlusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPlusIntervalDatumOp) Init() {
-	p.Input.Init()
-}
-
 type projPlusDatumIntervalOp struct {
 	projOpBase
 }
 
-func (p projPlusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p projPlusDatumIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -7053,22 +6836,18 @@ func (p projPlusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPlusDatumIntervalOp) Init() {
-	p.Input.Init()
-}
-
 type projPlusDatumInt16Op struct {
 	projOpBase
 }
 
-func (p projPlusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusDatumInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -7207,24 +6986,20 @@ func (p projPlusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusDatumInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusDatumInt32Op struct {
 	projOpBase
 }
 
-func (p projPlusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusDatumInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -7363,24 +7138,20 @@ func (p projPlusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPlusDatumInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projPlusDatumInt64Op struct {
 	projOpBase
 }
 
-func (p projPlusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projPlusDatumInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -7521,22 +7292,18 @@ func (p projPlusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPlusDatumInt64Op) Init() {
-	p.Input.Init()
-}
-
 type projMinusDecimalInt16Op struct {
 	projOpBase
 }
 
-func (p projMinusDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDecimalInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -7661,24 +7428,20 @@ func (p projMinusDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusDecimalInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projMinusDecimalInt32Op struct {
 	projOpBase
 }
 
-func (p projMinusDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDecimalInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -7803,24 +7566,20 @@ func (p projMinusDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusDecimalInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projMinusDecimalInt64Op struct {
 	projOpBase
 }
 
-func (p projMinusDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDecimalInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -7945,24 +7704,20 @@ func (p projMinusDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusDecimalInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projMinusDecimalDecimalOp struct {
 	projOpBase
 }
 
-func (p projMinusDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDecimalDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -8085,22 +7840,18 @@ func (p projMinusDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusDecimalDecimalOp) Init() {
-	p.Input.Init()
-}
-
 type projMinusInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projMinusInt16Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt16Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -8221,24 +7972,20 @@ func (p projMinusInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusInt16Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projMinusInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projMinusInt16Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt16Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -8359,24 +8106,20 @@ func (p projMinusInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusInt16Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projMinusInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projMinusInt16Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt16Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -8497,24 +8240,20 @@ func (p projMinusInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusInt16Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projMinusInt16DecimalOp struct {
 	projOpBase
 }
 
-func (p projMinusInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt16DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -8643,24 +8382,20 @@ func (p projMinusInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusInt16DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusInt16DatumOp struct {
 	projOpBase
 }
 
-func (p projMinusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt16DatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -8809,22 +8544,18 @@ func (p projMinusInt16DatumOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusInt16DatumOp) Init() {
-	p.Input.Init()
-}
-
 type projMinusInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projMinusInt32Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt32Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -8945,24 +8676,20 @@ func (p projMinusInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusInt32Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projMinusInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projMinusInt32Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt32Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -9085,22 +8812,18 @@ func (p projMinusInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusInt32Int32Op) Init() {
-	p.Input.Init()
-}
-
 type projMinusInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projMinusInt32Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt32Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -9223,22 +8946,18 @@ func (p projMinusInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusInt32Int64Op) Init() {
-	p.Input.Init()
-}
-
 type projMinusInt32DecimalOp struct {
 	projOpBase
 }
 
-func (p projMinusInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt32DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -9369,22 +9088,18 @@ func (p projMinusInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusInt32DecimalOp) Init() {
-	p.Input.Init()
-}
-
 type projMinusInt32DatumOp struct {
 	projOpBase
 }
 
-func (p projMinusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt32DatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -9533,22 +9248,18 @@ func (p projMinusInt32DatumOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusInt32DatumOp) Init() {
-	p.Input.Init()
-}
-
 type projMinusInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projMinusInt64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -9671,22 +9382,18 @@ func (p projMinusInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusInt64Int16Op) Init() {
-	p.Input.Init()
-}
-
 type projMinusInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projMinusInt64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -9809,22 +9516,18 @@ func (p projMinusInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusInt64Int32Op) Init() {
-	p.Input.Init()
-}
-
 type projMinusInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projMinusInt64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -9947,22 +9650,18 @@ func (p projMinusInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusInt64Int64Op) Init() {
-	p.Input.Init()
-}
-
 type projMinusInt64DecimalOp struct {
 	projOpBase
 }
 
-func (p projMinusInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -10093,22 +9792,18 @@ func (p projMinusInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusInt64DecimalOp) Init() {
-	p.Input.Init()
-}
-
 type projMinusInt64DatumOp struct {
 	projOpBase
 }
 
-func (p projMinusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusInt64DatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -10257,22 +9952,18 @@ func (p projMinusInt64DatumOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusInt64DatumOp) Init() {
-	p.Input.Init()
-}
-
 type projMinusFloat64Float64Op struct {
 	projOpBase
 }
 
-func (p projMinusFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusFloat64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -10383,22 +10074,18 @@ func (p projMinusFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusFloat64Float64Op) Init() {
-	p.Input.Init()
-}
-
 type projMinusTimestampTimestampOp struct {
 	projOpBase
 }
 
-func (p projMinusTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -10501,22 +10188,18 @@ func (p projMinusTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusTimestampTimestampOp) Init() {
-	p.Input.Init()
-}
-
 type projMinusTimestampIntervalOp struct {
 	projOpBase
 }
 
-func (p projMinusTimestampIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusTimestampIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -10607,22 +10290,18 @@ func (p projMinusTimestampIntervalOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projMinusTimestampIntervalOp) Init() {
-	p.Input.Init()
-}
-
 type projMinusIntervalIntervalOp struct {
 	projOpBase
 }
 
-func (p projMinusIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusIntervalIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -10711,24 +10390,20 @@ func (p projMinusIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusIntervalIntervalOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusIntervalDatumOp struct {
 	projOpBase
 }
 
-func (p projMinusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusIntervalDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -10875,24 +10550,20 @@ func (p projMinusIntervalDatumOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusIntervalDatumOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusJSONBytesOp struct {
 	projOpBase
 }
 
-func (p projMinusJSONBytesOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusJSONBytesOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -11013,24 +10684,20 @@ func (p projMinusJSONBytesOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusJSONBytesOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusJSONInt16Op struct {
 	projOpBase
 }
 
-func (p projMinusJSONInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusJSONInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -11137,24 +10804,20 @@ func (p projMinusJSONInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusJSONInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projMinusJSONInt32Op struct {
 	projOpBase
 }
 
-func (p projMinusJSONInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusJSONInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -11261,24 +10924,20 @@ func (p projMinusJSONInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusJSONInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projMinusJSONInt64Op struct {
 	projOpBase
 }
 
-func (p projMinusJSONInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusJSONInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -11385,24 +11044,20 @@ func (p projMinusJSONInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusJSONInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projMinusDatumDatumOp struct {
 	projOpBase
 }
 
-func (p projMinusDatumDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDatumDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -11523,24 +11178,20 @@ func (p projMinusDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusDatumDatumOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusDatumIntervalOp struct {
 	projOpBase
 }
 
-func (p projMinusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDatumIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -11679,24 +11330,20 @@ func (p projMinusDatumIntervalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusDatumIntervalOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusDatumBytesOp struct {
 	projOpBase
 }
 
-func (p projMinusDatumBytesOp) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDatumBytesOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -11833,24 +11480,20 @@ func (p projMinusDatumBytesOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusDatumBytesOp) Init() {
-	p.Input.Init()
 }
 
 type projMinusDatumInt16Op struct {
 	projOpBase
 }
 
-func (p projMinusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDatumInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -11989,24 +11632,20 @@ func (p projMinusDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusDatumInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projMinusDatumInt32Op struct {
 	projOpBase
 }
 
-func (p projMinusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDatumInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -12145,24 +11784,20 @@ func (p projMinusDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusDatumInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projMinusDatumInt64Op struct {
 	projOpBase
 }
 
-func (p projMinusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projMinusDatumInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -12301,24 +11936,20 @@ func (p projMinusDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMinusDatumInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projMultDecimalInt16Op struct {
 	projOpBase
 }
 
-func (p projMultDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultDecimalInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -12443,24 +12074,20 @@ func (p projMultDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultDecimalInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projMultDecimalInt32Op struct {
 	projOpBase
 }
 
-func (p projMultDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultDecimalInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -12585,24 +12212,20 @@ func (p projMultDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultDecimalInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projMultDecimalInt64Op struct {
 	projOpBase
 }
 
-func (p projMultDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultDecimalInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -12727,24 +12350,20 @@ func (p projMultDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultDecimalInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projMultDecimalDecimalOp struct {
 	projOpBase
 }
 
-func (p projMultDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultDecimalDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -12865,24 +12484,20 @@ func (p projMultDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultDecimalDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projMultDecimalIntervalOp struct {
 	projOpBase
 }
 
-func (p projMultDecimalIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultDecimalIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -12991,24 +12606,20 @@ func (p projMultDecimalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultDecimalIntervalOp) Init() {
-	p.Input.Init()
 }
 
 type projMultInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projMultInt16Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt16Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -13161,24 +12772,20 @@ func (p projMultInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt16Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projMultInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projMultInt16Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt16Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -13331,24 +12938,20 @@ func (p projMultInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt16Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projMultInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projMultInt16Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt16Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -13501,24 +13104,20 @@ func (p projMultInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt16Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projMultInt16DecimalOp struct {
 	projOpBase
 }
 
-func (p projMultInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt16DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -13647,24 +13246,20 @@ func (p projMultInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt16DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projMultInt16IntervalOp struct {
 	projOpBase
 }
 
-func (p projMultInt16IntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt16IntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -13753,24 +13348,20 @@ func (p projMultInt16IntervalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt16IntervalOp) Init() {
-	p.Input.Init()
 }
 
 type projMultInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projMultInt32Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt32Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -13923,24 +13514,20 @@ func (p projMultInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt32Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projMultInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projMultInt32Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt32Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -14093,24 +13680,20 @@ func (p projMultInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt32Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projMultInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projMultInt32Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt32Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -14263,24 +13846,20 @@ func (p projMultInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt32Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projMultInt32DecimalOp struct {
 	projOpBase
 }
 
-func (p projMultInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt32DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -14409,24 +13988,20 @@ func (p projMultInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt32DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projMultInt32IntervalOp struct {
 	projOpBase
 }
 
-func (p projMultInt32IntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt32IntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -14515,24 +14090,20 @@ func (p projMultInt32IntervalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt32IntervalOp) Init() {
-	p.Input.Init()
 }
 
 type projMultInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projMultInt64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -14685,24 +14256,20 @@ func (p projMultInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projMultInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projMultInt64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -14855,24 +14422,20 @@ func (p projMultInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt64Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projMultInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projMultInt64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -15025,24 +14588,20 @@ func (p projMultInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt64Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projMultInt64DecimalOp struct {
 	projOpBase
 }
 
-func (p projMultInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -15171,24 +14730,20 @@ func (p projMultInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt64DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projMultInt64IntervalOp struct {
 	projOpBase
 }
 
-func (p projMultInt64IntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultInt64IntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -15277,24 +14832,20 @@ func (p projMultInt64IntervalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultInt64IntervalOp) Init() {
-	p.Input.Init()
 }
 
 type projMultFloat64Float64Op struct {
 	projOpBase
 }
 
-func (p projMultFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultFloat64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -15403,24 +14954,20 @@ func (p projMultFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultFloat64Float64Op) Init() {
-	p.Input.Init()
 }
 
 type projMultFloat64IntervalOp struct {
 	projOpBase
 }
 
-func (p projMultFloat64IntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultFloat64IntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -15509,24 +15056,20 @@ func (p projMultFloat64IntervalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultFloat64IntervalOp) Init() {
-	p.Input.Init()
 }
 
 type projMultIntervalInt16Op struct {
 	projOpBase
 }
 
-func (p projMultIntervalInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultIntervalInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -15615,24 +15158,20 @@ func (p projMultIntervalInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultIntervalInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projMultIntervalInt32Op struct {
 	projOpBase
 }
 
-func (p projMultIntervalInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultIntervalInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -15721,24 +15260,20 @@ func (p projMultIntervalInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultIntervalInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projMultIntervalInt64Op struct {
 	projOpBase
 }
 
-func (p projMultIntervalInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultIntervalInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -15827,24 +15362,20 @@ func (p projMultIntervalInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultIntervalInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projMultIntervalFloat64Op struct {
 	projOpBase
 }
 
-func (p projMultIntervalFloat64Op) Next(ctx context.Context) coldata.Batch {
+func (p projMultIntervalFloat64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -15933,24 +15464,20 @@ func (p projMultIntervalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultIntervalFloat64Op) Init() {
-	p.Input.Init()
 }
 
 type projMultIntervalDecimalOp struct {
 	projOpBase
 }
 
-func (p projMultIntervalDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projMultIntervalDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -16059,24 +15586,20 @@ func (p projMultIntervalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projMultIntervalDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projDivDecimalInt16Op struct {
 	projOpBase
 }
 
-func (p projDivDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivDecimalInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -16217,24 +15740,20 @@ func (p projDivDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivDecimalInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projDivDecimalInt32Op struct {
 	projOpBase
 }
 
-func (p projDivDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivDecimalInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -16375,24 +15894,20 @@ func (p projDivDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivDecimalInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projDivDecimalInt64Op struct {
 	projOpBase
 }
 
-func (p projDivDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivDecimalInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -16533,24 +16048,20 @@ func (p projDivDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivDecimalInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projDivDecimalDecimalOp struct {
 	projOpBase
 }
 
-func (p projDivDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projDivDecimalDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -16687,24 +16198,20 @@ func (p projDivDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivDecimalDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projDivInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projDivInt16Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt16Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -16841,24 +16348,20 @@ func (p projDivInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt16Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projDivInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projDivInt16Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt16Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -16995,24 +16498,20 @@ func (p projDivInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt16Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projDivInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projDivInt16Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt16Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -17149,24 +16648,20 @@ func (p projDivInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt16Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projDivInt16DecimalOp struct {
 	projOpBase
 }
 
-func (p projDivInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt16DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -17311,24 +16806,20 @@ func (p projDivInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt16DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projDivInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projDivInt32Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt32Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -17465,24 +16956,20 @@ func (p projDivInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt32Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projDivInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projDivInt32Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt32Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -17619,24 +17106,20 @@ func (p projDivInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt32Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projDivInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projDivInt32Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt32Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -17773,24 +17256,20 @@ func (p projDivInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt32Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projDivInt32DecimalOp struct {
 	projOpBase
 }
 
-func (p projDivInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt32DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -17935,24 +17414,20 @@ func (p projDivInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt32DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projDivInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projDivInt64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -18089,24 +17564,20 @@ func (p projDivInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projDivInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projDivInt64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -18243,24 +17714,20 @@ func (p projDivInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt64Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projDivInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projDivInt64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -18397,24 +17864,20 @@ func (p projDivInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt64Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projDivInt64DecimalOp struct {
 	projOpBase
 }
 
-func (p projDivInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projDivInt64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -18559,24 +18022,20 @@ func (p projDivInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivInt64DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projDivFloat64Float64Op struct {
 	projOpBase
 }
 
-func (p projDivFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivFloat64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -18701,24 +18160,20 @@ func (p projDivFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivFloat64Float64Op) Init() {
-	p.Input.Init()
 }
 
 type projDivIntervalInt64Op struct {
 	projOpBase
 }
 
-func (p projDivIntervalInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivIntervalInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -18823,24 +18278,20 @@ func (p projDivIntervalInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projDivIntervalInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projDivIntervalFloat64Op struct {
 	projOpBase
 }
 
-func (p projDivIntervalFloat64Op) Next(ctx context.Context) coldata.Batch {
+func (p projDivIntervalFloat64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -18947,22 +18398,18 @@ func (p projDivIntervalFloat64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projDivIntervalFloat64Op) Init() {
-	p.Input.Init()
-}
-
 type projFloorDivDecimalInt16Op struct {
 	projOpBase
 }
 
-func (p projFloorDivDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivDecimalInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -19103,24 +18550,20 @@ func (p projFloorDivDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivDecimalInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivDecimalInt32Op struct {
 	projOpBase
 }
 
-func (p projFloorDivDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivDecimalInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -19261,24 +18704,20 @@ func (p projFloorDivDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivDecimalInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivDecimalInt64Op struct {
 	projOpBase
 }
 
-func (p projFloorDivDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivDecimalInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -19419,24 +18858,20 @@ func (p projFloorDivDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivDecimalInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivDecimalDecimalOp struct {
 	projOpBase
 }
 
-func (p projFloorDivDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivDecimalDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -19573,24 +19008,20 @@ func (p projFloorDivDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivDecimalDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projFloorDivInt16Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt16Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -19707,24 +19138,20 @@ func (p projFloorDivInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt16Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projFloorDivInt16Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt16Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -19841,24 +19268,20 @@ func (p projFloorDivInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt16Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projFloorDivInt16Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt16Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -19975,24 +19398,20 @@ func (p projFloorDivInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt16Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt16DecimalOp struct {
 	projOpBase
 }
 
-func (p projFloorDivInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt16DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -20137,24 +19556,20 @@ func (p projFloorDivInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt16DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projFloorDivInt32Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt32Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -20271,24 +19686,20 @@ func (p projFloorDivInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt32Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projFloorDivInt32Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt32Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -20405,24 +19816,20 @@ func (p projFloorDivInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt32Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projFloorDivInt32Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt32Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -20539,24 +19946,20 @@ func (p projFloorDivInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt32Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt32DecimalOp struct {
 	projOpBase
 }
 
-func (p projFloorDivInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt32DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -20701,24 +20104,20 @@ func (p projFloorDivInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt32DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projFloorDivInt64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -20835,24 +20234,20 @@ func (p projFloorDivInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projFloorDivInt64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -20969,24 +20364,20 @@ func (p projFloorDivInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt64Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projFloorDivInt64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -21103,24 +20494,20 @@ func (p projFloorDivInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt64Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivInt64DecimalOp struct {
 	projOpBase
 }
 
-func (p projFloorDivInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivInt64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -21265,24 +20652,20 @@ func (p projFloorDivInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivInt64DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projFloorDivFloat64Float64Op struct {
 	projOpBase
 }
 
-func (p projFloorDivFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projFloorDivFloat64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -21407,24 +20790,20 @@ func (p projFloorDivFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projFloorDivFloat64Float64Op) Init() {
-	p.Input.Init()
 }
 
 type projModDecimalInt16Op struct {
 	projOpBase
 }
 
-func (p projModDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projModDecimalInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -21565,24 +20944,20 @@ func (p projModDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModDecimalInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projModDecimalInt32Op struct {
 	projOpBase
 }
 
-func (p projModDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projModDecimalInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -21723,24 +21098,20 @@ func (p projModDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModDecimalInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projModDecimalInt64Op struct {
 	projOpBase
 }
 
-func (p projModDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projModDecimalInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -21881,24 +21252,20 @@ func (p projModDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModDecimalInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projModDecimalDecimalOp struct {
 	projOpBase
 }
 
-func (p projModDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projModDecimalDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -22035,24 +21402,20 @@ func (p projModDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModDecimalDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projModInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projModInt16Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projModInt16Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -22169,24 +21532,20 @@ func (p projModInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt16Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projModInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projModInt16Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projModInt16Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -22303,24 +21662,20 @@ func (p projModInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt16Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projModInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projModInt16Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projModInt16Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -22437,24 +21792,20 @@ func (p projModInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt16Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projModInt16DecimalOp struct {
 	projOpBase
 }
 
-func (p projModInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projModInt16DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -22599,24 +21950,20 @@ func (p projModInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt16DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projModInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projModInt32Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projModInt32Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -22733,24 +22080,20 @@ func (p projModInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt32Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projModInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projModInt32Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projModInt32Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -22867,24 +22210,20 @@ func (p projModInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt32Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projModInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projModInt32Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projModInt32Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -23001,24 +22340,20 @@ func (p projModInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt32Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projModInt32DecimalOp struct {
 	projOpBase
 }
 
-func (p projModInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projModInt32DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -23163,24 +22498,20 @@ func (p projModInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt32DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projModInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projModInt64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projModInt64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -23297,24 +22628,20 @@ func (p projModInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projModInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projModInt64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projModInt64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -23431,24 +22758,20 @@ func (p projModInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt64Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projModInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projModInt64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projModInt64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -23565,24 +22888,20 @@ func (p projModInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt64Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projModInt64DecimalOp struct {
 	projOpBase
 }
 
-func (p projModInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projModInt64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -23727,24 +23046,20 @@ func (p projModInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModInt64DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projModFloat64Float64Op struct {
 	projOpBase
 }
 
-func (p projModFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projModFloat64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -23869,24 +23184,20 @@ func (p projModFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projModFloat64Float64Op) Init() {
-	p.Input.Init()
 }
 
 type projPowDecimalInt16Op struct {
 	projOpBase
 }
 
-func (p projPowDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projPowDecimalInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -24011,24 +23322,20 @@ func (p projPowDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPowDecimalInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projPowDecimalInt32Op struct {
 	projOpBase
 }
 
-func (p projPowDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projPowDecimalInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -24153,24 +23460,20 @@ func (p projPowDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPowDecimalInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projPowDecimalInt64Op struct {
 	projOpBase
 }
 
-func (p projPowDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projPowDecimalInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -24295,24 +23598,20 @@ func (p projPowDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPowDecimalInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projPowDecimalDecimalOp struct {
 	projOpBase
 }
 
-func (p projPowDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projPowDecimalDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -24435,22 +23734,18 @@ func (p projPowDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPowDecimalDecimalOp) Init() {
-	p.Input.Init()
-}
-
 type projPowInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projPowInt16Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt16Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -24595,24 +23890,20 @@ func (p projPowInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPowInt16Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projPowInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projPowInt16Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt16Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -24757,24 +24048,20 @@ func (p projPowInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPowInt16Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projPowInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projPowInt16Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt16Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -24919,24 +24206,20 @@ func (p projPowInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPowInt16Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projPowInt16DecimalOp struct {
 	projOpBase
 }
 
-func (p projPowInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt16DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -25067,22 +24350,18 @@ func (p projPowInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPowInt16DecimalOp) Init() {
-	p.Input.Init()
-}
-
 type projPowInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projPowInt32Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt32Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -25227,24 +24506,20 @@ func (p projPowInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projPowInt32Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projPowInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projPowInt32Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt32Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -25391,22 +24666,18 @@ func (p projPowInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPowInt32Int32Op) Init() {
-	p.Input.Init()
-}
-
 type projPowInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projPowInt32Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt32Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -25553,22 +24824,18 @@ func (p projPowInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPowInt32Int64Op) Init() {
-	p.Input.Init()
-}
-
 type projPowInt32DecimalOp struct {
 	projOpBase
 }
 
-func (p projPowInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt32DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -25699,22 +24966,18 @@ func (p projPowInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPowInt32DecimalOp) Init() {
-	p.Input.Init()
-}
-
 type projPowInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projPowInt64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -25861,22 +25124,18 @@ func (p projPowInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPowInt64Int16Op) Init() {
-	p.Input.Init()
-}
-
 type projPowInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projPowInt64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -26023,22 +25282,18 @@ func (p projPowInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPowInt64Int32Op) Init() {
-	p.Input.Init()
-}
-
 type projPowInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projPowInt64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -26185,22 +25440,18 @@ func (p projPowInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPowInt64Int64Op) Init() {
-	p.Input.Init()
-}
-
 type projPowInt64DecimalOp struct {
 	projOpBase
 }
 
-func (p projPowInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projPowInt64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -26331,22 +25582,18 @@ func (p projPowInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPowInt64DecimalOp) Init() {
-	p.Input.Init()
-}
-
 type projPowFloat64Float64Op struct {
 	projOpBase
 }
 
-func (p projPowFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projPowFloat64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -26457,22 +25704,18 @@ func (p projPowFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projPowFloat64Float64Op) Init() {
-	p.Input.Init()
-}
-
 type projConcatBytesBytesOp struct {
 	projOpBase
 }
 
-func (p projConcatBytesBytesOp) Next(ctx context.Context) coldata.Batch {
+func (p projConcatBytesBytesOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -26585,24 +25828,20 @@ func (p projConcatBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projConcatBytesBytesOp) Init() {
-	p.Input.Init()
 }
 
 type projConcatJSONJSONOp struct {
 	projOpBase
 }
 
-func (p projConcatJSONJSONOp) Next(ctx context.Context) coldata.Batch {
+func (p projConcatJSONJSONOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -26711,24 +25950,20 @@ func (p projConcatJSONJSONOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projConcatJSONJSONOp) Init() {
-	p.Input.Init()
 }
 
 type projConcatDatumDatumOp struct {
 	projOpBase
 }
 
-func (p projConcatDatumDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projConcatDatumDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -26849,24 +26084,20 @@ func (p projConcatDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projConcatDatumDatumOp) Init() {
-	p.Input.Init()
 }
 
 type projLShiftInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projLShiftInt16Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftInt16Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -26987,24 +26218,20 @@ func (p projLShiftInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftInt16Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projLShiftInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projLShiftInt16Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftInt16Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -27125,24 +26352,20 @@ func (p projLShiftInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftInt16Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projLShiftInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projLShiftInt16Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftInt16Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -27263,24 +26486,20 @@ func (p projLShiftInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftInt16Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projLShiftInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projLShiftInt32Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftInt32Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -27401,24 +26620,20 @@ func (p projLShiftInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftInt32Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projLShiftInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projLShiftInt32Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftInt32Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -27539,24 +26754,20 @@ func (p projLShiftInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftInt32Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projLShiftInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projLShiftInt32Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftInt32Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -27677,24 +26888,20 @@ func (p projLShiftInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftInt32Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projLShiftInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projLShiftInt64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftInt64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -27815,24 +27022,20 @@ func (p projLShiftInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftInt64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projLShiftInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projLShiftInt64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftInt64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -27953,24 +27156,20 @@ func (p projLShiftInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftInt64Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projLShiftInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projLShiftInt64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftInt64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -28091,24 +27290,20 @@ func (p projLShiftInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftInt64Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projLShiftDatumInt16Op struct {
 	projOpBase
 }
 
-func (p projLShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftDatumInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -28247,24 +27442,20 @@ func (p projLShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftDatumInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projLShiftDatumInt32Op struct {
 	projOpBase
 }
 
-func (p projLShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftDatumInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -28403,24 +27594,20 @@ func (p projLShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftDatumInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projLShiftDatumInt64Op struct {
 	projOpBase
 }
 
-func (p projLShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projLShiftDatumInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -28559,24 +27746,20 @@ func (p projLShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLShiftDatumInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projRShiftInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projRShiftInt16Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftInt16Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -28697,24 +27880,20 @@ func (p projRShiftInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftInt16Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projRShiftInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projRShiftInt16Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftInt16Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -28835,24 +28014,20 @@ func (p projRShiftInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftInt16Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projRShiftInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projRShiftInt16Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftInt16Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -28973,24 +28148,20 @@ func (p projRShiftInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftInt16Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projRShiftInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projRShiftInt32Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftInt32Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -29111,24 +28282,20 @@ func (p projRShiftInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftInt32Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projRShiftInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projRShiftInt32Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftInt32Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -29249,24 +28416,20 @@ func (p projRShiftInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftInt32Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projRShiftInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projRShiftInt32Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftInt32Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -29387,24 +28550,20 @@ func (p projRShiftInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftInt32Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projRShiftInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projRShiftInt64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftInt64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -29525,24 +28684,20 @@ func (p projRShiftInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftInt64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projRShiftInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projRShiftInt64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftInt64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -29663,24 +28818,20 @@ func (p projRShiftInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftInt64Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projRShiftInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projRShiftInt64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftInt64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -29803,22 +28954,18 @@ func (p projRShiftInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projRShiftInt64Int64Op) Init() {
-	p.Input.Init()
-}
-
 type projRShiftDatumInt16Op struct {
 	projOpBase
 }
 
-func (p projRShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftDatumInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -29957,24 +29104,20 @@ func (p projRShiftDatumInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftDatumInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projRShiftDatumInt32Op struct {
 	projOpBase
 }
 
-func (p projRShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftDatumInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -30113,24 +29256,20 @@ func (p projRShiftDatumInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projRShiftDatumInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projRShiftDatumInt64Op struct {
 	projOpBase
 }
 
-func (p projRShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projRShiftDatumInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -30271,22 +29410,18 @@ func (p projRShiftDatumInt64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projRShiftDatumInt64Op) Init() {
-	p.Input.Init()
-}
-
 type projJSONFetchValJSONBytesOp struct {
 	projOpBase
 }
 
-func (p projJSONFetchValJSONBytesOp) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchValJSONBytesOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -30419,24 +29554,20 @@ func (p projJSONFetchValJSONBytesOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projJSONFetchValJSONBytesOp) Init() {
-	p.Input.Init()
 }
 
 type projJSONFetchValJSONInt16Op struct {
 	projOpBase
 }
 
-func (p projJSONFetchValJSONInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchValJSONInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -30559,24 +29690,20 @@ func (p projJSONFetchValJSONInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projJSONFetchValJSONInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projJSONFetchValJSONInt32Op struct {
 	projOpBase
 }
 
-func (p projJSONFetchValJSONInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchValJSONInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -30699,24 +29826,20 @@ func (p projJSONFetchValJSONInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projJSONFetchValJSONInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projJSONFetchValJSONInt64Op struct {
 	projOpBase
 }
 
-func (p projJSONFetchValJSONInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchValJSONInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -30839,24 +29962,20 @@ func (p projJSONFetchValJSONInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projJSONFetchValJSONInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projJSONFetchTextJSONBytesOp struct {
 	projOpBase
 }
 
-func (p projJSONFetchTextJSONBytesOp) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchTextJSONBytesOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -31027,22 +30146,18 @@ func (p projJSONFetchTextJSONBytesOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projJSONFetchTextJSONBytesOp) Init() {
-	p.Input.Init()
-}
-
 type projJSONFetchTextJSONInt16Op struct {
 	projOpBase
 }
 
-func (p projJSONFetchTextJSONInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchTextJSONInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -31203,22 +30318,18 @@ func (p projJSONFetchTextJSONInt16Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projJSONFetchTextJSONInt16Op) Init() {
-	p.Input.Init()
-}
-
 type projJSONFetchTextJSONInt32Op struct {
 	projOpBase
 }
 
-func (p projJSONFetchTextJSONInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchTextJSONInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -31379,22 +30490,18 @@ func (p projJSONFetchTextJSONInt32Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projJSONFetchTextJSONInt32Op) Init() {
-	p.Input.Init()
-}
-
 type projJSONFetchTextJSONInt64Op struct {
 	projOpBase
 }
 
-func (p projJSONFetchTextJSONInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchTextJSONInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -31555,22 +30662,18 @@ func (p projJSONFetchTextJSONInt64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projJSONFetchTextJSONInt64Op) Init() {
-	p.Input.Init()
-}
-
 type projJSONFetchValPathJSONDatumOp struct {
 	projOpBase
 }
 
-func (p projJSONFetchValPathJSONDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchValPathJSONDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -31693,22 +30796,18 @@ func (p projJSONFetchValPathJSONDatumOp) Next(ctx context.Context) coldata.Batch
 	return batch
 }
 
-func (p projJSONFetchValPathJSONDatumOp) Init() {
-	p.Input.Init()
-}
-
 type projJSONFetchTextPathJSONDatumOp struct {
 	projOpBase
 }
 
-func (p projJSONFetchTextPathJSONDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projJSONFetchTextPathJSONDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -31871,22 +30970,18 @@ func (p projJSONFetchTextPathJSONDatumOp) Next(ctx context.Context) coldata.Batc
 	return batch
 }
 
-func (p projJSONFetchTextPathJSONDatumOp) Init() {
-	p.Input.Init()
-}
-
 type projEQBoolBoolOp struct {
 	projOpBase
 }
 
-func (p projEQBoolBoolOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQBoolBoolOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -32031,24 +31126,20 @@ func (p projEQBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQBoolBoolOp) Init() {
-	p.Input.Init()
 }
 
 type projEQBytesBytesOp struct {
 	projOpBase
 }
 
-func (p projEQBytesBytesOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQBytesBytesOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -32157,24 +31248,20 @@ func (p projEQBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQBytesBytesOp) Init() {
-	p.Input.Init()
 }
 
 type projEQDecimalInt16Op struct {
 	projOpBase
 }
 
-func (p projEQDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projEQDecimalInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -32311,24 +31398,20 @@ func (p projEQDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQDecimalInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projEQDecimalInt32Op struct {
 	projOpBase
 }
 
-func (p projEQDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projEQDecimalInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -32465,24 +31548,20 @@ func (p projEQDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQDecimalInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projEQDecimalInt64Op struct {
 	projOpBase
 }
 
-func (p projEQDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projEQDecimalInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -32619,24 +31698,20 @@ func (p projEQDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQDecimalInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projEQDecimalFloat64Op struct {
 	projOpBase
 }
 
-func (p projEQDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
+func (p projEQDecimalFloat64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -32781,24 +31856,20 @@ func (p projEQDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQDecimalFloat64Op) Init() {
-	p.Input.Init()
 }
 
 type projEQDecimalDecimalOp struct {
 	projOpBase
 }
 
-func (p projEQDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQDecimalDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -32911,24 +31982,20 @@ func (p projEQDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQDecimalDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projEQInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projEQInt16Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt16Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -33085,24 +32152,20 @@ func (p projEQInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt16Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projEQInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projEQInt16Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt16Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -33259,24 +32322,20 @@ func (p projEQInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt16Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projEQInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projEQInt16Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt16Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -33433,24 +32492,20 @@ func (p projEQInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt16Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projEQInt16Float64Op struct {
 	projOpBase
 }
 
-func (p projEQInt16Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt16Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -33639,24 +32694,20 @@ func (p projEQInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt16Float64Op) Init() {
-	p.Input.Init()
 }
 
 type projEQInt16DecimalOp struct {
 	projOpBase
 }
 
-func (p projEQInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt16DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -33793,24 +32844,20 @@ func (p projEQInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt16DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projEQInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projEQInt32Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt32Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -33967,24 +33014,20 @@ func (p projEQInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt32Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projEQInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projEQInt32Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt32Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -34141,24 +33184,20 @@ func (p projEQInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt32Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projEQInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projEQInt32Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt32Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -34315,24 +33354,20 @@ func (p projEQInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt32Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projEQInt32Float64Op struct {
 	projOpBase
 }
 
-func (p projEQInt32Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt32Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -34521,24 +33556,20 @@ func (p projEQInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt32Float64Op) Init() {
-	p.Input.Init()
 }
 
 type projEQInt32DecimalOp struct {
 	projOpBase
 }
 
-func (p projEQInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt32DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -34675,24 +33706,20 @@ func (p projEQInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt32DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projEQInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projEQInt64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -34849,24 +33876,20 @@ func (p projEQInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projEQInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projEQInt64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -35023,24 +34046,20 @@ func (p projEQInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt64Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projEQInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projEQInt64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -35197,24 +34216,20 @@ func (p projEQInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt64Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projEQInt64Float64Op struct {
 	projOpBase
 }
 
-func (p projEQInt64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -35403,24 +34418,20 @@ func (p projEQInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt64Float64Op) Init() {
-	p.Input.Init()
 }
 
 type projEQInt64DecimalOp struct {
 	projOpBase
 }
 
-func (p projEQInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQInt64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -35557,24 +34568,20 @@ func (p projEQInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQInt64DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projEQFloat64Int16Op struct {
 	projOpBase
 }
 
-func (p projEQFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projEQFloat64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -35763,24 +34770,20 @@ func (p projEQFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQFloat64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projEQFloat64Int32Op struct {
 	projOpBase
 }
 
-func (p projEQFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projEQFloat64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -35969,24 +34972,20 @@ func (p projEQFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQFloat64Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projEQFloat64Int64Op struct {
 	projOpBase
 }
 
-func (p projEQFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projEQFloat64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -36175,24 +35174,20 @@ func (p projEQFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQFloat64Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projEQFloat64Float64Op struct {
 	projOpBase
 }
 
-func (p projEQFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projEQFloat64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -36381,24 +35376,20 @@ func (p projEQFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQFloat64Float64Op) Init() {
-	p.Input.Init()
 }
 
 type projEQFloat64DecimalOp struct {
 	projOpBase
 }
 
-func (p projEQFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQFloat64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -36543,24 +35534,20 @@ func (p projEQFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQFloat64DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projEQTimestampTimestampOp struct {
 	projOpBase
 }
 
-func (p projEQTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQTimestampTimestampOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -36701,24 +35688,20 @@ func (p projEQTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQTimestampTimestampOp) Init() {
-	p.Input.Init()
 }
 
 type projEQIntervalIntervalOp struct {
 	projOpBase
 }
 
-func (p projEQIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQIntervalIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -36831,24 +35814,20 @@ func (p projEQIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQIntervalIntervalOp) Init() {
-	p.Input.Init()
 }
 
 type projEQJSONJSONOp struct {
 	projOpBase
 }
 
-func (p projEQJSONJSONOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQJSONJSONOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -36981,24 +35960,20 @@ func (p projEQJSONJSONOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQJSONJSONOp) Init() {
-	p.Input.Init()
 }
 
 type projEQDatumDatumOp struct {
 	projOpBase
 }
 
-func (p projEQDatumDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projEQDatumDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -37115,24 +36090,20 @@ func (p projEQDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projEQDatumDatumOp) Init() {
-	p.Input.Init()
 }
 
 type projNEBoolBoolOp struct {
 	projOpBase
 }
 
-func (p projNEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEBoolBoolOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -37277,24 +36248,20 @@ func (p projNEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEBoolBoolOp) Init() {
-	p.Input.Init()
 }
 
 type projNEBytesBytesOp struct {
 	projOpBase
 }
 
-func (p projNEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEBytesBytesOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -37403,24 +36370,20 @@ func (p projNEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEBytesBytesOp) Init() {
-	p.Input.Init()
 }
 
 type projNEDecimalInt16Op struct {
 	projOpBase
 }
 
-func (p projNEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projNEDecimalInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -37557,24 +36520,20 @@ func (p projNEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEDecimalInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projNEDecimalInt32Op struct {
 	projOpBase
 }
 
-func (p projNEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projNEDecimalInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -37711,24 +36670,20 @@ func (p projNEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEDecimalInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projNEDecimalInt64Op struct {
 	projOpBase
 }
 
-func (p projNEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projNEDecimalInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -37865,24 +36820,20 @@ func (p projNEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEDecimalInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projNEDecimalFloat64Op struct {
 	projOpBase
 }
 
-func (p projNEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
+func (p projNEDecimalFloat64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -38027,24 +36978,20 @@ func (p projNEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEDecimalFloat64Op) Init() {
-	p.Input.Init()
 }
 
 type projNEDecimalDecimalOp struct {
 	projOpBase
 }
 
-func (p projNEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEDecimalDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -38157,24 +37104,20 @@ func (p projNEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEDecimalDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projNEInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projNEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt16Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -38331,24 +37274,20 @@ func (p projNEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt16Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projNEInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projNEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt16Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -38505,24 +37444,20 @@ func (p projNEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt16Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projNEInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projNEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt16Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -38679,24 +37614,20 @@ func (p projNEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt16Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projNEInt16Float64Op struct {
 	projOpBase
 }
 
-func (p projNEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt16Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -38885,24 +37816,20 @@ func (p projNEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt16Float64Op) Init() {
-	p.Input.Init()
 }
 
 type projNEInt16DecimalOp struct {
 	projOpBase
 }
 
-func (p projNEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt16DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -39039,24 +37966,20 @@ func (p projNEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt16DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projNEInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projNEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt32Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -39213,24 +38136,20 @@ func (p projNEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt32Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projNEInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projNEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt32Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -39387,24 +38306,20 @@ func (p projNEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt32Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projNEInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projNEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt32Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -39561,24 +38476,20 @@ func (p projNEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt32Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projNEInt32Float64Op struct {
 	projOpBase
 }
 
-func (p projNEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt32Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -39767,24 +38678,20 @@ func (p projNEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt32Float64Op) Init() {
-	p.Input.Init()
 }
 
 type projNEInt32DecimalOp struct {
 	projOpBase
 }
 
-func (p projNEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt32DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -39921,24 +38828,20 @@ func (p projNEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt32DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projNEInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projNEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -40095,24 +38998,20 @@ func (p projNEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projNEInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projNEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -40269,24 +39168,20 @@ func (p projNEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt64Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projNEInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projNEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -40443,24 +39338,20 @@ func (p projNEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt64Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projNEInt64Float64Op struct {
 	projOpBase
 }
 
-func (p projNEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -40649,24 +39540,20 @@ func (p projNEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt64Float64Op) Init() {
-	p.Input.Init()
 }
 
 type projNEInt64DecimalOp struct {
 	projOpBase
 }
 
-func (p projNEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEInt64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -40803,24 +39690,20 @@ func (p projNEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEInt64DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projNEFloat64Int16Op struct {
 	projOpBase
 }
 
-func (p projNEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projNEFloat64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -41009,24 +39892,20 @@ func (p projNEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEFloat64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projNEFloat64Int32Op struct {
 	projOpBase
 }
 
-func (p projNEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projNEFloat64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -41215,24 +40094,20 @@ func (p projNEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEFloat64Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projNEFloat64Int64Op struct {
 	projOpBase
 }
 
-func (p projNEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projNEFloat64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -41421,24 +40296,20 @@ func (p projNEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEFloat64Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projNEFloat64Float64Op struct {
 	projOpBase
 }
 
-func (p projNEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projNEFloat64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -41627,24 +40498,20 @@ func (p projNEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEFloat64Float64Op) Init() {
-	p.Input.Init()
 }
 
 type projNEFloat64DecimalOp struct {
 	projOpBase
 }
 
-func (p projNEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEFloat64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -41789,24 +40656,20 @@ func (p projNEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEFloat64DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projNETimestampTimestampOp struct {
 	projOpBase
 }
 
-func (p projNETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
+func (p projNETimestampTimestampOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -41947,24 +40810,20 @@ func (p projNETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNETimestampTimestampOp) Init() {
-	p.Input.Init()
 }
 
 type projNEIntervalIntervalOp struct {
 	projOpBase
 }
 
-func (p projNEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEIntervalIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -42077,24 +40936,20 @@ func (p projNEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEIntervalIntervalOp) Init() {
-	p.Input.Init()
 }
 
 type projNEJSONJSONOp struct {
 	projOpBase
 }
 
-func (p projNEJSONJSONOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEJSONJSONOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -42227,24 +41082,20 @@ func (p projNEJSONJSONOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEJSONJSONOp) Init() {
-	p.Input.Init()
 }
 
 type projNEDatumDatumOp struct {
 	projOpBase
 }
 
-func (p projNEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projNEDatumDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -42361,24 +41212,20 @@ func (p projNEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projNEDatumDatumOp) Init() {
-	p.Input.Init()
 }
 
 type projLTBoolBoolOp struct {
 	projOpBase
 }
 
-func (p projLTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTBoolBoolOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -42523,24 +41370,20 @@ func (p projLTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTBoolBoolOp) Init() {
-	p.Input.Init()
 }
 
 type projLTBytesBytesOp struct {
 	projOpBase
 }
 
-func (p projLTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTBytesBytesOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -42649,24 +41492,20 @@ func (p projLTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTBytesBytesOp) Init() {
-	p.Input.Init()
 }
 
 type projLTDecimalInt16Op struct {
 	projOpBase
 }
 
-func (p projLTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projLTDecimalInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -42803,24 +41642,20 @@ func (p projLTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTDecimalInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projLTDecimalInt32Op struct {
 	projOpBase
 }
 
-func (p projLTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projLTDecimalInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -42957,24 +41792,20 @@ func (p projLTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTDecimalInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projLTDecimalInt64Op struct {
 	projOpBase
 }
 
-func (p projLTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projLTDecimalInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -43111,24 +41942,20 @@ func (p projLTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTDecimalInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projLTDecimalFloat64Op struct {
 	projOpBase
 }
 
-func (p projLTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
+func (p projLTDecimalFloat64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -43273,24 +42100,20 @@ func (p projLTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTDecimalFloat64Op) Init() {
-	p.Input.Init()
 }
 
 type projLTDecimalDecimalOp struct {
 	projOpBase
 }
 
-func (p projLTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTDecimalDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -43403,24 +42226,20 @@ func (p projLTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTDecimalDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projLTInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projLTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt16Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -43577,24 +42396,20 @@ func (p projLTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt16Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projLTInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projLTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt16Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -43751,24 +42566,20 @@ func (p projLTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt16Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projLTInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projLTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt16Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -43925,24 +42736,20 @@ func (p projLTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt16Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projLTInt16Float64Op struct {
 	projOpBase
 }
 
-func (p projLTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt16Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -44131,24 +42938,20 @@ func (p projLTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt16Float64Op) Init() {
-	p.Input.Init()
 }
 
 type projLTInt16DecimalOp struct {
 	projOpBase
 }
 
-func (p projLTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt16DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -44285,24 +43088,20 @@ func (p projLTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt16DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projLTInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projLTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt32Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -44459,24 +43258,20 @@ func (p projLTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt32Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projLTInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projLTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt32Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -44633,24 +43428,20 @@ func (p projLTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt32Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projLTInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projLTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt32Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -44807,24 +43598,20 @@ func (p projLTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt32Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projLTInt32Float64Op struct {
 	projOpBase
 }
 
-func (p projLTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt32Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -45013,24 +43800,20 @@ func (p projLTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt32Float64Op) Init() {
-	p.Input.Init()
 }
 
 type projLTInt32DecimalOp struct {
 	projOpBase
 }
 
-func (p projLTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt32DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -45167,24 +43950,20 @@ func (p projLTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt32DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projLTInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projLTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -45341,24 +44120,20 @@ func (p projLTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projLTInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projLTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -45515,24 +44290,20 @@ func (p projLTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt64Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projLTInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projLTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -45689,24 +44460,20 @@ func (p projLTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt64Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projLTInt64Float64Op struct {
 	projOpBase
 }
 
-func (p projLTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -45895,24 +44662,20 @@ func (p projLTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt64Float64Op) Init() {
-	p.Input.Init()
 }
 
 type projLTInt64DecimalOp struct {
 	projOpBase
 }
 
-func (p projLTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTInt64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -46049,24 +44812,20 @@ func (p projLTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTInt64DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projLTFloat64Int16Op struct {
 	projOpBase
 }
 
-func (p projLTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projLTFloat64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -46255,24 +45014,20 @@ func (p projLTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTFloat64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projLTFloat64Int32Op struct {
 	projOpBase
 }
 
-func (p projLTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projLTFloat64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -46461,24 +45216,20 @@ func (p projLTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTFloat64Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projLTFloat64Int64Op struct {
 	projOpBase
 }
 
-func (p projLTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projLTFloat64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -46667,24 +45418,20 @@ func (p projLTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTFloat64Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projLTFloat64Float64Op struct {
 	projOpBase
 }
 
-func (p projLTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projLTFloat64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -46873,24 +45620,20 @@ func (p projLTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTFloat64Float64Op) Init() {
-	p.Input.Init()
 }
 
 type projLTFloat64DecimalOp struct {
 	projOpBase
 }
 
-func (p projLTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTFloat64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -47035,24 +45778,20 @@ func (p projLTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTFloat64DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projLTTimestampTimestampOp struct {
 	projOpBase
 }
 
-func (p projLTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTTimestampTimestampOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -47193,24 +45932,20 @@ func (p projLTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTTimestampTimestampOp) Init() {
-	p.Input.Init()
 }
 
 type projLTIntervalIntervalOp struct {
 	projOpBase
 }
 
-func (p projLTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTIntervalIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -47323,24 +46058,20 @@ func (p projLTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTIntervalIntervalOp) Init() {
-	p.Input.Init()
 }
 
 type projLTJSONJSONOp struct {
 	projOpBase
 }
 
-func (p projLTJSONJSONOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTJSONJSONOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -47473,24 +46204,20 @@ func (p projLTJSONJSONOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTJSONJSONOp) Init() {
-	p.Input.Init()
 }
 
 type projLTDatumDatumOp struct {
 	projOpBase
 }
 
-func (p projLTDatumDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projLTDatumDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -47607,24 +46334,20 @@ func (p projLTDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLTDatumDatumOp) Init() {
-	p.Input.Init()
 }
 
 type projLEBoolBoolOp struct {
 	projOpBase
 }
 
-func (p projLEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEBoolBoolOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -47769,24 +46492,20 @@ func (p projLEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEBoolBoolOp) Init() {
-	p.Input.Init()
 }
 
 type projLEBytesBytesOp struct {
 	projOpBase
 }
 
-func (p projLEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEBytesBytesOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -47895,24 +46614,20 @@ func (p projLEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEBytesBytesOp) Init() {
-	p.Input.Init()
 }
 
 type projLEDecimalInt16Op struct {
 	projOpBase
 }
 
-func (p projLEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projLEDecimalInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -48049,24 +46764,20 @@ func (p projLEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEDecimalInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projLEDecimalInt32Op struct {
 	projOpBase
 }
 
-func (p projLEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projLEDecimalInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -48203,24 +46914,20 @@ func (p projLEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEDecimalInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projLEDecimalInt64Op struct {
 	projOpBase
 }
 
-func (p projLEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projLEDecimalInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -48357,24 +47064,20 @@ func (p projLEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEDecimalInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projLEDecimalFloat64Op struct {
 	projOpBase
 }
 
-func (p projLEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
+func (p projLEDecimalFloat64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -48519,24 +47222,20 @@ func (p projLEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEDecimalFloat64Op) Init() {
-	p.Input.Init()
 }
 
 type projLEDecimalDecimalOp struct {
 	projOpBase
 }
 
-func (p projLEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEDecimalDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -48649,24 +47348,20 @@ func (p projLEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEDecimalDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projLEInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projLEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt16Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -48823,24 +47518,20 @@ func (p projLEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt16Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projLEInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projLEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt16Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -48997,24 +47688,20 @@ func (p projLEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt16Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projLEInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projLEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt16Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -49171,24 +47858,20 @@ func (p projLEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt16Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projLEInt16Float64Op struct {
 	projOpBase
 }
 
-func (p projLEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt16Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -49377,24 +48060,20 @@ func (p projLEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt16Float64Op) Init() {
-	p.Input.Init()
 }
 
 type projLEInt16DecimalOp struct {
 	projOpBase
 }
 
-func (p projLEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt16DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -49531,24 +48210,20 @@ func (p projLEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt16DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projLEInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projLEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt32Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -49705,24 +48380,20 @@ func (p projLEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt32Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projLEInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projLEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt32Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -49879,24 +48550,20 @@ func (p projLEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt32Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projLEInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projLEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt32Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -50053,24 +48720,20 @@ func (p projLEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt32Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projLEInt32Float64Op struct {
 	projOpBase
 }
 
-func (p projLEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt32Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -50259,24 +48922,20 @@ func (p projLEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt32Float64Op) Init() {
-	p.Input.Init()
 }
 
 type projLEInt32DecimalOp struct {
 	projOpBase
 }
 
-func (p projLEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt32DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -50413,24 +49072,20 @@ func (p projLEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt32DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projLEInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projLEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -50587,24 +49242,20 @@ func (p projLEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projLEInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projLEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -50761,24 +49412,20 @@ func (p projLEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt64Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projLEInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projLEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -50935,24 +49582,20 @@ func (p projLEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt64Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projLEInt64Float64Op struct {
 	projOpBase
 }
 
-func (p projLEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -51141,24 +49784,20 @@ func (p projLEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt64Float64Op) Init() {
-	p.Input.Init()
 }
 
 type projLEInt64DecimalOp struct {
 	projOpBase
 }
 
-func (p projLEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEInt64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -51295,24 +49934,20 @@ func (p projLEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEInt64DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projLEFloat64Int16Op struct {
 	projOpBase
 }
 
-func (p projLEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projLEFloat64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -51501,24 +50136,20 @@ func (p projLEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEFloat64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projLEFloat64Int32Op struct {
 	projOpBase
 }
 
-func (p projLEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projLEFloat64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -51707,24 +50338,20 @@ func (p projLEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEFloat64Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projLEFloat64Int64Op struct {
 	projOpBase
 }
 
-func (p projLEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projLEFloat64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -51913,24 +50540,20 @@ func (p projLEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEFloat64Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projLEFloat64Float64Op struct {
 	projOpBase
 }
 
-func (p projLEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projLEFloat64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -52119,24 +50742,20 @@ func (p projLEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEFloat64Float64Op) Init() {
-	p.Input.Init()
 }
 
 type projLEFloat64DecimalOp struct {
 	projOpBase
 }
 
-func (p projLEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEFloat64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -52281,24 +50900,20 @@ func (p projLEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEFloat64DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type projLETimestampTimestampOp struct {
 	projOpBase
 }
 
-func (p projLETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
+func (p projLETimestampTimestampOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -52439,24 +51054,20 @@ func (p projLETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLETimestampTimestampOp) Init() {
-	p.Input.Init()
 }
 
 type projLEIntervalIntervalOp struct {
 	projOpBase
 }
 
-func (p projLEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEIntervalIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -52569,24 +51180,20 @@ func (p projLEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEIntervalIntervalOp) Init() {
-	p.Input.Init()
 }
 
 type projLEJSONJSONOp struct {
 	projOpBase
 }
 
-func (p projLEJSONJSONOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEJSONJSONOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -52719,24 +51326,20 @@ func (p projLEJSONJSONOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEJSONJSONOp) Init() {
-	p.Input.Init()
 }
 
 type projLEDatumDatumOp struct {
 	projOpBase
 }
 
-func (p projLEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projLEDatumDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -52853,24 +51456,20 @@ func (p projLEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projLEDatumDatumOp) Init() {
-	p.Input.Init()
 }
 
 type projGTBoolBoolOp struct {
 	projOpBase
 }
 
-func (p projGTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTBoolBoolOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -53015,24 +51614,20 @@ func (p projGTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTBoolBoolOp) Init() {
-	p.Input.Init()
 }
 
 type projGTBytesBytesOp struct {
 	projOpBase
 }
 
-func (p projGTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTBytesBytesOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -53143,22 +51738,18 @@ func (p projGTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGTBytesBytesOp) Init() {
-	p.Input.Init()
-}
-
 type projGTDecimalInt16Op struct {
 	projOpBase
 }
 
-func (p projGTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projGTDecimalInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -53295,24 +51886,20 @@ func (p projGTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTDecimalInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projGTDecimalInt32Op struct {
 	projOpBase
 }
 
-func (p projGTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projGTDecimalInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -53449,24 +52036,20 @@ func (p projGTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTDecimalInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projGTDecimalInt64Op struct {
 	projOpBase
 }
 
-func (p projGTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projGTDecimalInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -53603,24 +52186,20 @@ func (p projGTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTDecimalInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projGTDecimalFloat64Op struct {
 	projOpBase
 }
 
-func (p projGTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
+func (p projGTDecimalFloat64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -53765,24 +52344,20 @@ func (p projGTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTDecimalFloat64Op) Init() {
-	p.Input.Init()
 }
 
 type projGTDecimalDecimalOp struct {
 	projOpBase
 }
 
-func (p projGTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTDecimalDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -53897,22 +52472,18 @@ func (p projGTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGTDecimalDecimalOp) Init() {
-	p.Input.Init()
-}
-
 type projGTInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projGTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt16Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -54069,24 +52640,20 @@ func (p projGTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTInt16Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projGTInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projGTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt16Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -54243,24 +52810,20 @@ func (p projGTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTInt16Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projGTInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projGTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt16Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -54417,24 +52980,20 @@ func (p projGTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTInt16Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projGTInt16Float64Op struct {
 	projOpBase
 }
 
-func (p projGTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt16Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -54623,24 +53182,20 @@ func (p projGTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTInt16Float64Op) Init() {
-	p.Input.Init()
 }
 
 type projGTInt16DecimalOp struct {
 	projOpBase
 }
 
-func (p projGTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt16DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -54779,22 +53334,18 @@ func (p projGTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGTInt16DecimalOp) Init() {
-	p.Input.Init()
-}
-
 type projGTInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projGTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt32Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -54951,24 +53502,20 @@ func (p projGTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTInt32Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projGTInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projGTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt32Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -55125,24 +53672,20 @@ func (p projGTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTInt32Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projGTInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projGTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt32Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -55299,24 +53842,20 @@ func (p projGTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTInt32Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projGTInt32Float64Op struct {
 	projOpBase
 }
 
-func (p projGTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt32Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -55505,24 +54044,20 @@ func (p projGTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTInt32Float64Op) Init() {
-	p.Input.Init()
 }
 
 type projGTInt32DecimalOp struct {
 	projOpBase
 }
 
-func (p projGTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt32DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -55661,22 +54196,18 @@ func (p projGTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGTInt32DecimalOp) Init() {
-	p.Input.Init()
-}
-
 type projGTInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projGTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -55833,24 +54364,20 @@ func (p projGTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGTInt64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projGTInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projGTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -56009,22 +54536,18 @@ func (p projGTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGTInt64Int32Op) Init() {
-	p.Input.Init()
-}
-
 type projGTInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projGTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -56183,22 +54706,18 @@ func (p projGTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGTInt64Int64Op) Init() {
-	p.Input.Init()
-}
-
 type projGTInt64Float64Op struct {
 	projOpBase
 }
 
-func (p projGTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -56389,22 +54908,18 @@ func (p projGTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGTInt64Float64Op) Init() {
-	p.Input.Init()
-}
-
 type projGTInt64DecimalOp struct {
 	projOpBase
 }
 
-func (p projGTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTInt64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -56543,22 +55058,18 @@ func (p projGTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGTInt64DecimalOp) Init() {
-	p.Input.Init()
-}
-
 type projGTFloat64Int16Op struct {
 	projOpBase
 }
 
-func (p projGTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projGTFloat64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -56749,22 +55260,18 @@ func (p projGTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGTFloat64Int16Op) Init() {
-	p.Input.Init()
-}
-
 type projGTFloat64Int32Op struct {
 	projOpBase
 }
 
-func (p projGTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projGTFloat64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -56955,22 +55462,18 @@ func (p projGTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGTFloat64Int32Op) Init() {
-	p.Input.Init()
-}
-
 type projGTFloat64Int64Op struct {
 	projOpBase
 }
 
-func (p projGTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projGTFloat64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -57161,22 +55664,18 @@ func (p projGTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGTFloat64Int64Op) Init() {
-	p.Input.Init()
-}
-
 type projGTFloat64Float64Op struct {
 	projOpBase
 }
 
-func (p projGTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projGTFloat64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -57367,22 +55866,18 @@ func (p projGTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGTFloat64Float64Op) Init() {
-	p.Input.Init()
-}
-
 type projGTFloat64DecimalOp struct {
 	projOpBase
 }
 
-func (p projGTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTFloat64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -57529,22 +56024,18 @@ func (p projGTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGTFloat64DecimalOp) Init() {
-	p.Input.Init()
-}
-
 type projGTTimestampTimestampOp struct {
 	projOpBase
 }
 
-func (p projGTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTTimestampTimestampOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -57687,22 +56178,18 @@ func (p projGTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGTTimestampTimestampOp) Init() {
-	p.Input.Init()
-}
-
 type projGTIntervalIntervalOp struct {
 	projOpBase
 }
 
-func (p projGTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTIntervalIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -57817,22 +56304,18 @@ func (p projGTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGTIntervalIntervalOp) Init() {
-	p.Input.Init()
-}
-
 type projGTJSONJSONOp struct {
 	projOpBase
 }
 
-func (p projGTJSONJSONOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTJSONJSONOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -57967,22 +56450,18 @@ func (p projGTJSONJSONOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGTJSONJSONOp) Init() {
-	p.Input.Init()
-}
-
 type projGTDatumDatumOp struct {
 	projOpBase
 }
 
-func (p projGTDatumDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projGTDatumDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -58101,22 +56580,18 @@ func (p projGTDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGTDatumDatumOp) Init() {
-	p.Input.Init()
-}
-
 type projGEBoolBoolOp struct {
 	projOpBase
 }
 
-func (p projGEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEBoolBoolOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -58263,22 +56738,18 @@ func (p projGEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGEBoolBoolOp) Init() {
-	p.Input.Init()
-}
-
 type projGEBytesBytesOp struct {
 	projOpBase
 }
 
-func (p projGEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEBytesBytesOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -58389,22 +56860,18 @@ func (p projGEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGEBytesBytesOp) Init() {
-	p.Input.Init()
-}
-
 type projGEDecimalInt16Op struct {
 	projOpBase
 }
 
-func (p projGEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p projGEDecimalInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -58541,24 +57008,20 @@ func (p projGEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEDecimalInt16Op) Init() {
-	p.Input.Init()
 }
 
 type projGEDecimalInt32Op struct {
 	projOpBase
 }
 
-func (p projGEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p projGEDecimalInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -58695,24 +57158,20 @@ func (p projGEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEDecimalInt32Op) Init() {
-	p.Input.Init()
 }
 
 type projGEDecimalInt64Op struct {
 	projOpBase
 }
 
-func (p projGEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p projGEDecimalInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -58849,24 +57308,20 @@ func (p projGEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEDecimalInt64Op) Init() {
-	p.Input.Init()
 }
 
 type projGEDecimalFloat64Op struct {
 	projOpBase
 }
 
-func (p projGEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
+func (p projGEDecimalFloat64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -59011,24 +57466,20 @@ func (p projGEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEDecimalFloat64Op) Init() {
-	p.Input.Init()
 }
 
 type projGEDecimalDecimalOp struct {
 	projOpBase
 }
 
-func (p projGEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEDecimalDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -59143,22 +57594,18 @@ func (p projGEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGEDecimalDecimalOp) Init() {
-	p.Input.Init()
-}
-
 type projGEInt16Int16Op struct {
 	projOpBase
 }
 
-func (p projGEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt16Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -59315,24 +57762,20 @@ func (p projGEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEInt16Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projGEInt16Int32Op struct {
 	projOpBase
 }
 
-func (p projGEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt16Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -59489,24 +57932,20 @@ func (p projGEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEInt16Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projGEInt16Int64Op struct {
 	projOpBase
 }
 
-func (p projGEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt16Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -59663,24 +58102,20 @@ func (p projGEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEInt16Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projGEInt16Float64Op struct {
 	projOpBase
 }
 
-func (p projGEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt16Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -59869,24 +58304,20 @@ func (p projGEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEInt16Float64Op) Init() {
-	p.Input.Init()
 }
 
 type projGEInt16DecimalOp struct {
 	projOpBase
 }
 
-func (p projGEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt16DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -60025,22 +58456,18 @@ func (p projGEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGEInt16DecimalOp) Init() {
-	p.Input.Init()
-}
-
 type projGEInt32Int16Op struct {
 	projOpBase
 }
 
-func (p projGEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt32Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -60197,24 +58624,20 @@ func (p projGEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEInt32Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projGEInt32Int32Op struct {
 	projOpBase
 }
 
-func (p projGEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt32Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -60371,24 +58794,20 @@ func (p projGEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEInt32Int32Op) Init() {
-	p.Input.Init()
 }
 
 type projGEInt32Int64Op struct {
 	projOpBase
 }
 
-func (p projGEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt32Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -60545,24 +58964,20 @@ func (p projGEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEInt32Int64Op) Init() {
-	p.Input.Init()
 }
 
 type projGEInt32Float64Op struct {
 	projOpBase
 }
 
-func (p projGEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt32Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -60751,24 +59166,20 @@ func (p projGEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEInt32Float64Op) Init() {
-	p.Input.Init()
 }
 
 type projGEInt32DecimalOp struct {
 	projOpBase
 }
 
-func (p projGEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt32DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -60907,22 +59318,18 @@ func (p projGEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGEInt32DecimalOp) Init() {
-	p.Input.Init()
-}
-
 type projGEInt64Int16Op struct {
 	projOpBase
 }
 
-func (p projGEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -61079,24 +59486,20 @@ func (p projGEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEInt64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type projGEInt64Int32Op struct {
 	projOpBase
 }
 
-func (p projGEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -61255,22 +59658,18 @@ func (p projGEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGEInt64Int32Op) Init() {
-	p.Input.Init()
-}
-
 type projGEInt64Int64Op struct {
 	projOpBase
 }
 
-func (p projGEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -61429,22 +59828,18 @@ func (p projGEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGEInt64Int64Op) Init() {
-	p.Input.Init()
-}
-
 type projGEInt64Float64Op struct {
 	projOpBase
 }
 
-func (p projGEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -61635,22 +60030,18 @@ func (p projGEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGEInt64Float64Op) Init() {
-	p.Input.Init()
-}
-
 type projGEInt64DecimalOp struct {
 	projOpBase
 }
 
-func (p projGEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEInt64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -61789,22 +60180,18 @@ func (p projGEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGEInt64DecimalOp) Init() {
-	p.Input.Init()
-}
-
 type projGEFloat64Int16Op struct {
 	projOpBase
 }
 
-func (p projGEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p projGEFloat64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -61995,22 +60382,18 @@ func (p projGEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGEFloat64Int16Op) Init() {
-	p.Input.Init()
-}
-
 type projGEFloat64Int32Op struct {
 	projOpBase
 }
 
-func (p projGEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p projGEFloat64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -62201,22 +60584,18 @@ func (p projGEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGEFloat64Int32Op) Init() {
-	p.Input.Init()
-}
-
 type projGEFloat64Int64Op struct {
 	projOpBase
 }
 
-func (p projGEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p projGEFloat64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -62407,22 +60786,18 @@ func (p projGEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGEFloat64Int64Op) Init() {
-	p.Input.Init()
-}
-
 type projGEFloat64Float64Op struct {
 	projOpBase
 }
 
-func (p projGEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p projGEFloat64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -62613,22 +60988,18 @@ func (p projGEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGEFloat64Float64Op) Init() {
-	p.Input.Init()
-}
-
 type projGEFloat64DecimalOp struct {
 	projOpBase
 }
 
-func (p projGEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEFloat64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -62775,22 +61146,18 @@ func (p projGEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGEFloat64DecimalOp) Init() {
-	p.Input.Init()
-}
-
 type projGETimestampTimestampOp struct {
 	projOpBase
 }
 
-func (p projGETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
+func (p projGETimestampTimestampOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -62933,22 +61300,18 @@ func (p projGETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGETimestampTimestampOp) Init() {
-	p.Input.Init()
-}
-
 type projGEIntervalIntervalOp struct {
 	projOpBase
 }
 
-func (p projGEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEIntervalIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -63063,22 +61426,18 @@ func (p projGEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGEIntervalIntervalOp) Init() {
-	p.Input.Init()
-}
-
 type projGEJSONJSONOp struct {
 	projOpBase
 }
 
-func (p projGEJSONJSONOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEJSONJSONOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -63213,22 +61572,18 @@ func (p projGEJSONJSONOp) Next(ctx context.Context) coldata.Batch {
 	return batch
 }
 
-func (p projGEJSONJSONOp) Init() {
-	p.Input.Init()
-}
-
 type projGEDatumDatumOp struct {
 	projOpBase
 }
 
-func (p projGEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p projGEDatumDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
 	// However, the scratch is not used in all of the projection operators, so
 	// we add this to go around "unused" error.
 	_ = _overloadHelper
-	batch := p.Input.Next(ctx)
+	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -63345,10 +61700,6 @@ func (p projGEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 		batch.SetLength(n)
 	})
 	return batch
-}
-
-func (p projGEDatumDatumOp) Init() {
-	p.Input.Init()
 }
 
 // GetProjectionOperator returns the appropriate projection operator for the
@@ -63368,7 +61719,7 @@ func GetProjectionOperator(
 ) (colexecop.Operator, error) {
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, outputType, outputIdx)
 	projOpBase := projOpBase{
-		OneInputNode:   colexecop.NewOneInputNode(input),
+		OneInputHelper: colexecop.MakeOneInputHelper(input),
 		allocator:      allocator,
 		col1Idx:        col1Idx,
 		col2Idx:        col2Idx,

--- a/pkg/sql/colexec/colexecproj/projection_ops_test.go
+++ b/pkg/sql/colexec/colexecproj/projection_ops_test.go
@@ -121,10 +121,10 @@ func TestGetProjectionConstOperator(t *testing.T) {
 	}
 	expected := &projMultFloat64Float64ConstOp{
 		projConstOpBase: projConstOpBase{
-			OneInputNode: colexecop.NewOneInputNode(op.(*projMultFloat64Float64ConstOp).Input),
-			allocator:    testAllocator,
-			colIdx:       colIdx,
-			outputIdx:    outputIdx,
+			OneInputHelper: colexecop.MakeOneInputHelper(op.(*projMultFloat64Float64ConstOp).Input),
+			allocator:      testAllocator,
+			colIdx:         colIdx,
+			outputIdx:      outputIdx,
 		},
 		constArg: constVal,
 	}
@@ -153,10 +153,10 @@ func TestGetProjectionConstMixedTypeOperator(t *testing.T) {
 	}
 	expected := &projGEInt64Int16ConstOp{
 		projConstOpBase: projConstOpBase{
-			OneInputNode: colexecop.NewOneInputNode(op.(*projGEInt64Int16ConstOp).Input),
-			allocator:    testAllocator,
-			colIdx:       colIdx,
-			outputIdx:    outputIdx,
+			OneInputHelper: colexecop.MakeOneInputHelper(op.(*projGEInt64Int16ConstOp).Input),
+			allocator:      testAllocator,
+			colIdx:         colIdx,
+			outputIdx:      outputIdx,
 		},
 		constArg: constVal,
 	}
@@ -245,9 +245,9 @@ func TestRandomComparisons(t *testing.T) {
 				fmt.Sprintf("@1 %s @2", cmpOp), false /* canFallbackToRowexec */, testMemAcc,
 			)
 			require.NoError(t, err)
-			op.Init()
+			op.Init(ctx)
 			var idx int
-			for batch := op.Next(ctx); batch.Length() > 0; batch = op.Next(ctx) {
+			for batch := op.Next(); batch.Length() > 0; batch = op.Next() {
 				for i := 0; i < batch.Length(); i++ {
 					absIdx := idx + i
 					assert.Equal(t, expected[absIdx], batch.ColVec(2).Bool()[i],
@@ -281,11 +281,11 @@ func TestGetProjectionOperator(t *testing.T) {
 	}
 	expected := &projMultInt16Int16Op{
 		projOpBase: projOpBase{
-			OneInputNode: colexecop.NewOneInputNode(op.(*projMultInt16Int16Op).Input),
-			allocator:    testAllocator,
-			col1Idx:      col1Idx,
-			col2Idx:      col2Idx,
-			outputIdx:    outputIdx,
+			OneInputHelper: colexecop.MakeOneInputHelper(op.(*projMultInt16Int16Op).Input),
+			allocator:      testAllocator,
+			col1Idx:        col1Idx,
+			col2Idx:        col2Idx,
+			outputIdx:      outputIdx,
 		},
 	}
 	if !reflect.DeepEqual(op, expected) {
@@ -332,12 +332,12 @@ func benchmarkProjOp(
 	source := colexecop.NewRepeatableBatchSource(testAllocator, batch, inputTypes)
 	op, err := makeProjOp(source)
 	require.NoError(b, err)
-	op.Init()
+	op.Init(ctx)
 
 	b.Run(name, func(b *testing.B) {
 		b.SetBytes(int64(len(inputTypes) * 8 * coldata.BatchSize()))
 		for i := 0; i < b.N; i++ {
-			op.Next(ctx)
+			op.Next()
 		}
 	})
 }

--- a/pkg/sql/colexec/colexecsel/default_cmp_sel_ops.eg.go
+++ b/pkg/sql/colexec/colexecsel/default_cmp_sel_ops.eg.go
@@ -10,8 +10,6 @@
 package colexecsel
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexeccmp"
@@ -29,13 +27,9 @@ type defaultCmpSelOp struct {
 
 var _ colexecop.Operator = &defaultCmpSelOp{}
 
-func (d *defaultCmpSelOp) Init() {
-	d.Input.Init()
-}
-
-func (d *defaultCmpSelOp) Next(ctx context.Context) coldata.Batch {
+func (d *defaultCmpSelOp) Next() coldata.Batch {
 	for {
-		batch := d.Input.Next(ctx)
+		batch := d.Input.Next()
 		n := batch.Length()
 		if n == 0 {
 			return coldata.ZeroBatch
@@ -85,13 +79,9 @@ type defaultCmpConstSelOp struct {
 
 var _ colexecop.Operator = &defaultCmpConstSelOp{}
 
-func (d *defaultCmpConstSelOp) Init() {
-	d.Input.Init()
-}
-
-func (d *defaultCmpConstSelOp) Next(ctx context.Context) coldata.Batch {
+func (d *defaultCmpConstSelOp) Next() coldata.Batch {
 	for {
-		batch := d.Input.Next(ctx)
+		batch := d.Input.Next()
 		n := batch.Length()
 		if n == 0 {
 			return coldata.ZeroBatch

--- a/pkg/sql/colexec/colexecsel/default_cmp_sel_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecsel/default_cmp_sel_ops_tmpl.go
@@ -20,8 +20,6 @@
 package colexecsel
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexeccmp"
@@ -46,13 +44,9 @@ type defaultCmp_KINDSelOp struct {
 
 var _ colexecop.Operator = &defaultCmp_KINDSelOp{}
 
-func (d *defaultCmp_KINDSelOp) Init() {
-	d.Input.Init()
-}
-
-func (d *defaultCmp_KINDSelOp) Next(ctx context.Context) coldata.Batch {
+func (d *defaultCmp_KINDSelOp) Next() coldata.Batch {
 	for {
-		batch := d.Input.Next(ctx)
+		batch := d.Input.Next()
 		n := batch.Length()
 		if n == 0 {
 			return coldata.ZeroBatch

--- a/pkg/sql/colexec/colexecsel/like_ops.go
+++ b/pkg/sql/colexec/colexecsel/like_ops.go
@@ -29,8 +29,8 @@ func GetLikeOperator(
 	}
 	pat := []byte(pattern)
 	base := selConstOpBase{
-		OneInputNode: colexecop.NewOneInputNode(input),
-		colIdx:       colIdx,
+		OneInputHelper: colexecop.MakeOneInputHelper(input),
+		colIdx:         colIdx,
 	}
 	switch likeOpType {
 	case colexeccmp.LikeConstant:

--- a/pkg/sql/colexec/colexecsel/like_ops_test.go
+++ b/pkg/sql/colexec/colexecsel/like_ops_test.go
@@ -127,11 +127,11 @@ func BenchmarkLikeOps(b *testing.B) {
 
 	batch.SetLength(coldata.BatchSize())
 	source := colexecop.NewRepeatableBatchSource(testAllocator, batch, typs)
-	source.Init()
+	source.Init(ctx)
 
 	base := selConstOpBase{
-		OneInputNode: colexecop.NewOneInputNode(source),
-		colIdx:       0,
+		OneInputHelper: colexecop.MakeOneInputHelper(source),
+		colIdx:         0,
 	}
 	prefixOp := &selPrefixBytesBytesConstOp{
 		selConstOpBase: base,
@@ -162,10 +162,10 @@ func BenchmarkLikeOps(b *testing.B) {
 	}
 	for _, tc := range testCases {
 		b.Run(tc.name, func(b *testing.B) {
-			tc.op.Init()
+			tc.op.Init(ctx)
 			b.SetBytes(int64(width * coldata.BatchSize()))
 			for i := 0; i < b.N; i++ {
-				tc.op.Next(ctx)
+				tc.op.Next()
 			}
 		})
 	}

--- a/pkg/sql/colexec/colexecsel/sel_like_ops.eg.go
+++ b/pkg/sql/colexec/colexecsel/sel_like_ops.eg.go
@@ -12,7 +12,6 @@ package colexecsel
 
 import (
 	"bytes"
-	"context"
 	"regexp"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -23,7 +22,7 @@ type selPrefixBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p *selPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selPrefixBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -32,7 +31,7 @@ func (p *selPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -104,10 +103,6 @@ func (p *selPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selPrefixBytesBytesConstOp) Init() {
-	p.Input.Init()
 }
 
 type selSuffixBytesBytesConstOp struct {
@@ -115,7 +110,7 @@ type selSuffixBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p *selSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selSuffixBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -124,7 +119,7 @@ func (p *selSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -196,10 +191,6 @@ func (p *selSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selSuffixBytesBytesConstOp) Init() {
-	p.Input.Init()
 }
 
 type selContainsBytesBytesConstOp struct {
@@ -207,7 +198,7 @@ type selContainsBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p *selContainsBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selContainsBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -216,7 +207,7 @@ func (p *selContainsBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -288,10 +279,6 @@ func (p *selContainsBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selContainsBytesBytesConstOp) Init() {
-	p.Input.Init()
 }
 
 type selRegexpBytesBytesConstOp struct {
@@ -299,7 +286,7 @@ type selRegexpBytesBytesConstOp struct {
 	constArg *regexp.Regexp
 }
 
-func (p *selRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selRegexpBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -308,7 +295,7 @@ func (p *selRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -380,10 +367,6 @@ func (p *selRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selRegexpBytesBytesConstOp) Init() {
-	p.Input.Init()
 }
 
 type selNotPrefixBytesBytesConstOp struct {
@@ -391,7 +374,7 @@ type selNotPrefixBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p *selNotPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNotPrefixBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -400,7 +383,7 @@ func (p *selNotPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -472,10 +455,6 @@ func (p *selNotPrefixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 			return batch
 		}
 	}
-}
-
-func (p *selNotPrefixBytesBytesConstOp) Init() {
-	p.Input.Init()
 }
 
 type selNotSuffixBytesBytesConstOp struct {
@@ -483,7 +462,7 @@ type selNotSuffixBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p *selNotSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNotSuffixBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -492,7 +471,7 @@ func (p *selNotSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -564,10 +543,6 @@ func (p *selNotSuffixBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 			return batch
 		}
 	}
-}
-
-func (p *selNotSuffixBytesBytesConstOp) Init() {
-	p.Input.Init()
 }
 
 type selNotContainsBytesBytesConstOp struct {
@@ -575,7 +550,7 @@ type selNotContainsBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p *selNotContainsBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNotContainsBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -584,7 +559,7 @@ func (p *selNotContainsBytesBytesConstOp) Next(ctx context.Context) coldata.Batc
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -656,10 +631,6 @@ func (p *selNotContainsBytesBytesConstOp) Next(ctx context.Context) coldata.Batc
 			return batch
 		}
 	}
-}
-
-func (p *selNotContainsBytesBytesConstOp) Init() {
-	p.Input.Init()
 }
 
 type selNotRegexpBytesBytesConstOp struct {
@@ -667,7 +638,7 @@ type selNotRegexpBytesBytesConstOp struct {
 	constArg *regexp.Regexp
 }
 
-func (p *selNotRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNotRegexpBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -676,7 +647,7 @@ func (p *selNotRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -748,8 +719,4 @@ func (p *selNotRegexpBytesBytesConstOp) Next(ctx context.Context) coldata.Batch 
 			return batch
 		}
 	}
-}
-
-func (p *selNotRegexpBytesBytesConstOp) Init() {
-	p.Input.Init()
 }

--- a/pkg/sql/colexec/colexecsel/selection_ops.eg.go
+++ b/pkg/sql/colexec/colexecsel/selection_ops.eg.go
@@ -11,7 +11,6 @@ package colexecsel
 
 import (
 	"bytes"
-	"context"
 	"math"
 	"time"
 
@@ -42,14 +41,14 @@ var (
 // selConstOpBase contains all of the fields for binary selections with a
 // constant, except for the constant itself.
 type selConstOpBase struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	colIdx         int
 	overloadHelper execgen.OverloadHelper
 }
 
 // selOpBase contains all of the fields for non-constant binary selections.
 type selOpBase struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	col1Idx        int
 	col2Idx        int
 	overloadHelper execgen.OverloadHelper
@@ -60,7 +59,7 @@ type selEQBoolBoolConstOp struct {
 	constArg bool
 }
 
-func (p *selEQBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQBoolBoolConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -69,7 +68,7 @@ func (p *selEQBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -201,15 +200,11 @@ func (p *selEQBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQBoolBoolConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQBoolBoolOp struct {
 	selOpBase
 }
 
-func (p *selEQBoolBoolOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQBoolBoolOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -218,7 +213,7 @@ func (p *selEQBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -359,10 +354,6 @@ func (p *selEQBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQBoolBoolOp) Init() {
-	p.Input.Init()
 }
 
 type selEQBytesBytesConstOp struct {
@@ -370,7 +361,7 @@ type selEQBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p *selEQBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -379,7 +370,7 @@ func (p *selEQBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -477,15 +468,11 @@ func (p *selEQBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQBytesBytesConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQBytesBytesOp struct {
 	selOpBase
 }
 
-func (p *selEQBytesBytesOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQBytesBytesOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -494,7 +481,7 @@ func (p *selEQBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -599,10 +586,6 @@ func (p *selEQBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQBytesBytesOp) Init() {
-	p.Input.Init()
 }
 
 type selEQDecimalInt16ConstOp struct {
@@ -610,7 +593,7 @@ type selEQDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p *selEQDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQDecimalInt16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -619,7 +602,7 @@ func (p *selEQDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -743,15 +726,11 @@ func (p *selEQDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQDecimalInt16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQDecimalInt16Op struct {
 	selOpBase
 }
 
-func (p *selEQDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selEQDecimalInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -760,7 +739,7 @@ func (p *selEQDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -893,10 +872,6 @@ func (p *selEQDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQDecimalInt16Op) Init() {
-	p.Input.Init()
 }
 
 type selEQDecimalInt32ConstOp struct {
@@ -904,7 +879,7 @@ type selEQDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p *selEQDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQDecimalInt32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -913,7 +888,7 @@ func (p *selEQDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -1037,15 +1012,11 @@ func (p *selEQDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQDecimalInt32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQDecimalInt32Op struct {
 	selOpBase
 }
 
-func (p *selEQDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selEQDecimalInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -1054,7 +1025,7 @@ func (p *selEQDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -1187,10 +1158,6 @@ func (p *selEQDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQDecimalInt32Op) Init() {
-	p.Input.Init()
 }
 
 type selEQDecimalInt64ConstOp struct {
@@ -1198,7 +1165,7 @@ type selEQDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p *selEQDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQDecimalInt64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -1207,7 +1174,7 @@ func (p *selEQDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -1331,15 +1298,11 @@ func (p *selEQDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQDecimalInt64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQDecimalInt64Op struct {
 	selOpBase
 }
 
-func (p *selEQDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selEQDecimalInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -1348,7 +1311,7 @@ func (p *selEQDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -1481,10 +1444,6 @@ func (p *selEQDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQDecimalInt64Op) Init() {
-	p.Input.Init()
 }
 
 type selEQDecimalFloat64ConstOp struct {
@@ -1492,7 +1451,7 @@ type selEQDecimalFloat64ConstOp struct {
 	constArg float64
 }
 
-func (p *selEQDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQDecimalFloat64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -1501,7 +1460,7 @@ func (p *selEQDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -1633,15 +1592,11 @@ func (p *selEQDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQDecimalFloat64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQDecimalFloat64Op struct {
 	selOpBase
 }
 
-func (p *selEQDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selEQDecimalFloat64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -1650,7 +1605,7 @@ func (p *selEQDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -1791,10 +1746,6 @@ func (p *selEQDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQDecimalFloat64Op) Init() {
-	p.Input.Init()
 }
 
 type selEQDecimalDecimalConstOp struct {
@@ -1802,7 +1753,7 @@ type selEQDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selEQDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQDecimalDecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -1811,7 +1762,7 @@ func (p *selEQDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -1911,15 +1862,11 @@ func (p *selEQDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQDecimalDecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQDecimalDecimalOp struct {
 	selOpBase
 }
 
-func (p *selEQDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQDecimalDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -1928,7 +1875,7 @@ func (p *selEQDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -2037,10 +1984,6 @@ func (p *selEQDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQDecimalDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type selEQInt16Int16ConstOp struct {
@@ -2048,7 +1991,7 @@ type selEQInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selEQInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt16Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -2057,7 +2000,7 @@ func (p *selEQInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -2201,15 +2144,11 @@ func (p *selEQInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQInt16Int16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQInt16Int16Op struct {
 	selOpBase
 }
 
-func (p *selEQInt16Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt16Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -2218,7 +2157,7 @@ func (p *selEQInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -2371,10 +2310,6 @@ func (p *selEQInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQInt16Int16Op) Init() {
-	p.Input.Init()
 }
 
 type selEQInt16Int32ConstOp struct {
@@ -2382,7 +2317,7 @@ type selEQInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selEQInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt16Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -2391,7 +2326,7 @@ func (p *selEQInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -2535,15 +2470,11 @@ func (p *selEQInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQInt16Int32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQInt16Int32Op struct {
 	selOpBase
 }
 
-func (p *selEQInt16Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt16Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -2552,7 +2483,7 @@ func (p *selEQInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -2705,10 +2636,6 @@ func (p *selEQInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQInt16Int32Op) Init() {
-	p.Input.Init()
 }
 
 type selEQInt16Int64ConstOp struct {
@@ -2716,7 +2643,7 @@ type selEQInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selEQInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt16Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -2725,7 +2652,7 @@ func (p *selEQInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -2869,15 +2796,11 @@ func (p *selEQInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQInt16Int64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQInt16Int64Op struct {
 	selOpBase
 }
 
-func (p *selEQInt16Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt16Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -2886,7 +2809,7 @@ func (p *selEQInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -3039,10 +2962,6 @@ func (p *selEQInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQInt16Int64Op) Init() {
-	p.Input.Init()
 }
 
 type selEQInt16Float64ConstOp struct {
@@ -3050,7 +2969,7 @@ type selEQInt16Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selEQInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt16Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -3059,7 +2978,7 @@ func (p *selEQInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -3235,15 +3154,11 @@ func (p *selEQInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQInt16Float64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQInt16Float64Op struct {
 	selOpBase
 }
 
-func (p *selEQInt16Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt16Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -3252,7 +3167,7 @@ func (p *selEQInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -3437,10 +3352,6 @@ func (p *selEQInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQInt16Float64Op) Init() {
-	p.Input.Init()
 }
 
 type selEQInt16DecimalConstOp struct {
@@ -3448,7 +3359,7 @@ type selEQInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selEQInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt16DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -3457,7 +3368,7 @@ func (p *selEQInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -3581,15 +3492,11 @@ func (p *selEQInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQInt16DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQInt16DecimalOp struct {
 	selOpBase
 }
 
-func (p *selEQInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt16DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -3598,7 +3505,7 @@ func (p *selEQInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -3731,10 +3638,6 @@ func (p *selEQInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQInt16DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type selEQInt32Int16ConstOp struct {
@@ -3742,7 +3645,7 @@ type selEQInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selEQInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt32Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -3751,7 +3654,7 @@ func (p *selEQInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -3895,15 +3798,11 @@ func (p *selEQInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQInt32Int16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQInt32Int16Op struct {
 	selOpBase
 }
 
-func (p *selEQInt32Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt32Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -3912,7 +3811,7 @@ func (p *selEQInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -4065,10 +3964,6 @@ func (p *selEQInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQInt32Int16Op) Init() {
-	p.Input.Init()
 }
 
 type selEQInt32Int32ConstOp struct {
@@ -4076,7 +3971,7 @@ type selEQInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selEQInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt32Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -4085,7 +3980,7 @@ func (p *selEQInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -4229,15 +4124,11 @@ func (p *selEQInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQInt32Int32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQInt32Int32Op struct {
 	selOpBase
 }
 
-func (p *selEQInt32Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt32Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -4246,7 +4137,7 @@ func (p *selEQInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -4399,10 +4290,6 @@ func (p *selEQInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQInt32Int32Op) Init() {
-	p.Input.Init()
 }
 
 type selEQInt32Int64ConstOp struct {
@@ -4410,7 +4297,7 @@ type selEQInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selEQInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt32Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -4419,7 +4306,7 @@ func (p *selEQInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -4563,15 +4450,11 @@ func (p *selEQInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQInt32Int64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQInt32Int64Op struct {
 	selOpBase
 }
 
-func (p *selEQInt32Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt32Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -4580,7 +4463,7 @@ func (p *selEQInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -4733,10 +4616,6 @@ func (p *selEQInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQInt32Int64Op) Init() {
-	p.Input.Init()
 }
 
 type selEQInt32Float64ConstOp struct {
@@ -4744,7 +4623,7 @@ type selEQInt32Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selEQInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt32Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -4753,7 +4632,7 @@ func (p *selEQInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -4929,15 +4808,11 @@ func (p *selEQInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQInt32Float64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQInt32Float64Op struct {
 	selOpBase
 }
 
-func (p *selEQInt32Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt32Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -4946,7 +4821,7 @@ func (p *selEQInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -5131,10 +5006,6 @@ func (p *selEQInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQInt32Float64Op) Init() {
-	p.Input.Init()
 }
 
 type selEQInt32DecimalConstOp struct {
@@ -5142,7 +5013,7 @@ type selEQInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selEQInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt32DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -5151,7 +5022,7 @@ func (p *selEQInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -5275,15 +5146,11 @@ func (p *selEQInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQInt32DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQInt32DecimalOp struct {
 	selOpBase
 }
 
-func (p *selEQInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt32DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -5292,7 +5159,7 @@ func (p *selEQInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -5425,10 +5292,6 @@ func (p *selEQInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQInt32DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type selEQInt64Int16ConstOp struct {
@@ -5436,7 +5299,7 @@ type selEQInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selEQInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -5445,7 +5308,7 @@ func (p *selEQInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -5589,15 +5452,11 @@ func (p *selEQInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQInt64Int16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQInt64Int16Op struct {
 	selOpBase
 }
 
-func (p *selEQInt64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -5606,7 +5465,7 @@ func (p *selEQInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -5759,10 +5618,6 @@ func (p *selEQInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQInt64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type selEQInt64Int32ConstOp struct {
@@ -5770,7 +5625,7 @@ type selEQInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selEQInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -5779,7 +5634,7 @@ func (p *selEQInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -5923,15 +5778,11 @@ func (p *selEQInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQInt64Int32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQInt64Int32Op struct {
 	selOpBase
 }
 
-func (p *selEQInt64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -5940,7 +5791,7 @@ func (p *selEQInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -6093,10 +5944,6 @@ func (p *selEQInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQInt64Int32Op) Init() {
-	p.Input.Init()
 }
 
 type selEQInt64Int64ConstOp struct {
@@ -6104,7 +5951,7 @@ type selEQInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selEQInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -6113,7 +5960,7 @@ func (p *selEQInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -6257,15 +6104,11 @@ func (p *selEQInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQInt64Int64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQInt64Int64Op struct {
 	selOpBase
 }
 
-func (p *selEQInt64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -6274,7 +6117,7 @@ func (p *selEQInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -6427,10 +6270,6 @@ func (p *selEQInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQInt64Int64Op) Init() {
-	p.Input.Init()
 }
 
 type selEQInt64Float64ConstOp struct {
@@ -6438,7 +6277,7 @@ type selEQInt64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selEQInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -6447,7 +6286,7 @@ func (p *selEQInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -6623,15 +6462,11 @@ func (p *selEQInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQInt64Float64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQInt64Float64Op struct {
 	selOpBase
 }
 
-func (p *selEQInt64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -6640,7 +6475,7 @@ func (p *selEQInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -6825,10 +6660,6 @@ func (p *selEQInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQInt64Float64Op) Init() {
-	p.Input.Init()
 }
 
 type selEQInt64DecimalConstOp struct {
@@ -6836,7 +6667,7 @@ type selEQInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selEQInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -6845,7 +6676,7 @@ func (p *selEQInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -6969,15 +6800,11 @@ func (p *selEQInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQInt64DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQInt64DecimalOp struct {
 	selOpBase
 }
 
-func (p *selEQInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQInt64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -6986,7 +6813,7 @@ func (p *selEQInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -7119,10 +6946,6 @@ func (p *selEQInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQInt64DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type selEQFloat64Int16ConstOp struct {
@@ -7130,7 +6953,7 @@ type selEQFloat64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selEQFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQFloat64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -7139,7 +6962,7 @@ func (p *selEQFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -7315,15 +7138,11 @@ func (p *selEQFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQFloat64Int16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQFloat64Int16Op struct {
 	selOpBase
 }
 
-func (p *selEQFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selEQFloat64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -7332,7 +7151,7 @@ func (p *selEQFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -7517,10 +7336,6 @@ func (p *selEQFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQFloat64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type selEQFloat64Int32ConstOp struct {
@@ -7528,7 +7343,7 @@ type selEQFloat64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selEQFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQFloat64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -7537,7 +7352,7 @@ func (p *selEQFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -7713,15 +7528,11 @@ func (p *selEQFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQFloat64Int32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQFloat64Int32Op struct {
 	selOpBase
 }
 
-func (p *selEQFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selEQFloat64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -7730,7 +7541,7 @@ func (p *selEQFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -7915,10 +7726,6 @@ func (p *selEQFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQFloat64Int32Op) Init() {
-	p.Input.Init()
 }
 
 type selEQFloat64Int64ConstOp struct {
@@ -7926,7 +7733,7 @@ type selEQFloat64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selEQFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQFloat64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -7935,7 +7742,7 @@ func (p *selEQFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -8111,15 +7918,11 @@ func (p *selEQFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQFloat64Int64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQFloat64Int64Op struct {
 	selOpBase
 }
 
-func (p *selEQFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selEQFloat64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -8128,7 +7931,7 @@ func (p *selEQFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -8313,10 +8116,6 @@ func (p *selEQFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQFloat64Int64Op) Init() {
-	p.Input.Init()
 }
 
 type selEQFloat64Float64ConstOp struct {
@@ -8324,7 +8123,7 @@ type selEQFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selEQFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQFloat64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -8333,7 +8132,7 @@ func (p *selEQFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -8509,15 +8308,11 @@ func (p *selEQFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQFloat64Float64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQFloat64Float64Op struct {
 	selOpBase
 }
 
-func (p *selEQFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selEQFloat64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -8526,7 +8321,7 @@ func (p *selEQFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -8711,10 +8506,6 @@ func (p *selEQFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQFloat64Float64Op) Init() {
-	p.Input.Init()
 }
 
 type selEQFloat64DecimalConstOp struct {
@@ -8722,7 +8513,7 @@ type selEQFloat64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selEQFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQFloat64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -8731,7 +8522,7 @@ func (p *selEQFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -8863,15 +8654,11 @@ func (p *selEQFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQFloat64DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQFloat64DecimalOp struct {
 	selOpBase
 }
 
-func (p *selEQFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQFloat64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -8880,7 +8667,7 @@ func (p *selEQFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -9021,10 +8808,6 @@ func (p *selEQFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQFloat64DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type selEQTimestampTimestampConstOp struct {
@@ -9032,7 +8815,7 @@ type selEQTimestampTimestampConstOp struct {
 	constArg time.Time
 }
 
-func (p *selEQTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQTimestampTimestampConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -9041,7 +8824,7 @@ func (p *selEQTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -9169,15 +8952,11 @@ func (p *selEQTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 	}
 }
 
-func (p *selEQTimestampTimestampConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQTimestampTimestampOp struct {
 	selOpBase
 }
 
-func (p *selEQTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQTimestampTimestampOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -9186,7 +8965,7 @@ func (p *selEQTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -9323,10 +9102,6 @@ func (p *selEQTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQTimestampTimestampOp) Init() {
-	p.Input.Init()
 }
 
 type selEQIntervalIntervalConstOp struct {
@@ -9334,7 +9109,7 @@ type selEQIntervalIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p *selEQIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQIntervalIntervalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -9343,7 +9118,7 @@ func (p *selEQIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -9443,15 +9218,11 @@ func (p *selEQIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQIntervalIntervalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQIntervalIntervalOp struct {
 	selOpBase
 }
 
-func (p *selEQIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQIntervalIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -9460,7 +9231,7 @@ func (p *selEQIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -9569,10 +9340,6 @@ func (p *selEQIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQIntervalIntervalOp) Init() {
-	p.Input.Init()
 }
 
 type selEQJSONJSONConstOp struct {
@@ -9580,7 +9347,7 @@ type selEQJSONJSONConstOp struct {
 	constArg json.JSON
 }
 
-func (p *selEQJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQJSONJSONConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -9589,7 +9356,7 @@ func (p *selEQJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -9711,15 +9478,11 @@ func (p *selEQJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQJSONJSONConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQJSONJSONOp struct {
 	selOpBase
 }
 
-func (p *selEQJSONJSONOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQJSONJSONOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -9728,7 +9491,7 @@ func (p *selEQJSONJSONOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -9857,10 +9620,6 @@ func (p *selEQJSONJSONOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQJSONJSONOp) Init() {
-	p.Input.Init()
 }
 
 type selEQDatumDatumConstOp struct {
@@ -9868,7 +9627,7 @@ type selEQDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p *selEQDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQDatumDatumConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -9877,7 +9636,7 @@ func (p *selEQDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -9983,15 +9742,11 @@ func (p *selEQDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selEQDatumDatumConstOp) Init() {
-	p.Input.Init()
-}
-
 type selEQDatumDatumOp struct {
 	selOpBase
 }
 
-func (p *selEQDatumDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p *selEQDatumDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -10000,7 +9755,7 @@ func (p *selEQDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -10113,10 +9868,6 @@ func (p *selEQDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selEQDatumDatumOp) Init() {
-	p.Input.Init()
 }
 
 type selNEBoolBoolConstOp struct {
@@ -10124,7 +9875,7 @@ type selNEBoolBoolConstOp struct {
 	constArg bool
 }
 
-func (p *selNEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEBoolBoolConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -10133,7 +9884,7 @@ func (p *selNEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -10265,15 +10016,11 @@ func (p *selNEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEBoolBoolConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEBoolBoolOp struct {
 	selOpBase
 }
 
-func (p *selNEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEBoolBoolOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -10282,7 +10029,7 @@ func (p *selNEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -10423,10 +10170,6 @@ func (p *selNEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEBoolBoolOp) Init() {
-	p.Input.Init()
 }
 
 type selNEBytesBytesConstOp struct {
@@ -10434,7 +10177,7 @@ type selNEBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p *selNEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -10443,7 +10186,7 @@ func (p *selNEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -10541,15 +10284,11 @@ func (p *selNEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEBytesBytesConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEBytesBytesOp struct {
 	selOpBase
 }
 
-func (p *selNEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEBytesBytesOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -10558,7 +10297,7 @@ func (p *selNEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -10663,10 +10402,6 @@ func (p *selNEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEBytesBytesOp) Init() {
-	p.Input.Init()
 }
 
 type selNEDecimalInt16ConstOp struct {
@@ -10674,7 +10409,7 @@ type selNEDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p *selNEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEDecimalInt16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -10683,7 +10418,7 @@ func (p *selNEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -10807,15 +10542,11 @@ func (p *selNEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEDecimalInt16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEDecimalInt16Op struct {
 	selOpBase
 }
 
-func (p *selNEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selNEDecimalInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -10824,7 +10555,7 @@ func (p *selNEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -10957,10 +10688,6 @@ func (p *selNEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEDecimalInt16Op) Init() {
-	p.Input.Init()
 }
 
 type selNEDecimalInt32ConstOp struct {
@@ -10968,7 +10695,7 @@ type selNEDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p *selNEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEDecimalInt32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -10977,7 +10704,7 @@ func (p *selNEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -11101,15 +10828,11 @@ func (p *selNEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEDecimalInt32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEDecimalInt32Op struct {
 	selOpBase
 }
 
-func (p *selNEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selNEDecimalInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -11118,7 +10841,7 @@ func (p *selNEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -11251,10 +10974,6 @@ func (p *selNEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEDecimalInt32Op) Init() {
-	p.Input.Init()
 }
 
 type selNEDecimalInt64ConstOp struct {
@@ -11262,7 +10981,7 @@ type selNEDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p *selNEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEDecimalInt64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -11271,7 +10990,7 @@ func (p *selNEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -11395,15 +11114,11 @@ func (p *selNEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEDecimalInt64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEDecimalInt64Op struct {
 	selOpBase
 }
 
-func (p *selNEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selNEDecimalInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -11412,7 +11127,7 @@ func (p *selNEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -11545,10 +11260,6 @@ func (p *selNEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEDecimalInt64Op) Init() {
-	p.Input.Init()
 }
 
 type selNEDecimalFloat64ConstOp struct {
@@ -11556,7 +11267,7 @@ type selNEDecimalFloat64ConstOp struct {
 	constArg float64
 }
 
-func (p *selNEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEDecimalFloat64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -11565,7 +11276,7 @@ func (p *selNEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -11697,15 +11408,11 @@ func (p *selNEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEDecimalFloat64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEDecimalFloat64Op struct {
 	selOpBase
 }
 
-func (p *selNEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selNEDecimalFloat64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -11714,7 +11421,7 @@ func (p *selNEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -11855,10 +11562,6 @@ func (p *selNEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEDecimalFloat64Op) Init() {
-	p.Input.Init()
 }
 
 type selNEDecimalDecimalConstOp struct {
@@ -11866,7 +11569,7 @@ type selNEDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selNEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEDecimalDecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -11875,7 +11578,7 @@ func (p *selNEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -11975,15 +11678,11 @@ func (p *selNEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEDecimalDecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEDecimalDecimalOp struct {
 	selOpBase
 }
 
-func (p *selNEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEDecimalDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -11992,7 +11691,7 @@ func (p *selNEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -12101,10 +11800,6 @@ func (p *selNEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEDecimalDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type selNEInt16Int16ConstOp struct {
@@ -12112,7 +11807,7 @@ type selNEInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selNEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt16Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -12121,7 +11816,7 @@ func (p *selNEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -12265,15 +11960,11 @@ func (p *selNEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEInt16Int16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEInt16Int16Op struct {
 	selOpBase
 }
 
-func (p *selNEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt16Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -12282,7 +11973,7 @@ func (p *selNEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -12435,10 +12126,6 @@ func (p *selNEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEInt16Int16Op) Init() {
-	p.Input.Init()
 }
 
 type selNEInt16Int32ConstOp struct {
@@ -12446,7 +12133,7 @@ type selNEInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selNEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt16Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -12455,7 +12142,7 @@ func (p *selNEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -12599,15 +12286,11 @@ func (p *selNEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEInt16Int32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEInt16Int32Op struct {
 	selOpBase
 }
 
-func (p *selNEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt16Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -12616,7 +12299,7 @@ func (p *selNEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -12769,10 +12452,6 @@ func (p *selNEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEInt16Int32Op) Init() {
-	p.Input.Init()
 }
 
 type selNEInt16Int64ConstOp struct {
@@ -12780,7 +12459,7 @@ type selNEInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selNEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt16Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -12789,7 +12468,7 @@ func (p *selNEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -12933,15 +12612,11 @@ func (p *selNEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEInt16Int64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEInt16Int64Op struct {
 	selOpBase
 }
 
-func (p *selNEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt16Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -12950,7 +12625,7 @@ func (p *selNEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -13103,10 +12778,6 @@ func (p *selNEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEInt16Int64Op) Init() {
-	p.Input.Init()
 }
 
 type selNEInt16Float64ConstOp struct {
@@ -13114,7 +12785,7 @@ type selNEInt16Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selNEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt16Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -13123,7 +12794,7 @@ func (p *selNEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -13299,15 +12970,11 @@ func (p *selNEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEInt16Float64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEInt16Float64Op struct {
 	selOpBase
 }
 
-func (p *selNEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt16Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -13316,7 +12983,7 @@ func (p *selNEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -13501,10 +13168,6 @@ func (p *selNEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEInt16Float64Op) Init() {
-	p.Input.Init()
 }
 
 type selNEInt16DecimalConstOp struct {
@@ -13512,7 +13175,7 @@ type selNEInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selNEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt16DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -13521,7 +13184,7 @@ func (p *selNEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -13645,15 +13308,11 @@ func (p *selNEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEInt16DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEInt16DecimalOp struct {
 	selOpBase
 }
 
-func (p *selNEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt16DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -13662,7 +13321,7 @@ func (p *selNEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -13795,10 +13454,6 @@ func (p *selNEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEInt16DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type selNEInt32Int16ConstOp struct {
@@ -13806,7 +13461,7 @@ type selNEInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selNEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt32Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -13815,7 +13470,7 @@ func (p *selNEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -13959,15 +13614,11 @@ func (p *selNEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEInt32Int16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEInt32Int16Op struct {
 	selOpBase
 }
 
-func (p *selNEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt32Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -13976,7 +13627,7 @@ func (p *selNEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -14129,10 +13780,6 @@ func (p *selNEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEInt32Int16Op) Init() {
-	p.Input.Init()
 }
 
 type selNEInt32Int32ConstOp struct {
@@ -14140,7 +13787,7 @@ type selNEInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selNEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt32Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -14149,7 +13796,7 @@ func (p *selNEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -14293,15 +13940,11 @@ func (p *selNEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEInt32Int32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEInt32Int32Op struct {
 	selOpBase
 }
 
-func (p *selNEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt32Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -14310,7 +13953,7 @@ func (p *selNEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -14463,10 +14106,6 @@ func (p *selNEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEInt32Int32Op) Init() {
-	p.Input.Init()
 }
 
 type selNEInt32Int64ConstOp struct {
@@ -14474,7 +14113,7 @@ type selNEInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selNEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt32Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -14483,7 +14122,7 @@ func (p *selNEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -14627,15 +14266,11 @@ func (p *selNEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEInt32Int64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEInt32Int64Op struct {
 	selOpBase
 }
 
-func (p *selNEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt32Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -14644,7 +14279,7 @@ func (p *selNEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -14797,10 +14432,6 @@ func (p *selNEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEInt32Int64Op) Init() {
-	p.Input.Init()
 }
 
 type selNEInt32Float64ConstOp struct {
@@ -14808,7 +14439,7 @@ type selNEInt32Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selNEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt32Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -14817,7 +14448,7 @@ func (p *selNEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -14993,15 +14624,11 @@ func (p *selNEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEInt32Float64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEInt32Float64Op struct {
 	selOpBase
 }
 
-func (p *selNEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt32Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -15010,7 +14637,7 @@ func (p *selNEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -15195,10 +14822,6 @@ func (p *selNEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEInt32Float64Op) Init() {
-	p.Input.Init()
 }
 
 type selNEInt32DecimalConstOp struct {
@@ -15206,7 +14829,7 @@ type selNEInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selNEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt32DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -15215,7 +14838,7 @@ func (p *selNEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -15339,15 +14962,11 @@ func (p *selNEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEInt32DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEInt32DecimalOp struct {
 	selOpBase
 }
 
-func (p *selNEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt32DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -15356,7 +14975,7 @@ func (p *selNEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -15489,10 +15108,6 @@ func (p *selNEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEInt32DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type selNEInt64Int16ConstOp struct {
@@ -15500,7 +15115,7 @@ type selNEInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selNEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -15509,7 +15124,7 @@ func (p *selNEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -15653,15 +15268,11 @@ func (p *selNEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEInt64Int16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEInt64Int16Op struct {
 	selOpBase
 }
 
-func (p *selNEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -15670,7 +15281,7 @@ func (p *selNEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -15823,10 +15434,6 @@ func (p *selNEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEInt64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type selNEInt64Int32ConstOp struct {
@@ -15834,7 +15441,7 @@ type selNEInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selNEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -15843,7 +15450,7 @@ func (p *selNEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -15987,15 +15594,11 @@ func (p *selNEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEInt64Int32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEInt64Int32Op struct {
 	selOpBase
 }
 
-func (p *selNEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -16004,7 +15607,7 @@ func (p *selNEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -16157,10 +15760,6 @@ func (p *selNEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEInt64Int32Op) Init() {
-	p.Input.Init()
 }
 
 type selNEInt64Int64ConstOp struct {
@@ -16168,7 +15767,7 @@ type selNEInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selNEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -16177,7 +15776,7 @@ func (p *selNEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -16321,15 +15920,11 @@ func (p *selNEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEInt64Int64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEInt64Int64Op struct {
 	selOpBase
 }
 
-func (p *selNEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -16338,7 +15933,7 @@ func (p *selNEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -16491,10 +16086,6 @@ func (p *selNEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEInt64Int64Op) Init() {
-	p.Input.Init()
 }
 
 type selNEInt64Float64ConstOp struct {
@@ -16502,7 +16093,7 @@ type selNEInt64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selNEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -16511,7 +16102,7 @@ func (p *selNEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -16687,15 +16278,11 @@ func (p *selNEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEInt64Float64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEInt64Float64Op struct {
 	selOpBase
 }
 
-func (p *selNEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -16704,7 +16291,7 @@ func (p *selNEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -16889,10 +16476,6 @@ func (p *selNEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEInt64Float64Op) Init() {
-	p.Input.Init()
 }
 
 type selNEInt64DecimalConstOp struct {
@@ -16900,7 +16483,7 @@ type selNEInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selNEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -16909,7 +16492,7 @@ func (p *selNEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -17033,15 +16616,11 @@ func (p *selNEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEInt64DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEInt64DecimalOp struct {
 	selOpBase
 }
 
-func (p *selNEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEInt64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -17050,7 +16629,7 @@ func (p *selNEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -17183,10 +16762,6 @@ func (p *selNEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEInt64DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type selNEFloat64Int16ConstOp struct {
@@ -17194,7 +16769,7 @@ type selNEFloat64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selNEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEFloat64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -17203,7 +16778,7 @@ func (p *selNEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -17379,15 +16954,11 @@ func (p *selNEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEFloat64Int16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEFloat64Int16Op struct {
 	selOpBase
 }
 
-func (p *selNEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selNEFloat64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -17396,7 +16967,7 @@ func (p *selNEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -17581,10 +17152,6 @@ func (p *selNEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEFloat64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type selNEFloat64Int32ConstOp struct {
@@ -17592,7 +17159,7 @@ type selNEFloat64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selNEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEFloat64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -17601,7 +17168,7 @@ func (p *selNEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -17777,15 +17344,11 @@ func (p *selNEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEFloat64Int32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEFloat64Int32Op struct {
 	selOpBase
 }
 
-func (p *selNEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selNEFloat64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -17794,7 +17357,7 @@ func (p *selNEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -17979,10 +17542,6 @@ func (p *selNEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEFloat64Int32Op) Init() {
-	p.Input.Init()
 }
 
 type selNEFloat64Int64ConstOp struct {
@@ -17990,7 +17549,7 @@ type selNEFloat64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selNEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEFloat64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -17999,7 +17558,7 @@ func (p *selNEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -18175,15 +17734,11 @@ func (p *selNEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEFloat64Int64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEFloat64Int64Op struct {
 	selOpBase
 }
 
-func (p *selNEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selNEFloat64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -18192,7 +17747,7 @@ func (p *selNEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -18377,10 +17932,6 @@ func (p *selNEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEFloat64Int64Op) Init() {
-	p.Input.Init()
 }
 
 type selNEFloat64Float64ConstOp struct {
@@ -18388,7 +17939,7 @@ type selNEFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selNEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEFloat64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -18397,7 +17948,7 @@ func (p *selNEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -18573,15 +18124,11 @@ func (p *selNEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEFloat64Float64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEFloat64Float64Op struct {
 	selOpBase
 }
 
-func (p *selNEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selNEFloat64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -18590,7 +18137,7 @@ func (p *selNEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -18775,10 +18322,6 @@ func (p *selNEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEFloat64Float64Op) Init() {
-	p.Input.Init()
 }
 
 type selNEFloat64DecimalConstOp struct {
@@ -18786,7 +18329,7 @@ type selNEFloat64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selNEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEFloat64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -18795,7 +18338,7 @@ func (p *selNEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -18927,15 +18470,11 @@ func (p *selNEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEFloat64DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEFloat64DecimalOp struct {
 	selOpBase
 }
 
-func (p *selNEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEFloat64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -18944,7 +18483,7 @@ func (p *selNEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -19085,10 +18624,6 @@ func (p *selNEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEFloat64DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type selNETimestampTimestampConstOp struct {
@@ -19096,7 +18631,7 @@ type selNETimestampTimestampConstOp struct {
 	constArg time.Time
 }
 
-func (p *selNETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNETimestampTimestampConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -19105,7 +18640,7 @@ func (p *selNETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -19233,15 +18768,11 @@ func (p *selNETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 	}
 }
 
-func (p *selNETimestampTimestampConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNETimestampTimestampOp struct {
 	selOpBase
 }
 
-func (p *selNETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNETimestampTimestampOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -19250,7 +18781,7 @@ func (p *selNETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -19387,10 +18918,6 @@ func (p *selNETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNETimestampTimestampOp) Init() {
-	p.Input.Init()
 }
 
 type selNEIntervalIntervalConstOp struct {
@@ -19398,7 +18925,7 @@ type selNEIntervalIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p *selNEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEIntervalIntervalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -19407,7 +18934,7 @@ func (p *selNEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -19507,15 +19034,11 @@ func (p *selNEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEIntervalIntervalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEIntervalIntervalOp struct {
 	selOpBase
 }
 
-func (p *selNEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEIntervalIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -19524,7 +19047,7 @@ func (p *selNEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -19633,10 +19156,6 @@ func (p *selNEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEIntervalIntervalOp) Init() {
-	p.Input.Init()
 }
 
 type selNEJSONJSONConstOp struct {
@@ -19644,7 +19163,7 @@ type selNEJSONJSONConstOp struct {
 	constArg json.JSON
 }
 
-func (p *selNEJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEJSONJSONConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -19653,7 +19172,7 @@ func (p *selNEJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -19775,15 +19294,11 @@ func (p *selNEJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEJSONJSONConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEJSONJSONOp struct {
 	selOpBase
 }
 
-func (p *selNEJSONJSONOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEJSONJSONOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -19792,7 +19307,7 @@ func (p *selNEJSONJSONOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -19921,10 +19436,6 @@ func (p *selNEJSONJSONOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEJSONJSONOp) Init() {
-	p.Input.Init()
 }
 
 type selNEDatumDatumConstOp struct {
@@ -19932,7 +19443,7 @@ type selNEDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p *selNEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEDatumDatumConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -19941,7 +19452,7 @@ func (p *selNEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -20047,15 +19558,11 @@ func (p *selNEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selNEDatumDatumConstOp) Init() {
-	p.Input.Init()
-}
-
 type selNEDatumDatumOp struct {
 	selOpBase
 }
 
-func (p *selNEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p *selNEDatumDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -20064,7 +19571,7 @@ func (p *selNEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -20177,10 +19684,6 @@ func (p *selNEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selNEDatumDatumOp) Init() {
-	p.Input.Init()
 }
 
 type selLTBoolBoolConstOp struct {
@@ -20188,7 +19691,7 @@ type selLTBoolBoolConstOp struct {
 	constArg bool
 }
 
-func (p *selLTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTBoolBoolConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -20197,7 +19700,7 @@ func (p *selLTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -20329,15 +19832,11 @@ func (p *selLTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTBoolBoolConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTBoolBoolOp struct {
 	selOpBase
 }
 
-func (p *selLTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTBoolBoolOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -20346,7 +19845,7 @@ func (p *selLTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -20487,10 +19986,6 @@ func (p *selLTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTBoolBoolOp) Init() {
-	p.Input.Init()
 }
 
 type selLTBytesBytesConstOp struct {
@@ -20498,7 +19993,7 @@ type selLTBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p *selLTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -20507,7 +20002,7 @@ func (p *selLTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -20605,15 +20100,11 @@ func (p *selLTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTBytesBytesConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTBytesBytesOp struct {
 	selOpBase
 }
 
-func (p *selLTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTBytesBytesOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -20622,7 +20113,7 @@ func (p *selLTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -20727,10 +20218,6 @@ func (p *selLTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTBytesBytesOp) Init() {
-	p.Input.Init()
 }
 
 type selLTDecimalInt16ConstOp struct {
@@ -20738,7 +20225,7 @@ type selLTDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p *selLTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTDecimalInt16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -20747,7 +20234,7 @@ func (p *selLTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -20871,15 +20358,11 @@ func (p *selLTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTDecimalInt16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTDecimalInt16Op struct {
 	selOpBase
 }
 
-func (p *selLTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLTDecimalInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -20888,7 +20371,7 @@ func (p *selLTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -21021,10 +20504,6 @@ func (p *selLTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTDecimalInt16Op) Init() {
-	p.Input.Init()
 }
 
 type selLTDecimalInt32ConstOp struct {
@@ -21032,7 +20511,7 @@ type selLTDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p *selLTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTDecimalInt32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -21041,7 +20520,7 @@ func (p *selLTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -21165,15 +20644,11 @@ func (p *selLTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTDecimalInt32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTDecimalInt32Op struct {
 	selOpBase
 }
 
-func (p *selLTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLTDecimalInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -21182,7 +20657,7 @@ func (p *selLTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -21315,10 +20790,6 @@ func (p *selLTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTDecimalInt32Op) Init() {
-	p.Input.Init()
 }
 
 type selLTDecimalInt64ConstOp struct {
@@ -21326,7 +20797,7 @@ type selLTDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p *selLTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTDecimalInt64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -21335,7 +20806,7 @@ func (p *selLTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -21459,15 +20930,11 @@ func (p *selLTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTDecimalInt64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTDecimalInt64Op struct {
 	selOpBase
 }
 
-func (p *selLTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLTDecimalInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -21476,7 +20943,7 @@ func (p *selLTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -21609,10 +21076,6 @@ func (p *selLTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTDecimalInt64Op) Init() {
-	p.Input.Init()
 }
 
 type selLTDecimalFloat64ConstOp struct {
@@ -21620,7 +21083,7 @@ type selLTDecimalFloat64ConstOp struct {
 	constArg float64
 }
 
-func (p *selLTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTDecimalFloat64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -21629,7 +21092,7 @@ func (p *selLTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -21761,15 +21224,11 @@ func (p *selLTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTDecimalFloat64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTDecimalFloat64Op struct {
 	selOpBase
 }
 
-func (p *selLTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLTDecimalFloat64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -21778,7 +21237,7 @@ func (p *selLTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -21919,10 +21378,6 @@ func (p *selLTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTDecimalFloat64Op) Init() {
-	p.Input.Init()
 }
 
 type selLTDecimalDecimalConstOp struct {
@@ -21930,7 +21385,7 @@ type selLTDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selLTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTDecimalDecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -21939,7 +21394,7 @@ func (p *selLTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -22039,15 +21494,11 @@ func (p *selLTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTDecimalDecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTDecimalDecimalOp struct {
 	selOpBase
 }
 
-func (p *selLTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTDecimalDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -22056,7 +21507,7 @@ func (p *selLTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -22165,10 +21616,6 @@ func (p *selLTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTDecimalDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type selLTInt16Int16ConstOp struct {
@@ -22176,7 +21623,7 @@ type selLTInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selLTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt16Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -22185,7 +21632,7 @@ func (p *selLTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -22329,15 +21776,11 @@ func (p *selLTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTInt16Int16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTInt16Int16Op struct {
 	selOpBase
 }
 
-func (p *selLTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt16Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -22346,7 +21789,7 @@ func (p *selLTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -22499,10 +21942,6 @@ func (p *selLTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTInt16Int16Op) Init() {
-	p.Input.Init()
 }
 
 type selLTInt16Int32ConstOp struct {
@@ -22510,7 +21949,7 @@ type selLTInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selLTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt16Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -22519,7 +21958,7 @@ func (p *selLTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -22663,15 +22102,11 @@ func (p *selLTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTInt16Int32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTInt16Int32Op struct {
 	selOpBase
 }
 
-func (p *selLTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt16Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -22680,7 +22115,7 @@ func (p *selLTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -22833,10 +22268,6 @@ func (p *selLTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTInt16Int32Op) Init() {
-	p.Input.Init()
 }
 
 type selLTInt16Int64ConstOp struct {
@@ -22844,7 +22275,7 @@ type selLTInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selLTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt16Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -22853,7 +22284,7 @@ func (p *selLTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -22997,15 +22428,11 @@ func (p *selLTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTInt16Int64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTInt16Int64Op struct {
 	selOpBase
 }
 
-func (p *selLTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt16Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -23014,7 +22441,7 @@ func (p *selLTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -23167,10 +22594,6 @@ func (p *selLTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTInt16Int64Op) Init() {
-	p.Input.Init()
 }
 
 type selLTInt16Float64ConstOp struct {
@@ -23178,7 +22601,7 @@ type selLTInt16Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selLTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt16Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -23187,7 +22610,7 @@ func (p *selLTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -23363,15 +22786,11 @@ func (p *selLTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTInt16Float64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTInt16Float64Op struct {
 	selOpBase
 }
 
-func (p *selLTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt16Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -23380,7 +22799,7 @@ func (p *selLTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -23565,10 +22984,6 @@ func (p *selLTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTInt16Float64Op) Init() {
-	p.Input.Init()
 }
 
 type selLTInt16DecimalConstOp struct {
@@ -23576,7 +22991,7 @@ type selLTInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selLTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt16DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -23585,7 +23000,7 @@ func (p *selLTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -23709,15 +23124,11 @@ func (p *selLTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTInt16DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTInt16DecimalOp struct {
 	selOpBase
 }
 
-func (p *selLTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt16DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -23726,7 +23137,7 @@ func (p *selLTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -23859,10 +23270,6 @@ func (p *selLTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTInt16DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type selLTInt32Int16ConstOp struct {
@@ -23870,7 +23277,7 @@ type selLTInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selLTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt32Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -23879,7 +23286,7 @@ func (p *selLTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -24023,15 +23430,11 @@ func (p *selLTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTInt32Int16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTInt32Int16Op struct {
 	selOpBase
 }
 
-func (p *selLTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt32Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -24040,7 +23443,7 @@ func (p *selLTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -24193,10 +23596,6 @@ func (p *selLTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTInt32Int16Op) Init() {
-	p.Input.Init()
 }
 
 type selLTInt32Int32ConstOp struct {
@@ -24204,7 +23603,7 @@ type selLTInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selLTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt32Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -24213,7 +23612,7 @@ func (p *selLTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -24357,15 +23756,11 @@ func (p *selLTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTInt32Int32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTInt32Int32Op struct {
 	selOpBase
 }
 
-func (p *selLTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt32Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -24374,7 +23769,7 @@ func (p *selLTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -24527,10 +23922,6 @@ func (p *selLTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTInt32Int32Op) Init() {
-	p.Input.Init()
 }
 
 type selLTInt32Int64ConstOp struct {
@@ -24538,7 +23929,7 @@ type selLTInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selLTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt32Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -24547,7 +23938,7 @@ func (p *selLTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -24691,15 +24082,11 @@ func (p *selLTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTInt32Int64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTInt32Int64Op struct {
 	selOpBase
 }
 
-func (p *selLTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt32Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -24708,7 +24095,7 @@ func (p *selLTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -24861,10 +24248,6 @@ func (p *selLTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTInt32Int64Op) Init() {
-	p.Input.Init()
 }
 
 type selLTInt32Float64ConstOp struct {
@@ -24872,7 +24255,7 @@ type selLTInt32Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selLTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt32Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -24881,7 +24264,7 @@ func (p *selLTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -25057,15 +24440,11 @@ func (p *selLTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTInt32Float64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTInt32Float64Op struct {
 	selOpBase
 }
 
-func (p *selLTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt32Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -25074,7 +24453,7 @@ func (p *selLTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -25259,10 +24638,6 @@ func (p *selLTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTInt32Float64Op) Init() {
-	p.Input.Init()
 }
 
 type selLTInt32DecimalConstOp struct {
@@ -25270,7 +24645,7 @@ type selLTInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selLTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt32DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -25279,7 +24654,7 @@ func (p *selLTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -25403,15 +24778,11 @@ func (p *selLTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTInt32DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTInt32DecimalOp struct {
 	selOpBase
 }
 
-func (p *selLTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt32DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -25420,7 +24791,7 @@ func (p *selLTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -25553,10 +24924,6 @@ func (p *selLTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTInt32DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type selLTInt64Int16ConstOp struct {
@@ -25564,7 +24931,7 @@ type selLTInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selLTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -25573,7 +24940,7 @@ func (p *selLTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -25717,15 +25084,11 @@ func (p *selLTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTInt64Int16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTInt64Int16Op struct {
 	selOpBase
 }
 
-func (p *selLTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -25734,7 +25097,7 @@ func (p *selLTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -25887,10 +25250,6 @@ func (p *selLTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTInt64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type selLTInt64Int32ConstOp struct {
@@ -25898,7 +25257,7 @@ type selLTInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selLTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -25907,7 +25266,7 @@ func (p *selLTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -26051,15 +25410,11 @@ func (p *selLTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTInt64Int32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTInt64Int32Op struct {
 	selOpBase
 }
 
-func (p *selLTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -26068,7 +25423,7 @@ func (p *selLTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -26221,10 +25576,6 @@ func (p *selLTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTInt64Int32Op) Init() {
-	p.Input.Init()
 }
 
 type selLTInt64Int64ConstOp struct {
@@ -26232,7 +25583,7 @@ type selLTInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selLTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -26241,7 +25592,7 @@ func (p *selLTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -26385,15 +25736,11 @@ func (p *selLTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTInt64Int64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTInt64Int64Op struct {
 	selOpBase
 }
 
-func (p *selLTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -26402,7 +25749,7 @@ func (p *selLTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -26555,10 +25902,6 @@ func (p *selLTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTInt64Int64Op) Init() {
-	p.Input.Init()
 }
 
 type selLTInt64Float64ConstOp struct {
@@ -26566,7 +25909,7 @@ type selLTInt64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selLTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -26575,7 +25918,7 @@ func (p *selLTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -26751,15 +26094,11 @@ func (p *selLTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTInt64Float64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTInt64Float64Op struct {
 	selOpBase
 }
 
-func (p *selLTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -26768,7 +26107,7 @@ func (p *selLTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -26953,10 +26292,6 @@ func (p *selLTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTInt64Float64Op) Init() {
-	p.Input.Init()
 }
 
 type selLTInt64DecimalConstOp struct {
@@ -26964,7 +26299,7 @@ type selLTInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selLTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -26973,7 +26308,7 @@ func (p *selLTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -27097,15 +26432,11 @@ func (p *selLTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTInt64DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTInt64DecimalOp struct {
 	selOpBase
 }
 
-func (p *selLTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTInt64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -27114,7 +26445,7 @@ func (p *selLTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -27247,10 +26578,6 @@ func (p *selLTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTInt64DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type selLTFloat64Int16ConstOp struct {
@@ -27258,7 +26585,7 @@ type selLTFloat64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selLTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTFloat64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -27267,7 +26594,7 @@ func (p *selLTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -27443,15 +26770,11 @@ func (p *selLTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTFloat64Int16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTFloat64Int16Op struct {
 	selOpBase
 }
 
-func (p *selLTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLTFloat64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -27460,7 +26783,7 @@ func (p *selLTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -27645,10 +26968,6 @@ func (p *selLTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTFloat64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type selLTFloat64Int32ConstOp struct {
@@ -27656,7 +26975,7 @@ type selLTFloat64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selLTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTFloat64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -27665,7 +26984,7 @@ func (p *selLTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -27841,15 +27160,11 @@ func (p *selLTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTFloat64Int32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTFloat64Int32Op struct {
 	selOpBase
 }
 
-func (p *selLTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLTFloat64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -27858,7 +27173,7 @@ func (p *selLTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -28043,10 +27358,6 @@ func (p *selLTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTFloat64Int32Op) Init() {
-	p.Input.Init()
 }
 
 type selLTFloat64Int64ConstOp struct {
@@ -28054,7 +27365,7 @@ type selLTFloat64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selLTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTFloat64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -28063,7 +27374,7 @@ func (p *selLTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -28239,15 +27550,11 @@ func (p *selLTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTFloat64Int64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTFloat64Int64Op struct {
 	selOpBase
 }
 
-func (p *selLTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLTFloat64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -28256,7 +27563,7 @@ func (p *selLTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -28441,10 +27748,6 @@ func (p *selLTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTFloat64Int64Op) Init() {
-	p.Input.Init()
 }
 
 type selLTFloat64Float64ConstOp struct {
@@ -28452,7 +27755,7 @@ type selLTFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selLTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTFloat64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -28461,7 +27764,7 @@ func (p *selLTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -28637,15 +27940,11 @@ func (p *selLTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTFloat64Float64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTFloat64Float64Op struct {
 	selOpBase
 }
 
-func (p *selLTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLTFloat64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -28654,7 +27953,7 @@ func (p *selLTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -28839,10 +28138,6 @@ func (p *selLTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTFloat64Float64Op) Init() {
-	p.Input.Init()
 }
 
 type selLTFloat64DecimalConstOp struct {
@@ -28850,7 +28145,7 @@ type selLTFloat64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selLTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTFloat64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -28859,7 +28154,7 @@ func (p *selLTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -28991,15 +28286,11 @@ func (p *selLTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTFloat64DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTFloat64DecimalOp struct {
 	selOpBase
 }
 
-func (p *selLTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTFloat64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -29008,7 +28299,7 @@ func (p *selLTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -29149,10 +28440,6 @@ func (p *selLTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTFloat64DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type selLTTimestampTimestampConstOp struct {
@@ -29160,7 +28447,7 @@ type selLTTimestampTimestampConstOp struct {
 	constArg time.Time
 }
 
-func (p *selLTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTTimestampTimestampConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -29169,7 +28456,7 @@ func (p *selLTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -29297,15 +28584,11 @@ func (p *selLTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 	}
 }
 
-func (p *selLTTimestampTimestampConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTTimestampTimestampOp struct {
 	selOpBase
 }
 
-func (p *selLTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTTimestampTimestampOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -29314,7 +28597,7 @@ func (p *selLTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -29451,10 +28734,6 @@ func (p *selLTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTTimestampTimestampOp) Init() {
-	p.Input.Init()
 }
 
 type selLTIntervalIntervalConstOp struct {
@@ -29462,7 +28741,7 @@ type selLTIntervalIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p *selLTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTIntervalIntervalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -29471,7 +28750,7 @@ func (p *selLTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -29571,15 +28850,11 @@ func (p *selLTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTIntervalIntervalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTIntervalIntervalOp struct {
 	selOpBase
 }
 
-func (p *selLTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTIntervalIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -29588,7 +28863,7 @@ func (p *selLTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -29697,10 +28972,6 @@ func (p *selLTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTIntervalIntervalOp) Init() {
-	p.Input.Init()
 }
 
 type selLTJSONJSONConstOp struct {
@@ -29708,7 +28979,7 @@ type selLTJSONJSONConstOp struct {
 	constArg json.JSON
 }
 
-func (p *selLTJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTJSONJSONConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -29717,7 +28988,7 @@ func (p *selLTJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -29839,15 +29110,11 @@ func (p *selLTJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTJSONJSONConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTJSONJSONOp struct {
 	selOpBase
 }
 
-func (p *selLTJSONJSONOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTJSONJSONOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -29856,7 +29123,7 @@ func (p *selLTJSONJSONOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -29985,10 +29252,6 @@ func (p *selLTJSONJSONOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTJSONJSONOp) Init() {
-	p.Input.Init()
 }
 
 type selLTDatumDatumConstOp struct {
@@ -29996,7 +29259,7 @@ type selLTDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p *selLTDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTDatumDatumConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -30005,7 +29268,7 @@ func (p *selLTDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -30111,15 +29374,11 @@ func (p *selLTDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLTDatumDatumConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLTDatumDatumOp struct {
 	selOpBase
 }
 
-func (p *selLTDatumDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLTDatumDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -30128,7 +29387,7 @@ func (p *selLTDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -30241,10 +29500,6 @@ func (p *selLTDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLTDatumDatumOp) Init() {
-	p.Input.Init()
 }
 
 type selLEBoolBoolConstOp struct {
@@ -30252,7 +29507,7 @@ type selLEBoolBoolConstOp struct {
 	constArg bool
 }
 
-func (p *selLEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEBoolBoolConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -30261,7 +29516,7 @@ func (p *selLEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -30393,15 +29648,11 @@ func (p *selLEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEBoolBoolConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEBoolBoolOp struct {
 	selOpBase
 }
 
-func (p *selLEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEBoolBoolOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -30410,7 +29661,7 @@ func (p *selLEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -30551,10 +29802,6 @@ func (p *selLEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEBoolBoolOp) Init() {
-	p.Input.Init()
 }
 
 type selLEBytesBytesConstOp struct {
@@ -30562,7 +29809,7 @@ type selLEBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p *selLEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -30571,7 +29818,7 @@ func (p *selLEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -30669,15 +29916,11 @@ func (p *selLEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEBytesBytesConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEBytesBytesOp struct {
 	selOpBase
 }
 
-func (p *selLEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEBytesBytesOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -30686,7 +29929,7 @@ func (p *selLEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -30791,10 +30034,6 @@ func (p *selLEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEBytesBytesOp) Init() {
-	p.Input.Init()
 }
 
 type selLEDecimalInt16ConstOp struct {
@@ -30802,7 +30041,7 @@ type selLEDecimalInt16ConstOp struct {
 	constArg int16
 }
 
-func (p *selLEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEDecimalInt16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -30811,7 +30050,7 @@ func (p *selLEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -30935,15 +30174,11 @@ func (p *selLEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEDecimalInt16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEDecimalInt16Op struct {
 	selOpBase
 }
 
-func (p *selLEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLEDecimalInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -30952,7 +30187,7 @@ func (p *selLEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -31085,10 +30320,6 @@ func (p *selLEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEDecimalInt16Op) Init() {
-	p.Input.Init()
 }
 
 type selLEDecimalInt32ConstOp struct {
@@ -31096,7 +30327,7 @@ type selLEDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p *selLEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEDecimalInt32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -31105,7 +30336,7 @@ func (p *selLEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -31229,15 +30460,11 @@ func (p *selLEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEDecimalInt32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEDecimalInt32Op struct {
 	selOpBase
 }
 
-func (p *selLEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLEDecimalInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -31246,7 +30473,7 @@ func (p *selLEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -31379,10 +30606,6 @@ func (p *selLEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEDecimalInt32Op) Init() {
-	p.Input.Init()
 }
 
 type selLEDecimalInt64ConstOp struct {
@@ -31390,7 +30613,7 @@ type selLEDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p *selLEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEDecimalInt64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -31399,7 +30622,7 @@ func (p *selLEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -31523,15 +30746,11 @@ func (p *selLEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEDecimalInt64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEDecimalInt64Op struct {
 	selOpBase
 }
 
-func (p *selLEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLEDecimalInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -31540,7 +30759,7 @@ func (p *selLEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -31673,10 +30892,6 @@ func (p *selLEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEDecimalInt64Op) Init() {
-	p.Input.Init()
 }
 
 type selLEDecimalFloat64ConstOp struct {
@@ -31684,7 +30899,7 @@ type selLEDecimalFloat64ConstOp struct {
 	constArg float64
 }
 
-func (p *selLEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEDecimalFloat64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -31693,7 +30908,7 @@ func (p *selLEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -31825,15 +31040,11 @@ func (p *selLEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEDecimalFloat64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEDecimalFloat64Op struct {
 	selOpBase
 }
 
-func (p *selLEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLEDecimalFloat64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -31842,7 +31053,7 @@ func (p *selLEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -31983,10 +31194,6 @@ func (p *selLEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEDecimalFloat64Op) Init() {
-	p.Input.Init()
 }
 
 type selLEDecimalDecimalConstOp struct {
@@ -31994,7 +31201,7 @@ type selLEDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selLEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEDecimalDecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -32003,7 +31210,7 @@ func (p *selLEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -32103,15 +31310,11 @@ func (p *selLEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEDecimalDecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEDecimalDecimalOp struct {
 	selOpBase
 }
 
-func (p *selLEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEDecimalDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -32120,7 +31323,7 @@ func (p *selLEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -32229,10 +31432,6 @@ func (p *selLEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEDecimalDecimalOp) Init() {
-	p.Input.Init()
 }
 
 type selLEInt16Int16ConstOp struct {
@@ -32240,7 +31439,7 @@ type selLEInt16Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selLEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt16Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -32249,7 +31448,7 @@ func (p *selLEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -32393,15 +31592,11 @@ func (p *selLEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEInt16Int16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEInt16Int16Op struct {
 	selOpBase
 }
 
-func (p *selLEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt16Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -32410,7 +31605,7 @@ func (p *selLEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -32563,10 +31758,6 @@ func (p *selLEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEInt16Int16Op) Init() {
-	p.Input.Init()
 }
 
 type selLEInt16Int32ConstOp struct {
@@ -32574,7 +31765,7 @@ type selLEInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selLEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt16Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -32583,7 +31774,7 @@ func (p *selLEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -32727,15 +31918,11 @@ func (p *selLEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEInt16Int32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEInt16Int32Op struct {
 	selOpBase
 }
 
-func (p *selLEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt16Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -32744,7 +31931,7 @@ func (p *selLEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -32897,10 +32084,6 @@ func (p *selLEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEInt16Int32Op) Init() {
-	p.Input.Init()
 }
 
 type selLEInt16Int64ConstOp struct {
@@ -32908,7 +32091,7 @@ type selLEInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selLEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt16Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -32917,7 +32100,7 @@ func (p *selLEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -33061,15 +32244,11 @@ func (p *selLEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEInt16Int64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEInt16Int64Op struct {
 	selOpBase
 }
 
-func (p *selLEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt16Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -33078,7 +32257,7 @@ func (p *selLEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -33231,10 +32410,6 @@ func (p *selLEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEInt16Int64Op) Init() {
-	p.Input.Init()
 }
 
 type selLEInt16Float64ConstOp struct {
@@ -33242,7 +32417,7 @@ type selLEInt16Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selLEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt16Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -33251,7 +32426,7 @@ func (p *selLEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -33427,15 +32602,11 @@ func (p *selLEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEInt16Float64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEInt16Float64Op struct {
 	selOpBase
 }
 
-func (p *selLEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt16Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -33444,7 +32615,7 @@ func (p *selLEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -33629,10 +32800,6 @@ func (p *selLEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEInt16Float64Op) Init() {
-	p.Input.Init()
 }
 
 type selLEInt16DecimalConstOp struct {
@@ -33640,7 +32807,7 @@ type selLEInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selLEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt16DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -33649,7 +32816,7 @@ func (p *selLEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -33773,15 +32940,11 @@ func (p *selLEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEInt16DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEInt16DecimalOp struct {
 	selOpBase
 }
 
-func (p *selLEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt16DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -33790,7 +32953,7 @@ func (p *selLEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -33923,10 +33086,6 @@ func (p *selLEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEInt16DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type selLEInt32Int16ConstOp struct {
@@ -33934,7 +33093,7 @@ type selLEInt32Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selLEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt32Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -33943,7 +33102,7 @@ func (p *selLEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -34087,15 +33246,11 @@ func (p *selLEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEInt32Int16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEInt32Int16Op struct {
 	selOpBase
 }
 
-func (p *selLEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt32Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -34104,7 +33259,7 @@ func (p *selLEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -34257,10 +33412,6 @@ func (p *selLEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEInt32Int16Op) Init() {
-	p.Input.Init()
 }
 
 type selLEInt32Int32ConstOp struct {
@@ -34268,7 +33419,7 @@ type selLEInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selLEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt32Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -34277,7 +33428,7 @@ func (p *selLEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -34421,15 +33572,11 @@ func (p *selLEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEInt32Int32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEInt32Int32Op struct {
 	selOpBase
 }
 
-func (p *selLEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt32Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -34438,7 +33585,7 @@ func (p *selLEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -34591,10 +33738,6 @@ func (p *selLEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEInt32Int32Op) Init() {
-	p.Input.Init()
 }
 
 type selLEInt32Int64ConstOp struct {
@@ -34602,7 +33745,7 @@ type selLEInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selLEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt32Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -34611,7 +33754,7 @@ func (p *selLEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -34755,15 +33898,11 @@ func (p *selLEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEInt32Int64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEInt32Int64Op struct {
 	selOpBase
 }
 
-func (p *selLEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt32Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -34772,7 +33911,7 @@ func (p *selLEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -34925,10 +34064,6 @@ func (p *selLEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEInt32Int64Op) Init() {
-	p.Input.Init()
 }
 
 type selLEInt32Float64ConstOp struct {
@@ -34936,7 +34071,7 @@ type selLEInt32Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selLEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt32Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -34945,7 +34080,7 @@ func (p *selLEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -35121,15 +34256,11 @@ func (p *selLEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEInt32Float64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEInt32Float64Op struct {
 	selOpBase
 }
 
-func (p *selLEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt32Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -35138,7 +34269,7 @@ func (p *selLEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -35323,10 +34454,6 @@ func (p *selLEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEInt32Float64Op) Init() {
-	p.Input.Init()
 }
 
 type selLEInt32DecimalConstOp struct {
@@ -35334,7 +34461,7 @@ type selLEInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selLEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt32DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -35343,7 +34470,7 @@ func (p *selLEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -35467,15 +34594,11 @@ func (p *selLEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEInt32DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEInt32DecimalOp struct {
 	selOpBase
 }
 
-func (p *selLEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt32DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -35484,7 +34607,7 @@ func (p *selLEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -35617,10 +34740,6 @@ func (p *selLEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEInt32DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type selLEInt64Int16ConstOp struct {
@@ -35628,7 +34747,7 @@ type selLEInt64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selLEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -35637,7 +34756,7 @@ func (p *selLEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -35781,15 +34900,11 @@ func (p *selLEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEInt64Int16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEInt64Int16Op struct {
 	selOpBase
 }
 
-func (p *selLEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -35798,7 +34913,7 @@ func (p *selLEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -35951,10 +35066,6 @@ func (p *selLEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEInt64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type selLEInt64Int32ConstOp struct {
@@ -35962,7 +35073,7 @@ type selLEInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selLEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -35971,7 +35082,7 @@ func (p *selLEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -36115,15 +35226,11 @@ func (p *selLEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEInt64Int32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEInt64Int32Op struct {
 	selOpBase
 }
 
-func (p *selLEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -36132,7 +35239,7 @@ func (p *selLEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -36285,10 +35392,6 @@ func (p *selLEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEInt64Int32Op) Init() {
-	p.Input.Init()
 }
 
 type selLEInt64Int64ConstOp struct {
@@ -36296,7 +35399,7 @@ type selLEInt64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selLEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -36305,7 +35408,7 @@ func (p *selLEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -36449,15 +35552,11 @@ func (p *selLEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEInt64Int64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEInt64Int64Op struct {
 	selOpBase
 }
 
-func (p *selLEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -36466,7 +35565,7 @@ func (p *selLEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -36619,10 +35718,6 @@ func (p *selLEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEInt64Int64Op) Init() {
-	p.Input.Init()
 }
 
 type selLEInt64Float64ConstOp struct {
@@ -36630,7 +35725,7 @@ type selLEInt64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selLEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -36639,7 +35734,7 @@ func (p *selLEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -36815,15 +35910,11 @@ func (p *selLEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEInt64Float64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEInt64Float64Op struct {
 	selOpBase
 }
 
-func (p *selLEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -36832,7 +35923,7 @@ func (p *selLEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -37017,10 +36108,6 @@ func (p *selLEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEInt64Float64Op) Init() {
-	p.Input.Init()
 }
 
 type selLEInt64DecimalConstOp struct {
@@ -37028,7 +36115,7 @@ type selLEInt64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selLEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -37037,7 +36124,7 @@ func (p *selLEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -37161,15 +36248,11 @@ func (p *selLEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEInt64DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEInt64DecimalOp struct {
 	selOpBase
 }
 
-func (p *selLEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEInt64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -37178,7 +36261,7 @@ func (p *selLEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -37311,10 +36394,6 @@ func (p *selLEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEInt64DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type selLEFloat64Int16ConstOp struct {
@@ -37322,7 +36401,7 @@ type selLEFloat64Int16ConstOp struct {
 	constArg int16
 }
 
-func (p *selLEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEFloat64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -37331,7 +36410,7 @@ func (p *selLEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -37507,15 +36586,11 @@ func (p *selLEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEFloat64Int16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEFloat64Int16Op struct {
 	selOpBase
 }
 
-func (p *selLEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLEFloat64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -37524,7 +36599,7 @@ func (p *selLEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -37709,10 +36784,6 @@ func (p *selLEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEFloat64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type selLEFloat64Int32ConstOp struct {
@@ -37720,7 +36791,7 @@ type selLEFloat64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selLEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEFloat64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -37729,7 +36800,7 @@ func (p *selLEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -37905,15 +36976,11 @@ func (p *selLEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEFloat64Int32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEFloat64Int32Op struct {
 	selOpBase
 }
 
-func (p *selLEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLEFloat64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -37922,7 +36989,7 @@ func (p *selLEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -38107,10 +37174,6 @@ func (p *selLEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEFloat64Int32Op) Init() {
-	p.Input.Init()
 }
 
 type selLEFloat64Int64ConstOp struct {
@@ -38118,7 +37181,7 @@ type selLEFloat64Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selLEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEFloat64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -38127,7 +37190,7 @@ func (p *selLEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -38303,15 +37366,11 @@ func (p *selLEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEFloat64Int64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEFloat64Int64Op struct {
 	selOpBase
 }
 
-func (p *selLEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLEFloat64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -38320,7 +37379,7 @@ func (p *selLEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -38505,10 +37564,6 @@ func (p *selLEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEFloat64Int64Op) Init() {
-	p.Input.Init()
 }
 
 type selLEFloat64Float64ConstOp struct {
@@ -38516,7 +37571,7 @@ type selLEFloat64Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selLEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEFloat64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -38525,7 +37580,7 @@ func (p *selLEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -38701,15 +37756,11 @@ func (p *selLEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEFloat64Float64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEFloat64Float64Op struct {
 	selOpBase
 }
 
-func (p *selLEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selLEFloat64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -38718,7 +37769,7 @@ func (p *selLEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -38903,10 +37954,6 @@ func (p *selLEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEFloat64Float64Op) Init() {
-	p.Input.Init()
 }
 
 type selLEFloat64DecimalConstOp struct {
@@ -38914,7 +37961,7 @@ type selLEFloat64DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selLEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEFloat64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -38923,7 +37970,7 @@ func (p *selLEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -39055,15 +38102,11 @@ func (p *selLEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEFloat64DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEFloat64DecimalOp struct {
 	selOpBase
 }
 
-func (p *selLEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEFloat64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -39072,7 +38115,7 @@ func (p *selLEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -39213,10 +38256,6 @@ func (p *selLEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEFloat64DecimalOp) Init() {
-	p.Input.Init()
 }
 
 type selLETimestampTimestampConstOp struct {
@@ -39224,7 +38263,7 @@ type selLETimestampTimestampConstOp struct {
 	constArg time.Time
 }
 
-func (p *selLETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLETimestampTimestampConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -39233,7 +38272,7 @@ func (p *selLETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -39361,15 +38400,11 @@ func (p *selLETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 	}
 }
 
-func (p *selLETimestampTimestampConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLETimestampTimestampOp struct {
 	selOpBase
 }
 
-func (p *selLETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLETimestampTimestampOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -39378,7 +38413,7 @@ func (p *selLETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -39515,10 +38550,6 @@ func (p *selLETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLETimestampTimestampOp) Init() {
-	p.Input.Init()
 }
 
 type selLEIntervalIntervalConstOp struct {
@@ -39526,7 +38557,7 @@ type selLEIntervalIntervalConstOp struct {
 	constArg duration.Duration
 }
 
-func (p *selLEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEIntervalIntervalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -39535,7 +38566,7 @@ func (p *selLEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -39635,15 +38666,11 @@ func (p *selLEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEIntervalIntervalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEIntervalIntervalOp struct {
 	selOpBase
 }
 
-func (p *selLEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEIntervalIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -39652,7 +38679,7 @@ func (p *selLEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -39761,10 +38788,6 @@ func (p *selLEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEIntervalIntervalOp) Init() {
-	p.Input.Init()
 }
 
 type selLEJSONJSONConstOp struct {
@@ -39772,7 +38795,7 @@ type selLEJSONJSONConstOp struct {
 	constArg json.JSON
 }
 
-func (p *selLEJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEJSONJSONConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -39781,7 +38804,7 @@ func (p *selLEJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -39903,15 +38926,11 @@ func (p *selLEJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEJSONJSONConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEJSONJSONOp struct {
 	selOpBase
 }
 
-func (p *selLEJSONJSONOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEJSONJSONOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -39920,7 +38939,7 @@ func (p *selLEJSONJSONOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -40049,10 +39068,6 @@ func (p *selLEJSONJSONOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEJSONJSONOp) Init() {
-	p.Input.Init()
 }
 
 type selLEDatumDatumConstOp struct {
@@ -40060,7 +39075,7 @@ type selLEDatumDatumConstOp struct {
 	constArg interface{}
 }
 
-func (p *selLEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEDatumDatumConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -40069,7 +39084,7 @@ func (p *selLEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -40175,15 +39190,11 @@ func (p *selLEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selLEDatumDatumConstOp) Init() {
-	p.Input.Init()
-}
-
 type selLEDatumDatumOp struct {
 	selOpBase
 }
 
-func (p *selLEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p *selLEDatumDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -40192,7 +39203,7 @@ func (p *selLEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -40305,10 +39316,6 @@ func (p *selLEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selLEDatumDatumOp) Init() {
-	p.Input.Init()
 }
 
 type selGTBoolBoolConstOp struct {
@@ -40316,7 +39323,7 @@ type selGTBoolBoolConstOp struct {
 	constArg bool
 }
 
-func (p *selGTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTBoolBoolConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -40325,7 +39332,7 @@ func (p *selGTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -40457,15 +39464,11 @@ func (p *selGTBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTBoolBoolConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTBoolBoolOp struct {
 	selOpBase
 }
 
-func (p *selGTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTBoolBoolOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -40474,7 +39477,7 @@ func (p *selGTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -40615,10 +39618,6 @@ func (p *selGTBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selGTBoolBoolOp) Init() {
-	p.Input.Init()
 }
 
 type selGTBytesBytesConstOp struct {
@@ -40626,7 +39625,7 @@ type selGTBytesBytesConstOp struct {
 	constArg []byte
 }
 
-func (p *selGTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -40635,7 +39634,7 @@ func (p *selGTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -40733,15 +39732,11 @@ func (p *selGTBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTBytesBytesConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTBytesBytesOp struct {
 	selOpBase
 }
 
-func (p *selGTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTBytesBytesOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -40750,7 +39745,7 @@ func (p *selGTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -40857,16 +39852,12 @@ func (p *selGTBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTBytesBytesOp) Init() {
-	p.Input.Init()
-}
-
 type selGTDecimalInt16ConstOp struct {
 	selConstOpBase
 	constArg int16
 }
 
-func (p *selGTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTDecimalInt16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -40875,7 +39866,7 @@ func (p *selGTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -40999,15 +39990,11 @@ func (p *selGTDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTDecimalInt16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTDecimalInt16Op struct {
 	selOpBase
 }
 
-func (p *selGTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGTDecimalInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -41016,7 +40003,7 @@ func (p *selGTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -41149,10 +40136,6 @@ func (p *selGTDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selGTDecimalInt16Op) Init() {
-	p.Input.Init()
 }
 
 type selGTDecimalInt32ConstOp struct {
@@ -41160,7 +40143,7 @@ type selGTDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p *selGTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTDecimalInt32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -41169,7 +40152,7 @@ func (p *selGTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -41293,15 +40276,11 @@ func (p *selGTDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTDecimalInt32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTDecimalInt32Op struct {
 	selOpBase
 }
 
-func (p *selGTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGTDecimalInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -41310,7 +40289,7 @@ func (p *selGTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -41443,10 +40422,6 @@ func (p *selGTDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selGTDecimalInt32Op) Init() {
-	p.Input.Init()
 }
 
 type selGTDecimalInt64ConstOp struct {
@@ -41454,7 +40429,7 @@ type selGTDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p *selGTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTDecimalInt64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -41463,7 +40438,7 @@ func (p *selGTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -41587,15 +40562,11 @@ func (p *selGTDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTDecimalInt64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTDecimalInt64Op struct {
 	selOpBase
 }
 
-func (p *selGTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGTDecimalInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -41604,7 +40575,7 @@ func (p *selGTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -41737,10 +40708,6 @@ func (p *selGTDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selGTDecimalInt64Op) Init() {
-	p.Input.Init()
 }
 
 type selGTDecimalFloat64ConstOp struct {
@@ -41748,7 +40715,7 @@ type selGTDecimalFloat64ConstOp struct {
 	constArg float64
 }
 
-func (p *selGTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTDecimalFloat64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -41757,7 +40724,7 @@ func (p *selGTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -41889,15 +40856,11 @@ func (p *selGTDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTDecimalFloat64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTDecimalFloat64Op struct {
 	selOpBase
 }
 
-func (p *selGTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGTDecimalFloat64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -41906,7 +40869,7 @@ func (p *selGTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -42047,10 +41010,6 @@ func (p *selGTDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selGTDecimalFloat64Op) Init() {
-	p.Input.Init()
 }
 
 type selGTDecimalDecimalConstOp struct {
@@ -42058,7 +41017,7 @@ type selGTDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selGTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTDecimalDecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -42067,7 +41026,7 @@ func (p *selGTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -42167,15 +41126,11 @@ func (p *selGTDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTDecimalDecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTDecimalDecimalOp struct {
 	selOpBase
 }
 
-func (p *selGTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTDecimalDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -42184,7 +41139,7 @@ func (p *selGTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -42295,16 +41250,12 @@ func (p *selGTDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTDecimalDecimalOp) Init() {
-	p.Input.Init()
-}
-
 type selGTInt16Int16ConstOp struct {
 	selConstOpBase
 	constArg int16
 }
 
-func (p *selGTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt16Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -42313,7 +41264,7 @@ func (p *selGTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -42457,15 +41408,11 @@ func (p *selGTInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTInt16Int16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTInt16Int16Op struct {
 	selOpBase
 }
 
-func (p *selGTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt16Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -42474,7 +41421,7 @@ func (p *selGTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -42627,10 +41574,6 @@ func (p *selGTInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selGTInt16Int16Op) Init() {
-	p.Input.Init()
 }
 
 type selGTInt16Int32ConstOp struct {
@@ -42638,7 +41581,7 @@ type selGTInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selGTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt16Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -42647,7 +41590,7 @@ func (p *selGTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -42791,15 +41734,11 @@ func (p *selGTInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTInt16Int32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTInt16Int32Op struct {
 	selOpBase
 }
 
-func (p *selGTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt16Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -42808,7 +41747,7 @@ func (p *selGTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -42961,10 +41900,6 @@ func (p *selGTInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selGTInt16Int32Op) Init() {
-	p.Input.Init()
 }
 
 type selGTInt16Int64ConstOp struct {
@@ -42972,7 +41907,7 @@ type selGTInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selGTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt16Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -42981,7 +41916,7 @@ func (p *selGTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -43125,15 +42060,11 @@ func (p *selGTInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTInt16Int64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTInt16Int64Op struct {
 	selOpBase
 }
 
-func (p *selGTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt16Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -43142,7 +42073,7 @@ func (p *selGTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -43295,10 +42226,6 @@ func (p *selGTInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selGTInt16Int64Op) Init() {
-	p.Input.Init()
 }
 
 type selGTInt16Float64ConstOp struct {
@@ -43306,7 +42233,7 @@ type selGTInt16Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selGTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt16Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -43315,7 +42242,7 @@ func (p *selGTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -43491,15 +42418,11 @@ func (p *selGTInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTInt16Float64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTInt16Float64Op struct {
 	selOpBase
 }
 
-func (p *selGTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt16Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -43508,7 +42431,7 @@ func (p *selGTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -43693,10 +42616,6 @@ func (p *selGTInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selGTInt16Float64Op) Init() {
-	p.Input.Init()
 }
 
 type selGTInt16DecimalConstOp struct {
@@ -43704,7 +42623,7 @@ type selGTInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selGTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt16DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -43713,7 +42632,7 @@ func (p *selGTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -43837,15 +42756,11 @@ func (p *selGTInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTInt16DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTInt16DecimalOp struct {
 	selOpBase
 }
 
-func (p *selGTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt16DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -43854,7 +42769,7 @@ func (p *selGTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -43989,16 +42904,12 @@ func (p *selGTInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTInt16DecimalOp) Init() {
-	p.Input.Init()
-}
-
 type selGTInt32Int16ConstOp struct {
 	selConstOpBase
 	constArg int16
 }
 
-func (p *selGTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt32Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -44007,7 +42918,7 @@ func (p *selGTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -44151,15 +43062,11 @@ func (p *selGTInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTInt32Int16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTInt32Int16Op struct {
 	selOpBase
 }
 
-func (p *selGTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt32Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -44168,7 +43075,7 @@ func (p *selGTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -44321,10 +43228,6 @@ func (p *selGTInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selGTInt32Int16Op) Init() {
-	p.Input.Init()
 }
 
 type selGTInt32Int32ConstOp struct {
@@ -44332,7 +43235,7 @@ type selGTInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selGTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt32Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -44341,7 +43244,7 @@ func (p *selGTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -44485,15 +43388,11 @@ func (p *selGTInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTInt32Int32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTInt32Int32Op struct {
 	selOpBase
 }
 
-func (p *selGTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt32Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -44502,7 +43401,7 @@ func (p *selGTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -44655,10 +43554,6 @@ func (p *selGTInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selGTInt32Int32Op) Init() {
-	p.Input.Init()
 }
 
 type selGTInt32Int64ConstOp struct {
@@ -44666,7 +43561,7 @@ type selGTInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selGTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt32Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -44675,7 +43570,7 @@ func (p *selGTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -44819,15 +43714,11 @@ func (p *selGTInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTInt32Int64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTInt32Int64Op struct {
 	selOpBase
 }
 
-func (p *selGTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt32Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -44836,7 +43727,7 @@ func (p *selGTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -44989,10 +43880,6 @@ func (p *selGTInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selGTInt32Int64Op) Init() {
-	p.Input.Init()
 }
 
 type selGTInt32Float64ConstOp struct {
@@ -45000,7 +43887,7 @@ type selGTInt32Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selGTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt32Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -45009,7 +43896,7 @@ func (p *selGTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -45185,15 +44072,11 @@ func (p *selGTInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTInt32Float64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTInt32Float64Op struct {
 	selOpBase
 }
 
-func (p *selGTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt32Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -45202,7 +44085,7 @@ func (p *selGTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -45387,10 +44270,6 @@ func (p *selGTInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selGTInt32Float64Op) Init() {
-	p.Input.Init()
 }
 
 type selGTInt32DecimalConstOp struct {
@@ -45398,7 +44277,7 @@ type selGTInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selGTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt32DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -45407,7 +44286,7 @@ func (p *selGTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -45531,15 +44410,11 @@ func (p *selGTInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTInt32DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTInt32DecimalOp struct {
 	selOpBase
 }
 
-func (p *selGTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt32DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -45548,7 +44423,7 @@ func (p *selGTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -45683,16 +44558,12 @@ func (p *selGTInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTInt32DecimalOp) Init() {
-	p.Input.Init()
-}
-
 type selGTInt64Int16ConstOp struct {
 	selConstOpBase
 	constArg int16
 }
 
-func (p *selGTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -45701,7 +44572,7 @@ func (p *selGTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -45845,15 +44716,11 @@ func (p *selGTInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTInt64Int16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTInt64Int16Op struct {
 	selOpBase
 }
 
-func (p *selGTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -45862,7 +44729,7 @@ func (p *selGTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -46015,10 +44882,6 @@ func (p *selGTInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selGTInt64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type selGTInt64Int32ConstOp struct {
@@ -46026,7 +44889,7 @@ type selGTInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selGTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -46035,7 +44898,7 @@ func (p *selGTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -46179,15 +45042,11 @@ func (p *selGTInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTInt64Int32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTInt64Int32Op struct {
 	selOpBase
 }
 
-func (p *selGTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -46196,7 +45055,7 @@ func (p *selGTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -46351,16 +45210,12 @@ func (p *selGTInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTInt64Int32Op) Init() {
-	p.Input.Init()
-}
-
 type selGTInt64Int64ConstOp struct {
 	selConstOpBase
 	constArg int64
 }
 
-func (p *selGTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -46369,7 +45224,7 @@ func (p *selGTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -46513,15 +45368,11 @@ func (p *selGTInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTInt64Int64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTInt64Int64Op struct {
 	selOpBase
 }
 
-func (p *selGTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -46530,7 +45381,7 @@ func (p *selGTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -46685,16 +45536,12 @@ func (p *selGTInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTInt64Int64Op) Init() {
-	p.Input.Init()
-}
-
 type selGTInt64Float64ConstOp struct {
 	selConstOpBase
 	constArg float64
 }
 
-func (p *selGTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -46703,7 +45550,7 @@ func (p *selGTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -46879,15 +45726,11 @@ func (p *selGTInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTInt64Float64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTInt64Float64Op struct {
 	selOpBase
 }
 
-func (p *selGTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -46896,7 +45739,7 @@ func (p *selGTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -47083,16 +45926,12 @@ func (p *selGTInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTInt64Float64Op) Init() {
-	p.Input.Init()
-}
-
 type selGTInt64DecimalConstOp struct {
 	selConstOpBase
 	constArg apd.Decimal
 }
 
-func (p *selGTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -47101,7 +45940,7 @@ func (p *selGTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -47225,15 +46064,11 @@ func (p *selGTInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTInt64DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTInt64DecimalOp struct {
 	selOpBase
 }
 
-func (p *selGTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTInt64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -47242,7 +46077,7 @@ func (p *selGTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -47377,16 +46212,12 @@ func (p *selGTInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTInt64DecimalOp) Init() {
-	p.Input.Init()
-}
-
 type selGTFloat64Int16ConstOp struct {
 	selConstOpBase
 	constArg int16
 }
 
-func (p *selGTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTFloat64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -47395,7 +46226,7 @@ func (p *selGTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -47571,15 +46402,11 @@ func (p *selGTFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTFloat64Int16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTFloat64Int16Op struct {
 	selOpBase
 }
 
-func (p *selGTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGTFloat64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -47588,7 +46415,7 @@ func (p *selGTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -47775,16 +46602,12 @@ func (p *selGTFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTFloat64Int16Op) Init() {
-	p.Input.Init()
-}
-
 type selGTFloat64Int32ConstOp struct {
 	selConstOpBase
 	constArg int32
 }
 
-func (p *selGTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTFloat64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -47793,7 +46616,7 @@ func (p *selGTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -47969,15 +46792,11 @@ func (p *selGTFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTFloat64Int32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTFloat64Int32Op struct {
 	selOpBase
 }
 
-func (p *selGTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGTFloat64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -47986,7 +46805,7 @@ func (p *selGTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -48173,16 +46992,12 @@ func (p *selGTFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTFloat64Int32Op) Init() {
-	p.Input.Init()
-}
-
 type selGTFloat64Int64ConstOp struct {
 	selConstOpBase
 	constArg int64
 }
 
-func (p *selGTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTFloat64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -48191,7 +47006,7 @@ func (p *selGTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -48367,15 +47182,11 @@ func (p *selGTFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTFloat64Int64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTFloat64Int64Op struct {
 	selOpBase
 }
 
-func (p *selGTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGTFloat64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -48384,7 +47195,7 @@ func (p *selGTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -48571,16 +47382,12 @@ func (p *selGTFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTFloat64Int64Op) Init() {
-	p.Input.Init()
-}
-
 type selGTFloat64Float64ConstOp struct {
 	selConstOpBase
 	constArg float64
 }
 
-func (p *selGTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTFloat64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -48589,7 +47396,7 @@ func (p *selGTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -48765,15 +47572,11 @@ func (p *selGTFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTFloat64Float64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTFloat64Float64Op struct {
 	selOpBase
 }
 
-func (p *selGTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGTFloat64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -48782,7 +47585,7 @@ func (p *selGTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -48969,16 +47772,12 @@ func (p *selGTFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTFloat64Float64Op) Init() {
-	p.Input.Init()
-}
-
 type selGTFloat64DecimalConstOp struct {
 	selConstOpBase
 	constArg apd.Decimal
 }
 
-func (p *selGTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTFloat64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -48987,7 +47786,7 @@ func (p *selGTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -49119,15 +47918,11 @@ func (p *selGTFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTFloat64DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTFloat64DecimalOp struct {
 	selOpBase
 }
 
-func (p *selGTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTFloat64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -49136,7 +47931,7 @@ func (p *selGTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -49279,16 +48074,12 @@ func (p *selGTFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTFloat64DecimalOp) Init() {
-	p.Input.Init()
-}
-
 type selGTTimestampTimestampConstOp struct {
 	selConstOpBase
 	constArg time.Time
 }
 
-func (p *selGTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTTimestampTimestampConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -49297,7 +48088,7 @@ func (p *selGTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -49425,15 +48216,11 @@ func (p *selGTTimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 	}
 }
 
-func (p *selGTTimestampTimestampConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTTimestampTimestampOp struct {
 	selOpBase
 }
 
-func (p *selGTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTTimestampTimestampOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -49442,7 +48229,7 @@ func (p *selGTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -49581,16 +48368,12 @@ func (p *selGTTimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTTimestampTimestampOp) Init() {
-	p.Input.Init()
-}
-
 type selGTIntervalIntervalConstOp struct {
 	selConstOpBase
 	constArg duration.Duration
 }
 
-func (p *selGTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTIntervalIntervalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -49599,7 +48382,7 @@ func (p *selGTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -49699,15 +48482,11 @@ func (p *selGTIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTIntervalIntervalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTIntervalIntervalOp struct {
 	selOpBase
 }
 
-func (p *selGTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTIntervalIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -49716,7 +48495,7 @@ func (p *selGTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -49827,16 +48606,12 @@ func (p *selGTIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTIntervalIntervalOp) Init() {
-	p.Input.Init()
-}
-
 type selGTJSONJSONConstOp struct {
 	selConstOpBase
 	constArg json.JSON
 }
 
-func (p *selGTJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTJSONJSONConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -49845,7 +48620,7 @@ func (p *selGTJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -49967,15 +48742,11 @@ func (p *selGTJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTJSONJSONConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTJSONJSONOp struct {
 	selOpBase
 }
 
-func (p *selGTJSONJSONOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTJSONJSONOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -49984,7 +48755,7 @@ func (p *selGTJSONJSONOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -50115,16 +48886,12 @@ func (p *selGTJSONJSONOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTJSONJSONOp) Init() {
-	p.Input.Init()
-}
-
 type selGTDatumDatumConstOp struct {
 	selConstOpBase
 	constArg interface{}
 }
 
-func (p *selGTDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTDatumDatumConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -50133,7 +48900,7 @@ func (p *selGTDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -50239,15 +49006,11 @@ func (p *selGTDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTDatumDatumConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGTDatumDatumOp struct {
 	selOpBase
 }
 
-func (p *selGTDatumDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGTDatumDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -50256,7 +49019,7 @@ func (p *selGTDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -50371,16 +49134,12 @@ func (p *selGTDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGTDatumDatumOp) Init() {
-	p.Input.Init()
-}
-
 type selGEBoolBoolConstOp struct {
 	selConstOpBase
 	constArg bool
 }
 
-func (p *selGEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEBoolBoolConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -50389,7 +49148,7 @@ func (p *selGEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -50521,15 +49280,11 @@ func (p *selGEBoolBoolConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEBoolBoolConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEBoolBoolOp struct {
 	selOpBase
 }
 
-func (p *selGEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEBoolBoolOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -50538,7 +49293,7 @@ func (p *selGEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -50681,16 +49436,12 @@ func (p *selGEBoolBoolOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEBoolBoolOp) Init() {
-	p.Input.Init()
-}
-
 type selGEBytesBytesConstOp struct {
 	selConstOpBase
 	constArg []byte
 }
 
-func (p *selGEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEBytesBytesConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -50699,7 +49450,7 @@ func (p *selGEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -50797,15 +49548,11 @@ func (p *selGEBytesBytesConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEBytesBytesConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEBytesBytesOp struct {
 	selOpBase
 }
 
-func (p *selGEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEBytesBytesOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -50814,7 +49561,7 @@ func (p *selGEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -50921,16 +49668,12 @@ func (p *selGEBytesBytesOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEBytesBytesOp) Init() {
-	p.Input.Init()
-}
-
 type selGEDecimalInt16ConstOp struct {
 	selConstOpBase
 	constArg int16
 }
 
-func (p *selGEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEDecimalInt16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -50939,7 +49682,7 @@ func (p *selGEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -51063,15 +49806,11 @@ func (p *selGEDecimalInt16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEDecimalInt16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEDecimalInt16Op struct {
 	selOpBase
 }
 
-func (p *selGEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGEDecimalInt16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -51080,7 +49819,7 @@ func (p *selGEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -51213,10 +49952,6 @@ func (p *selGEDecimalInt16Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selGEDecimalInt16Op) Init() {
-	p.Input.Init()
 }
 
 type selGEDecimalInt32ConstOp struct {
@@ -51224,7 +49959,7 @@ type selGEDecimalInt32ConstOp struct {
 	constArg int32
 }
 
-func (p *selGEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEDecimalInt32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -51233,7 +49968,7 @@ func (p *selGEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -51357,15 +50092,11 @@ func (p *selGEDecimalInt32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEDecimalInt32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEDecimalInt32Op struct {
 	selOpBase
 }
 
-func (p *selGEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGEDecimalInt32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -51374,7 +50105,7 @@ func (p *selGEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -51507,10 +50238,6 @@ func (p *selGEDecimalInt32Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selGEDecimalInt32Op) Init() {
-	p.Input.Init()
 }
 
 type selGEDecimalInt64ConstOp struct {
@@ -51518,7 +50245,7 @@ type selGEDecimalInt64ConstOp struct {
 	constArg int64
 }
 
-func (p *selGEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEDecimalInt64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -51527,7 +50254,7 @@ func (p *selGEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -51651,15 +50378,11 @@ func (p *selGEDecimalInt64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEDecimalInt64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEDecimalInt64Op struct {
 	selOpBase
 }
 
-func (p *selGEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGEDecimalInt64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -51668,7 +50391,7 @@ func (p *selGEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -51801,10 +50524,6 @@ func (p *selGEDecimalInt64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selGEDecimalInt64Op) Init() {
-	p.Input.Init()
 }
 
 type selGEDecimalFloat64ConstOp struct {
@@ -51812,7 +50531,7 @@ type selGEDecimalFloat64ConstOp struct {
 	constArg float64
 }
 
-func (p *selGEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEDecimalFloat64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -51821,7 +50540,7 @@ func (p *selGEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -51953,15 +50672,11 @@ func (p *selGEDecimalFloat64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEDecimalFloat64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEDecimalFloat64Op struct {
 	selOpBase
 }
 
-func (p *selGEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGEDecimalFloat64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -51970,7 +50685,7 @@ func (p *selGEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -52111,10 +50826,6 @@ func (p *selGEDecimalFloat64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selGEDecimalFloat64Op) Init() {
-	p.Input.Init()
 }
 
 type selGEDecimalDecimalConstOp struct {
@@ -52122,7 +50833,7 @@ type selGEDecimalDecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selGEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEDecimalDecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -52131,7 +50842,7 @@ func (p *selGEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -52231,15 +50942,11 @@ func (p *selGEDecimalDecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEDecimalDecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEDecimalDecimalOp struct {
 	selOpBase
 }
 
-func (p *selGEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEDecimalDecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -52248,7 +50955,7 @@ func (p *selGEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -52359,16 +51066,12 @@ func (p *selGEDecimalDecimalOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEDecimalDecimalOp) Init() {
-	p.Input.Init()
-}
-
 type selGEInt16Int16ConstOp struct {
 	selConstOpBase
 	constArg int16
 }
 
-func (p *selGEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt16Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -52377,7 +51080,7 @@ func (p *selGEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -52521,15 +51224,11 @@ func (p *selGEInt16Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEInt16Int16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEInt16Int16Op struct {
 	selOpBase
 }
 
-func (p *selGEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt16Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -52538,7 +51237,7 @@ func (p *selGEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -52691,10 +51390,6 @@ func (p *selGEInt16Int16Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selGEInt16Int16Op) Init() {
-	p.Input.Init()
 }
 
 type selGEInt16Int32ConstOp struct {
@@ -52702,7 +51397,7 @@ type selGEInt16Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selGEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt16Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -52711,7 +51406,7 @@ func (p *selGEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -52855,15 +51550,11 @@ func (p *selGEInt16Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEInt16Int32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEInt16Int32Op struct {
 	selOpBase
 }
 
-func (p *selGEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt16Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -52872,7 +51563,7 @@ func (p *selGEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -53025,10 +51716,6 @@ func (p *selGEInt16Int32Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selGEInt16Int32Op) Init() {
-	p.Input.Init()
 }
 
 type selGEInt16Int64ConstOp struct {
@@ -53036,7 +51723,7 @@ type selGEInt16Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selGEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt16Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -53045,7 +51732,7 @@ func (p *selGEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -53189,15 +51876,11 @@ func (p *selGEInt16Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEInt16Int64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEInt16Int64Op struct {
 	selOpBase
 }
 
-func (p *selGEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt16Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -53206,7 +51889,7 @@ func (p *selGEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -53359,10 +52042,6 @@ func (p *selGEInt16Int64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selGEInt16Int64Op) Init() {
-	p.Input.Init()
 }
 
 type selGEInt16Float64ConstOp struct {
@@ -53370,7 +52049,7 @@ type selGEInt16Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selGEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt16Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -53379,7 +52058,7 @@ func (p *selGEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -53555,15 +52234,11 @@ func (p *selGEInt16Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEInt16Float64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEInt16Float64Op struct {
 	selOpBase
 }
 
-func (p *selGEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt16Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -53572,7 +52247,7 @@ func (p *selGEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -53757,10 +52432,6 @@ func (p *selGEInt16Float64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selGEInt16Float64Op) Init() {
-	p.Input.Init()
 }
 
 type selGEInt16DecimalConstOp struct {
@@ -53768,7 +52439,7 @@ type selGEInt16DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selGEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt16DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -53777,7 +52448,7 @@ func (p *selGEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -53901,15 +52572,11 @@ func (p *selGEInt16DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEInt16DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEInt16DecimalOp struct {
 	selOpBase
 }
 
-func (p *selGEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt16DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -53918,7 +52585,7 @@ func (p *selGEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -54053,16 +52720,12 @@ func (p *selGEInt16DecimalOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEInt16DecimalOp) Init() {
-	p.Input.Init()
-}
-
 type selGEInt32Int16ConstOp struct {
 	selConstOpBase
 	constArg int16
 }
 
-func (p *selGEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt32Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -54071,7 +52734,7 @@ func (p *selGEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -54215,15 +52878,11 @@ func (p *selGEInt32Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEInt32Int16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEInt32Int16Op struct {
 	selOpBase
 }
 
-func (p *selGEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt32Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -54232,7 +52891,7 @@ func (p *selGEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -54385,10 +53044,6 @@ func (p *selGEInt32Int16Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selGEInt32Int16Op) Init() {
-	p.Input.Init()
 }
 
 type selGEInt32Int32ConstOp struct {
@@ -54396,7 +53051,7 @@ type selGEInt32Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selGEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt32Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -54405,7 +53060,7 @@ func (p *selGEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -54549,15 +53204,11 @@ func (p *selGEInt32Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEInt32Int32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEInt32Int32Op struct {
 	selOpBase
 }
 
-func (p *selGEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt32Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -54566,7 +53217,7 @@ func (p *selGEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -54719,10 +53370,6 @@ func (p *selGEInt32Int32Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selGEInt32Int32Op) Init() {
-	p.Input.Init()
 }
 
 type selGEInt32Int64ConstOp struct {
@@ -54730,7 +53377,7 @@ type selGEInt32Int64ConstOp struct {
 	constArg int64
 }
 
-func (p *selGEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt32Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -54739,7 +53386,7 @@ func (p *selGEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -54883,15 +53530,11 @@ func (p *selGEInt32Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEInt32Int64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEInt32Int64Op struct {
 	selOpBase
 }
 
-func (p *selGEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt32Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -54900,7 +53543,7 @@ func (p *selGEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -55053,10 +53696,6 @@ func (p *selGEInt32Int64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selGEInt32Int64Op) Init() {
-	p.Input.Init()
 }
 
 type selGEInt32Float64ConstOp struct {
@@ -55064,7 +53703,7 @@ type selGEInt32Float64ConstOp struct {
 	constArg float64
 }
 
-func (p *selGEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt32Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -55073,7 +53712,7 @@ func (p *selGEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -55249,15 +53888,11 @@ func (p *selGEInt32Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEInt32Float64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEInt32Float64Op struct {
 	selOpBase
 }
 
-func (p *selGEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt32Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -55266,7 +53901,7 @@ func (p *selGEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -55451,10 +54086,6 @@ func (p *selGEInt32Float64Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selGEInt32Float64Op) Init() {
-	p.Input.Init()
 }
 
 type selGEInt32DecimalConstOp struct {
@@ -55462,7 +54093,7 @@ type selGEInt32DecimalConstOp struct {
 	constArg apd.Decimal
 }
 
-func (p *selGEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt32DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -55471,7 +54102,7 @@ func (p *selGEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -55595,15 +54226,11 @@ func (p *selGEInt32DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEInt32DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEInt32DecimalOp struct {
 	selOpBase
 }
 
-func (p *selGEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt32DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -55612,7 +54239,7 @@ func (p *selGEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -55747,16 +54374,12 @@ func (p *selGEInt32DecimalOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEInt32DecimalOp) Init() {
-	p.Input.Init()
-}
-
 type selGEInt64Int16ConstOp struct {
 	selConstOpBase
 	constArg int16
 }
 
-func (p *selGEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -55765,7 +54388,7 @@ func (p *selGEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -55909,15 +54532,11 @@ func (p *selGEInt64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEInt64Int16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEInt64Int16Op struct {
 	selOpBase
 }
 
-func (p *selGEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -55926,7 +54545,7 @@ func (p *selGEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -56079,10 +54698,6 @@ func (p *selGEInt64Int16Op) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selGEInt64Int16Op) Init() {
-	p.Input.Init()
 }
 
 type selGEInt64Int32ConstOp struct {
@@ -56090,7 +54705,7 @@ type selGEInt64Int32ConstOp struct {
 	constArg int32
 }
 
-func (p *selGEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -56099,7 +54714,7 @@ func (p *selGEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -56243,15 +54858,11 @@ func (p *selGEInt64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEInt64Int32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEInt64Int32Op struct {
 	selOpBase
 }
 
-func (p *selGEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -56260,7 +54871,7 @@ func (p *selGEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -56415,16 +55026,12 @@ func (p *selGEInt64Int32Op) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEInt64Int32Op) Init() {
-	p.Input.Init()
-}
-
 type selGEInt64Int64ConstOp struct {
 	selConstOpBase
 	constArg int64
 }
 
-func (p *selGEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -56433,7 +55040,7 @@ func (p *selGEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -56577,15 +55184,11 @@ func (p *selGEInt64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEInt64Int64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEInt64Int64Op struct {
 	selOpBase
 }
 
-func (p *selGEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -56594,7 +55197,7 @@ func (p *selGEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -56749,16 +55352,12 @@ func (p *selGEInt64Int64Op) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEInt64Int64Op) Init() {
-	p.Input.Init()
-}
-
 type selGEInt64Float64ConstOp struct {
 	selConstOpBase
 	constArg float64
 }
 
-func (p *selGEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -56767,7 +55366,7 @@ func (p *selGEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -56943,15 +55542,11 @@ func (p *selGEInt64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEInt64Float64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEInt64Float64Op struct {
 	selOpBase
 }
 
-func (p *selGEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -56960,7 +55555,7 @@ func (p *selGEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -57147,16 +55742,12 @@ func (p *selGEInt64Float64Op) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEInt64Float64Op) Init() {
-	p.Input.Init()
-}
-
 type selGEInt64DecimalConstOp struct {
 	selConstOpBase
 	constArg apd.Decimal
 }
 
-func (p *selGEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -57165,7 +55756,7 @@ func (p *selGEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -57289,15 +55880,11 @@ func (p *selGEInt64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEInt64DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEInt64DecimalOp struct {
 	selOpBase
 }
 
-func (p *selGEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEInt64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -57306,7 +55893,7 @@ func (p *selGEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -57441,16 +56028,12 @@ func (p *selGEInt64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEInt64DecimalOp) Init() {
-	p.Input.Init()
-}
-
 type selGEFloat64Int16ConstOp struct {
 	selConstOpBase
 	constArg int16
 }
 
-func (p *selGEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEFloat64Int16ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -57459,7 +56042,7 @@ func (p *selGEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -57635,15 +56218,11 @@ func (p *selGEFloat64Int16ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEFloat64Int16ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEFloat64Int16Op struct {
 	selOpBase
 }
 
-func (p *selGEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGEFloat64Int16Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -57652,7 +56231,7 @@ func (p *selGEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -57839,16 +56418,12 @@ func (p *selGEFloat64Int16Op) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEFloat64Int16Op) Init() {
-	p.Input.Init()
-}
-
 type selGEFloat64Int32ConstOp struct {
 	selConstOpBase
 	constArg int32
 }
 
-func (p *selGEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEFloat64Int32ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -57857,7 +56432,7 @@ func (p *selGEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -58033,15 +56608,11 @@ func (p *selGEFloat64Int32ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEFloat64Int32ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEFloat64Int32Op struct {
 	selOpBase
 }
 
-func (p *selGEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGEFloat64Int32Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -58050,7 +56621,7 @@ func (p *selGEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -58237,16 +56808,12 @@ func (p *selGEFloat64Int32Op) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEFloat64Int32Op) Init() {
-	p.Input.Init()
-}
-
 type selGEFloat64Int64ConstOp struct {
 	selConstOpBase
 	constArg int64
 }
 
-func (p *selGEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEFloat64Int64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -58255,7 +56822,7 @@ func (p *selGEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -58431,15 +56998,11 @@ func (p *selGEFloat64Int64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEFloat64Int64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEFloat64Int64Op struct {
 	selOpBase
 }
 
-func (p *selGEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGEFloat64Int64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -58448,7 +57011,7 @@ func (p *selGEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -58635,16 +57198,12 @@ func (p *selGEFloat64Int64Op) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEFloat64Int64Op) Init() {
-	p.Input.Init()
-}
-
 type selGEFloat64Float64ConstOp struct {
 	selConstOpBase
 	constArg float64
 }
 
-func (p *selGEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEFloat64Float64ConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -58653,7 +57212,7 @@ func (p *selGEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -58829,15 +57388,11 @@ func (p *selGEFloat64Float64ConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEFloat64Float64ConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEFloat64Float64Op struct {
 	selOpBase
 }
 
-func (p *selGEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
+func (p *selGEFloat64Float64Op) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -58846,7 +57401,7 @@ func (p *selGEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -59033,16 +57588,12 @@ func (p *selGEFloat64Float64Op) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEFloat64Float64Op) Init() {
-	p.Input.Init()
-}
-
 type selGEFloat64DecimalConstOp struct {
 	selConstOpBase
 	constArg apd.Decimal
 }
 
-func (p *selGEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEFloat64DecimalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -59051,7 +57602,7 @@ func (p *selGEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -59183,15 +57734,11 @@ func (p *selGEFloat64DecimalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEFloat64DecimalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEFloat64DecimalOp struct {
 	selOpBase
 }
 
-func (p *selGEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEFloat64DecimalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -59200,7 +57747,7 @@ func (p *selGEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -59343,16 +57890,12 @@ func (p *selGEFloat64DecimalOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEFloat64DecimalOp) Init() {
-	p.Input.Init()
-}
-
 type selGETimestampTimestampConstOp struct {
 	selConstOpBase
 	constArg time.Time
 }
 
-func (p *selGETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGETimestampTimestampConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -59361,7 +57904,7 @@ func (p *selGETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -59489,15 +58032,11 @@ func (p *selGETimestampTimestampConstOp) Next(ctx context.Context) coldata.Batch
 	}
 }
 
-func (p *selGETimestampTimestampConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGETimestampTimestampOp struct {
 	selOpBase
 }
 
-func (p *selGETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGETimestampTimestampOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -59506,7 +58045,7 @@ func (p *selGETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -59645,16 +58184,12 @@ func (p *selGETimestampTimestampOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGETimestampTimestampOp) Init() {
-	p.Input.Init()
-}
-
 type selGEIntervalIntervalConstOp struct {
 	selConstOpBase
 	constArg duration.Duration
 }
 
-func (p *selGEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEIntervalIntervalConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -59663,7 +58198,7 @@ func (p *selGEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -59763,15 +58298,11 @@ func (p *selGEIntervalIntervalConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEIntervalIntervalConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEIntervalIntervalOp struct {
 	selOpBase
 }
 
-func (p *selGEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEIntervalIntervalOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -59780,7 +58311,7 @@ func (p *selGEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -59891,16 +58422,12 @@ func (p *selGEIntervalIntervalOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEIntervalIntervalOp) Init() {
-	p.Input.Init()
-}
-
 type selGEJSONJSONConstOp struct {
 	selConstOpBase
 	constArg json.JSON
 }
 
-func (p *selGEJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEJSONJSONConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -59909,7 +58436,7 @@ func (p *selGEJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -60031,15 +58558,11 @@ func (p *selGEJSONJSONConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEJSONJSONConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEJSONJSONOp struct {
 	selOpBase
 }
 
-func (p *selGEJSONJSONOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEJSONJSONOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -60048,7 +58571,7 @@ func (p *selGEJSONJSONOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -60179,16 +58702,12 @@ func (p *selGEJSONJSONOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEJSONJSONOp) Init() {
-	p.Input.Init()
-}
-
 type selGEDatumDatumConstOp struct {
 	selConstOpBase
 	constArg interface{}
 }
 
-func (p *selGEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEDatumDatumConstOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -60197,7 +58716,7 @@ func (p *selGEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -60303,15 +58822,11 @@ func (p *selGEDatumDatumConstOp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (p *selGEDatumDatumConstOp) Init() {
-	p.Input.Init()
-}
-
 type selGEDatumDatumOp struct {
 	selOpBase
 }
 
-func (p *selGEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
+func (p *selGEDatumDatumOp) Next() coldata.Batch {
 	// In order to inline the templated code of overloads, we need to have a
 	// `_overloadHelper` local variable of type `execgen.OverloadHelper`.
 	_overloadHelper := p.overloadHelper
@@ -60320,7 +58835,7 @@ func (p *selGEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 	_ = _overloadHelper
 	var isNull bool
 	for {
-		batch := p.Input.Next(ctx)
+		batch := p.Input.Next()
 		if batch.Length() == 0 {
 			return batch
 		}
@@ -60433,10 +58948,6 @@ func (p *selGEDatumDatumOp) Next(ctx context.Context) coldata.Batch {
 			return batch
 		}
 	}
-}
-
-func (p *selGEDatumDatumOp) Init() {
-	p.Input.Init()
 }
 
 // GetSelectionConstOperator returns the appropriate constant selection operator
@@ -60453,8 +58964,8 @@ func GetSelectionConstOperator(
 	leftType, constType := inputTypes[colIdx], constArg.ResolvedType()
 	c := colconv.GetDatumToPhysicalFn(constType)(constArg)
 	selConstOpBase := selConstOpBase{
-		OneInputNode: colexecop.NewOneInputNode(input),
-		colIdx:       colIdx,
+		OneInputHelper: colexecop.MakeOneInputHelper(input),
+		colIdx:         colIdx,
 	}
 	if leftType.Family() != types.TupleFamily && constType.Family() != types.TupleFamily {
 		// Tuple comparison has special null-handling semantics, so we will
@@ -61792,9 +60303,9 @@ func GetSelectionOperator(
 ) (colexecop.Operator, error) {
 	leftType, rightType := inputTypes[col1Idx], inputTypes[col2Idx]
 	selOpBase := selOpBase{
-		OneInputNode: colexecop.NewOneInputNode(input),
-		col1Idx:      col1Idx,
-		col2Idx:      col2Idx,
+		OneInputHelper: colexecop.MakeOneInputHelper(input),
+		col1Idx:        col1Idx,
+		col2Idx:        col2Idx,
 	}
 	if leftType.Family() != types.TupleFamily && rightType.Family() != types.TupleFamily {
 		// Tuple comparison has special null-handling semantics, so we will

--- a/pkg/sql/colexec/colexecsel/selection_ops_test.go
+++ b/pkg/sql/colexec/colexecsel/selection_ops_test.go
@@ -39,8 +39,8 @@ func TestSelLTInt64Int64ConstOp(t *testing.T) {
 	colexectestutils.RunTests(t, testAllocator, []colexectestutils.Tuples{tups}, colexectestutils.Tuples{{0}, {1}}, colexectestutils.OrderedVerifier, func(input []colexecop.Operator) (colexecop.Operator, error) {
 		return &selLTInt64Int64ConstOp{
 			selConstOpBase: selConstOpBase{
-				OneInputNode: colexecop.NewOneInputNode(input[0]),
-				colIdx:       0,
+				OneInputHelper: colexecop.MakeOneInputHelper(input[0]),
+				colIdx:         0,
 			},
 			constArg: 2,
 		}, nil
@@ -62,9 +62,9 @@ func TestSelLTInt64Int64(t *testing.T) {
 	colexectestutils.RunTests(t, testAllocator, []colexectestutils.Tuples{tups}, colexectestutils.Tuples{{0, 1}}, colexectestutils.OrderedVerifier, func(input []colexecop.Operator) (colexecop.Operator, error) {
 		return &selLTInt64Int64Op{
 			selOpBase: selOpBase{
-				OneInputNode: colexecop.NewOneInputNode(input[0]),
-				col1Idx:      0,
-				col2Idx:      1,
+				OneInputHelper: colexecop.MakeOneInputHelper(input[0]),
+				col1Idx:        0,
+				col2Idx:        1,
 			},
 		}, nil
 	})
@@ -88,8 +88,8 @@ func TestGetSelectionConstOperator(t *testing.T) {
 	}
 	expected := &selLTInt64Int64ConstOp{
 		selConstOpBase: selConstOpBase{
-			OneInputNode: colexecop.NewOneInputNode(input),
-			colIdx:       colIdx,
+			OneInputHelper: colexecop.MakeOneInputHelper(input),
+			colIdx:         colIdx,
 		},
 		constArg: constVal,
 	}
@@ -116,8 +116,8 @@ func TestGetSelectionConstMixedTypeOperator(t *testing.T) {
 	}
 	expected := &selLTInt16Int64ConstOp{
 		selConstOpBase: selConstOpBase{
-			OneInputNode: colexecop.NewOneInputNode(input),
-			colIdx:       colIdx,
+			OneInputHelper: colexecop.MakeOneInputHelper(input),
+			colIdx:         colIdx,
 		},
 		constArg: constVal,
 	}
@@ -145,9 +145,9 @@ func TestGetSelectionOperator(t *testing.T) {
 	}
 	expected := &selGEInt16Int16Op{
 		selOpBase: selOpBase{
-			OneInputNode: colexecop.NewOneInputNode(input),
-			col1Idx:      col1Idx,
-			col2Idx:      col2Idx,
+			OneInputHelper: colexecop.MakeOneInputHelper(input),
+			col1Idx:        col1Idx,
+			col2Idx:        col2Idx,
 		},
 	}
 	if !reflect.DeepEqual(op, expected) {
@@ -185,21 +185,21 @@ func benchmarkSelLTInt64Int64ConstOp(b *testing.B, useSelectionVector bool, hasN
 		}
 	}
 	source := colexecop.NewRepeatableBatchSource(testAllocator, batch, typs)
-	source.Init()
+	source.Init(ctx)
 
 	plusOp := &selLTInt64Int64ConstOp{
 		selConstOpBase: selConstOpBase{
-			OneInputNode: colexecop.NewOneInputNode(source),
-			colIdx:       0,
+			OneInputHelper: colexecop.MakeOneInputHelper(source),
+			colIdx:         0,
 		},
 		constArg: 0,
 	}
-	plusOp.Init()
+	plusOp.Init(ctx)
 
 	b.SetBytes(int64(8 * coldata.BatchSize()))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		plusOp.Next(ctx)
+		plusOp.Next()
 	}
 }
 
@@ -247,21 +247,21 @@ func benchmarkSelLTInt64Int64Op(b *testing.B, useSelectionVector bool, hasNulls 
 		}
 	}
 	source := colexecop.NewRepeatableBatchSource(testAllocator, batch, typs)
-	source.Init()
+	source.Init(ctx)
 
 	plusOp := &selLTInt64Int64Op{
 		selOpBase: selOpBase{
-			OneInputNode: colexecop.NewOneInputNode(source),
-			col1Idx:      0,
-			col2Idx:      1,
+			OneInputHelper: colexecop.MakeOneInputHelper(source),
+			col1Idx:        0,
+			col2Idx:        1,
 		},
 	}
-	plusOp.Init()
+	plusOp.Init(ctx)
 
 	b.SetBytes(int64(8 * coldata.BatchSize() * 2))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		plusOp.Next(ctx)
+		plusOp.Next()
 	}
 }
 

--- a/pkg/sql/colexec/colexectestutils/utils_test.go
+++ b/pkg/sql/colexec/colexectestutils/utils_test.go
@@ -54,12 +54,13 @@ func TestRepeatableBatchSource(t *testing.T) {
 	}
 	batch.SetLength(batchLen)
 	input := colexecop.NewRepeatableBatchSource(testAllocator, batch, typs)
+	input.Init(context.Background())
 
-	b := input.Next(context.Background())
+	b := input.Next()
 	b.SetLength(0)
 	b.SetSelection(true)
 
-	b = input.Next(context.Background())
+	b = input.Next()
 	if b.Length() != batchLen {
 		t.Fatalf("expected RepeatableBatchSource to reset batch length to %d, found %d", batchLen, b.Length())
 	}
@@ -84,11 +85,12 @@ func TestRepeatableBatchSourceWithFixedSel(t *testing.T) {
 	batch.SetSelection(true)
 	copy(batch.Selection(), sel)
 	input := colexecop.NewRepeatableBatchSource(testAllocator, batch, typs)
-	b := input.Next(context.Background())
+	input.Init(context.Background())
+	b := input.Next()
 
 	b.SetLength(0)
 	b.SetSelection(false)
-	b = input.Next(context.Background())
+	b = input.Next()
 	if b.Length() != batchLen {
 		t.Fatalf("expected RepeatableBatchSource to reset batch length to %d, found %d", batchLen, b.Length())
 	}
@@ -107,7 +109,7 @@ func TestRepeatableBatchSourceWithFixedSel(t *testing.T) {
 	b.SetLength(newBatchLen)
 	b.SetSelection(true)
 	copy(b.Selection(), newSel)
-	b = input.Next(context.Background())
+	b = input.Next()
 	if b.Length() != batchLen {
 		t.Fatalf("expected RepeatableBatchSource to reset batch length to %d, found %d", batchLen, b.Length())
 	}

--- a/pkg/sql/colexec/colexecutils/cancel_checker.go
+++ b/pkg/sql/colexec/colexecutils/cancel_checker.go
@@ -19,20 +19,19 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
 )
 
-// CancelChecker is an Operator that checks whether query cancellation has
-// occurred. The check happens on every batch.
+// CancelChecker is a colexecop.Operator that checks whether query cancellation
+// has occurred. The check happens on every batch.
+//
+// It also can be used for its utility Check*() methods, but it must be
+// initialized still.
 type CancelChecker struct {
 	colexecop.OneInputNode
+	colexecop.InitHelper
 	colexecop.NonExplainable
 
 	// Number of times check() has been called since last context cancellation
 	// check.
 	callsSinceLastCheck uint32
-}
-
-// Init is part of the Operator interface.
-func (c *CancelChecker) Init() {
-	c.Input.Init()
 }
 
 var _ colexecop.Operator = &CancelChecker{}
@@ -42,10 +41,22 @@ func NewCancelChecker(op colexecop.Operator) *CancelChecker {
 	return &CancelChecker{OneInputNode: colexecop.NewOneInputNode(op)}
 }
 
-// Next is part of Operator interface.
-func (c *CancelChecker) Next(ctx context.Context) coldata.Batch {
-	c.CheckEveryCall(ctx)
-	return c.Input.Next(ctx)
+// Init is part of colexecop.Operator interface.
+func (c *CancelChecker) Init(ctx context.Context) {
+	if !c.InitHelper.Init(ctx) {
+		return
+	}
+	if c.Input != nil {
+		// In some cases, the cancel checker is used as a utility to provide
+		// Check*() methods, and the input remains nil then.
+		c.Input.Init(c.Ctx)
+	}
+}
+
+// Next is part of colexecop.Operator interface.
+func (c *CancelChecker) Next() coldata.Batch {
+	c.CheckEveryCall()
+	return c.Input.Next()
 }
 
 // Interval of Check() calls to wait between checks for context cancellation.
@@ -56,9 +67,9 @@ const cancelCheckInterval = 1024
 // Check panics with a query canceled error if the associated query has been
 // canceled. The check is performed on every cancelCheckInterval'th call. This
 // should be used only during long-running operations.
-func (c *CancelChecker) Check(ctx context.Context) {
+func (c *CancelChecker) Check() {
 	if c.callsSinceLastCheck%cancelCheckInterval == 0 {
-		c.CheckEveryCall(ctx)
+		c.CheckEveryCall()
 	}
 
 	// Increment. This may rollover when the 32-bit capacity is reached, but
@@ -69,9 +80,9 @@ func (c *CancelChecker) Check(ctx context.Context) {
 // CheckEveryCall panics with query canceled error (which will be caught at the
 // materializer level and will be propagated forward as metadata) if the
 // associated query has been canceled. The check is performed on every call.
-func (c *CancelChecker) CheckEveryCall(ctx context.Context) {
+func (c *CancelChecker) CheckEveryCall() {
 	select {
-	case <-ctx.Done():
+	case <-c.Ctx.Done():
 		colexecerror.ExpectedError(cancelchecker.QueryCanceledError)
 	default:
 	}

--- a/pkg/sql/colexec/colexecutils/cancel_checker_test.go
+++ b/pkg/sql/colexec/colexecutils/cancel_checker_test.go
@@ -33,9 +33,10 @@ func TestCancelChecker(t *testing.T) {
 	typs := []*types.T{types.Int}
 	batch := testAllocator.NewMemBatchWithMaxCapacity(typs)
 	op := NewCancelChecker(colexecop.NewRepeatableBatchSource(testAllocator, batch, typs))
+	op.Init(ctx)
 	cancel()
 	err := colexecerror.CatchVectorizedRuntimeError(func() {
-		op.Next(ctx)
+		op.Next()
 	})
 	require.True(t, errors.Is(err, cancelchecker.QueryCanceledError))
 }

--- a/pkg/sql/colexec/colexecutils/deselector_test.go
+++ b/pkg/sql/colexec/colexecutils/deselector_test.go
@@ -111,11 +111,11 @@ func BenchmarkDeselector(b *testing.B) {
 				batch.SetLength(batchLen)
 				input := colexecop.NewRepeatableBatchSource(testAllocator, batch, inputTypes)
 				op := NewDeselectorOp(testAllocator, input, inputTypes)
-				op.Init()
+				op.Init(ctx)
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
 					input.ResetBatchesToReturn(nBatches)
-					for b := op.Next(ctx); b.Length() != 0; b = op.Next(ctx) {
+					for b := op.Next(); b.Length() != 0; b = op.Next() {
 					}
 					// We don't need to reset the deselector because it doesn't keep any
 					// state. We do, however, want to keep its already allocated memory

--- a/pkg/sql/colexec/colexecutils/operator.go
+++ b/pkg/sql/colexec/colexecutils/operator.go
@@ -22,7 +22,7 @@ import (
 )
 
 type zeroOperator struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	colexecop.NonExplainable
 }
 
@@ -30,14 +30,10 @@ var _ colexecop.Operator = &zeroOperator{}
 
 // NewZeroOp creates a new operator which just returns an empty batch.
 func NewZeroOp(input colexecop.Operator) colexecop.Operator {
-	return &zeroOperator{OneInputNode: colexecop.NewOneInputNode(input)}
+	return &zeroOperator{OneInputHelper: colexecop.MakeOneInputHelper(input)}
 }
 
-func (s *zeroOperator) Init() {
-	s.Input.Init()
-}
-
-func (s *zeroOperator) Next(context.Context) coldata.Batch {
+func (s *zeroOperator) Next() coldata.Batch {
 	return coldata.ZeroBatch
 }
 
@@ -70,13 +66,13 @@ func NewFixedNumTuplesNoInputOp(
 	}
 }
 
-func (s *fixedNumTuplesNoInputOp) Init() {
+func (s *fixedNumTuplesNoInputOp) Init(ctx context.Context) {
 	if s.opToInitialize != nil {
-		s.opToInitialize.Init()
+		s.opToInitialize.Init(ctx)
 	}
 }
 
-func (s *fixedNumTuplesNoInputOp) Next(context.Context) coldata.Batch {
+func (s *fixedNumTuplesNoInputOp) Next() coldata.Batch {
 	if s.numTuplesLeft == 0 {
 		return coldata.ZeroBatch
 	}
@@ -115,7 +111,7 @@ func (s *fixedNumTuplesNoInputOp) Next(context.Context) coldata.Batch {
 //   ---------------------              in column at position of N+1)
 //
 type vectorTypeEnforcer struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 	colexecop.NonExplainable
 
 	allocator *colmem.Allocator
@@ -130,19 +126,15 @@ func NewVectorTypeEnforcer(
 	allocator *colmem.Allocator, input colexecop.Operator, typ *types.T, idx int,
 ) colexecop.Operator {
 	return &vectorTypeEnforcer{
-		OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-		allocator:            allocator,
-		typ:                  typ,
-		idx:                  idx,
+		OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+		allocator:                allocator,
+		typ:                      typ,
+		idx:                      idx,
 	}
 }
 
-func (e *vectorTypeEnforcer) Init() {
-	e.Input.Init()
-}
-
-func (e *vectorTypeEnforcer) Next(ctx context.Context) coldata.Batch {
-	b := e.Input.Next(ctx)
+func (e *vectorTypeEnforcer) Next() coldata.Batch {
+	b := e.Input.Next()
 	if b.Length() == 0 {
 		return b
 	}
@@ -170,7 +162,7 @@ func (e *vectorTypeEnforcer) Reset(ctx context.Context) {
 // NOTE: the type schema passed into BatchSchemaSubsetEnforcer *must* include
 // the output type of the Operator that the enforcer will be the input to.
 type BatchSchemaSubsetEnforcer struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 	colexecop.NonExplainable
 
 	allocator                    *colmem.Allocator
@@ -191,25 +183,25 @@ func NewBatchSchemaSubsetEnforcer(
 	subsetStartIdx, subsetEndIdx int,
 ) *BatchSchemaSubsetEnforcer {
 	return &BatchSchemaSubsetEnforcer{
-		OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-		allocator:            allocator,
-		typs:                 typs,
-		subsetStartIdx:       subsetStartIdx,
-		subsetEndIdx:         subsetEndIdx,
+		OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+		allocator:                allocator,
+		typs:                     typs,
+		subsetStartIdx:           subsetStartIdx,
+		subsetEndIdx:             subsetEndIdx,
 	}
 }
 
 // Init implements the colexecop.Operator interface.
-func (e *BatchSchemaSubsetEnforcer) Init() {
-	e.Input.Init()
+func (e *BatchSchemaSubsetEnforcer) Init(ctx context.Context) {
 	if e.subsetStartIdx >= e.subsetEndIdx {
 		colexecerror.InternalError(errors.AssertionFailedf("unexpectedly subsetStartIdx is not less than subsetEndIdx"))
 	}
+	e.OneInputInitCloserHelper.Init(ctx)
 }
 
 // Next implements the colexecop.Operator interface.
-func (e *BatchSchemaSubsetEnforcer) Next(ctx context.Context) coldata.Batch {
-	b := e.Input.Next(ctx)
+func (e *BatchSchemaSubsetEnforcer) Next() coldata.Batch {
+	b := e.Input.Next()
 	if b.Length() == 0 {
 		return b
 	}

--- a/pkg/sql/colexec/colexecutils/spilling_queue_test.go
+++ b/pkg/sql/colexec/colexecutils/spilling_queue_test.go
@@ -103,6 +103,7 @@ func TestSpillingQueue(t *testing.T) {
 					tuples.AppendTuples(b, 0 /* startIdx */, b.Length())
 				},
 			})
+			op.Init(ctx)
 			typs := op.Typs()
 
 			queueCfg.CacheMode = diskQueueCacheMode
@@ -180,7 +181,7 @@ func TestSpillingQueue(t *testing.T) {
 			}
 
 			for {
-				b = op.Next(ctx)
+				b = op.Next()
 				q.Enqueue(ctx, b)
 				if b.Length() == 0 {
 					break
@@ -270,6 +271,7 @@ func TestSpillingQueueDidntSpill(t *testing.T) {
 		BatchSize:         1 + rng.Intn(coldata.BatchSize()),
 		Nulls:             true,
 	})
+	op.Init(ctx)
 
 	typs := op.Typs()
 	// Choose a memory limit such that at most two batches can be kept in the
@@ -299,7 +301,7 @@ func TestSpillingQueueDidntSpill(t *testing.T) {
 	)
 
 	for {
-		b := op.Next(ctx)
+		b := op.Next()
 		q.Enqueue(ctx, b)
 		b, err := q.Dequeue(ctx)
 		require.NoError(t, err)

--- a/pkg/sql/colexec/colexecwindow/partitioner.go
+++ b/pkg/sql/colexec/colexecwindow/partitioner.go
@@ -11,8 +11,6 @@
 package colexecwindow
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
@@ -54,7 +52,7 @@ func NewWindowSortingPartitioner(
 
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, types.Bool, partitionColIdx)
 	return &windowSortingPartitioner{
-		OneInputNode:    colexecop.NewOneInputNode(input),
+		OneInputHelper:  colexecop.MakeOneInputHelper(input),
 		allocator:       allocator,
 		distinctCol:     distinctCol,
 		partitionColIdx: partitionColIdx,
@@ -62,7 +60,7 @@ func NewWindowSortingPartitioner(
 }
 
 type windowSortingPartitioner struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	allocator *colmem.Allocator
 	// distinctCol is the output column of the chain of ordered distinct
@@ -72,12 +70,8 @@ type windowSortingPartitioner struct {
 	partitionColIdx int
 }
 
-func (p *windowSortingPartitioner) Init() {
-	p.Input.Init()
-}
-
-func (p *windowSortingPartitioner) Next(ctx context.Context) coldata.Batch {
-	b := p.Input.Next(ctx)
+func (p *windowSortingPartitioner) Next() coldata.Batch {
+	b := p.Input.Next()
 	if b.Length() == 0 {
 		return coldata.ZeroBatch
 	}

--- a/pkg/sql/colexec/colexecwindow/rank.eg.go
+++ b/pkg/sql/colexec/colexecwindow/rank.eg.go
@@ -71,6 +71,7 @@ func NewRankOperator(
 
 type rankInitFields struct {
 	colexecop.OneInputNode
+	colexecop.InitHelper
 
 	allocator       *colmem.Allocator
 	outputColIdx    int
@@ -90,8 +91,11 @@ type rankNoPartitionOp struct {
 
 var _ colexecop.Operator = &rankNoPartitionOp{}
 
-func (r *rankNoPartitionOp) Init() {
-	r.Input.Init()
+func (r *rankNoPartitionOp) Init(ctx context.Context) {
+	if !r.InitHelper.Init(ctx) {
+		return
+	}
+	r.Input.Init(r.Ctx)
 	// All rank functions start counting from 1. Before we assign the rank to a
 	// tuple in the batch, we first increment r.rank, so setting this
 	// rankIncrement to 1 will update r.rank to 1 on the very first tuple (as
@@ -99,8 +103,8 @@ func (r *rankNoPartitionOp) Init() {
 	r.rankIncrement = 1
 }
 
-func (r *rankNoPartitionOp) Next(ctx context.Context) coldata.Batch {
-	batch := r.Input.Next(ctx)
+func (r *rankNoPartitionOp) Next() coldata.Batch {
+	batch := r.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -157,8 +161,11 @@ type rankWithPartitionOp struct {
 
 var _ colexecop.Operator = &rankWithPartitionOp{}
 
-func (r *rankWithPartitionOp) Init() {
-	r.Input.Init()
+func (r *rankWithPartitionOp) Init(ctx context.Context) {
+	if !r.InitHelper.Init(ctx) {
+		return
+	}
+	r.Input.Init(r.Ctx)
 	// All rank functions start counting from 1. Before we assign the rank to a
 	// tuple in the batch, we first increment r.rank, so setting this
 	// rankIncrement to 1 will update r.rank to 1 on the very first tuple (as
@@ -166,8 +173,8 @@ func (r *rankWithPartitionOp) Init() {
 	r.rankIncrement = 1
 }
 
-func (r *rankWithPartitionOp) Next(ctx context.Context) coldata.Batch {
-	batch := r.Input.Next(ctx)
+func (r *rankWithPartitionOp) Next() coldata.Batch {
+	batch := r.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -243,8 +250,11 @@ type denseRankNoPartitionOp struct {
 
 var _ colexecop.Operator = &denseRankNoPartitionOp{}
 
-func (r *denseRankNoPartitionOp) Init() {
-	r.Input.Init()
+func (r *denseRankNoPartitionOp) Init(ctx context.Context) {
+	if !r.InitHelper.Init(ctx) {
+		return
+	}
+	r.Input.Init(r.Ctx)
 	// All rank functions start counting from 1. Before we assign the rank to a
 	// tuple in the batch, we first increment r.rank, so setting this
 	// rankIncrement to 1 will update r.rank to 1 on the very first tuple (as
@@ -252,8 +262,8 @@ func (r *denseRankNoPartitionOp) Init() {
 	r.rankIncrement = 1
 }
 
-func (r *denseRankNoPartitionOp) Next(ctx context.Context) coldata.Batch {
-	batch := r.Input.Next(ctx)
+func (r *denseRankNoPartitionOp) Next() coldata.Batch {
+	batch := r.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -308,8 +318,11 @@ type denseRankWithPartitionOp struct {
 
 var _ colexecop.Operator = &denseRankWithPartitionOp{}
 
-func (r *denseRankWithPartitionOp) Init() {
-	r.Input.Init()
+func (r *denseRankWithPartitionOp) Init(ctx context.Context) {
+	if !r.InitHelper.Init(ctx) {
+		return
+	}
+	r.Input.Init(r.Ctx)
 	// All rank functions start counting from 1. Before we assign the rank to a
 	// tuple in the batch, we first increment r.rank, so setting this
 	// rankIncrement to 1 will update r.rank to 1 on the very first tuple (as
@@ -317,8 +330,8 @@ func (r *denseRankWithPartitionOp) Init() {
 	r.rankIncrement = 1
 }
 
-func (r *denseRankWithPartitionOp) Next(ctx context.Context) coldata.Batch {
-	batch := r.Input.Next(ctx)
+func (r *denseRankWithPartitionOp) Next() coldata.Batch {
+	batch := r.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch

--- a/pkg/sql/colexec/colexecwindow/relative_rank.eg.go
+++ b/pkg/sql/colexec/colexecwindow/relative_rank.eg.go
@@ -182,8 +182,11 @@ type percentRankNoPartitionOp struct {
 
 var _ colexecop.ClosableOperator = &percentRankNoPartitionOp{}
 
-func (r *percentRankNoPartitionOp) Init() {
-	r.Input.Init()
+func (r *percentRankNoPartitionOp) Init(ctx context.Context) {
+	if !r.InitHelper.Init(ctx) {
+		return
+	}
+	r.Input.Init(r.Ctx)
 	r.state = relativeRankBuffering
 	usedMemoryLimitFraction := 0.0
 	r.bufferedTuples = colexecutils.NewSpillingQueue(
@@ -205,7 +208,7 @@ func (r *percentRankNoPartitionOp) Init() {
 	r.rankIncrement = 1
 }
 
-func (r *percentRankNoPartitionOp) Next(ctx context.Context) coldata.Batch {
+func (r *percentRankNoPartitionOp) Next() coldata.Batch {
 	var err error
 	for {
 		switch r.state {
@@ -236,10 +239,10 @@ func (r *percentRankNoPartitionOp) Next(ctx context.Context) coldata.Batch {
 			// This example also shows why we need to use two different queues
 			// (since every partition can have multiple peer groups, the
 			// schedule of "flushing" is different).
-			batch := r.Input.Next(ctx)
+			batch := r.Input.Next()
 			n := batch.Length()
 			if n == 0 {
-				r.bufferedTuples.Enqueue(ctx, coldata.ZeroBatch)
+				r.bufferedTuples.Enqueue(r.Ctx, coldata.ZeroBatch)
 				// We have fully consumed the input, so now we can populate the output.
 				r.state = relativeRankEmitting
 				continue
@@ -265,7 +268,7 @@ func (r *percentRankNoPartitionOp) Next(ctx context.Context) coldata.Batch {
 				}
 				r.scratch.SetLength(n)
 			})
-			r.bufferedTuples.Enqueue(ctx, r.scratch)
+			r.bufferedTuples.Enqueue(r.Ctx, r.scratch)
 
 			// Then, we need to update the sizes of the partitions.
 			// There is a single partition in the whole input.
@@ -274,7 +277,7 @@ func (r *percentRankNoPartitionOp) Next(ctx context.Context) coldata.Batch {
 			continue
 
 		case relativeRankEmitting:
-			if r.scratch, err = r.bufferedTuples.Dequeue(ctx); err != nil {
+			if r.scratch, err = r.bufferedTuples.Dequeue(r.Ctx); err != nil {
 				colexecerror.InternalError(err)
 			}
 			n := r.scratch.Length()
@@ -335,7 +338,7 @@ func (r *percentRankNoPartitionOp) Next(ctx context.Context) coldata.Batch {
 			return r.output
 
 		case relativeRankFinished:
-			if err := r.Close(ctx); err != nil {
+			if err := r.Close(r.Ctx); err != nil {
 				colexecerror.InternalError(err)
 			}
 			return coldata.ZeroBatch
@@ -380,8 +383,11 @@ type percentRankWithPartitionOp struct {
 
 var _ colexecop.ClosableOperator = &percentRankWithPartitionOp{}
 
-func (r *percentRankWithPartitionOp) Init() {
-	r.Input.Init()
+func (r *percentRankWithPartitionOp) Init(ctx context.Context) {
+	if !r.InitHelper.Init(ctx) {
+		return
+	}
+	r.Input.Init(r.Ctx)
 	r.state = relativeRankBuffering
 	usedMemoryLimitFraction := 0.0
 	r.partitionsState.SpillingQueue = colexecutils.NewSpillingQueue(
@@ -415,7 +421,7 @@ func (r *percentRankWithPartitionOp) Init() {
 	r.rankIncrement = 1
 }
 
-func (r *percentRankWithPartitionOp) Next(ctx context.Context) coldata.Batch {
+func (r *percentRankWithPartitionOp) Next() coldata.Batch {
 	var err error
 	for {
 		switch r.state {
@@ -446,18 +452,18 @@ func (r *percentRankWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 			// This example also shows why we need to use two different queues
 			// (since every partition can have multiple peer groups, the
 			// schedule of "flushing" is different).
-			batch := r.Input.Next(ctx)
+			batch := r.Input.Next()
 			n := batch.Length()
 			if n == 0 {
-				r.bufferedTuples.Enqueue(ctx, coldata.ZeroBatch)
+				r.bufferedTuples.Enqueue(r.Ctx, coldata.ZeroBatch)
 				// We need to flush the last vector of the running partitions
 				// sizes, including the very last partition.
 				runningPartitionsSizesCol := r.partitionsState.runningSizes.ColVec(0).Int64()
 				runningPartitionsSizesCol[r.partitionsState.idx] = r.numTuplesInPartition
 				r.partitionsState.idx++
 				r.partitionsState.runningSizes.SetLength(r.partitionsState.idx)
-				r.partitionsState.Enqueue(ctx, r.partitionsState.runningSizes)
-				r.partitionsState.Enqueue(ctx, coldata.ZeroBatch)
+				r.partitionsState.Enqueue(r.Ctx, r.partitionsState.runningSizes)
+				r.partitionsState.Enqueue(r.Ctx, coldata.ZeroBatch)
 				// We have fully consumed the input, so now we can populate the output.
 				r.state = relativeRankEmitting
 				continue
@@ -485,7 +491,7 @@ func (r *percentRankWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 				}
 				r.scratch.SetLength(n)
 			})
-			r.bufferedTuples.Enqueue(ctx, r.scratch)
+			r.bufferedTuples.Enqueue(r.Ctx, r.scratch)
 
 			// Then, we need to update the sizes of the partitions.
 			partitionCol := batch.ColVec(r.partitionColIdx).Bool()
@@ -506,7 +512,7 @@ func (r *percentRankWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 							if r.partitionsState.idx == coldata.BatchSize() {
 								// We need to flush the vector of partitions sizes.
 								r.partitionsState.runningSizes.SetLength(coldata.BatchSize())
-								r.partitionsState.Enqueue(ctx, r.partitionsState.runningSizes)
+								r.partitionsState.Enqueue(r.Ctx, r.partitionsState.runningSizes)
 								r.partitionsState.idx = 0
 								r.partitionsState.runningSizes.ResetInternalBatch()
 							}
@@ -529,7 +535,7 @@ func (r *percentRankWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 							if r.partitionsState.idx == coldata.BatchSize() {
 								// We need to flush the vector of partitions sizes.
 								r.partitionsState.runningSizes.SetLength(coldata.BatchSize())
-								r.partitionsState.Enqueue(ctx, r.partitionsState.runningSizes)
+								r.partitionsState.Enqueue(r.Ctx, r.partitionsState.runningSizes)
 								r.partitionsState.idx = 0
 								r.partitionsState.runningSizes.ResetInternalBatch()
 							}
@@ -542,7 +548,7 @@ func (r *percentRankWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 			continue
 
 		case relativeRankEmitting:
-			if r.scratch, err = r.bufferedTuples.Dequeue(ctx); err != nil {
+			if r.scratch, err = r.bufferedTuples.Dequeue(r.Ctx); err != nil {
 				colexecerror.InternalError(err)
 			}
 			n := r.scratch.Length()
@@ -552,7 +558,7 @@ func (r *percentRankWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 			}
 			// Get the next batch of partition sizes if we haven't already.
 			if r.partitionsState.dequeuedSizes == nil {
-				if r.partitionsState.dequeuedSizes, err = r.partitionsState.Dequeue(ctx); err != nil {
+				if r.partitionsState.dequeuedSizes, err = r.partitionsState.Dequeue(r.Ctx); err != nil {
 					colexecerror.InternalError(err)
 				}
 				r.partitionsState.idx = 0
@@ -591,7 +597,7 @@ func (r *percentRankWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 				//gcassert:bce
 				if partitionCol[i] {
 					if r.partitionsState.idx == r.partitionsState.dequeuedSizes.Length() {
-						if r.partitionsState.dequeuedSizes, err = r.partitionsState.Dequeue(ctx); err != nil {
+						if r.partitionsState.dequeuedSizes, err = r.partitionsState.Dequeue(r.Ctx); err != nil {
 							colexecerror.InternalError(err)
 						}
 						r.partitionsState.idx = 0
@@ -626,7 +632,7 @@ func (r *percentRankWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 			return r.output
 
 		case relativeRankFinished:
-			if err := r.Close(ctx); err != nil {
+			if err := r.Close(r.Ctx); err != nil {
 				colexecerror.InternalError(err)
 			}
 			return coldata.ZeroBatch
@@ -675,8 +681,11 @@ type cumeDistNoPartitionOp struct {
 
 var _ colexecop.ClosableOperator = &cumeDistNoPartitionOp{}
 
-func (r *cumeDistNoPartitionOp) Init() {
-	r.Input.Init()
+func (r *cumeDistNoPartitionOp) Init(ctx context.Context) {
+	if !r.InitHelper.Init(ctx) {
+		return
+	}
+	r.Input.Init(r.Ctx)
 	r.state = relativeRankBuffering
 	usedMemoryLimitFraction := 0.0
 	r.peerGroupsState.SpillingQueue = colexecutils.NewSpillingQueue(
@@ -705,7 +714,7 @@ func (r *cumeDistNoPartitionOp) Init() {
 	r.output = r.allocator.NewMemBatchWithFixedCapacity(append(r.inputTypes, types.Float), coldata.BatchSize())
 }
 
-func (r *cumeDistNoPartitionOp) Next(ctx context.Context) coldata.Batch {
+func (r *cumeDistNoPartitionOp) Next() coldata.Batch {
 	var err error
 	for {
 		switch r.state {
@@ -736,18 +745,18 @@ func (r *cumeDistNoPartitionOp) Next(ctx context.Context) coldata.Batch {
 			// This example also shows why we need to use two different queues
 			// (since every partition can have multiple peer groups, the
 			// schedule of "flushing" is different).
-			batch := r.Input.Next(ctx)
+			batch := r.Input.Next()
 			n := batch.Length()
 			if n == 0 {
-				r.bufferedTuples.Enqueue(ctx, coldata.ZeroBatch)
+				r.bufferedTuples.Enqueue(r.Ctx, coldata.ZeroBatch)
 				// We need to flush the last vector of the running peer groups
 				// sizes, including the very last peer group.
 				runningPeerGroupsSizesCol := r.peerGroupsState.runningSizes.ColVec(0).Int64()
 				runningPeerGroupsSizesCol[r.peerGroupsState.idx] = r.numPeers
 				r.peerGroupsState.idx++
 				r.peerGroupsState.runningSizes.SetLength(r.peerGroupsState.idx)
-				r.peerGroupsState.Enqueue(ctx, r.peerGroupsState.runningSizes)
-				r.peerGroupsState.Enqueue(ctx, coldata.ZeroBatch)
+				r.peerGroupsState.Enqueue(r.Ctx, r.peerGroupsState.runningSizes)
+				r.peerGroupsState.Enqueue(r.Ctx, coldata.ZeroBatch)
 				// We have fully consumed the input, so now we can populate the output.
 				r.state = relativeRankEmitting
 				continue
@@ -773,7 +782,7 @@ func (r *cumeDistNoPartitionOp) Next(ctx context.Context) coldata.Batch {
 				}
 				r.scratch.SetLength(n)
 			})
-			r.bufferedTuples.Enqueue(ctx, r.scratch)
+			r.bufferedTuples.Enqueue(r.Ctx, r.scratch)
 
 			// Then, we need to update the sizes of the partitions.
 			// There is a single partition in the whole input.
@@ -798,7 +807,7 @@ func (r *cumeDistNoPartitionOp) Next(ctx context.Context) coldata.Batch {
 							if r.peerGroupsState.idx == coldata.BatchSize() {
 								// We need to flush the vector of peer group sizes.
 								r.peerGroupsState.runningSizes.SetLength(coldata.BatchSize())
-								r.peerGroupsState.Enqueue(ctx, r.peerGroupsState.runningSizes)
+								r.peerGroupsState.Enqueue(r.Ctx, r.peerGroupsState.runningSizes)
 								r.peerGroupsState.idx = 0
 								r.peerGroupsState.runningSizes.ResetInternalBatch()
 							}
@@ -821,7 +830,7 @@ func (r *cumeDistNoPartitionOp) Next(ctx context.Context) coldata.Batch {
 							if r.peerGroupsState.idx == coldata.BatchSize() {
 								// We need to flush the vector of peer group sizes.
 								r.peerGroupsState.runningSizes.SetLength(coldata.BatchSize())
-								r.peerGroupsState.Enqueue(ctx, r.peerGroupsState.runningSizes)
+								r.peerGroupsState.Enqueue(r.Ctx, r.peerGroupsState.runningSizes)
 								r.peerGroupsState.idx = 0
 								r.peerGroupsState.runningSizes.ResetInternalBatch()
 							}
@@ -833,7 +842,7 @@ func (r *cumeDistNoPartitionOp) Next(ctx context.Context) coldata.Batch {
 			continue
 
 		case relativeRankEmitting:
-			if r.scratch, err = r.bufferedTuples.Dequeue(ctx); err != nil {
+			if r.scratch, err = r.bufferedTuples.Dequeue(r.Ctx); err != nil {
 				colexecerror.InternalError(err)
 			}
 			n := r.scratch.Length()
@@ -843,7 +852,7 @@ func (r *cumeDistNoPartitionOp) Next(ctx context.Context) coldata.Batch {
 			}
 			// Get the next batch of peer group sizes if we haven't already.
 			if r.peerGroupsState.dequeuedSizes == nil {
-				if r.peerGroupsState.dequeuedSizes, err = r.peerGroupsState.Dequeue(ctx); err != nil {
+				if r.peerGroupsState.dequeuedSizes, err = r.peerGroupsState.Dequeue(r.Ctx); err != nil {
 					colexecerror.InternalError(err)
 				}
 				r.peerGroupsState.idx = 0
@@ -887,7 +896,7 @@ func (r *cumeDistNoPartitionOp) Next(ctx context.Context) coldata.Batch {
 					// this peer group.
 					r.numPrecedingTuples += r.numPeers
 					if r.peerGroupsState.idx == r.peerGroupsState.dequeuedSizes.Length() {
-						if r.peerGroupsState.dequeuedSizes, err = r.peerGroupsState.Dequeue(ctx); err != nil {
+						if r.peerGroupsState.dequeuedSizes, err = r.peerGroupsState.Dequeue(r.Ctx); err != nil {
 							colexecerror.InternalError(err)
 						}
 						r.peerGroupsState.idx = 0
@@ -905,7 +914,7 @@ func (r *cumeDistNoPartitionOp) Next(ctx context.Context) coldata.Batch {
 			return r.output
 
 		case relativeRankFinished:
-			if err := r.Close(ctx); err != nil {
+			if err := r.Close(r.Ctx); err != nil {
 				colexecerror.InternalError(err)
 			}
 			return coldata.ZeroBatch
@@ -955,8 +964,11 @@ type cumeDistWithPartitionOp struct {
 
 var _ colexecop.ClosableOperator = &cumeDistWithPartitionOp{}
 
-func (r *cumeDistWithPartitionOp) Init() {
-	r.Input.Init()
+func (r *cumeDistWithPartitionOp) Init(ctx context.Context) {
+	if !r.InitHelper.Init(ctx) {
+		return
+	}
+	r.Input.Init(r.Ctx)
 	r.state = relativeRankBuffering
 	usedMemoryLimitFraction := 0.0
 	r.partitionsState.SpillingQueue = colexecutils.NewSpillingQueue(
@@ -997,7 +1009,7 @@ func (r *cumeDistWithPartitionOp) Init() {
 	r.output = r.allocator.NewMemBatchWithFixedCapacity(append(r.inputTypes, types.Float), coldata.BatchSize())
 }
 
-func (r *cumeDistWithPartitionOp) Next(ctx context.Context) coldata.Batch {
+func (r *cumeDistWithPartitionOp) Next() coldata.Batch {
 	var err error
 	for {
 		switch r.state {
@@ -1028,26 +1040,26 @@ func (r *cumeDistWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 			// This example also shows why we need to use two different queues
 			// (since every partition can have multiple peer groups, the
 			// schedule of "flushing" is different).
-			batch := r.Input.Next(ctx)
+			batch := r.Input.Next()
 			n := batch.Length()
 			if n == 0 {
-				r.bufferedTuples.Enqueue(ctx, coldata.ZeroBatch)
+				r.bufferedTuples.Enqueue(r.Ctx, coldata.ZeroBatch)
 				// We need to flush the last vector of the running partitions
 				// sizes, including the very last partition.
 				runningPartitionsSizesCol := r.partitionsState.runningSizes.ColVec(0).Int64()
 				runningPartitionsSizesCol[r.partitionsState.idx] = r.numTuplesInPartition
 				r.partitionsState.idx++
 				r.partitionsState.runningSizes.SetLength(r.partitionsState.idx)
-				r.partitionsState.Enqueue(ctx, r.partitionsState.runningSizes)
-				r.partitionsState.Enqueue(ctx, coldata.ZeroBatch)
+				r.partitionsState.Enqueue(r.Ctx, r.partitionsState.runningSizes)
+				r.partitionsState.Enqueue(r.Ctx, coldata.ZeroBatch)
 				// We need to flush the last vector of the running peer groups
 				// sizes, including the very last peer group.
 				runningPeerGroupsSizesCol := r.peerGroupsState.runningSizes.ColVec(0).Int64()
 				runningPeerGroupsSizesCol[r.peerGroupsState.idx] = r.numPeers
 				r.peerGroupsState.idx++
 				r.peerGroupsState.runningSizes.SetLength(r.peerGroupsState.idx)
-				r.peerGroupsState.Enqueue(ctx, r.peerGroupsState.runningSizes)
-				r.peerGroupsState.Enqueue(ctx, coldata.ZeroBatch)
+				r.peerGroupsState.Enqueue(r.Ctx, r.peerGroupsState.runningSizes)
+				r.peerGroupsState.Enqueue(r.Ctx, coldata.ZeroBatch)
 				// We have fully consumed the input, so now we can populate the output.
 				r.state = relativeRankEmitting
 				continue
@@ -1075,7 +1087,7 @@ func (r *cumeDistWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 				}
 				r.scratch.SetLength(n)
 			})
-			r.bufferedTuples.Enqueue(ctx, r.scratch)
+			r.bufferedTuples.Enqueue(r.Ctx, r.scratch)
 
 			// Then, we need to update the sizes of the partitions.
 			partitionCol := batch.ColVec(r.partitionColIdx).Bool()
@@ -1096,7 +1108,7 @@ func (r *cumeDistWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 							if r.partitionsState.idx == coldata.BatchSize() {
 								// We need to flush the vector of partitions sizes.
 								r.partitionsState.runningSizes.SetLength(coldata.BatchSize())
-								r.partitionsState.Enqueue(ctx, r.partitionsState.runningSizes)
+								r.partitionsState.Enqueue(r.Ctx, r.partitionsState.runningSizes)
 								r.partitionsState.idx = 0
 								r.partitionsState.runningSizes.ResetInternalBatch()
 							}
@@ -1119,7 +1131,7 @@ func (r *cumeDistWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 							if r.partitionsState.idx == coldata.BatchSize() {
 								// We need to flush the vector of partitions sizes.
 								r.partitionsState.runningSizes.SetLength(coldata.BatchSize())
-								r.partitionsState.Enqueue(ctx, r.partitionsState.runningSizes)
+								r.partitionsState.Enqueue(r.Ctx, r.partitionsState.runningSizes)
 								r.partitionsState.idx = 0
 								r.partitionsState.runningSizes.ResetInternalBatch()
 							}
@@ -1148,7 +1160,7 @@ func (r *cumeDistWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 							if r.peerGroupsState.idx == coldata.BatchSize() {
 								// We need to flush the vector of peer group sizes.
 								r.peerGroupsState.runningSizes.SetLength(coldata.BatchSize())
-								r.peerGroupsState.Enqueue(ctx, r.peerGroupsState.runningSizes)
+								r.peerGroupsState.Enqueue(r.Ctx, r.peerGroupsState.runningSizes)
 								r.peerGroupsState.idx = 0
 								r.peerGroupsState.runningSizes.ResetInternalBatch()
 							}
@@ -1171,7 +1183,7 @@ func (r *cumeDistWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 							if r.peerGroupsState.idx == coldata.BatchSize() {
 								// We need to flush the vector of peer group sizes.
 								r.peerGroupsState.runningSizes.SetLength(coldata.BatchSize())
-								r.peerGroupsState.Enqueue(ctx, r.peerGroupsState.runningSizes)
+								r.peerGroupsState.Enqueue(r.Ctx, r.peerGroupsState.runningSizes)
 								r.peerGroupsState.idx = 0
 								r.peerGroupsState.runningSizes.ResetInternalBatch()
 							}
@@ -1183,7 +1195,7 @@ func (r *cumeDistWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 			continue
 
 		case relativeRankEmitting:
-			if r.scratch, err = r.bufferedTuples.Dequeue(ctx); err != nil {
+			if r.scratch, err = r.bufferedTuples.Dequeue(r.Ctx); err != nil {
 				colexecerror.InternalError(err)
 			}
 			n := r.scratch.Length()
@@ -1193,7 +1205,7 @@ func (r *cumeDistWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 			}
 			// Get the next batch of partition sizes if we haven't already.
 			if r.partitionsState.dequeuedSizes == nil {
-				if r.partitionsState.dequeuedSizes, err = r.partitionsState.Dequeue(ctx); err != nil {
+				if r.partitionsState.dequeuedSizes, err = r.partitionsState.Dequeue(r.Ctx); err != nil {
 					colexecerror.InternalError(err)
 				}
 				r.partitionsState.idx = 0
@@ -1201,7 +1213,7 @@ func (r *cumeDistWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 			}
 			// Get the next batch of peer group sizes if we haven't already.
 			if r.peerGroupsState.dequeuedSizes == nil {
-				if r.peerGroupsState.dequeuedSizes, err = r.peerGroupsState.Dequeue(ctx); err != nil {
+				if r.peerGroupsState.dequeuedSizes, err = r.peerGroupsState.Dequeue(r.Ctx); err != nil {
 					colexecerror.InternalError(err)
 				}
 				r.peerGroupsState.idx = 0
@@ -1240,7 +1252,7 @@ func (r *cumeDistWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 				//gcassert:bce
 				if partitionCol[i] {
 					if r.partitionsState.idx == r.partitionsState.dequeuedSizes.Length() {
-						if r.partitionsState.dequeuedSizes, err = r.partitionsState.Dequeue(ctx); err != nil {
+						if r.partitionsState.dequeuedSizes, err = r.partitionsState.Dequeue(r.Ctx); err != nil {
 							colexecerror.InternalError(err)
 						}
 						r.partitionsState.idx = 0
@@ -1260,7 +1272,7 @@ func (r *cumeDistWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 					// this peer group.
 					r.numPrecedingTuples += r.numPeers
 					if r.peerGroupsState.idx == r.peerGroupsState.dequeuedSizes.Length() {
-						if r.peerGroupsState.dequeuedSizes, err = r.peerGroupsState.Dequeue(ctx); err != nil {
+						if r.peerGroupsState.dequeuedSizes, err = r.peerGroupsState.Dequeue(r.Ctx); err != nil {
 							colexecerror.InternalError(err)
 						}
 						r.peerGroupsState.idx = 0
@@ -1278,7 +1290,7 @@ func (r *cumeDistWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 			return r.output
 
 		case relativeRankFinished:
-			if err := r.Close(ctx); err != nil {
+			if err := r.Close(r.Ctx); err != nil {
 				colexecerror.InternalError(err)
 			}
 			return coldata.ZeroBatch

--- a/pkg/sql/colexec/colexecwindow/relative_rank_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/relative_rank_tmpl.go
@@ -160,7 +160,7 @@ func _COMPUTE_PARTITIONS_SIZES(_HAS_SEL bool) { // */}}
 			if r.partitionsState.idx == coldata.BatchSize() {
 				// We need to flush the vector of partitions sizes.
 				r.partitionsState.runningSizes.SetLength(coldata.BatchSize())
-				r.partitionsState.Enqueue(ctx, r.partitionsState.runningSizes)
+				r.partitionsState.Enqueue(r.Ctx, r.partitionsState.runningSizes)
 				r.partitionsState.idx = 0
 				r.partitionsState.runningSizes.ResetInternalBatch()
 			}
@@ -192,7 +192,7 @@ func _COMPUTE_PEER_GROUPS_SIZES(_HAS_SEL bool) { // */}}
 			if r.peerGroupsState.idx == coldata.BatchSize() {
 				// We need to flush the vector of peer group sizes.
 				r.peerGroupsState.runningSizes.SetLength(coldata.BatchSize())
-				r.peerGroupsState.Enqueue(ctx, r.peerGroupsState.runningSizes)
+				r.peerGroupsState.Enqueue(r.Ctx, r.peerGroupsState.runningSizes)
 				r.peerGroupsState.idx = 0
 				r.peerGroupsState.runningSizes.ResetInternalBatch()
 			}
@@ -273,8 +273,11 @@ type _RELATIVE_RANK_STRINGOp struct {
 
 var _ colexecop.ClosableOperator = &_RELATIVE_RANK_STRINGOp{}
 
-func (r *_RELATIVE_RANK_STRINGOp) Init() {
-	r.Input.Init()
+func (r *_RELATIVE_RANK_STRINGOp) Init(ctx context.Context) {
+	if !r.InitHelper.Init(ctx) {
+		return
+	}
+	r.Input.Init(r.Ctx)
 	r.state = relativeRankBuffering
 	usedMemoryLimitFraction := 0.0
 	// {{if .HasPartition}}
@@ -326,7 +329,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Init() {
 	// {{end}}
 }
 
-func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
+func (r *_RELATIVE_RANK_STRINGOp) Next() coldata.Batch {
 	var err error
 	for {
 		switch r.state {
@@ -361,10 +364,10 @@ func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 			// This example also shows why we need to use two different queues
 			// (since every partition can have multiple peer groups, the
 			// schedule of "flushing" is different).
-			batch := r.Input.Next(ctx)
+			batch := r.Input.Next()
 			n := batch.Length()
 			if n == 0 {
-				r.bufferedTuples.Enqueue(ctx, coldata.ZeroBatch)
+				r.bufferedTuples.Enqueue(r.Ctx, coldata.ZeroBatch)
 				// {{if .HasPartition}}
 				// We need to flush the last vector of the running partitions
 				// sizes, including the very last partition.
@@ -372,8 +375,8 @@ func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 				runningPartitionsSizesCol[r.partitionsState.idx] = r.numTuplesInPartition
 				r.partitionsState.idx++
 				r.partitionsState.runningSizes.SetLength(r.partitionsState.idx)
-				r.partitionsState.Enqueue(ctx, r.partitionsState.runningSizes)
-				r.partitionsState.Enqueue(ctx, coldata.ZeroBatch)
+				r.partitionsState.Enqueue(r.Ctx, r.partitionsState.runningSizes)
+				r.partitionsState.Enqueue(r.Ctx, coldata.ZeroBatch)
 				// {{end}}
 				// {{if .IsCumeDist}}
 				// We need to flush the last vector of the running peer groups
@@ -382,8 +385,8 @@ func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 				runningPeerGroupsSizesCol[r.peerGroupsState.idx] = r.numPeers
 				r.peerGroupsState.idx++
 				r.peerGroupsState.runningSizes.SetLength(r.peerGroupsState.idx)
-				r.peerGroupsState.Enqueue(ctx, r.peerGroupsState.runningSizes)
-				r.peerGroupsState.Enqueue(ctx, coldata.ZeroBatch)
+				r.peerGroupsState.Enqueue(r.Ctx, r.peerGroupsState.runningSizes)
+				r.peerGroupsState.Enqueue(r.Ctx, coldata.ZeroBatch)
 				// {{end}}
 				// We have fully consumed the input, so now we can populate the output.
 				r.state = relativeRankEmitting
@@ -417,7 +420,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 				}
 				r.scratch.SetLength(n)
 			})
-			r.bufferedTuples.Enqueue(ctx, r.scratch)
+			r.bufferedTuples.Enqueue(r.Ctx, r.scratch)
 
 			// Then, we need to update the sizes of the partitions.
 			// {{if .HasPartition}}
@@ -462,7 +465,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 			continue
 
 		case relativeRankEmitting:
-			if r.scratch, err = r.bufferedTuples.Dequeue(ctx); err != nil {
+			if r.scratch, err = r.bufferedTuples.Dequeue(r.Ctx); err != nil {
 				colexecerror.InternalError(err)
 			}
 			n := r.scratch.Length()
@@ -473,7 +476,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 			// {{if .HasPartition}}
 			// Get the next batch of partition sizes if we haven't already.
 			if r.partitionsState.dequeuedSizes == nil {
-				if r.partitionsState.dequeuedSizes, err = r.partitionsState.Dequeue(ctx); err != nil {
+				if r.partitionsState.dequeuedSizes, err = r.partitionsState.Dequeue(r.Ctx); err != nil {
 					colexecerror.InternalError(err)
 				}
 				r.partitionsState.idx = 0
@@ -483,7 +486,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 			// {{if .IsCumeDist}}
 			// Get the next batch of peer group sizes if we haven't already.
 			if r.peerGroupsState.dequeuedSizes == nil {
-				if r.peerGroupsState.dequeuedSizes, err = r.peerGroupsState.Dequeue(ctx); err != nil {
+				if r.peerGroupsState.dequeuedSizes, err = r.peerGroupsState.Dequeue(r.Ctx); err != nil {
 					colexecerror.InternalError(err)
 				}
 				r.peerGroupsState.idx = 0
@@ -526,7 +529,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 				//gcassert:bce
 				if partitionCol[i] {
 					if r.partitionsState.idx == r.partitionsState.dequeuedSizes.Length() {
-						if r.partitionsState.dequeuedSizes, err = r.partitionsState.Dequeue(ctx); err != nil {
+						if r.partitionsState.dequeuedSizes, err = r.partitionsState.Dequeue(r.Ctx); err != nil {
 							colexecerror.InternalError(err)
 						}
 						r.partitionsState.idx = 0
@@ -563,7 +566,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 					// this peer group.
 					r.numPrecedingTuples += r.numPeers
 					if r.peerGroupsState.idx == r.peerGroupsState.dequeuedSizes.Length() {
-						if r.peerGroupsState.dequeuedSizes, err = r.peerGroupsState.Dequeue(ctx); err != nil {
+						if r.peerGroupsState.dequeuedSizes, err = r.peerGroupsState.Dequeue(r.Ctx); err != nil {
 							colexecerror.InternalError(err)
 						}
 						r.peerGroupsState.idx = 0
@@ -595,7 +598,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 			return r.output
 
 		case relativeRankFinished:
-			if err := r.Close(ctx); err != nil {
+			if err := r.Close(r.Ctx); err != nil {
 				colexecerror.InternalError(err)
 			}
 			return coldata.ZeroBatch

--- a/pkg/sql/colexec/colexecwindow/row_number_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/row_number_tmpl.go
@@ -20,8 +20,6 @@
 package colexecwindow
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
@@ -39,7 +37,7 @@ func NewRowNumberOperator(
 ) colexecop.Operator {
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, types.Int, outputColIdx)
 	base := rowNumberBase{
-		OneInputNode:    colexecop.NewOneInputNode(input),
+		OneInputHelper:  colexecop.MakeOneInputHelper(input),
 		allocator:       allocator,
 		outputColIdx:    outputColIdx,
 		partitionColIdx: partitionColIdx,
@@ -54,16 +52,12 @@ func NewRowNumberOperator(
 // variations of row number operators. Note that it is not an operator itself
 // and should not be used directly.
 type rowNumberBase struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	allocator       *colmem.Allocator
 	outputColIdx    int
 	partitionColIdx int
 
 	rowNumber int64
-}
-
-func (r *rowNumberBase) Init() {
-	r.Input.Init()
 }
 
 // {{/*
@@ -98,8 +92,8 @@ type _ROW_NUMBER_STRINGOp struct {
 
 var _ colexecop.Operator = &_ROW_NUMBER_STRINGOp{}
 
-func (r *_ROW_NUMBER_STRINGOp) Next(ctx context.Context) coldata.Batch {
-	batch := r.Input.Next(ctx)
+func (r *_ROW_NUMBER_STRINGOp) Next() coldata.Batch {
+	batch := r.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch

--- a/pkg/sql/colexec/colexecwindow/window_peer_grouper.eg.go
+++ b/pkg/sql/colexec/colexecwindow/window_peer_grouper.eg.go
@@ -10,8 +10,6 @@
 package colexecwindow
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
@@ -54,7 +52,7 @@ func NewWindowPeerGrouper(
 	}
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, types.Bool, outputColIdx)
 	initFields := windowPeerGrouperInitFields{
-		OneInputNode:    colexecop.NewOneInputNode(input),
+		OneInputHelper:  colexecop.MakeOneInputHelper(input),
 		allocator:       allocator,
 		partitionColIdx: partitionColIdx,
 		distinctCol:     distinctCol,
@@ -81,7 +79,7 @@ func NewWindowPeerGrouper(
 }
 
 type windowPeerGrouperInitFields struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	allocator       *colmem.Allocator
 	partitionColIdx int
@@ -98,12 +96,8 @@ type windowPeerGrouperNoPartitionOp struct {
 
 var _ colexecop.Operator = &windowPeerGrouperNoPartitionOp{}
 
-func (p *windowPeerGrouperNoPartitionOp) Init() {
-	p.Input.Init()
-}
-
-func (p *windowPeerGrouperNoPartitionOp) Next(ctx context.Context) coldata.Batch {
-	b := p.Input.Next(ctx)
+func (p *windowPeerGrouperNoPartitionOp) Next() coldata.Batch {
+	b := p.Input.Next()
 	n := b.Length()
 	if n == 0 {
 		return b
@@ -137,12 +131,8 @@ type windowPeerGrouperWithPartitionOp struct {
 
 var _ colexecop.Operator = &windowPeerGrouperWithPartitionOp{}
 
-func (p *windowPeerGrouperWithPartitionOp) Init() {
-	p.Input.Init()
-}
-
-func (p *windowPeerGrouperWithPartitionOp) Next(ctx context.Context) coldata.Batch {
-	b := p.Input.Next(ctx)
+func (p *windowPeerGrouperWithPartitionOp) Next() coldata.Batch {
+	b := p.Input.Next()
 	n := b.Length()
 	if n == 0 {
 		return b
@@ -187,12 +177,8 @@ type windowPeerGrouperAllPeersNoPartitionOp struct {
 
 var _ colexecop.Operator = &windowPeerGrouperAllPeersNoPartitionOp{}
 
-func (p *windowPeerGrouperAllPeersNoPartitionOp) Init() {
-	p.Input.Init()
-}
-
-func (p *windowPeerGrouperAllPeersNoPartitionOp) Next(ctx context.Context) coldata.Batch {
-	b := p.Input.Next(ctx)
+func (p *windowPeerGrouperAllPeersNoPartitionOp) Next() coldata.Batch {
+	b := p.Input.Next()
 	n := b.Length()
 	if n == 0 {
 		return b
@@ -228,12 +214,8 @@ type windowPeerGrouperAllPeersWithPartitionOp struct {
 
 var _ colexecop.Operator = &windowPeerGrouperAllPeersWithPartitionOp{}
 
-func (p *windowPeerGrouperAllPeersWithPartitionOp) Init() {
-	p.Input.Init()
-}
-
-func (p *windowPeerGrouperAllPeersWithPartitionOp) Next(ctx context.Context) coldata.Batch {
-	b := p.Input.Next(ctx)
+func (p *windowPeerGrouperAllPeersWithPartitionOp) Next() coldata.Batch {
+	b := p.Input.Next()
 	n := b.Length()
 	if n == 0 {
 		return b

--- a/pkg/sql/colexec/colexecwindow/window_peer_grouper_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/window_peer_grouper_tmpl.go
@@ -20,8 +20,6 @@
 package colexecwindow
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
@@ -64,7 +62,7 @@ func NewWindowPeerGrouper(
 	}
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, types.Bool, outputColIdx)
 	initFields := windowPeerGrouperInitFields{
-		OneInputNode:    colexecop.NewOneInputNode(input),
+		OneInputHelper:  colexecop.MakeOneInputHelper(input),
 		allocator:       allocator,
 		partitionColIdx: partitionColIdx,
 		distinctCol:     distinctCol,
@@ -91,7 +89,7 @@ func NewWindowPeerGrouper(
 }
 
 type windowPeerGrouperInitFields struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	allocator       *colmem.Allocator
 	partitionColIdx int
@@ -113,12 +111,8 @@ type _PEER_GROUPER_STRINGOp struct {
 
 var _ colexecop.Operator = &_PEER_GROUPER_STRINGOp{}
 
-func (p *_PEER_GROUPER_STRINGOp) Init() {
-	p.Input.Init()
-}
-
-func (p *_PEER_GROUPER_STRINGOp) Next(ctx context.Context) coldata.Batch {
-	b := p.Input.Next(ctx)
+func (p *_PEER_GROUPER_STRINGOp) Next() coldata.Batch {
+	b := p.Input.Next()
 	n := b.Length()
 	if n == 0 {
 		return b

--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -45,22 +45,23 @@ const (
 // reading the input in chunks of size coldata.BatchSize() and converting each
 // chunk into a coldata.Batch column by column.
 type Columnarizer struct {
+	// Note that we consciously don't embed a colexecop.InitHelper here because
+	// we currently rely on the ProcessorBase to provide the same (and more)
+	// functionality.
 	// TODO(yuzefovich): consider whether embedding ProcessorBase into the
 	// columnarizers makes sense.
 	execinfra.ProcessorBase
 	colexecop.NonExplainable
 
-	mode       columnarizerMode
-	allocator  *colmem.Allocator
-	input      execinfra.RowSource
-	da         rowenc.DatumAlloc
-	initStatus colexecop.OperatorInitStatus
+	mode      columnarizerMode
+	allocator *colmem.Allocator
+	input     execinfra.RowSource
+	da        rowenc.DatumAlloc
 
 	buffered        rowenc.EncDatumRows
 	batch           coldata.Batch
 	maxBatchMemSize int64
 	accumulatedMeta []execinfrapb.ProducerMetadata
-	ctx             context.Context
 	typs            []*types.T
 
 	// removedFromFlow marks this Columnarizer as having been removed from the
@@ -75,30 +76,27 @@ var _ colexecop.VectorizedStatsCollector = &Columnarizer{}
 // NewBufferingColumnarizer returns a new Columnarizer that will be buffering up
 // rows before emitting them as output batches.
 func NewBufferingColumnarizer(
-	ctx context.Context,
 	allocator *colmem.Allocator,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	input execinfra.RowSource,
 ) (*Columnarizer, error) {
-	return newColumnarizer(ctx, allocator, flowCtx, processorID, input, columnarizerBufferingMode)
+	return newColumnarizer(allocator, flowCtx, processorID, input, columnarizerBufferingMode)
 }
 
 // NewStreamingColumnarizer returns a new Columnarizer that emits every input
 // row as a separate batch.
 func NewStreamingColumnarizer(
-	ctx context.Context,
 	allocator *colmem.Allocator,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	input execinfra.RowSource,
 ) (*Columnarizer, error) {
-	return newColumnarizer(ctx, allocator, flowCtx, processorID, input, columnarizerStreamingMode)
+	return newColumnarizer(allocator, flowCtx, processorID, input, columnarizerStreamingMode)
 }
 
 // newColumnarizer returns a new Columnarizer.
 func newColumnarizer(
-	ctx context.Context,
 	allocator *colmem.Allocator,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
@@ -115,7 +113,6 @@ func newColumnarizer(
 		allocator:       allocator,
 		input:           input,
 		maxBatchMemSize: execinfra.GetWorkMemLimit(flowCtx),
-		ctx:             ctx,
 		mode:            mode,
 	}
 	if err = c.ProcessorBase.Init(
@@ -146,33 +143,30 @@ func newColumnarizer(
 }
 
 // Init is part of the Operator interface.
-func (c *Columnarizer) Init() {
+func (c *Columnarizer) Init(ctx context.Context) {
 	if c.removedFromFlow {
 		return
 	}
-	// We don't want to call Start on the input to columnarizer and allocating
-	// internal objects several times if Init method is called more than once, so
-	// we have this check in place.
-	if c.initStatus == colexecop.OperatorNotInitialized {
-		c.accumulatedMeta = make([]execinfrapb.ProducerMetadata, 0, 1)
-		c.ctx = c.StartInternalNoSpan(c.ctx)
-		c.input.Start(c.ctx)
-		c.initStatus = colexecop.OperatorInitialized
-		if execStatsHijacker, ok := c.input.(execinfra.ExecStatsForTraceHijacker); ok {
-			// The columnarizer is now responsible for propagating the execution
-			// stats of the wrapped processor.
-			//
-			// Note that this columnarizer cannot be removed from the flow
-			// because it will have a vectorized stats collector planned on top,
-			// so the optimization of wrapRowSources() in execplan.go will never
-			// trigger. We check this assumption with an assertion below in the
-			// test setting.
-			//
-			// Still, just to be safe, we delay the hijacking until Init so that
-			// in case the assumption is wrong, we still get the stats from the
-			// wrapped processor.
-			c.ExecStatsForTrace = execStatsHijacker.HijackExecStatsForTrace()
-		}
+	if c.Ctx != nil {
+		// Init has already been called.
+		return
+	}
+	c.accumulatedMeta = make([]execinfrapb.ProducerMetadata, 0, 1)
+	ctx = c.StartInternalNoSpan(ctx)
+	c.input.Start(ctx)
+	if execStatsHijacker, ok := c.input.(execinfra.ExecStatsForTraceHijacker); ok {
+		// The columnarizer is now responsible for propagating the execution
+		// stats of the wrapped processor.
+		//
+		// Note that this columnarizer cannot be removed from the flow because
+		// it will have a vectorized stats collector planned on top, so the
+		// optimization of wrapRowSources() in execplan.go will never trigger.
+		// We check this assumption with an assertion below in the test setting.
+		//
+		// Still, just to be safe, we delay the hijacking until Init so that in
+		// case the assumption is wrong, we still get the stats from the wrapped
+		// processor.
+		c.ExecStatsForTrace = execStatsHijacker.HijackExecStatsForTrace()
 	}
 }
 
@@ -192,7 +186,7 @@ func (c *Columnarizer) GetStats() *execinfrapb.ComponentStats {
 }
 
 // Next is part of the Operator interface.
-func (c *Columnarizer) Next(context.Context) coldata.Batch {
+func (c *Columnarizer) Next() coldata.Batch {
 	if c.removedFromFlow {
 		return coldata.ZeroBatch
 	}
@@ -277,11 +271,11 @@ var (
 )
 
 // DrainMeta is part of the colexecop.MetadataSource interface.
-func (c *Columnarizer) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
+func (c *Columnarizer) DrainMeta(context.Context) []execinfrapb.ProducerMetadata {
 	if c.removedFromFlow {
 		return nil
 	}
-	if c.initStatus == colexecop.OperatorNotInitialized {
+	if c.Ctx == nil {
 		// The columnarizer wasn't initialized, so the wrapped processors might
 		// not have been started leaving them in an unsafe to drain state, so
 		// we skip the draining. Mostly likely this happened because a panic was

--- a/pkg/sql/colexec/columnarizer_test.go
+++ b/pkg/sql/colexec/columnarizer_test.go
@@ -51,14 +51,14 @@ func TestColumnarizerResetsInternalBatch(t *testing.T) {
 		EvalCtx: &evalCtx,
 	}
 
-	c, err := NewBufferingColumnarizer(ctx, testAllocator, flowCtx, 0, input)
+	c, err := NewBufferingColumnarizer(testAllocator, flowCtx, 0, input)
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Init()
+	c.Init(ctx)
 	foundRows := 0
 	for {
-		batch := c.Next(ctx)
+		batch := c.Next()
 		require.Nil(t, batch.Selection(), "Columnarizer didn't reset the internal batch")
 		if batch.Length() == 0 {
 			break
@@ -101,14 +101,14 @@ func TestColumnarizerDrainsAndClosesInput(t *testing.T) {
 			const errMsg = "artificial error"
 			rb := distsqlutils.NewRowBuffer([]*types.T{types.Int}, nil /* rows */, distsqlutils.RowBufferArgs{})
 			rb.Push(nil, &execinfrapb.ProducerMetadata{Err: errors.New(errMsg)})
-			c, err := NewBufferingColumnarizer(ctx, testAllocator, flowCtx, 0 /* processorID */, rb)
+			c, err := NewBufferingColumnarizer(testAllocator, flowCtx, 0 /* processorID */, rb)
 			require.NoError(t, err)
 
-			c.Init()
+			c.Init(ctx)
 
 			// If the metadata is obtained through this Next call, the Columnarizer still
 			// returns it in DrainMeta.
-			err = colexecerror.CatchVectorizedRuntimeError(func() { c.Next(ctx) })
+			err = colexecerror.CatchVectorizedRuntimeError(func() { c.Next() })
 			require.True(t, testutils.IsError(err, errMsg), "unexpected error %v", err)
 
 			if tc.consumerClosed {
@@ -148,15 +148,15 @@ func BenchmarkColumnarize(b *testing.B) {
 
 	b.SetBytes(int64(nRows * nCols * int(unsafe.Sizeof(int64(0)))))
 
-	c, err := NewBufferingColumnarizer(ctx, testAllocator, flowCtx, 0, input)
+	c, err := NewBufferingColumnarizer(testAllocator, flowCtx, 0, input)
 	if err != nil {
 		b.Fatal(err)
 	}
-	c.Init()
+	c.Init(ctx)
 	for i := 0; i < b.N; i++ {
 		foundRows := 0
 		for {
-			batch := c.Next(ctx)
+			batch := c.Next()
 			if batch.Length() == 0 {
 				break
 			}

--- a/pkg/sql/colexec/crossjoiner_test.go
+++ b/pkg/sql/colexec/crossjoiner_test.go
@@ -467,8 +467,8 @@ func BenchmarkCrossJoiner(b *testing.B) {
 						monitors = append(monitors, result.OpMonitors...)
 						require.NoError(b, err)
 						cj := result.Root
-						cj.Init()
-						for b := cj.Next(ctx); b.Length() > 0; b = cj.Next(ctx) {
+						cj.Init(ctx)
+						for b := cj.Next(); b.Length() > 0; b = cj.Next() {
 						}
 					}
 				})

--- a/pkg/sql/colexec/disk_spiller.go
+++ b/pkg/sql/colexec/disk_spiller.go
@@ -150,10 +150,8 @@ func NewTwoInputDiskSpiller(
 	return &diskSpillerBase{
 		inputs:                 []colexecop.Operator{inputOne, inputTwo},
 		inMemoryOp:             inMemoryOp,
-		inMemoryOpInitStatus:   colexecop.OperatorNotInitialized,
 		inMemoryMemMonitorName: inMemoryMemMonitorName,
 		diskBackedOp:           diskBackedOpConstructor(diskBackedOpInputOne, diskBackedOpInputTwo),
-		distBackedOpInitStatus: colexecop.OperatorNotInitialized,
 		spillingCallbackFn:     spillingCallbackFn,
 	}
 }
@@ -162,24 +160,23 @@ func NewTwoInputDiskSpiller(
 // spillers.
 type diskSpillerBase struct {
 	colexecop.NonExplainable
-
+	colexecop.InitHelper
 	colexecop.CloserHelper
 
 	inputs  []colexecop.Operator
 	spilled bool
 
-	inMemoryOp             colexecop.BufferingInMemoryOperator
-	inMemoryOpInitStatus   colexecop.OperatorInitStatus
-	inMemoryMemMonitorName string
-	diskBackedOp           colexecop.Operator
-	distBackedOpInitStatus colexecop.OperatorInitStatus
-	spillingCallbackFn     func()
+	inMemoryOp              colexecop.BufferingInMemoryOperator
+	inMemoryMemMonitorName  string
+	diskBackedOp            colexecop.Operator
+	diskBackedOpInitialized bool
+	spillingCallbackFn      func()
 }
 
 var _ colexecop.ResettableOperator = &diskSpillerBase{}
 
-func (d *diskSpillerBase) Init() {
-	if d.inMemoryOpInitStatus == colexecop.OperatorInitialized {
+func (d *diskSpillerBase) Init(ctx context.Context) {
+	if !d.InitHelper.Init(ctx) {
 		return
 	}
 	// It is possible that Init() call below will hit an out of memory error,
@@ -187,18 +184,17 @@ func (d *diskSpillerBase) Init() {
 	//
 	// Also note that d.input is the input to d.inMemoryOp, so calling Init()
 	// only on the latter is sufficient.
-	d.inMemoryOp.Init()
-	d.inMemoryOpInitStatus = colexecop.OperatorInitialized
+	d.inMemoryOp.Init(d.Ctx)
 }
 
-func (d *diskSpillerBase) Next(ctx context.Context) coldata.Batch {
+func (d *diskSpillerBase) Next() coldata.Batch {
 	if d.spilled {
-		return d.diskBackedOp.Next(ctx)
+		return d.diskBackedOp.Next()
 	}
 	var batch coldata.Batch
 	if err := colexecerror.CatchVectorizedRuntimeError(
 		func() {
-			batch = d.inMemoryOp.Next(ctx)
+			batch = d.inMemoryOp.Next()
 		},
 	); err != nil {
 		if sqlerrors.IsOutOfMemoryError(err) &&
@@ -207,14 +203,11 @@ func (d *diskSpillerBase) Next(ctx context.Context) coldata.Batch {
 			if d.spillingCallbackFn != nil {
 				d.spillingCallbackFn()
 			}
-			if d.distBackedOpInitStatus == colexecop.OperatorNotInitialized {
-				// The disk spiller might be reset for reuse in which case the
-				// the disk-backed operator has already been initialized and we
-				// don't want to perform the initialization again.
-				d.diskBackedOp.Init()
-				d.distBackedOpInitStatus = colexecop.OperatorInitialized
-			}
-			return d.diskBackedOp.Next(ctx)
+			// It is ok if we call Init() multiple times (once after every
+			// Reset) since all calls except for the first one are noops.
+			d.diskBackedOp.Init(d.Ctx)
+			d.diskBackedOpInitialized = true
+			return d.diskBackedOp.Next()
 		}
 		// Either not an out of memory error or an OOM error coming from a
 		// different operator, so we propagate it further.
@@ -229,12 +222,10 @@ func (d *diskSpillerBase) Reset(ctx context.Context) {
 			r.Reset(ctx)
 		}
 	}
-	if d.inMemoryOpInitStatus == colexecop.OperatorInitialized {
-		if r, ok := d.inMemoryOp.(colexecop.Resetter); ok {
-			r.Reset(ctx)
-		}
+	if r, ok := d.inMemoryOp.(colexecop.Resetter); ok {
+		r.Reset(ctx)
 	}
-	if d.distBackedOpInitStatus == colexecop.OperatorInitialized {
+	if d.diskBackedOpInitialized {
 		if r, ok := d.diskBackedOp.(colexecop.Resetter); ok {
 			r.Reset(ctx)
 		}
@@ -318,19 +309,19 @@ func newBufferExportingOperator(
 	}
 }
 
-func (b *bufferExportingOperator) Init() {
+func (b *bufferExportingOperator) Init(context.Context) {
 	// Init here is a noop because the operator assumes that both sources have
 	// already been initialized.
 }
 
-func (b *bufferExportingOperator) Next(ctx context.Context) coldata.Batch {
+func (b *bufferExportingOperator) Next() coldata.Batch {
 	if b.firstSourceDone {
-		return b.secondSource.Next(ctx)
+		return b.secondSource.Next()
 	}
-	batch := b.firstSource.ExportBuffered(ctx, b.secondSource)
+	batch := b.firstSource.ExportBuffered(b.secondSource)
 	if batch.Length() == 0 {
 		b.firstSourceDone = true
-		return b.secondSource.Next(ctx)
+		return b.secondSource.Next()
 	}
 	return batch
 }

--- a/pkg/sql/colexec/distinct_test.go
+++ b/pkg/sql/colexec/distinct_test.go
@@ -378,8 +378,8 @@ func runDistinctBenchmarks(
 								if err != nil {
 									b.Fatal(err)
 								}
-								distinct.Init()
-								for b := distinct.Next(ctx); b.Length() > 0; b = distinct.Next(ctx) {
+								distinct.Init(ctx)
+								for b := distinct.Next(); b.Length() > 0; b = distinct.Next() {
 								}
 							}
 							b.StopTimer()

--- a/pkg/sql/colexec/execgen/cmd/execgen/hash_utils_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/hash_utils_gen.go
@@ -31,8 +31,8 @@ func genHashUtils(inputFileContents string, wr io.Writer) error {
 	assignHash := makeFunctionRegex("_ASSIGN_HASH", 4)
 	s = assignHash.ReplaceAllString(s, makeTemplateFunctionCall("Global.UnaryAssign", 4))
 
-	rehash := makeFunctionRegex("_REHASH_BODY", 8)
-	s = rehash.ReplaceAllString(s, `{{template "rehashBody" buildDict "Global" . "HasSel" $7 "HasNulls" $8}}`)
+	rehash := makeFunctionRegex("_REHASH_BODY", 7)
+	s = rehash.ReplaceAllString(s, `{{template "rehashBody" buildDict "Global" . "HasSel" $6 "HasNulls" $7}}`)
 
 	s = replaceManipulationFuncsAmbiguous(".Global", s)
 

--- a/pkg/sql/colexec/external_distinct.go
+++ b/pkg/sql/colexec/external_distinct.go
@@ -83,8 +83,8 @@ func NewExternalDistinct(
 	// in-memory operator tuples, so we plan a special filterer operator to
 	// remove all such tuples.
 	input = &unorderedDistinctFilterer{
-		OneInputNode: colexecop.NewOneInputNode(input),
-		ht:           inMemUnorderedDistinct.(*unorderedDistinct).ht,
+		OneInputHelper: colexecop.MakeOneInputHelper(input),
+		ud:             inMemUnorderedDistinct.(*unorderedDistinct),
 	}
 	numRequiredActivePartitions := colexecop.ExternalSorterMinPartitions
 	ed := newHashBasedPartitioner(

--- a/pkg/sql/colexec/external_hash_joiner_test.go
+++ b/pkg/sql/colexec/external_hash_joiner_test.go
@@ -179,12 +179,12 @@ func TestExternalHashJoinerFallbackToSortMergeJoin(t *testing.T) {
 		}
 	}()
 	require.NoError(t, err)
-	hj.Init()
+	hj.Init(ctx)
 	// We have a full cross-product, so we should get the number of tuples
 	// squared in the output.
 	expectedTuplesCount := nBatches * nBatches * coldata.BatchSize() * coldata.BatchSize()
 	actualTuplesCount := 0
-	for b := hj.Next(ctx); b.Length() > 0; b = hj.Next(ctx) {
+	for b := hj.Next(); b.Length() > 0; b = hj.Next() {
 		actualTuplesCount += b.Length()
 	}
 	require.True(t, spilled)
@@ -270,8 +270,8 @@ func BenchmarkExternalHashJoiner(b *testing.B) {
 						memAccounts = append(memAccounts, accounts...)
 						memMonitors = append(memMonitors, monitors...)
 						require.NoError(b, err)
-						hj.Init()
-						for b := hj.Next(ctx); b.Length() > 0; b = hj.Next(ctx) {
+						hj.Init(ctx)
+						for b := hj.Next(); b.Length() > 0; b = hj.Next() {
 						}
 					}
 				})

--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -303,8 +303,8 @@ func TestExternalSortMemoryAccounting(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(closers))
 
-	sorter.Init()
-	for b := sorter.Next(ctx); b.Length() > 0; b = sorter.Next(ctx) {
+	sorter.Init(ctx)
+	for b := sorter.Next(); b.Length() > 0; b = sorter.Next() {
 	}
 	for _, c := range closers {
 		require.NoError(t, c.Close(ctx))
@@ -428,8 +428,8 @@ func BenchmarkExternalSort(b *testing.B) {
 						if err != nil {
 							b.Fatal(err)
 						}
-						sorter.Init()
-						for out := sorter.Next(ctx); out.Length() != 0; out = sorter.Next(ctx) {
+						sorter.Init(ctx)
+						for out := sorter.Next(); out.Length() != 0; out = sorter.Next() {
 						}
 						require.Equal(b, spillForced, spilled, fmt.Sprintf(
 							"expected: spilled=%t\tactual: spilled=%t", spillForced, spilled,

--- a/pkg/sql/colexec/hash_based_partitioner.go
+++ b/pkg/sql/colexec/hash_based_partitioner.go
@@ -116,6 +116,7 @@ const (
 // seem to make progress in reducing the size of the partitions).
 type hashBasedPartitioner struct {
 	colexecop.NonExplainable
+	colexecop.InitHelper
 	colexecop.CloserHelper
 
 	unlimitedAllocator                 *colmem.Allocator
@@ -309,9 +310,12 @@ func calculateMaxNumberActivePartitions(
 	return maxNumberActivePartitions
 }
 
-func (op *hashBasedPartitioner) Init() {
+func (op *hashBasedPartitioner) Init(ctx context.Context) {
+	if !op.InitHelper.Init(ctx) {
+		return
+	}
 	for i := range op.inputs {
-		op.inputs[i].Init()
+		op.inputs[i].Init(op.Ctx)
 	}
 	op.partitionsToProcessUsingMain = make(map[int]*hbpPartitionInfo)
 	// If we are initializing the hash-based partitioner, it means that we had
@@ -343,18 +347,19 @@ func (op *hashBasedPartitioner) Init() {
 	op.tupleDistributor = colexechash.NewTupleHashDistributor(
 		colexechash.DefaultInitHashValue+1, op.numBuckets,
 	)
+	op.tupleDistributor.Init(op.Ctx)
 	op.state = hbpInitialPartitioning
 }
 
 func (op *hashBasedPartitioner) partitionBatch(
-	ctx context.Context, batch coldata.Batch, inputIdx int, parentMemSize int64,
+	batch coldata.Batch, inputIdx int, parentMemSize int64,
 ) {
 	batchLen := batch.Length()
 	if batchLen == 0 {
 		return
 	}
 	scratchBatch := op.scratch.batches[inputIdx]
-	selections := op.tupleDistributor.Distribute(ctx, batch, op.hashCols[inputIdx])
+	selections := op.tupleDistributor.Distribute(batch, op.hashCols[inputIdx])
 	for idx, sel := range selections {
 		partitionIdx := op.partitionIdxOffset + idx
 		if len(sel) > 0 {
@@ -375,7 +380,7 @@ func (op *hashBasedPartitioner) partitionBatch(
 				}
 				scratchBatch.SetLength(len(sel))
 			})
-			if err := op.partitioners[inputIdx].Enqueue(ctx, partitionIdx, scratchBatch); err != nil {
+			if err := op.partitioners[inputIdx].Enqueue(op.Ctx, partitionIdx, scratchBatch); err != nil {
 				colexecutils.HandleErrorFromDiskQueue(err)
 			}
 			partitionInfo, ok := op.partitionsToProcessUsingMain[partitionIdx]
@@ -394,7 +399,7 @@ func (op *hashBasedPartitioner) partitionBatch(
 	}
 }
 
-func (op *hashBasedPartitioner) Next(ctx context.Context) coldata.Batch {
+func (op *hashBasedPartitioner) Next() coldata.Batch {
 	var batches [2]coldata.Batch
 StateChanged:
 	for {
@@ -402,7 +407,7 @@ StateChanged:
 		case hbpInitialPartitioning:
 			allZero := true
 			for i := range op.inputs {
-				batches[i] = op.inputs[i].Next(ctx)
+				batches[i] = op.inputs[i].Next()
 				allZero = allZero && batches[i].Length() == 0
 			}
 			if allZero {
@@ -422,31 +427,31 @@ StateChanged:
 				// from before doing that to exempt them from releasing their
 				// FDs to the semaphore.
 				for i := range op.inputs {
-					if err := op.partitioners[i].CloseAllOpenWriteFileDescriptors(ctx); err != nil {
+					if err := op.partitioners[i].CloseAllOpenWriteFileDescriptors(op.Ctx); err != nil {
 						colexecerror.InternalError(err)
 					}
 				}
-				op.inMemMainOp.Init()
+				op.inMemMainOp.Init(op.Ctx)
 				op.partitionIdxOffset += op.numBuckets
 				op.state = hbpProcessNewPartitionUsingMain
-				log.VEventf(ctx, 1, "%s consumed its input", op.name)
+				log.VEventf(op.Ctx, 1, "%s consumed its input", op.name)
 				continue
 			}
 			if !op.testingKnobs.delegateFDAcquisitions && op.fdState.acquiredFDs == 0 {
 				toAcquire := op.maxNumberActivePartitions
-				if err := op.fdState.fdSemaphore.Acquire(ctx, toAcquire); err != nil {
+				if err := op.fdState.fdSemaphore.Acquire(op.Ctx, toAcquire); err != nil {
 					colexecerror.InternalError(err)
 				}
 				op.fdState.acquiredFDs = toAcquire
 			}
 			for i := range op.inputs {
-				op.partitionBatch(ctx, batches[i], i, math.MaxInt64)
+				op.partitionBatch(batches[i], i, math.MaxInt64)
 			}
 
 		case hbpRecursivePartitioning:
 			op.numRepartitions++
 			if op.numRepartitions%10 == 0 {
-				log.VEventf(ctx, 2,
+				log.VEventf(op.Ctx, 2,
 					"%s is performing %d'th repartition", op.name, op.numRepartitions,
 				)
 			}
@@ -467,18 +472,18 @@ StateChanged:
 					partitioner := op.partitioners[i]
 					for {
 						op.unlimitedAllocator.PerformOperation(batch.ColVecs(), func() {
-							if err := partitioner.Dequeue(ctx, parentPartitionIdx, batch); err != nil {
+							if err := partitioner.Dequeue(op.Ctx, parentPartitionIdx, batch); err != nil {
 								colexecerror.InternalError(err)
 							}
 						})
 						if batch.Length() == 0 {
 							break
 						}
-						op.partitionBatch(ctx, batch, i, parentPartitionInfo.memSize)
+						op.partitionBatch(batch, i, parentPartitionInfo.memSize)
 					}
 					// We're done reading from this partition, and it will never
 					// be read from again, so we can close it.
-					if err := partitioner.CloseInactiveReadPartitions(ctx); err != nil {
+					if err := partitioner.CloseInactiveReadPartitions(op.Ctx); err != nil {
 						colexecerror.InternalError(err)
 					}
 					// We're done writing to the newly created partitions.
@@ -492,7 +497,7 @@ StateChanged:
 					// descriptors and whatever number of write partitions we
 					// want. This will allow us to remove the call to
 					// CloseAllOpen... in the first state as well.
-					if err := partitioner.CloseAllOpenWriteFileDescriptors(ctx); err != nil {
+					if err := partitioner.CloseAllOpenWriteFileDescriptors(op.Ctx); err != nil {
 						colexecerror.InternalError(err)
 					}
 				}
@@ -531,14 +536,14 @@ StateChanged:
 			// recursively repartition.
 			for partitionIdx, partitionInfo := range op.partitionsToProcessUsingMain {
 				if partitionInfo.memSize <= op.maxPartitionSizeToProcessUsingMain {
-					log.VEventf(ctx, 2,
+					log.VEventf(op.Ctx, 2,
 						`%s processes partition with idx %d of size %s using the "main" strategy`,
 						op.name, partitionIdx, humanizeutil.IBytes(partitionInfo.memSize),
 					)
 					for i := range op.partitionedInputs {
 						op.partitionedInputs[i].partitionIdx = partitionIdx
 					}
-					op.inMemMainOp.Reset(ctx)
+					op.inMemMainOp.Reset(op.Ctx)
 					delete(op.partitionsToProcessUsingMain, partitionIdx)
 					op.state = hbpProcessingUsingMain
 					continue StateChanged
@@ -550,8 +555,8 @@ StateChanged:
 				if len(op.partitionsToProcessUsingFallback) > 0 {
 					// But there are still some partitions to process using the
 					// "fallback" strategy.
-					op.diskBackedFallbackOp.Init()
-					log.VEventf(ctx, 1,
+					op.diskBackedFallbackOp.Init(op.Ctx)
+					log.VEventf(op.Ctx, 1,
 						`%s will process %d partitions using the "fallback" strategy`,
 						op.name, len(op.partitionsToProcessUsingFallback),
 					)
@@ -569,12 +574,12 @@ StateChanged:
 			continue
 
 		case hbpProcessingUsingMain:
-			b := op.inMemMainOp.Next(ctx)
+			b := op.inMemMainOp.Next()
 			if b.Length() == 0 {
 				// We're done processing these partitions, so we close them and
 				// transition to processing new ones.
 				for i := range op.inputs {
-					if err := op.partitioners[i].CloseInactiveReadPartitions(ctx); err != nil {
+					if err := op.partitioners[i].CloseInactiveReadPartitions(op.Ctx); err != nil {
 						colexecerror.InternalError(err)
 					}
 				}
@@ -595,17 +600,17 @@ StateChanged:
 			for i := range op.partitionedInputs {
 				op.partitionedInputs[i].partitionIdx = partitionIdx
 			}
-			op.diskBackedFallbackOp.Reset(ctx)
+			op.diskBackedFallbackOp.Reset(op.Ctx)
 			op.state = hbpProcessingUsingFallback
 			continue
 
 		case hbpProcessingUsingFallback:
-			b := op.diskBackedFallbackOp.Next(ctx)
+			b := op.diskBackedFallbackOp.Next()
 			if b.Length() == 0 {
 				// We're done processing these partitions, so we close them and
 				// transition to processing new ones.
 				for i := range op.inputs {
-					if err := op.partitioners[i].CloseInactiveReadPartitions(ctx); err != nil {
+					if err := op.partitioners[i].CloseInactiveReadPartitions(op.Ctx); err != nil {
 						colexecerror.InternalError(err)
 					}
 				}
@@ -615,7 +620,7 @@ StateChanged:
 			return b
 
 		case hbpFinished:
-			if err := op.Close(ctx); err != nil {
+			if err := op.Close(op.Ctx); err != nil {
 				colexecerror.InternalError(err)
 			}
 			return coldata.ZeroBatch

--- a/pkg/sql/colexec/hashjoiner_test.go
+++ b/pkg/sql/colexec/hashjoiner_test.go
@@ -1095,12 +1095,12 @@ func BenchmarkHashJoiner(b *testing.B) {
 											leftSource, rightSource,
 											colexecjoin.HashJoinerInitialNumBuckets, execinfra.DefaultMemoryLimit,
 										)
-										hj.Init()
+										hj.Init(ctx)
 
 										for i := 0; i < nBatches; i++ {
 											// Technically, the non-distinct hash join will produce much more
 											// than nBatches of output.
-											hj.Next(ctx)
+											hj.Next()
 										}
 									}
 								})
@@ -1171,8 +1171,8 @@ func TestHashJoinerProjection(t *testing.T) {
 	args.TestingKnobs.DiskSpillingDisabled = true
 	hjOp, err := colexecargs.TestNewColOperator(ctx, flowCtx, args)
 	require.NoError(t, err)
-	hjOp.Root.Init()
-	for b := hjOp.Root.Next(ctx); b.Length() > 0; b = hjOp.Root.Next(ctx) {
+	hjOp.Root.Init(ctx)
+	for b := hjOp.Root.Next(); b.Length() > 0; b = hjOp.Root.Next() {
 		// The output types should be {Int64, Int64, Bool, Decimal, Float64, Bytes}
 		// and we check this explicitly.
 		b.ColVec(0).Int64()

--- a/pkg/sql/colexec/is_null_ops.eg.go
+++ b/pkg/sql/colexec/is_null_ops.eg.go
@@ -10,8 +10,6 @@
 package colexec
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
@@ -22,7 +20,7 @@ import (
 )
 
 type isNullProjBase struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	allocator *colmem.Allocator
 	colIdx    int
 	outputIdx int
@@ -43,11 +41,11 @@ func NewIsNullProjOp(
 ) colexecop.Operator {
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, types.Bool, outputIdx)
 	base := isNullProjBase{
-		OneInputNode: colexecop.NewOneInputNode(input),
-		allocator:    allocator,
-		colIdx:       colIdx,
-		outputIdx:    outputIdx,
-		negate:       negate,
+		OneInputHelper: colexecop.MakeOneInputHelper(input),
+		allocator:      allocator,
+		colIdx:         colIdx,
+		outputIdx:      outputIdx,
+		negate:         negate,
 	}
 	if isTupleNull {
 		return &isTupleNullProjOp{isNullProjBase: base}
@@ -66,12 +64,8 @@ type isNullProjOp struct {
 
 var _ colexecop.Operator = &isNullProjOp{}
 
-func (o *isNullProjOp) Init() {
-	o.Input.Init()
-}
-
-func (o *isNullProjOp) Next(ctx context.Context) coldata.Batch {
-	batch := o.Input.Next(ctx)
+func (o *isNullProjOp) Next() coldata.Batch {
+	batch := o.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -130,12 +124,8 @@ type isTupleNullProjOp struct {
 
 var _ colexecop.Operator = &isTupleNullProjOp{}
 
-func (o *isTupleNullProjOp) Init() {
-	o.Input.Init()
-}
-
-func (o *isTupleNullProjOp) Next(ctx context.Context) coldata.Batch {
-	batch := o.Input.Next(ctx)
+func (o *isTupleNullProjOp) Next() coldata.Batch {
+	batch := o.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -199,7 +189,7 @@ func (o *isTupleNullProjOp) Next(ctx context.Context) coldata.Batch {
 }
 
 type isNullSelBase struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	colIdx int
 	negate bool
 }
@@ -213,9 +203,9 @@ func NewIsNullSelOp(
 	input colexecop.Operator, colIdx int, negate bool, isTupleNull bool,
 ) colexecop.Operator {
 	base := isNullSelBase{
-		OneInputNode: colexecop.NewOneInputNode(input),
-		colIdx:       colIdx,
-		negate:       negate,
+		OneInputHelper: colexecop.MakeOneInputHelper(input),
+		colIdx:         colIdx,
+		negate:         negate,
 	}
 	if isTupleNull {
 		return &isTupleNullSelOp{isNullSelBase: base}
@@ -232,13 +222,9 @@ type isNullSelOp struct {
 
 var _ colexecop.Operator = &isNullSelOp{}
 
-func (o *isNullSelOp) Init() {
-	o.Input.Init()
-}
-
-func (o *isNullSelOp) Next(ctx context.Context) coldata.Batch {
+func (o *isNullSelOp) Next() coldata.Batch {
 	for {
-		batch := o.Input.Next(ctx)
+		batch := o.Input.Next()
 		n := batch.Length()
 		if n == 0 {
 			return batch
@@ -295,13 +281,9 @@ type isTupleNullSelOp struct {
 
 var _ colexecop.Operator = &isTupleNullSelOp{}
 
-func (o *isTupleNullSelOp) Init() {
-	o.Input.Init()
-}
-
-func (o *isTupleNullSelOp) Next(ctx context.Context) coldata.Batch {
+func (o *isTupleNullSelOp) Next() coldata.Batch {
 	for {
-		batch := o.Input.Next(ctx)
+		batch := o.Input.Next()
 		n := batch.Length()
 		if n == 0 {
 			return batch

--- a/pkg/sql/colexec/limit.go
+++ b/pkg/sql/colexec/limit.go
@@ -11,8 +11,6 @@
 package colexec
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 )
@@ -20,7 +18,7 @@ import (
 // limitOp is an operator that implements limit, returning only the first n
 // tuples from its input.
 type limitOp struct {
-	colexecop.OneInputCloserHelper
+	colexecop.OneInputInitCloserHelper
 
 	limit uint64
 
@@ -36,21 +34,17 @@ var _ colexecop.ClosableOperator = &limitOp{}
 // NewLimitOp returns a new limit operator with the given limit.
 func NewLimitOp(input colexecop.Operator, limit uint64) colexecop.Operator {
 	c := &limitOp{
-		OneInputCloserHelper: colexecop.MakeOneInputCloserHelper(input),
-		limit:                limit,
+		OneInputInitCloserHelper: colexecop.MakeOneInputInitCloserHelper(input),
+		limit:                    limit,
 	}
 	return c
 }
 
-func (c *limitOp) Init() {
-	c.Input.Init()
-}
-
-func (c *limitOp) Next(ctx context.Context) coldata.Batch {
+func (c *limitOp) Next() coldata.Batch {
 	if c.done {
 		return coldata.ZeroBatch
 	}
-	bat := c.Input.Next(ctx)
+	bat := c.Input.Next()
 	length := bat.Length()
 	if length == 0 {
 		return bat

--- a/pkg/sql/colexec/materializer.go
+++ b/pkg/sql/colexec/materializer.go
@@ -262,7 +262,9 @@ func (m *Materializer) Start(ctx context.Context) {
 	// We can encounter an expected error during Init (e.g. an operator
 	// attempts to allocate a batch, but the memory budget limit has been
 	// reached), so we need to wrap it with a catcher.
-	if err := colexecerror.CatchVectorizedRuntimeError(m.input.Init); err != nil {
+	if err := colexecerror.CatchVectorizedRuntimeError(func() {
+		m.input.Init(ctx)
+	}); err != nil {
 		m.MoveToDraining(err)
 	} else {
 		// Note that we intentionally only start the drain helper if
@@ -279,7 +281,7 @@ func (m *Materializer) Start(ctx context.Context) {
 func (m *Materializer) next() rowenc.EncDatumRow {
 	if m.batch == nil || m.curIdx >= m.batch.Length() {
 		// Get a fresh batch.
-		m.batch = m.input.Next(m.Ctx)
+		m.batch = m.input.Next()
 		if m.batch.Length() == 0 {
 			return nil
 		}

--- a/pkg/sql/colexec/materializer_test.go
+++ b/pkg/sql/colexec/materializer_test.go
@@ -58,7 +58,7 @@ func TestColumnarizeMaterialize(t *testing.T) {
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
 	}
-	c, err := NewBufferingColumnarizer(ctx, testAllocator, flowCtx, 0, input)
+	c, err := NewBufferingColumnarizer(testAllocator, flowCtx, 0, input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -240,7 +240,7 @@ func BenchmarkColumnarizeMaterialize(b *testing.B) {
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
 	}
-	c, err := NewBufferingColumnarizer(ctx, testAllocator, flowCtx, 0, input)
+	c, err := NewBufferingColumnarizer(testAllocator, flowCtx, 0, input)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -1727,9 +1727,9 @@ func TestFullOuterMergeJoinWithMaximumNumberOfGroups(t *testing.T) {
 	if err != nil {
 		t.Fatal("error in merge join op constructor", err)
 	}
-	a.Init()
+	a.Init(ctx)
 	i, count, expVal := 0, 0, int64(0)
-	for b := a.Next(ctx); b.Length() != 0; b = a.Next(ctx) {
+	for b := a.Next(); b.Length() != 0; b = a.Next() {
 		count += b.Length()
 		leftOutCol := b.ColVec(0).Int64()
 		leftNulls := b.ColVec(0).Nulls()
@@ -1798,12 +1798,12 @@ func TestMergeJoinerMultiBatch(t *testing.T) {
 				if err != nil {
 					t.Fatal("error in merge join op constructor", err)
 				}
-				a.Init()
+				a.Init(ctx)
 				i := 0
 				count := 0
 				// Keep track of the last comparison value.
 				expVal := int64(0)
-				for b := a.Next(ctx); b.Length() != 0; b = a.Next(ctx) {
+				for b := a.Next(); b.Length() != 0; b = a.Next() {
 					count += b.Length()
 					outCol := b.ColVec(0).Int64()
 					for j := int64(0); j < int64(b.Length()); j++ {
@@ -1874,12 +1874,12 @@ func TestMergeJoinerMultiBatchRuns(t *testing.T) {
 					if err != nil {
 						t.Fatal("error in merge join op constructor", err)
 					}
-					a.Init()
+					a.Init(ctx)
 					i := 0
 					count := 0
 					// Keep track of the last comparison value.
 					lastVal := int64(0)
-					for b := a.Next(ctx); b.Length() != 0; b = a.Next(ctx) {
+					for b := a.Next(); b.Length() != 0; b = a.Next() {
 						count += b.Length()
 						outCol := b.ColVec(0).Int64()
 						for j := int64(0); j < int64(b.Length()); j++ {
@@ -2002,11 +2002,11 @@ func TestMergeJoinerRandomized(t *testing.T) {
 					if err != nil {
 						t.Fatal("error in merge join op constructor", err)
 					}
-					a.Init()
+					a.Init(ctx)
 					i := 0
 					count := 0
 					cpIdx := 0
-					for b := a.Next(ctx); b.Length() != 0; b = a.Next(ctx) {
+					for b := a.Next(); b.Length() != 0; b = a.Next() {
 						count += b.Length()
 						outCol := b.ColVec(0).Int64()
 						for j := 0; j < b.Length(); j++ {

--- a/pkg/sql/colexec/offset.go
+++ b/pkg/sql/colexec/offset.go
@@ -11,8 +11,6 @@
 package colexec
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 )
@@ -20,7 +18,7 @@ import (
 // offsetOp is an operator that implements offset, returning everything
 // after the first n tuples in its input.
 type offsetOp struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	offset uint64
 
@@ -32,20 +30,15 @@ var _ colexecop.Operator = &offsetOp{}
 
 // NewOffsetOp returns a new offset operator with the given offset.
 func NewOffsetOp(input colexecop.Operator, offset uint64) colexecop.Operator {
-	c := &offsetOp{
-		OneInputNode: colexecop.NewOneInputNode(input),
-		offset:       offset,
+	return &offsetOp{
+		OneInputHelper: colexecop.MakeOneInputHelper(input),
+		offset:         offset,
 	}
-	return c
 }
 
-func (c *offsetOp) Init() {
-	c.Input.Init()
-}
-
-func (c *offsetOp) Next(ctx context.Context) coldata.Batch {
+func (c *offsetOp) Next() coldata.Batch {
 	for {
-		bat := c.Input.Next(ctx)
+		bat := c.Input.Next()
 		length := bat.Length()
 		if length == 0 {
 			return bat
@@ -65,6 +58,7 @@ func (c *offsetOp) Next(ctx context.Context) coldata.Batch {
 				bat.SetSelection(true)
 				sel = bat.Selection()[:delta] // slice for bounds check elimination
 				for i := range sel {
+					//gcassert:bce
 					sel[i] = outputStartIdx + i
 				}
 			}
@@ -75,10 +69,4 @@ func (c *offsetOp) Next(ctx context.Context) coldata.Batch {
 			return bat
 		}
 	}
-}
-
-// Reset resets the offsetOp for another run. Primarily used for
-// benchmarks.
-func (c *offsetOp) Reset() {
-	c.seen = 0
 }

--- a/pkg/sql/colexec/offset_test.go
+++ b/pkg/sql/colexec/offset_test.go
@@ -73,13 +73,13 @@ func BenchmarkOffset(b *testing.B) {
 	batch := testAllocator.NewMemBatchWithMaxCapacity(typs)
 	batch.SetLength(coldata.BatchSize())
 	source := colexecop.NewRepeatableBatchSource(testAllocator, batch, typs)
-	source.Init()
 
 	o := NewOffsetOp(source, 1)
+	o.Init(ctx)
 	// Set throughput proportional to size of the selection vector.
 	b.SetBytes(int64(2 * coldata.BatchSize()))
 	for i := 0; i < b.N; i++ {
-		o.(*offsetOp).Reset()
-		o.Next(ctx)
+		o.(*offsetOp).seen = 0
+		o.Next()
 	}
 }

--- a/pkg/sql/colexec/ordered_aggregator.go
+++ b/pkg/sql/colexec/ordered_aggregator.go
@@ -83,6 +83,7 @@ const (
 // value is part of a new group).
 type orderedAggregator struct {
 	colexecop.OneInputNode
+	colexecop.InitHelper
 
 	state orderedAggregatorState
 
@@ -178,12 +179,15 @@ func NewOrderedAggregator(
 	return a, nil
 }
 
-func (a *orderedAggregator) Init() {
-	a.Input.Init()
+func (a *orderedAggregator) Init(ctx context.Context) {
+	if !a.InitHelper.Init(ctx) {
+		return
+	}
+	a.Input.Init(a.Ctx)
 	a.bucket.init(a.bucket.fns, a.aggHelper.makeSeenMaps(), a.groupCol)
 }
 
-func (a *orderedAggregator) Next(ctx context.Context) coldata.Batch {
+func (a *orderedAggregator) Next() coldata.Batch {
 	stateAfterOutputting := orderedAggregatorUnknown
 	for {
 		switch a.state {
@@ -201,7 +205,7 @@ func (a *orderedAggregator) Next(ctx context.Context) coldata.Batch {
 			batch := a.lastReadBatch
 			a.lastReadBatch = nil
 			if batch == nil {
-				batch = a.Input.Next(ctx)
+				batch = a.Input.Next()
 			}
 			batchLength := batch.Length()
 
@@ -241,7 +245,7 @@ func (a *orderedAggregator) Next(ctx context.Context) coldata.Batch {
 				if batchLength > 0 {
 					a.inputArgsConverter.ConvertBatch(batch)
 					a.aggHelper.performAggregation(
-						ctx, batch.ColVecs(), batchLength, batch.Selection(), &a.bucket, a.groupCol,
+						a.Ctx, batch.ColVecs(), batchLength, batch.Selection(), &a.bucket, a.groupCol,
 					)
 				} else {
 					a.allocator.PerformOperation(a.scratch.ColVecs(), func() {

--- a/pkg/sql/colexec/ordered_synchronizer_test.go
+++ b/pkg/sql/colexec/ordered_synchronizer_test.go
@@ -190,7 +190,7 @@ func TestOrderedSyncRandomInput(t *testing.T) {
 	}
 	ordering := colinfo.ColumnOrdering{{ColIdx: 0, Direction: encoding.Ascending}}
 	op := NewOrderedSynchronizer(testAllocator, execinfra.DefaultMemoryLimit, inputs, typs, ordering)
-	op.Init()
+	op.Init(context.Background())
 	out := colexectestutils.NewOpTestOutput(op, expected)
 	if err := out.Verify(); err != nil {
 		t.Error(err)
@@ -220,11 +220,11 @@ func BenchmarkOrderedSynchronizer(b *testing.B) {
 
 	ordering := colinfo.ColumnOrdering{{ColIdx: 0, Direction: encoding.Ascending}}
 	op := NewOrderedSynchronizer(testAllocator, execinfra.DefaultMemoryLimit, inputs, typs, ordering)
-	op.Init()
+	op.Init(ctx)
 
 	b.SetBytes(8 * int64(coldata.BatchSize()) * numInputs)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		op.Next(ctx)
+		op.Next()
 	}
 }

--- a/pkg/sql/colexec/ordered_synchronizer_tmpl.go
+++ b/pkg/sql/colexec/ordered_synchronizer_tmpl.go
@@ -57,7 +57,7 @@ const _TYPE_WIDTH = 0
 // stream of rows, ordered according to a set of columns. The rows in each input
 // stream are assumed to be ordered according to the same set of columns.
 type OrderedSynchronizer struct {
-	ctx  context.Context
+	colexecop.InitHelper
 	span *tracing.Span
 
 	allocator             *colmem.Allocator
@@ -136,24 +136,13 @@ func NewOrderedSynchronizer(
 	}
 }
 
-// maybeStartTracingSpan stores the context and possibly starts a tracing span
-// on its first call and is a noop on all consequent calls.
-// TODO(yuzefovich): remove this once ctx is passed in Init.
-func (o *OrderedSynchronizer) maybeStartTracingSpan(ctx context.Context) {
-	if o.ctx == nil {
-		// It is the very first call to maybeStartTracingSpan.
-		o.ctx, o.span = execinfra.ProcessorSpan(ctx, "ordered sync")
-	}
-}
-
 // Next is part of the Operator interface.
-func (o *OrderedSynchronizer) Next(ctx context.Context) coldata.Batch {
+func (o *OrderedSynchronizer) Next() coldata.Batch {
 	if o.inputBatches == nil {
-		o.maybeStartTracingSpan(ctx)
 		o.inputBatches = make([]coldata.Batch, len(o.inputs))
 		o.heap = make([]int, 0, len(o.inputs))
 		for i := range o.inputs {
-			o.inputBatches[i] = o.inputs[i].Root.Next(o.ctx)
+			o.inputBatches[i] = o.inputs[i].Root.Next()
 			o.updateComparators(i)
 			if o.inputBatches[i].Length() > 0 {
 				o.heap = append(o.heap, i)
@@ -205,7 +194,7 @@ func (o *OrderedSynchronizer) Next(ctx context.Context) coldata.Batch {
 			if o.inputIndices[minBatch]+1 < o.inputBatches[minBatch].Length() {
 				o.inputIndices[minBatch]++
 			} else {
-				o.inputBatches[minBatch] = o.inputs[minBatch].Root.Next(o.ctx)
+				o.inputBatches[minBatch] = o.inputs[minBatch].Root.Next()
 				o.inputIndices[minBatch] = 0
 				o.updateComparators(minBatch)
 			}
@@ -255,12 +244,16 @@ func (o *OrderedSynchronizer) resetOutput() {
 }
 
 // Init is part of the Operator interface.
-func (o *OrderedSynchronizer) Init() {
+func (o *OrderedSynchronizer) Init(ctx context.Context) {
+	if !o.InitHelper.Init(ctx) {
+		return
+	}
+	o.Ctx, o.span = execinfra.ProcessorSpan(o.Ctx, "ordered sync")
 	o.inputIndices = make([]int, len(o.inputs))
 	o.outNulls = make([]*coldata.Nulls, len(o.typs))
 	o.outColsMap = make([]int, len(o.typs))
 	for i := range o.inputs {
-		o.inputs[i].Root.Init()
+		o.inputs[i].Root.Init(o.Ctx)
 	}
 	o.comparators = make([]vecComparator, len(o.ordering))
 	for i := range o.ordering {
@@ -271,8 +264,6 @@ func (o *OrderedSynchronizer) Init() {
 
 func (o *OrderedSynchronizer) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
 	var bufferedMeta []execinfrapb.ProducerMetadata
-	// It is possible that Next was never called, yet the tracing is enabled.
-	o.maybeStartTracingSpan(ctx)
 	if o.span != nil {
 		for i := range o.inputs {
 			for _, stats := range o.inputs[i].StatsCollectors {
@@ -284,7 +275,7 @@ func (o *OrderedSynchronizer) DrainMeta(ctx context.Context) []execinfrapb.Produ
 		}
 	}
 	for _, input := range o.inputs {
-		bufferedMeta = append(bufferedMeta, input.MetadataSources.DrainMeta(o.ctx)...)
+		bufferedMeta = append(bufferedMeta, input.MetadataSources.DrainMeta(o.Ctx)...)
 	}
 	return bufferedMeta
 }

--- a/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
@@ -72,7 +72,7 @@ func TestParallelUnorderedSynchronizer(t *testing.T) {
 
 	var wg sync.WaitGroup
 	s := NewParallelUnorderedSynchronizer(inputs, &wg)
-	s.Init()
+	s.Init(ctx)
 
 	type synchronizerTerminationScenario int
 	const (
@@ -119,7 +119,7 @@ func TestParallelUnorderedSynchronizer(t *testing.T) {
 				expectZeroBatch = true
 			}
 			var b coldata.Batch
-			if err := colexecerror.CatchVectorizedRuntimeError(func() { b = s.Next(ctx) }); err != nil {
+			if err := colexecerror.CatchVectorizedRuntimeError(func() { b = s.Next() }); err != nil {
 				if terminationScenario == synchronizerContextCanceled {
 					require.True(t, testutils.IsError(err, "context canceled"), err)
 					break
@@ -155,7 +155,7 @@ func TestUnorderedSynchronizerNoLeaksOnError(t *testing.T) {
 	ctx := context.Background()
 
 	inputs := make([]colexecargs.OpWithMetaInfo, 6)
-	inputs[0].Root = &colexecop.CallbackOperator{NextCb: func(context.Context) coldata.Batch {
+	inputs[0].Root = &colexecop.CallbackOperator{NextCb: func() coldata.Batch {
 		colexecerror.InternalError(errors.New(expectedErr))
 		// This code is unreachable, but the compiler cannot infer that.
 		return nil
@@ -165,7 +165,7 @@ func TestUnorderedSynchronizerNoLeaksOnError(t *testing.T) {
 		defer acc.Close(ctx)
 		func(allocator *colmem.Allocator) {
 			inputs[i].Root = &colexecop.CallbackOperator{
-				NextCb: func(ctx context.Context) coldata.Batch {
+				NextCb: func() coldata.Batch {
 					// All inputs that do not encounter an error will continue to return
 					// batches.
 					b := allocator.NewMemBatchWithMaxCapacity([]*types.T{types.Int})
@@ -182,9 +182,9 @@ func TestUnorderedSynchronizerNoLeaksOnError(t *testing.T) {
 
 	var wg sync.WaitGroup
 	s := NewParallelUnorderedSynchronizer(inputs, &wg)
-	s.Init()
+	s.Init(ctx)
 	for {
-		if err := colexecerror.CatchVectorizedRuntimeError(func() { _ = s.Next(ctx) }); err != nil {
+		if err := colexecerror.CatchVectorizedRuntimeError(func() { _ = s.Next() }); err != nil {
 			require.True(t, testutils.IsError(err, expectedErr), err)
 			break
 		}
@@ -210,11 +210,11 @@ func BenchmarkParallelUnorderedSynchronizer(b *testing.B) {
 	var wg sync.WaitGroup
 	ctx, cancelFn := context.WithCancel(context.Background())
 	s := NewParallelUnorderedSynchronizer(inputs, &wg)
-	s.Init()
+	s.Init(ctx)
 	b.SetBytes(8 * int64(coldata.BatchSize()))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		s.Next(ctx)
+		s.Next()
 	}
 	b.StopTimer()
 	cancelFn()

--- a/pkg/sql/colexec/quicksort.eg.go
+++ b/pkg/sql/colexec/quicksort.eg.go
@@ -13,8 +13,6 @@
 
 package colexec
 
-import "context"
-
 // This file is copied from the Go standard library's sort
 // implementation, found in https://golang.org/src/sort/sort.go. The only
 // modifications are to template each function into each sort_* struct, so
@@ -60,14 +58,14 @@ func (p *sortBoolAscWithNullsOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortBoolAscWithNullsOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortBoolAscWithNullsOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -191,22 +189,22 @@ func (p *sortBoolAscWithNullsOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortBoolAscWithNullsOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortBoolAscWithNullsOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -251,14 +249,14 @@ func (p *sortBytesAscWithNullsOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortBytesAscWithNullsOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortBytesAscWithNullsOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -382,22 +380,22 @@ func (p *sortBytesAscWithNullsOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortBytesAscWithNullsOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortBytesAscWithNullsOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -442,14 +440,14 @@ func (p *sortDecimalAscWithNullsOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortDecimalAscWithNullsOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortDecimalAscWithNullsOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -573,22 +571,22 @@ func (p *sortDecimalAscWithNullsOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortDecimalAscWithNullsOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortDecimalAscWithNullsOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -633,14 +631,14 @@ func (p *sortInt16AscWithNullsOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortInt16AscWithNullsOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortInt16AscWithNullsOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -764,22 +762,22 @@ func (p *sortInt16AscWithNullsOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortInt16AscWithNullsOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortInt16AscWithNullsOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -824,14 +822,14 @@ func (p *sortInt32AscWithNullsOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortInt32AscWithNullsOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortInt32AscWithNullsOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -955,22 +953,22 @@ func (p *sortInt32AscWithNullsOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortInt32AscWithNullsOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortInt32AscWithNullsOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -1015,14 +1013,14 @@ func (p *sortInt64AscWithNullsOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortInt64AscWithNullsOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortInt64AscWithNullsOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -1146,22 +1144,22 @@ func (p *sortInt64AscWithNullsOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortInt64AscWithNullsOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortInt64AscWithNullsOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -1206,14 +1204,14 @@ func (p *sortFloat64AscWithNullsOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortFloat64AscWithNullsOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortFloat64AscWithNullsOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -1337,22 +1335,22 @@ func (p *sortFloat64AscWithNullsOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortFloat64AscWithNullsOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortFloat64AscWithNullsOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -1397,14 +1395,14 @@ func (p *sortTimestampAscWithNullsOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortTimestampAscWithNullsOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortTimestampAscWithNullsOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -1528,22 +1526,22 @@ func (p *sortTimestampAscWithNullsOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortTimestampAscWithNullsOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortTimestampAscWithNullsOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -1588,14 +1586,14 @@ func (p *sortIntervalAscWithNullsOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortIntervalAscWithNullsOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortIntervalAscWithNullsOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -1719,22 +1717,22 @@ func (p *sortIntervalAscWithNullsOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortIntervalAscWithNullsOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortIntervalAscWithNullsOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -1779,14 +1777,14 @@ func (p *sortJSONAscWithNullsOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortJSONAscWithNullsOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortJSONAscWithNullsOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -1910,22 +1908,22 @@ func (p *sortJSONAscWithNullsOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortJSONAscWithNullsOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortJSONAscWithNullsOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -1970,14 +1968,14 @@ func (p *sortDatumAscWithNullsOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortDatumAscWithNullsOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortDatumAscWithNullsOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -2101,22 +2099,22 @@ func (p *sortDatumAscWithNullsOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortDatumAscWithNullsOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortDatumAscWithNullsOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -2161,14 +2159,14 @@ func (p *sortBoolDescWithNullsOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortBoolDescWithNullsOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortBoolDescWithNullsOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -2292,22 +2290,22 @@ func (p *sortBoolDescWithNullsOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortBoolDescWithNullsOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortBoolDescWithNullsOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -2352,14 +2350,14 @@ func (p *sortBytesDescWithNullsOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortBytesDescWithNullsOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortBytesDescWithNullsOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -2483,22 +2481,22 @@ func (p *sortBytesDescWithNullsOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortBytesDescWithNullsOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortBytesDescWithNullsOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -2543,14 +2541,14 @@ func (p *sortDecimalDescWithNullsOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortDecimalDescWithNullsOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortDecimalDescWithNullsOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -2674,22 +2672,22 @@ func (p *sortDecimalDescWithNullsOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortDecimalDescWithNullsOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortDecimalDescWithNullsOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -2734,14 +2732,14 @@ func (p *sortInt16DescWithNullsOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortInt16DescWithNullsOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortInt16DescWithNullsOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -2865,22 +2863,22 @@ func (p *sortInt16DescWithNullsOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortInt16DescWithNullsOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortInt16DescWithNullsOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -2925,14 +2923,14 @@ func (p *sortInt32DescWithNullsOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortInt32DescWithNullsOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortInt32DescWithNullsOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -3056,22 +3054,22 @@ func (p *sortInt32DescWithNullsOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortInt32DescWithNullsOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortInt32DescWithNullsOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -3116,14 +3114,14 @@ func (p *sortInt64DescWithNullsOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortInt64DescWithNullsOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortInt64DescWithNullsOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -3247,22 +3245,22 @@ func (p *sortInt64DescWithNullsOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortInt64DescWithNullsOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortInt64DescWithNullsOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -3307,14 +3305,14 @@ func (p *sortFloat64DescWithNullsOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortFloat64DescWithNullsOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortFloat64DescWithNullsOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -3438,22 +3436,22 @@ func (p *sortFloat64DescWithNullsOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortFloat64DescWithNullsOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortFloat64DescWithNullsOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -3498,14 +3496,14 @@ func (p *sortTimestampDescWithNullsOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortTimestampDescWithNullsOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortTimestampDescWithNullsOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -3629,22 +3627,22 @@ func (p *sortTimestampDescWithNullsOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortTimestampDescWithNullsOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortTimestampDescWithNullsOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -3689,14 +3687,14 @@ func (p *sortIntervalDescWithNullsOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortIntervalDescWithNullsOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortIntervalDescWithNullsOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -3820,22 +3818,22 @@ func (p *sortIntervalDescWithNullsOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortIntervalDescWithNullsOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortIntervalDescWithNullsOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -3880,14 +3878,14 @@ func (p *sortJSONDescWithNullsOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortJSONDescWithNullsOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortJSONDescWithNullsOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -4011,22 +4009,22 @@ func (p *sortJSONDescWithNullsOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortJSONDescWithNullsOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortJSONDescWithNullsOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -4071,14 +4069,14 @@ func (p *sortDatumDescWithNullsOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortDatumDescWithNullsOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortDatumDescWithNullsOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -4202,22 +4200,22 @@ func (p *sortDatumDescWithNullsOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortDatumDescWithNullsOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortDatumDescWithNullsOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -4262,14 +4260,14 @@ func (p *sortBoolAscOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortBoolAscOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortBoolAscOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -4393,22 +4391,22 @@ func (p *sortBoolAscOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortBoolAscOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortBoolAscOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -4453,14 +4451,14 @@ func (p *sortBytesAscOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortBytesAscOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortBytesAscOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -4584,22 +4582,22 @@ func (p *sortBytesAscOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortBytesAscOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortBytesAscOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -4644,14 +4642,14 @@ func (p *sortDecimalAscOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortDecimalAscOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortDecimalAscOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -4775,22 +4773,22 @@ func (p *sortDecimalAscOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortDecimalAscOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortDecimalAscOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -4835,14 +4833,14 @@ func (p *sortInt16AscOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortInt16AscOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortInt16AscOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -4966,22 +4964,22 @@ func (p *sortInt16AscOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortInt16AscOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortInt16AscOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -5026,14 +5024,14 @@ func (p *sortInt32AscOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortInt32AscOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortInt32AscOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -5157,22 +5155,22 @@ func (p *sortInt32AscOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortInt32AscOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortInt32AscOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -5217,14 +5215,14 @@ func (p *sortInt64AscOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortInt64AscOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortInt64AscOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -5348,22 +5346,22 @@ func (p *sortInt64AscOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortInt64AscOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortInt64AscOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -5408,14 +5406,14 @@ func (p *sortFloat64AscOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortFloat64AscOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortFloat64AscOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -5539,22 +5537,22 @@ func (p *sortFloat64AscOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortFloat64AscOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortFloat64AscOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -5599,14 +5597,14 @@ func (p *sortTimestampAscOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortTimestampAscOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortTimestampAscOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -5730,22 +5728,22 @@ func (p *sortTimestampAscOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortTimestampAscOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortTimestampAscOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -5790,14 +5788,14 @@ func (p *sortIntervalAscOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortIntervalAscOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortIntervalAscOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -5921,22 +5919,22 @@ func (p *sortIntervalAscOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortIntervalAscOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortIntervalAscOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -5981,14 +5979,14 @@ func (p *sortJSONAscOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortJSONAscOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortJSONAscOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -6112,22 +6110,22 @@ func (p *sortJSONAscOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortJSONAscOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortJSONAscOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -6172,14 +6170,14 @@ func (p *sortDatumAscOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortDatumAscOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortDatumAscOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -6303,22 +6301,22 @@ func (p *sortDatumAscOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortDatumAscOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortDatumAscOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -6363,14 +6361,14 @@ func (p *sortBoolDescOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortBoolDescOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortBoolDescOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -6494,22 +6492,22 @@ func (p *sortBoolDescOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortBoolDescOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortBoolDescOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -6554,14 +6552,14 @@ func (p *sortBytesDescOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortBytesDescOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortBytesDescOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -6685,22 +6683,22 @@ func (p *sortBytesDescOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortBytesDescOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortBytesDescOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -6745,14 +6743,14 @@ func (p *sortDecimalDescOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortDecimalDescOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortDecimalDescOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -6876,22 +6874,22 @@ func (p *sortDecimalDescOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortDecimalDescOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortDecimalDescOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -6936,14 +6934,14 @@ func (p *sortInt16DescOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortInt16DescOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortInt16DescOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -7067,22 +7065,22 @@ func (p *sortInt16DescOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortInt16DescOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortInt16DescOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -7127,14 +7125,14 @@ func (p *sortInt32DescOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortInt32DescOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortInt32DescOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -7258,22 +7256,22 @@ func (p *sortInt32DescOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortInt32DescOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortInt32DescOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -7318,14 +7316,14 @@ func (p *sortInt64DescOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortInt64DescOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortInt64DescOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -7449,22 +7447,22 @@ func (p *sortInt64DescOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortInt64DescOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortInt64DescOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -7509,14 +7507,14 @@ func (p *sortFloat64DescOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortFloat64DescOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortFloat64DescOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -7640,22 +7638,22 @@ func (p *sortFloat64DescOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortFloat64DescOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortFloat64DescOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -7700,14 +7698,14 @@ func (p *sortTimestampDescOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortTimestampDescOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortTimestampDescOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -7831,22 +7829,22 @@ func (p *sortTimestampDescOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortTimestampDescOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortTimestampDescOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -7891,14 +7889,14 @@ func (p *sortIntervalDescOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortIntervalDescOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortIntervalDescOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -8022,22 +8020,22 @@ func (p *sortIntervalDescOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortIntervalDescOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortIntervalDescOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -8082,14 +8080,14 @@ func (p *sortJSONDescOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortJSONDescOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortJSONDescOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -8213,22 +8211,22 @@ func (p *sortJSONDescOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortJSONDescOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortJSONDescOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}
@@ -8273,14 +8271,14 @@ func (p *sortDatumDescOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sortDatumDescOp) heapSort(ctx context.Context, a, b int) {
+func (p *sortDatumDescOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -8404,22 +8402,22 @@ func (p *sortDatumDescOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sortDatumDescOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sortDatumDescOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}

--- a/pkg/sql/colexec/quicksort_tmpl.go
+++ b/pkg/sql/colexec/quicksort_tmpl.go
@@ -18,8 +18,6 @@
 
 package colexec
 
-import "context"
-
 // This file is copied from the Go standard library's sort
 // implementation, found in https://golang.org/src/sort/sort.go. The only
 // modifications are to template each function into each sort_* struct, so
@@ -72,14 +70,14 @@ func (p *sort_TYPE_DIR_HANDLES_NULLSOp) siftDown(lo, hi, first int) {
 	}
 }
 
-func (p *sort_TYPE_DIR_HANDLES_NULLSOp) heapSort(ctx context.Context, a, b int) {
+func (p *sort_TYPE_DIR_HANDLES_NULLSOp) heapSort(a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
 
 	// Build heap with greatest element at top.
 	for i := (hi - 1) / 2; i >= 0; i-- {
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		p.siftDown(i, hi, first)
 	}
 
@@ -203,22 +201,22 @@ func (p *sort_TYPE_DIR_HANDLES_NULLSOp) doPivot(lo, hi int) (midlo, midhi int) {
 	return b - 1, c
 }
 
-func (p *sort_TYPE_DIR_HANDLES_NULLSOp) quickSort(ctx context.Context, a, b, maxDepth int) {
+func (p *sort_TYPE_DIR_HANDLES_NULLSOp) quickSort(a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
-			p.heapSort(ctx, a, b)
+			p.heapSort(a, b)
 			return
 		}
 		maxDepth--
-		p.cancelChecker.Check(ctx)
+		p.cancelChecker.Check()
 		mlo, mhi := p.doPivot(a, b)
 		// Avoiding recursion on the larger subproblem guarantees
 		// a stack depth of at most lg(b-a).
 		if mlo-a < b-mhi {
-			p.quickSort(ctx, a, mlo, maxDepth)
+			p.quickSort(a, mlo, maxDepth)
 			a = mhi // i.e., quickSort(data, mhi, b)
 		} else {
-			p.quickSort(ctx, mhi, b, maxDepth)
+			p.quickSort(mhi, b, maxDepth)
 			b = mlo // i.e., quickSort(data, a, mlo)
 		}
 	}

--- a/pkg/sql/colexec/select_in.eg.go
+++ b/pkg/sql/colexec/select_in.eg.go
@@ -11,7 +11,6 @@ package colexec
 
 import (
 	"bytes"
-	"context"
 	"math"
 	"time"
 
@@ -70,11 +69,11 @@ func GetInProjectionOperator(
 		case -1:
 		default:
 			obj := &projectInOpBool{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				allocator:    allocator,
-				colIdx:       colIdx,
-				outputIdx:    resultIdx,
-				negate:       negate,
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				allocator:      allocator,
+				colIdx:         colIdx,
+				outputIdx:      resultIdx,
+				negate:         negate,
 			}
 			obj.filterRow, obj.hasNulls = fillDatumRowBool(t, datumTuple)
 			return obj, nil
@@ -84,11 +83,11 @@ func GetInProjectionOperator(
 		case -1:
 		default:
 			obj := &projectInOpBytes{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				allocator:    allocator,
-				colIdx:       colIdx,
-				outputIdx:    resultIdx,
-				negate:       negate,
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				allocator:      allocator,
+				colIdx:         colIdx,
+				outputIdx:      resultIdx,
+				negate:         negate,
 			}
 			obj.filterRow, obj.hasNulls = fillDatumRowBytes(t, datumTuple)
 			return obj, nil
@@ -98,11 +97,11 @@ func GetInProjectionOperator(
 		case -1:
 		default:
 			obj := &projectInOpDecimal{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				allocator:    allocator,
-				colIdx:       colIdx,
-				outputIdx:    resultIdx,
-				negate:       negate,
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				allocator:      allocator,
+				colIdx:         colIdx,
+				outputIdx:      resultIdx,
+				negate:         negate,
 			}
 			obj.filterRow, obj.hasNulls = fillDatumRowDecimal(t, datumTuple)
 			return obj, nil
@@ -111,32 +110,32 @@ func GetInProjectionOperator(
 		switch t.Width() {
 		case 16:
 			obj := &projectInOpInt16{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				allocator:    allocator,
-				colIdx:       colIdx,
-				outputIdx:    resultIdx,
-				negate:       negate,
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				allocator:      allocator,
+				colIdx:         colIdx,
+				outputIdx:      resultIdx,
+				negate:         negate,
 			}
 			obj.filterRow, obj.hasNulls = fillDatumRowInt16(t, datumTuple)
 			return obj, nil
 		case 32:
 			obj := &projectInOpInt32{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				allocator:    allocator,
-				colIdx:       colIdx,
-				outputIdx:    resultIdx,
-				negate:       negate,
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				allocator:      allocator,
+				colIdx:         colIdx,
+				outputIdx:      resultIdx,
+				negate:         negate,
 			}
 			obj.filterRow, obj.hasNulls = fillDatumRowInt32(t, datumTuple)
 			return obj, nil
 		case -1:
 		default:
 			obj := &projectInOpInt64{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				allocator:    allocator,
-				colIdx:       colIdx,
-				outputIdx:    resultIdx,
-				negate:       negate,
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				allocator:      allocator,
+				colIdx:         colIdx,
+				outputIdx:      resultIdx,
+				negate:         negate,
 			}
 			obj.filterRow, obj.hasNulls = fillDatumRowInt64(t, datumTuple)
 			return obj, nil
@@ -146,11 +145,11 @@ func GetInProjectionOperator(
 		case -1:
 		default:
 			obj := &projectInOpFloat64{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				allocator:    allocator,
-				colIdx:       colIdx,
-				outputIdx:    resultIdx,
-				negate:       negate,
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				allocator:      allocator,
+				colIdx:         colIdx,
+				outputIdx:      resultIdx,
+				negate:         negate,
 			}
 			obj.filterRow, obj.hasNulls = fillDatumRowFloat64(t, datumTuple)
 			return obj, nil
@@ -160,11 +159,11 @@ func GetInProjectionOperator(
 		case -1:
 		default:
 			obj := &projectInOpTimestamp{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				allocator:    allocator,
-				colIdx:       colIdx,
-				outputIdx:    resultIdx,
-				negate:       negate,
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				allocator:      allocator,
+				colIdx:         colIdx,
+				outputIdx:      resultIdx,
+				negate:         negate,
 			}
 			obj.filterRow, obj.hasNulls = fillDatumRowTimestamp(t, datumTuple)
 			return obj, nil
@@ -174,11 +173,11 @@ func GetInProjectionOperator(
 		case -1:
 		default:
 			obj := &projectInOpInterval{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				allocator:    allocator,
-				colIdx:       colIdx,
-				outputIdx:    resultIdx,
-				negate:       negate,
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				allocator:      allocator,
+				colIdx:         colIdx,
+				outputIdx:      resultIdx,
+				negate:         negate,
 			}
 			obj.filterRow, obj.hasNulls = fillDatumRowInterval(t, datumTuple)
 			return obj, nil
@@ -188,11 +187,11 @@ func GetInProjectionOperator(
 		case -1:
 		default:
 			obj := &projectInOpJSON{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				allocator:    allocator,
-				colIdx:       colIdx,
-				outputIdx:    resultIdx,
-				negate:       negate,
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				allocator:      allocator,
+				colIdx:         colIdx,
+				outputIdx:      resultIdx,
+				negate:         negate,
 			}
 			obj.filterRow, obj.hasNulls = fillDatumRowJSON(t, datumTuple)
 			return obj, nil
@@ -202,11 +201,11 @@ func GetInProjectionOperator(
 		case -1:
 		default:
 			obj := &projectInOpDatum{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				allocator:    allocator,
-				colIdx:       colIdx,
-				outputIdx:    resultIdx,
-				negate:       negate,
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				allocator:      allocator,
+				colIdx:         colIdx,
+				outputIdx:      resultIdx,
+				negate:         negate,
 			}
 			obj.filterRow, obj.hasNulls = fillDatumRowDatum(t, datumTuple)
 			return obj, nil
@@ -224,9 +223,9 @@ func GetInOperator(
 		case -1:
 		default:
 			obj := &selectInOpBool{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				colIdx:       colIdx,
-				negate:       negate,
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				colIdx:         colIdx,
+				negate:         negate,
 			}
 			obj.filterRow, obj.hasNulls = fillDatumRowBool(t, datumTuple)
 			return obj, nil
@@ -236,9 +235,9 @@ func GetInOperator(
 		case -1:
 		default:
 			obj := &selectInOpBytes{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				colIdx:       colIdx,
-				negate:       negate,
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				colIdx:         colIdx,
+				negate:         negate,
 			}
 			obj.filterRow, obj.hasNulls = fillDatumRowBytes(t, datumTuple)
 			return obj, nil
@@ -248,9 +247,9 @@ func GetInOperator(
 		case -1:
 		default:
 			obj := &selectInOpDecimal{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				colIdx:       colIdx,
-				negate:       negate,
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				colIdx:         colIdx,
+				negate:         negate,
 			}
 			obj.filterRow, obj.hasNulls = fillDatumRowDecimal(t, datumTuple)
 			return obj, nil
@@ -259,26 +258,26 @@ func GetInOperator(
 		switch t.Width() {
 		case 16:
 			obj := &selectInOpInt16{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				colIdx:       colIdx,
-				negate:       negate,
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				colIdx:         colIdx,
+				negate:         negate,
 			}
 			obj.filterRow, obj.hasNulls = fillDatumRowInt16(t, datumTuple)
 			return obj, nil
 		case 32:
 			obj := &selectInOpInt32{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				colIdx:       colIdx,
-				negate:       negate,
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				colIdx:         colIdx,
+				negate:         negate,
 			}
 			obj.filterRow, obj.hasNulls = fillDatumRowInt32(t, datumTuple)
 			return obj, nil
 		case -1:
 		default:
 			obj := &selectInOpInt64{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				colIdx:       colIdx,
-				negate:       negate,
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				colIdx:         colIdx,
+				negate:         negate,
 			}
 			obj.filterRow, obj.hasNulls = fillDatumRowInt64(t, datumTuple)
 			return obj, nil
@@ -288,9 +287,9 @@ func GetInOperator(
 		case -1:
 		default:
 			obj := &selectInOpFloat64{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				colIdx:       colIdx,
-				negate:       negate,
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				colIdx:         colIdx,
+				negate:         negate,
 			}
 			obj.filterRow, obj.hasNulls = fillDatumRowFloat64(t, datumTuple)
 			return obj, nil
@@ -300,9 +299,9 @@ func GetInOperator(
 		case -1:
 		default:
 			obj := &selectInOpTimestamp{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				colIdx:       colIdx,
-				negate:       negate,
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				colIdx:         colIdx,
+				negate:         negate,
 			}
 			obj.filterRow, obj.hasNulls = fillDatumRowTimestamp(t, datumTuple)
 			return obj, nil
@@ -312,9 +311,9 @@ func GetInOperator(
 		case -1:
 		default:
 			obj := &selectInOpInterval{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				colIdx:       colIdx,
-				negate:       negate,
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				colIdx:         colIdx,
+				negate:         negate,
 			}
 			obj.filterRow, obj.hasNulls = fillDatumRowInterval(t, datumTuple)
 			return obj, nil
@@ -324,9 +323,9 @@ func GetInOperator(
 		case -1:
 		default:
 			obj := &selectInOpJSON{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				colIdx:       colIdx,
-				negate:       negate,
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				colIdx:         colIdx,
+				negate:         negate,
 			}
 			obj.filterRow, obj.hasNulls = fillDatumRowJSON(t, datumTuple)
 			return obj, nil
@@ -336,9 +335,9 @@ func GetInOperator(
 		case -1:
 		default:
 			obj := &selectInOpDatum{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				colIdx:       colIdx,
-				negate:       negate,
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				colIdx:         colIdx,
+				negate:         negate,
 			}
 			obj.filterRow, obj.hasNulls = fillDatumRowDatum(t, datumTuple)
 			return obj, nil
@@ -348,7 +347,7 @@ func GetInOperator(
 }
 
 type selectInOpBool struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	colIdx    int
 	filterRow []bool
 	hasNulls  bool
@@ -358,7 +357,7 @@ type selectInOpBool struct {
 var _ colexecop.Operator = &selectInOpBool{}
 
 type projectInOpBool struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	allocator *colmem.Allocator
 	colIdx    int
 	outputIdx int
@@ -420,17 +419,9 @@ func cmpInBool(
 	}
 }
 
-func (si *selectInOpBool) Init() {
-	si.Input.Init()
-}
-
-func (pi *projectInOpBool) Init() {
-	pi.Input.Init()
-}
-
-func (si *selectInOpBool) Next(ctx context.Context) coldata.Batch {
+func (si *selectInOpBool) Next() coldata.Batch {
 	for {
-		batch := si.Input.Next(ctx)
+		batch := si.Input.Next()
 		if batch.Length() == 0 {
 			return coldata.ZeroBatch
 		}
@@ -501,8 +492,8 @@ func (si *selectInOpBool) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (pi *projectInOpBool) Next(ctx context.Context) coldata.Batch {
-	batch := pi.Input.Next(ctx)
+func (pi *projectInOpBool) Next() coldata.Batch {
+	batch := pi.Input.Next()
 	if batch.Length() == 0 {
 		return coldata.ZeroBatch
 	}
@@ -590,7 +581,7 @@ func (pi *projectInOpBool) Next(ctx context.Context) coldata.Batch {
 }
 
 type selectInOpBytes struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	colIdx    int
 	filterRow [][]byte
 	hasNulls  bool
@@ -600,7 +591,7 @@ type selectInOpBytes struct {
 var _ colexecop.Operator = &selectInOpBytes{}
 
 type projectInOpBytes struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	allocator *colmem.Allocator
 	colIdx    int
 	outputIdx int
@@ -654,17 +645,9 @@ func cmpInBytes(
 	}
 }
 
-func (si *selectInOpBytes) Init() {
-	si.Input.Init()
-}
-
-func (pi *projectInOpBytes) Init() {
-	pi.Input.Init()
-}
-
-func (si *selectInOpBytes) Next(ctx context.Context) coldata.Batch {
+func (si *selectInOpBytes) Next() coldata.Batch {
 	for {
-		batch := si.Input.Next(ctx)
+		batch := si.Input.Next()
 		if batch.Length() == 0 {
 			return coldata.ZeroBatch
 		}
@@ -733,8 +716,8 @@ func (si *selectInOpBytes) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (pi *projectInOpBytes) Next(ctx context.Context) coldata.Batch {
-	batch := pi.Input.Next(ctx)
+func (pi *projectInOpBytes) Next() coldata.Batch {
+	batch := pi.Input.Next()
 	if batch.Length() == 0 {
 		return coldata.ZeroBatch
 	}
@@ -820,7 +803,7 @@ func (pi *projectInOpBytes) Next(ctx context.Context) coldata.Batch {
 }
 
 type selectInOpDecimal struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	colIdx    int
 	filterRow []apd.Decimal
 	hasNulls  bool
@@ -830,7 +813,7 @@ type selectInOpDecimal struct {
 var _ colexecop.Operator = &selectInOpDecimal{}
 
 type projectInOpDecimal struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	allocator *colmem.Allocator
 	colIdx    int
 	outputIdx int
@@ -884,17 +867,9 @@ func cmpInDecimal(
 	}
 }
 
-func (si *selectInOpDecimal) Init() {
-	si.Input.Init()
-}
-
-func (pi *projectInOpDecimal) Init() {
-	pi.Input.Init()
-}
-
-func (si *selectInOpDecimal) Next(ctx context.Context) coldata.Batch {
+func (si *selectInOpDecimal) Next() coldata.Batch {
 	for {
-		batch := si.Input.Next(ctx)
+		batch := si.Input.Next()
 		if batch.Length() == 0 {
 			return coldata.ZeroBatch
 		}
@@ -965,8 +940,8 @@ func (si *selectInOpDecimal) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (pi *projectInOpDecimal) Next(ctx context.Context) coldata.Batch {
-	batch := pi.Input.Next(ctx)
+func (pi *projectInOpDecimal) Next() coldata.Batch {
+	batch := pi.Input.Next()
 	if batch.Length() == 0 {
 		return coldata.ZeroBatch
 	}
@@ -1054,7 +1029,7 @@ func (pi *projectInOpDecimal) Next(ctx context.Context) coldata.Batch {
 }
 
 type selectInOpInt16 struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	colIdx    int
 	filterRow []int16
 	hasNulls  bool
@@ -1064,7 +1039,7 @@ type selectInOpInt16 struct {
 var _ colexecop.Operator = &selectInOpInt16{}
 
 type projectInOpInt16 struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	allocator *colmem.Allocator
 	colIdx    int
 	outputIdx int
@@ -1129,17 +1104,9 @@ func cmpInInt16(
 	}
 }
 
-func (si *selectInOpInt16) Init() {
-	si.Input.Init()
-}
-
-func (pi *projectInOpInt16) Init() {
-	pi.Input.Init()
-}
-
-func (si *selectInOpInt16) Next(ctx context.Context) coldata.Batch {
+func (si *selectInOpInt16) Next() coldata.Batch {
 	for {
-		batch := si.Input.Next(ctx)
+		batch := si.Input.Next()
 		if batch.Length() == 0 {
 			return coldata.ZeroBatch
 		}
@@ -1210,8 +1177,8 @@ func (si *selectInOpInt16) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (pi *projectInOpInt16) Next(ctx context.Context) coldata.Batch {
-	batch := pi.Input.Next(ctx)
+func (pi *projectInOpInt16) Next() coldata.Batch {
+	batch := pi.Input.Next()
 	if batch.Length() == 0 {
 		return coldata.ZeroBatch
 	}
@@ -1299,7 +1266,7 @@ func (pi *projectInOpInt16) Next(ctx context.Context) coldata.Batch {
 }
 
 type selectInOpInt32 struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	colIdx    int
 	filterRow []int32
 	hasNulls  bool
@@ -1309,7 +1276,7 @@ type selectInOpInt32 struct {
 var _ colexecop.Operator = &selectInOpInt32{}
 
 type projectInOpInt32 struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	allocator *colmem.Allocator
 	colIdx    int
 	outputIdx int
@@ -1374,17 +1341,9 @@ func cmpInInt32(
 	}
 }
 
-func (si *selectInOpInt32) Init() {
-	si.Input.Init()
-}
-
-func (pi *projectInOpInt32) Init() {
-	pi.Input.Init()
-}
-
-func (si *selectInOpInt32) Next(ctx context.Context) coldata.Batch {
+func (si *selectInOpInt32) Next() coldata.Batch {
 	for {
-		batch := si.Input.Next(ctx)
+		batch := si.Input.Next()
 		if batch.Length() == 0 {
 			return coldata.ZeroBatch
 		}
@@ -1455,8 +1414,8 @@ func (si *selectInOpInt32) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (pi *projectInOpInt32) Next(ctx context.Context) coldata.Batch {
-	batch := pi.Input.Next(ctx)
+func (pi *projectInOpInt32) Next() coldata.Batch {
+	batch := pi.Input.Next()
 	if batch.Length() == 0 {
 		return coldata.ZeroBatch
 	}
@@ -1544,7 +1503,7 @@ func (pi *projectInOpInt32) Next(ctx context.Context) coldata.Batch {
 }
 
 type selectInOpInt64 struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	colIdx    int
 	filterRow []int64
 	hasNulls  bool
@@ -1554,7 +1513,7 @@ type selectInOpInt64 struct {
 var _ colexecop.Operator = &selectInOpInt64{}
 
 type projectInOpInt64 struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	allocator *colmem.Allocator
 	colIdx    int
 	outputIdx int
@@ -1619,17 +1578,9 @@ func cmpInInt64(
 	}
 }
 
-func (si *selectInOpInt64) Init() {
-	si.Input.Init()
-}
-
-func (pi *projectInOpInt64) Init() {
-	pi.Input.Init()
-}
-
-func (si *selectInOpInt64) Next(ctx context.Context) coldata.Batch {
+func (si *selectInOpInt64) Next() coldata.Batch {
 	for {
-		batch := si.Input.Next(ctx)
+		batch := si.Input.Next()
 		if batch.Length() == 0 {
 			return coldata.ZeroBatch
 		}
@@ -1700,8 +1651,8 @@ func (si *selectInOpInt64) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (pi *projectInOpInt64) Next(ctx context.Context) coldata.Batch {
-	batch := pi.Input.Next(ctx)
+func (pi *projectInOpInt64) Next() coldata.Batch {
+	batch := pi.Input.Next()
 	if batch.Length() == 0 {
 		return coldata.ZeroBatch
 	}
@@ -1789,7 +1740,7 @@ func (pi *projectInOpInt64) Next(ctx context.Context) coldata.Batch {
 }
 
 type selectInOpFloat64 struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	colIdx    int
 	filterRow []float64
 	hasNulls  bool
@@ -1799,7 +1750,7 @@ type selectInOpFloat64 struct {
 var _ colexecop.Operator = &selectInOpFloat64{}
 
 type projectInOpFloat64 struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	allocator *colmem.Allocator
 	colIdx    int
 	outputIdx int
@@ -1872,17 +1823,9 @@ func cmpInFloat64(
 	}
 }
 
-func (si *selectInOpFloat64) Init() {
-	si.Input.Init()
-}
-
-func (pi *projectInOpFloat64) Init() {
-	pi.Input.Init()
-}
-
-func (si *selectInOpFloat64) Next(ctx context.Context) coldata.Batch {
+func (si *selectInOpFloat64) Next() coldata.Batch {
 	for {
-		batch := si.Input.Next(ctx)
+		batch := si.Input.Next()
 		if batch.Length() == 0 {
 			return coldata.ZeroBatch
 		}
@@ -1953,8 +1896,8 @@ func (si *selectInOpFloat64) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (pi *projectInOpFloat64) Next(ctx context.Context) coldata.Batch {
-	batch := pi.Input.Next(ctx)
+func (pi *projectInOpFloat64) Next() coldata.Batch {
+	batch := pi.Input.Next()
 	if batch.Length() == 0 {
 		return coldata.ZeroBatch
 	}
@@ -2042,7 +1985,7 @@ func (pi *projectInOpFloat64) Next(ctx context.Context) coldata.Batch {
 }
 
 type selectInOpTimestamp struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	colIdx    int
 	filterRow []time.Time
 	hasNulls  bool
@@ -2052,7 +1995,7 @@ type selectInOpTimestamp struct {
 var _ colexecop.Operator = &selectInOpTimestamp{}
 
 type projectInOpTimestamp struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	allocator *colmem.Allocator
 	colIdx    int
 	outputIdx int
@@ -2113,17 +2056,9 @@ func cmpInTimestamp(
 	}
 }
 
-func (si *selectInOpTimestamp) Init() {
-	si.Input.Init()
-}
-
-func (pi *projectInOpTimestamp) Init() {
-	pi.Input.Init()
-}
-
-func (si *selectInOpTimestamp) Next(ctx context.Context) coldata.Batch {
+func (si *selectInOpTimestamp) Next() coldata.Batch {
 	for {
-		batch := si.Input.Next(ctx)
+		batch := si.Input.Next()
 		if batch.Length() == 0 {
 			return coldata.ZeroBatch
 		}
@@ -2194,8 +2129,8 @@ func (si *selectInOpTimestamp) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (pi *projectInOpTimestamp) Next(ctx context.Context) coldata.Batch {
-	batch := pi.Input.Next(ctx)
+func (pi *projectInOpTimestamp) Next() coldata.Batch {
+	batch := pi.Input.Next()
 	if batch.Length() == 0 {
 		return coldata.ZeroBatch
 	}
@@ -2283,7 +2218,7 @@ func (pi *projectInOpTimestamp) Next(ctx context.Context) coldata.Batch {
 }
 
 type selectInOpInterval struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	colIdx    int
 	filterRow []duration.Duration
 	hasNulls  bool
@@ -2293,7 +2228,7 @@ type selectInOpInterval struct {
 var _ colexecop.Operator = &selectInOpInterval{}
 
 type projectInOpInterval struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	allocator *colmem.Allocator
 	colIdx    int
 	outputIdx int
@@ -2347,17 +2282,9 @@ func cmpInInterval(
 	}
 }
 
-func (si *selectInOpInterval) Init() {
-	si.Input.Init()
-}
-
-func (pi *projectInOpInterval) Init() {
-	pi.Input.Init()
-}
-
-func (si *selectInOpInterval) Next(ctx context.Context) coldata.Batch {
+func (si *selectInOpInterval) Next() coldata.Batch {
 	for {
-		batch := si.Input.Next(ctx)
+		batch := si.Input.Next()
 		if batch.Length() == 0 {
 			return coldata.ZeroBatch
 		}
@@ -2428,8 +2355,8 @@ func (si *selectInOpInterval) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (pi *projectInOpInterval) Next(ctx context.Context) coldata.Batch {
-	batch := pi.Input.Next(ctx)
+func (pi *projectInOpInterval) Next() coldata.Batch {
+	batch := pi.Input.Next()
 	if batch.Length() == 0 {
 		return coldata.ZeroBatch
 	}
@@ -2517,7 +2444,7 @@ func (pi *projectInOpInterval) Next(ctx context.Context) coldata.Batch {
 }
 
 type selectInOpJSON struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	colIdx    int
 	filterRow []json.JSON
 	hasNulls  bool
@@ -2527,7 +2454,7 @@ type selectInOpJSON struct {
 var _ colexecop.Operator = &selectInOpJSON{}
 
 type projectInOpJSON struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	allocator *colmem.Allocator
 	colIdx    int
 	outputIdx int
@@ -2587,17 +2514,9 @@ func cmpInJSON(
 	}
 }
 
-func (si *selectInOpJSON) Init() {
-	si.Input.Init()
-}
-
-func (pi *projectInOpJSON) Init() {
-	pi.Input.Init()
-}
-
-func (si *selectInOpJSON) Next(ctx context.Context) coldata.Batch {
+func (si *selectInOpJSON) Next() coldata.Batch {
 	for {
-		batch := si.Input.Next(ctx)
+		batch := si.Input.Next()
 		if batch.Length() == 0 {
 			return coldata.ZeroBatch
 		}
@@ -2666,8 +2585,8 @@ func (si *selectInOpJSON) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (pi *projectInOpJSON) Next(ctx context.Context) coldata.Batch {
-	batch := pi.Input.Next(ctx)
+func (pi *projectInOpJSON) Next() coldata.Batch {
+	batch := pi.Input.Next()
 	if batch.Length() == 0 {
 		return coldata.ZeroBatch
 	}
@@ -2753,7 +2672,7 @@ func (pi *projectInOpJSON) Next(ctx context.Context) coldata.Batch {
 }
 
 type selectInOpDatum struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	colIdx    int
 	filterRow []interface{}
 	hasNulls  bool
@@ -2763,7 +2682,7 @@ type selectInOpDatum struct {
 var _ colexecop.Operator = &selectInOpDatum{}
 
 type projectInOpDatum struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	allocator *colmem.Allocator
 	colIdx    int
 	outputIdx int
@@ -2819,17 +2738,9 @@ func cmpInDatum(
 	}
 }
 
-func (si *selectInOpDatum) Init() {
-	si.Input.Init()
-}
-
-func (pi *projectInOpDatum) Init() {
-	pi.Input.Init()
-}
-
-func (si *selectInOpDatum) Next(ctx context.Context) coldata.Batch {
+func (si *selectInOpDatum) Next() coldata.Batch {
 	for {
-		batch := si.Input.Next(ctx)
+		batch := si.Input.Next()
 		if batch.Length() == 0 {
 			return coldata.ZeroBatch
 		}
@@ -2898,8 +2809,8 @@ func (si *selectInOpDatum) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (pi *projectInOpDatum) Next(ctx context.Context) coldata.Batch {
-	batch := pi.Input.Next(ctx)
+func (pi *projectInOpDatum) Next() coldata.Batch {
+	batch := pi.Input.Next()
 	if batch.Length() == 0 {
 		return coldata.ZeroBatch
 	}

--- a/pkg/sql/colexec/select_in_test.go
+++ b/pkg/sql/colexec/select_in_test.go
@@ -76,11 +76,11 @@ func TestSelectInInt64(t *testing.T) {
 		log.Infof(context.Background(), "%s", c.desc)
 		opConstructor := func(input []colexecop.Operator) (colexecop.Operator, error) {
 			op := selectInOpInt64{
-				OneInputNode: colexecop.NewOneInputNode(input[0]),
-				colIdx:       0,
-				filterRow:    c.filterRow,
-				negate:       c.negate,
-				hasNulls:     c.hasNulls,
+				OneInputHelper: colexecop.MakeOneInputHelper(input[0]),
+				colIdx:         0,
+				filterRow:      c.filterRow,
+				negate:         c.negate,
+				hasNulls:       c.hasNulls,
 			}
 			return &op, nil
 		}
@@ -132,18 +132,17 @@ func benchmarkSelectInInt64(b *testing.B, useSelectionVector bool, hasNulls bool
 	}
 
 	source := colexecop.NewRepeatableBatchSource(testAllocator, batch, typs)
-	source.Init()
 	inOp := &selectInOpInt64{
-		OneInputNode: colexecop.NewOneInputNode(source),
-		colIdx:       0,
-		filterRow:    []int64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+		OneInputHelper: colexecop.MakeOneInputHelper(source),
+		colIdx:         0,
+		filterRow:      []int64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 	}
-	inOp.Init()
+	inOp.Init(ctx)
 
 	b.SetBytes(int64(8 * coldata.BatchSize()))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		inOp.Next(ctx)
+		inOp.Next()
 	}
 }
 

--- a/pkg/sql/colexec/select_in_tmpl.go
+++ b/pkg/sql/colexec/select_in_tmpl.go
@@ -20,8 +20,6 @@
 package colexec
 
 import (
-	"context"
-
 	"github.com/cockroachdb/apd/v2"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
@@ -96,11 +94,11 @@ func GetInProjectionOperator(
 		// {{range .WidthOverloads}}
 		case _TYPE_WIDTH:
 			obj := &projectInOp_TYPE{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				allocator:    allocator,
-				colIdx:       colIdx,
-				outputIdx:    resultIdx,
-				negate:       negate,
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				allocator:      allocator,
+				colIdx:         colIdx,
+				outputIdx:      resultIdx,
+				negate:         negate,
 			}
 			obj.filterRow, obj.hasNulls = fillDatumRow_TYPE(t, datumTuple)
 			return obj, nil
@@ -121,9 +119,9 @@ func GetInOperator(
 		// {{range .WidthOverloads}}
 		case _TYPE_WIDTH:
 			obj := &selectInOp_TYPE{
-				OneInputNode: colexecop.NewOneInputNode(input),
-				colIdx:       colIdx,
-				negate:       negate,
+				OneInputHelper: colexecop.MakeOneInputHelper(input),
+				colIdx:         colIdx,
+				negate:         negate,
 			}
 			obj.filterRow, obj.hasNulls = fillDatumRow_TYPE(t, datumTuple)
 			return obj, nil
@@ -138,7 +136,7 @@ func GetInOperator(
 // {{range .WidthOverloads}}
 
 type selectInOp_TYPE struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	colIdx    int
 	filterRow []_GOTYPE
 	hasNulls  bool
@@ -148,7 +146,7 @@ type selectInOp_TYPE struct {
 var _ colexecop.Operator = &selectInOp_TYPE{}
 
 type projectInOp_TYPE struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	allocator *colmem.Allocator
 	colIdx    int
 	outputIdx int
@@ -202,17 +200,9 @@ func cmpIn_TYPE(
 	}
 }
 
-func (si *selectInOp_TYPE) Init() {
-	si.Input.Init()
-}
-
-func (pi *projectInOp_TYPE) Init() {
-	pi.Input.Init()
-}
-
-func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
+func (si *selectInOp_TYPE) Next() coldata.Batch {
 	for {
-		batch := si.Input.Next(ctx)
+		batch := si.Input.Next()
 		if batch.Length() == 0 {
 			return coldata.ZeroBatch
 		}
@@ -287,8 +277,8 @@ func (si *selectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (pi *projectInOp_TYPE) Next(ctx context.Context) coldata.Batch {
-	batch := pi.Input.Next(ctx)
+func (pi *projectInOp_TYPE) Next() coldata.Batch {
+	batch := pi.Input.Next()
 	if batch.Length() == 0 {
 		return coldata.ZeroBatch
 	}

--- a/pkg/sql/colexec/serial_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/serial_unordered_synchronizer_test.go
@@ -54,9 +54,10 @@ func TestSerialUnorderedSynchronizer(t *testing.T) {
 		}
 	}
 	s := NewSerialUnorderedSynchronizer(inputs)
+	s.Init(ctx)
 	resultBatches := 0
 	for {
-		b := s.Next(ctx)
+		b := s.Next()
 		if b.Length() == 0 {
 			require.Equal(t, len(inputs), len(s.DrainMeta(ctx)))
 			break

--- a/pkg/sql/colexec/sort.eg.go
+++ b/pkg/sql/colexec/sort.eg.go
@@ -427,18 +427,19 @@ type sortBoolAscWithNullsOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortBoolAscWithNullsOp) init(col coldata.Vec, order []int) {
+func (s *sortBoolAscWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Bool()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortBoolAscWithNullsOp) sort(ctx context.Context) {
+func (s *sortBoolAscWithNullsOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortBoolAscWithNullsOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortBoolAscWithNullsOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -452,7 +453,7 @@ func (s *sortBoolAscWithNullsOp) sortPartitions(ctx context.Context, partitions 
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -505,18 +506,19 @@ type sortBytesAscWithNullsOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortBytesAscWithNullsOp) init(col coldata.Vec, order []int) {
+func (s *sortBytesAscWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Bytes()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortBytesAscWithNullsOp) sort(ctx context.Context) {
+func (s *sortBytesAscWithNullsOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortBytesAscWithNullsOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortBytesAscWithNullsOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -530,7 +532,7 @@ func (s *sortBytesAscWithNullsOp) sortPartitions(ctx context.Context, partitions
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -575,18 +577,19 @@ type sortDecimalAscWithNullsOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortDecimalAscWithNullsOp) init(col coldata.Vec, order []int) {
+func (s *sortDecimalAscWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Decimal()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortDecimalAscWithNullsOp) sort(ctx context.Context) {
+func (s *sortDecimalAscWithNullsOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortDecimalAscWithNullsOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortDecimalAscWithNullsOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -600,7 +603,7 @@ func (s *sortDecimalAscWithNullsOp) sortPartitions(ctx context.Context, partitio
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -645,18 +648,19 @@ type sortInt16AscWithNullsOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortInt16AscWithNullsOp) init(col coldata.Vec, order []int) {
+func (s *sortInt16AscWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Int16()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortInt16AscWithNullsOp) sort(ctx context.Context) {
+func (s *sortInt16AscWithNullsOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortInt16AscWithNullsOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortInt16AscWithNullsOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -670,7 +674,7 @@ func (s *sortInt16AscWithNullsOp) sortPartitions(ctx context.Context, partitions
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -726,18 +730,19 @@ type sortInt32AscWithNullsOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortInt32AscWithNullsOp) init(col coldata.Vec, order []int) {
+func (s *sortInt32AscWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Int32()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortInt32AscWithNullsOp) sort(ctx context.Context) {
+func (s *sortInt32AscWithNullsOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortInt32AscWithNullsOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortInt32AscWithNullsOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -751,7 +756,7 @@ func (s *sortInt32AscWithNullsOp) sortPartitions(ctx context.Context, partitions
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -807,18 +812,19 @@ type sortInt64AscWithNullsOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortInt64AscWithNullsOp) init(col coldata.Vec, order []int) {
+func (s *sortInt64AscWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Int64()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortInt64AscWithNullsOp) sort(ctx context.Context) {
+func (s *sortInt64AscWithNullsOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortInt64AscWithNullsOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortInt64AscWithNullsOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -832,7 +838,7 @@ func (s *sortInt64AscWithNullsOp) sortPartitions(ctx context.Context, partitions
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -888,18 +894,19 @@ type sortFloat64AscWithNullsOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortFloat64AscWithNullsOp) init(col coldata.Vec, order []int) {
+func (s *sortFloat64AscWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Float64()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortFloat64AscWithNullsOp) sort(ctx context.Context) {
+func (s *sortFloat64AscWithNullsOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortFloat64AscWithNullsOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortFloat64AscWithNullsOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -913,7 +920,7 @@ func (s *sortFloat64AscWithNullsOp) sortPartitions(ctx context.Context, partitio
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -977,18 +984,19 @@ type sortTimestampAscWithNullsOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortTimestampAscWithNullsOp) init(col coldata.Vec, order []int) {
+func (s *sortTimestampAscWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Timestamp()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortTimestampAscWithNullsOp) sort(ctx context.Context) {
+func (s *sortTimestampAscWithNullsOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortTimestampAscWithNullsOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortTimestampAscWithNullsOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -1002,7 +1010,7 @@ func (s *sortTimestampAscWithNullsOp) sortPartitions(ctx context.Context, partit
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -1054,18 +1062,19 @@ type sortIntervalAscWithNullsOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortIntervalAscWithNullsOp) init(col coldata.Vec, order []int) {
+func (s *sortIntervalAscWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Interval()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortIntervalAscWithNullsOp) sort(ctx context.Context) {
+func (s *sortIntervalAscWithNullsOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortIntervalAscWithNullsOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortIntervalAscWithNullsOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -1079,7 +1088,7 @@ func (s *sortIntervalAscWithNullsOp) sortPartitions(ctx context.Context, partiti
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -1124,18 +1133,19 @@ type sortJSONAscWithNullsOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortJSONAscWithNullsOp) init(col coldata.Vec, order []int) {
+func (s *sortJSONAscWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.JSON()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortJSONAscWithNullsOp) sort(ctx context.Context) {
+func (s *sortJSONAscWithNullsOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortJSONAscWithNullsOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortJSONAscWithNullsOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -1149,7 +1159,7 @@ func (s *sortJSONAscWithNullsOp) sortPartitions(ctx context.Context, partitions 
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -1200,18 +1210,19 @@ type sortDatumAscWithNullsOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortDatumAscWithNullsOp) init(col coldata.Vec, order []int) {
+func (s *sortDatumAscWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Datum()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortDatumAscWithNullsOp) sort(ctx context.Context) {
+func (s *sortDatumAscWithNullsOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortDatumAscWithNullsOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortDatumAscWithNullsOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -1225,7 +1236,7 @@ func (s *sortDatumAscWithNullsOp) sortPartitions(ctx context.Context, partitions
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -1272,18 +1283,19 @@ type sortBoolDescWithNullsOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortBoolDescWithNullsOp) init(col coldata.Vec, order []int) {
+func (s *sortBoolDescWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Bool()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortBoolDescWithNullsOp) sort(ctx context.Context) {
+func (s *sortBoolDescWithNullsOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortBoolDescWithNullsOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortBoolDescWithNullsOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -1297,7 +1309,7 @@ func (s *sortBoolDescWithNullsOp) sortPartitions(ctx context.Context, partitions
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -1350,18 +1362,19 @@ type sortBytesDescWithNullsOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortBytesDescWithNullsOp) init(col coldata.Vec, order []int) {
+func (s *sortBytesDescWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Bytes()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortBytesDescWithNullsOp) sort(ctx context.Context) {
+func (s *sortBytesDescWithNullsOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortBytesDescWithNullsOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortBytesDescWithNullsOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -1375,7 +1388,7 @@ func (s *sortBytesDescWithNullsOp) sortPartitions(ctx context.Context, partition
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -1420,18 +1433,19 @@ type sortDecimalDescWithNullsOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortDecimalDescWithNullsOp) init(col coldata.Vec, order []int) {
+func (s *sortDecimalDescWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Decimal()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortDecimalDescWithNullsOp) sort(ctx context.Context) {
+func (s *sortDecimalDescWithNullsOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortDecimalDescWithNullsOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortDecimalDescWithNullsOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -1445,7 +1459,7 @@ func (s *sortDecimalDescWithNullsOp) sortPartitions(ctx context.Context, partiti
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -1490,18 +1504,19 @@ type sortInt16DescWithNullsOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortInt16DescWithNullsOp) init(col coldata.Vec, order []int) {
+func (s *sortInt16DescWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Int16()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortInt16DescWithNullsOp) sort(ctx context.Context) {
+func (s *sortInt16DescWithNullsOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortInt16DescWithNullsOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortInt16DescWithNullsOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -1515,7 +1530,7 @@ func (s *sortInt16DescWithNullsOp) sortPartitions(ctx context.Context, partition
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -1571,18 +1586,19 @@ type sortInt32DescWithNullsOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortInt32DescWithNullsOp) init(col coldata.Vec, order []int) {
+func (s *sortInt32DescWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Int32()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortInt32DescWithNullsOp) sort(ctx context.Context) {
+func (s *sortInt32DescWithNullsOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortInt32DescWithNullsOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortInt32DescWithNullsOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -1596,7 +1612,7 @@ func (s *sortInt32DescWithNullsOp) sortPartitions(ctx context.Context, partition
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -1652,18 +1668,19 @@ type sortInt64DescWithNullsOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortInt64DescWithNullsOp) init(col coldata.Vec, order []int) {
+func (s *sortInt64DescWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Int64()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortInt64DescWithNullsOp) sort(ctx context.Context) {
+func (s *sortInt64DescWithNullsOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortInt64DescWithNullsOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortInt64DescWithNullsOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -1677,7 +1694,7 @@ func (s *sortInt64DescWithNullsOp) sortPartitions(ctx context.Context, partition
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -1733,18 +1750,19 @@ type sortFloat64DescWithNullsOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortFloat64DescWithNullsOp) init(col coldata.Vec, order []int) {
+func (s *sortFloat64DescWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Float64()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortFloat64DescWithNullsOp) sort(ctx context.Context) {
+func (s *sortFloat64DescWithNullsOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortFloat64DescWithNullsOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortFloat64DescWithNullsOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -1758,7 +1776,7 @@ func (s *sortFloat64DescWithNullsOp) sortPartitions(ctx context.Context, partiti
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -1822,18 +1840,19 @@ type sortTimestampDescWithNullsOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortTimestampDescWithNullsOp) init(col coldata.Vec, order []int) {
+func (s *sortTimestampDescWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Timestamp()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortTimestampDescWithNullsOp) sort(ctx context.Context) {
+func (s *sortTimestampDescWithNullsOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortTimestampDescWithNullsOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortTimestampDescWithNullsOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -1847,7 +1866,7 @@ func (s *sortTimestampDescWithNullsOp) sortPartitions(ctx context.Context, parti
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -1899,18 +1918,19 @@ type sortIntervalDescWithNullsOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortIntervalDescWithNullsOp) init(col coldata.Vec, order []int) {
+func (s *sortIntervalDescWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Interval()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortIntervalDescWithNullsOp) sort(ctx context.Context) {
+func (s *sortIntervalDescWithNullsOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortIntervalDescWithNullsOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortIntervalDescWithNullsOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -1924,7 +1944,7 @@ func (s *sortIntervalDescWithNullsOp) sortPartitions(ctx context.Context, partit
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -1969,18 +1989,19 @@ type sortJSONDescWithNullsOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortJSONDescWithNullsOp) init(col coldata.Vec, order []int) {
+func (s *sortJSONDescWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.JSON()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortJSONDescWithNullsOp) sort(ctx context.Context) {
+func (s *sortJSONDescWithNullsOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortJSONDescWithNullsOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortJSONDescWithNullsOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -1994,7 +2015,7 @@ func (s *sortJSONDescWithNullsOp) sortPartitions(ctx context.Context, partitions
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -2045,18 +2066,19 @@ type sortDatumDescWithNullsOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortDatumDescWithNullsOp) init(col coldata.Vec, order []int) {
+func (s *sortDatumDescWithNullsOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Datum()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortDatumDescWithNullsOp) sort(ctx context.Context) {
+func (s *sortDatumDescWithNullsOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortDatumDescWithNullsOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortDatumDescWithNullsOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -2070,7 +2092,7 @@ func (s *sortDatumDescWithNullsOp) sortPartitions(ctx context.Context, partition
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -2117,18 +2139,19 @@ type sortBoolAscOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortBoolAscOp) init(col coldata.Vec, order []int) {
+func (s *sortBoolAscOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Bool()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortBoolAscOp) sort(ctx context.Context) {
+func (s *sortBoolAscOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortBoolAscOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortBoolAscOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -2142,7 +2165,7 @@ func (s *sortBoolAscOp) sortPartitions(ctx context.Context, partitions []int) {
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -2185,18 +2208,19 @@ type sortBytesAscOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortBytesAscOp) init(col coldata.Vec, order []int) {
+func (s *sortBytesAscOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Bytes()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortBytesAscOp) sort(ctx context.Context) {
+func (s *sortBytesAscOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortBytesAscOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortBytesAscOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -2210,7 +2234,7 @@ func (s *sortBytesAscOp) sortPartitions(ctx context.Context, partitions []int) {
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -2245,18 +2269,19 @@ type sortDecimalAscOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortDecimalAscOp) init(col coldata.Vec, order []int) {
+func (s *sortDecimalAscOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Decimal()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortDecimalAscOp) sort(ctx context.Context) {
+func (s *sortDecimalAscOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortDecimalAscOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortDecimalAscOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -2270,7 +2295,7 @@ func (s *sortDecimalAscOp) sortPartitions(ctx context.Context, partitions []int)
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -2305,18 +2330,19 @@ type sortInt16AscOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortInt16AscOp) init(col coldata.Vec, order []int) {
+func (s *sortInt16AscOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Int16()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortInt16AscOp) sort(ctx context.Context) {
+func (s *sortInt16AscOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortInt16AscOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortInt16AscOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -2330,7 +2356,7 @@ func (s *sortInt16AscOp) sortPartitions(ctx context.Context, partitions []int) {
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -2376,18 +2402,19 @@ type sortInt32AscOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortInt32AscOp) init(col coldata.Vec, order []int) {
+func (s *sortInt32AscOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Int32()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortInt32AscOp) sort(ctx context.Context) {
+func (s *sortInt32AscOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortInt32AscOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortInt32AscOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -2401,7 +2428,7 @@ func (s *sortInt32AscOp) sortPartitions(ctx context.Context, partitions []int) {
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -2447,18 +2474,19 @@ type sortInt64AscOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortInt64AscOp) init(col coldata.Vec, order []int) {
+func (s *sortInt64AscOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Int64()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortInt64AscOp) sort(ctx context.Context) {
+func (s *sortInt64AscOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortInt64AscOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortInt64AscOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -2472,7 +2500,7 @@ func (s *sortInt64AscOp) sortPartitions(ctx context.Context, partitions []int) {
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -2518,18 +2546,19 @@ type sortFloat64AscOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortFloat64AscOp) init(col coldata.Vec, order []int) {
+func (s *sortFloat64AscOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Float64()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortFloat64AscOp) sort(ctx context.Context) {
+func (s *sortFloat64AscOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortFloat64AscOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortFloat64AscOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -2543,7 +2572,7 @@ func (s *sortFloat64AscOp) sortPartitions(ctx context.Context, partitions []int)
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -2597,18 +2626,19 @@ type sortTimestampAscOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortTimestampAscOp) init(col coldata.Vec, order []int) {
+func (s *sortTimestampAscOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Timestamp()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortTimestampAscOp) sort(ctx context.Context) {
+func (s *sortTimestampAscOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortTimestampAscOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortTimestampAscOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -2622,7 +2652,7 @@ func (s *sortTimestampAscOp) sortPartitions(ctx context.Context, partitions []in
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -2664,18 +2694,19 @@ type sortIntervalAscOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortIntervalAscOp) init(col coldata.Vec, order []int) {
+func (s *sortIntervalAscOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Interval()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortIntervalAscOp) sort(ctx context.Context) {
+func (s *sortIntervalAscOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortIntervalAscOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortIntervalAscOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -2689,7 +2720,7 @@ func (s *sortIntervalAscOp) sortPartitions(ctx context.Context, partitions []int
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -2724,18 +2755,19 @@ type sortJSONAscOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortJSONAscOp) init(col coldata.Vec, order []int) {
+func (s *sortJSONAscOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.JSON()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortJSONAscOp) sort(ctx context.Context) {
+func (s *sortJSONAscOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortJSONAscOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortJSONAscOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -2749,7 +2781,7 @@ func (s *sortJSONAscOp) sortPartitions(ctx context.Context, partitions []int) {
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -2790,18 +2822,19 @@ type sortDatumAscOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortDatumAscOp) init(col coldata.Vec, order []int) {
+func (s *sortDatumAscOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Datum()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortDatumAscOp) sort(ctx context.Context) {
+func (s *sortDatumAscOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortDatumAscOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortDatumAscOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -2815,7 +2848,7 @@ func (s *sortDatumAscOp) sortPartitions(ctx context.Context, partitions []int) {
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -2852,18 +2885,19 @@ type sortBoolDescOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortBoolDescOp) init(col coldata.Vec, order []int) {
+func (s *sortBoolDescOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Bool()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortBoolDescOp) sort(ctx context.Context) {
+func (s *sortBoolDescOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortBoolDescOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortBoolDescOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -2877,7 +2911,7 @@ func (s *sortBoolDescOp) sortPartitions(ctx context.Context, partitions []int) {
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -2920,18 +2954,19 @@ type sortBytesDescOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortBytesDescOp) init(col coldata.Vec, order []int) {
+func (s *sortBytesDescOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Bytes()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortBytesDescOp) sort(ctx context.Context) {
+func (s *sortBytesDescOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortBytesDescOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortBytesDescOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -2945,7 +2980,7 @@ func (s *sortBytesDescOp) sortPartitions(ctx context.Context, partitions []int) 
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -2980,18 +3015,19 @@ type sortDecimalDescOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortDecimalDescOp) init(col coldata.Vec, order []int) {
+func (s *sortDecimalDescOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Decimal()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortDecimalDescOp) sort(ctx context.Context) {
+func (s *sortDecimalDescOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortDecimalDescOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortDecimalDescOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -3005,7 +3041,7 @@ func (s *sortDecimalDescOp) sortPartitions(ctx context.Context, partitions []int
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -3040,18 +3076,19 @@ type sortInt16DescOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortInt16DescOp) init(col coldata.Vec, order []int) {
+func (s *sortInt16DescOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Int16()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortInt16DescOp) sort(ctx context.Context) {
+func (s *sortInt16DescOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortInt16DescOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortInt16DescOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -3065,7 +3102,7 @@ func (s *sortInt16DescOp) sortPartitions(ctx context.Context, partitions []int) 
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -3111,18 +3148,19 @@ type sortInt32DescOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortInt32DescOp) init(col coldata.Vec, order []int) {
+func (s *sortInt32DescOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Int32()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortInt32DescOp) sort(ctx context.Context) {
+func (s *sortInt32DescOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortInt32DescOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortInt32DescOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -3136,7 +3174,7 @@ func (s *sortInt32DescOp) sortPartitions(ctx context.Context, partitions []int) 
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -3182,18 +3220,19 @@ type sortInt64DescOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortInt64DescOp) init(col coldata.Vec, order []int) {
+func (s *sortInt64DescOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Int64()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortInt64DescOp) sort(ctx context.Context) {
+func (s *sortInt64DescOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortInt64DescOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortInt64DescOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -3207,7 +3246,7 @@ func (s *sortInt64DescOp) sortPartitions(ctx context.Context, partitions []int) 
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -3253,18 +3292,19 @@ type sortFloat64DescOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortFloat64DescOp) init(col coldata.Vec, order []int) {
+func (s *sortFloat64DescOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Float64()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortFloat64DescOp) sort(ctx context.Context) {
+func (s *sortFloat64DescOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortFloat64DescOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortFloat64DescOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -3278,7 +3318,7 @@ func (s *sortFloat64DescOp) sortPartitions(ctx context.Context, partitions []int
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -3332,18 +3372,19 @@ type sortTimestampDescOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortTimestampDescOp) init(col coldata.Vec, order []int) {
+func (s *sortTimestampDescOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Timestamp()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortTimestampDescOp) sort(ctx context.Context) {
+func (s *sortTimestampDescOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortTimestampDescOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortTimestampDescOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -3357,7 +3398,7 @@ func (s *sortTimestampDescOp) sortPartitions(ctx context.Context, partitions []i
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -3399,18 +3440,19 @@ type sortIntervalDescOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortIntervalDescOp) init(col coldata.Vec, order []int) {
+func (s *sortIntervalDescOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Interval()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortIntervalDescOp) sort(ctx context.Context) {
+func (s *sortIntervalDescOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortIntervalDescOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortIntervalDescOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -3424,7 +3466,7 @@ func (s *sortIntervalDescOp) sortPartitions(ctx context.Context, partitions []in
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -3459,18 +3501,19 @@ type sortJSONDescOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortJSONDescOp) init(col coldata.Vec, order []int) {
+func (s *sortJSONDescOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.JSON()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortJSONDescOp) sort(ctx context.Context) {
+func (s *sortJSONDescOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortJSONDescOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortJSONDescOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -3484,7 +3527,7 @@ func (s *sortJSONDescOp) sortPartitions(ctx context.Context, partitions []int) {
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 
@@ -3525,18 +3568,19 @@ type sortDatumDescOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sortDatumDescOp) init(col coldata.Vec, order []int) {
+func (s *sortDatumDescOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.Datum()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sortDatumDescOp) sort(ctx context.Context) {
+func (s *sortDatumDescOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sortDatumDescOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sortDatumDescOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -3550,7 +3594,7 @@ func (s *sortDatumDescOp) sortPartitions(ctx context.Context, partitions []int) 
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 

--- a/pkg/sql/colexec/sort.go
+++ b/pkg/sql/colexec/sort.go
@@ -74,9 +74,9 @@ type spooler interface {
 	execinfra.OpNode
 
 	// init initializes this spooler and will be called once at the setup time.
-	init()
+	init(context.Context)
 	// spool performs the actual spooling.
-	spool(context.Context)
+	spool()
 	// getValues returns ith Vec of the already spooled data.
 	getValues(i int) coldata.Vec
 	// getNumTuples returns the number of spooled tuples.
@@ -126,18 +126,18 @@ func newAllSpooler(
 	}
 }
 
-func (p *allSpooler) init() {
-	p.Input.Init()
+func (p *allSpooler) init(ctx context.Context) {
+	p.Input.Init(ctx)
 	p.bufferedTuples = colexecutils.NewAppendOnlyBufferedBatch(p.allocator, p.inputTypes, nil /* colsToStore */)
 	p.windowedBatch = p.allocator.NewMemBatchWithFixedCapacity(p.inputTypes, 0 /* size */)
 }
 
-func (p *allSpooler) spool(ctx context.Context) {
+func (p *allSpooler) spool() {
 	if p.spooled {
 		colexecerror.InternalError(errors.AssertionFailedf("spool() is called for the second time"))
 	}
 	p.spooled = true
-	for batch := p.Input.Next(ctx); batch.Length() != 0; batch = p.Input.Next(ctx) {
+	for batch := p.Input.Next(); batch.Length() != 0; batch = p.Input.Next() {
 		p.allocator.PerformOperation(p.bufferedTuples.ColVecs(), func() {
 			p.bufferedTuples.AppendTuples(batch, 0 /* startIdx */, batch.Length())
 		})
@@ -184,6 +184,8 @@ func (p *allSpooler) Reset(ctx context.Context) {
 }
 
 type sortOp struct {
+	colexecop.InitHelper
+
 	allocator *colmem.Allocator
 	input     spooler
 
@@ -224,16 +226,19 @@ type colSorter interface {
 	// init prepares this sorter, given a particular Vec and an order vector,
 	// which must be the same size as the input Vec and will be permuted with
 	// the same swaps as the column.
-	init(col coldata.Vec, order []int)
+	init(ctx context.Context, col coldata.Vec, order []int)
 	// sort globally sorts this sorter's column.
-	sort(ctx context.Context)
+	sort()
 	// sortPartitions sorts this sorter's column once for every partition in the
 	// partition slice.
-	sortPartitions(ctx context.Context, partitions []int)
+	sortPartitions(partitions []int)
 }
 
-func (p *sortOp) Init() {
-	p.input.init()
+func (p *sortOp) Init(ctx context.Context) {
+	if !p.InitHelper.Init(ctx) {
+		return
+	}
+	p.input.init(p.Ctx)
 }
 
 // sortState represents the state of the sort operator.
@@ -254,14 +259,14 @@ const (
 	sortDone
 )
 
-func (p *sortOp) Next(ctx context.Context) coldata.Batch {
+func (p *sortOp) Next() coldata.Batch {
 	for {
 		switch p.state {
 		case sortSpooling:
-			p.input.spool(ctx)
+			p.input.spool()
 			p.state = sortSorting
 		case sortSorting:
-			p.sort(ctx)
+			p.sort()
 			p.state = sortEmitting
 		case sortEmitting:
 			toEmit := p.input.getNumTuples() - p.emitted
@@ -309,7 +314,7 @@ func (p *sortOp) Next(ctx context.Context) coldata.Batch {
 
 // sort sorts the spooled tuples, so it must be called after spool() has been
 // performed.
-func (p *sortOp) sort(ctx context.Context) {
+func (p *sortOp) sort() {
 	spooledTuples := p.input.getNumTuples()
 	if spooledTuples == 0 {
 		// There is nothing to sort.
@@ -330,7 +335,7 @@ func (p *sortOp) sort(ctx context.Context) {
 	for i := range p.orderingCols {
 		inputVec := p.input.getValues(int(p.orderingCols[i].ColIdx))
 		p.sorters[i] = newSingleSorter(p.inputTypes[p.orderingCols[i].ColIdx], p.orderingCols[i].Direction, inputVec.MaybeHasNulls())
-		p.sorters[i].init(inputVec, p.order)
+		p.sorters[i].init(p.Ctx, inputVec, p.order)
 	}
 
 	// Now, sort each column in turn.
@@ -341,7 +346,7 @@ func (p *sortOp) sort(ctx context.Context) {
 	if partitionsCol == nil {
 		// All spooled tuples belong to the same partition, so the first column
 		// doesn't need special treatment - we just globally sort it.
-		p.sorters[0].sort(ctx)
+		p.sorters[0].sort()
 		if len(p.sorters) == 1 {
 			// We're done sorting. Transition to emitting.
 			return
@@ -400,7 +405,7 @@ func (p *sortOp) sort(ctx context.Context) {
 		partitions = boolVecToSel64(partitionsCol, partitions[:0])
 		// For each partition (set of tuples that are identical in all of the sort
 		// columns we've seen so far), sort based on the new column.
-		sorter.sortPartitions(ctx, partitions)
+		sorter.sortPartitions(partitions)
 	}
 }
 
@@ -426,7 +431,7 @@ func (p *sortOp) Child(nth int, verbose bool) execinfra.OpNode {
 	return nil
 }
 
-func (p *sortOp) ExportBuffered(context.Context, colexecop.Operator) coldata.Batch {
+func (p *sortOp) ExportBuffered(colexecop.Operator) coldata.Batch {
 	if p.exported == p.input.getNumTuples() {
 		return coldata.ZeroBatch
 	}

--- a/pkg/sql/colexec/sort_chunks_test.go
+++ b/pkg/sql/colexec/sort_chunks_test.go
@@ -300,8 +300,8 @@ func BenchmarkSortChunks(b *testing.B) {
 										b.Fatal(err)
 									}
 
-									sorter.Init()
-									for out := sorter.Next(ctx); out.Length() != 0; out = sorter.Next(ctx) {
+									sorter.Init(ctx)
+									for out := sorter.Next(); out.Length() != 0; out = sorter.Next() {
 									}
 								}
 								b.StopTimer()

--- a/pkg/sql/colexec/sort_test.go
+++ b/pkg/sql/colexec/sort_test.go
@@ -258,8 +258,8 @@ func TestAllSpooler(t *testing.T) {
 	for _, tc := range tcs {
 		colexectestutils.RunTestsWithFn(t, testAllocator, []colexectestutils.Tuples{tc.tuples}, nil, func(t *testing.T, input []colexecop.Operator) {
 			allSpooler := newAllSpooler(testAllocator, input[0], tc.typ)
-			allSpooler.init()
-			allSpooler.spool(context.Background())
+			allSpooler.init(context.Background())
+			allSpooler.spool()
 			if len(tc.tuples) != allSpooler.getNumTuples() {
 				t.Fatal(fmt.Sprintf("allSpooler spooled wrong number of tuples: expected %d, but received %d", len(tc.tuples), allSpooler.getNumTuples()))
 			}
@@ -322,8 +322,8 @@ func BenchmarkSort(b *testing.B) {
 								b.Fatal(err)
 							}
 						}
-						sorter.Init()
-						for out := sorter.Next(ctx); out.Length() != 0; out = sorter.Next(ctx) {
+						sorter.Init(ctx)
+						for out := sorter.Next(); out.Length() != 0; out = sorter.Next() {
 						}
 					}
 				})
@@ -359,8 +359,8 @@ func BenchmarkAllSpooler(b *testing.B) {
 				for n := 0; n < b.N; n++ {
 					source := colexectestutils.NewFiniteBatchSource(testAllocator, batch, typs, nBatches)
 					allSpooler := newAllSpooler(testAllocator, source, typs)
-					allSpooler.init()
-					allSpooler.spool(ctx)
+					allSpooler.init(ctx)
+					allSpooler.spool()
 				}
 			})
 		}

--- a/pkg/sql/colexec/sort_tmpl.go
+++ b/pkg/sql/colexec/sort_tmpl.go
@@ -137,18 +137,19 @@ type sort_TYPE_DIR_HANDLES_NULLSOp struct {
 	cancelChecker colexecutils.CancelChecker
 }
 
-func (s *sort_TYPE_DIR_HANDLES_NULLSOp) init(col coldata.Vec, order []int) {
+func (s *sort_TYPE_DIR_HANDLES_NULLSOp) init(ctx context.Context, col coldata.Vec, order []int) {
 	s.sortCol = col.TemplateType()
 	s.nulls = col.Nulls()
 	s.order = order
+	s.cancelChecker.Init(ctx)
 }
 
-func (s *sort_TYPE_DIR_HANDLES_NULLSOp) sort(ctx context.Context) {
+func (s *sort_TYPE_DIR_HANDLES_NULLSOp) sort() {
 	n := s.sortCol.Len()
-	s.quickSort(ctx, 0, n, maxDepth(n))
+	s.quickSort(0, n, maxDepth(n))
 }
 
-func (s *sort_TYPE_DIR_HANDLES_NULLSOp) sortPartitions(ctx context.Context, partitions []int) {
+func (s *sort_TYPE_DIR_HANDLES_NULLSOp) sortPartitions(partitions []int) {
 	if len(partitions) < 1 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid partitions list %v", partitions))
 	}
@@ -162,7 +163,7 @@ func (s *sort_TYPE_DIR_HANDLES_NULLSOp) sortPartitions(ctx context.Context, part
 		}
 		s.order = order[partitionStart:partitionEnd]
 		n := partitionEnd - partitionStart
-		s.quickSort(ctx, 0, n, maxDepth(n))
+		s.quickSort(0, n, maxDepth(n))
 	}
 }
 

--- a/pkg/sql/colexec/sorttopk.go
+++ b/pkg/sql/colexec/sorttopk.go
@@ -68,6 +68,7 @@ const (
 
 type topKSorter struct {
 	colexecop.OneInputNode
+	colexecop.InitHelper
 
 	allocator    *colmem.Allocator
 	orderingCols []execinfrapb.Ordering_Column
@@ -98,8 +99,11 @@ type topKSorter struct {
 	windowedBatch     coldata.Batch
 }
 
-func (t *topKSorter) Init() {
-	t.Input.Init()
+func (t *topKSorter) Init(ctx context.Context) {
+	if !t.InitHelper.Init(ctx) {
+		return
+	}
+	t.Input.Init(t.Ctx)
 	t.topK = colexecutils.NewAppendOnlyBufferedBatch(t.allocator, t.inputTypes, nil /* colsToStore */)
 	t.comparators = make([]vecComparator, len(t.inputTypes))
 	for i, typ := range t.inputTypes {
@@ -111,11 +115,11 @@ func (t *topKSorter) Init() {
 	t.windowedBatch = coldata.NewMemBatchNoCols(t.inputTypes, coldata.BatchSize())
 }
 
-func (t *topKSorter) Next(ctx context.Context) coldata.Batch {
+func (t *topKSorter) Next() coldata.Batch {
 	for {
 		switch t.state {
 		case topKSortSpooling:
-			t.spool(ctx)
+			t.spool()
 			t.state = topKSortEmitting
 		case topKSortEmitting:
 			output := t.emit()
@@ -142,9 +146,9 @@ func (t *topKSorter) Next(ctx context.Context) coldata.Batch {
 // After all the input has been read, we pop everything off the heap to
 // determine the final output ordering. This is used in emit() to output the rows
 // in sorted order.
-func (t *topKSorter) spool(ctx context.Context) {
+func (t *topKSorter) spool() {
 	// Fill up t.topK by spooling up to K rows from the input.
-	t.inputBatch = t.Input.Next(ctx)
+	t.inputBatch = t.Input.Next()
 	remainingRows := t.k
 	for remainingRows > 0 && t.inputBatch.Length() > 0 {
 		fromLength := t.inputBatch.Length()
@@ -158,7 +162,7 @@ func (t *topKSorter) spool(ctx context.Context) {
 		})
 		remainingRows -= uint64(fromLength)
 		if fromLength == t.inputBatch.Length() {
-			t.inputBatch = t.Input.Next(ctx)
+			t.inputBatch = t.Input.Next()
 			t.firstUnprocessedTupleIdx = 0
 		}
 	}
@@ -195,7 +199,7 @@ func (t *topKSorter) spool(ctx context.Context) {
 				t.firstUnprocessedTupleIdx = t.inputBatch.Length()
 			},
 		)
-		t.inputBatch = t.Input.Next(ctx)
+		t.inputBatch = t.Input.Next()
 		t.firstUnprocessedTupleIdx = 0
 	}
 
@@ -269,7 +273,7 @@ func (t *topKSorter) updateComparators(vecIdx int, batch coldata.Batch) {
 	}
 }
 
-func (t *topKSorter) ExportBuffered(context.Context, colexecop.Operator) coldata.Batch {
+func (t *topKSorter) ExportBuffered(colexecop.Operator) coldata.Batch {
 	topKLen := t.topK.Length()
 	// First, we check whether we have exported all tuples from the topK vector.
 	if t.exportedFromTopK < topKLen {

--- a/pkg/sql/colexec/substring.eg.go
+++ b/pkg/sql/colexec/substring.eg.go
@@ -10,8 +10,6 @@
 package colexec
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
@@ -30,10 +28,10 @@ func newSubstringOperator(
 	startType := typs[argumentCols[1]]
 	lengthType := typs[argumentCols[2]]
 	base := substringFunctionBase{
-		OneInputNode: colexecop.NewOneInputNode(input),
-		allocator:    allocator,
-		argumentCols: argumentCols,
-		outputIdx:    outputIdx,
+		OneInputHelper: colexecop.MakeOneInputHelper(input),
+		allocator:      allocator,
+		argumentCols:   argumentCols,
+		outputIdx:      outputIdx,
 	}
 	if startType.Family() != types.IntFamily {
 		colexecerror.InternalError(errors.AssertionFailedf("non-int start argument type %s", startType))
@@ -80,14 +78,10 @@ func newSubstringOperator(
 }
 
 type substringFunctionBase struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	allocator    *colmem.Allocator
 	argumentCols []int
 	outputIdx    int
-}
-
-func (s *substringFunctionBase) Init() {
-	s.Input.Init()
 }
 
 type substringInt64Int16Operator struct {
@@ -96,8 +90,8 @@ type substringInt64Int16Operator struct {
 
 var _ colexecop.Operator = &substringInt64Int16Operator{}
 
-func (s *substringInt64Int16Operator) Next(ctx context.Context) coldata.Batch {
-	batch := s.Input.Next(ctx)
+func (s *substringInt64Int16Operator) Next() coldata.Batch {
+	batch := s.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -178,8 +172,8 @@ type substringInt64Int32Operator struct {
 
 var _ colexecop.Operator = &substringInt64Int32Operator{}
 
-func (s *substringInt64Int32Operator) Next(ctx context.Context) coldata.Batch {
-	batch := s.Input.Next(ctx)
+func (s *substringInt64Int32Operator) Next() coldata.Batch {
+	batch := s.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -260,8 +254,8 @@ type substringInt64Int64Operator struct {
 
 var _ colexecop.Operator = &substringInt64Int64Operator{}
 
-func (s *substringInt64Int64Operator) Next(ctx context.Context) coldata.Batch {
-	batch := s.Input.Next(ctx)
+func (s *substringInt64Int64Operator) Next() coldata.Batch {
+	batch := s.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -342,8 +336,8 @@ type substringInt16Int16Operator struct {
 
 var _ colexecop.Operator = &substringInt16Int16Operator{}
 
-func (s *substringInt16Int16Operator) Next(ctx context.Context) coldata.Batch {
-	batch := s.Input.Next(ctx)
+func (s *substringInt16Int16Operator) Next() coldata.Batch {
+	batch := s.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -424,8 +418,8 @@ type substringInt16Int32Operator struct {
 
 var _ colexecop.Operator = &substringInt16Int32Operator{}
 
-func (s *substringInt16Int32Operator) Next(ctx context.Context) coldata.Batch {
-	batch := s.Input.Next(ctx)
+func (s *substringInt16Int32Operator) Next() coldata.Batch {
+	batch := s.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -506,8 +500,8 @@ type substringInt16Int64Operator struct {
 
 var _ colexecop.Operator = &substringInt16Int64Operator{}
 
-func (s *substringInt16Int64Operator) Next(ctx context.Context) coldata.Batch {
-	batch := s.Input.Next(ctx)
+func (s *substringInt16Int64Operator) Next() coldata.Batch {
+	batch := s.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -588,8 +582,8 @@ type substringInt32Int16Operator struct {
 
 var _ colexecop.Operator = &substringInt32Int16Operator{}
 
-func (s *substringInt32Int16Operator) Next(ctx context.Context) coldata.Batch {
-	batch := s.Input.Next(ctx)
+func (s *substringInt32Int16Operator) Next() coldata.Batch {
+	batch := s.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -670,8 +664,8 @@ type substringInt32Int32Operator struct {
 
 var _ colexecop.Operator = &substringInt32Int32Operator{}
 
-func (s *substringInt32Int32Operator) Next(ctx context.Context) coldata.Batch {
-	batch := s.Input.Next(ctx)
+func (s *substringInt32Int32Operator) Next() coldata.Batch {
+	batch := s.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch
@@ -752,8 +746,8 @@ type substringInt32Int64Operator struct {
 
 var _ colexecop.Operator = &substringInt32Int64Operator{}
 
-func (s *substringInt32Int64Operator) Next(ctx context.Context) coldata.Batch {
-	batch := s.Input.Next(ctx)
+func (s *substringInt32Int64Operator) Next() coldata.Batch {
+	batch := s.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch

--- a/pkg/sql/colexec/substring_tmpl.go
+++ b/pkg/sql/colexec/substring_tmpl.go
@@ -20,8 +20,6 @@
 package colexec
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
@@ -50,10 +48,10 @@ func newSubstringOperator(
 	startType := typs[argumentCols[1]]
 	lengthType := typs[argumentCols[2]]
 	base := substringFunctionBase{
-		OneInputNode: colexecop.NewOneInputNode(input),
-		allocator:    allocator,
-		argumentCols: argumentCols,
-		outputIdx:    outputIdx,
+		OneInputHelper: colexecop.MakeOneInputHelper(input),
+		allocator:      allocator,
+		argumentCols:   argumentCols,
+		outputIdx:      outputIdx,
 	}
 	if startType.Family() != types.IntFamily {
 		colexecerror.InternalError(errors.AssertionFailedf("non-int start argument type %s", startType))
@@ -78,14 +76,10 @@ func newSubstringOperator(
 }
 
 type substringFunctionBase struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	allocator    *colmem.Allocator
 	argumentCols []int
 	outputIdx    int
-}
-
-func (s *substringFunctionBase) Init() {
-	s.Input.Init()
 }
 
 // {{range $startWidth, $lengthWidths := .}}
@@ -97,8 +91,8 @@ type substring_StartType_LengthTypeOperator struct {
 
 var _ colexecop.Operator = &substring_StartType_LengthTypeOperator{}
 
-func (s *substring_StartType_LengthTypeOperator) Next(ctx context.Context) coldata.Batch {
-	batch := s.Input.Next(ctx)
+func (s *substring_StartType_LengthTypeOperator) Next() coldata.Batch {
+	batch := s.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch

--- a/pkg/sql/colexec/tuple_proj_op.go
+++ b/pkg/sql/colexec/tuple_proj_op.go
@@ -11,8 +11,6 @@
 package colexec
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
@@ -35,7 +33,7 @@ func NewTupleProjOp(
 ) colexecop.Operator {
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, outputType, outputIdx)
 	return &tupleProjOp{
-		OneInputNode:      colexecop.NewOneInputNode(input),
+		OneInputHelper:    colexecop.MakeOneInputHelper(input),
 		allocator:         allocator,
 		converter:         colconv.NewVecToDatumConverter(len(inputTypes), tupleContentsIdxs),
 		tupleContentsIdxs: tupleContentsIdxs,
@@ -45,7 +43,7 @@ func NewTupleProjOp(
 }
 
 type tupleProjOp struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 
 	allocator         *colmem.Allocator
 	converter         *colconv.VecToDatumConverter
@@ -56,12 +54,8 @@ type tupleProjOp struct {
 
 var _ colexecop.Operator = &tupleProjOp{}
 
-func (t *tupleProjOp) Init() {
-	t.Input.Init()
-}
-
-func (t *tupleProjOp) Next(ctx context.Context) coldata.Batch {
-	batch := t.Input.Next(ctx)
+func (t *tupleProjOp) Next() coldata.Batch {
+	batch := t.Input.Next()
 	n := batch.Length()
 	if n == 0 {
 		return coldata.ZeroBatch

--- a/pkg/sql/colexec/unordered_distinct.go
+++ b/pkg/sql/colexec/unordered_distinct.go
@@ -25,23 +25,11 @@ import (
 func NewUnorderedDistinct(
 	allocator *colmem.Allocator, input colexecop.Operator, distinctCols []uint32, typs []*types.T,
 ) colexecop.ResettableOperator {
-	// These numbers were chosen after running the micro-benchmarks.
-	const hashTableLoadFactor = 2.0
-	const hashTableNumBuckets = 128
-	ht := colexechash.NewHashTable(
-		allocator,
-		hashTableLoadFactor,
-		hashTableNumBuckets,
-		typs,
-		distinctCols,
-		true, /* allowNullEquality */
-		colexechash.HashTableDistinctBuildMode,
-		colexechash.HashTableDefaultProbeMode,
-	)
-
 	return &unorderedDistinct{
 		OneInputNode: colexecop.NewOneInputNode(input),
-		ht:           ht,
+		allocator:    allocator,
+		distinctCols: distinctCols,
+		typs:         typs,
 	}
 }
 
@@ -50,9 +38,13 @@ func NewUnorderedDistinct(
 // distinct tuples from each input batch. Once at least one tuple is appended,
 // all of the distinct tuples from the batch are emitted in the output.
 type unorderedDistinct struct {
+	colexecop.InitHelper
 	colexecop.OneInputNode
 
-	ht *colexechash.HashTable
+	allocator    *colmem.Allocator
+	distinctCols []uint32
+	typs         []*types.T
+	ht           *colexechash.HashTable
 	// lastInputBatch tracks the last input batch read from the input and not
 	// emitted into the output. It is the only batch that we need to export when
 	// spilling to disk, and it will contain only the distinct tuples that need
@@ -63,13 +55,30 @@ type unorderedDistinct struct {
 var _ colexecop.BufferingInMemoryOperator = &unorderedDistinct{}
 var _ colexecop.ResettableOperator = &unorderedDistinct{}
 
-func (op *unorderedDistinct) Init() {
-	op.Input.Init()
+func (op *unorderedDistinct) Init(ctx context.Context) {
+	if !op.InitHelper.Init(ctx) {
+		return
+	}
+	op.Input.Init(op.Ctx)
+	// These numbers were chosen after running the micro-benchmarks.
+	const hashTableLoadFactor = 2.0
+	const hashTableNumBuckets = 128
+	op.ht = colexechash.NewHashTable(
+		op.Ctx,
+		op.allocator,
+		hashTableLoadFactor,
+		hashTableNumBuckets,
+		op.typs,
+		op.distinctCols,
+		true, /* allowNullEquality */
+		colexechash.HashTableDistinctBuildMode,
+		colexechash.HashTableDefaultProbeMode,
+	)
 }
 
-func (op *unorderedDistinct) Next(ctx context.Context) coldata.Batch {
+func (op *unorderedDistinct) Next() coldata.Batch {
 	for {
-		op.lastInputBatch = op.Input.Next(ctx)
+		op.lastInputBatch = op.Input.Next()
 		if op.lastInputBatch.Length() == 0 {
 			return coldata.ZeroBatch
 		}
@@ -78,7 +87,7 @@ func (op *unorderedDistinct) Next(ctx context.Context) coldata.Batch {
 		// OOM occurs, we are careful not to filter them out (since the
 		// filtering has already been performed); if an OOM doesn't occur, we
 		// will emit the updated last input batch here.
-		op.ht.DistinctBuild(ctx, op.lastInputBatch)
+		op.ht.DistinctBuild(op.lastInputBatch)
 		if op.lastInputBatch.Length() > 0 {
 			// We've just appended some distinct tuples to the hash table, so we
 			// will emit all of them as the output. Note that the selection
@@ -89,7 +98,7 @@ func (op *unorderedDistinct) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-func (op *unorderedDistinct) ExportBuffered(context.Context, colexecop.Operator) coldata.Batch {
+func (op *unorderedDistinct) ExportBuffered(colexecop.Operator) coldata.Batch {
 	if op.lastInputBatch != nil {
 		batch := op.lastInputBatch
 		op.lastInputBatch = nil
@@ -101,7 +110,7 @@ func (op *unorderedDistinct) ExportBuffered(context.Context, colexecop.Operator)
 	return coldata.ZeroBatch
 }
 
-// reset resets the unorderedDistinct.
+// Reset resets the unorderedDistinct.
 func (op *unorderedDistinct) Reset(ctx context.Context) {
 	if r, ok := op.Input.(colexecop.Resetter); ok {
 		r.Reset(ctx)
@@ -112,10 +121,10 @@ func (op *unorderedDistinct) Reset(ctx context.Context) {
 // unorderedDistinctFilterer filters out tuples that are duplicates of the
 // tuples already emitted by the unordered distinct.
 type unorderedDistinctFilterer struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	colexecop.NonExplainable
 
-	ht *colexechash.HashTable
+	ud *unorderedDistinct
 	// seenBatch tracks whether the operator has already read at least one
 	// batch.
 	seenBatch bool
@@ -123,17 +132,13 @@ type unorderedDistinctFilterer struct {
 
 var _ colexecop.Operator = &unorderedDistinctFilterer{}
 
-func (f *unorderedDistinctFilterer) Init() {
-	f.Input.Init()
-}
-
-func (f *unorderedDistinctFilterer) Next(ctx context.Context) coldata.Batch {
-	if f.ht.Vals.Length() == 0 {
+func (f *unorderedDistinctFilterer) Next() coldata.Batch {
+	if f.ud.ht.Vals.Length() == 0 {
 		// The hash table is empty, so there is nothing to filter against.
-		return f.Input.Next(ctx)
+		return f.Input.Next()
 	}
 	for {
-		batch := f.Input.Next(ctx)
+		batch := f.Input.Next()
 		if batch.Length() == 0 {
 			return coldata.ZeroBatch
 		}
@@ -151,17 +156,17 @@ func (f *unorderedDistinctFilterer) Next(ctx context.Context) coldata.Batch {
 			//
 			// See https://github.com/cockroachdb/cockroach/pull/58006#pullrequestreview-565859919
 			// for all the gory details.
-			f.ht.MaybeRepairAfterDistinctBuild(ctx)
+			f.ud.ht.MaybeRepairAfterDistinctBuild()
 			f.seenBatch = true
 			return batch
 		}
 		// The unordered distinct has emitted some tuples, so we need to check
 		// all tuples in batch against the hash table.
-		f.ht.ComputeHashAndBuildChains(ctx, batch)
+		f.ud.ht.ComputeHashAndBuildChains(batch)
 		// Remove the duplicates within batch itself.
-		f.ht.RemoveDuplicates(batch, f.ht.Keys, f.ht.ProbeScratch.First, f.ht.ProbeScratch.Next, f.ht.CheckProbeForDistinct)
+		f.ud.ht.RemoveDuplicates(batch, f.ud.ht.Keys, f.ud.ht.ProbeScratch.First, f.ud.ht.ProbeScratch.Next, f.ud.ht.CheckProbeForDistinct)
 		// Remove the duplicates of already emitted distinct tuples.
-		f.ht.RemoveDuplicates(batch, f.ht.Keys, f.ht.BuildScratch.First, f.ht.BuildScratch.Next, f.ht.CheckBuildForDistinct)
+		f.ud.ht.RemoveDuplicates(batch, f.ud.ht.Keys, f.ud.ht.BuildScratch.First, f.ud.ht.BuildScratch.Next, f.ud.ht.CheckBuildForDistinct)
 		if batch.Length() > 0 {
 			return batch
 		}

--- a/pkg/sql/colexecop/operator.go
+++ b/pkg/sql/colexecop/operator.go
@@ -24,23 +24,20 @@ import (
 
 // Operator is a column vector operator that produces a Batch as output.
 type Operator interface {
-	// Init initializes this operator. Will be called once at operator setup
-	// time. If an operator has an input operator, it's responsible for calling
-	// Init on that input operator as well.
+	// Init initializes this operator. It will be called once at operator setup
+	// time. Second, third, etc calls should be noops. If an operator has any
+	// input operators, it's responsible for calling Init on all of those input
+	// operators as well.
+	//
+	// Canceling the provided context results in forceful termination of
+	// execution. The operators are expected to hold onto the provided context
+	// (and derive a new one if needed) that is then used for Next() calls.
 	//
 	// It might panic with an expected error, so there must be a "root"
 	// component that will catch that panic.
-	// TODO(yuzefovich): we might need to clarify whether it is ok to call
-	// Init() multiple times before the first call to Next(). It is possible to
-	// hit the memory limit during Init(), and a disk-backed operator needs to
-	// make sure that the input has been initialized. We could also in case that
-	// Init() doesn't succeed for bufferingInMemoryOperator - which should only
-	// happen when 'workmem' setting is too low - just bail, even if we have
-	// disk spilling for that operator.
-	// TODO(yuzefovich): we probably should move ctx argument from Next into
-	// Init, the operator will then capture the context and use it (or the one
-	// derived from it) in Next and DrainMeta (when applicable) calls.
-	Init()
+	// TODO(yuzefovich): use the stored context for DrainMeta calls (when
+	// applicable) too.
+	Init(ctx context.Context)
 
 	// Next returns the next Batch from this operator. Once the operator is
 	// finished, it will return a Batch with length 0. Subsequent calls to
@@ -48,12 +45,10 @@ type Operator interface {
 	//
 	// Calling Next may invalidate the contents of the last Batch returned by
 	// Next.
-	// Canceling the provided context results in forceful termination of
-	// execution.
 	//
 	// It might panic with an expected error, so there must be a "root"
 	// component that will catch that panic.
-	Next(context.Context) coldata.Batch
+	Next() coldata.Batch
 
 	execinfra.OpNode
 }
@@ -134,7 +129,7 @@ type BufferingInMemoryOperator interface {
 	//
 	// Calling ExportBuffered may invalidate the contents of the last batch
 	// returned by ExportBuffered.
-	ExportBuffered(ctx context.Context, input Operator) coldata.Batch
+	ExportBuffered(input Operator) coldata.Batch
 }
 
 // Closer is an object that releases resources when Close is called. Note that
@@ -201,10 +196,10 @@ func NewFeedOperator() *FeedOperator {
 }
 
 // Init implements the colexecop.Operator interface.
-func (FeedOperator) Init() {}
+func (FeedOperator) Init(context.Context) {}
 
 // Next implements the colexecop.Operator interface.
-func (o *FeedOperator) Next(context.Context) coldata.Batch {
+func (o *FeedOperator) Next() coldata.Batch {
 	return o.batch
 }
 
@@ -223,33 +218,68 @@ type NonExplainable interface {
 	nonExplainableMarker()
 }
 
-// OperatorInitStatus indicates whether Init method has already been called on
-// an Operator.
-type OperatorInitStatus int
+// InitHelper is a simple struct that helps Operators implement Init() method.
+type InitHelper struct {
+	// Ctx is the context passed on the first call to Init(). If it is nil, then
+	// Init() hasn't been called yet.
+	Ctx context.Context
+}
 
-const (
-	// OperatorNotInitialized indicates that Init has not been called yet.
-	OperatorNotInitialized OperatorInitStatus = iota
-	// OperatorInitialized indicates that Init has already been called.
-	OperatorInitialized
-)
+// Init marks the InitHelper as initialized. If true is returned, this is the
+// first call to Init.
+func (h *InitHelper) Init(ctx context.Context) bool {
+	if h.Ctx != nil {
+		return false
+	}
+	if ctx == nil {
+		colexecerror.InternalError(errors.AssertionFailedf("nil context is passed"))
+	}
+	h.Ctx = ctx
+	return true
+}
 
-// CloserHelper is a simple helper that helps Operators implement
-// Closer. If close returns true, resources may be released, if it
-// returns false, close has already been called.
-// use.
+// MakeOneInputHelper returns a new OneInputHelper.
+func MakeOneInputHelper(input Operator) OneInputHelper {
+	return OneInputHelper{
+		OneInputNode: NewOneInputNode(input),
+	}
+}
+
+// OneInputHelper is an execinfra.OpNode which only needs to initialize its
+// single Operator input in Init().
+type OneInputHelper struct {
+	OneInputNode
+	InitHelper
+}
+
+// Init implements the Operator interface.
+func (h *OneInputHelper) Init(ctx context.Context) {
+	if !h.InitHelper.Init(ctx) {
+		return
+	}
+	h.Input.Init(h.Ctx)
+}
+
+// CloserHelper is a simple helper that helps Operators implement Closer. If
+// close returns true, resources may be released, if it returns false, close has
+// already been called.
 type CloserHelper struct {
-	Closed bool
+	closed bool
 }
 
 // Close marks the CloserHelper as closed. If true is returned, this is the
-// first call to close.
+// first call to Close.
 func (c *CloserHelper) Close() bool {
-	if c.Closed {
+	if c.closed {
 		return false
 	}
-	c.Closed = true
+	c.closed = true
 	return true
+}
+
+// Reset resets the CloserHelper so that it can be closed again.
+func (c *CloserHelper) Reset() {
+	c.closed = false
 }
 
 // ClosableOperator is an Operator that needs to be Close()'d.
@@ -265,7 +295,7 @@ func MakeOneInputCloserHelper(input Operator) OneInputCloserHelper {
 	}
 }
 
-// OneInputCloserHelper is an execinfrapb.OpNode with a single Operator input
+// OneInputCloserHelper is an execinfra.OpNode with a single Operator input
 // that might need to be Close()'d.
 type OneInputCloserHelper struct {
 	OneInputNode
@@ -285,8 +315,30 @@ func (c *OneInputCloserHelper) Close(ctx context.Context) error {
 	return nil
 }
 
-type noopOperator struct {
+// MakeOneInputInitCloserHelper returns a new OneInputInitCloserHelper.
+func MakeOneInputInitCloserHelper(input Operator) OneInputInitCloserHelper {
+	return OneInputInitCloserHelper{
+		OneInputCloserHelper: MakeOneInputCloserHelper(input),
+	}
+}
+
+// OneInputInitCloserHelper is an execinfra.OpNode that only needs to initialize
+// its single Operator input in Init() and might need to Close() it too.
+type OneInputInitCloserHelper struct {
+	InitHelper
 	OneInputCloserHelper
+}
+
+// Init implements the Operator interface.
+func (h *OneInputInitCloserHelper) Init(ctx context.Context) {
+	if !h.InitHelper.Init(ctx) {
+		return
+	}
+	h.Input.Init(h.Ctx)
+}
+
+type noopOperator struct {
+	OneInputInitCloserHelper
 	NonExplainable
 }
 
@@ -294,15 +346,11 @@ var _ ResettableOperator = &noopOperator{}
 
 // NewNoop returns a new noop Operator.
 func NewNoop(input Operator) ResettableOperator {
-	return &noopOperator{OneInputCloserHelper: MakeOneInputCloserHelper(input)}
+	return &noopOperator{OneInputInitCloserHelper: MakeOneInputInitCloserHelper(input)}
 }
 
-func (n *noopOperator) Init() {
-	n.Input.Init()
-}
-
-func (n *noopOperator) Next(ctx context.Context) coldata.Batch {
-	return n.Input.Next(ctx)
+func (n *noopOperator) Next() coldata.Batch {
+	return n.Input.Next()
 }
 
 func (n *noopOperator) Reset(ctx context.Context) {

--- a/pkg/sql/colexecop/testutils.go
+++ b/pkg/sql/colexecop/testutils.go
@@ -42,10 +42,10 @@ func (b *BatchBuffer) Add(batch coldata.Batch, _ []*types.T) {
 }
 
 // Init is part of the Operator interface.
-func (b *BatchBuffer) Init() {}
+func (b *BatchBuffer) Init(context.Context) {}
 
 // Next is part of the Operator interface.
-func (b *BatchBuffer) Next(context.Context) coldata.Batch {
+func (b *BatchBuffer) Next() coldata.Batch {
 	batch := b.buffer[0]
 	b.buffer = b.buffer[1:]
 	return batch
@@ -103,7 +103,7 @@ func NewRepeatableBatchSource(
 }
 
 // Next is part of the Operator interface.
-func (s *RepeatableBatchSource) Next(context.Context) coldata.Batch {
+func (s *RepeatableBatchSource) Next() coldata.Batch {
 	s.batchesReturned++
 	if s.batchesToReturn != 0 && s.batchesReturned > s.batchesToReturn {
 		return coldata.ZeroBatch
@@ -128,7 +128,7 @@ func (s *RepeatableBatchSource) Next(context.Context) coldata.Batch {
 }
 
 // Init is part of the Operator interface.
-func (s *RepeatableBatchSource) Init() {}
+func (s *RepeatableBatchSource) Init(context.Context) {}
 
 // ResetBatchesToReturn sets a limit on how many batches the source returns, as
 // well as resetting how many batches the source has returned so far.
@@ -141,15 +141,15 @@ func (s *RepeatableBatchSource) ResetBatchesToReturn(b int) {
 // callback provided by the user.
 type CallbackOperator struct {
 	ZeroInputNode
-	NextCb func(ctx context.Context) coldata.Batch
+	NextCb func() coldata.Batch
 }
 
 // Init is part of the Operator interface.
-func (o *CallbackOperator) Init() {}
+func (o *CallbackOperator) Init(context.Context) {}
 
 // Next is part of the Operator interface.
-func (o *CallbackOperator) Next(ctx context.Context) coldata.Batch {
-	return o.NextCb(ctx)
+func (o *CallbackOperator) Next() coldata.Batch {
+	return o.NextCb()
 }
 
 // TestingSemaphore is a semaphore.Semaphore that never blocks and is always

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -46,6 +46,8 @@ import (
 // from kv, presenting it as coldata.Batches via the exec.Operator interface.
 type ColBatchScan struct {
 	colexecop.ZeroInputNode
+	colexecop.InitHelper
+
 	spans       roachpb.Spans
 	flowCtx     *execinfra.FlowCtx
 	rf          *cFetcher
@@ -56,9 +58,6 @@ type ColBatchScan struct {
 	tracingSpan *tracing.Span
 	mu          struct {
 		syncutil.Mutex
-		ctx context.Context
-		// init is true after Init() has been called.
-		init bool
 		// rowsRead contains the number of total rows this ColBatchScan has
 		// returned so far.
 		rowsRead int64
@@ -75,12 +74,15 @@ var _ colexecop.Closer = &ColBatchScan{}
 var _ colexecop.Operator = &ColBatchScan{}
 
 // Init initializes a ColBatchScan.
-func (s *ColBatchScan) Init() {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	// Note that we're intentionally holding the lock until the cFetcher is
-	// properly initialized.
-	s.mu.init = true
+func (s *ColBatchScan) Init(ctx context.Context) {
+	if !s.InitHelper.Init(ctx) {
+		return
+	}
+	if execinfra.ShouldCollectStats(s.Ctx, s.flowCtx) {
+		// We need to start a child span so that the only contention events
+		// present in the recording would be because of this cFetcher.
+		s.Ctx, s.tracingSpan = execinfra.ProcessorSpan(s.Ctx, "colbatchscan")
+	}
 	limitBatches := !s.parallelize
 	if err := s.rf.StartScan(
 		s.flowCtx.Txn, s.spans, limitBatches, s.limitHint, s.flowCtx.TraceKV,
@@ -91,21 +93,8 @@ func (s *ColBatchScan) Init() {
 }
 
 // Next is part of the Operator interface.
-func (s *ColBatchScan) Next(ctx context.Context) coldata.Batch {
-	s.mu.Lock()
-	if s.mu.ctx == nil {
-		// This is the first call to Next(), so we will capture the context and
-		// possibly replace it with a child below.
-		s.mu.ctx = ctx
-		if execinfra.ShouldCollectStats(s.mu.ctx, s.flowCtx) {
-			// We need to start a child span so that the only contention events
-			// present in the recording would be because of this cFetcher.
-			s.mu.ctx, s.tracingSpan = execinfra.ProcessorSpan(s.mu.ctx, "colbatchscan")
-		}
-	}
-	ctx = s.mu.ctx
-	s.mu.Unlock()
-	bat, err := s.rf.NextBatch(ctx)
+func (s *ColBatchScan) Next() coldata.Batch {
+	bat, err := s.rf.NextBatch(s.Ctx)
 	if err != nil {
 		colexecerror.InternalError(err)
 	}
@@ -119,30 +108,18 @@ func (s *ColBatchScan) Next(ctx context.Context) coldata.Batch {
 }
 
 // DrainMeta is part of the colexecop.MetadataSource interface.
-func (s *ColBatchScan) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
-	s.mu.Lock()
-	initialized := s.mu.init
-	s.mu.Unlock()
-	if !initialized {
-		// In some pathological queries like `SELECT 1 FROM t HAVING true`, Init()
-		// and Next() may never get called. Return early to avoid using an
-		// uninitialized fetcher.
-		// TODO(yuzefovich): we probably don't need this anymore given that we
-		// call Init() on fixedNumTuplesNoInputOp and we have the invariants
-		// checker ensuring that Init() is called before DrainMeta().
-		return nil
-	}
+func (s *ColBatchScan) DrainMeta(context.Context) []execinfrapb.ProducerMetadata {
 	var trailingMeta []execinfrapb.ProducerMetadata
 	if !s.flowCtx.Local {
 		nodeID, ok := s.flowCtx.NodeID.OptionalNodeID()
 		if ok {
-			ranges := execinfra.MisplannedRanges(ctx, s.spans, nodeID, s.flowCtx.Cfg.RangeCache)
+			ranges := execinfra.MisplannedRanges(s.Ctx, s.spans, nodeID, s.flowCtx.Cfg.RangeCache)
 			if ranges != nil {
 				trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{Ranges: ranges})
 			}
 		}
 	}
-	if tfs := execinfra.GetLeafTxnFinalState(ctx, s.flowCtx.Txn); tfs != nil {
+	if tfs := execinfra.GetLeafTxnFinalState(s.Ctx, s.flowCtx.Txn); tfs != nil {
 		trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{LeafTxnFinalState: tfs})
 	}
 	meta := execinfrapb.GetProducerMeta()
@@ -152,20 +129,14 @@ func (s *ColBatchScan) DrainMeta(ctx context.Context) []execinfrapb.ProducerMeta
 	trailingMeta = append(trailingMeta, *meta)
 	if s.tracingSpan != nil {
 		// If tracingSpan is non-nil, then we have derived a new context in
-		// Next() and we have to collect the trace data.
+		// Init() and we have to collect the trace data.
 		//
 		// If tracingSpan is nil, then we used the same context that was passed
-		// in Next() and it is the responsibility of the caller-component
+		// in Init() and it is the responsibility of the caller-component
 		// (either materializer, or wrapped processor, or an outbox) to collect
 		// the trace data. If we were to do it here too, we would see duplicate
 		// spans.
-		// TODO(yuzefovich): this is temporary hack that will be fixed by adding
-		// context.Context argument to Init() and removing it from Next() and
-		// DrainMeta().
-		s.mu.Lock()
-		traceCtx := s.mu.ctx
-		s.mu.Unlock()
-		if trace := execinfra.GetTraceData(traceCtx); trace != nil {
+		if trace := execinfra.GetTraceData(s.Ctx); trace != nil {
 			trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{TraceData: trace})
 		}
 	}
@@ -192,13 +163,7 @@ func (s *ColBatchScan) GetRowsRead() int64 {
 
 // GetCumulativeContentionTime is part of the colexecop.KVReader interface.
 func (s *ColBatchScan) GetCumulativeContentionTime() time.Duration {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.mu.ctx == nil {
-		// Next was never called, so there was no contention events.
-		return 0
-	}
-	return execinfra.GetCumulativeContentionTime(s.mu.ctx)
+	return execinfra.GetCumulativeContentionTime(s.Ctx)
 }
 
 var colBatchScanPool = sync.Pool{

--- a/pkg/sql/colflow/colbatch_scan_test.go
+++ b/pkg/sql/colflow/colbatch_scan_test.go
@@ -94,7 +94,7 @@ func TestColBatchScanMeta(t *testing.T) {
 		t.Fatal(err)
 	}
 	tr := res.Root
-	tr.Init()
+	tr.Init(ctx)
 	meta := tr.(*colexecutils.CancelChecker).Input.(*colfetcher.ColBatchScan).DrainMeta(ctx)
 	var txnFinalStateSeen bool
 	for _, m := range meta {
@@ -166,10 +166,10 @@ func BenchmarkColBatchScan(b *testing.B) {
 					b.Fatal(err)
 				}
 				tr := res.Root
-				tr.Init()
+				tr.Init(ctx)
 				b.StartTimer()
 				for {
-					bat := tr.Next(ctx)
+					bat := tr.Next()
 					if bat.Length() == 0 {
 						break
 					}

--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -38,7 +38,7 @@ type flowStreamServer interface {
 	Recv() (*execinfrapb.ProducerMessage, error)
 }
 
-// Inbox is used to expose data from remote flows through an exec.Operator
+// Inbox is used to expose data from remote flows through a colexecop.Operator
 // interface. FlowStream RPC handlers should call RunWithStream (which blocks
 // until operation terminates, gracefully or unexpectedly) to pass the stream
 // to the inbox. Next may be called before RunWithStream, it will just block
@@ -50,6 +50,8 @@ type flowStreamServer interface {
 // closing the stream.
 type Inbox struct {
 	colexecop.ZeroInputNode
+	colexecop.InitHelper
+
 	typs []*types.T
 
 	allocator  *colmem.Allocator
@@ -63,7 +65,7 @@ type Inbox struct {
 	// streamCh is the channel over which the stream is passed from the stream
 	// handler to the reader goroutine.
 	streamCh chan flowStreamServer
-	// contextCh is the channel over which the reader goroutine passes the first
+	// contextCh is the channel over which the reader goroutine passes the
 	// context to the stream handler so that it can listen for context
 	// cancellation.
 	contextCh chan context.Context
@@ -82,9 +84,6 @@ type Inbox struct {
 	// right after init. To be used for unit testing.
 	ctxInterceptorFn func(context.Context)
 
-	// initialized prevents double initialization. Should not be used by the
-	// RunWithStream goroutine.
-	initialized bool
 	// done prevents double closing. It should not be used by the RunWithStream
 	// goroutine.
 	done bool
@@ -95,14 +94,6 @@ type Inbox struct {
 	// stream is the RPC stream. It is set when RunWithStream is called but
 	// only the Next/DrainMeta goroutine may access it.
 	stream flowStreamServer
-
-	// flowCtx is a temporary field that captures a flow's context during
-	// initialization. This is so that RunWithStream can listen for cancellation
-	// even in the case in which Next is not called (e.g. in cases where the Inbox
-	// is the left side of a HashJoiner). The best solution for this problem would
-	// be to refactor Operator.Init to accept a context since that must be called
-	// regardless of whether or not Next is called.
-	flowCtx context.Context
 
 	// statsAtomics are the execution statistics that need to be atomically
 	// accessed. This is necessary since Get*() methods can be called from
@@ -131,7 +122,7 @@ var _ colexecop.Operator = &Inbox{}
 
 // NewInbox creates a new Inbox.
 func NewInbox(
-	ctx context.Context, allocator *colmem.Allocator, typs []*types.T, streamID execinfrapb.StreamID,
+	allocator *colmem.Allocator, typs []*types.T, streamID execinfrapb.StreamID,
 ) (*Inbox, error) {
 	c, err := colserde.NewArrowBatchConverter(typs)
 	if err != nil {
@@ -151,53 +142,18 @@ func NewInbox(
 		contextCh:                make(chan context.Context, 1),
 		timeoutCh:                make(chan error, 1),
 		errCh:                    make(chan error, 1),
-		flowCtx:                  ctx,
 		deserializationStopWatch: timeutil.NewStopWatch(),
 	}
 	i.scratch.data = make([]*array.Data, len(typs))
 	return i, nil
 }
 
-// maybeInit calls Inbox.init if the inbox is not initialized and returns an
-// error if the initialization was not successful. Usually this is because the
-// given context is canceled before the remote stream arrives.
-func (i *Inbox) maybeInit(ctx context.Context) error {
-	if !i.initialized {
-		if err := i.init(ctx); err != nil {
-			return err
-		}
-		i.initialized = true
-	}
-	return nil
-}
-
-// init initializes the Inbox for operation by blocking until
-// RunWithStream sets the stream to read from. ctx ownership is retained until
-// the stream arrives (to allow for unblocking the wait for a stream), at which
-// point ownership is transferred to RunWithStream. This should only be called
-// from the reader goroutine when it needs a stream.
-func (i *Inbox) init(ctx context.Context) error {
-	// Wait for the stream to be initialized. We're essentially waiting for the
-	// remote connection.
-	select {
-	case i.stream = <-i.streamCh:
-	case err := <-i.timeoutCh:
-		i.errCh <- fmt.Errorf("%s: remote stream arrived too late", err)
-		return err
-	case <-ctx.Done():
-		i.errCh <- fmt.Errorf("%s: Inbox while waiting for stream", ctx.Err())
-		return ctx.Err()
-	}
-
-	if i.ctxInterceptorFn != nil {
-		i.ctxInterceptorFn(ctx)
-	}
-	i.contextCh <- ctx
-	return nil
-}
-
-// close closes the inbox, ensuring that any call to RunWithStream will
-// return immediately. close is idempotent.
+// close closes the inbox, ensuring that any call to RunWithStream will return
+// immediately. close is idempotent.
+// NOTE: It is very important to close the Inbox only when execution terminates
+// ungracefully or when DrainMeta has been called (which indicates a graceful
+// termination). DrainMeta will use the stream to read any remaining metadata
+// after Next returns a zero-length batch during normal execution.
 func (i *Inbox) close() {
 	if !i.done {
 		i.done = true
@@ -206,8 +162,8 @@ func (i *Inbox) close() {
 }
 
 // RunWithStream sets the Inbox's stream and waits until either streamCtx is
-// canceled, a caller of Next cancels the first context passed into Next, or
-// an EOF is encountered on the stream by the Next goroutine.
+// canceled, a caller of Next cancels the context passed into Init, or an EOF is
+// encountered on the stream by the Next goroutine.
 func (i *Inbox) RunWithStream(streamCtx context.Context, stream flowStreamServer) error {
 	streamCtx = logtags.AddTag(streamCtx, "streamID", i.streamID)
 	log.VEvent(streamCtx, 2, "Inbox handling stream")
@@ -223,8 +179,6 @@ func (i *Inbox) RunWithStream(streamCtx context.Context, stream flowStreamServer
 		log.VEvent(streamCtx, 2, "Inbox reader arrived")
 	case <-streamCtx.Done():
 		return fmt.Errorf("%s: streamCtx while waiting for reader (remote client canceled)", streamCtx.Err())
-	case <-i.flowCtx.Done():
-		return fmt.Errorf("%s: flowCtx while waiting for reader (local server canceled)", i.flowCtx.Err())
 	}
 
 	// Now wait for one of the events described in the method comment. If a
@@ -250,37 +204,59 @@ func (i *Inbox) Timeout(err error) {
 }
 
 // Init is part of the Operator interface.
-func (i *Inbox) Init() {}
+func (i *Inbox) Init(ctx context.Context) {
+	if !i.InitHelper.Init(ctx) {
+		return
+	}
+
+	i.Ctx = logtags.AddTag(ctx, "streamID", i.streamID)
+	// Initializes the Inbox for operation by blocking until RunWithStream sets
+	// the stream to read from.
+	if err := func() error {
+		// Wait for the stream to be initialized. We're essentially waiting for
+		// the remote connection.
+		select {
+		case i.stream = <-i.streamCh:
+		case err := <-i.timeoutCh:
+			i.errCh <- fmt.Errorf("%s: remote stream arrived too late", err)
+			return err
+		case <-i.Ctx.Done():
+			i.errCh <- fmt.Errorf("%s: Inbox while waiting for stream", i.Ctx.Err())
+			return i.Ctx.Err()
+		}
+
+		if i.ctxInterceptorFn != nil {
+			i.ctxInterceptorFn(i.Ctx)
+		}
+		i.contextCh <- i.Ctx
+		return nil
+	}(); err != nil {
+		// An error occurred while initializing the Inbox and is likely caused
+		// by the connection issues. It is expected that such an error can
+		// occur. The Inbox must still be closed.
+		i.close()
+		colexecerror.ExpectedError(err)
+	}
+}
 
 // Next returns the next batch. It will block until there is data available.
-// The Inbox will exit when either the context passed in on the first call to
-// Next is canceled or when DrainMeta goroutine tells it to do so.
-func (i *Inbox) Next(ctx context.Context) coldata.Batch {
+// The Inbox will exit when either the context passed in Init() is canceled or
+// when DrainMeta goroutine tells it to do so.
+func (i *Inbox) Next() coldata.Batch {
 	if i.done {
 		return coldata.ZeroBatch
 	}
 
-	ctx = logtags.AddTag(ctx, "streamID", i.streamID)
-
 	defer func() {
-		// Catch any panics that occur and close the errCh in order to not leak the
-		// goroutine listening for context cancellation. errCh must still be closed
-		// during normal termination.
+		// Catch any panics that occur and close the Inbox in order to not leak
+		// the goroutine listening for context cancellation. The Inbox must
+		// still be closed during normal termination.
 		if err := recover(); err != nil {
+			// Only close the Inbox here in case of an ungraceful termination.
 			i.close()
 			colexecerror.InternalError(logcrash.PanicAsError(0, err))
 		}
 	}()
-
-	// NOTE: It is very important to close i.errCh only when execution terminates
-	// ungracefully or when DrainMeta has been called (which indicates a graceful
-	// termination). DrainMeta will use the stream to read any remaining metadata
-	// after Next returns a zero-length batch during normal execution.
-	if err := i.maybeInit(ctx); err != nil {
-		// An error occurred while initializing the Inbox and is likely caused by
-		// the connection issues. It is expected that such an error can occur.
-		colexecerror.ExpectedError(err)
-	}
 
 	i.deserializationStopWatch.Start()
 	defer i.deserializationStopWatch.Stop()
@@ -306,7 +282,7 @@ func (i *Inbox) Next(ctx context.Context) coldata.Batch {
 		}
 		if len(m.Data.Metadata) != 0 {
 			for _, rpm := range m.Data.Metadata {
-				meta, ok := execinfrapb.RemoteProducerMetaToLocalMeta(ctx, rpm)
+				meta, ok := execinfrapb.RemoteProducerMetaToLocalMeta(i.Ctx, rpm)
 				if !ok {
 					continue
 				}
@@ -377,7 +353,7 @@ func (i *Inbox) sendDrainSignal(ctx context.Context) error {
 
 // DrainMeta is part of the MetadataGenerator interface. DrainMeta may not be
 // called concurrently with Next.
-func (i *Inbox) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
+func (i *Inbox) DrainMeta(context.Context) []execinfrapb.ProducerMetadata {
 	allMeta := i.bufferedMeta
 	i.bufferedMeta = i.bufferedMeta[:0]
 
@@ -387,15 +363,7 @@ func (i *Inbox) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
 	}
 	defer i.close()
 
-	ctx = logtags.AddTag(ctx, "streamID", i.streamID)
-
-	if err := i.maybeInit(ctx); err != nil {
-		if log.V(1) {
-			log.Warningf(ctx, "Inbox unable to initialize stream while draining metadata: %+v", err)
-		}
-		return allMeta
-	}
-	if err := i.sendDrainSignal(ctx); err != nil {
+	if err := i.sendDrainSignal(i.Ctx); err != nil {
 		return allMeta
 	}
 
@@ -406,12 +374,12 @@ func (i *Inbox) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
 				break
 			}
 			if log.V(1) {
-				log.Warningf(ctx, "Inbox Recv connection error while draining metadata: %+v", err)
+				log.Warningf(i.Ctx, "Inbox Recv connection error while draining metadata: %+v", err)
 			}
 			return allMeta
 		}
 		for _, remoteMeta := range msg.Data.Metadata {
-			meta, ok := execinfrapb.RemoteProducerMetaToLocalMeta(ctx, remoteMeta)
+			meta, ok := execinfrapb.RemoteProducerMetaToLocalMeta(i.Ctx, remoteMeta)
 			if !ok {
 				continue
 			}

--- a/pkg/sql/colflow/colrpc/inbox_test.go
+++ b/pkg/sql/colflow/colrpc/inbox_test.go
@@ -61,13 +61,13 @@ func TestInboxCancellation(t *testing.T) {
 
 	typs := []*types.T{types.Int}
 	t.Run("ReaderWaitingForStreamHandler", func(t *testing.T) {
-		inbox, err := NewInbox(context.Background(), testAllocator, typs, execinfrapb.StreamID(0))
+		inbox, err := NewInbox(testAllocator, typs, execinfrapb.StreamID(0))
 		require.NoError(t, err)
 		ctx, cancelFn := context.WithCancel(context.Background())
 		// Cancel the context.
 		cancelFn()
-		// Next should not block if the context is canceled.
-		err = colexecerror.CatchVectorizedRuntimeError(func() { inbox.Next(ctx) })
+		// Init should encounter an error if the context is canceled.
+		err = colexecerror.CatchVectorizedRuntimeError(func() { inbox.Init(ctx) })
 		require.True(t, testutils.IsError(err, "context canceled"), err)
 		// Now, the remote stream arrives.
 		err = inbox.RunWithStream(context.Background(), mockFlowStreamServer{})
@@ -76,13 +76,14 @@ func TestInboxCancellation(t *testing.T) {
 
 	t.Run("DuringRecv", func(t *testing.T) {
 		rpcLayer := makeMockFlowStreamRPCLayer()
-		inbox, err := NewInbox(context.Background(), testAllocator, typs, execinfrapb.StreamID(0))
+		inbox, err := NewInbox(testAllocator, typs, execinfrapb.StreamID(0))
 		require.NoError(t, err)
 		ctx, cancelFn := context.WithCancel(context.Background())
 
 		// Setup reader and stream.
 		go func() {
-			inbox.Next(ctx)
+			inbox.Init(ctx)
+			inbox.Next()
 		}()
 		recvCalled := make(chan struct{})
 		streamHandlerErrCh := handleStream(context.Background(), inbox, callbackFlowStreamServer{
@@ -107,7 +108,7 @@ func TestInboxCancellation(t *testing.T) {
 
 	t.Run("StreamHandlerWaitingForReader", func(t *testing.T) {
 		rpcLayer := makeMockFlowStreamRPCLayer()
-		inbox, err := NewInbox(context.Background(), testAllocator, typs, execinfrapb.StreamID(0))
+		inbox, err := NewInbox(testAllocator, typs, execinfrapb.StreamID(0))
 		require.NoError(t, err)
 
 		ctx, cancelFn := context.WithCancel(context.Background())
@@ -125,7 +126,7 @@ func TestInboxCancellation(t *testing.T) {
 func TestInboxNextPanicDoesntLeakGoroutines(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	inbox, err := NewInbox(context.Background(), testAllocator, []*types.T{types.Int}, execinfrapb.StreamID(0))
+	inbox, err := NewInbox(testAllocator, []*types.T{types.Int}, execinfrapb.StreamID(0))
 	require.NoError(t, err)
 
 	rpcLayer := makeMockFlowStreamRPCLayer()
@@ -140,7 +141,10 @@ func TestInboxNextPanicDoesntLeakGoroutines(t *testing.T) {
 
 	// inbox.Next should panic given that the deserializer will encounter garbage
 	// data.
-	require.Panics(t, func() { inbox.Next(context.Background()) })
+	require.Panics(t, func() {
+		inbox.Init(context.Background())
+		inbox.Next()
+	})
 
 	// We require no error from the stream handler as nothing was canceled. The
 	// panic is bubbled up through the Next chain on the Inbox's host.
@@ -152,7 +156,7 @@ func TestInboxTimeout(t *testing.T) {
 
 	ctx := context.Background()
 
-	inbox, err := NewInbox(ctx, testAllocator, []*types.T{types.Int}, execinfrapb.StreamID(0))
+	inbox, err := NewInbox(testAllocator, []*types.T{types.Int}, execinfrapb.StreamID(0))
 	require.NoError(t, err)
 
 	var (
@@ -160,7 +164,10 @@ func TestInboxTimeout(t *testing.T) {
 		rpcLayer    = makeMockFlowStreamRPCLayer()
 	)
 	go func() {
-		readerErrCh <- colexecerror.CatchVectorizedRuntimeError(func() { inbox.Next(ctx) })
+		readerErrCh <- colexecerror.CatchVectorizedRuntimeError(func() {
+			inbox.Init(ctx)
+			inbox.Next()
+		})
 	}()
 
 	// Timeout the inbox.
@@ -255,7 +262,7 @@ func TestInboxShutdown(t *testing.T) {
 					inboxCtx, inboxCancel := context.WithCancel(context.Background())
 					inboxMemAccount := testMemMonitor.MakeBoundAccount()
 					defer inboxMemAccount.Close(inboxCtx)
-					inbox, err := NewInbox(context.Background(), colmem.NewAllocator(inboxCtx, &inboxMemAccount, coldata.StandardColumnFactory), typs, execinfrapb.StreamID(0))
+					inbox, err := NewInbox(colmem.NewAllocator(inboxCtx, &inboxMemAccount, coldata.StandardColumnFactory), typs, execinfrapb.StreamID(0))
 					require.NoError(t, err)
 					c, err := colserde.NewArrowBatchConverter(typs)
 					require.NoError(t, err)
@@ -358,6 +365,14 @@ func TestInboxShutdown(t *testing.T) {
 									if !runNextGoroutine {
 										return
 									}
+									// Init must always be called in any scenario.
+									err = colexecerror.CatchVectorizedRuntimeError(func() {
+										inbox.Init(inboxCtx)
+									})
+									if err != nil {
+										errCh <- err
+										return
+									}
 									if drainScenario == drainMetaBeforeNext {
 										_ = inbox.DrainMeta(inboxCtx)
 										return
@@ -365,12 +380,9 @@ func TestInboxShutdown(t *testing.T) {
 									if nextSleep != 0 {
 										time.Sleep(nextSleep)
 									}
-									var (
-										done bool
-										err  error
-									)
+									var done bool
 									for !done && err == nil {
-										err = colexecerror.CatchVectorizedRuntimeError(func() { b := inbox.Next(inboxCtx); done = b.Length() == 0 })
+										err = colexecerror.CatchVectorizedRuntimeError(func() { b := inbox.Next(); done = b.Length() == 0 })
 										if drainScenario == drainMetaPrematurely {
 											_ = inbox.DrainMeta(inboxCtx)
 											return

--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -247,14 +247,14 @@ func (o *Outbox) sendBatches(
 		o.runnerCtx = ctx
 	}
 	errToSend = colexecerror.CatchVectorizedRuntimeError(func() {
-		o.Input.Init()
+		o.Input.Init(o.runnerCtx)
 		for {
 			if atomic.LoadUint32(&o.draining) == 1 {
 				terminatedGracefully = true
 				return
 			}
 
-			batch := o.Input.Next(o.runnerCtx)
+			batch := o.Input.Next()
 			n := batch.Length()
 			if n == 0 {
 				terminatedGracefully = true

--- a/pkg/sql/colflow/panic_injector.go
+++ b/pkg/sql/colflow/panic_injector.go
@@ -28,7 +28,7 @@ type panicInjector struct {
 	rng *rand.Rand
 }
 
-var _ colexecop.Operator = panicInjector{}
+var _ colexecop.Operator = &panicInjector{}
 
 const (
 	// These constants were chosen arbitrarily with the guiding thought that
@@ -49,16 +49,16 @@ func newPanicInjector(input colexecop.Operator) colexecop.Operator {
 	}
 }
 
-func (i panicInjector) Init() {
+func (i *panicInjector) Init(ctx context.Context) {
 	if i.rng.Float64() < initPanicInjectionProbability {
 		colexecerror.ExpectedError(errors.New("injected panic in Init"))
 	}
-	i.Input.Init()
+	i.Input.Init(ctx)
 }
 
-func (i panicInjector) Next(ctx context.Context) coldata.Batch {
+func (i *panicInjector) Next() coldata.Batch {
 	if i.rng.Float64() < nextPanicInjectionProbability {
 		colexecerror.ExpectedError(errors.New("injected panic in Next"))
 	}
-	return i.Input.Next(ctx)
+	return i.Input.Next()
 }

--- a/pkg/sql/colflow/routers.go
+++ b/pkg/sql/colflow/routers.go
@@ -101,6 +101,7 @@ type drainCoordinator interface {
 }
 
 type routerOutputOp struct {
+	colexecop.InitHelper
 	// input is a reference to our router.
 	input execinfra.OpNode
 	// drainCoordinator is a reference to the HashRouter to be able to notify it
@@ -212,15 +213,17 @@ func newRouterOutputOp(args routerOutputOpArgs) *routerOutputOp {
 	return o
 }
 
-func (o *routerOutputOp) Init() {}
+func (o *routerOutputOp) Init(ctx context.Context) {
+	o.InitHelper.Init(ctx)
+}
 
 // nextErrorLocked is a helper method that handles an error encountered in Next.
-func (o *routerOutputOp) nextErrorLocked(ctx context.Context, err error) {
+func (o *routerOutputOp) nextErrorLocked(err error) {
 	o.mu.state = routerOutputOpDraining
 	o.maybeUnblockLocked()
 	// Unlock the mutex, since the HashRouter will cancel all outputs.
 	o.mu.Unlock()
-	o.drainCoordinator.encounteredError(ctx)
+	o.drainCoordinator.encounteredError(o.Ctx)
 	o.mu.Lock()
 	colexecerror.InternalError(err)
 }
@@ -228,7 +231,7 @@ func (o *routerOutputOp) nextErrorLocked(ctx context.Context, err error) {
 // Next returns the next coldata.Batch from the routerOutputOp. Note that Next
 // is designed for only one concurrent caller and will block until data is
 // ready.
-func (o *routerOutputOp) Next(ctx context.Context) coldata.Batch {
+func (o *routerOutputOp) Next() coldata.Batch {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	for o.mu.forwardedErr == nil && o.mu.state == routerOutputOpRunning && o.mu.data.Empty() {
@@ -241,12 +244,12 @@ func (o *routerOutputOp) Next(ctx context.Context) coldata.Batch {
 	if o.mu.state == routerOutputOpDraining {
 		return coldata.ZeroBatch
 	}
-	b, err := o.mu.data.Dequeue(ctx)
+	b, err := o.mu.data.Dequeue(o.Ctx)
 	if err == nil && o.testingKnobs.nextTestInducedErrorCb != nil {
 		err = o.testingKnobs.nextTestInducedErrorCb()
 	}
 	if err != nil {
-		o.nextErrorLocked(ctx, err)
+		o.nextErrorLocked(err)
 	}
 	o.mu.numUnread -= b.Length()
 	if o.mu.numUnread <= o.testingKnobs.blockedThreshold {
@@ -255,13 +258,13 @@ func (o *routerOutputOp) Next(ctx context.Context) coldata.Batch {
 	if b.Length() == 0 {
 		if o.testingKnobs.nextTestInducedErrorCb != nil {
 			if err := o.testingKnobs.nextTestInducedErrorCb(); err != nil {
-				o.nextErrorLocked(ctx, err)
+				o.nextErrorLocked(err)
 			}
 		}
 		// This is the last batch. closeLocked will set done to protect against
 		// further calls to Next since this is allowed by the interface as well as
 		// cleaning up and releasing possible disk infrastructure.
-		o.closeLocked(ctx)
+		o.closeLocked(o.Ctx)
 	}
 	return b
 }
@@ -552,7 +555,7 @@ func (r *HashRouter) Run(ctx context.Context) {
 	// method with a catcher. Note that we also have "internal" catchers as
 	// well for more fine-grained control of error propagation.
 	if err := colexecerror.CatchVectorizedRuntimeError(func() {
-		r.Input.Init()
+		r.Input.Init(ctx)
 		var done bool
 		processNextBatch := func() {
 			done = r.processNextBatch(ctx)
@@ -627,7 +630,7 @@ func (r *HashRouter) Run(ctx context.Context) {
 // each column to its corresponding output, returning whether the input is
 // done.
 func (r *HashRouter) processNextBatch(ctx context.Context) bool {
-	b := r.Input.Next(ctx)
+	b := r.Input.Next()
 	n := b.Length()
 	if n == 0 {
 		// Done. Push an empty batch to outputs to tell them the data is done as
@@ -638,7 +641,10 @@ func (r *HashRouter) processNextBatch(ctx context.Context) bool {
 		return true
 	}
 
-	selections := r.tupleDistributor.Distribute(ctx, b, r.hashCols)
+	// It is ok that we call Init() on every batch since all calls except for
+	// the first one are noops.
+	r.tupleDistributor.Init(ctx)
+	selections := r.tupleDistributor.Distribute(b, r.hashCols)
 	for i, o := range r.outputs {
 		if len(selections[i]) > 0 {
 			b.SetSelection(true)

--- a/pkg/sql/colflow/stats.go
+++ b/pkg/sql/colflow/stats.go
@@ -81,10 +81,10 @@ func makeBatchInfoCollector(
 }
 
 // Next is part of the Operator interface.
-func (bic *batchInfoCollector) Next(ctx context.Context) coldata.Batch {
+func (bic *batchInfoCollector) Next() coldata.Batch {
 	var batch coldata.Batch
 	bic.stopwatch.Start()
-	batch = bic.Operator.Next(ctx)
+	batch = bic.Operator.Next()
 	bic.stopwatch.Stop()
 	if batch.Length() > 0 {
 		bic.mu.Lock()
@@ -264,9 +264,9 @@ type statsInvariantChecker struct {
 var _ colexecop.VectorizedStatsCollector = &statsInvariantChecker{}
 var _ colexecop.MetadataSource = &statsInvariantChecker{}
 
-func (i *statsInvariantChecker) Init() {}
+func (i *statsInvariantChecker) Init(context.Context) {}
 
-func (i *statsInvariantChecker) Next(context.Context) coldata.Batch {
+func (i *statsInvariantChecker) Next() coldata.Batch {
 	return coldata.ZeroBatch
 }
 

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -434,7 +434,7 @@ type remoteComponentCreator interface {
 		metadataSources []colexecop.MetadataSource,
 		toClose []colexecop.Closer,
 	) (*colrpc.Outbox, error)
-	newInbox(ctx context.Context, allocator *colmem.Allocator, typs []*types.T, streamID execinfrapb.StreamID) (*colrpc.Inbox, error)
+	newInbox(allocator *colmem.Allocator, typs []*types.T, streamID execinfrapb.StreamID) (*colrpc.Inbox, error)
 }
 
 type vectorizedRemoteComponentCreator struct{}
@@ -451,9 +451,9 @@ func (vectorizedRemoteComponentCreator) newOutbox(
 }
 
 func (vectorizedRemoteComponentCreator) newInbox(
-	ctx context.Context, allocator *colmem.Allocator, typs []*types.T, streamID execinfrapb.StreamID,
+	allocator *colmem.Allocator, typs []*types.T, streamID execinfrapb.StreamID,
 ) (*colrpc.Inbox, error) {
-	return colrpc.NewInbox(ctx, allocator, typs, streamID)
+	return colrpc.NewInbox(allocator, typs, streamID)
 }
 
 // vectorizedFlowCreator performs all the setup of vectorized flows. Depending
@@ -839,9 +839,7 @@ func (s *vectorizedFlowCreator) setupInput(
 				}
 			}
 
-			inbox, err := s.remoteComponentCreator.newInbox(
-				ctx, colmem.NewAllocator(ctx, s.newStreamingMemAccount(flowCtx), factory), input.ColumnTypes, inputStream.StreamID,
-			)
+			inbox, err := s.remoteComponentCreator.newInbox(colmem.NewAllocator(ctx, s.newStreamingMemAccount(flowCtx), factory), input.ColumnTypes, inputStream.StreamID)
 
 			if err != nil {
 				return colexecargs.OpWithMetaInfo{}, err

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -67,9 +67,9 @@ func (c callbackCloser) Close(_ context.Context) error {
 // TestVectorizedFlowShutdown tests that closing the materializer correctly
 // closes all the infrastructure corresponding to the flow ending in that
 // materializer. Namely:
-// - on a remote node, it creates an exec.HashRouter with 3 outputs (with a
-// corresponding to each Outbox) as well as 3 standalone Outboxes;
-// - on a local node, it creates 6 exec.Inboxes that feed into an unordered
+// - on a remote node, it creates a colflow.HashRouter with 3 outputs (with a
+// corresponding to each colrpc.Outbox) as well as 3 standalone Outboxes;
+// - on a local node, it creates 6 colrpc.Inboxes that feed into an unordered
 // synchronizer which then outputs all the data into a materializer.
 // The resulting scheme looks as follows:
 //
@@ -211,12 +211,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 				for i := 0; i < numInboxes; i++ {
 					inboxMemAccount := testMemMonitor.MakeBoundAccount()
 					defer inboxMemAccount.Close(ctxLocal)
-					inbox, err := colrpc.NewInbox(
-						ctxLocal,
-						colmem.NewAllocator(ctxLocal, &inboxMemAccount, testColumnFactory),
-						typs,
-						execinfrapb.StreamID(streamID),
-					)
+					inbox, err := colrpc.NewInbox(colmem.NewAllocator(ctxLocal, &inboxMemAccount, testColumnFactory), typs, execinfrapb.StreamID(streamID))
 					require.NoError(t, err)
 					inboxes = append(inboxes, inbox)
 					synchronizerInputs = append(
@@ -238,7 +233,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 				}{}
 				idToClosed.mapping = make(map[int]bool)
 				runOutboxInbox := func(
-					ctx context.Context,
+					outboxCtx context.Context,
 					cancelFn context.CancelFunc,
 					outboxMemAcc *mon.BoundAccount,
 					outboxInput colexecop.Operator,
@@ -250,7 +245,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					idToClosed.mapping[id] = false
 					idToClosed.Unlock()
 					outbox, err := colrpc.NewOutbox(
-						colmem.NewAllocator(ctx, outboxMemAcc, testColumnFactory),
+						colmem.NewAllocator(outboxCtx, outboxMemAcc, testColumnFactory),
 						outboxInput,
 						typs,
 						nil, /* getStats */
@@ -267,7 +262,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					wg.Add(1)
 					go func(id int) {
 						outbox.Run(
-							ctx,
+							outboxCtx,
 							dialer,
 							execinfra.StaticNodeID,
 							flowID,
@@ -326,12 +321,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					// Add another "remote" node to the flow.
 					inboxMemAccount := testMemMonitor.MakeBoundAccount()
 					defer inboxMemAccount.Close(ctxAnotherRemote)
-					inbox, err := colrpc.NewInbox(
-						ctxAnotherRemote,
-						colmem.NewAllocator(ctxAnotherRemote, &inboxMemAccount, testColumnFactory),
-						typs,
-						execinfrapb.StreamID(streamID),
-					)
+					inbox, err := colrpc.NewInbox(colmem.NewAllocator(ctxAnotherRemote, &inboxMemAccount, testColumnFactory), typs, execinfrapb.StreamID(streamID))
 					require.NoError(t, err)
 					inboxes = append(inboxes, inbox)
 					outboxMemAccount := testMemMonitor.MakeBoundAccount()

--- a/pkg/sql/colflow/vectorized_flow_space_test.go
+++ b/pkg/sql/colflow/vectorized_flow_space_test.go
@@ -240,9 +240,9 @@ func TestVectorizeAllocatorSpaceError(t *testing.T) {
 					require.NoError(t, err)
 				}); err == nil {
 					err = colexecerror.CatchVectorizedRuntimeError(func() {
-						result.Root.Init()
-						result.Root.Next(ctx)
-						result.Root.Next(ctx)
+						result.Root.Init(ctx)
+						result.Root.Next()
+						result.Root.Next()
 					})
 				}
 				if result != nil {

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -52,7 +52,7 @@ func (c callbackRemoteComponentCreator) newOutbox(
 }
 
 func (c callbackRemoteComponentCreator) newInbox(
-	ctx context.Context, allocator *colmem.Allocator, typs []*types.T, streamID execinfrapb.StreamID,
+	allocator *colmem.Allocator, typs []*types.T, streamID execinfrapb.StreamID,
 ) (*colrpc.Inbox, error) {
 	return c.newInboxFn(allocator, typs, streamID)
 }
@@ -207,7 +207,7 @@ func TestDrainOnlyInputDAG(t *testing.T) {
 			return colrpc.NewOutbox(allocator, op, typs, nil /* getStats */, sources, nil /* toClose */)
 		},
 		newInboxFn: func(allocator *colmem.Allocator, typs []*types.T, streamID execinfrapb.StreamID) (*colrpc.Inbox, error) {
-			inbox, err := colrpc.NewInbox(context.Background(), allocator, typs, streamID)
+			inbox, err := colrpc.NewInbox(allocator, typs, streamID)
 			inboxToNumInputTypes[inbox] = typs
 			return inbox, err
 		},

--- a/pkg/sql/colflow/vectorized_meta_propagation_test.go
+++ b/pkg/sql/colflow/vectorized_meta_propagation_test.go
@@ -68,7 +68,7 @@ func TestVectorizedMetaPropagation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	col, err := colexec.NewBufferingColumnarizer(ctx, testAllocator, &flowCtx, 1, mts)
+	col, err := colexec.NewBufferingColumnarizer(testAllocator, &flowCtx, 1, mts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/colflow/vectorized_panic_propagation_test.go
+++ b/pkg/sql/colflow/vectorized_panic_propagation_test.go
@@ -50,7 +50,7 @@ func TestVectorizedInternalPanic(t *testing.T) {
 	typs := types.OneIntCol
 	input := execinfra.NewRepeatableRowSource(typs, randgen.MakeIntRows(nRows, nCols))
 
-	col, err := colexec.NewBufferingColumnarizer(ctx, testAllocator, &flowCtx, 0 /* processorID */, input)
+	col, err := colexec.NewBufferingColumnarizer(testAllocator, &flowCtx, 0 /* processorID */, input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +94,7 @@ func TestNonVectorizedPanicPropagation(t *testing.T) {
 	typs := types.OneIntCol
 	input := execinfra.NewRepeatableRowSource(typs, randgen.MakeIntRows(nRows, nCols))
 
-	col, err := colexec.NewBufferingColumnarizer(ctx, testAllocator, &flowCtx, 0 /* processorID */, input)
+	col, err := colexec.NewBufferingColumnarizer(testAllocator, &flowCtx, 0 /* processorID */, input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,12 +116,12 @@ func TestNonVectorizedPanicPropagation(t *testing.T) {
 	require.Panics(t, func() { mat.Next() }, "NonVectorizedPanic was caught by the operators")
 }
 
-// testVectorizedInternalPanicEmitter is an colexec.Operator that panics with
+// testVectorizedInternalPanicEmitter is a colexecop.Operator that panics with
 // colexecerror.InternalError on every odd-numbered invocation of Next()
 // and returns the next batch from the input on every even-numbered (i.e. it
 // becomes a noop for those iterations). Used for tests only.
 type testVectorizedInternalPanicEmitter struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	emitBatch bool
 }
 
@@ -129,32 +129,27 @@ var _ colexecop.Operator = &testVectorizedInternalPanicEmitter{}
 
 func newTestVectorizedInternalPanicEmitter(input colexecop.Operator) colexecop.Operator {
 	return &testVectorizedInternalPanicEmitter{
-		OneInputNode: colexecop.NewOneInputNode(input),
+		OneInputHelper: colexecop.MakeOneInputHelper(input),
 	}
 }
 
-// Init is part of exec.Operator interface.
-func (e *testVectorizedInternalPanicEmitter) Init() {
-	e.Input.Init()
-}
-
-// Next is part of exec.Operator interface.
-func (e *testVectorizedInternalPanicEmitter) Next(ctx context.Context) coldata.Batch {
+// Next is part of colexecop.Operator interface.
+func (e *testVectorizedInternalPanicEmitter) Next() coldata.Batch {
 	if !e.emitBatch {
 		e.emitBatch = true
 		colexecerror.InternalError(errors.AssertionFailedf(""))
 	}
 
 	e.emitBatch = false
-	return e.Input.Next(ctx)
+	return e.Input.Next()
 }
 
 // testNonVectorizedPanicEmitter is the same as
 // testVectorizedInternalPanicEmitter but it panics with the builtin panic
-// function. Used for tests only. It is the only colexec.Operator panics from
+// function. Used for tests only. It is the only colexecop.Operator panics from
 // which are not caught.
 type testNonVectorizedPanicEmitter struct {
-	colexecop.OneInputNode
+	colexecop.OneInputHelper
 	emitBatch bool
 }
 
@@ -162,22 +157,17 @@ var _ colexecop.Operator = &testVectorizedInternalPanicEmitter{}
 
 func newTestNonVectorizedPanicEmitter(input colexecop.Operator) colexecop.Operator {
 	return &testNonVectorizedPanicEmitter{
-		OneInputNode: colexecop.NewOneInputNode(input),
+		OneInputHelper: colexecop.MakeOneInputHelper(input),
 	}
 }
 
-// Init is part of exec.Operator interface.
-func (e *testNonVectorizedPanicEmitter) Init() {
-	e.Input.Init()
-}
-
-// Next is part of exec.Operator interface.
-func (e *testNonVectorizedPanicEmitter) Next(ctx context.Context) coldata.Batch {
+// Next is part of colexecop.Operator interface.
+func (e *testNonVectorizedPanicEmitter) Next() coldata.Batch {
 	if !e.emitBatch {
 		e.emitBatch = true
 		colexecerror.NonCatchablePanic("")
 	}
 
 	e.emitBatch = false
-	return e.Input.Next(ctx)
+	return e.Input.Next()
 }

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -130,7 +130,7 @@ func verifyColOperator(t *testing.T, args verifyColOperatorArgs) error {
 	testAllocator := colmem.NewAllocator(ctx, &acc, coldataext.NewExtendedColumnFactory(&evalCtx))
 	columnarizers := make([]colexecop.Operator, len(args.inputs))
 	for i, input := range inputsColOp {
-		c, err := colexec.NewBufferingColumnarizer(ctx, testAllocator, flowCtx, int32(i)+1, input)
+		c, err := colexec.NewBufferingColumnarizer(testAllocator, flowCtx, int32(i)+1, input)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/distsql/vectorized_panic_propagation_test.go
+++ b/pkg/sql/distsql/vectorized_panic_propagation_test.go
@@ -55,7 +55,7 @@ func TestNonVectorizedPanicDoesntHangServer(t *testing.T) {
 		&flowCtx,
 		0, /* processorID */
 		colexecargs.OpWithMetaInfo{Root: &colexecop.CallbackOperator{
-			NextCb: func(ctx context.Context) coldata.Batch {
+			NextCb: func() coldata.Batch {
 				panic("")
 			},
 		}},

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -230,9 +230,9 @@ query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 WHERE message LIKE '%DelRange%' OR message LIKE '%DelRng%'
 ----
-flow              DelRange /Table/57/1 - /Table/57/2
+materializer      DelRange /Table/57/1 - /Table/57/2
 dist sender send  r37: sending batch 1 DelRng to (n1,s1):1
-flow              DelRange /Table/57/1/601/0 - /Table/57/2
+materializer      DelRange /Table/57/1/601/0 - /Table/57/2
 dist sender send  r37: sending batch 1 DelRng to (n1,s1):1
 
 # Ensure that DelRange requests are autocommitted when DELETE FROM happens on a
@@ -248,7 +248,7 @@ query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 WHERE message LIKE '%DelRange%' OR message LIKE '%sending batch%'
 ----
-flow              DelRange /Table/57/1/5 - /Table/57/1/5/#
+materializer      DelRange /Table/57/1/5 - /Table/57/1/5/#
 dist sender send  r37: sending batch 1 DelRng, 1 EndTxn to (n1,s1):1
 
 # Test use of fast path when there are interleaved tables.

--- a/pkg/sql/opt/exec/execbuilder/testdata/interleaved
+++ b/pkg/sql/opt/exec/execbuilder/testdata/interleaved
@@ -248,7 +248,7 @@ SET TRACING = on,kv,results; DELETE FROM a where a_id <= 7 and a_id >= 5; SET tr
 # Only look at traces from SQL land.
 query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION]
-WHERE operation='flow' OR operation='exec stmt'
+WHERE operation='materializer' OR operation='exec stmt'
 ----
 DelRange /Table/61/1/5 - /Table/61/1/7/NULL
 fast path completed
@@ -289,7 +289,7 @@ SET TRACING = on,kv,results; DELETE FROM a; SET tracing = off
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION]
-WHERE operation='flow' OR operation='exec stmt'
+WHERE operation='materializer' OR operation='exec stmt'
 ----
 DelRange /Table/61/1 - /Table/61/3
 fast path completed

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace_nonmetamorphic
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace_nonmetamorphic
@@ -17,10 +17,10 @@ WHERE message NOT LIKE '%Z/%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow       CPut /NamespaceTable/30/1/0/0/"t"/4/1 -> 53
-flow       CPut /Table/3/1/53/2/1 -> database:<name:"t" id:53 modification_time:<> version:1 privileges:<users:<user_proto:"admin" privileges:2 > users:<user_proto:"root" privileges:2 > owner_proto:"root" version:1 > state:PUBLIC offline_reason:"" >
-flow       CPut /NamespaceTable/30/1/53/0/"public"/4/1 -> 29
-exec stmt  rows affected: 0
+materializer  CPut /NamespaceTable/30/1/0/0/"t"/4/1 -> 53
+materializer  CPut /Table/3/1/53/2/1 -> database:<name:"t" id:53 modification_time:<> version:1 privileges:<users:<user_proto:"admin" privileges:2 > users:<user_proto:"root" privileges:2 > owner_proto:"root" version:1 > state:PUBLIC offline_reason:"" >
+materializer  CPut /NamespaceTable/30/1/53/0/"public"/4/1 -> 29
+exec stmt     rows affected: 0
 
 
 # More KV operations.
@@ -38,9 +38,9 @@ WHERE message NOT LIKE '%Z/%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow       CPut /NamespaceTable/30/1/53/29/"kv"/4/1 -> 54
-flow       CPut /Table/3/1/54/2/1 -> table:<name:"kv" id:54 version:1 modification_time:<> parent_id:53 unexposed_parent_schema_id:29 columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false > TypeMeta:<Version:0 > > nullable:false hidden:false virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false > TypeMeta:<Version:0 > > nullable:true hidden:false virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true version:2 column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:false encoding_type:0 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" > next_index_id:2 privileges:<users:<user_proto:"admin" privileges:2 > users:<user_proto:"root" privileges:2 > owner_proto:"root" version:1 > next_mutation_id:1 format_version:3 state:PUBLIC offline_reason:"" view_query:"" is_materialized_view:false drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"" create_as_of_time:<> temporary:false partition_all_by:false >
-exec stmt  rows affected: 0
+materializer  CPut /NamespaceTable/30/1/53/29/"kv"/4/1 -> 54
+materializer  CPut /Table/3/1/54/2/1 -> table:<name:"kv" id:54 version:1 modification_time:<> parent_id:53 unexposed_parent_schema_id:29 columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false > TypeMeta:<Version:0 > > nullable:false hidden:false virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false > TypeMeta:<Version:0 > > nullable:true hidden:false virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true version:2 column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:false encoding_type:0 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" > next_index_id:2 privileges:<users:<user_proto:"admin" privileges:2 > users:<user_proto:"root" privileges:2 > owner_proto:"root" version:1 > next_mutation_id:1 format_version:3 state:PUBLIC offline_reason:"" view_query:"" is_materialized_view:false drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"" create_as_of_time:<> temporary:false partition_all_by:false >
+exec stmt     rows affected: 0
 
 # We avoid using the full trace output, because that would make the
 # ensuing trace especially chatty, as it traces the index backfill at
@@ -65,8 +65,8 @@ WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow       Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 version:2 modification_time:<> parent_id:53 unexposed_parent_schema_id:29 columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false > TypeMeta:<Version:0 > > nullable:false hidden:false virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false > TypeMeta:<Version:0 > > nullable:true hidden:false virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true version:2 column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:false encoding_type:0 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" > next_index_id:3 privileges:<users:<user_proto:"admin" privileges:2 > users:<user_proto:"root" privileges:2 > owner_proto:"root" version:1 > mutations:<index:<name:"woo" id:2 unique:true version:2 column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:true encoding_type:0 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" > state:DELETE_ONLY direction:ADD mutation_id:1 rollback:false > next_mutation_id:2 format_version:3 state:PUBLIC offline_reason:"" view_query:"" is_materialized_view:false mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"" create_as_of_time:<...> temporary:false partition_all_by:false >
-exec stmt  rows affected: 0
+materializer  Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 version:2 modification_time:<> parent_id:53 unexposed_parent_schema_id:29 columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false > TypeMeta:<Version:0 > > nullable:false hidden:false virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false > TypeMeta:<Version:0 > > nullable:true hidden:false virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true version:2 column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:false encoding_type:0 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" > next_index_id:3 privileges:<users:<user_proto:"admin" privileges:2 > users:<user_proto:"root" privileges:2 > owner_proto:"root" version:1 > mutations:<index:<name:"woo" id:2 unique:true version:2 column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:true encoding_type:0 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" > state:DELETE_ONLY direction:ADD mutation_id:1 rollback:false > next_mutation_id:2 format_version:3 state:PUBLIC offline_reason:"" view_query:"" is_materialized_view:false mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"" create_as_of_time:<...> temporary:false partition_all_by:false >
+exec stmt     rows affected: 0
 
 statement ok
 SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = off
@@ -75,10 +75,10 @@ query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
-flow       CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
-flow       InitPut /Table/54/2/2/0 -> /BYTES/0x89
-flow       fast path completed
-exec stmt  rows affected: 1
+materializer  CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
+materializer  InitPut /Table/54/2/2/0 -> /BYTES/0x89
+materializer  fast path completed
+exec stmt     rows affected: 1
 
 
 statement error duplicate key value
@@ -89,9 +89,9 @@ set tracing=off;
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
-flow       CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
-flow       InitPut /Table/54/2/2/0 -> /BYTES/0x89
-exec stmt  execution failed after 0 rows: duplicate key value violates unique constraint "primary"
+materializer  CPut /Table/54/1/1/0 -> /TUPLE/2:2:Int/2
+materializer  InitPut /Table/54/2/2/0 -> /BYTES/0x89
+exec stmt     execution failed after 0 rows: duplicate key value violates unique constraint "primary"
 
 statement error duplicate key value
 SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (2,2); SET tracing = off
@@ -101,9 +101,9 @@ set tracing=off;
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
-flow       CPut /Table/54/1/2/0 -> /TUPLE/2:2:Int/2
-flow       InitPut /Table/54/2/2/0 -> /BYTES/0x8a
-exec stmt  execution failed after 0 rows: duplicate key value violates unique constraint "woo"
+materializer  CPut /Table/54/1/2/0 -> /TUPLE/2:2:Int/2
+materializer  InitPut /Table/54/2/2/0 -> /BYTES/0x8a
+exec stmt     execution failed after 0 rows: duplicate key value violates unique constraint "woo"
 
 statement ok
 SET tracing = on,kv,results; CREATE TABLE t.kv2 AS TABLE t.kv; SET tracing = off
@@ -119,9 +119,9 @@ WHERE message NOT LIKE '%Z/%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow       CPut /NamespaceTable/30/1/53/29/"kv2"/4/1 -> 55
-flow       CPut /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 version:1 modification_time:<> parent_id:53 unexposed_parent_schema_id:29 columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false > TypeMeta:<Version:0 > > nullable:true hidden:false virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false > TypeMeta:<Version:0 > > nullable:true hidden:false virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"rowid" id:3 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false > TypeMeta:<Version:0 > > nullable:false default_expr:"unique_rowid()" hidden:true virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true version:0 column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:false encoding_type:0 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" > next_index_id:2 privileges:<users:<user_proto:"admin" privileges:2 > users:<user_proto:"root" privileges:2 > owner_proto:"root" version:1 > next_mutation_id:1 format_version:3 state:ADD offline_reason:"" view_query:"" is_materialized_view:false drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"TABLE t.public.kv" create_as_of_time:<> temporary:false partition_all_by:false >
-exec stmt  rows affected: 0
+materializer  CPut /NamespaceTable/30/1/53/29/"kv2"/4/1 -> 55
+materializer  CPut /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 version:1 modification_time:<> parent_id:53 unexposed_parent_schema_id:29 columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false > TypeMeta:<Version:0 > > nullable:true hidden:false virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false > TypeMeta:<Version:0 > > nullable:true hidden:false virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"rowid" id:3 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false > TypeMeta:<Version:0 > > nullable:false default_expr:"unique_rowid()" hidden:true virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true version:0 column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:false encoding_type:0 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" > next_index_id:2 privileges:<users:<user_proto:"admin" privileges:2 > users:<user_proto:"root" privileges:2 > owner_proto:"root" version:1 > next_mutation_id:1 format_version:3 state:ADD offline_reason:"" view_query:"" is_materialized_view:false drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"TABLE t.public.kv" create_as_of_time:<> temporary:false partition_all_by:false >
+exec stmt     rows affected: 0
 
 statement ok
 SET tracing = on,kv,results; UPDATE t.kv2 SET v = v + 2; SET tracing = off
@@ -138,8 +138,8 @@ WHERE message NOT LIKE '%Z/%'
 ----
 colbatchscan  Scan /Table/55/{1-2}
 colbatchscan  fetched: /kv2/primary/-9222809086901354496/k/v -> /1/2
-flow          Put /Table/55/1/-9222809086901354496/0 -> /TUPLE/1:1:Int/1/1:2:Int/4
-flow          fast path completed
+materializer  Put /Table/55/1/-9222809086901354496/0 -> /TUPLE/1:1:Int/1/1:2:Int/4
+materializer  fast path completed
 exec stmt     rows affected: 1
 
 statement ok
@@ -149,9 +149,9 @@ query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
-flow       DelRange /Table/55/1 - /Table/55/2
-flow       fast path completed
-exec stmt  rows affected: 1
+materializer  DelRange /Table/55/1 - /Table/55/2
+materializer  fast path completed
+exec stmt     rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; DROP TABLE t.kv2; SET tracing = off
@@ -168,8 +168,8 @@ WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow       Put /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 version:3 modification_time:<> draining_names:<parent_id:53 parent_schema_id:29 name:"kv2" > parent_id:53 unexposed_parent_schema_id:29 columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false > TypeMeta:<Version:0 > > nullable:true hidden:false virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false > TypeMeta:<Version:0 > > nullable:true hidden:false virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"rowid" id:3 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false > TypeMeta:<Version:0 > > nullable:false default_expr:"unique_rowid()" hidden:true virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true version:0 column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:false encoding_type:0 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" > next_index_id:2 privileges:<users:<user_proto:"admin" privileges:2 > users:<user_proto:"root" privileges:2 > owner_proto:"root" version:1 > next_mutation_id:1 format_version:3 state:DROP offline_reason:"" view_query:"" is_materialized_view:false drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"TABLE t.public.kv" create_as_of_time:<...> temporary:false partition_all_by:false >
-exec stmt  rows affected: 0
+materializer  Put /Table/3/1/55/2/1 -> table:<name:"kv2" id:55 version:3 modification_time:<> draining_names:<parent_id:53 parent_schema_id:29 name:"kv2" > parent_id:53 unexposed_parent_schema_id:29 columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false > TypeMeta:<Version:0 > > nullable:true hidden:false virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false > TypeMeta:<Version:0 > > nullable:true hidden:false virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"rowid" id:3 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false > TypeMeta:<Version:0 > > nullable:false default_expr:"unique_rowid()" hidden:true virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true version:0 column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:false encoding_type:0 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" > next_index_id:2 privileges:<users:<user_proto:"admin" privileges:2 > users:<user_proto:"root" privileges:2 > owner_proto:"root" version:1 > next_mutation_id:1 format_version:3 state:DROP offline_reason:"" view_query:"" is_materialized_view:false drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"TABLE t.public.kv" create_as_of_time:<...> temporary:false partition_all_by:false >
+exec stmt     rows affected: 0
 
 statement ok
 SET tracing = on,kv,results; DELETE FROM t.kv; SET tracing = off
@@ -180,9 +180,9 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 ----
 colbatchscan  Scan /Table/54/{1-2}
 colbatchscan  fetched: /kv/primary/1/v -> /2
-flow          Del /Table/54/2/2/0
-flow          Del /Table/54/1/1/0
-flow          fast path completed
+materializer  Del /Table/54/2/2/0
+materializer  Del /Table/54/1/1/0
+materializer  fast path completed
 exec stmt     rows affected: 1
 
 statement ok
@@ -202,8 +202,8 @@ WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow       Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 version:5 modification_time:<> parent_id:53 unexposed_parent_schema_id:29 columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false > TypeMeta:<Version:0 > > nullable:false hidden:false virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false > TypeMeta:<Version:0 > > nullable:true hidden:false virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true version:2 column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:false encoding_type:0 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" > next_index_id:3 privileges:<users:<user_proto:"admin" privileges:2 > users:<user_proto:"root" privileges:2 > owner_proto:"root" version:1 > mutations:<index:<name:"woo" id:2 unique:true version:2 column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:true encoding_type:0 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" > state:DELETE_AND_WRITE_ONLY direction:DROP mutation_id:2 rollback:false > next_mutation_id:3 format_version:3 state:PUBLIC offline_reason:"" view_query:"" is_materialized_view:false mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"" create_as_of_time:<...> temporary:false partition_all_by:false >
-exec stmt  rows affected: 0
+materializer  Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 version:5 modification_time:<> parent_id:53 unexposed_parent_schema_id:29 columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false > TypeMeta:<Version:0 > > nullable:false hidden:false virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false > TypeMeta:<Version:0 > > nullable:true hidden:false virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true version:2 column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:false encoding_type:0 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" > next_index_id:3 privileges:<users:<user_proto:"admin" privileges:2 > users:<user_proto:"root" privileges:2 > owner_proto:"root" version:1 > mutations:<index:<name:"woo" id:2 unique:true version:2 column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:true encoding_type:0 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" > state:DELETE_AND_WRITE_ONLY direction:DROP mutation_id:2 rollback:false > next_mutation_id:3 format_version:3 state:PUBLIC offline_reason:"" view_query:"" is_materialized_view:false mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"" create_as_of_time:<...> temporary:false partition_all_by:false >
+exec stmt     rows affected: 0
 
 statement ok
 SET tracing = on,kv,results; DROP TABLE t.kv; SET tracing = off
@@ -219,8 +219,8 @@ WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND tag NOT LIKE '%IndexBackfiller%'
   AND operation != 'dist sender send'
 ----
-flow       Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 version:8 modification_time:<> draining_names:<parent_id:53 parent_schema_id:29 name:"kv" > parent_id:53 unexposed_parent_schema_id:29 columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false > TypeMeta:<Version:0 > > nullable:false hidden:false virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false > TypeMeta:<Version:0 > > nullable:true hidden:false virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true version:2 column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:false encoding_type:0 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" > next_index_id:3 privileges:<users:<user_proto:"admin" privileges:2 > users:<user_proto:"root" privileges:2 > owner_proto:"root" version:1 > next_mutation_id:3 format_version:3 state:DROP offline_reason:"" view_query:"" is_materialized_view:false drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 gc_mutations:<index_id:2 drop_time:... job_id:0 > create_query:"" create_as_of_time:<...> temporary:false partition_all_by:false >
-exec stmt  rows affected: 0
+materializer  Put /Table/3/1/54/2/1 -> table:<name:"kv" id:54 version:8 modification_time:<> draining_names:<parent_id:53 parent_schema_id:29 name:"kv" > parent_id:53 unexposed_parent_schema_id:29 columns:<name:"k" id:1 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false > TypeMeta:<Version:0 > > nullable:false hidden:false virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"v" id:2 type:<InternalType:<family:IntFamily width:64 precision:0 locale:"" visible_type:0 oid:20 time_precision_is_set:false > TypeMeta:<Version:0 > > nullable:true hidden:false virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true version:2 column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:false encoding_type:0 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" > next_index_id:3 privileges:<users:<user_proto:"admin" privileges:2 > users:<user_proto:"root" privileges:2 > owner_proto:"root" version:1 > next_mutation_id:3 format_version:3 state:DROP offline_reason:"" view_query:"" is_materialized_view:false drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 gc_mutations:<index_id:2 drop_time:... job_id:0 > create_query:"" create_as_of_time:<...> temporary:false partition_all_by:false >
+exec stmt     rows affected: 0
 
 # Check that session tracing does not inhibit the fast path for inserts &
 # friends (the path resulting in 1PC transactions).

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert_nonmetamorphic
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert_nonmetamorphic
@@ -39,9 +39,9 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
 colbatchscan  Scan /Table/55/1/2/0
-flow          CPut /Table/55/1/2/0 -> /TUPLE/2:2:Int/3
-flow          InitPut /Table/55/2/3/0 -> /BYTES/0x8a
-flow          fast path completed
+materializer  CPut /Table/55/1/2/0 -> /TUPLE/2:2:Int/3
+materializer  InitPut /Table/55/2/3/0 -> /BYTES/0x8a
+materializer  fast path completed
 exec stmt     rows affected: 1
 
 statement ok
@@ -52,9 +52,9 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
 colbatchscan  Scan /Table/55/1/1/0
-flow          CPut /Table/55/1/1/0 -> /TUPLE/2:2:Int/2
-flow          InitPut /Table/55/2/2/0 -> /BYTES/0x89
-flow          fast path completed
+materializer  CPut /Table/55/1/1/0 -> /TUPLE/2:2:Int/2
+materializer  InitPut /Table/55/2/2/0 -> /BYTES/0x89
+materializer  fast path completed
 exec stmt     rows affected: 1
 
 statement error duplicate key value
@@ -67,7 +67,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 ----
 colbatchscan  Scan /Table/55/1/2/0
 colbatchscan  fetched: /kv/primary/2/v -> /3
-flow          Put /Table/55/1/2/0 -> /TUPLE/2:2:Int/2
-flow          Del /Table/55/2/3/0
-flow          CPut /Table/55/2/2/0 -> /BYTES/0x8a (expecting does not exist)
+materializer  Put /Table/55/1/2/0 -> /TUPLE/2:2:Int/2
+materializer  Del /Table/55/2/3/0
+materializer  CPut /Table/55/2/2/0 -> /BYTES/0x8a (expecting does not exist)
 exec stmt     execution failed after 0 rows: duplicate key value violates unique constraint "woo"

--- a/pkg/sql/sem/tree/eval_test/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test/eval_test.go
@@ -176,7 +176,7 @@ func TestEval(t *testing.T) {
 				},
 				Inputs: []colexecargs.OpWithMetaInfo{{
 					Root: &colexecop.CallbackOperator{
-						NextCb: func(_ context.Context) coldata.Batch {
+						NextCb: func() coldata.Batch {
 							if batchesReturned > 0 {
 								return coldata.ZeroBatch
 							}


### PR DESCRIPTION
This commit moves the context argument from `Next()` method into
`Init()`. The idea is that now the `Operator` interface looks similar to
`RowSource` with the following context management:
- in `Init`, all operators are expected to capture the passed-in
context. They could optionally derive their own context if necessary and
pass that derived context into its inputs. The contract of `Init` method
now is that all calls except for the first one are noops.
- any work performed in `Next` that needs a context should use the one
captured by the operator.

The follow-up commit will remove the context argument from `DrainMeta`
signature.

The motivation for this change is that we want to improve tracing in the
vectorized engine. In the row-by-row engine we create a tracing span for
every processor which allows us to more precisely attribute the time
spent during the execution to each of the processors. However, in the
vectorized engine we currently only create spans at root components
(either root materializer or outboxes) as well as in ColBatchScans (in
order to disambiguate the contention events coming from different
components). After this change we will be able to easily start tracing
spans in `Init` of the operators.

In order to simplify the handling of the context this commit introduces
several utility structs into `colexecop` package. Many operators that
don't need to perform any work in their `Init` method other than calling
`Init` on its single input can now embed `OneInputHelper` and "inherit"
the default implementation of `Init`.

A notable change is to an Inbox - we now remove `flowCtx` which was
captured temporarily until this change (of adding context argument to
`Init`) is made.

Addresses: #55821.

Release note: None