### PR TITLE
release-20.2: sql: prevent DROP SCHEMA CASCADE from droping types with references

### DIFF
--- a/pkg/sql/drop_type.go
+++ b/pkg/sql/drop_type.go
@@ -97,17 +97,9 @@ func (p *planner) canDropTypeDesc(
 		return err
 	}
 	if len(desc.ReferencingDescriptorIDs) > 0 && behavior != tree.DropCascade {
-		var dependentNames []string
-		for _, id := range desc.ReferencingDescriptorIDs {
-			desc, err := p.Descriptors().GetMutableTableVersionByID(ctx, id, p.txn)
-			if err != nil {
-				return errors.Wrapf(err, "type has dependent objects")
-			}
-			fqName, err := p.getQualifiedTableName(ctx, desc)
-			if err != nil {
-				return errors.Wrapf(err, "type %q has dependent objects", desc.Name)
-			}
-			dependentNames = append(dependentNames, fqName.FQString())
+		dependentNames, err := p.getFullyQualifiedTableNamesFromIDs(ctx, desc.ReferencingDescriptorIDs)
+		if err != nil {
+			return errors.Wrapf(err, "type %q has dependent objects", desc.Name)
 		}
 		return pgerror.Newf(
 			pgcode.DependentObjectsStillExist,

--- a/pkg/sql/logictest/testdata/logic_test/drop_type
+++ b/pkg/sql/logictest/testdata/logic_test/drop_type
@@ -353,3 +353,24 @@ subtest regression_58461
 statement ok
 CREATE TYPE pet AS ENUM('cat');
 DROP TYPE IF EXISTS pet, alien;
+
+# Test that dropping a schema which contains a type which refers to things
+# outside of that schema works.
+
+subtest drop_schema_cascade
+
+statement ok
+CREATE SCHEMA schema_to_drop;
+CREATE TYPE schema_to_drop.typ AS ENUM ('a');
+CREATE TABLE t (k schema_to_drop.typ PRIMARY KEY);
+CREATE TABLE schema_to_drop.t (k schema_to_drop.typ PRIMARY KEY);
+
+statement error pgcode 0A000 unimplemented: cannot drop type "test.schema_to_drop._typ" because other objects \(\[test\.public\.t\]\) still depend on it
+DROP SCHEMA schema_to_drop CASCADE;
+
+statement ok
+DROP TABLE t;
+
+statement ok
+DROP SCHEMA schema_to_drop CASCADE;
+

--- a/pkg/sql/logictest/testdata/logic_test/drop_type
+++ b/pkg/sql/logictest/testdata/logic_test/drop_type
@@ -374,3 +374,22 @@ DROP TABLE t;
 statement ok
 DROP SCHEMA schema_to_drop CASCADE;
 
+# Test that dropping a table via a DROP SCHEMA CASCADE properly removes
+# back-references to types in different schemas which are not being dropped.
+
+statement ok
+CREATE SCHEMA sc1;
+CREATE SCHEMA sc2;
+CREATE TYPE sc2.typ AS ENUM ('a');
+CREATE TABLE sc1.table (k sc2.typ);
+DROP SCHEMA sc1 CASCADE;
+
+
+# If the backreference to the type had not been properly removed
+# for sc1.table above, the below statement would fail.
+statement ok
+DROP TYPE sc2.typ;
+
+# This is just cleanup.
+statement ok
+DROP SCHEMA sc2 CASCADE;

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -394,6 +394,31 @@ func getDescriptorsFromTargetListForPrivilegeChange(
 	return descs, nil
 }
 
+// getFullyQualifiedTableNamesFromIDs resolves a list of table IDs to their
+// fully qualified names.
+func (p *planner) getFullyQualifiedTableNamesFromIDs(
+	ctx context.Context, ids []descpb.ID,
+) (fullyQualifiedNames []*tree.TableName, _ error) {
+	for _, id := range ids {
+		desc, err := p.Descriptors().GetTableVersionByID(ctx, p.txn, id, tree.ObjectLookupFlags{
+			CommonLookupFlags: tree.CommonLookupFlags{
+				AvoidCached:    true,
+				IncludeDropped: true,
+				IncludeOffline: true,
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		fqName, err := p.getQualifiedTableName(ctx, desc)
+		if err != nil {
+			return nil, err
+		}
+		fullyQualifiedNames = append(fullyQualifiedNames, fqName)
+	}
+	return fullyQualifiedNames, nil
+}
+
 // getQualifiedTableName returns the database-qualified name of the table
 // or view represented by the provided descriptor. It is a sort of
 // reverse of the Resolve() functions.


### PR DESCRIPTION
Backport 2/2 commits from #59281.

/cc @cockroachdb/release

---

Before this patch, a DROP SCHEMA CASCADE could cause database corruption
by dropping types which were referenced by other tables. This would lead to
bad errors like:

```
ERROR: object already exists: desc 687: type ID 685 in descriptor not found: descriptor not found
SQLSTATE: 42710
```

And doctor errors like:
```
   Table 687: ParentID  50, ParentSchemaID 29, Name 't': type ID 685 in descriptor not found: descriptor not found
```

Fixes #59021.

Release note (bug fix): Fixed a bug where `DROP SCHEMA ... CASCADE` could
result in types which are referenced being dropped.
