### PR TITLE
vendor: upgrade go-geom to pickup more GEOMETRYCOLLECTION EMPTY fixes

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -3240,8 +3240,8 @@ def go_deps():
         name = "com_github_twpayne_go_geom",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/twpayne/go-geom",
-        sum = "h1:yh2fcro1FLk9uTYi3OSXxtI3JRzaghtsNgaku2ASZbE=",
-        version = "v1.3.7-0.20210224233516-acd1d64d533a",
+        sum = "h1:SRMQNnhXCCgFBGAYFnM8iOSMYcOlOwkaTP3pwRCcuOY=",
+        version = "v1.3.7-0.20210228220813-9d9885b50d3e",
     )
     go_repository(
         name = "com_github_twpayne_go_kml",

--- a/go.mod
+++ b/go.mod
@@ -139,7 +139,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
-	github.com/twpayne/go-geom v1.3.7-0.20210224233516-acd1d64d533a
+	github.com/twpayne/go-geom v1.3.7-0.20210228220813-9d9885b50d3e
 	github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad
 	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c
 	github.com/zabawaba99/go-gitignore v0.0.0-20200117185801-39e6bddfb292

--- a/go.sum
+++ b/go.sum
@@ -964,8 +964,8 @@ github.com/tinylib/msgp v1.1.1/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDW
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
-github.com/twpayne/go-geom v1.3.7-0.20210224233516-acd1d64d533a h1:yh2fcro1FLk9uTYi3OSXxtI3JRzaghtsNgaku2ASZbE=
-github.com/twpayne/go-geom v1.3.7-0.20210224233516-acd1d64d533a/go.mod h1:XTyWHR6+l9TUYONbbK4ImUTYbWDCu2ySSPrZmmiA0Pg=
+github.com/twpayne/go-geom v1.3.7-0.20210228220813-9d9885b50d3e h1:SRMQNnhXCCgFBGAYFnM8iOSMYcOlOwkaTP3pwRCcuOY=
+github.com/twpayne/go-geom v1.3.7-0.20210228220813-9d9885b50d3e/go.mod h1:XTyWHR6+l9TUYONbbK4ImUTYbWDCu2ySSPrZmmiA0Pg=
 github.com/twpayne/go-kml v1.5.1 h1:RI0JKh/VzdK/d+ZxdJzt8Ar921KMYPfg9qkw7vsbAGw=
 github.com/twpayne/go-kml v1.5.1/go.mod h1:kz8jAiIz6FIdU2Zjce9qGlVtgFYES9vt7BTPBHf5jl4=
 github.com/twpayne/go-polyline v1.0.0/go.mod h1:ICh24bcLYBX8CknfvNPKqoTbe+eg+MX1NPyJmSBo7pU=

--- a/pkg/geo/geomfn/affine_transforms_test.go
+++ b/pkg/geo/geomfn/affine_transforms_test.go
@@ -280,10 +280,10 @@ func TestCollectionScaleRelativeToOrigin(t *testing.T) {
 		},
 		{
 			desc:     "scale empty collection",
-			input:    geom.NewGeometryCollection(),
+			input:    geom.NewGeometryCollection().MustSetLayout(geom.XY),
 			factor:   geom.NewPointFlat(geom.XY, []float64{2, 2}),
 			origin:   geom.NewPointFlat(geom.XY, []float64{1, 1}),
-			expected: geom.NewGeometryCollection(),
+			expected: geom.NewGeometryCollection().MustSetLayout(geom.XY),
 		},
 	}
 

--- a/pkg/geo/geomfn/flip_coordinates_test.go
+++ b/pkg/geo/geomfn/flip_coordinates_test.go
@@ -110,8 +110,8 @@ func TestFlipCoordinates(t *testing.T) {
 		},
 		{
 			desc:     "flip coordinates of an empty collection",
-			input:    geom.NewGeometryCollection(),
-			expected: geom.NewGeometryCollection(),
+			input:    geom.NewGeometryCollection().MustSetLayout(geom.XY),
+			expected: geom.NewGeometryCollection().MustSetLayout(geom.XY),
 		},
 	}
 


### PR DESCRIPTION
This allows us to further differentiate GEOMETRYCOLLECTION EMPTY from
GEOMETRYCOLLECTION Z/ZM/M EMPTY.

Release justification: low risk change to new functionality

Release note: None