### PR TITLE
cli: command misaligned usage

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1429,9 +1429,8 @@ Available Commands:
 
 Flags:
   -h, --help                 help for cockroach
-      --log <string>         
-                                     Logging configuration. See the documentation for details.
-                                    
+      --log <string>         Logging configuration. See the documentation for details.
+                             
       --version              version for cockroach
 
 Use "cockroach [command] --help" for more information about a command.

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -80,7 +80,7 @@ func wrapDescription(s string) string {
 // * indentation
 // * env variable name (if set)
 func (f FlagInfo) Usage() string {
-	s := "\n" + wrapDescription(f.Description) + "\n"
+	s := wrapDescription(f.Description) + "\n"
 	if f.EnvVar != "" {
 		// Check that the environment variable name matches the flag name. Note: we
 		// don't want to automatically generate the name so that grepping for a flag
@@ -92,10 +92,7 @@ func (f FlagInfo) Usage() string {
 		}
 		s = s + "Environment variable: " + f.EnvVar + "\n"
 	}
-	// github.com/spf13/pflag appends the default value after the usage text. Add
-	// the correct indentation (7 spaces) here. This is admittedly fragile.
-	return text.Indent(s, strings.Repeat(" ", usageIndentation)) +
-		strings.Repeat(" ", usageIndentation-1)
+	return s
 }
 
 // Attrs and others store the static information for CLI flags.


### PR DESCRIPTION
The CLI command usage printing has misaligned text due to indentation
we are doing on the description.

This commit fixes the indentation of the description and also aligns
it parallels to the flag name

Fixes #49345

Release justification: non-production code changes

Release note: None

Signed-off-by: Tharun <rajendrantharun@live.com>

Before:
<img width="1010" alt="before" src="https://user-images.githubusercontent.com/14926492/109479344-4bccc880-7aa0-11eb-9c85-53c490f2aa07.png">

You can see `help` description and global flag description are not properly intended and also flag description is not present at the same level.

After: 
<img width="966" alt="Screen Shot 2021-03-01 at 3 10 14 PM" src="https://user-images.githubusercontent.com/14926492/109479567-846ca200-7aa0-11eb-9f9d-60ddb74a8029.png">

