### PR TITLE
cli: Fix demo command's nodeName argument index while returning error

### DIFF
--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -546,7 +546,7 @@ func (c *cliState) handleDemo(cmd []string, nextState, errState cliStateEnum) cl
 	}
 
 	if len(cmd) != 2 {
-		return c.invalidSyntax(errState, `\demo expects 2 parameters`)
+		return c.invalidSyntax(errState, `\demo expects 2 parameters, but passed %v`, len(cmd))
 	}
 
 	// Special case the add command it takes a string instead of a node number.
@@ -588,7 +588,7 @@ func (c *cliState) handleDemoNodeCommands(
 		return c.invalidSyntax(
 			errState,
 			"%s",
-			errors.Wrapf(err, "cannot convert %s to string", cmd[2]).Error(),
+			errors.Wrapf(err, "cannot convert %s to string", cmd[1]),
 		)
 	}
 

--- a/pkg/cli/sql_test.go
+++ b/pkg/cli/sql_test.go
@@ -234,6 +234,18 @@ func TestHandleCliCmdSlashDInvalidSyntax(t *testing.T) {
 	}
 }
 
+func TestHandleDemoNodeCommandsInvalidNodeName(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	initCLIDefaults()
+
+	demoNodeCommandTests := []string{"shutdown", "*"}
+
+	c := setupTestCliState()
+	c.handleDemoNodeCommands(demoNodeCommandTests, cliStateEnum(0), cliStateEnum(1))
+	assert.Equal(t, errInvalidSyntax, c.exitErr)
+}
+
 func setupTestCliState() cliState {
 	c := cliState{}
 	c.ins = noLineEditor


### PR DESCRIPTION
Release justification: fixes for high-priority or high-severity bugs
in existing functionality.

The demo command has a wrong nodeName index args while returning an error
which is leading to panic.
To address this, this patch contains the correct args index for nodeName.

Release note (bug fix): Fix demo commands nodeName error argument index handling.

Signed-off-by: Tharun <rajendrantharun@live.com>