### PR TITLE
streamingest: flush first resolved event in stream ingestion

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -10,6 +10,7 @@ package streamingest
 
 import (
 	"context"
+	"math"
 	"sort"
 	"sync"
 	"time"
@@ -166,6 +167,9 @@ func newStreamIngestionDataProcessor(
 		maxFlushRateTimer:   timeutil.NewTimer(),
 		cutoverCh:           make(chan struct{}),
 		closePoller:         make(chan struct{}),
+		// lastFlushTime is set to be far in the future so we always flush when we
+		// see the first checkpoint event.
+		lastFlushTime: timeutil.Unix(math.MaxInt64, 0),
 	}
 
 	if err := sip.Init(sip, post, streamIngestionResultTypes, flowCtx, processorID, output, nil, /* memMonitor */


### PR DESCRIPTION
This commit properly initializes the lastFlushTime to be far in the
future so that we always flush on the first event. This change unflakes
TestRandomClientGeneration.

Fixes #https://github.com/cockroachdb/cockroach/issues/61287.

Release justification: fix test flake
Release note: None