### PR TITLE
release-20.2: sql: deal with column renames on existing mutations

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/rename_column
+++ b/pkg/sql/logictest/testdata/logic_test/rename_column
@@ -142,3 +142,43 @@ SELECT species FROM users
 ----
 cat woo
 rat woo
+
+# Test that renaming columns works inside transactions that create resources
+# which reference those columns.
+
+subtest rename_in_transaction
+
+statement ok
+CREATE TABLE foo (j INT);
+
+statement ok
+BEGIN;
+    ALTER TABLE foo ADD CONSTRAINT check_not_negative CHECK (j >= 0);
+    ALTER TABLE foo RENAME COLUMN j TO i;
+COMMIT;
+
+statement ok
+BEGIN;
+    ALTER TABLE foo ADD COLUMN k INT AS (i+1) STORED;
+    ALTER TABLE foo RENAME COLUMN i TO j;
+COMMIT;
+
+statement ok
+BEGIN;
+    ALTER TABLE foo ALTER COLUMN j SET NOT NULL;
+    ALTER TABLE foo RENAME COLUMN j TO i;
+COMMIT;
+
+statement ok
+BEGIN;
+    CREATE INDEX ON foo(i) WHERE i > 0;
+    ALTER TABLE foo RENAME COLUMN i TO j;
+COMMIT;
+
+statement ok
+INSERT INTO foo(j) VALUES (1);
+
+query II
+SELECT j, k FROM foo;
+----
+1  2

--- a/pkg/sql/rename_column.go
+++ b/pkg/sql/rename_column.go
@@ -149,7 +149,6 @@ func (p *planner) renameColumn(
 	}
 
 	// Rename the column in CHECK constraints.
-	// Renaming columns that are being referenced by checks that are being added is not allowed.
 	for i := range tableDesc.Checks {
 		var err error
 		tableDesc.Checks[i].Expr, err = schemaexpr.RenameColumn(tableDesc.Checks[i].Expr, *oldName, *newName)
@@ -177,6 +176,38 @@ func (p *planner) renameColumn(
 				return false, err
 			}
 			index.Predicate = newExpr
+		}
+	}
+
+	// Do all of the above renames inside check constraints, computed expressions,
+	// and index predicates that are in mutations.
+	for i := range tableDesc.Mutations {
+		m := &tableDesc.Mutations[i]
+		if constraint := m.GetConstraint(); constraint != nil {
+			if constraint.ConstraintType == descpb.ConstraintToUpdate_CHECK ||
+				constraint.ConstraintType == descpb.ConstraintToUpdate_NOT_NULL {
+				var err error
+				constraint.Check.Expr, err = schemaexpr.RenameColumn(constraint.Check.Expr, *oldName, *newName)
+				if err != nil {
+					return false, err
+				}
+			}
+		} else if otherCol := m.GetColumn(); otherCol != nil {
+			if otherCol.IsComputed() {
+				newExpr, err := schemaexpr.RenameColumn(*otherCol.ComputeExpr, *oldName, *newName)
+				if err != nil {
+					return false, err
+				}
+				otherCol.ComputeExpr = &newExpr
+			}
+		} else if index := m.GetIndex(); index != nil {
+			if index.IsPartial() {
+				var err error
+				index.Predicate, err = schemaexpr.RenameColumn(index.Predicate, *oldName, *newName)
+				if err != nil {
+					return false, err
+				}
+			}
 		}
 	}
 

--- a/pkg/sql/tests/rename_column_test.go
+++ b/pkg/sql/tests/rename_column_test.go
@@ -1,0 +1,123 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"context"
+	"path"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRenameColumnDuringConcurrentMutation tests the behavior of renaming
+// a column that was created in a different, prior transaction but is not
+// yet public.
+func TestRenameColumnDuringConcurrentMutation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// The structure of the test is to intentionally block a complex
+	// column addition schema change at various events and then issue
+	// a rename while it is blocked. The events are hooked up via testing
+	// knobs.
+	type eventType int
+
+	const (
+		_ eventType = iota
+		publishDeleteAndWriteOnly
+		backfill
+		resume
+	)
+
+	type event struct {
+		unblock chan struct{}
+	}
+	var eventToBlockOn eventType
+	eventChan := make(chan event)
+	maybeBlockOnEvent := func(evType eventType) {
+		if evType != eventToBlockOn {
+			return
+		}
+		ev := event{
+			unblock: make(chan struct{}),
+		}
+		eventChan <- ev
+		<-ev.unblock
+	}
+	ctx := context.Background()
+	var tc *testcluster.TestCluster
+	tc = testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+					RunBeforePublishWriteAndDelete: func() {
+						maybeBlockOnEvent(publishDeleteAndWriteOnly)
+					},
+					RunBeforeBackfill: func() error {
+						maybeBlockOnEvent(backfill)
+						return nil
+					},
+					RunBeforeResume: func(jobID int64) error {
+						// Load the job to figure out if it's the rename or the
+						// backfill.
+						scJob, err := tc.Server(0).JobRegistry().(*jobs.Registry).LoadJob(ctx, jobID)
+						if err != nil {
+							return err
+						}
+						pl := scJob.Payload()
+						if pl.GetSchemaChange().TableMutationID == descpb.InvalidMutationID {
+							return nil
+						}
+						maybeBlockOnEvent(resume)
+						return nil
+					},
+				},
+			},
+		},
+	})
+	defer tc.Stopper().Stop(ctx)
+	for _, testCase := range []struct {
+		name   string
+		evType eventType
+	}{
+		{"publishDeleteAndWriteOnly", publishDeleteAndWriteOnly},
+		{"backfill", backfill},
+		{"resume", resume},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			eventToBlockOn = testCase.evType
+			dbName := path.Base(t.Name())
+			tdb := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+			tdb.Exec(t, "CREATE DATABASE "+dbName)
+			tdb.Exec(t, "CREATE TABLE "+dbName+".foo (i INT PRIMARY KEY)")
+			scDone := make(chan error)
+			go func() {
+				_, err := tc.ServerConn(0).Exec(
+					"ALTER TABLE " + dbName + ".foo ADD COLUMN j INT NOT NULL DEFAULT 7 CHECK (j > 0) REFERENCES " + dbName + ".foo(i)")
+				scDone <- err
+			}()
+
+			ev := <-eventChan
+			tdb.Exec(t, "ALTER TABLE "+dbName+".foo RENAME COLUMN j TO k")
+			close(ev.unblock)
+			require.NoError(t, <-scDone)
+			tdb.Exec(t, "INSERT INTO "+dbName+".foo(i, k) VALUES (7, 7)")
+		})
+	}
+
+}


### PR DESCRIPTION
Backport 1/1 commits from #59384.

/cc @cockroachdb/release

---

This fixes a rather egregious bug that prevented renaming of columns which
have been referenced in earlier mutations.

Release note (bug fix): Fixed a bug which prevented renaming a column that
was referenced earlier in a transaction as part of a computed expression,
index predicate, check expression, or not null constraint.
