### PR TITLE
sql: fix bug where zone config gets created on ALTER PRIMARY KEY

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -174,6 +174,13 @@ child  CREATE TABLE public.child (
        FAMILY fam_0_x_y_z (x, y, z)
 )
 
+# Check zone configs behave as appropriate.
+query TT
+SELECT target, raw_config_sql FROM crdb_internal.zones
+WHERE target = 'TABLE test.public.child'
+----
+
+
 query T
 SELECT * FROM [EXPLAIN SELECT * FROM child WHERE y >=2 AND y <= 6] OFFSET 2
 ----

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -966,8 +966,10 @@ func RemoveIndexZoneConfigs(
 	zone, err := getZoneConfigRaw(ctx, txn, execCfg.Codec, tableID)
 	if err != nil {
 		return err
-	} else if zone == nil {
-		zone = zonepb.NewZoneConfig()
+	}
+	// If there are no zone configs, there's nothing to remove.
+	if zone == nil {
+		return nil
 	}
 
 	for _, indexDesc := range indexDescs {


### PR DESCRIPTION
Release justification: fix high-severity bug in existing functionality

Release note (bug fix): Fix a case where empty zone configurations get
created for certain indexes during ALTER PRIMARY KEY.