### PR TITLE
util/log: ensure that all channel logs are displayed with `-show-logs`

### DIFF
--- a/pkg/util/log/flags.go
+++ b/pkg/util/log/flags.go
@@ -53,10 +53,8 @@ func init() {
 	// Default stderrThreshold to log everything to the process'
 	// external stderr (OrigStderr).
 	defaultConfig.Sinks.Stderr.Filter = severity.INFO
-	// We only register it for the DEV channels. No other
-	// channels get a configuration, whereby every channel
-	// ends up sharing the DEV logger (debugLog).
-	defaultConfig.Sinks.Stderr.Channels.Channels = []logpb.Channel{channel.DEV}
+	// Ensure all channels go to stderr.
+	defaultConfig.Sinks.Stderr.Channels.Channels = logconfig.SelectAllChannels()
 	// We also don't capture internal writes to fd2 by default:
 	// let the writes go to the external stderr.
 	defaultConfig.CaptureFd2.Enable = false

--- a/pkg/util/log/flags_test.go
+++ b/pkg/util/log/flags_test.go
@@ -25,7 +25,7 @@ func TestAppliedStandaloneConfig(t *testing.T) {
 
 	const expected = `sinks:
   stderr:
-    channels: [DEV]
+    channels: all
     filter: INFO
     format: crdb-v2-tty
     redact: false

--- a/pkg/util/log/logconfig/config.go
+++ b/pkg/util/log/logconfig/config.go
@@ -564,7 +564,7 @@ func parseChannelList(s string) ([]logpb.Channel, error) {
 
 	// Special case: "ALL" selects all channels.
 	if s == "ALL" {
-		return selectAllChannels(), nil
+		return SelectAllChannels(), nil
 	}
 
 	// If channels starts with "all except", we invert the selection.
@@ -597,7 +597,7 @@ func selectChannels(invert bool, parts []string) ([]logpb.Channel, error) {
 			if len(parts) != 1 {
 				return nil, errors.New("cannot use ALL if there are other channel names present in the list")
 			}
-			return selectAllChannels(), nil
+			return SelectAllChannels(), nil
 		}
 
 		// Verify the channel name is known.
@@ -636,9 +636,9 @@ func selectChannels(invert bool, parts []string) ([]logpb.Channel, error) {
 	return selected, nil
 }
 
-// selectAllChannels returns a copy of channelValues,
+// SelectAllChannels returns a copy of channelValues,
 // for use in the ALL configuration.
-func selectAllChannels() []logpb.Channel {
+func SelectAllChannels() []logpb.Channel {
 	// Copy the default in case the code that uses a Config overwrites
 	// its channel list in-place.
 	chans := make([]logpb.Channel, 0, len(channelValues))


### PR DESCRIPTION
When `-show-logs` is specified, the `log.Scope` becomes a no-op and
the default configuration in the `log` package is used. This is the
only time ever when the default configuration is used.

Prior to this patch, only the logging for the DEV channel would
make its way to the standard error (and the test output) in that
case. This was unfortunate, since the intent (as spelled out in a
comment already) was to display everything.

This patch fixes that.

Release justification: non-production code changes

Release note: None