### PR TITLE
kvserver: add new version of Stores.GetReplForRange 

### DIFF
--- a/pkg/kv/kvserver/client_atomic_membership_change_test.go
+++ b/pkg/kv/kvserver/client_atomic_membership_change_test.go
@@ -68,7 +68,7 @@ func TestAtomicReplicationChange(t *testing.T) {
 		testutils.SucceedsSoon(t, func() error {
 			var sawStores []roachpb.StoreID
 			for _, s := range tc.Servers {
-				r, _, _ := s.Stores().GetReplicaForRangeID(desc.RangeID)
+				r, _, _ := s.Stores().GetReplicaForRangeID(ctx, desc.RangeID)
 				if r == nil {
 					continue
 				}

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -2810,7 +2810,7 @@ func TestAdminRelocateRangeSafety(t *testing.T) {
 	// completed.
 
 	// Code above verified r1 is the leaseholder, so use it to ChangeReplicas.
-	r1, _, err := tc.Servers[0].Stores().GetReplicaForRangeID(rangeInfo.Desc.RangeID)
+	r1, _, err := tc.Servers[0].Stores().GetReplicaForRangeID(ctx, rangeInfo.Desc.RangeID)
 	assert.Nil(t, err)
 	expDescAfterAdd := rangeInfo.Desc // for use with ChangeReplicas
 	expDescAfterAdd.NextReplicaID++
@@ -3658,7 +3658,7 @@ func TestTenantID(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		uninitializedRepl, _, err := tc.Server(1).GetStores().(*kvserver.Stores).GetReplicaForRangeID(repl.RangeID)
+		uninitializedRepl, _, err := tc.Server(1).GetStores().(*kvserver.Stores).GetReplicaForRangeID(ctx, repl.RangeID)
 		require.NoError(t, err)
 		ri := uninitializedRepl.State()
 		require.Equal(t, uint64(0), ri.TenantID)

--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -1175,7 +1175,7 @@ func replsForRange(
 	testutils.SucceedsSoon(t, func() error {
 		repls = nil
 		for i := 0; i < numNodes; i++ {
-			repl, _, err := tc.Server(i).GetStores().(*kvserver.Stores).GetReplicaForRangeID(desc.RangeID)
+			repl, _, err := tc.Server(i).GetStores().(*kvserver.Stores).GetReplicaForRangeID(ctx, desc.RangeID)
 			if err != nil {
 				return err
 			}

--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -664,7 +664,7 @@ func testConsistencyQueueRecomputeStatsImpl(t *testing.T, hadEstimates bool) {
 
 	// The stats should magically repair themselves. We'll first do a quick check
 	// and then a full recomputation.
-	repl, _, err := ts.Stores().GetReplicaForRangeID(rangeID)
+	repl, _, err := ts.Stores().GetReplicaForRangeID(ctx, rangeID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kv/kvserver/reports/reporter.go
+++ b/pkg/kv/kvserver/reports/reporter.go
@@ -258,7 +258,7 @@ func (stats *Reporter) update(
 // range or nil if none of the node's stores are holding the Meta1 lease.
 func (stats *Reporter) meta1LeaseHolderStore(ctx context.Context) *kvserver.Store {
 	const meta1RangeID = roachpb.RangeID(1)
-	repl, store, err := stats.localStores.GetReplicaForRangeID(meta1RangeID)
+	repl, store, err := stats.localStores.GetReplicaForRangeID(ctx, meta1RangeID)
 	if roachpb.IsRangeNotFoundError(err) {
 		return nil
 	}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2163,11 +2163,21 @@ func checkCanInitializeEngine(ctx context.Context, eng storage.Engine) error {
 }
 
 // GetReplica fetches a replica by Range ID. Returns an error if no replica is found.
+//
+// See also GetReplicaIfExists for a more perfomant version.
 func (s *Store) GetReplica(rangeID roachpb.RangeID) (*Replica, error) {
-	if value, ok := s.mu.replicas.Load(int64(rangeID)); ok {
-		return (*Replica)(value), nil
+	if r := s.GetReplicaIfExists(rangeID); r != nil {
+		return r, nil
 	}
 	return nil, roachpb.NewRangeNotFoundError(rangeID, s.StoreID())
+}
+
+// GetReplicaIfExists returns the replica with the given RangeID or nil.
+func (s *Store) GetReplicaIfExists(rangeID roachpb.RangeID) *Replica {
+	if value, ok := s.mu.replicas.Load(int64(rangeID)); ok {
+		return (*Replica)(value)
+	}
+	return nil
 }
 
 // LookupReplica looks up the replica that contains the specified key. It

--- a/pkg/kv/kvserver/stores.go
+++ b/pkg/kv/kvserver/stores.go
@@ -62,7 +62,7 @@ func NewStores(ambient log.AmbientContext, clock *hlc.Clock) *Stores {
 // IsMeta1Leaseholder returns whether the specified stores owns
 // the meta1 lease. Returns an error if any.
 func (ls *Stores) IsMeta1Leaseholder(ctx context.Context, now hlc.ClockTimestamp) (bool, error) {
-	repl, _, err := ls.GetReplicaForRangeID(1)
+	repl, _, err := ls.GetReplicaForRangeID(ctx, 1)
 	if roachpb.IsRangeNotFoundError(err) {
 		return false, nil
 	}
@@ -138,17 +138,18 @@ func (ls *Stores) VisitStores(visitor func(s *Store) error) error {
 // specified range. If the replica is not found on any store then
 // roachpb.RangeNotFoundError will be returned.
 func (ls *Stores) GetReplicaForRangeID(
-	rangeID roachpb.RangeID,
-) (replica *Replica, store *Store, err error) {
-	err = ls.VisitStores(func(s *Store) error {
+	ctx context.Context, rangeID roachpb.RangeID,
+) (*Replica, *Store, error) {
+	var replica *Replica
+	var store *Store
+	if err := ls.VisitStores(func(s *Store) error {
 		r := s.GetReplicaIfExists(rangeID)
 		if r != nil {
 			replica, store = r, s
 		}
 		return nil
-	})
-	if err != nil {
-		return nil, nil, err
+	}); err != nil {
+		log.Fatalf(ctx, "unexpected error: %s", err)
 	}
 	if replica == nil {
 		return nil, nil, roachpb.NewRangeNotFoundError(rangeID, 0)

--- a/pkg/kv/kvserver/stores.go
+++ b/pkg/kv/kvserver/stores.go
@@ -141,15 +141,11 @@ func (ls *Stores) GetReplicaForRangeID(
 	rangeID roachpb.RangeID,
 ) (replica *Replica, store *Store, err error) {
 	err = ls.VisitStores(func(s *Store) error {
-		r, err := s.GetReplica(rangeID)
-		if err == nil {
+		r := s.GetReplicaIfExists(rangeID)
+		if r != nil {
 			replica, store = r, s
-			return nil
 		}
-		if errors.HasType(err, (*roachpb.RangeNotFoundError)(nil)) {
-			return nil
-		}
-		return err
+		return nil
 	})
 	if err != nil {
 		return nil, nil, err

--- a/pkg/kv/kvserver/stores_test.go
+++ b/pkg/kv/kvserver/stores_test.go
@@ -165,7 +165,7 @@ func TestStoresGetReplicaForRangeID(t *testing.T) {
 
 	// Test the case where the replica we're looking for exists.
 	rangeID1 := roachpb.RangeID(5)
-	replica1, _, err1 := ls.GetReplicaForRangeID(rangeID1)
+	replica1, _, err1 := ls.GetReplicaForRangeID(ctx, rangeID1)
 	if replica1 == nil {
 		t.Fatal("expected replica to be found; was nil")
 	}
@@ -178,7 +178,7 @@ func TestStoresGetReplicaForRangeID(t *testing.T) {
 
 	// Test the case where the replica we're looking for doesn't exist.
 	rangeID2 := roachpb.RangeID(1000)
-	replica2, _, err2 := ls.GetReplicaForRangeID(rangeID2)
+	replica2, _, err2 := ls.GetReplicaForRangeID(ctx, rangeID2)
 	if replica2 != nil {
 		t.Fatalf("expected replica to be nil; was %v", replica2)
 	}

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -2307,12 +2307,9 @@ func (s *adminServer) enqueueRangeLocal(
 	var store *kvserver.Store
 	var repl *kvserver.Replica
 	if err := s.server.node.stores.VisitStores(func(s *kvserver.Store) error {
-		r, err := s.GetReplica(req.RangeID)
-		if roachpb.IsRangeNotFoundError(err) {
+		r := s.GetReplicaIfExists(req.RangeID)
+		if r == nil {
 			return nil
-		}
-		if err != nil {
-			return err
 		}
 		repl = r
 		store = s

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -543,7 +543,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 			// before this is ever called.
 			Refresh: func(rangeIDs ...roachpb.RangeID) {
 				for _, rangeID := range rangeIDs {
-					repl, _, err := lateBoundNode.stores.GetReplicaForRangeID(rangeID)
+					repl, _, err := lateBoundNode.stores.GetReplicaForRangeID(ctx, rangeID)
 					if err != nil || repl == nil {
 						continue
 					}

--- a/pkg/server/server_systemlog_gc.go
+++ b/pkg/server/server_systemlog_gc.go
@@ -70,7 +70,7 @@ func (s *Server) gcSystemLog(
 	ctx context.Context, table string, timestampLowerBound, timestampUpperBound time.Time,
 ) (time.Time, int64, error) {
 	var totalRowsAffected int64
-	repl, _, err := s.node.stores.GetReplicaForRangeID(roachpb.RangeID(1))
+	repl, _, err := s.node.stores.GetReplicaForRangeID(ctx, roachpb.RangeID(1))
 	if roachpb.IsRangeNotFoundError(err) {
 		return timestampLowerBound, 0, nil
 	}

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -567,12 +567,9 @@ func (s *statusServer) Allocator(
 			// because it's already exported.
 			err := kvserver.IterateRangeDescriptors(ctx, store.Engine(),
 				func(desc roachpb.RangeDescriptor) error {
-					rep, err := store.GetReplica(desc.RangeID)
-					if err != nil {
-						if errors.HasType(err, (*roachpb.RangeNotFoundError)(nil)) {
-							return nil // continue
-						}
-						return err
+					rep := store.GetReplicaIfExists(desc.RangeID)
+					if rep == nil {
+						return nil // continue
 					}
 					if !rep.OwnsValidLease(ctx, store.Clock().NowAsClockTimestamp()) {
 						return nil
@@ -1694,12 +1691,9 @@ func (s *statusServer) rangesHelper(
 			// because it's already exported.
 			err := kvserver.IterateRangeDescriptors(ctx, store.Engine(),
 				func(desc roachpb.RangeDescriptor) error {
-					rep, err := store.GetReplica(desc.RangeID)
-					if errors.HasType(err, (*roachpb.RangeNotFoundError)(nil)) {
+					rep := store.GetReplicaIfExists(desc.RangeID)
+					if rep == nil {
 						return nil // continue
-					}
-					if err != nil {
-						return err
 					}
 					output.Ranges = append(output.Ranges,
 						constructRangeInfo(


### PR DESCRIPTION
The existing version is broken because it doesn't handle multiple stores
having a replica for the same range, and it's also inneficient because
it allocates in case of failure to find the replicas.

This patch adds a new version of the function which returns all the
replicas, and modifies some callers to use it. The new version takes in
slices to be populated in order to avoid repeated allocations for these
slices.

Release note: None
Release justification: low risk, needed by a different patch