### PR TITLE
builtins: implement ST_Force3D, ST_Force3DM, ST_Force3DZ, ST_Force4D

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1700,7 +1700,25 @@ Bottom Left.</p>
 </span></td></tr>
 <tr><td><a name="st_flipcoordinates"></a><code>st_flipcoordinates(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a new geometry with the X and Y axes flipped.</p>
 </span></td></tr>
-<tr><td><a name="st_force2d"></a><code>st_force2d(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Geometry which only contains X and Y coordinates.</p>
+<tr><td><a name="st_force2d"></a><code>st_force2d(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Geometry that is forced into XY layout with any Z or M dimensions discarded.</p>
+</span></td></tr>
+<tr><td><a name="st_force3d"></a><code>st_force3d(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Geometry that is forced into XYZ layout. If a Z coordinate doesn’t exist, it will be set to 0. If a M coordinate is present, it will be discarded.</p>
+</span></td></tr>
+<tr><td><a name="st_force3d"></a><code>st_force3d(geometry: geometry, defaultZ: <a href="float.html">float</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Geometry that is forced into XYZ layout. If a Z coordinate doesn’t exist, it will be set to the specified default Z value. If a M coordinate is present, it will be discarded.</p>
+</span></td></tr>
+<tr><td><a name="st_force3dm"></a><code>st_force3dm(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Geometry that is forced into XYM layout. If a M coordinate doesn’t exist, it will be set to 0. If a Z coordinate is present, it will be discarded.</p>
+</span></td></tr>
+<tr><td><a name="st_force3dm"></a><code>st_force3dm(geometry: geometry, defaultM: <a href="float.html">float</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Geometry that is forced into XYM layout. If a M coordinate doesn’t exist, it will be set to the specified default M value. If a Z coordinate is present, it will be discarded.</p>
+</span></td></tr>
+<tr><td><a name="st_force3dz"></a><code>st_force3dz(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Geometry that is forced into XYZ layout. If a Z coordinate doesn’t exist, it will be set to 0. If a M coordinate is present, it will be discarded.</p>
+</span></td></tr>
+<tr><td><a name="st_force3dz"></a><code>st_force3dz(geometry: geometry, defaultZ: <a href="float.html">float</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Geometry that is forced into XYZ layout. If a Z coordinate doesn’t exist, it will be set to the specified default Z value. If a M coordinate is present, it will be discarded.</p>
+</span></td></tr>
+<tr><td><a name="st_force4d"></a><code>st_force4d(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Geometry that is forced into XYZM layout. If a Z coordinate doesn’t exist, it will be set to 0. If a M coordinate doesn’t exist, it will be set to 0.</p>
+</span></td></tr>
+<tr><td><a name="st_force4d"></a><code>st_force4d(geometry: geometry, defaultZ: <a href="float.html">float</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Geometry that is forced into XYZ layout. If a Z coordinate doesn’t exist, it will be set to the specified default Z value. If a M coordinate doesn’t exist, it will be set to 0.</p>
+</span></td></tr>
+<tr><td><a name="st_force4d"></a><code>st_force4d(geometry: geometry, defaultZ: <a href="float.html">float</a>, defaultM: <a href="float.html">float</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Geometry that is forced into XYZ layout. If a Z coordinate doesn’t exist, it will be set to the specified Z value. If a M coordinate doesn’t exist, it will be set to the specified M value.</p>
 </span></td></tr>
 <tr><td><a name="st_forcecollection"></a><code>st_forcecollection(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Converts the geometry into a GeometryCollection.</p>
 </span></td></tr>

--- a/pkg/geo/geomfn/force_layout.go
+++ b/pkg/geo/geomfn/force_layout.go
@@ -17,29 +17,61 @@ import (
 )
 
 // ForceLayout forces a geometry into the given layout.
-// If dimensions are added, 0 coordinates are padded to them.
+// If a Z dimension is added, 0 is added as the Z value.
+// If an M dimension is added, 0 is added as the M value.
 func ForceLayout(g geo.Geometry, layout geom.Layout) (geo.Geometry, error) {
+	return ForceLayoutWithDefaultZM(g, layout, 0, 0)
+}
+
+// ForceLayoutWithDefaultZ forces a geometry into the given layout.
+// If a Z dimension is added, defaultZ is added as the Z value.
+// If an M dimension is added, 0 is added as the M value.
+func ForceLayoutWithDefaultZ(
+	g geo.Geometry, layout geom.Layout, defaultZ float64,
+) (geo.Geometry, error) {
+	return ForceLayoutWithDefaultZM(g, layout, defaultZ, 0)
+}
+
+// ForceLayoutWithDefaultM forces a geometry into the given layout.
+// If a Z dimension is added, 0 is added as the Z value.
+// If an M dimension is added, defaultM is added as the M value.
+func ForceLayoutWithDefaultM(
+	g geo.Geometry, layout geom.Layout, defaultM float64,
+) (geo.Geometry, error) {
+	return ForceLayoutWithDefaultZM(g, layout, 0, defaultM)
+}
+
+// ForceLayoutWithDefaultZM forces a geometry into the given layout.
+// If a Z dimension is added, defaultZ is added as the Z value.
+// If an M dimension is added, defaultM is added as the M value.
+func ForceLayoutWithDefaultZM(
+	g geo.Geometry, layout geom.Layout, defaultZ float64, defaultM float64,
+) (geo.Geometry, error) {
 	geomT, err := g.AsGeomT()
 	if err != nil {
 		return geo.Geometry{}, err
 	}
-	retGeomT, err := forceLayout(geomT, layout)
+	retGeomT, err := forceLayout(geomT, layout, defaultZ, defaultM)
 	if err != nil {
 		return geo.Geometry{}, err
 	}
 	return geo.MakeGeometryFromGeomT(retGeomT)
 }
 
-// forceLayout forces a geom.T into the given layout.
-func forceLayout(t geom.T, layout geom.Layout) (geom.T, error) {
+// forceLayout forces a geom.T into the given layout and uses
+// the specified default Z and M values as needed.
+func forceLayout(t geom.T, layout geom.Layout, defaultZ float64, defaultM float64) (geom.T, error) {
 	if t.Layout() == layout {
 		return t, nil
 	}
 	switch t := t.(type) {
 	case *geom.GeometryCollection:
 		ret := geom.NewGeometryCollection().SetSRID(t.SRID())
+		if err := ret.SetLayout(layout); err != nil {
+			return nil, err
+		}
 		for i := 0; i < t.NumGeoms(); i++ {
-			toPush, err := forceLayout(t.Geom(i), layout)
+			toPush, err := forceLayout(t.Geom(i), layout, defaultZ, defaultM)
 			if err != nil {
 				return nil, err
 			}
@@ -49,25 +81,27 @@ func forceLayout(t geom.T, layout geom.Layout) (geom.T, error) {
 		}
 		return ret, nil
 	case *geom.Point:
-		return geom.NewPointFlat(layout, forceFlatCoordsLayout(t, layout)).SetSRID(t.SRID()), nil
+		return geom.NewPointFlat(
+			layout, forceFlatCoordsLayout(t, layout, defaultZ, defaultM)).SetSRID(t.SRID()), nil
 	case *geom.LineString:
-		return geom.NewLineStringFlat(layout, forceFlatCoordsLayout(t, layout)).SetSRID(t.SRID()), nil
+		return geom.NewLineStringFlat(
+			layout, forceFlatCoordsLayout(t, layout, defaultZ, defaultM)).SetSRID(t.SRID()), nil
 	case *geom.Polygon:
 		return geom.NewPolygonFlat(
 			layout,
-			forceFlatCoordsLayout(t, layout),
+			forceFlatCoordsLayout(t, layout, defaultZ, defaultM),
 			forceEnds(t.Ends(), t.Layout(), layout),
 		).SetSRID(t.SRID()), nil
 	case *geom.MultiPoint:
 		return geom.NewMultiPointFlat(
 			layout,
-			forceFlatCoordsLayout(t, layout),
+			forceFlatCoordsLayout(t, layout, defaultZ, defaultM),
 			geom.NewMultiPointFlatOptionWithEnds(forceEnds(t.Ends(), t.Layout(), layout)),
 		).SetSRID(t.SRID()), nil
 	case *geom.MultiLineString:
 		return geom.NewMultiLineStringFlat(
 			layout,
-			forceFlatCoordsLayout(t, layout),
+			forceFlatCoordsLayout(t, layout, defaultZ, defaultM),
 			forceEnds(t.Ends(), t.Layout(), layout),
 		).SetSRID(t.SRID()), nil
 	case *geom.MultiPolygon:
@@ -77,7 +111,7 @@ func forceLayout(t geom.T, layout geom.Layout) (geom.T, error) {
 		}
 		return geom.NewMultiPolygonFlat(
 			layout,
-			forceFlatCoordsLayout(t, layout),
+			forceFlatCoordsLayout(t, layout, defaultZ, defaultM),
 			endss,
 		).SetSRID(t.SRID()), nil
 	default:
@@ -97,22 +131,25 @@ func forceEnds(ends []int, oldLayout geom.Layout, newLayout geom.Layout) []int {
 	return newEnds
 }
 
-// forceFlatCoordsLayout forces the flatCoords layout of a geometry into the new layout.
-func forceFlatCoordsLayout(t geom.T, layout geom.Layout) []float64 {
+// forceFlatCoordsLayout forces the flatCoords layout of a geometry into the new layout
+// and uses the specified default Z and M values as needed.
+func forceFlatCoordsLayout(
+	t geom.T, layout geom.Layout, defaultZ float64, defaultM float64,
+) []float64 {
 	oldFlatCoords := t.FlatCoords()
 	newFlatCoords := make([]float64, (len(oldFlatCoords)/t.Stride())*layout.Stride())
 	for coordIdx := 0; coordIdx < len(oldFlatCoords)/t.Stride(); coordIdx++ {
 		newFlatCoords[coordIdx*layout.Stride()] = oldFlatCoords[coordIdx*t.Stride()]
 		newFlatCoords[coordIdx*layout.Stride()+1] = oldFlatCoords[coordIdx*t.Stride()+1]
 		if layout.ZIndex() != -1 {
-			z := float64(0)
+			z := defaultZ
 			if t.Layout().ZIndex() != -1 {
 				z = oldFlatCoords[coordIdx*t.Stride()+t.Layout().ZIndex()]
 			}
 			newFlatCoords[coordIdx*layout.Stride()+layout.ZIndex()] = z
 		}
 		if layout.MIndex() != -1 {
-			m := float64(0)
+			m := defaultM
 			if t.Layout().MIndex() != -1 {
 				m = oldFlatCoords[coordIdx*t.Stride()+t.Layout().MIndex()]
 			}

--- a/pkg/geo/geomfn/force_layout_test.go
+++ b/pkg/geo/geomfn/force_layout_test.go
@@ -202,7 +202,7 @@ func TestForceLayout(t *testing.T) {
 			).SetSRID(4326),
 		},
 		{
-			geom.NewGeometryCollection().MustPush(
+			geom.NewGeometryCollection().MustSetLayout(geom.XYZ).MustPush(
 				geom.NewPointFlat(geom.XYZ, []float64{1, 2, 3}),
 				geom.NewLineStringFlat(geom.XYZ, []float64{1, 2, 3, 4, 5, 6}),
 				geom.NewMultiPointFlat(geom.XYZ, []float64{1, 2, 3, 4, 5, 6}, geom.NewMultiPointFlatOptionWithEnds([]int{3, 3, 6})),
@@ -210,7 +210,7 @@ func TestForceLayout(t *testing.T) {
 				geom.NewMultiPolygonFlat(geom.XYZ, []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3}, [][]int{{12}, {12}}),
 			).SetSRID(4326),
 			geom.XY,
-			geom.NewGeometryCollection().MustPush(
+			geom.NewGeometryCollection().MustSetLayout(geom.XY).MustPush(
 				geom.NewPointFlat(geom.XY, []float64{1, 2}),
 				geom.NewLineStringFlat(geom.XY, []float64{1, 2, 4, 5}),
 				geom.NewMultiPointFlat(geom.XY, []float64{1, 2, 4, 5}, geom.NewMultiPointFlatOptionWithEnds([]int{2, 2, 4})),
@@ -219,7 +219,7 @@ func TestForceLayout(t *testing.T) {
 			).SetSRID(4326),
 		},
 		{
-			geom.NewGeometryCollection().MustPush(
+			geom.NewGeometryCollection().MustSetLayout(geom.XY).MustPush(
 				geom.NewPointFlat(geom.XY, []float64{1, 2}),
 				geom.NewLineStringFlat(geom.XY, []float64{1, 2, 4, 5}),
 				geom.NewMultiPointFlat(geom.XY, []float64{1, 2, 4, 5}, geom.NewMultiPointFlatOptionWithEnds([]int{2, 2, 4})),
@@ -227,7 +227,7 @@ func TestForceLayout(t *testing.T) {
 				geom.NewMultiPolygonFlat(geom.XY, []float64{1, 2, 4, 5, 7, 8, 1, 2}, [][]int{{8}, {8}}),
 			).SetSRID(4326),
 			geom.XYZ,
-			geom.NewGeometryCollection().MustPush(
+			geom.NewGeometryCollection().MustSetLayout(geom.XYZ).MustPush(
 				geom.NewPointFlat(geom.XYZ, []float64{1, 2, 0}),
 				geom.NewLineStringFlat(geom.XYZ, []float64{1, 2, 0, 4, 5, 0}),
 				geom.NewMultiPointFlat(geom.XYZ, []float64{1, 2, 0, 4, 5, 0}, geom.NewMultiPointFlatOptionWithEnds([]int{3, 3, 6})),
@@ -241,7 +241,7 @@ func TestForceLayout(t *testing.T) {
 		text, err := wkt.Marshal(tc.g)
 		require.NoError(t, err)
 		t.Run(fmt.Sprintf("%s->%s", text, tc.layout), func(t *testing.T) {
-			ret, err := forceLayout(tc.g, tc.layout)
+			ret, err := forceLayout(tc.g, tc.layout, 0, 0)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, ret)
 		})

--- a/pkg/sql/logictest/testdata/logic_test/geospatial_zm
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial_zm
@@ -158,3 +158,130 @@ FROM (VALUES
 1
 2
 3
+
+# Builtins for forcing geometries into other dimensions
+query T
+SELECT st_astext(st_force2d(geom)) FROM
+( VALUES
+  ('POINT(1 2)'::geometry),
+  ('POINT M (1 2 3)'::geometry),
+  ('POINT(1 2 3)'::geometry),
+  ('POINT(1 2 3 4)'::geometry),
+  ('POINT M EMPTY'::geometry),
+  ('GEOMETRYCOLLECTION Z EMPTY'::geometry)
+) AS t(geom)
+----
+POINT (1 2)
+POINT (1 2)
+POINT (1 2)
+POINT (1 2)
+POINT EMPTY
+GEOMETRYCOLLECTION EMPTY
+
+query T
+SELECT st_astext(st_force3d(geom)) FROM
+( VALUES
+  ('POINT(1 2)'::geometry),
+  ('POINT M (1 2 3)'::geometry),
+  ('POINT(1 2 3)'::geometry),
+  ('POINT(1 2 3 4)'::geometry),
+  ('GEOMETRYCOLLECTION(POINT(1 2))'::geometry)
+) AS t(geom)
+----
+POINT Z (1 2 0)
+POINT Z (1 2 0)
+POINT Z (1 2 3)
+POINT Z (1 2 3)
+GEOMETRYCOLLECTION Z (POINT Z (1 2 0))
+
+query T
+SELECT st_astext(st_force3dz(geom, 7)) FROM
+( VALUES
+  ('POINT(1 2)'::geometry),
+  ('POINT M (1 2 3)'::geometry),
+  ('POINT(1 2 3)'::geometry),
+  ('POINT(1 2 3 4)'::geometry),
+  ('GEOMETRYCOLLECTION(LINESTRING(1 2, 3 4))'::geometry)
+) AS t(geom)
+----
+POINT Z (1 2 7)
+POINT Z (1 2 7)
+POINT Z (1 2 3)
+POINT Z (1 2 3)
+GEOMETRYCOLLECTION Z (LINESTRING Z (1 2 7, 3 4 7))
+
+query T
+SELECT st_astext(st_force3dm(geom)) FROM
+( VALUES
+  ('POINT(1 2)'::geometry),
+  ('POINT M (1 2 3)'::geometry),
+  ('POINT(1 2 3)'::geometry),
+  ('POINT(1 2 3 4)'::geometry),
+  ('GEOMETRYCOLLECTION(MULTIPOINT((1 2 3), (4 5 6)))'::geometry)
+) AS t(geom)
+----
+POINT M (1 2 0)
+POINT M (1 2 3)
+POINT M (1 2 0)
+POINT M (1 2 4)
+GEOMETRYCOLLECTION M (MULTIPOINT M (1 2 0, 4 5 0))
+
+query T
+SELECT st_astext(st_force3dm(geom, 7)) FROM
+( VALUES
+  ('POINT(1 2)'::geometry),
+  ('POINT M (1 2 3)'::geometry),
+  ('POINT(1 2 3)'::geometry),
+  ('POINT(1 2 3 4)'::geometry)
+) AS t(geom)
+----
+POINT M (1 2 7)
+POINT M (1 2 3)
+POINT M (1 2 7)
+POINT M (1 2 4)
+
+query T
+SELECT st_astext(st_force4d(geom)) FROM
+( VALUES
+  ('POINT(1 2)'::geometry),
+  ('POINT M (1 2 3)'::geometry),
+  ('POINT(1 2 3)'::geometry),
+  ('POINT(1 2 3 4)'::geometry),
+  ('POLYGON((1 2, 5 5, 0 8, 1 2))'::geometry)
+) AS t(geom)
+----
+POINT ZM (1 2 0 0)
+POINT ZM (1 2 0 3)
+POINT ZM (1 2 3 0)
+POINT ZM (1 2 3 4)
+POLYGON ZM ((1 2 0 0, 5 5 0 0, 0 8 0 0, 1 2 0 0))
+
+query T
+SELECT st_astext(st_force4d(geom, 7)) FROM
+( VALUES
+  ('POINT(1 2)'::geometry),
+  ('POINT M (1 2 3)'::geometry),
+  ('POINT(1 2 3)'::geometry),
+  ('POINT(1 2 3 4)'::geometry)
+) AS t(geom)
+----
+POINT ZM (1 2 7 0)
+POINT ZM (1 2 7 3)
+POINT ZM (1 2 3 0)
+POINT ZM (1 2 3 4)
+
+query T
+SELECT st_astext(st_force4d(geom, 7, 17)) FROM
+( VALUES
+  ('POINT(1 2)'::geometry),
+  ('POINT M (1 2 3)'::geometry),
+  ('POINT(1 2 3)'::geometry),
+  ('POINT(1 2 3 4)'::geometry),
+  ('GEOMETRYCOLLECTION(POINT EMPTY, LINESTRING(1 2, 3 4))'::geometry)
+) AS t(geom)
+----
+POINT ZM (1 2 7 17)
+POINT ZM (1 2 7 3)
+POINT ZM (1 2 3 17)
+POINT ZM (1 2 3 4)
+GEOMETRYCOLLECTION ZM (POINT ZM EMPTY, LINESTRING ZM (1 2 7 17, 3 4 7 17))

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -2388,10 +2388,141 @@ The requested number of points must be not larger than 65336.`,
 			},
 			types.Geometry,
 			infoBuilder{
-				info: "Returns a Geometry which only contains X and Y coordinates.",
+				info: "Returns a Geometry that is forced into XY layout with any Z or M dimensions discarded.",
 			},
 			tree.VolatilityImmutable,
 		),
+	),
+	// TODO(ayang): see if it's possible to refactor default args
+	"st_force3dz": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				ret, err := geomfn.ForceLayout(g.Geometry, geom.XYZ)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(ret), nil
+			},
+			types.Geometry,
+			infoBuilder{
+				info: "Returns a Geometry that is forced into XYZ layout. " +
+					"If a Z coordinate doesn't exist, it will be set to 0. " +
+					"If a M coordinate is present, it will be discarded.",
+			},
+			tree.VolatilityImmutable,
+		),
+		tree.Overload{
+			Types:      tree.ArgTypes{{"geometry", types.Geometry}, {"defaultZ", types.Float}},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				g := tree.MustBeDGeometry(args[0])
+				defaultZ := tree.MustBeDFloat(args[1])
+
+				ret, err := geomfn.ForceLayoutWithDefaultZ(g.Geometry, geom.XYZ, float64(defaultZ))
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(ret), nil
+			},
+			Info: infoBuilder{info: "Returns a Geometry that is forced into XYZ layout. " +
+				"If a Z coordinate doesn't exist, it will be set to the specified default Z value. " +
+				"If a M coordinate is present, it will be discarded."}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
+	"st_force3dm": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				ret, err := geomfn.ForceLayout(g.Geometry, geom.XYM)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(ret), nil
+			},
+			types.Geometry,
+			infoBuilder{
+				info: "Returns a Geometry that is forced into XYM layout. " +
+					"If a M coordinate doesn't exist, it will be set to 0. " +
+					"If a Z coordinate is present, it will be discarded.",
+			},
+			tree.VolatilityImmutable,
+		),
+		tree.Overload{
+			Types:      tree.ArgTypes{{"geometry", types.Geometry}, {"defaultM", types.Float}},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				g := tree.MustBeDGeometry(args[0])
+				defaultM := tree.MustBeDFloat(args[1])
+
+				ret, err := geomfn.ForceLayoutWithDefaultM(g.Geometry, geom.XYM, float64(defaultM))
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(ret), nil
+			},
+			Info: infoBuilder{info: "Returns a Geometry that is forced into XYM layout. " +
+				"If a M coordinate doesn't exist, it will be set to the specified default M value. " +
+				"If a Z coordinate is present, it will be discarded."}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
+	"st_force4d": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(ctx *tree.EvalContext, g *tree.DGeometry) (tree.Datum, error) {
+				ret, err := geomfn.ForceLayout(g.Geometry, geom.XYZM)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(ret), nil
+			},
+			types.Geometry,
+			infoBuilder{
+				info: "Returns a Geometry that is forced into XYZM layout. " +
+					"If a Z coordinate doesn't exist, it will be set to 0. " +
+					"If a M coordinate doesn't exist, it will be set to 0.",
+			},
+			tree.VolatilityImmutable,
+		),
+		tree.Overload{
+			Types:      tree.ArgTypes{{"geometry", types.Geometry}, {"defaultZ", types.Float}},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				g := tree.MustBeDGeometry(args[0])
+				defaultZ := tree.MustBeDFloat(args[1])
+
+				ret, err := geomfn.ForceLayoutWithDefaultZ(g.Geometry, geom.XYZM, float64(defaultZ))
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(ret), nil
+			},
+			Info: infoBuilder{info: "Returns a Geometry that is forced into XYZ layout. " +
+				"If a Z coordinate doesn't exist, it will be set to the specified default Z value. " +
+				"If a M coordinate doesn't exist, it will be set to 0."}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"geometry", types.Geometry}, {"defaultZ", types.Float}, {"defaultM", types.Float}},
+			ReturnType: tree.FixedReturnType(types.Geometry),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				g := tree.MustBeDGeometry(args[0])
+				defaultZ := tree.MustBeDFloat(args[1])
+				defaultM := tree.MustBeDFloat(args[2])
+
+				ret, err := geomfn.ForceLayoutWithDefaultZM(g.Geometry, geom.XYZM, float64(defaultZ), float64(defaultM))
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(ret), nil
+			},
+			Info: infoBuilder{info: "Returns a Geometry that is forced into XYZ layout. " +
+				"If a Z coordinate doesn't exist, it will be set to the specified Z value. " +
+				"If a M coordinate doesn't exist, it will be set to the specified M value."}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
 	),
 	"st_forcepolygoncw": makeBuiltin(
 		defProps(),
@@ -6439,6 +6570,7 @@ func initGeoBuiltins() {
 		{"st_geomfromtext", "st_geometryfromtext"},
 		{"st_numinteriorring", "st_numinteriorrings"},
 		{"st_symmetricdifference", "st_symdifference"},
+		{"st_force3d", "st_force3dz"},
 	} {
 		if _, ok := geoBuiltins[alias.builtinName]; !ok {
 			panic("expected builtin definition for alias: " + alias.builtinName)


### PR DESCRIPTION
This patch implements the geometry builtins `ST_Force3D`,
`ST_Force3DM`, `ST_Force3DZ`, and `ST_Force4D`.

Resolves #60880.
Resolves #60881.
Resolves #60882.

Release justification: low-risk update to new functionality
Release note (sql change): Geometry builtins for forcing geometries
into non-2D layouts are now available.