### PR TITLE
bazel: Stringer missing files.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -112,6 +112,7 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 # gazelle:exclude pkg/sql/privilege/kind_string.go
 # gazelle:exclude pkg/sql/roleoption/option_string.go
 # gazelle:exclude pkg/sql/schemachange/columnconversionkind_string.go
+# gazelle:exclude pkg/sql/schemachanger/scop/type_string.go
 # gazelle:exclude pkg/sql/sem/tree/createtypevariety_string.go
 # gazelle:exclude pkg/sql/sem/tree/statementtype_string.go
 # gazelle:exclude pkg/sql/txnevent_string.go
@@ -120,6 +121,7 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 # gazelle:exclude pkg/util/timeutil/pgdate/field_string.go
 # gazelle:exclude pkg/util/timeutil/pgdate/parsemode_string.go
 # gazelle:exclude pkg/workload/schemachange/optype_string.go
+# gazelle:exclude pkg/workload/schemachange/txstatus_string.go
 # gazelle:exclude pkg/geo/wkt/wkt_generated.go
 # gazelle:exclude pkg/sql/schemachanger/scop/backfill_visitor_generated.go
 # gazelle:exclude pkg/sql/schemachanger/scop/mutation_visitor_generated.go

--- a/pkg/sql/schemachanger/scop/BUILD.bazel
+++ b/pkg/sql/schemachanger/scop/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//build:STRINGER.bzl", "stringer")
 
 go_library(
     name = "scop",
@@ -6,10 +7,10 @@ go_library(
         "backfill.go",
         "mutation.go",
         "ops.go",
-        "type_string.go",
         "validation.go",
         ":gen-backfill",  # keep
         ":gen-mutation",  # keep
+        ":gen-type-stringer",  # keep
         ":gen-validation",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop",
@@ -65,4 +66,10 @@ genrule(
     exec_tools = [
         ":gen-visitors",
     ],
+)
+
+stringer(
+    name = "gen-type-stringer",
+    src = "ops.go",
+    typ = "Type",
 )

--- a/pkg/workload/schemachange/BUILD.bazel
+++ b/pkg/workload/schemachange/BUILD.bazel
@@ -9,11 +9,9 @@ go_library(
         "error_screening.go",
         "operation_generator.go",
         "schemachange.go",
-        # TODO(alanmas,irfansharif): Generate this stringer file within the
-        # sandbox as well.
-        "txstatus_string.go",
         "type_resolver.go",
         ":gen-optype-stringer",  # keep
+        ":gen-txstatus-stringer",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/workload/schemachange",
     visibility = ["//visibility:public"],
@@ -36,12 +34,6 @@ go_library(
         "@com_github_lib_pq//oid",
         "@com_github_spf13_pflag//:pflag",
     ],
-)
-
-stringer(
-    name = "gen-optype-stringer",
-    src = "operation_generator.go",
-    typ = "opType",
 )
 
 go_test(
@@ -68,4 +60,16 @@ go_test(
         "@com_github_stretchr_testify//require",
         "@org_golang_x_sync//errgroup",
     ],
+)
+
+stringer(
+    name = "gen-optype-stringer",
+    src = "operation_generator.go",
+    typ = "opType",
+)
+
+stringer(
+    name = "gen-txstatus-stringer",
+    src = "schemachange.go",
+    typ = "TxStatus",
 )

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -291,12 +291,22 @@ type TxStatus int
 
 //go:generate stringer -type TxStatus
 const (
-	TxStatusInFailure       TxStatus = pgx.TxStatusInFailure
-	TxStatusRollbackFailure TxStatus = pgx.TxStatusRollbackFailure
-	TxStatusCommitFailure   TxStatus = pgx.TxStatusCommitFailure
-	TxStatusInProgress      TxStatus = pgx.TxStatusInProgress
-	TxStatusCommitSuccess   TxStatus = pgx.TxStatusCommitSuccess
-	TxStatusRollbackSuccess TxStatus = pgx.TxStatusRollbackSuccess
+	TxStatusInFailure       TxStatus = -3
+	TxStatusRollbackFailure TxStatus = -2
+	TxStatusCommitFailure   TxStatus = -1
+	TxStatusInProgress      TxStatus = 0
+	TxStatusCommitSuccess   TxStatus = 1
+	TxStatusRollbackSuccess TxStatus = 2
+)
+
+// Workaround to do compile-time asserts that values are equal.
+const (
+	_ = uint((TxStatusInFailure - pgx.TxStatusInFailure) * (pgx.TxStatusInFailure - TxStatusInFailure))
+	_ = uint((TxStatusRollbackFailure - pgx.TxStatusRollbackFailure) * (pgx.TxStatusRollbackFailure - TxStatusRollbackFailure))
+	_ = uint((TxStatusCommitFailure - pgx.TxStatusCommitFailure) * (pgx.TxStatusCommitFailure - TxStatusCommitFailure))
+	_ = uint((TxStatusInProgress - pgx.TxStatusInProgress) * (pgx.TxStatusInProgress - TxStatusInProgress))
+	_ = uint((TxStatusCommitSuccess - pgx.TxStatusCommitSuccess) * (pgx.TxStatusCommitSuccess - TxStatusCommitSuccess))
+	_ = uint((TxStatusRollbackSuccess - pgx.TxStatusRollbackSuccess) * (pgx.TxStatusRollbackSuccess - TxStatusRollbackSuccess))
 )
 
 // MarshalJSON encodes a TxStatus to a string.


### PR DESCRIPTION
This is the last part of the stringer auto-generated .go files that we need to include within bazel sandbox #57787
some of these files need an specific treatment so we might need to create a custom genrule.


Release note: None

Release justification: non-production code changes