### PR TITLE
release-20.2: sql: make schema change jobs for databases and schemas non-cancelable

### DIFF
--- a/pkg/sql/drop_schema.go
+++ b/pkg/sql/drop_schema.go
@@ -207,7 +207,8 @@ func (p *planner) createDropSchemaJob(
 			// drop schemas.
 			FormatVersion: jobspb.DatabaseJobFormatVersion,
 		},
-		Progress: jobspb.SchemaChangeProgress{},
+		Progress:      jobspb.SchemaChangeProgress{},
+		NonCancelable: true,
 	})
 	return err
 }

--- a/pkg/sql/schema.go
+++ b/pkg/sql/schema.go
@@ -79,7 +79,8 @@ func (p *planner) writeSchemaDescChange(
 				// jobs.
 				FormatVersion: jobspb.DatabaseJobFormatVersion,
 			},
-			Progress: jobspb.SchemaChangeProgress{},
+			Progress:      jobspb.SchemaChangeProgress{},
+			NonCancelable: true,
 		}
 		newJob, err := p.extendedEvalCtx.QueueJob(jobRecord)
 		if err != nil {

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -65,7 +65,8 @@ func (p *planner) createDropDatabaseJob(
 			DroppedDatabaseID: databaseID,
 			FormatVersion:     formatVersion,
 		},
-		Progress: jobspb.SchemaChangeProgress{},
+		Progress:      jobspb.SchemaChangeProgress{},
+		NonCancelable: true,
 	}
 	newJob, err := p.extendedEvalCtx.QueueJob(jobRecord)
 	if err != nil {
@@ -93,7 +94,8 @@ func (p *planner) createNonDropDatabaseChangeJob(
 			DescID:        databaseID,
 			FormatVersion: formatVersion,
 		},
-		Progress: jobspb.SchemaChangeProgress{},
+		Progress:      jobspb.SchemaChangeProgress{},
+		NonCancelable: true,
 	}
 	newJob, err := p.extendedEvalCtx.QueueJob(jobRecord)
 	if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #61210.

/cc @cockroachdb/release

---

Schema change jobs to drop, rename, or change privileges on databases
and schemas cannot be meaningfully reverted, because they just wait for
leases to drain, or handle draining names when applicable. Currently, if
we ever enter `OnFailOrCancel` for a schema change job on a database or
schema, we return with an error. This PR reduces the risk of this
happening by disallowing cancelation of these jobs.

Partially addresses #59545.

Release note (bug fix): Schema change jobs associated with databases and
schemas can no longer be canceled. Such jobs cannot actually be reverted
successfully, so cancelation had no benefit and could have caused
namespace corruption.
