### PR TITLE
sql: fix internal error when EXPLAINing a zero row insert

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -1555,3 +1555,14 @@ vectorized: true
   estimated row count: 1 (<0.01% of the table)
   table: percent@primary
   spans: [/1 - /1]
+
+# Regression test for #61248: insert fast path with no rows.
+query T
+EXPLAIN INSERT INTO t2 SELECT x FROM t2 WHERE false
+----
+distribution: local
+vectorized: true
+·
+• insert fast path
+  into: t2(x)
+  auto commit

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -661,7 +661,9 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 				"FK check", fmt.Sprintf("%s@%s", fk.ReferencedTable.Name(), fk.ReferencedIndex.Name()),
 			)
 		}
-		e.emitTuples(a.Rows, len(a.Rows[0]))
+		if len(a.Rows) > 0 {
+			e.emitTuples(a.Rows, len(a.Rows[0]))
+		}
 
 	case upsertOp:
 		a := n.args.(*upsertArgs)


### PR DESCRIPTION
Fixes #61248.

Release justification: fixes for high-priority or high-severity bugs
in existing functionality.

Release note (bug fix): fixed an internal error when EXPLAINing an
INSERT with an input that was determined by the optimizer to produce
no rows.