### PR TITLE
cli: fix inconsistent db admin-ui naming

### DIFF
--- a/pkg/cli/demo_cluster.go
+++ b/pkg/cli/demo_cluster.go
@@ -892,18 +892,18 @@ func (c *transientCluster) listDemoNodes(w io.Writer, justOne bool) {
 			serverURL.Path = server.DemoLoginPath
 			serverURL.RawQuery = pwauth.Encode()
 		}
-		fmt.Fprintf(w, "  (console) %s\n", serverURL)
+		fmt.Fprintln(w, "  (console) ", serverURL)
 		// Print unix socket if defined.
 		if c.useSockets {
 			sock := c.sockForServer(nodeID)
-			fmt.Fprintln(w, "  (sql)    ", sock)
+			fmt.Fprintln(w, "  (sql/unix)", sock)
 		}
 		// Print network URL if defined.
 		netURL, err := c.getNetworkURLForServer(i, nil, false /*includeAppName*/)
 		if err != nil {
 			fmt.Fprintln(stderr, errors.Wrap(err, "retrieving network URL"))
 		} else {
-			fmt.Fprintln(w, "  (sql/tcp)", netURL)
+			fmt.Fprintln(w, "  (sql)     ", netURL)
 		}
 		fmt.Fprintln(w)
 	}

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -607,7 +607,7 @@ If problems persist, please see %s.`
 			buf.Printf("CockroachDB node starting at %s (took %0.1fs)\n", timeutil.Now(), timeutil.Since(tBegin).Seconds())
 			buf.Printf("build:\t%s %s @ %s (%s)\n",
 				redact.Safe(info.Distribution), redact.Safe(info.Tag), redact.Safe(info.Time), redact.Safe(info.GoVersion))
-			buf.Printf("webui:\t%s\n", serverCfg.AdminURL())
+			buf.Printf("console:\t%s\n", serverCfg.AdminURL())
 
 			// (Re-)compute the client connection URL. We cannot do this
 			// earlier (e.g. above, in the runStart function) because


### PR DESCRIPTION
Release justification: non-production code changes

making admin-ui name to be consistent across
start and demo commands

Resolves #56993 #47977

Release note: None

Signed-off-by: Tharun <rajendrantharun@live.com>