### PR TITLE
release-20.2: sql: fixed a bug in crdb_internal.unsafe_upsert_namespace_entry validation

### DIFF
--- a/pkg/sql/repair.go
+++ b/pkg/sql/repair.go
@@ -258,14 +258,14 @@ func (p *planner) UnsafeUpsertNamespaceEntry(
 			return nil
 		}
 		schema, err := p.Descriptors().GetMutableDescriptorByID(
-			ctx, parentID, p.txn,
+			ctx, parentSchemaID, p.txn,
 		)
 		if err != nil {
 			return err
 		}
 		if _, isSchema := schema.(catalog.SchemaDescriptor); !isSchema {
 			return pgerror.Newf(pgcode.InvalidCatalogName,
-				"parentSchemaID %d is a %T, not a schema", parentID, schema)
+				"parentSchemaID %d is a %T, not a schema", parentSchemaID, schema)
 		}
 		return nil
 	}


### PR DESCRIPTION
Backport 1/3 commits from #60510.

/cc @cockroachdb/release

---

This bug would have prevented injecting a namespace entry for tables or
types in user-defined schemas.

Release note (bug fix): Fixed a bug in
`crdb_internal.unsafe_upsert_namespace_entry` related to tables and types
in user-defined schemas.