### PR TITLE
builtins: implement ST_Affine

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1273,6 +1273,13 @@ the locality flag on node startup. Returns an error if no region is set.</p>
 </span></td></tr>
 <tr><td><a name="st_addpoint"></a><code>st_addpoint(line_string: geometry, point: geometry, index: <a href="int.html">int</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Adds a Point to a LineString at the given 0-based index (-1 to append).</p>
 </span></td></tr>
+<tr><td><a name="st_affine"></a><code>st_affine(geometry: geometry, a: <a href="float.html">float</a>, b: <a href="float.html">float</a>, c: <a href="float.html">float</a>, d: <a href="float.html">float</a>, e: <a href="float.html">float</a>, f: <a href="float.html">float</a>, g: <a href="float.html">float</a>, h: <a href="float.html">float</a>, i: <a href="float.html">float</a>, x_off: <a href="float.html">float</a>, y_off: <a href="float.html">float</a>, z_off: <a href="float.html">float</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Applies a 3D affine transformation to the given geometry.</p>
+<p>The matrix transformation will be applied as follows for each coordinate:
+/ a  b  c x_off \  / x <br />
+| d  e  f y_off |  | y |
+| g  h  i z_off |  | z |
+\ 0  0  0     1 /  \ 0 /</p>
+</span></td></tr>
 <tr><td><a name="st_affine"></a><code>st_affine(geometry: geometry, a: <a href="float.html">float</a>, b: <a href="float.html">float</a>, d: <a href="float.html">float</a>, e: <a href="float.html">float</a>, x_off: <a href="float.html">float</a>, y_off: <a href="float.html">float</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Applies a 2D affine transformation to the given geometry.</p>
 <p>The matrix transformation will be applied as follows for each coordinate:
 / a  b  x_off \  / x <br />

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -4862,6 +4862,26 @@ POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))           POLYGON ((4.9 5.7, 6 9, 8
 POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))                 POLYGON ((4 3, 5 6, 7 10, 6 7, 4 3))
 POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))                    POLYGON ((5 6, 6 9, 8 13, 7 10, 5 6))
 
+query TT
+SELECT
+  ST_AsText(a.geom) d,
+  ST_AsText(ST_Affine(a.geom, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12), 3)
+FROM geom_operators_test a
+ORDER BY d ASC
+----
+NULL                                                   NULL
+GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (10 11)))
+GEOMETRYCOLLECTION EMPTY                               GEOMETRYCOLLECTION EMPTY
+LINESTRING (-0.5 0.5, 0.5 0.5)                         LINESTRING (10.5 11.5, 11.5 15.5)
+LINESTRING EMPTY                                       LINESTRING EMPTY
+POINT (-0.5 0.5)                                       POINT (10.5 11.5)
+POINT (0.5 0.5)                                        POINT (11.5 15.5)
+POINT (5 5)                                            POINT (25 56)
+POINT EMPTY                                            POINT EMPTY
+POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))           POLYGON ((9.9 10.6, 11 15, 13 20, 11.9 15.6, 9.9 10.6))
+POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))                 POLYGON ((9 7, 10 11, 12 16, 11 12, 9 7))
+POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))                    POLYGON ((10 11, 11 15, 13 20, 12 16, 10 11))
+
 query T
 SELECT ST_Summary('POINT(0 0)'::geometry)
 ----

--- a/pkg/sql/logictest/testdata/logic_test/geospatial_zm
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial_zm
@@ -100,3 +100,9 @@ POINT (1 2)
 POINT Z (1 2 3)
 POINT ZM (1 2 3 4)
 POINT M (1 2 3)
+
+query TT
+SELECT
+  ST_AsText(a.geom) d,
+  ST_AsText(ST_Affine(a.geom, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12), 3)
+FROM geom_operators_test a

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -4232,6 +4232,51 @@ The matrix transformation will be applied as follows for each coordinate:
 			}.String(),
 			Volatility: tree.VolatilityImmutable,
 		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"geometry", types.Geometry},
+				{"a", types.Float},
+				{"b", types.Float},
+				{"c", types.Float},
+				{"d", types.Float},
+				{"e", types.Float},
+				{"f", types.Float},
+				{"g", types.Float},
+				{"h", types.Float},
+				{"i", types.Float},
+				{"x_off", types.Float},
+				{"y_off", types.Float},
+				{"z_off", types.Float},
+			},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				g := tree.MustBeDGeometry(args[0])
+				ret, err := geomfn.Affine(
+					g.Geometry,
+					geomfn.AffineMatrix([][]float64{
+						{float64(tree.MustBeDFloat(args[1])), float64(tree.MustBeDFloat(args[2])), float64(tree.MustBeDFloat(args[3])), float64(tree.MustBeDFloat(args[10]))},
+						{float64(tree.MustBeDFloat(args[4])), float64(tree.MustBeDFloat(args[5])), float64(tree.MustBeDFloat(args[6])), float64(tree.MustBeDFloat(args[11]))},
+						{float64(tree.MustBeDFloat(args[7])), float64(tree.MustBeDFloat(args[8])), float64(tree.MustBeDFloat(args[9])), float64(tree.MustBeDFloat(args[12]))},
+						{0, 0, 0, 1},
+					}),
+				)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(ret), nil
+			},
+			Info: infoBuilder{
+				info: `Applies a 3D affine transformation to the given geometry.
+
+The matrix transformation will be applied as follows for each coordinate:
+/ a  b  c x_off \  / x \
+| d  e  f y_off |  | y |
+| g  h  i z_off |  | z |
+\ 0  0  0     1 /  \ 0 /
+				`,
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
 	),
 	"st_scale": makeBuiltin(
 		defProps(),


### PR DESCRIPTION
This PR implements the geometry builtin ST_Affine for 3D transformations. See [PostGIS's ST_Affine _version 1_](https://postgis.net/docs/ST_Affine.html)

Resolves #60874.

Release note (sql change): The geography builtin ST_Affine now supports 3D transformations.

(apologies in advance if I missed anything)