### PR TITLE
sql: bump array type alias version on enum value add/drop

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type
@@ -465,4 +465,34 @@ statement error enum value "a" is being dropped
 BEGIN;
 ALTER TYPE a DROP VALUE 'a';
 ALTER TYPE a RENAME VALUE 'a' TO 'new_name';
-ROLLBACK;
+
+statement ok
+ROLLBACK
+
+# Ensure changes to the type are picked up by the array type descriptor as well.
+subtest regression_58710
+
+statement ok
+CREATE TYPE ab_58710 AS ENUM ('a', 'b')
+
+# NB: This step is important as it hydrates the array type alias based on the
+# state of the underlying enum type descriptor.
+statement error invalid input value for enum ab_58710: "c"
+SELECT ARRAY['c']::_ab_58710
+
+statement ok
+SELECT ARRAY['a']::_ab_58710;
+
+statement ok
+ALTER TYPE ab_58710 ADD VALUE 'c';
+
+statement ok
+ALTER TYPE ab_58710 DROP VALUE 'a';
+
+# 'c' was added to the enum above and 'a' was dropped, so the array type alias
+# should reflect this.
+statement ok
+SELECT ARRAY['c']::_ab_58710;
+
+statement error invalid input value for enum ab_58710: "a"
+SELECT ARRAY['a']::_ab_58710


### PR DESCRIPTION
Previously, when a value was added/dropped from a user defined type,
the corresponding type alias' version was not bumped. This is
problematic because the changes to the underlying enum type descriptor
wouldn't be picked up by the type alias (until the lease expired and
the descriptor was leased again). This behavior may seem slightly
surprising, but it has to do with the fact that the array type alias
stores a `types.T` inside the descriptor. This `types.T` is hydrated
only once and subsequent accesses don't rehydrate it (even if the
underlying enum type descriptor, that hydrated it to begin with, has had
its version bumped). Put another way, for all intents and purposes, we
were violating the two descriptor version invariant for array type
aliases in a bunch of places before this patch.

Fixes #58710

Release justification: bug fixes in existing functionality that affects
multiregion.
Release note (bug fix): `ALTER TYPE ... ADD VALUE` changes are picked
up by the array type alias correctly.