### PR TITLE
sql: block hash sharded indexes for REGIONAL BY ROW

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
+++ b/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
@@ -2616,3 +2616,14 @@ TABLE rbt_table_gc_ttl  ALTER TABLE rbt_table_gc_ttl CONFIGURE ZONE USING
                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
                         voter_constraints = '[+region=ca-central-1]',
                         lease_preferences = '[[+region=ca-central-1]]'
+
+statement ok
+SET experimental_enable_hash_sharded_indexes = true
+
+statement ok
+CREATE TABLE hash_sharded_idx_table (
+  pk INT PRIMARY KEY USING HASH WITH BUCKET_COUNT = 8
+)
+
+statement error cannot convert a table to REGIONAL BY ROW if table table contains hash sharded indexes
+ALTER TABLE hash_sharded_idx_table SET LOCALITY REGIONAL BY ROW

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -23,6 +23,28 @@ CREATE TABLE regional_by_row_table (
 PARTITION BY NOTHING
 LOCALITY REGIONAL BY ROW
 
+statement ok
+SET experimental_enable_hash_sharded_indexes = true
+
+statement error hash sharded indexes are not compatible with REGIONAL BY ROW tables
+CREATE TABLE regional_by_row_table (
+  pk INT PRIMARY KEY USING HASH WITH BUCKET_COUNT = 8
+) LOCALITY REGIONAL BY ROW
+
+statement error hash sharded indexes are not compatible with REGIONAL BY ROW tables
+CREATE TABLE regional_by_row_table (
+  pk INT NOT NULL,
+  a INT,
+  PRIMARY KEY(pk) USING HASH WITH BUCKET_COUNT = 8
+) LOCALITY REGIONAL BY ROW
+
+statement error hash sharded indexes are not compatible with REGIONAL BY ROW tables
+CREATE TABLE regional_by_row_table (
+  pk INT NOT NULL,
+  a INT,
+  INDEX(a) USING HASH WITH BUCKET_COUNT = 8
+) LOCALITY REGIONAL BY ROW
+
 statement error REGIONAL BY ROW on a table with an INDEX containing PARTITION BY is not supported
 CREATE TABLE regional_by_row_table (
   pk int,
@@ -436,6 +458,13 @@ CREATE TABLE public.regional_by_row_table (
 ) LOCALITY REGIONAL BY ROW;
 ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING "gc.ttlseconds" = 10
 
+# Prohibit certain actions on a REGIONAL BY ROW table.
+statement error hash sharded indexes are not compatible with REGIONAL BY ROW tables
+CREATE INDEX bad_idx ON regional_by_row_table(a) USING HASH WITH BUCKET_COUNT = 8
+
+statement error hash sharded indexes are not compatible with REGIONAL BY ROW tables
+ALTER TABLE regional_by_row_table ALTER PRIMARY KEY USING COLUMNS(pk2) USING HASH WITH BUCKET_COUNT = 8
+
 # Insert some rows into the regional_by_row_table.
 query TI
 INSERT INTO regional_by_row_table (pk, pk2, a, b, j) VALUES
@@ -568,7 +597,7 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  OR message LIKE 'Scan%'
  ORDER BY ordinality ASC
 ----
-Scan /Table/66/1/"@"/1{-/#}, /Table/66/1/"\x80"/1{-/#}, /Table/66/1/"\xc0"/1{-/#}
+Scan /Table/69/1/"@"/1{-/#}, /Table/69/1/"\x80"/1{-/#}, /Table/69/1/"\xc0"/1{-/#}
 fetched: /regional_by_row_table/primary/'ap-southeast-2'/1/pk2/a/b/j -> /1/2/3/'{"a": "b"}'
 output row: [1 1 2 3 '{"a": "b"}']
 
@@ -607,7 +636,7 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  OR message LIKE 'Scan%'
  ORDER BY ordinality ASC
 ----
-Scan /Table/66/1/"@"/1{-/#}
+Scan /Table/69/1/"@"/1{-/#}
 fetched: /regional_by_row_table/primary/'ap-southeast-2'/1/pk2/a/b/j -> /1/2/3/'{"a": "b"}'
 output row: [1 1 2 3 '{"a": "b"}']
 
@@ -622,8 +651,8 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  OR message LIKE 'Scan%'
  ORDER BY ordinality ASC
 ----
-Scan /Table/66/1/"@"/10{-/#}
-Scan /Table/66/1/"\x80"/10{-/#}, /Table/66/1/"\xc0"/10{-/#}
+Scan /Table/69/1/"@"/10{-/#}
+Scan /Table/69/1/"\x80"/10{-/#}, /Table/69/1/"\xc0"/10{-/#}
 fetched: /regional_by_row_table/primary/'ca-central-1'/10/pk2/a/b -> /10/11/12
 output row: [10 10 11 12 NULL]
 

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -63,6 +63,9 @@ func (p *planner) AlterPrimaryKey(
 		if alterPKNode.Interleave != nil {
 			return pgerror.Newf(pgcode.FeatureNotSupported, "interleaved indexes cannot also be hash sharded")
 		}
+		if tableDesc.IsLocalityRegionalByRow() {
+			return pgerror.New(pgcode.FeatureNotSupported, "hash sharded indexes are not compatible with REGIONAL BY ROW tables")
+		}
 	}
 
 	// Ensure that other schema changes on this table are not currently

--- a/pkg/sql/alter_table_locality.go
+++ b/pkg/sql/alter_table_locality.go
@@ -246,6 +246,12 @@ func (n *alterTableSetLocalityNode) alterTableLocalityToRegionalByRow(
 		primaryIndexColIdxStart = int(n.tableDesc.PrimaryIndex.Partitioning.NumImplicitColumns)
 	}
 
+	for _, idx := range n.tableDesc.NonDropIndexes() {
+		if idx.IsSharded() {
+			return pgerror.New(pgcode.FeatureNotSupported, "cannot convert a table to REGIONAL BY ROW if table table contains hash sharded indexes")
+		}
+	}
+
 	if newLocality.RegionalByRowColumn == tree.RegionalByRowRegionNotSpecifiedName {
 		partColName = tree.RegionalByRowRegionDefaultColName
 		mayNeedImplicitCRDBRegionCol = true

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -205,6 +205,9 @@ func MakeIndexDescriptor(
 		if n.PartitionByIndex.ContainsPartitions() {
 			return nil, pgerror.New(pgcode.FeatureNotSupported, "sharded indexes don't support partitioning")
 		}
+		if tableDesc.IsLocalityRegionalByRow() {
+			return nil, hashShardedIndexesOnRegionalByRowError()
+		}
 		if n.Interleave != nil {
 			return nil, pgerror.New(pgcode.FeatureNotSupported, "interleaved indexes cannot also be hash sharded")
 		}


### PR DESCRIPTION
This is not supported, so block entry points where a REGIONAL BY ROW
table becomes hash sharded.

Release justification: low risk change to new functionality

Release note: None