### PR TITLE
bazel: pin c++ toolchain to clang 10.0 for dev work

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -133,6 +133,31 @@ load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
 
+# Load up the pinned clang toolchain.
+
+http_archive(
+    name = "com_grail_bazel_toolchain",
+    sha256 = "b924b102adc0c3368d38a19bd971cb4fa75362a27bc363d0084b90ca6877d3f0",
+    strip_prefix = "bazel-toolchain-0.5.7",
+    urls = ["https://github.com/grailbio/bazel-toolchain/archive/0.5.7.tar.gz"],
+)
+
+load("@com_grail_bazel_toolchain//toolchain:deps.bzl", "bazel_toolchain_dependencies")
+
+bazel_toolchain_dependencies()
+
+load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
+
+llvm_toolchain(
+    name = "llvm_toolchain",
+    absolute_paths = True,
+    llvm_version = "10.0.0",
+)
+
+load("@llvm_toolchain//:toolchains.bzl", "llvm_register_toolchains")
+
+llvm_register_toolchains()
+
 # Load up cockroachdb's go dependencies (the ones listed under go.mod). The
 # `DEPS.bzl` file is kept up to date using the `update-repos` Gazelle command
 # (see `make bazel-generate`).
@@ -148,15 +173,15 @@ load("//c-deps:REPOSITORIES.bzl", "c_deps")
 c_deps()
 
 # Load the bazel utility that lets us build C/C++ projects using
-# cmake/make/etc. We point our fork which adds autoconf support
-# (https://github.com/bazelbuild/rules_foreign_cc/pull/432) and BSD support
-# (https://github.com/bazelbuild/rules_foreign_cc/pull/387).
+# cmake/make/etc. We point to our fork which adds BSD support
+# (https://github.com/bazelbuild/rules_foreign_cc/pull/387) and sysroot
+# support (https://github.com/bazelbuild/rules_foreign_cc/pull/532).
 #
 # TODO(irfansharif): Point to an upstream SHA once maintainers pick up the
 # aforementioned PRs.
 git_repository(
     name = "rules_foreign_cc",
-    commit = "8fdca4480f3fa9c084f4a73749a46fa17996beb1",
+    commit = "6127817283221408069d4ae6765f2d8144f09b9f",
     remote = "https://github.com/cockroachdb/rules_foreign_cc",
 )
 

--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
     gnupg2 \
     libncurses-dev \
     make \
+    python3 \
     unzip \
  && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100 \
     --slave /usr/bin/clang++ clang++ /usr/bin/clang++-10 \

--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -1,1 +1,1 @@
-BAZEL_IMAGE=cockroachdb/bazel:20210201-174432
+BAZEL_IMAGE=cockroachdb/bazel:20210301-143622


### PR DESCRIPTION
This can be enabled with:

    build --extra_toolchains=@llvm_toolchain//:cc-toolchain-darwin

in `.bazelrc.user`.

Use the open-source `grailbio/bazel-toolchain` library to pin to clang
v10.0. I selected this library because it appears to be the most
complete Clang toolchain in the open-source world for Bazel, and
it didn't seem like writing my own thing from scratch would provide any
benefits over what already exists here.

The open-source library is incomplete in several important ways, namely
that the toolchain detection is based on which OS you're using, so
remote execution builds and cross-compiled builds are very likely to not
work. We have to solve both of these problems anyway, but that's not
urgent. As appropriate, we can fork and submit pull requests for the
upstream repo, or if it's more sensible to write our own custom
toolchain specifically for cross-compilation, we can do so.

Fixes #56054
Fixes #56055
Fixes #56056
Fixes #56057

Release note: None

Release justification: Non-production code changes