### PR TITLE
kvserver: fail fast when a range becomes unavailable

### DIFF
--- a/pkg/base/constants.go
+++ b/pkg/base/constants.go
@@ -30,6 +30,10 @@ const (
 	// request to be "slow".
 	SlowRequestThreshold = 60 * time.Second
 
+	// UnavailableRangeCheckThreshold is the amount of time to wait before checking
+	// if a range is stuck and unavailable.
+	UnavailableRangeCheckThreshold = 5 * time.Second
+
 	// ChunkRaftCommandThresholdBytes is the threshold in bytes at which
 	// to chunk or otherwise limit commands being sent to Raft.
 	ChunkRaftCommandThresholdBytes = 256 * 1000

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -213,6 +213,8 @@ var (
 	LockTableSingleKeyEnd = roachpb.Key(
 		makeKey(LocalRangeLockTablePrefix, roachpb.Key(LockTableSingleKeyInfix).PrefixEnd()))
 
+	LocalRangeProbeSuffix = roachpb.RKey("prbw")
+
 	// The global keyspace includes the meta{1,2}, system, system tenant SQL
 	// keys, and non-system tenant SQL keys.
 

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -494,6 +494,15 @@ func (r *Replica) IsQuiescent() bool {
 	return r.mu.quiescent
 }
 
+// IsMaybeUnavailable returns if the replica thinks this range is unavailable.
+// This value would only be set correctly on the leader, since we determine
+// this during a proposal.
+func (r *Replica) IsMaybeUnavailable() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.mu.maybeUnavailable
+}
+
 // GetQueueLastProcessed returns the last processed timestamp for the
 // specified queue, or the zero timestamp if not available.
 func (r *Replica) GetQueueLastProcessed(ctx context.Context, queue string) (hlc.Timestamp, error) {


### PR DESCRIPTION
Fixes #33007

This commit introduces a new Timer to the raft proposal write path.
If the timer has a timeout while waiting for a proposal to commit
and the range's appliedIndex has not moved in that time it will
assume the range is unavailable. This will kick off a new async
task to write a periodically write a dummy value to the range. Once a
write on the range succeeds it is marked as available.

Release note (performance improvement): if a range becomes unavilable,
all operations on that range will fail fast until it comes bacK up.