### PR TITLE
colexec: improve handling of operators when they are removed from the tree

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -716,7 +716,7 @@ func NewColOperator(
 					core.Values.NumRows, len(core.Values.Columns),
 				)
 			}
-			result.Op = colexecutils.NewFixedNumTuplesNoInputOp(streamingAllocator, int(core.Values.NumRows))
+			result.Op = colexecutils.NewFixedNumTuplesNoInputOp(streamingAllocator, int(core.Values.NumRows), nil /* opToInitialize */)
 			result.ColumnTypes = make([]*types.T, len(core.Values.Columns))
 			for i, col := range core.Values.Columns {
 				result.ColumnTypes[i] = col.Type
@@ -778,7 +778,7 @@ func NewColOperator(
 				// TableReader, so we end up creating an orphaned colBatchScan.
 				// We should avoid that. Ideally the optimizer would not plan a
 				// scan in this unusual case.
-				result.Op, err = colexecutils.NewFixedNumTuplesNoInputOp(streamingAllocator, 1 /* numTuples */), nil
+				result.Op, err = colexecutils.NewFixedNumTuplesNoInputOp(streamingAllocator, 1 /* numTuples */, inputs[0]), nil
 				// We make ColumnTypes non-nil so that sanity check doesn't
 				// panic.
 				result.ColumnTypes = []*types.T{}

--- a/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
@@ -66,10 +66,12 @@ func TestParallelUnorderedSynchronizer(t *testing.T) {
 		}
 	}
 
+	ctx, cancelFn := context.WithCancel(context.Background())
+
 	var wg sync.WaitGroup
 	s := NewParallelUnorderedSynchronizer(inputs, &wg)
+	s.Init()
 
-	ctx, cancelFn := context.WithCancel(context.Background())
 	type synchronizerTerminationScenario int
 	const (
 		// synchronizerGracefulTermination is a termination scenario where the
@@ -178,6 +180,7 @@ func TestUnorderedSynchronizerNoLeaksOnError(t *testing.T) {
 
 	var wg sync.WaitGroup
 	s := NewParallelUnorderedSynchronizer(inputs, &wg)
+	s.Init()
 	for {
 		if err := colexecerror.CatchVectorizedRuntimeError(func() { _ = s.Next(ctx) }); err != nil {
 			require.True(t, testutils.IsError(err, expectedErr), err)
@@ -204,6 +207,7 @@ func BenchmarkParallelUnorderedSynchronizer(b *testing.B) {
 	var wg sync.WaitGroup
 	ctx, cancelFn := context.WithCancel(context.Background())
 	s := NewParallelUnorderedSynchronizer(inputs, &wg)
+	s.Init()
 	b.SetBytes(8 * int64(coldata.BatchSize()))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
@@ -113,7 +113,13 @@ func TestParallelUnorderedSynchronizer(t *testing.T) {
 				// for Next to be called even though it's not technically supported to
 				// ensure that a zero-length batch is returned.
 				meta := s.DrainMeta(ctx)
-				require.Equal(t, len(inputs), len(meta), "metadata length mismatch, returned metadata is: %v", meta)
+				if batchesReturned == 0 {
+					// If Next() hasn't been called, then the input goroutines
+					// haven't been spawned, and there will be no metadata.
+					require.Equal(t, 0, len(meta), "metadata length mismatch, returned metadata is: %v", meta)
+				} else {
+					require.Equal(t, len(inputs), len(meta), "metadata length mismatch, returned metadata is: %v", meta)
+				}
 				expectZeroBatch = true
 			}
 			var b coldata.Batch

--- a/pkg/sql/colflow/vectorized_flow_space_test.go
+++ b/pkg/sql/colflow/vectorized_flow_space_test.go
@@ -73,9 +73,9 @@ func TestVectorizeInternalMemorySpaceError(t *testing.T) {
 	for _, tc := range testCases {
 		for _, success := range []bool{true, false} {
 			t.Run(fmt.Sprintf("%s-success-expected-%t", tc.desc, success), func(t *testing.T) {
-				inputs := []colexecop.Operator{colexecutils.NewFixedNumTuplesNoInputOp(testAllocator, 0 /* numTuples */)}
+				inputs := []colexecop.Operator{colexecutils.NewFixedNumTuplesNoInputOp(testAllocator, 0 /* numTuples */, nil /* opToInitialize */)}
 				if len(tc.spec.Input) > 1 {
-					inputs = append(inputs, colexecutils.NewFixedNumTuplesNoInputOp(testAllocator, 0 /* numTuples */))
+					inputs = append(inputs, colexecutils.NewFixedNumTuplesNoInputOp(testAllocator, 0 /* numTuples */, nil /* opToInitialize */))
 				}
 				memMon := mon.NewMonitor("MemoryMonitor", mon.MemoryResource, nil, nil, 0, math.MaxInt64, st)
 				if success {


### PR DESCRIPTION
**colexec: initialize operators in an edge case**

Previously, it was possible that `Init` is not called on some operators
but `DrainMeta` is. In particular, it was the case if we planned
`fixedNumTuplesNoInputOp` operator which replaced the whole subtree, and
that subtree contained some metadata sources. The assumption that all
operators in use are `Init`ialized was broken, so this commit updates
that utility operator to also initialize the subtree even though it
doesn't consider it as its input.

I noticed this when I was looking into the parallel unordered
synchronizer, and there is an open question whether the synchronizer
should perform its "full" initialization (i.e. spawn up the reader
goroutines) or whether the synchronizer should transition into "done"
state if `DrainMeta` is called before `Next`. The follow-up commit will
implement the latter.

Release justification: low-risk fix to existing functionality.

Release note: None

**colexec: fix parallel unordered sync DrainMeta if Next not called**

Due to the way we construct the vectorized flows (see previous commit),
it is possible to create an operator and add it to MetadataSources queue
and ToClose array even if the operator eventually is not part of the
operator tree that is being run. However, DrainMeta and Close might
still be called on it. Previously, if DrainMeta is called on the
parallel unordered synchronizer on which Next hasn't been called, the
synchronizer would proceed to initialize its reader goroutines and then
would drain them. However, this is unnecessary and complicated and
blocks follow-up work on simplifying context management in operators. To
go around the issue, this commit now simplifies the model so that in
this edge case the reader goroutines are not spawned up, and DrainMeta
goroutine is responsible for shutting down all infrastructure.

Additionally, we forgot to close the error channel when the last reader
goroutine exited in the happy case.

Release justification: low-risk update to existing functionality.

Release note: None