### PR TITLE
 kvserver: add closedts side-transport consumer 

### DIFF
--- a/pkg/kv/kvserver/client_closed_timestamp_test.go
+++ b/pkg/kv/kvserver/client_closed_timestamp_test.go
@@ -61,6 +61,8 @@ func TestClosedTimestampWorksWhenRequestsAreSentToNonLeaseHolders(t *testing.T) 
 	const closeInterval = 10 * time.Millisecond
 	sqlRunner.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.target_duration = '"+
 		closeInterval.String()+"'")
+	sqlRunner.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '"+
+		closeInterval.String()+"'")
 
 	// To make node3 have a large epoch, synthesize a liveness record for with
 	// epoch 1000 before starting the node.

--- a/pkg/kv/kvserver/client_metrics_test.go
+++ b/pkg/kv/kvserver/client_metrics_test.go
@@ -352,6 +352,8 @@ func TestStoreMaxBehindNanosOnlyTracksEpochBasedLeases(t *testing.T) {
 		closedTimestampDuration.String())
 	tdb.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.close_fraction = $1",
 		closedTimestampFraction)
+	tdb.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = $1",
+		closedTimestampDuration.String())
 
 	// Let's get to a point where we know that we have an expiration based lease
 	// with a start time more than some time ago and then we have a max closed

--- a/pkg/kv/kvserver/closedts/closedts.go
+++ b/pkg/kv/kvserver/closedts/closedts.go
@@ -46,6 +46,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
+// IssueTrackingRemovalOfOldClosedTimestampsCode is the Github issue tracking
+// the deletion of the "old" closed timestamps code (i.e. everything around
+// here) in 21.2, now that 21.1 has a new Raft-based closed-timestamps
+// mechanism. The old mechanism is disabled when the cluster version is
+// sufficiently high, and all the tests failing because of it are skipped with
+// this issue.
+const IssueTrackingRemovalOfOldClosedTimestampsCode = 61299
+
 // ReleaseFunc is a closure returned from Track which is used to record the
 // LeaseAppliedIndex (LAI) given to a tracked proposal. The supplied epoch must
 // match that of the lease under which the proposal was proposed.

--- a/pkg/kv/kvserver/closedts/container/BUILD.bazel
+++ b/pkg/kv/kvserver/closedts/container/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
         "//pkg/roachpb",
         "//pkg/settings/cluster",
         "//pkg/testutils",
+        "//pkg/testutils/skip",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/stop",

--- a/pkg/kv/kvserver/closedts/container/container_test.go
+++ b/pkg/kv/kvserver/closedts/container/container_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -129,6 +130,7 @@ func setupTwoNodeTest() (_ *TestContainer, _ *TestContainer, shutdown func()) {
 
 func TestTwoNodes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, closedts.IssueTrackingRemovalOfOldClosedTimestampsCode)
 
 	ctx := context.Background()
 

--- a/pkg/kv/kvserver/closedts/ctpb/service.pb.go
+++ b/pkg/kv/kvserver/closedts/ctpb/service.pb.go
@@ -61,8 +61,9 @@ type Update struct {
 	// to result in a stream failing and a new one being established).
 	Snapshot         bool                 `protobuf:"varint,3,opt,name=snapshot,proto3" json:"snapshot,omitempty"`
 	ClosedTimestamps []Update_GroupUpdate `protobuf:"bytes,4,rep,name=closed_timestamps,json=closedTimestamps,proto3" json:"closed_timestamps"`
-	// removed contains the set of ranges that are no longer registered on the
-	// stream and who future updates are no longer applicable to.
+	// removed contains the set of ranges that are no longer tracked on this
+	// stream. The closed timestamps in this message and future messages no longer
+	// apply to these removed ranges.
 	//
 	// The field will be empty if snapshot is true, as a snapshot message implies
 	// that all ranges not present in the snapshot's added_or_updated list are no
@@ -75,7 +76,7 @@ func (m *Update) Reset()         { *m = Update{} }
 func (m *Update) String() string { return proto.CompactTextString(m) }
 func (*Update) ProtoMessage()    {}
 func (*Update) Descriptor() ([]byte, []int) {
-	return fileDescriptor_service_96a1a4bff833e11e, []int{0}
+	return fileDescriptor_service_458097978ab919fe, []int{0}
 }
 func (m *Update) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -118,7 +119,7 @@ func (m *Update_GroupUpdate) Reset()         { *m = Update_GroupUpdate{} }
 func (m *Update_GroupUpdate) String() string { return proto.CompactTextString(m) }
 func (*Update_GroupUpdate) ProtoMessage()    {}
 func (*Update_GroupUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_service_96a1a4bff833e11e, []int{0, 0}
+	return fileDescriptor_service_458097978ab919fe, []int{0, 0}
 }
 func (m *Update_GroupUpdate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -159,7 +160,7 @@ func (m *Update_RangeUpdate) Reset()         { *m = Update_RangeUpdate{} }
 func (m *Update_RangeUpdate) String() string { return proto.CompactTextString(m) }
 func (*Update_RangeUpdate) ProtoMessage()    {}
 func (*Update_RangeUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_service_96a1a4bff833e11e, []int{0, 1}
+	return fileDescriptor_service_458097978ab919fe, []int{0, 1}
 }
 func (m *Update_RangeUpdate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -191,7 +192,7 @@ func (m *Response) Reset()         { *m = Response{} }
 func (m *Response) String() string { return proto.CompactTextString(m) }
 func (*Response) ProtoMessage()    {}
 func (*Response) Descriptor() ([]byte, []int) {
-	return fileDescriptor_service_96a1a4bff833e11e, []int{1}
+	return fileDescriptor_service_458097978ab919fe, []int{1}
 }
 func (m *Response) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1290,10 +1291,10 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("kv/kvserver/closedts/ctpb/service.proto", fileDescriptor_service_96a1a4bff833e11e)
+	proto.RegisterFile("kv/kvserver/closedts/ctpb/service.proto", fileDescriptor_service_458097978ab919fe)
 }
 
-var fileDescriptor_service_96a1a4bff833e11e = []byte{
+var fileDescriptor_service_458097978ab919fe = []byte{
 	// 628 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x54, 0xc1, 0x4e, 0xdb, 0x30,
 	0x18, 0x6e, 0x96, 0x92, 0x56, 0xae, 0x06, 0xcc, 0xda, 0x21, 0x8a, 0xb6, 0xa4, 0x62, 0x82, 0xe5,

--- a/pkg/kv/kvserver/closedts/ctpb/service.proto
+++ b/pkg/kv/kvserver/closedts/ctpb/service.proto
@@ -72,8 +72,9 @@ message Update {
   }
   repeated GroupUpdate closed_timestamps = 4 [(gogoproto.nullable) = false];
 
-  // removed contains the set of ranges that are no longer registered on the
-  // stream and who future updates are no longer applicable to.
+  // removed contains the set of ranges that are no longer tracked on this
+  // stream. The closed timestamps in this message and future messages no longer
+  // apply to these removed ranges.
   //
   // The field will be empty if snapshot is true, as a snapshot message implies
   // that all ranges not present in the snapshot's added_or_updated list are no

--- a/pkg/kv/kvserver/closedts/provider/BUILD.bazel
+++ b/pkg/kv/kvserver/closedts/provider/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/provider",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/kv/kvserver/closedts",
         "//pkg/kv/kvserver/closedts/ctpb",
         "//pkg/roachpb",
@@ -31,6 +32,7 @@ go_test(
         "//pkg/roachpb",
         "//pkg/settings/cluster",
         "//pkg/testutils",
+        "//pkg/testutils/skip",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/kv/kvserver/closedts/provider/provider_test.go
+++ b/pkg/kv/kvserver/closedts/provider/provider_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -37,6 +38,7 @@ import (
 
 func TestProviderSubscribeNotify(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, closedts.IssueTrackingRemovalOfOldClosedTimestampsCode)
 
 	ctx := context.Background()
 	stopper := stop.NewStopper()
@@ -293,6 +295,7 @@ func TestProviderSubscribeConcurrent(t *testing.T) {
 // value re-enables it.
 func TestProviderTargetDurationSetting(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, closedts.IssueTrackingRemovalOfOldClosedTimestampsCode)
 
 	st := cluster.MakeTestingClusterSettings()
 	closedts.TargetDuration.Override(&st.SV, time.Millisecond)

--- a/pkg/kv/kvserver/closedts/sidetransport/BUILD.bazel
+++ b/pkg/kv/kvserver/closedts/sidetransport/BUILD.bazel
@@ -2,10 +2,14 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "sidetransport",
-    srcs = ["sender.go"],
+    srcs = [
+        "receiver.go",
+        "sender.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/sidetransport",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/base",
         "//pkg/clusterversion",
         "//pkg/kv/kvserver/closedts",
         "//pkg/kv/kvserver/closedts/ctpb",
@@ -19,15 +23,20 @@ go_library(
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+        "@com_github_cockroachdb_errors//:errors",
         "@org_golang_google_grpc//:go_default_library",
     ],
 )
 
 go_test(
     name = "sidetransport_test",
-    srcs = ["sender_test.go"],
+    srcs = [
+        "receiver_test.go",
+        "sender_test.go",
+    ],
     embed = [":sidetransport"],
     deps = [
+        "//pkg/base",
         "//pkg/kv/kvserver/closedts",
         "//pkg/kv/kvserver/closedts/ctpb",
         "//pkg/roachpb",
@@ -35,8 +44,10 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
+        "//pkg/util/log",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//:go_default_library",
     ],

--- a/pkg/kv/kvserver/closedts/sidetransport/receiver.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/receiver.go
@@ -1,0 +1,345 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sidetransport
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/ctpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+)
+
+// Receiver is the gRPC server for the closed timestamp side-transport,
+// receiving updates from remote nodes. It maintains the set of current
+// streaming connections.
+type Receiver struct {
+	log.AmbientContext
+	stop         *stop.Stopper
+	stores       Stores
+	testingKnobs receiverTestingKnobs
+
+	mu struct {
+		syncutil.RWMutex
+		conns map[roachpb.NodeID]*incomingStream
+	}
+}
+
+// receiverTestingKnobs contains knobs for incomingStreams connected to a
+// Receiver. The map is indexed by the sender NodeID.
+type receiverTestingKnobs map[roachpb.NodeID]incomingStreamTestingKnobs
+
+var _ ctpb.SideTransportServer = &Receiver{}
+
+// NewReceiver creates a Receiver, to be used as a gRPC server with
+// ctpb.RegisterClosedTimestampSideTransportServer.
+func NewReceiver(
+	nodeID *base.NodeIDContainer,
+	stop *stop.Stopper,
+	stores Stores,
+	testingKnobs receiverTestingKnobs,
+) *Receiver {
+	r := &Receiver{
+		stop:         stop,
+		stores:       stores,
+		testingKnobs: testingKnobs,
+	}
+	r.AmbientContext.AddLogTag("n", nodeID)
+	r.mu.conns = make(map[roachpb.NodeID]*incomingStream)
+	return r
+}
+
+// PushUpdates is the streaming RPC handler.
+func (s *Receiver) PushUpdates(stream ctpb.SideTransport_PushUpdatesServer) error {
+	// Create a steam to service this connection. The stream will call back into
+	// the Receiver through onFirstMsg to register itself once it finds out the
+	// sender's node id.
+	ctx := s.AnnotateCtx(stream.Context())
+	return newIncomingStream(s, s.stores).Run(ctx, s.stop, stream)
+}
+
+// GetClosedTimestamp returns the latest closed timestamp that the receiver
+// knows for a particular range, together with the LAI needed to have applied in
+// order to use this closed timestamp.
+//
+// leaseholderNode is the last known leaseholder for the range. For efficiency
+// reasons, only the closed timestamp info received from that node is checked
+// for closed timestamp info about this range.
+func (s *Receiver) GetClosedTimestamp(
+	ctx context.Context, rangeID roachpb.RangeID, leaseholderNode roachpb.NodeID,
+) (hlc.Timestamp, ctpb.LAI) {
+	s.mu.RLock()
+	conn, ok := s.mu.conns[leaseholderNode]
+	s.mu.RUnlock()
+	if !ok {
+		return hlc.Timestamp{}, 0
+	}
+	return conn.GetClosedTimestamp(ctx, rangeID)
+}
+
+// onFirstMsg is called when the first message on a stream is received. This is
+// the point where the stream finds out what node it's receiving data from.
+func (s *Receiver) onFirstMsg(ctx context.Context, r *incomingStream, nodeID roachpb.NodeID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	log.VEventf(ctx, 2, "n%d opened a closed timestamps side-transport connection", nodeID)
+	// If we already have a connection from nodeID, we don't accept this one. The
+	// other one has to be zombie going away soon. The client is expected to retry
+	// to establish the new connection.
+	//
+	// We could figure out a way to signal the existing connection to terminate,
+	// but it doesn't seem worth it.
+	if _, ok := s.mu.conns[nodeID]; ok {
+		return errors.Errorf("connection from n%d already exists", nodeID)
+	}
+	s.mu.conns[nodeID] = r
+	r.testingKnobs = s.testingKnobs[nodeID]
+	return nil
+}
+
+// onRecvErr is called when one of the inbound streams errors out. The stream is
+// removed from the Receiver's collection.
+func (s *Receiver) onRecvErr(ctx context.Context, nodeID roachpb.NodeID, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err != io.EOF {
+		log.Warningf(ctx, "closed timestamps side-transport connection dropped from node: %d", nodeID)
+	} else {
+		log.VEventf(ctx, 2, "closed timestamps side-transport connection dropped from node: %d (%s)", nodeID, err)
+	}
+	if nodeID != 0 {
+		delete(s.mu.conns, nodeID)
+	}
+}
+
+// incomingStream represents an inbound connection to a node publishing closed
+// timestamp information. It maintains the latest closed timestamps communicated
+// by the sender node.
+type incomingStream struct {
+	// The server that created this stream.
+	server       *Receiver
+	stores       Stores
+	testingKnobs incomingStreamTestingKnobs
+	// The node that's sending info on this stream.
+	nodeID roachpb.NodeID
+
+	mu struct {
+		syncutil.RWMutex
+		streamState
+	}
+}
+
+type incomingStreamTestingKnobs struct {
+	onFirstMsg chan struct{}
+	onRecvErr  func(sender roachpb.NodeID, err error)
+	onMsg      chan *ctpb.Update
+}
+
+// Stores is the interface of *Stores needed by incomingStream.
+type Stores interface {
+	// ForwardSideTransportClosedTimestampForRange forwards the side-transport
+	// closed timestamp for the local replica(s) of the given range.
+	ForwardSideTransportClosedTimestampForRange(
+		ctx context.Context, rangeID roachpb.RangeID, closedTS hlc.Timestamp, lai ctpb.LAI)
+}
+
+func newIncomingStream(s *Receiver, stores Stores) *incomingStream {
+	r := &incomingStream{
+		server: s,
+		stores: stores,
+	}
+	return r
+}
+
+// GetClosedTimestamp returns the latest closed timestamp that the receiver
+// knows for a particular range, together with the LAI needed to have applied in
+// order to use this closed timestamp. Returns an empty timestamp if the stream
+// does not have state for the range.
+func (r *incomingStream) GetClosedTimestamp(
+	ctx context.Context, rangeID roachpb.RangeID,
+) (hlc.Timestamp, ctpb.LAI) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	info, ok := r.mu.tracked[rangeID]
+	if !ok {
+		return hlc.Timestamp{}, 0
+	}
+	return r.mu.lastClosed[info.policy], info.lai
+}
+
+// processUpdate processes one update received on the stream, updating the local
+// state.
+func (r *incomingStream) processUpdate(ctx context.Context, msg *ctpb.Update) {
+	log.VEventf(ctx, 4, "received side-transport update: %v", msg)
+
+	if msg.NodeID == 0 {
+		log.Fatalf(ctx, "missing NodeID in message: %s", msg)
+	}
+
+	if msg.NodeID != r.nodeID {
+		log.Fatalf(ctx, "wrong NodeID; expected %d, got %d", r.nodeID, msg.NodeID)
+	}
+
+	// Handle the removed ranges. In order to not lose closed ts info, before we
+	// can remove a range from our tracking, we copy the info about its closed
+	// timestamp to the local replica(s). Note that it's important to do this
+	// before updating lastClosed below since, by definition, the closed
+	// timestamps in this message don't apply to the Removed ranges.
+	if len(msg.Removed) != 0 {
+		// Note that we call r.stores.ForwardSideTransportClosedTimestampForRange while holding
+		// our read lock, not write lock. ForwardSideTransportClosedTimestampForRange will call
+		// into each Replica, telling it to hold on locally to the the info we're about to
+		// remove from the stream. We can't do this with the mutex write-locked
+		// because replicas call GetClosedTimestamp() independently, with r.mu held
+		// (=> deadlock).
+		r.mu.RLock()
+		for _, rangeID := range msg.Removed {
+			info, ok := r.mu.tracked[rangeID]
+			if !ok {
+				log.Fatalf(ctx, "attempting to unregister a missing range: r%d", rangeID)
+			}
+			r.stores.ForwardSideTransportClosedTimestampForRange(
+				ctx, rangeID, r.mu.lastClosed[info.policy], info.lai)
+		}
+		r.mu.RUnlock()
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Reset all the state on snapshots.
+	if msg.Snapshot {
+		for i := range r.mu.lastClosed {
+			r.mu.lastClosed[i] = hlc.Timestamp{}
+		}
+		r.mu.tracked = make(map[roachpb.RangeID]trackedRange, len(r.mu.tracked))
+	} else if msg.SeqNum != r.mu.lastSeqNum+1 {
+		log.Fatalf(ctx, "expected closed timestamp side-transport message with sequence number "+
+			"%d, got %d", r.mu.lastSeqNum+1, msg.SeqNum)
+	}
+	r.mu.lastSeqNum = msg.SeqNum
+
+	for _, rng := range msg.AddedOrUpdated {
+		r.mu.tracked[rng.RangeID] = trackedRange{
+			lai:    rng.LAI,
+			policy: rng.Policy,
+		}
+	}
+	for _, rangeID := range msg.Removed {
+		delete(r.mu.tracked, rangeID)
+	}
+	for _, update := range msg.ClosedTimestamps {
+		r.mu.lastClosed[update.Policy] = update.ClosedTimestamp
+	}
+}
+
+// Run handles an incoming stream of closed timestamps.
+func (r *incomingStream) Run(
+	ctx context.Context,
+	stopper *stop.Stopper,
+	// The gRPC stream with incoming messages.
+	stream ctpb.SideTransport_PushUpdatesServer,
+) error {
+	// We have to do the stream processing on a separate goroutine because Recv()
+	// is blocking, with no way to interrupt it other than returning from the RPC
+	// handler (i.e. this Run function).
+	// The main goroutine remains in charge of listening for stopper quiescence.
+	streamDone := make(chan struct{})
+	if err := stopper.RunAsyncTask(ctx, "closedts side-transport server conn", func(ctx context.Context) {
+		// On exit, signal the other goroutine to terminate.
+		defer close(streamDone)
+		for {
+			msg, err := stream.Recv()
+			if err != nil {
+				if fn := r.testingKnobs.onRecvErr; fn != nil {
+					fn(r.nodeID, err)
+				}
+				r.server.onRecvErr(ctx, r.nodeID, err)
+				return
+			}
+
+			if r.nodeID == 0 {
+				r.nodeID = msg.NodeID
+
+				if err := r.server.onFirstMsg(ctx, r, r.nodeID); err != nil {
+					log.Warningf(ctx, "%s", err.Error())
+					return
+				} else if ch := r.testingKnobs.onFirstMsg; ch != nil {
+					ch <- struct{}{}
+				}
+				if !msg.Snapshot {
+					log.Fatal(ctx, "expected the first message to be a snapshot")
+				}
+			}
+
+			r.processUpdate(ctx, msg)
+			if ch := r.testingKnobs.onMsg; ch != nil {
+				select {
+				case ch <- msg:
+				default:
+				}
+			}
+		}
+	}); err != nil {
+		return err
+	}
+
+	// Block until the client terminates (or there's another stream error) or
+	// the stopper signals us to bail.
+	select {
+	case <-streamDone:
+	case <-stopper.ShouldQuiesce():
+	}
+	// Returning causes a blocked stream.Recv() (if there still is one) to return.
+	return nil
+}
+
+func (r *incomingStream) String() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var s strings.Builder
+	s.WriteString(fmt.Sprintf("n%d closed timestamps: ", r.nodeID))
+	now := timeutil.Now()
+	rangesByPoicy := make(map[roachpb.RangeClosedTimestampPolicy]*strings.Builder)
+	for pol, ts := range r.mu.lastClosed {
+		if pol != 0 {
+			s.WriteString(", ")
+		}
+		policy := roachpb.RangeClosedTimestampPolicy(pol)
+		s.WriteString(fmt.Sprintf("%s: %s (lead/lag: %s)", policy, ts, now.Sub(ts.GoTime())))
+		rangesByPoicy[policy] = &strings.Builder{}
+	}
+	s.WriteRune('\n')
+	for rid, info := range r.mu.tracked {
+		rangesByPoicy[info.policy].WriteString(fmt.Sprintf("%d, ", rid))
+	}
+	first := true
+	for policy, sb := range rangesByPoicy {
+		if !first {
+			s.WriteRune('\n')
+		} else {
+			first = false
+		}
+		s.WriteString(fmt.Sprintf("%s tracked: %s", policy, sb.String()))
+	}
+	return s.String()
+}

--- a/pkg/kv/kvserver/closedts/sidetransport/receiver_test.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/receiver_test.go
@@ -1,0 +1,218 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sidetransport
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/ctpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/stretchr/testify/require"
+)
+
+type mockStores struct {
+	recording []rangeUpdate
+	sem       chan struct{}
+}
+
+type rangeUpdate struct {
+	rid      roachpb.RangeID
+	closedTS hlc.Timestamp
+	lai      ctpb.LAI
+}
+
+var _ Stores = &mockStores{}
+
+func (m *mockStores) ForwardSideTransportClosedTimestampForRange(
+	ctx context.Context, rangeID roachpb.RangeID, closedTS hlc.Timestamp, lai ctpb.LAI,
+) {
+	upd := rangeUpdate{
+		rid:      rangeID,
+		closedTS: closedTS,
+		lai:      lai,
+	}
+	m.recording = append(m.recording, upd)
+	if m.sem != nil {
+		m.sem <- struct{}{}
+		<-m.sem
+	}
+}
+
+func (m *mockStores) getAndClearRecording() []rangeUpdate {
+	res := m.recording
+	m.recording = nil
+	return res
+}
+
+var ts10 = hlc.Timestamp{WallTime: 10}
+var ts11 = hlc.Timestamp{WallTime: 11}
+var ts12 = hlc.Timestamp{WallTime: 12}
+var ts20 = hlc.Timestamp{WallTime: 20, Synthetic: true}
+var ts21 = hlc.Timestamp{WallTime: 21, Synthetic: true}
+var ts22 = hlc.Timestamp{WallTime: 22, Synthetic: true}
+var laiZero = ctpb.LAI(0)
+
+const lai100 = ctpb.LAI(100)
+const lai101 = ctpb.LAI(101)
+const lai102 = ctpb.LAI(102)
+const lai103 = ctpb.LAI(102)
+
+func TestIncomingStreamProcessUpdateBasic(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	nid := &base.NodeIDContainer{}
+	nid.Set(ctx, 1)
+	stores := &mockStores{}
+	server := NewReceiver(nid, stopper, stores, receiverTestingKnobs{})
+	r := newIncomingStream(server, stores)
+	r.nodeID = 1
+
+	msg := &ctpb.Update{
+		NodeID:   1,
+		SeqNum:   1,
+		Snapshot: true,
+		ClosedTimestamps: []ctpb.Update_GroupUpdate{
+			{Policy: roachpb.LAG_BY_CLUSTER_SETTING, ClosedTimestamp: ts10},
+			{Policy: roachpb.LEAD_FOR_GLOBAL_READS, ClosedTimestamp: ts20},
+		},
+		AddedOrUpdated: []ctpb.Update_RangeUpdate{
+			{RangeID: 1, LAI: lai100, Policy: roachpb.LAG_BY_CLUSTER_SETTING},
+			{RangeID: 2, LAI: lai101, Policy: roachpb.LAG_BY_CLUSTER_SETTING},
+			{RangeID: 3, LAI: lai102, Policy: roachpb.LEAD_FOR_GLOBAL_READS},
+		},
+		Removed: nil,
+	}
+	r.processUpdate(ctx, msg)
+	ts, lai := r.GetClosedTimestamp(ctx, 1)
+	require.Equal(t, ts10, ts)
+	require.Equal(t, lai100, lai)
+	ts, lai = r.GetClosedTimestamp(ctx, 2)
+	require.Equal(t, ts10, ts)
+	require.Equal(t, lai101, lai)
+	ts, lai = r.GetClosedTimestamp(ctx, 3)
+	require.Equal(t, ts20, ts)
+	require.Equal(t, lai102, lai)
+	require.Empty(t, stores.getAndClearRecording())
+
+	// Remove range 1, update 2 implicitly, update 3 explicitly.
+	msg = &ctpb.Update{
+		NodeID:   1,
+		SeqNum:   2,
+		Snapshot: false,
+		ClosedTimestamps: []ctpb.Update_GroupUpdate{
+			{Policy: roachpb.LAG_BY_CLUSTER_SETTING, ClosedTimestamp: ts11},
+			{Policy: roachpb.LEAD_FOR_GLOBAL_READS, ClosedTimestamp: ts21},
+		},
+		AddedOrUpdated: []ctpb.Update_RangeUpdate{
+			{RangeID: 3, LAI: lai103, Policy: roachpb.LEAD_FOR_GLOBAL_READS},
+		},
+		Removed: []roachpb.RangeID{1},
+	}
+	r.processUpdate(ctx, msg)
+	ts, lai = r.GetClosedTimestamp(ctx, 1)
+	require.Empty(t, ts)
+	require.Equal(t, laiZero, lai)
+	ts, lai = r.GetClosedTimestamp(ctx, 2)
+	require.Equal(t, ts11, ts)
+	require.Equal(t, lai101, lai)
+	ts, lai = r.GetClosedTimestamp(ctx, 3)
+	require.Equal(t, ts21, ts)
+	require.Equal(t, lai103, lai)
+	require.Equal(t, []rangeUpdate{{rid: 1, closedTS: ts10, lai: lai100}}, stores.getAndClearRecording())
+
+	// Send a snapshot and check that it rests all the state.
+	msg = &ctpb.Update{
+		NodeID:   1,
+		SeqNum:   3,
+		Snapshot: true,
+		ClosedTimestamps: []ctpb.Update_GroupUpdate{
+			{Policy: roachpb.LAG_BY_CLUSTER_SETTING, ClosedTimestamp: ts12},
+			{Policy: roachpb.LEAD_FOR_GLOBAL_READS, ClosedTimestamp: ts22},
+		},
+		AddedOrUpdated: []ctpb.Update_RangeUpdate{
+			{RangeID: 3, LAI: lai102, Policy: roachpb.LEAD_FOR_GLOBAL_READS},
+			{RangeID: 4, LAI: lai100, Policy: roachpb.LAG_BY_CLUSTER_SETTING},
+		},
+		Removed: nil,
+	}
+	r.processUpdate(ctx, msg)
+	ts, lai = r.GetClosedTimestamp(ctx, 2)
+	require.Empty(t, ts)
+	require.Equal(t, laiZero, lai)
+	ts, lai = r.GetClosedTimestamp(ctx, 3)
+	require.Equal(t, ts22, ts)
+	require.Equal(t, lai102, lai)
+	ts, lai = r.GetClosedTimestamp(ctx, 4)
+	require.Equal(t, ts12, ts)
+	require.Equal(t, lai100, lai)
+	require.Empty(t, stores.getAndClearRecording())
+}
+
+// Test that when the incomingStream calls into the Stores to update a range, it
+// doesn't hold its internal lock. Or, in other words, test that replicas can
+// call into the stream while the stream is blocked updating the stores. In
+// particular, the replica being updated might be calling into the stream to get
+// its closed timestamp (async, for another operation), and it'd better not
+// deadlock.
+func TestIncomingStreamCallsIntoStoresDontHoldLock(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	nid := &base.NodeIDContainer{}
+	nid.Set(ctx, 1)
+	stores := &mockStores{}
+	server := NewReceiver(nid, stopper, stores, receiverTestingKnobs{})
+	r := newIncomingStream(server, stores)
+	r.nodeID = 1
+
+	// Add a range to the stream.
+	msg := &ctpb.Update{
+		NodeID: 1, SeqNum: 1, Snapshot: true,
+		ClosedTimestamps: []ctpb.Update_GroupUpdate{
+			{Policy: roachpb.LEAD_FOR_GLOBAL_READS, ClosedTimestamp: ts10},
+		},
+		AddedOrUpdated: []ctpb.Update_RangeUpdate{
+			{RangeID: 1, LAI: lai100, Policy: roachpb.LEAD_FOR_GLOBAL_READS},
+		},
+		Removed: nil,
+	}
+	r.processUpdate(ctx, msg)
+
+	// Remove the range and block the removal in the Stores.
+	ch := make(chan struct{})
+	stores.sem = ch
+	msg = &ctpb.Update{
+		NodeID: 1, SeqNum: 2, Snapshot: false,
+		Removed: []roachpb.RangeID{1},
+	}
+	go r.processUpdate(ctx, msg)
+	// Wait for the processUpdate to block.
+	<-ch
+	// With the update blocked, call into the stream. We're testing that this
+	// doesn't deadlock.
+	ts, _ := r.GetClosedTimestamp(ctx, 1)
+	require.Equal(t, ts10, ts)
+	// Unblock the process.
+	ch <- struct{}{}
+}

--- a/pkg/kv/kvserver/closedts/sidetransport/sender.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/sender.go
@@ -62,16 +62,7 @@ type Sender struct {
 
 	trackedMu struct {
 		syncutil.Mutex
-		// lastSeqNum is the sequence number of the last message published.
-		lastSeqNum ctpb.SeqNum
-		// lastClosed is the closed timestamp published for each policy in the
-		// last message.
-		lastClosed [roachpb.MAX_CLOSED_TIMESTAMP_POLICY]hlc.Timestamp
-		// tracked maintains the information that was communicated to connections in
-		// the last sent message (implicitly or explicitly). A range enters this
-		// structure as soon as it's included in a message, and exits it when it's
-		// removed through Update.Removed.
-		tracked map[roachpb.RangeID]trackedRange
+		streamState
 	}
 
 	leaseholdersMu struct {
@@ -88,6 +79,22 @@ type Sender struct {
 	// for ranges with local leases and removed when the respective node no
 	// longer has any replicas with local leases.
 	conns map[roachpb.NodeID]conn
+}
+
+// streamState encapsulates the state that's tracked by a stream. Both the
+// Sender and the Receiver use this struct and, for a given stream, both ends
+// are supposed to correspond (modulo message delays), in wonderful symmetry.
+type streamState struct {
+	// lastSeqNum is the sequence number of the last message published.
+	lastSeqNum ctpb.SeqNum
+	// lastClosed is the closed timestamp published for each policy in the
+	// last message.
+	lastClosed [roachpb.MAX_CLOSED_TIMESTAMP_POLICY]hlc.Timestamp
+	// tracked maintains the information that was communicated to connections in
+	// the last sent message (implicitly or explicitly). A range enters this
+	// structure as soon as it's included in a message, and exits it when it's
+	// removed through Update.Removed.
+	tracked map[roachpb.RangeID]trackedRange
 }
 
 type connTestingKnobs struct {
@@ -166,6 +173,7 @@ func newSenderWithConnFactory(
 // This is not know at construction time.
 func (s *Sender) Run(ctx context.Context, nodeID roachpb.NodeID) {
 	s.nodeID = nodeID
+	waitForUpgrade := !s.st.Version.IsActive(ctx, clusterversion.ClosedTimestampsRaftTransport)
 
 	confCh := make(chan struct{}, 1)
 	confChanged := func() {
@@ -197,8 +205,11 @@ func (s *Sender) Run(ctx context.Context, nodeID roachpb.NodeID) {
 				select {
 				case <-timer.C:
 					timer.Read = true
-					if !s.st.Version.IsActive(ctx, clusterversion.ClosedTimestampsRaftTransport) {
+					if waitForUpgrade && !s.st.Version.IsActive(ctx, clusterversion.ClosedTimestampsRaftTransport) {
 						continue
+					} else if waitForUpgrade {
+						waitForUpgrade = false
+						log.Infof(ctx, "closed-timestamps v2 mechanism enabled by cluster version upgrade")
 					}
 					s.publish(ctx)
 				case <-confCh:
@@ -252,6 +263,7 @@ func (s *Sender) UnregisterLeaseholder(
 func (s *Sender) publish(ctx context.Context) hlc.ClockTimestamp {
 	s.trackedMu.Lock()
 	defer s.trackedMu.Unlock()
+	log.VEventf(ctx, 2, "side-transport publishing a new message")
 
 	msg := &ctpb.Update{
 		NodeID:           s.nodeID,
@@ -383,6 +395,7 @@ func (s *Sender) publish(ctx context.Context) hlc.ClockTimestamp {
 	})
 
 	// Publish the new message to all connections.
+	log.VEventf(ctx, 4, "side-transport publishing message with closed timestamps: %v (%v)", msg.ClosedTimestamps, msg)
 	s.buf.Push(ctx, msg)
 
 	// Return the publication time, for tests.
@@ -608,7 +621,8 @@ type rpcConn struct {
 	nodeID       roachpb.NodeID
 	testingKnobs connTestingKnobs
 
-	stream ctpb.SideTransport_PushUpdatesClient
+	stream   ctpb.SideTransport_PushUpdatesClient
+	lastSent ctpb.SeqNum
 	// cancelStreamCtx cleans up the resources (goroutine) associated with stream.
 	// It needs to be called whenever stream is discarded.
 	cancelStreamCtx context.CancelFunc
@@ -638,6 +652,11 @@ func (r *rpcConn) cleanupStream() {
 	r.stream = nil
 	r.cancelStreamCtx()
 	r.cancelStreamCtx = nil
+	// If we've been disconnected, reset the message sequence. If we ever
+	// reconnect, we'll ask the buffer for message 1, which was a snapshot.
+	// Generally, the buffer is not going to have that message any more and so
+	// we'll generate a new snapshot.
+	r.lastSent = 0
 }
 
 // close makes the connection stop sending messages. The run() goroutine will
@@ -684,7 +703,6 @@ func (r *rpcConn) run(ctx context.Context, stopper *stop.Stopper) {
 			// On sending errors, we sleep a bit as to not spin on a tripped
 			// circuit-breaker in the Dialer.
 			const sleepOnErr = time.Second
-			var lastSent ctpb.SeqNum
 			for {
 				if ctx.Err() != nil {
 					return
@@ -698,19 +716,8 @@ func (r *rpcConn) run(ctx context.Context, stopper *stop.Stopper) {
 				}
 
 				var msg *ctpb.Update
-
-				// If we've been disconnected, reset the message sequence. We'll ask the
-				// buffer for the very first message ever, which was a snapshot.
-				// Generally, the buffer is not going to have that message any more and
-				// so we'll generate a snapshot below. Except soon after startup when
-				// streams are initially established, when the initial message should
-				// still be in the buffer.
-				if r.stream == nil {
-					lastSent = 0
-				}
-
 				var ok bool
-				msg, ok = r.producer.buf.GetBySeq(ctx, lastSent+1)
+				msg, ok = r.producer.buf.GetBySeq(ctx, r.lastSent+1)
 				// We can be signaled to stop in two ways: the buffer can be closed (in
 				// which case all connections must exit), or this connection was closed
 				// via close(). In either case, we quit.
@@ -723,20 +730,21 @@ func (r *rpcConn) run(ctx context.Context, stopper *stop.Stopper) {
 				}
 
 				if msg == nil {
-					// The sequence number we've requested is no longer in the buffer.
-					// We need to generate a snapshot in order to re-initialize the
-					// stream.
+					// The sequence number we've requested is no longer in the buffer. We
+					// need to generate a snapshot in order to re-initialize the stream.
+					// The snapshot will give us the sequence number to use for future
+					// incrementals.
 					msg = r.producer.GetSnapshot()
 				}
+				r.lastSent = msg.SeqNum
 
-				lastSent = msg.SeqNum
 				if fn := r.testingKnobs.beforeSend; fn != nil {
 					fn(r.nodeID, msg)
 				}
 				if err := r.stream.Send(msg); err != nil {
 					if err != io.EOF && everyN.ShouldLog() {
 						log.Warningf(ctx, "failed to send closed timestamp message %d to n%d: %s",
-							lastSent, r.nodeID, err)
+							r.lastSent, r.nodeID, err)
 					}
 					// Keep track of the fact that we need a new connection.
 					//

--- a/pkg/kv/kvserver/closedts/sidetransport/sender.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/sender.go
@@ -263,7 +263,7 @@ func (s *Sender) UnregisterLeaseholder(
 func (s *Sender) publish(ctx context.Context) hlc.ClockTimestamp {
 	s.trackedMu.Lock()
 	defer s.trackedMu.Unlock()
-	log.VEventf(ctx, 2, "side-transport publishing a new message")
+	log.VEventf(ctx, 4, "side-transport generating a new message")
 
 	msg := &ctpb.Update{
 		NodeID:           s.nodeID,

--- a/pkg/kv/kvserver/closedts/sidetransport/sender_test.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/sender_test.go
@@ -12,10 +12,12 @@ package sidetransport
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/ctpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -23,8 +25,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
@@ -33,20 +37,43 @@ import (
 type mockReplica struct {
 	storeID roachpb.StoreID
 	rangeID roachpb.RangeID
-	desc    roachpb.RangeDescriptor
+	mu      struct {
+		syncutil.Mutex
+		desc roachpb.RangeDescriptor
+	}
 
 	canBump bool
 	lai     ctpb.LAI
 	policy  roachpb.RangeClosedTimestampPolicy
 }
 
-func (m *mockReplica) StoreID() roachpb.StoreID       { return m.storeID }
-func (m *mockReplica) GetRangeID() roachpb.RangeID    { return m.rangeID }
-func (m *mockReplica) Desc() *roachpb.RangeDescriptor { return &m.desc }
+var _ Replica = &mockReplica{}
+
+func (m *mockReplica) StoreID() roachpb.StoreID    { return m.storeID }
+func (m *mockReplica) GetRangeID() roachpb.RangeID { return m.rangeID }
+func (m *mockReplica) Desc() *roachpb.RangeDescriptor {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return &m.mu.desc
+}
 func (m *mockReplica) BumpSideTransportClosed(
 	_ context.Context, _ hlc.ClockTimestamp, _ [roachpb.MAX_CLOSED_TIMESTAMP_POLICY]hlc.Timestamp,
 ) (bool, ctpb.LAI, roachpb.RangeClosedTimestampPolicy) {
 	return m.canBump, m.lai, m.policy
+}
+
+func (m *mockReplica) removeReplica(nid roachpb.NodeID) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	replicas := m.mu.desc.Replicas()
+	for _, rd := range replicas.Descriptors() {
+		if rd.NodeID == nid {
+			replicas.RemoveReplica(rd.NodeID, rd.StoreID)
+			m.mu.desc.SetReplicas(replicas)
+			return
+		}
+	}
+	panic(fmt.Sprintf("replica not found for n%d", nid))
 }
 
 // mockConnFactory is a mock implementation of the connFactory interface.
@@ -81,14 +108,15 @@ func newMockReplica(id roachpb.RangeID, nodes ...roachpb.NodeID) *mockReplica {
 	for _, nodeID := range nodes {
 		desc.AddReplica(nodeID, roachpb.StoreID(nodeID), roachpb.VOTER_FULL)
 	}
-	return &mockReplica{
+	r := &mockReplica{
 		storeID: 1,
 		rangeID: id,
-		desc:    desc,
 		canBump: true,
 		lai:     5,
 		policy:  roachpb.LAG_BY_CLUSTER_SETTING,
 	}
+	r.mu.desc = desc
+	return r
 }
 
 func expGroupUpdates(s *Sender, now hlc.ClockTimestamp) []ctpb.Update_GroupUpdate {
@@ -105,6 +133,7 @@ func expGroupUpdates(s *Sender, now hlc.ClockTimestamp) []ctpb.Update_GroupUpdat
 
 func TestSenderBasic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 	connFactory := &mockConnFactory{}
 	s, stopper := newMockSender(connFactory)
@@ -245,62 +274,93 @@ func (s *mockReceiver) getCalled() bool {
 	return s.mu.called
 }
 
-// mockSideTransportGRPCServer wraps a mockReceiver in a gRPC server listening
-// on a network interface.
-type mockSideTransportGRPCServer struct {
+// sideTransportGRPCServer wraps a Receiver (a real one of a mock) in a gRPC
+// server listening on a network interface.
+type sideTransportGRPCServer struct {
 	lis      net.Listener
 	srv      *grpc.Server
-	receiver *mockReceiver
-	stopper  *stop.Stopper
+	receiver ctpb.SideTransportServer
 }
 
-func (s *mockSideTransportGRPCServer) close() {
-	s.receiver.close()
+func (s *sideTransportGRPCServer) Close() {
 	s.srv.Stop()
 	_ /* err */ = s.lis.Close()
-	s.stopper.Stop(context.Background())
 }
 
-func (s *mockSideTransportGRPCServer) addr() net.Addr {
+func (s *sideTransportGRPCServer) addr() net.Addr {
 	return s.lis.Addr()
 }
 
-func newMockSideTransportGRPCServer() (*mockSideTransportGRPCServer, error) {
+func newMockSideTransportGRPCServer(stopper *stop.Stopper) (*sideTransportGRPCServer, error) {
+	receiver := newMockReceiver()
+	stopper.AddCloser(receiver)
+	server, err := newMockSideTransportGRPCServerWithOpts(stopper, receiver)
+	if err != nil {
+		return nil, err
+	}
+	return server, nil
+}
+
+func newMockSideTransportGRPCServerWithOpts(
+	stopper *stop.Stopper, receiver ctpb.SideTransportServer,
+) (*sideTransportGRPCServer, error) {
 	lis, err := net.Listen("tcp", "localhost:")
 	if err != nil {
 		return nil, err
 	}
 
-	stopper := stop.NewStopper()
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 	grpcServer := rpc.NewServer(rpc.NewInsecureTestingContext(clock, stopper))
-
-	receiver := newMockReceiver()
 	ctpb.RegisterSideTransportServer(grpcServer, receiver)
 	go func() {
 		_ /* err */ = grpcServer.Serve(lis)
 	}()
-	return &mockSideTransportGRPCServer{
+	server := &sideTransportGRPCServer{
 		lis:      lis,
 		srv:      grpcServer,
 		receiver: receiver,
-		stopper:  stopper,
-	}, nil
+	}
+	stopper.AddCloser(server)
+	return server, nil
 }
 
-func (s *mockReceiver) close() {
+func (s *sideTransportGRPCServer) mockReceiver() *mockReceiver {
+	return s.receiver.(*mockReceiver)
+}
+
+func (s *mockReceiver) Close() {
 	close(s.stop)
 }
 
 type mockDialer struct {
-	serverAddr string
-	mu         struct {
+	mu struct {
 		syncutil.Mutex
+		addrs map[roachpb.NodeID]string
 		conns []*grpc.ClientConn
 	}
 }
 
 var _ nodeDialer = &mockDialer{}
+
+type nodeAddr struct {
+	nid  roachpb.NodeID
+	addr string
+}
+
+func newMockDialer(addrs ...nodeAddr) *mockDialer {
+	d := &mockDialer{}
+	d.mu.addrs = make(map[roachpb.NodeID]string)
+	for _, addr := range addrs {
+		d.mu.addrs[addr.nid] = addr.addr
+	}
+	return d
+}
+
+func (m *mockDialer) addOrUpdateNode(nid roachpb.NodeID, addr string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.mu.addrs[nid] = addr
+}
 
 func (m *mockDialer) Dial(
 	ctx context.Context, nodeID roachpb.NodeID, class rpc.ConnectionClass,
@@ -308,7 +368,12 @@ func (m *mockDialer) Dial(
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	c, err := grpc.Dial(m.serverAddr, grpc.WithInsecure())
+	addr, ok := m.mu.addrs[nodeID]
+	if !ok {
+		return nil, errors.Errorf("node not configured in mockDialer: n%d", nodeID)
+	}
+
+	c, err := grpc.Dial(addr, grpc.WithInsecure())
 	if err == nil {
 		m.mu.conns = append(m.mu.conns, c)
 	}
@@ -326,12 +391,17 @@ func (m *mockDialer) Close() {
 // Test that the stopper quiescence interrupts a stream.Send.
 func TestRPCConnUnblocksOnStopper(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	srv, err := newMockSideTransportGRPCServer()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	srv, err := newMockSideTransportGRPCServer(stopper)
 	require.NoError(t, err)
-	defer srv.close()
-	dialer := &mockDialer{serverAddr: srv.addr().String()}
+	dialer := newMockDialer(nodeAddr{
+		nid:  2,
+		addr: srv.addr().String(),
+	})
 	defer dialer.Close()
 
 	ch := make(chan struct{})
@@ -376,5 +446,72 @@ func TestRPCConnUnblocksOnStopper(t *testing.T) {
 	// have been unblocked.
 	stopper.Stop(ctx)
 
-	require.True(t, srv.receiver.getCalled())
+	require.True(t, srv.mockReceiver().getCalled())
+}
+
+// Test a Sender and Receiver talking gRPC to each other.
+func TestSenderReceiverIntegration(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	// We're going to create Receivers, corresponding to 3 nodes. Node 1 will also
+	// be the Sender, so we won't expect a connection to it (the Sender doesn't
+	// connect to itself).
+	const numNodes = 3
+	receivers := make([]*Receiver, numNodes)
+	dialer := newMockDialer(nodeAddr{})
+	defer dialer.Close()
+	incomingStreamOnN2FromN1Terminated := make(chan error)
+	for i := 0; i < numNodes; i++ {
+		receiverStop := stop.NewStopper()
+		defer func(i int) {
+			receiverStop.Stop(ctx)
+		}(i)
+		nid := &base.NodeIDContainer{}
+		nid.Set(ctx, roachpb.NodeID(i+1))
+		stores := &mockStores{}
+		knobs := receiverTestingKnobs{
+			roachpb.NodeID(1): {
+				onFirstMsg: make(chan struct{}),
+				onMsg:      make(chan *ctpb.Update),
+			},
+		}
+		incomingFromN1Knobs := knobs[1]
+		switch nid.Get() {
+		case 1:
+			// n1 doesn't expect any streams, since the only active sender will be on
+			// n1 and it's not supposed to connect to the local receiver.
+			incomingFromN1Knobs.onRecvErr = func(_ roachpb.NodeID, _ error) {
+				t.Errorf("unexpected receive error on node n%d", nid)
+			}
+		case 2:
+			// n2 gets a special handler.
+			incomingFromN1Knobs.onRecvErr = func(_ roachpb.NodeID, err error) {
+				incomingStreamOnN2FromN1Terminated <- err
+			}
+		}
+		knobs[1] = incomingFromN1Knobs
+		receivers[i] = NewReceiver(nid, receiverStop, stores, knobs)
+		srv, err := newMockSideTransportGRPCServerWithOpts(receiverStop, receivers[i])
+		dialer.addOrUpdateNode(nid.Get(), srv.addr().String())
+		require.NoError(t, err)
+	}
+
+	s, senderStopper := newMockSender(newRPCConnFactory(dialer, connTestingKnobs{}))
+	defer senderStopper.Stop(ctx)
+	s.Run(ctx, roachpb.NodeID(1))
+
+	// Add a replica with replicas on n2 and n3.
+	r1 := newMockReplica(15, 1, 2, 3)
+	s.RegisterLeaseholder(ctx, r1, 1 /* leaseSeq */)
+	// Check that connections to n2,3 are established.
+	<-receivers[1].testingKnobs[1].onFirstMsg
+	<-receivers[2].testingKnobs[1].onFirstMsg
+	// Remove one of the replicas and check that the connection to the respective
+	// Receiver drops (since there's no other ranges with replicas on n2).
+	r1.removeReplica(roachpb.NodeID(2))
+	<-incomingStreamOnN2FromN1Terminated
+	// Check that the other Receiver is still receiving updates.
+	<-receivers[2].testingKnobs[1].onMsg
 }

--- a/pkg/kv/kvserver/closedts/sidetransport/sender_test.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/sender_test.go
@@ -412,9 +412,24 @@ func TestRPCConnUnblocksOnStopper(t *testing.T) {
 		}}))
 	defer stopper.Stop(ctx)
 
-	// Add a leaseholder that can close, in order to establish a connection to n2.
-	r1 := newMockReplica(15, 1, 2)
-	s.RegisterLeaseholder(ctx, r1, 1)
+	// Add leaseholders that can close, in order to establish a connection to n2.
+	// We add many of them, and we'll increment their LAIs periodically such that
+	// all messages need to explicitly mention all of them, in order to get large
+	// messages. This speeds up the test, since the large messages make the sender
+	// block quicker.
+	const numReplicas = 10000
+	replicas := make([]*mockReplica, numReplicas)
+	for i := 0; i < numReplicas; i++ {
+		replicas[i] = newMockReplica(roachpb.RangeID(i+1), 1, 2)
+		s.RegisterLeaseholder(ctx, replicas[i], 1 /* leaseSeq */)
+	}
+
+	incrementLAIs := func() {
+		for _, r := range replicas {
+			r.lai++
+		}
+	}
+
 	s.publish(ctx)
 	require.Len(t, s.conns, 1)
 
@@ -430,6 +445,7 @@ func TestRPCConnUnblocksOnStopper(t *testing.T) {
 			case <-ch:
 				// As soon as the conn send a message, publish another update to cause
 				// the conn to send another message.
+				incrementLAIs()
 				s.publish(ctx)
 			case <-time.After(100 * time.Millisecond):
 				// The conn hasn't sent anything in a while. It must be blocked on Send.

--- a/pkg/kv/kvserver/closedts/transport/BUILD.bazel
+++ b/pkg/kv/kvserver/closedts/transport/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/transport",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/kv/kvserver/closedts",
         "//pkg/kv/kvserver/closedts/ctpb",
         "//pkg/roachpb",
@@ -31,11 +32,13 @@ go_test(
     ],
     deps = [
         ":transport",
+        "//pkg/kv/kvserver/closedts",
         "//pkg/kv/kvserver/closedts/ctpb",
         "//pkg/kv/kvserver/closedts/transport/testutils",
         "//pkg/roachpb",
         "//pkg/settings/cluster",
         "//pkg/testutils",
+        "//pkg/testutils/skip",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/stop",

--- a/pkg/kv/kvserver/closedts/transport/clients.go
+++ b/pkg/kv/kvserver/closedts/transport/clients.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"unsafe"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/ctpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -66,6 +67,11 @@ type client struct {
 // done so, the information should soon thereafter be available to the Sink and
 // from there, further follower read attempts. Does not block.
 func (pr *Clients) Request(nodeID roachpb.NodeID, rangeID roachpb.RangeID) {
+	// If the new closed timestamps is enabled, this old one is disabled.
+	if pr.cfg.Settings.Version.IsActive(context.TODO(), clusterversion.ClosedTimestampsRaftTransport) {
+		return
+	}
+
 	if nodeID == pr.cfg.NodeID {
 		return
 	}

--- a/pkg/kv/kvserver/closedts/transport/transport_test.go
+++ b/pkg/kv/kvserver/closedts/transport/transport_test.go
@@ -16,12 +16,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/ctpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/transport"
 	transporttestutils "github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/transport/testutils"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -76,6 +78,7 @@ func assertNumSubscribers(t *testing.T, p *TestProducer, exp int) {
 
 func TestTransportConnectOnRequest(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, closedts.IssueTrackingRemovalOfOldClosedTimestampsCode)
 
 	container := NewTestContainer()
 	defer container.Stopper.Stop(context.Background())
@@ -108,6 +111,7 @@ func TestTransportConnectOnRequest(t *testing.T) {
 
 func TestTransportClientReceivesEntries(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, closedts.IssueTrackingRemovalOfOldClosedTimestampsCode)
 
 	container := NewTestContainer()
 	defer container.Stopper.Stop(context.Background())

--- a/pkg/kv/kvserver/replica_closedts.go
+++ b/pkg/kv/kvserver/replica_closedts.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/ctpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // EmitMLAI registers the replica's last assigned max lease index with the
@@ -149,4 +150,37 @@ func (r *Replica) closedTimestampTargetRLocked() hlc.Timestamp {
 	lagTargetDuration := closedts.TargetDuration.Get(&r.ClusterSettings().SV)
 	policy := r.closedTimestampPolicyRLocked()
 	return closedts.TargetForPolicy(now, maxClockOffset, lagTargetDuration, policy)
+}
+
+// ForwardSideTransportClosedTimestamp forwards
+// r.mu.sideTransportClosedTimestamp. It is called by the closed timestamp
+// side-transport receiver.
+func (r *Replica) ForwardSideTransportClosedTimestamp(
+	ctx context.Context, closedTS hlc.Timestamp, lai ctpb.LAI,
+) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.mu.sideTransportClosedTimestamp.Forward(closedTS) {
+		if r.mu.sideTransportCloseTimestampLAI > lai {
+			log.Fatalf(ctx, "received side-transport notification with higher closed timestamp "+
+				"but lower LAI: r%d current LAI: %d received LAI: %d",
+				r.RangeID, r.mu.sideTransportCloseTimestampLAI, lai)
+		}
+		r.mu.sideTransportCloseTimestampLAI = lai
+	}
+}
+
+// getSideTransportClosedTimestamp returns the replica's information about the
+// timestamp that was closed by the side-transport. Note that this not include
+// r.mu.state.RaftClosedTimestamp. Also note that this might not be the highest
+// closed timestamp communicated by the side-transport - the
+// ClosedTimestampReceiver should be checked too if an up-to-date value is
+// required.
+//
+// It's the responsibility of the caller to check the returned LAI against the
+// replica's applied LAI. If the returned LAI hasn't applied, the closed
+// timestamp cannot be used.
+func (r *Replica) getSideTransportClosedTimestampRLocked() (closedTS hlc.Timestamp, lai ctpb.LAI) {
+	return r.mu.sideTransportClosedTimestamp, r.mu.sideTransportCloseTimestampLAI
 }

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -465,9 +465,15 @@ func (r *Replica) handleInvalidLeaseError(
 	// not be necessary once we break the dependency between closed timestamps
 	// and leases and address the TODO in checkExecutionCanProceed to check the
 	// closed timestamp before consulting the lease.
+
+	var update replicaUpdate
+	defer update.apply(ctx, r)
+
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	if r.canServeFollowerReadRLocked(ctx, ba, pErr.GoError()) {
+	var ok bool
+	ok, update = r.canServeFollowerReadRLocked(ctx, ba, pErr.GoError())
+	if ok {
 		// Follower read possible. Retry command.
 		return nil
 	}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -649,8 +649,9 @@ type StoreConfig struct {
 	RPCContext              *rpc.Context
 	RangeDescriptorCache    *rangecache.RangeCache
 
-	ClosedTimestamp       *container.Container
-	ClosedTimestampSender *sidetransport.Sender
+	ClosedTimestamp         *container.Container
+	ClosedTimestampSender   *sidetransport.Sender
+	ClosedTimestampReceiver *sidetransport.Receiver
 
 	// SQLExecutor is used by the store to execute SQL statements.
 	SQLExecutor sqlutil.InternalExecutor

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangecache"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/container"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/ctpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/sidetransport"
@@ -1575,6 +1576,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 
 	// Connect rangefeeds to closed timestamp updates.
 	s.startClosedTimestampRangefeedSubscriber(ctx)
+	s.startRangefeedUpdater(ctx)
 
 	if s.replicateQueue != nil {
 		s.storeRebalancer = NewStoreRebalancer(
@@ -1776,6 +1778,10 @@ func (s *Store) startClosedTimestampRangefeedSubscriber(ctx context.Context) {
 	_ = s.stopper.RunAsyncTask(ctx, "ct-subscriber", func(ctx context.Context) {
 		var replIDs []roachpb.RangeID
 		for {
+			if s.cfg.Settings.Version.IsActive(ctx, clusterversion.ClosedTimestampsRaftTransport) {
+				// The startRangefeedUpdater goroutine takes over.
+				return
+			}
 			select {
 			case <-ch:
 				// Drain all notifications from the channel.
@@ -1811,6 +1817,75 @@ func (s *Store) startClosedTimestampRangefeedSubscriber(ctx context.Context) {
 			case <-s.stopper.ShouldQuiesce():
 				return
 			}
+		}
+	})
+}
+
+// startRangefeedUpdater periodically informs all the replicas with rangefeeds
+// about closed timestamp updates.
+func (s *Store) startRangefeedUpdater(ctx context.Context) {
+	const name = "closedts-rangefeed-updater"
+	_ /* err */ = s.stopper.RunAsyncTask(ctx, name, func(ctx context.Context) {
+		timer := timeutil.NewTimer()
+		defer timer.Stop()
+		var replIDs []roachpb.RangeID
+		st := s.cfg.Settings
+
+		confCh := make(chan struct{}, 1)
+		confChanged := func() {
+			select {
+			case confCh <- struct{}{}:
+			default:
+			}
+		}
+		closedts.SideTransportCloseInterval.SetOnChange(&st.SV, confChanged)
+		RangeFeedRefreshInterval.SetOnChange(&st.SV, confChanged)
+
+		getInterval := func() time.Duration {
+			refresh := RangeFeedRefreshInterval.Get(&st.SV)
+			if refresh != 0 {
+				return refresh
+			}
+			return closedts.SideTransportCloseInterval.Get(&st.SV)
+		}
+
+		for {
+			interval := getInterval()
+			if interval > 0 {
+				timer.Reset(interval)
+			} else {
+				// Disable the side-transport.
+				timer.Stop()
+				timer = timeutil.NewTimer()
+			}
+			select {
+			case <-timer.C:
+				timer.Read = true
+				if !s.cfg.Settings.Version.IsActive(ctx, clusterversion.ClosedTimestampsRaftTransport) {
+					continue
+				}
+				s.rangefeedReplicas.Lock()
+				replIDs = replIDs[:0]
+				for replID := range s.rangefeedReplicas.m {
+					replIDs = append(replIDs, replID)
+				}
+				s.rangefeedReplicas.Unlock()
+				// Notify each replica with an active rangefeed to check for an updated
+				// closed timestamp.
+				for _, replID := range replIDs {
+					r := s.GetReplicaIfExists(replID)
+					if r == nil {
+						continue
+					}
+					r.handleClosedTimestampUpdate(ctx)
+				}
+			case <-confCh:
+				// Loop around to use the updated timer.
+				continue
+			case <-s.stopper.ShouldQuiesce():
+				return
+			}
+
 		}
 	})
 }

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -72,6 +72,7 @@ go_library(
         "//pkg/kv/kvprober",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/closedts/container",
+        "//pkg/kv/kvserver/closedts/ctpb",
         "//pkg/kv/kvserver/closedts/sidetransport",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/kvserverpb",

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -287,6 +287,7 @@ func NewNode(
 	reg *metric.Registry,
 	stopper *stop.Stopper,
 	txnMetrics kvcoord.TxnMetrics,
+	stores *kvserver.Stores,
 	execCfg *sql.ExecutorConfig,
 	clusterID *base.ClusterIDContainer,
 ) *Node {
@@ -299,7 +300,7 @@ func NewNode(
 		stopper:    stopper,
 		recorder:   recorder,
 		metrics:    makeNodeMetrics(reg, cfg.HistogramWindowInterval),
-		stores:     kvserver.NewStores(cfg.AmbientCtx, cfg.Clock),
+		stores:     stores,
 		txnMetrics: txnMetrics,
 		sqlExec:    sqlExec,
 		clusterID:  clusterID,


### PR DESCRIPTION
Add the consumer of closed timestamps communicated by the side transport
(i.e. the gRPC server for our new push-based streaming protocol).

This side-transport consumer accumulates closed timestamps communicated
to it by other nodes (the leaseholders of the respective ranges). Its
state is queried whenever a range needs a higher closed timestamp than
what it has locally in the Replica state, at which point the Replica's
state is lazily updated.

Release note: None
Release justification: Needed for GLOBAL tables.