### PR TITLE
kvserver: plug a tracing span leak

### DIFF
--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -135,13 +135,6 @@ func (r *Replica) evalAndPropose(
 		// Fork the proposal's context span so that the proposal's context
 		// can outlive the original proposer's context.
 		proposal.ctx, proposal.sp = tracing.ForkSpan(ctx, "async consensus")
-		{
-			// This span sometimes leaks. Disable it for the time being.
-			//
-			// Tracked in: https://github.com/cockroachdb/cockroach/issues/60677
-			proposal.sp.Finish()
-			proposal.sp = nil
-		}
 
 		// Signal the proposal's response channel immediately.
 		reply := *proposal.Local.Reply

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -142,7 +142,7 @@ func (tc *TestCluster) stopServers(ctx context.Context) {
 				return nil
 			}
 			var buf strings.Builder
-			buf.WriteString("unexpectedly found active spans:\n")
+			fmt.Fprintf(&buf, "unexpectedly found %d active spans:\n", len(sps))
 			for _, sp := range sps {
 				fmt.Fprintln(&buf, sp.GetRecording())
 				fmt.Fprintln(&buf)


### PR DESCRIPTION
Fixes #60677, removing a stop-gap introduced in #59992.

We were previously leaking  "async consensus" spans, which was possible
when a given proposal was never flushed out of the replica's proposal
buffer. On server shut down, this buffered proposal was never finished,
and thus the embedded span never closed. We now add a closer to clean up
after ourselves.

Release justification: bug fixes and low-risk updates to new
functionality.

Release note: None

---

+cc @angelapwen / @knz / @erikgrinaker for pod-visibility.