### PR TITLE
release-20.2: sql: fix internal error when EXPLAINing a zero row insert

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -1223,3 +1223,13 @@ project                  ·                    ·                               
 ·                        estimated row count  10 (missing stats)                      ·                            ·
 ·                        table                pg_attribute@pg_attribute_attrelid_idx  ·                            ·
 ·                        spans                [/ab - /ab]                             ·                            ·
+
+# Regression test for #61248: insert fast path with no rows.
+query TTT
+EXPLAIN INSERT INTO t2 SELECT x FROM t2 WHERE false
+----
+·                 distribution  local
+·                 vectorized    true
+insert fast path  ·             ·
+·                 into          t2(x)
+·                 auto commit   ·

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -617,7 +617,9 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 				"FK check", fmt.Sprintf("%s@%s", fk.ReferencedTable.Name(), fk.ReferencedIndex.Name()),
 			)
 		}
-		e.emitTuples(a.Rows, len(a.Rows[0]))
+		if len(a.Rows) > 0 {
+			e.emitTuples(a.Rows, len(a.Rows[0]))
+		}
 
 	case upsertOp:
 		a := n.args.(*upsertArgs)


### PR DESCRIPTION
Backport 1/1 commits from #61278.

/cc @cockroachdb/release

---

Fixes #61248.

Release justification: fixes for high-priority or high-severity bugs
in existing functionality.

Release note (bug fix): fixed an internal error when EXPLAINing an
INSERT with an input that was determined by the optimizer to produce
no rows.
