### PR TITLE
kvserver: handle range-level rebalancing of non-voting replicas

### DIFF
--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -2312,18 +2312,20 @@ func TestChangeReplicasSwapVoterWithNonVoter(t *testing.T) {
 	firstStore, err := tc.Server(0).GetStores().(*kvserver.Stores).GetStore(tc.Server(0).GetFirstStoreID())
 	require.NoError(t, err)
 	firstRepl := firstStore.LookupReplica(roachpb.RKey(key))
-	require.NotNil(t, firstRepl, `the first node in the TestCluster must have a replica for the ScratchRange`)
+	require.NotNil(t, firstRepl, "the first node in the TestCluster must have a"+
+		" replica for the ScratchRange")
 
+	tc.AddNonVotersOrFatal(t, key, nonVoter)
 	// TODO(aayush): Trying to swap the last voting replica with a non-voter hits
 	// the safeguard inside Replica.propose() as the last voting replica is always
 	// the leaseholder. There are a bunch of subtleties around getting a
 	// leaseholder to remove itself without another voter to immediately transfer
-	// the lease to. Determine if/how this needs to be fixed.
-	tc.AddNonVotersOrFatal(t, key, nonVoter)
+	// the lease to. See #40333.
 	_, err = tc.SwapVoterWithNonVoter(key, firstVoter, nonVoter)
 	require.Regexp(t, "received invalid ChangeReplicasTrigger", err)
 
 	tc.AddVotersOrFatal(t, key, secondVoter)
+
 	tc.SwapVoterWithNonVoterOrFatal(t, key, secondVoter, nonVoter)
 }
 

--- a/pkg/kv/kvserver/store_pool.go
+++ b/pkg/kv/kvserver/store_pool.go
@@ -384,11 +384,11 @@ func (sp *StorePool) updateLocalStoreAfterRebalance(
 		return
 	}
 	switch changeType {
-	case roachpb.ADD_VOTER:
+	case roachpb.ADD_VOTER, roachpb.ADD_NON_VOTER:
 		detail.desc.Capacity.RangeCount++
 		detail.desc.Capacity.LogicalBytes += rangeUsageInfo.LogicalBytes
 		detail.desc.Capacity.WritesPerSecond += rangeUsageInfo.WritesPerSecond
-	case roachpb.REMOVE_VOTER:
+	case roachpb.REMOVE_VOTER, roachpb.REMOVE_NON_VOTER:
 		detail.desc.Capacity.RangeCount--
 		if detail.desc.Capacity.LogicalBytes <= rangeUsageInfo.LogicalBytes {
 			detail.desc.Capacity.LogicalBytes = 0
@@ -400,6 +400,8 @@ func (sp *StorePool) updateLocalStoreAfterRebalance(
 		} else {
 			detail.desc.Capacity.WritesPerSecond -= rangeUsageInfo.WritesPerSecond
 		}
+	default:
+		return
 	}
 	sp.detailsMu.storeDetails[storeID] = &detail
 }

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -1397,6 +1397,22 @@ func MakeReplicationChanges(
 	return chgs
 }
 
+// ReplicationChangesForPromotion returns the replication changes that
+// correspond to the promotion of a non-voter to a voter.
+func ReplicationChangesForPromotion(target ReplicationTarget) []ReplicationChange {
+	return []ReplicationChange{
+		{ChangeType: ADD_VOTER, Target: target}, {ChangeType: REMOVE_NON_VOTER, Target: target},
+	}
+}
+
+// ReplicationChangesForDemotion returns the replication changes that correspond
+// to the demotion of a voter to a non-voter.
+func ReplicationChangesForDemotion(target ReplicationTarget) []ReplicationChange {
+	return []ReplicationChange{
+		{ChangeType: ADD_NON_VOTER, Target: target}, {ChangeType: REMOVE_VOTER, Target: target},
+	}
+}
+
 // AddChanges adds a batch of changes to the request in a backwards-compatible
 // way.
 func (acrr *AdminChangeReplicasRequest) AddChanges(chgs ...ReplicationChange) {

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1466,8 +1466,16 @@ var charts = []sectionDescription{
 				Metrics: []string{"queue.replicate.purgatory"},
 			},
 			{
-				Title:   "Reblance Count",
+				Title:   "Rebalance Count",
 				Metrics: []string{"queue.replicate.rebalancereplica"},
+			},
+			{
+				Title:   "Demotions of Voters to Non Voters",
+				Metrics: []string{"queue.replicate.voterdemotions"},
+			},
+			{
+				Title:   "Promotions of Non Voters to Voters",
+				Metrics: []string{"queue.replicate.nonvoterpromotions"},
 			},
 			{
 				Title: "Remove Replica Count",


### PR DESCRIPTION
First commit from #60029

This PR adds the necessary machinery within the allocator and the
plumbing within the replicateQueue to be able to rebalance non-voting
replicas.

A few things to note are:

Voting replicas are allowed to rebalance to nodes that already have a
non-voting replica. This will trigger what is, essentially, a metadata
operation: flipping the replica type of the corresponding non-voter to a
voter and the type of the voter to a non_voter. Notably, this PR changes
voter allocation code to also be able to do this.

Computation of diversity scores works slightly differently for voting
replicas and non-voting replicas. Non-voting replicas compute candidate
diversity scores based off of all existing replicas, whereas voting
replicas compute candidate diversity scores off of just the set of
voting replicas.

This PR does not yet add support in the store rebalancer to make rebalancing
decisions for non-voting replicas and we don't yet support removal/
replacement of dead and decommissioning non-voters. These things are
coming in follow-up PRs.

Release justification: necessary for non-voting replicas

Release note: None
