### PR TITLE
cli: add scheduled_jobs table to the debug zip

### DIFF
--- a/pkg/cli/testdata/zip/partial1
+++ b/pkg/cli/testdata/zip/partial1
@@ -21,6 +21,7 @@ retrieving SQL data for system.jobs... writing: debug/system.jobs.txt
 retrieving SQL data for system.descriptor... writing: debug/system.descriptor.txt
 retrieving SQL data for system.namespace... writing: debug/system.namespace.txt
 retrieving SQL data for system.namespace2... writing: debug/system.namespace2.txt
+retrieving SQL data for system.scheduled_jobs... writing: debug/system.scheduled_jobs.txt
 retrieving SQL data for crdb_internal.kv_node_status... writing: debug/crdb_internal.kv_node_status.txt
 retrieving SQL data for crdb_internal.kv_store_status... writing: debug/crdb_internal.kv_store_status.txt
 retrieving SQL data for crdb_internal.schema_changes... writing: debug/crdb_internal.schema_changes.txt

--- a/pkg/cli/testdata/zip/partial1_excluded
+++ b/pkg/cli/testdata/zip/partial1_excluded
@@ -21,6 +21,7 @@ retrieving SQL data for system.jobs... writing: debug/system.jobs.txt
 retrieving SQL data for system.descriptor... writing: debug/system.descriptor.txt
 retrieving SQL data for system.namespace... writing: debug/system.namespace.txt
 retrieving SQL data for system.namespace2... writing: debug/system.namespace2.txt
+retrieving SQL data for system.scheduled_jobs... writing: debug/system.scheduled_jobs.txt
 retrieving SQL data for crdb_internal.kv_node_status... writing: debug/crdb_internal.kv_node_status.txt
 retrieving SQL data for crdb_internal.kv_store_status... writing: debug/crdb_internal.kv_store_status.txt
 retrieving SQL data for crdb_internal.schema_changes... writing: debug/crdb_internal.schema_changes.txt

--- a/pkg/cli/testdata/zip/partial2
+++ b/pkg/cli/testdata/zip/partial2
@@ -21,6 +21,7 @@ retrieving SQL data for system.jobs... writing: debug/system.jobs.txt
 retrieving SQL data for system.descriptor... writing: debug/system.descriptor.txt
 retrieving SQL data for system.namespace... writing: debug/system.namespace.txt
 retrieving SQL data for system.namespace2... writing: debug/system.namespace2.txt
+retrieving SQL data for system.scheduled_jobs... writing: debug/system.scheduled_jobs.txt
 retrieving SQL data for crdb_internal.kv_node_status... writing: debug/crdb_internal.kv_node_status.txt
 retrieving SQL data for crdb_internal.kv_store_status... writing: debug/crdb_internal.kv_store_status.txt
 retrieving SQL data for crdb_internal.schema_changes... writing: debug/crdb_internal.schema_changes.txt

--- a/pkg/cli/testdata/zip/testzip
+++ b/pkg/cli/testdata/zip/testzip
@@ -21,6 +21,7 @@ retrieving SQL data for system.jobs... writing: debug/system.jobs.txt
 retrieving SQL data for system.descriptor... writing: debug/system.descriptor.txt
 retrieving SQL data for system.namespace... writing: debug/system.namespace.txt
 retrieving SQL data for system.namespace2... writing: debug/system.namespace2.txt
+retrieving SQL data for system.scheduled_jobs... writing: debug/system.scheduled_jobs.txt
 retrieving SQL data for crdb_internal.kv_node_status... writing: debug/crdb_internal.kv_node_status.txt
 retrieving SQL data for crdb_internal.kv_store_status... writing: debug/crdb_internal.kv_store_status.txt
 retrieving SQL data for crdb_internal.schema_changes... writing: debug/crdb_internal.schema_changes.txt

--- a/pkg/cli/testdata/zip/unavailable
+++ b/pkg/cli/testdata/zip/unavailable
@@ -40,6 +40,9 @@ writing: debug/system.namespace.txt.err.txt
 retrieving SQL data for system.namespace2... writing: debug/system.namespace2.txt
 writing: debug/system.namespace2.txt.err.txt
   ^- resulted in ...
+retrieving SQL data for system.scheduled_jobs... writing: debug/system.scheduled_jobs.txt
+writing: debug/system.scheduled_jobs.txt.err.txt
+  ^- resulted in ...
 retrieving SQL data for crdb_internal.kv_node_status... writing: debug/crdb_internal.kv_node_status.txt
 writing: debug/crdb_internal.kv_node_status.txt.err.txt
   ^- resulted in ...

--- a/pkg/cli/zip_cluster_wide.go
+++ b/pkg/cli/zip_cluster_wide.go
@@ -84,6 +84,7 @@ var debugZipTablesPerCluster = []string{
 	"system.descriptor", // descriptors also contain job-like mutation state.
 	"system.namespace",
 	"system.namespace2", // TODO(sqlexec): consider removing in 20.2 or later.
+	"system.scheduled_jobs",
 
 	"crdb_internal.kv_node_status",
 	"crdb_internal.kv_store_status",

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -96,6 +96,7 @@ ORDER BY name ASC`)
 		"system.descriptor",
 		"system.namespace",
 		"system.namespace2",
+		"system.scheduled_jobs",
 	)
 	sort.Strings(tables)
 


### PR DESCRIPTION
With scheduled backups in version 20.2 and beyond we would like to
expose the raw scheduled_jobs table to allow for easier debugging of
scheduled backup related issues.

Fixes: #61143

Release justification: non-production code changes

Release note: None