### PR TITLE
sql: set zone configs before backfill on ALTER TABLE LOCALITY/PRIMARY KEY

### DIFF
--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
         "//pkg/base",
         "//pkg/ccl/multiregionccl/multiregionccltestutils",
         "//pkg/ccl/partitionccl",
+        "//pkg/ccl/testutilsccl",
         "//pkg/ccl/utilccl",
         "//pkg/jobs",
         "//pkg/keys",

--- a/pkg/ccl/partitionccl/BUILD.bazel
+++ b/pkg/ccl/partitionccl/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
     name = "partitionccl_test",
     size = "medium",
     srcs = [
+        "alter_primary_key_test.go",
         "drop_test.go",
         "main_test.go",
         "partition_test.go",
@@ -40,6 +41,7 @@ go_test(
         "//pkg/base",
         "//pkg/ccl/importccl",
         "//pkg/ccl/storageccl",
+        "//pkg/ccl/testutilsccl",
         "//pkg/ccl/utilccl",
         "//pkg/config",
         "//pkg/config/zonepb",

--- a/pkg/ccl/partitionccl/alter_primary_key_test.go
+++ b/pkg/ccl/partitionccl/alter_primary_key_test.go
@@ -1,0 +1,51 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package partitionccl
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+func TestAlterPrimaryKeyCorrectZoneConfigBeforeBackfill(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testCases := []testutilsccl.AlterPrimaryKeyCorrectZoneConfigTestCase{
+		{
+			Desc: "ALTER PRIMARY KEY",
+			SetupQuery: `CREATE TABLE t.test (k INT NOT NULL, v INT NOT NULL, INDEX v_idx (v));
+ALTER INDEX t.test@v_idx CONFIGURE ZONE USING gc.ttlseconds = 888
+			`,
+			AlterQuery: `ALTER TABLE t.test ALTER PRIMARY KEY USING COLUMNS (v)`,
+			ExpectedIntermediateZoneConfigs: []testutilsccl.AlterPrimaryKeyCorrectZoneConfigIntermediateZoneConfig{
+				{
+					ShowConfigStatement: `SHOW ZONE CONFIGURATION FOR INDEX t.test@v_idx_rewrite_for_primary_key_change`,
+					ExpectedTarget:      `INDEX t.public.test@v_idx_rewrite_for_primary_key_change`,
+					ExpectedSQL: `ALTER INDEX t.public.test@v_idx_rewrite_for_primary_key_change CONFIGURE ZONE USING
+	range_min_bytes = 134217728,
+	range_max_bytes = 536870912,
+	gc.ttlseconds = 888,
+	num_replicas = 1,
+	constraints = '[]',
+	lease_preferences = '[]'`,
+				},
+			},
+		},
+	}
+
+	testutilsccl.AlterPrimaryKeyCorrectZoneConfigTest(
+		t,
+		`CREATE DATABASE t`,
+		testCases,
+	)
+}

--- a/pkg/ccl/testutilsccl/BUILD.bazel
+++ b/pkg/ccl/testutilsccl/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "testutilsccl",
+    srcs = ["alter_primary_key.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/base",
+        "//pkg/roachpb",
+        "//pkg/sql",
+        "//pkg/sql/execinfra",
+        "//pkg/sql/sqltestutils",
+        "//pkg/sql/tests",
+        "//pkg/testutils/serverutils",
+        "//pkg/util",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/ccl/testutilsccl/alter_primary_key.go
+++ b/pkg/ccl/testutilsccl/alter_primary_key.go
@@ -1,0 +1,118 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package testutilsccl
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/stretchr/testify/require"
+)
+
+// AlterPrimaryKeyCorrectZoneConfigIntermediateZoneConfig is an expected
+// intermediate zone configuration in the AlterPrimaryKeyCorrectZoneConfigTestCase.
+type AlterPrimaryKeyCorrectZoneConfigIntermediateZoneConfig struct {
+	ShowConfigStatement string
+	ExpectedTarget      string
+	ExpectedSQL         string
+}
+
+// AlterPrimaryKeyCorrectZoneConfigTestCase is a test case for
+// AlterPrimaryKeyCorrectZoneConfigTest.
+type AlterPrimaryKeyCorrectZoneConfigTestCase struct {
+	Desc                            string
+	SetupQuery                      string
+	AlterQuery                      string
+	ExpectedIntermediateZoneConfigs []AlterPrimaryKeyCorrectZoneConfigIntermediateZoneConfig
+}
+
+// AlterPrimaryKeyCorrectZoneConfigTest tests that zone configurations
+// are correctly set before the backfill of a PRIMARY KEY.
+func AlterPrimaryKeyCorrectZoneConfigTest(
+	t *testing.T, createDBStatement string, testCases []AlterPrimaryKeyCorrectZoneConfigTestCase,
+) {
+	// Decrease the adopt loop interval so that retries happen quickly.
+	defer sqltestutils.SetTestJobsAdoptInterval()()
+
+	chunkSize := int64(100)
+	maxValue := 4000
+
+	if util.RaceEnabled {
+		// Race builds are a lot slower, so use a smaller number of rows.
+		maxValue = 200
+		chunkSize = 5
+	}
+
+	ctx := context.Background()
+
+	for _, tc := range testCases {
+		t.Run(tc.Desc, func(t *testing.T) {
+			var db *gosql.DB
+			params, _ := tests.CreateTestServerParams()
+			params.Locality.Tiers = []roachpb.Tier{
+				{Key: "region", Value: "ajstorm-1"},
+			}
+
+			runCheck := false
+			params.Knobs = base.TestingKnobs{
+				SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+					BackfillChunkSize: chunkSize,
+				},
+				DistSQL: &execinfra.TestingKnobs{
+					RunBeforeBackfillChunk: func(sp roachpb.Span) error {
+						if runCheck {
+							for _, subTC := range tc.ExpectedIntermediateZoneConfigs {
+								t.Run(subTC.ShowConfigStatement, func(t *testing.T) {
+									var target, sql string
+									require.NoError(
+										t,
+										db.QueryRow(subTC.ShowConfigStatement).Scan(&target, &sql),
+									)
+									require.Equal(t, subTC.ExpectedTarget, target)
+									require.Equal(t, subTC.ExpectedSQL, sql)
+								})
+							}
+							runCheck = false
+						}
+						return nil
+					},
+				},
+			}
+			s, sqlDB, _ := serverutils.StartServer(t, params)
+			db = sqlDB
+			defer s.Stopper().Stop(ctx)
+
+			if _, err := sqlDB.Exec(fmt.Sprintf(`
+%s;
+USE t;
+%s
+`, createDBStatement, tc.SetupQuery)); err != nil {
+				t.Fatal(err)
+			}
+
+			// Insert some rows so we can interrupt inspect state during backfill.
+			require.NoError(t, sqltestutils.BulkInsertIntoTable(sqlDB, maxValue))
+
+			runCheck = true
+			_, err := sqlDB.Exec(tc.AlterQuery)
+			require.NoError(t, err)
+		})
+	}
+
+}

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -537,7 +537,7 @@ func ApplyZoneConfigForMultiRegionTable(
 	if err != nil {
 		return err
 	}
-	var zoneConfig zonepb.ZoneConfig
+	zoneConfig := *zonepb.NewZoneConfig()
 	if zoneRaw != nil {
 		zoneConfig = *zoneRaw
 	}


### PR DESCRIPTION
Ensure that the zone configurations are correctly set before the
backfill runs, so data is backfilled to the correct location upfront for
REGIONAL BY ROW tables. Note this bug also exists on existing ALTER
PRIMARY KEY statements.

Release justification: bug fixes and low-risk updates to new
functionality

Release note (bug fix): Fix bug where zone configurations on indexes
were not copied before the backfill of an ALTER PRIMARY KEY. They used
to be copied afterwards instead.

