### PR TITLE
cli: Hide pprof port flag in workload init and run

### DIFF
--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -72,6 +72,9 @@ var histogramsMaxLatency = runFlags.Duration(
 	"Expected maximum latency of running a query")
 
 func init() {
+
+	_ = sharedFlags.MarkHidden("pprofport")
+
 	AddSubCmd(func(userFacing bool) *cobra.Command {
 		var initCmd = SetCmdDefaults(&cobra.Command{
 			Use:   `init`,


### PR DESCRIPTION
Release justification: non-production code changes

Previously, pprof-port flag is visible on workload
and now it is removed from the docs.

This patch contains hiding the flag on workload command

Resolves #39566

Release note (cli-change): None

Signed-off-by: Tharun <rajendrantharun@live.com>