### PR TITLE
cli: ensure that `--log` is recognized for non-server commands

### DIFF
--- a/pkg/acceptance/cluster/dockercluster.go
+++ b/pkg/acceptance/cluster/dockercluster.go
@@ -523,7 +523,8 @@ func (l *DockerCluster) RunInitCommand(ctx context.Context, nodeIdx int) {
 			"init",
 			"--certs-dir=/certs/",
 			"--host=" + l.Nodes[nodeIdx].nodeStr,
-			"--logtostderr",
+			"--log-dir=/logs/init-command",
+			"--logtostderr=NONE",
 		},
 	}
 
@@ -639,14 +640,15 @@ func (l *DockerCluster) Start(ctx context.Context) {
 	log.Infof(ctx, "creating node certs (%dbit) in: %s", keyLen, certsDir)
 	l.createNodeCerts()
 
+	log.Infof(ctx, "starting %d nodes", len(l.Nodes))
 	l.monitorCtx, l.monitorCtxCancelFunc = context.WithCancel(context.Background())
 	go l.monitor(ctx)
 	var wg sync.WaitGroup
 	wg.Add(len(l.Nodes))
 	for _, node := range l.Nodes {
 		go func(node *testNode) {
+			defer wg.Done()
 			l.startNode(ctx, node)
-			wg.Done()
 		}(node)
 	}
 	wg.Wait()

--- a/pkg/cli/interactive_tests/test_log_flags.tcl
+++ b/pkg/cli/interactive_tests/test_log_flags.tcl
@@ -63,5 +63,23 @@ eexpect "parsing \"cantparse\": invalid syntax"
 eexpect ":/# "
 end_test
 
+start_test "Check that conflicting legacy and new flags are properly rejected for server commands"
+send "$argv start-single-node --insecure --logtostderr=true --log=abc\r"
+eexpect "log is incompatible with legacy discrete logging flag"
+eexpect ":/# "
+end_test
+
+start_test "Check that conflicting legacy and new flags are properly rejected for client commands"
+send "$argv sql --insecure --logtostderr=true --log=abc\r"
+eexpect "log is incompatible with legacy discrete logging flag"
+eexpect ":/# "
+end_test
+
+start_test "Check that the log flag is properly recognized for non-server commands"
+send "$argv debug reset-quorum 123 --log='sinks: {stderr: {format: json }}'\r"
+eexpect "\"severity\":\"ERROR\""
+eexpect "connection to server failed"
+eexpect ":/# "
+
 send "exit 0\r"
 eexpect eof


### PR DESCRIPTION
cc @taroface 

Release justification: bug fixes and low-risk updates to new functionality

Release note (bug fix): The non-server `cockroach` commands now
recognize the new `--log` flag properly. This had been broken
unadvertently in one of the earlier 21.1 alpha releases.