### PR TITLE
cli: Rename demo empty flag and introduce env variable

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -417,7 +417,7 @@ func Example_demo() {
 
 	testData := [][]string{
 		{`demo`, `-e`, `show database`},
-		{`demo`, `-e`, `show database`, `--empty`},
+		{`demo`, `-e`, `show database`, `--empty-database`},
 		{`demo`, `-e`, `show application_name`},
 		{`demo`, `--format=table`, `-e`, `show database`},
 		{`demo`, `-e`, `select 1 as "1"`, `-e`, `select 3 as "3"`},
@@ -448,7 +448,7 @@ func Example_demo() {
 	// demo -e show database
 	// database
 	// movr
-	// demo -e show database --empty
+	// demo -e show database --empty-database
 	// database
 	// defaultdb
 	// demo -e show application_name

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1162,7 +1162,8 @@ If set, disable cockroach demo from attempting to obtain a temporary license.`,
 	}
 
 	UseEmptyDatabase = FlagInfo{
-		Name: "empty",
+		Name:   "empty-database",
+		EnvVar: "COCKROACH_EMPTY_DATABASE",
 		Description: `
 Start with an empty database: avoid pre-loading a default dataset in
 the demo shell.`,

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -36,7 +36,7 @@ Start an in-memory, standalone, single-node CockroachDB instance, and open an
 interactive SQL prompt to it. Various datasets are available to be preloaded as
 subcommands: e.g. "cockroach demo startrek". See --help for a full list.
 
-By default, the 'movr' dataset is pre-loaded. You can also use --empty
+By default, the 'movr' dataset is pre-loaded. You can also use --empty-database
 to avoid pre-loading a dataset.
 
 cockroach demo attempts to connect to a Cockroach Labs server to obtain a
@@ -176,7 +176,7 @@ func checkDemoConfiguration(
 	cmd *cobra.Command, gen workload.Generator,
 ) (workload.Generator, error) {
 	if gen == nil && !demoCtx.useEmptyDatabase {
-		// Use a default dataset unless prevented by --empty.
+		// Use a default dataset unless prevented by --empty-database.
 		gen = defaultGenerator
 	}
 

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -753,7 +753,7 @@ func init() {
 		// Mark the --global flag as hidden until we investigate it more.
 		boolFlag(f, &demoCtx.simulateLatency, cliflags.Global)
 		_ = f.MarkHidden(cliflags.Global.Name)
-		// The --empty flag is only valid for the top level demo command,
+		// The --empty-database flag is only valid for the top level demo command,
 		// so we use the regular flag set.
 		boolFlag(demoCmd.Flags(), &demoCtx.useEmptyDatabase, cliflags.UseEmptyDatabase)
 		// We also support overriding the GEOS library path for 'demo'.

--- a/pkg/cli/interactive_tests/test_demo.tcl
+++ b/pkg/cli/interactive_tests/test_demo.tcl
@@ -27,7 +27,7 @@ start_test "Check that demo insecure says hello properly"
 
 # With env var.
 set ::env(COCKROACH_INSECURE) "true"
-spawn $argv demo --empty
+spawn $argv demo --empty-database
 eexpect "Welcome"
 eexpect "defaultdb>"
 
@@ -51,7 +51,7 @@ eexpect eof
 
 # With command-line override.
 set ::env(COCKROACH_INSECURE) "false"
-spawn $argv demo --insecure=true --empty
+spawn $argv demo --insecure=true --empty-database
 eexpect "Welcome"
 eexpect "defaultdb>"
 
@@ -76,7 +76,7 @@ start_test "Check that demo secure says hello properly"
 
 # With env var.
 set ::env(COCKROACH_INSECURE) "false"
-spawn $argv demo --empty
+spawn $argv demo --empty-database
 eexpect "Welcome"
 eexpect "The user \"demo\" with password"
 eexpect "has been created."
@@ -102,7 +102,7 @@ eexpect eof
 
 # With command-line override.
 set ::env(COCKROACH_INSECURE) "true"
-spawn $argv demo --insecure=false --empty
+spawn $argv demo --insecure=false --empty-database
 eexpect "Welcome"
 eexpect "The user \"demo\" with password"
 eexpect "has been created."
@@ -126,7 +126,7 @@ end_test
 
 # Test that demo displays connection URLs for nodes in the cluster.
 start_test "Check that node URLs are displayed"
-spawn $argv demo --insecure --empty
+spawn $argv demo --insecure --empty-database
 # Check that we see our message.
 eexpect "Connection parameters"
 eexpect "(sql)"
@@ -136,7 +136,7 @@ send_eof
 eexpect eof
 
 # Start the test again with a multi node cluster.
-spawn $argv demo --insecure --nodes 3 --empty
+spawn $argv demo --insecure --nodes 3 --empty-database
 
 # Check that we get a message for each node.
 eexpect "Connection parameters"
@@ -159,7 +159,7 @@ eexpect "defaultdb>"
 send_eof
 eexpect eof
 
-spawn $argv demo --insecure=false --empty
+spawn $argv demo --insecure=false --empty-database
 # Expect that security related tags are part of the connection URL.
 eexpect "(sql/tcp)"
 eexpect "sslmode=require"
@@ -172,7 +172,7 @@ end_test
 
 start_test "Check that the port numbers can be overridden from the command line."
 
-spawn $argv demo --empty --nodes 3 --http-port 8000
+spawn $argv demo --empty-database --nodes 3 --http-port 8000
 eexpect "Welcome"
 eexpect "defaultdb>"
 
@@ -189,7 +189,7 @@ eexpect "defaultdb>"
 interrupt
 eexpect eof
 
-spawn $argv demo --empty --nodes 3 --sql-port 23000
+spawn $argv demo --empty-database --nodes 3 --sql-port 23000
 eexpect "Welcome"
 eexpect "defaultdb>"
 

--- a/pkg/cli/interactive_tests/test_demo_global.tcl
+++ b/pkg/cli/interactive_tests/test_demo_global.tcl
@@ -8,7 +8,7 @@ set timeout 90
 start_test "Check --global flag runs as expected"
 
 # Start a demo with --global set
-spawn $argv demo --empty --nodes 9 --global
+spawn $argv demo --empty-database --nodes 9 --global
 
 # Ensure db is defaultdb.
 eexpect "defaultdb>"

--- a/pkg/cli/interactive_tests/test_dump_sig.tcl
+++ b/pkg/cli/interactive_tests/test_dump_sig.tcl
@@ -25,7 +25,7 @@ eexpect ":/# "
 end_test
 
 start_test "Check that the client also can generate goroutine dumps."
-send "$argv demo --empty\r"
+send "$argv demo --empty-database\r"
 eexpect root@
 # Dump goroutines in server.
 system "killall -QUIT `basename \$(realpath $argv)`"

--- a/pkg/cli/interactive_tests/test_flags.tcl
+++ b/pkg/cli/interactive_tests/test_flags.tcl
@@ -80,7 +80,7 @@ eexpect {Failed running "start"}
 end_test
 
 start_test "Check that demo start-up flags are reported to telemetry"
-send "$argv demo --empty --echo-sql --logtostderr=WARNING\r"
+send "$argv demo --empty-database --echo-sql --logtostderr=WARNING\r"
 eexpect "defaultdb>"
 send "SELECT * FROM crdb_internal.feature_usage WHERE feature_name LIKE 'cli.demo.%' ORDER BY 1;\r"
 eexpect feature_name

--- a/pkg/cli/interactive_tests/test_local_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_local_cmds.tcl
@@ -290,7 +290,7 @@ stop_server $argv
 start_test "Check that client-side options can be overridden with set"
 
 # First establish a baseline with all the defaults.
-send "$argv demo --empty\r"
+send "$argv demo --empty-database\r"
 eexpect root@
 send "\\set display_format csv\r"
 send "\\set\r"
@@ -305,7 +305,7 @@ interrupt
 eexpect ":/# "
 
 # Then verify that the defaults can be overridden.
-send "$argv demo --empty --set=auto_trace=on --set=check_syntax=false --set=echo=true --set=errexit=true --set=prompt1=%n@haa --set=show_times=false\r"
+send "$argv demo --empty-database --set=auto_trace=on --set=check_syntax=false --set=echo=true --set=errexit=true --set=prompt1=%n@haa --set=show_times=false\r"
 eexpect root@
 send "\\set display_format csv\r"
 send "\\set\r"

--- a/pkg/cli/interactive_tests/test_notice.tcl
+++ b/pkg/cli/interactive_tests/test_notice.tcl
@@ -4,7 +4,7 @@ source [file join [file dirname $argv0] common.tcl]
 
 # This test ensures notices are being sent as expected.
 
-spawn $argv demo --empty
+spawn $argv demo --empty-database
 eexpect root@
 
 start_test "Test that notices always appear at the end after all results."

--- a/pkg/cmd/reduce/main.go
+++ b/pkg/cmd/reduce/main.go
@@ -117,7 +117,7 @@ func reduceSQL(path, contains string, workers int, verbose bool) (string, error)
 		// Disable telemetry and license generation.
 		cmd := exec.CommandContext(ctx, path,
 			"demo",
-			"--empty",
+			"--empty-database",
 			"--disable-demo-license",
 		)
 		cmd.Env = []string{"COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING", "true"}

--- a/pkg/cmd/smithtest/main.go
+++ b/pkg/cmd/smithtest/main.go
@@ -260,7 +260,7 @@ func (s WorkerSetup) run(ctx context.Context, rnd *rand.Rand) error {
 		// If we can't ping, check if the statement caused a panic.
 		if err := db.PingContext(ctx); err != nil {
 			input := fmt.Sprintf("%s; %s;", initSQL, stmt)
-			out, _ := exec.CommandContext(ctx, s.cockroach, "demo", "--empty", "-e", input).CombinedOutput()
+			out, _ := exec.CommandContext(ctx, s.cockroach, "demo", "--empty-database", "-e", input).CombinedOutput()
 			var pqerr pq.Error
 			if match := stackRE.FindStringSubmatch(string(out)); match != nil {
 				pqerr.Detail = strings.TrimSpace(match[1])


### PR DESCRIPTION
Release justification: non-production code changes

Previously, to start the demo cluster with an empty database
we need to pass --empty flag. And need to pass the flag
for every run.
To address this, this patch introduces a new env variable
for --empty flag and renamed the flag name to make it opt with the env.
Resolves #47757

Release note (cli change): renamed --empty flag and introduce
env variable for the new flag in the demo command

Signed-off-by: Tharun <rajendrantharun@live.com>

Docs change: https://github.com/cockroachdb/docs/pull/9910