### PR TITLE
execinfra,colflow: improve and harden MetadataSource interface

### DIFF
--- a/pkg/sql/colexec/colexectestutils/utils.go
+++ b/pkg/sql/colexec/colexectestutils/utils.go
@@ -1549,10 +1549,10 @@ func GenerateBatchSize() int {
 // CallbackMetadataSource is a utility struct that implements the
 // colexecop.MetadataSource interface by calling a provided callback.
 type CallbackMetadataSource struct {
-	DrainMetaCb func(context.Context) []execinfrapb.ProducerMetadata
+	DrainMetaCb func() []execinfrapb.ProducerMetadata
 }
 
 // DrainMeta is part of the colexecop.MetadataSource interface.
-func (s CallbackMetadataSource) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
-	return s.DrainMetaCb(ctx)
+func (s CallbackMetadataSource) DrainMeta() []execinfrapb.ProducerMetadata {
+	return s.DrainMetaCb()
 }

--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -272,7 +272,7 @@ var (
 )
 
 // DrainMeta is part of the colexecop.MetadataSource interface.
-func (c *Columnarizer) DrainMeta(context.Context) []execinfrapb.ProducerMetadata {
+func (c *Columnarizer) DrainMeta() []execinfrapb.ProducerMetadata {
 	if c.removedFromFlow {
 		return nil
 	}

--- a/pkg/sql/colexec/columnarizer_test.go
+++ b/pkg/sql/colexec/columnarizer_test.go
@@ -119,7 +119,7 @@ func TestColumnarizerDrainsAndClosesInput(t *testing.T) {
 				// Calling DrainMeta from the vectorized execution engine should propagate to
 				// non-vectorized components as calling ConsumerDone and then draining their
 				// metadata.
-				meta := c.DrainMeta(ctx)
+				meta := c.DrainMeta()
 				require.True(t, len(meta) == 0)
 				require.True(t, rb.Done)
 				require.Equal(t, execinfra.DrainRequested, rb.ConsumerStatus, "unexpected consumer status %d", rb.ConsumerStatus)

--- a/pkg/sql/colexec/invariants_checker.go
+++ b/pkg/sql/colexec/invariants_checker.go
@@ -100,12 +100,12 @@ func (i *InvariantsChecker) Next() coldata.Batch {
 }
 
 // DrainMeta implements the colexecop.MetadataSource interface.
-func (i *InvariantsChecker) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
+func (i *InvariantsChecker) DrainMeta() []execinfrapb.ProducerMetadata {
 	if shortCircuit := i.assertInitWasCalled(); shortCircuit {
 		return nil
 	}
 	if i.metadataSource == nil {
 		return nil
 	}
-	return i.metadataSource.DrainMeta(ctx)
+	return i.metadataSource.DrainMeta()
 }

--- a/pkg/sql/colexec/materializer.go
+++ b/pkg/sql/colexec/materializer.go
@@ -134,7 +134,7 @@ func (d *drainHelper) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata)
 		d.statsCollectors = nil
 	}
 	if d.bufferedMeta == nil {
-		d.bufferedMeta = d.sources.DrainMeta(d.ctx)
+		d.bufferedMeta = d.sources.DrainMeta()
 		if d.bufferedMeta == nil {
 			// Still nil, avoid more calls to DrainMeta.
 			d.bufferedMeta = []execinfrapb.ProducerMetadata{}

--- a/pkg/sql/colexec/materializer_test.go
+++ b/pkg/sql/colexec/materializer_test.go
@@ -184,7 +184,7 @@ func TestMaterializerNextErrorAfterConsumerDone(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	testError := errors.New("test-induced error")
-	metadataSource := &colexectestutils.CallbackMetadataSource{DrainMetaCb: func(_ context.Context) []execinfrapb.ProducerMetadata {
+	metadataSource := &colexectestutils.CallbackMetadataSource{DrainMetaCb: func() []execinfrapb.ProducerMetadata {
 		colexecerror.InternalError(testError)
 		// Unreachable
 		return nil

--- a/pkg/sql/colexec/ordered_synchronizer.eg.go
+++ b/pkg/sql/colexec/ordered_synchronizer.eg.go
@@ -387,7 +387,7 @@ func (o *OrderedSynchronizer) Init(ctx context.Context) {
 	}
 }
 
-func (o *OrderedSynchronizer) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
+func (o *OrderedSynchronizer) DrainMeta() []execinfrapb.ProducerMetadata {
 	var bufferedMeta []execinfrapb.ProducerMetadata
 	if o.span != nil {
 		for i := range o.inputs {
@@ -400,7 +400,7 @@ func (o *OrderedSynchronizer) DrainMeta(ctx context.Context) []execinfrapb.Produ
 		}
 	}
 	for _, input := range o.inputs {
-		bufferedMeta = append(bufferedMeta, input.MetadataSources.DrainMeta(o.Ctx)...)
+		bufferedMeta = append(bufferedMeta, input.MetadataSources.DrainMeta()...)
 	}
 	return bufferedMeta
 }

--- a/pkg/sql/colexec/ordered_synchronizer_tmpl.go
+++ b/pkg/sql/colexec/ordered_synchronizer_tmpl.go
@@ -262,7 +262,7 @@ func (o *OrderedSynchronizer) Init(ctx context.Context) {
 	}
 }
 
-func (o *OrderedSynchronizer) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
+func (o *OrderedSynchronizer) DrainMeta() []execinfrapb.ProducerMetadata {
 	var bufferedMeta []execinfrapb.ProducerMetadata
 	if o.span != nil {
 		for i := range o.inputs {
@@ -275,7 +275,7 @@ func (o *OrderedSynchronizer) DrainMeta(ctx context.Context) []execinfrapb.Produ
 		}
 	}
 	for _, input := range o.inputs {
-		bufferedMeta = append(bufferedMeta, input.MetadataSources.DrainMeta(o.Ctx)...)
+		bufferedMeta = append(bufferedMeta, input.MetadataSources.DrainMeta()...)
 	}
 	return bufferedMeta
 }

--- a/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
@@ -62,7 +62,7 @@ func TestParallelUnorderedSynchronizer(t *testing.T) {
 		inputs[i].Root = source
 		inputIdx := i
 		inputs[i].MetadataSources = []colexecop.MetadataSource{
-			colexectestutils.CallbackMetadataSource{DrainMetaCb: func(_ context.Context) []execinfrapb.ProducerMetadata {
+			colexectestutils.CallbackMetadataSource{DrainMetaCb: func() []execinfrapb.ProducerMetadata {
 				return []execinfrapb.ProducerMetadata{{Err: errors.Errorf("input %d test-induced metadata", inputIdx)}}
 			}},
 		}
@@ -114,7 +114,7 @@ func TestParallelUnorderedSynchronizer(t *testing.T) {
 				// Call DrainMeta before the input is finished. Intentionally allow
 				// for Next to be called even though it's not technically supported to
 				// ensure that a zero-length batch is returned.
-				meta := s.DrainMeta(ctx)
+				meta := s.DrainMeta()
 				require.Equal(t, len(inputs), len(meta), "metadata length mismatch, returned metadata is: %v", meta)
 				expectZeroBatch = true
 			}
@@ -130,7 +130,7 @@ func TestParallelUnorderedSynchronizer(t *testing.T) {
 			if b.Length() == 0 {
 				if terminationScenario == synchronizerGracefulTermination {
 					// Successful run, check that all inputs have returned metadata.
-					meta := s.DrainMeta(ctx)
+					meta := s.DrainMeta()
 					require.Equal(t, len(inputs), len(meta), "metadata length mismatch, returned metadata is: %v", meta)
 				}
 				break
@@ -191,7 +191,7 @@ func TestUnorderedSynchronizerNoLeaksOnError(t *testing.T) {
 		// Loop until we get an error.
 	}
 	// The caller must call DrainMeta on error.
-	require.Zero(t, len(s.DrainMeta(ctx)))
+	require.Zero(t, len(s.DrainMeta()))
 	// This is the crux of the test: assert that all inputs have finished.
 	require.Equal(t, len(inputs), int(atomic.LoadUint32(&s.numFinishedInputs)))
 }

--- a/pkg/sql/colexec/serial_unordered_synchronizer.go
+++ b/pkg/sql/colexec/serial_unordered_synchronizer.go
@@ -88,7 +88,7 @@ func (s *SerialUnorderedSynchronizer) Next() coldata.Batch {
 }
 
 // DrainMeta is part of the colexecop.MetadataSource interface.
-func (s *SerialUnorderedSynchronizer) DrainMeta(context.Context) []execinfrapb.ProducerMetadata {
+func (s *SerialUnorderedSynchronizer) DrainMeta() []execinfrapb.ProducerMetadata {
 	var bufferedMeta []execinfrapb.ProducerMetadata
 	if s.span != nil {
 		for i := range s.inputs {
@@ -101,7 +101,7 @@ func (s *SerialUnorderedSynchronizer) DrainMeta(context.Context) []execinfrapb.P
 		}
 	}
 	for _, input := range s.inputs {
-		bufferedMeta = append(bufferedMeta, input.MetadataSources.DrainMeta(s.Ctx)...)
+		bufferedMeta = append(bufferedMeta, input.MetadataSources.DrainMeta()...)
 	}
 	return bufferedMeta
 }

--- a/pkg/sql/colexec/serial_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/serial_unordered_synchronizer_test.go
@@ -47,7 +47,7 @@ func TestSerialUnorderedSynchronizer(t *testing.T) {
 		inputs[i].Root = source
 		inputs[i].MetadataSources = []colexecop.MetadataSource{
 			colexectestutils.CallbackMetadataSource{
-				DrainMetaCb: func(_ context.Context) []execinfrapb.ProducerMetadata {
+				DrainMetaCb: func() []execinfrapb.ProducerMetadata {
 					return []execinfrapb.ProducerMetadata{{Err: errors.Errorf("input %d test-induced metadata", inputIdx)}}
 				},
 			},
@@ -59,7 +59,7 @@ func TestSerialUnorderedSynchronizer(t *testing.T) {
 	for {
 		b := s.Next()
 		if b.Length() == 0 {
-			require.Equal(t, len(inputs), len(s.DrainMeta(ctx)))
+			require.Equal(t, len(inputs), len(s.DrainMeta()))
 			break
 		}
 		resultBatches++

--- a/pkg/sql/colexecop/operator.go
+++ b/pkg/sql/colexecop/operator.go
@@ -369,7 +369,7 @@ type MetadataSource interface {
 	// Implementers can choose what to do on subsequent calls (if such occur).
 	// TODO(yuzefovich): modify the contract to require returning nil on all
 	// calls after the first one.
-	DrainMeta(context.Context) []execinfrapb.ProducerMetadata
+	DrainMeta() []execinfrapb.ProducerMetadata
 }
 
 // MetadataSources is a slice of MetadataSource.
@@ -378,11 +378,11 @@ type MetadataSources []MetadataSource
 // DrainMeta calls DrainMeta on all MetadataSources and returns a single slice
 // with all the accumulated metadata. Note that this method wraps the draining
 // with the panic-catcher so that the callers don't have to.
-func (s MetadataSources) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
+func (s MetadataSources) DrainMeta() []execinfrapb.ProducerMetadata {
 	var result []execinfrapb.ProducerMetadata
 	if err := colexecerror.CatchVectorizedRuntimeError(func() {
 		for _, src := range s {
-			result = append(result, src.DrainMeta(ctx)...)
+			result = append(result, src.DrainMeta()...)
 		}
 	}); err != nil {
 		meta := execinfrapb.GetProducerMeta()

--- a/pkg/sql/colexecop/operator.go
+++ b/pkg/sql/colexecop/operator.go
@@ -361,6 +361,8 @@ func (n *noopOperator) Reset(ctx context.Context) {
 
 // MetadataSource is an interface implemented by processors and columnar
 // operators that can produce metadata.
+// TODO(yuzefovich): remove this interface in favor of DrainableOperator and
+// clarify that calling DrainMeta on an uninitialized operator is illegal.
 type MetadataSource interface {
 	// DrainMeta returns all the metadata produced by the processor or operator.
 	// It will be called exactly once, usually, when the processor or operator

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -78,11 +78,11 @@ func (s *ColBatchScan) Init(ctx context.Context) {
 	if !s.InitHelper.Init(ctx) {
 		return
 	}
-	if execinfra.ShouldCollectStats(s.Ctx, s.flowCtx) {
-		// We need to start a child span so that the only contention events
-		// present in the recording would be because of this cFetcher.
-		s.Ctx, s.tracingSpan = execinfra.ProcessorSpan(s.Ctx, "colbatchscan")
-	}
+	// If tracing is enabled, we need to start a child span so that the only
+	// contention events present in the recording would be because of this
+	// cFetcher. Note that ProcessorSpan method itself will check whether
+	// tracing is enabled.
+	s.Ctx, s.tracingSpan = execinfra.ProcessorSpan(s.Ctx, "colbatchscan")
 	limitBatches := !s.parallelize
 	if err := s.rf.StartScan(
 		s.flowCtx.Txn, s.spans, limitBatches, s.limitHint, s.flowCtx.TraceKV,
@@ -108,7 +108,7 @@ func (s *ColBatchScan) Next() coldata.Batch {
 }
 
 // DrainMeta is part of the colexecop.MetadataSource interface.
-func (s *ColBatchScan) DrainMeta(context.Context) []execinfrapb.ProducerMetadata {
+func (s *ColBatchScan) DrainMeta() []execinfrapb.ProducerMetadata {
 	var trailingMeta []execinfrapb.ProducerMetadata
 	if !s.flowCtx.Local {
 		nodeID, ok := s.flowCtx.NodeID.OptionalNodeID()
@@ -127,18 +127,8 @@ func (s *ColBatchScan) DrainMeta(context.Context) []execinfrapb.ProducerMetadata
 	meta.Metrics.BytesRead = s.GetBytesRead()
 	meta.Metrics.RowsRead = s.GetRowsRead()
 	trailingMeta = append(trailingMeta, *meta)
-	if s.tracingSpan != nil {
-		// If tracingSpan is non-nil, then we have derived a new context in
-		// Init() and we have to collect the trace data.
-		//
-		// If tracingSpan is nil, then we used the same context that was passed
-		// in Init() and it is the responsibility of the caller-component
-		// (either materializer, or wrapped processor, or an outbox) to collect
-		// the trace data. If we were to do it here too, we would see duplicate
-		// spans.
-		if trace := execinfra.GetTraceData(s.Ctx); trace != nil {
-			trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{TraceData: trace})
-		}
+	if trace := execinfra.GetTraceData(s.Ctx); trace != nil {
+		trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{TraceData: trace})
 	}
 	return trailingMeta
 }

--- a/pkg/sql/colflow/colbatch_scan_test.go
+++ b/pkg/sql/colflow/colbatch_scan_test.go
@@ -95,7 +95,7 @@ func TestColBatchScanMeta(t *testing.T) {
 	}
 	tr := res.Root
 	tr.Init(ctx)
-	meta := tr.(*colexecutils.CancelChecker).Input.(*colfetcher.ColBatchScan).DrainMeta(ctx)
+	meta := tr.(*colexecutils.CancelChecker).Input.(*colfetcher.ColBatchScan).DrainMeta()
 	var txnFinalStateSeen bool
 	for _, m := range meta {
 		if m.LeafTxnFinalState != nil {

--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -468,7 +468,7 @@ func TestOutboxInboxMetadataPropagation(t *testing.T) {
 				for i := 0; i < numNextsBeforeDrain; i++ {
 					inbox.Next()
 				}
-				return inbox.DrainMeta(ctx)
+				return inbox.DrainMeta()
 			},
 		},
 		{
@@ -483,7 +483,7 @@ func TestOutboxInboxMetadataPropagation(t *testing.T) {
 						break
 					}
 				}
-				return inbox.DrainMeta(ctx)
+				return inbox.DrainMeta()
 			},
 		},
 		{
@@ -542,7 +542,7 @@ func TestOutboxInboxMetadataPropagation(t *testing.T) {
 				colmem.NewAllocator(ctx, &outboxMemAcc, coldata.StandardColumnFactory),
 				input, typs, nil /* getStats */, []colexecop.MetadataSource{
 					colexectestutils.CallbackMetadataSource{
-						DrainMetaCb: func(context.Context) []execinfrapb.ProducerMetadata {
+						DrainMetaCb: func() []execinfrapb.ProducerMetadata {
 							return expectedMetadata
 						},
 					},
@@ -649,7 +649,7 @@ func BenchmarkOutboxInbox(b *testing.B) {
 	b.StopTimer()
 
 	// This is a way of telling the Outbox we're satisfied with the data received.
-	meta := inbox.DrainMeta(ctx)
+	meta := inbox.DrainMeta()
 	require.True(b, len(meta) == 0)
 
 	require.NoError(b, <-streamHandlerErrCh)
@@ -728,20 +728,20 @@ func TestInboxCtxStreamIDTagging(t *testing.T) {
 	testCases := []struct {
 		name string
 		// test is the body of the test to be run.
-		test func(context.Context, *Inbox)
+		test func(*Inbox)
 	}{
 		{
 			// CtxTaggedInNext verifies that Next adds StreamID to the Context in maybeInit.
 			name: "CtxTaggedInNext",
-			test: func(ctx context.Context, inbox *Inbox) {
+			test: func(inbox *Inbox) {
 				inbox.Next()
 			},
 		},
 		{
 			// CtxTaggedInDrainMeta verifies that DrainMeta adds StreamID to the Context in maybeInit.
 			name: "CtxTaggedInDrainMeta",
-			test: func(ctx context.Context, inbox *Inbox) {
-				inbox.DrainMeta(ctx)
+			test: func(inbox *Inbox) {
+				inbox.DrainMeta()
 			},
 		},
 	}
@@ -770,7 +770,7 @@ func TestInboxCtxStreamIDTagging(t *testing.T) {
 			inboxTested := make(chan struct{})
 			go func() {
 				inbox.Init(ctx)
-				tc.test(ctx, inbox)
+				tc.test(inbox)
 				inboxTested <- struct{}{}
 			}()
 

--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -361,9 +361,9 @@ func (i *Inbox) sendDrainSignal(ctx context.Context) error {
 	return nil
 }
 
-// DrainMeta is part of the MetadataGenerator interface. DrainMeta may not be
-// called concurrently with Next.
-func (i *Inbox) DrainMeta(context.Context) []execinfrapb.ProducerMetadata {
+// DrainMeta is part of the colexecop.MetadataSource interface. DrainMeta may
+// not be called concurrently with Next.
+func (i *Inbox) DrainMeta() []execinfrapb.ProducerMetadata {
 	allMeta := i.bufferedMeta
 	i.bufferedMeta = i.bufferedMeta[:0]
 

--- a/pkg/sql/colflow/colrpc/inbox_test.go
+++ b/pkg/sql/colflow/colrpc/inbox_test.go
@@ -378,7 +378,7 @@ func TestInboxShutdown(t *testing.T) {
 										return
 									}
 									if drainScenario == drainMetaBeforeNext {
-										_ = inbox.DrainMeta(inboxCtx)
+										_ = inbox.DrainMeta()
 										return
 									}
 									if nextSleep != 0 {
@@ -388,12 +388,12 @@ func TestInboxShutdown(t *testing.T) {
 									for !done && err == nil {
 										err = colexecerror.CatchVectorizedRuntimeError(func() { b := inbox.Next(); done = b.Length() == 0 })
 										if drainScenario == drainMetaPrematurely {
-											_ = inbox.DrainMeta(inboxCtx)
+											_ = inbox.DrainMeta()
 											return
 										}
 									}
 									if drainScenario == drainMetaAfterNextIsExhausted {
-										_ = inbox.DrainMeta(inboxCtx)
+										_ = inbox.DrainMeta()
 									}
 									errCh <- err
 								}()

--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -321,7 +321,7 @@ func (o *Outbox) sendMetadata(ctx context.Context, stream flowStreamClient, errT
 			},
 		})
 	}
-	for _, meta := range o.metadataSources.DrainMeta(ctx) {
+	for _, meta := range o.metadataSources.DrainMeta() {
 		msg.Data.Metadata = append(msg.Data.Metadata, execinfrapb.LocalMetaToRemoteProducerMeta(ctx, meta))
 	}
 	if len(msg.Data.Metadata) == 0 {

--- a/pkg/sql/colflow/colrpc/outbox_test.go
+++ b/pkg/sql/colflow/colrpc/outbox_test.go
@@ -71,7 +71,7 @@ func TestOutboxCatchesPanics(t *testing.T) {
 	require.Error(t, err)
 
 	// Expect no metadata.
-	meta := inbox.DrainMeta(ctx)
+	meta := inbox.DrainMeta()
 	require.True(t, len(meta) == 0)
 
 	require.True(t, testutils.IsError(err, "runtime error: index out of range"), err)
@@ -96,7 +96,7 @@ func TestOutboxDrainsMetadataSources(t *testing.T) {
 		var sourceDrained uint32
 		outbox, err := NewOutbox(allocator, input, typs, nil /* getStats */, []colexecop.MetadataSource{
 			colexectestutils.CallbackMetadataSource{
-				DrainMetaCb: func(context.Context) []execinfrapb.ProducerMetadata {
+				DrainMetaCb: func() []execinfrapb.ProducerMetadata {
 					atomic.StoreUint32(&sourceDrained, 1)
 					return nil
 				},

--- a/pkg/sql/colflow/routers.go
+++ b/pkg/sql/colflow/routers.go
@@ -550,12 +550,14 @@ func (r *HashRouter) Run(ctx context.Context) {
 	if span != nil {
 		defer span.Finish()
 	}
+	var inputInitialized bool
 	// Since HashRouter runs in a separate goroutine, we want to be safe and
 	// make sure that we catch errors in all code paths, so we wrap the whole
 	// method with a catcher. Note that we also have "internal" catchers as
 	// well for more fine-grained control of error propagation.
 	if err := colexecerror.CatchVectorizedRuntimeError(func() {
 		r.Input.Init(ctx)
+		inputInitialized = true
 		var done bool
 		processNextBatch := func() {
 			done = r.processNextBatch(ctx)
@@ -609,15 +611,19 @@ func (r *HashRouter) Run(ctx context.Context) {
 	}); err != nil {
 		r.cancelOutputs(ctx, err)
 	}
-	if span != nil {
-		for _, s := range r.inputMetaInfo.StatsCollectors {
-			span.RecordStructured(s.GetStats())
+	if inputInitialized {
+		// Retrieving stats and draining the metadata is only safe if the input
+		// to the hash router was properly initialized.
+		if span != nil {
+			for _, s := range r.inputMetaInfo.StatsCollectors {
+				span.RecordStructured(s.GetStats())
+			}
+			if meta := execinfra.GetTraceDataAsMetadata(span); meta != nil {
+				r.bufferedMeta = append(r.bufferedMeta, *meta)
+			}
 		}
-		if meta := execinfra.GetTraceDataAsMetadata(span); meta != nil {
-			r.bufferedMeta = append(r.bufferedMeta, *meta)
-		}
+		r.bufferedMeta = append(r.bufferedMeta, r.inputMetaInfo.MetadataSources.DrainMeta()...)
 	}
-	r.bufferedMeta = append(r.bufferedMeta, r.inputMetaInfo.MetadataSources.DrainMeta()...)
 	// Non-blocking send of metadata so that one of the outputs can return it
 	// in DrainMeta.
 	r.waitForMetadata <- r.bufferedMeta

--- a/pkg/sql/colflow/routers.go
+++ b/pkg/sql/colflow/routers.go
@@ -269,7 +269,7 @@ func (o *routerOutputOp) Next() coldata.Batch {
 	return b
 }
 
-func (o *routerOutputOp) DrainMeta(_ context.Context) []execinfrapb.ProducerMetadata {
+func (o *routerOutputOp) DrainMeta() []execinfrapb.ProducerMetadata {
 	o.mu.Lock()
 	o.mu.state = routerOutputOpDraining
 	o.maybeUnblockLocked()
@@ -617,7 +617,7 @@ func (r *HashRouter) Run(ctx context.Context) {
 			r.bufferedMeta = append(r.bufferedMeta, *meta)
 		}
 	}
-	r.bufferedMeta = append(r.bufferedMeta, r.inputMetaInfo.MetadataSources.DrainMeta(ctx)...)
+	r.bufferedMeta = append(r.bufferedMeta, r.inputMetaInfo.MetadataSources.DrainMeta()...)
 	// Non-blocking send of metadata so that one of the outputs can return it
 	// in DrainMeta.
 	r.waitForMetadata <- r.bufferedMeta

--- a/pkg/sql/colflow/routers_test.go
+++ b/pkg/sql/colflow/routers_test.go
@@ -929,7 +929,7 @@ func TestHashRouterOneOutput(t *testing.T) {
 			}
 			wg.Wait()
 			// Expect no metadata, this should be a successful run.
-			unexpectedMetadata := ro.DrainMeta(ctx)
+			unexpectedMetadata := ro.DrainMeta()
 			if len(unexpectedMetadata) != 0 {
 				t.Fatalf("unexpected metadata when draining HashRouter output: %+v", unexpectedMetadata)
 			}
@@ -1098,7 +1098,7 @@ func TestHashRouterRandom(t *testing.T) {
 						Root: inputs[0],
 						MetadataSources: []colexecop.MetadataSource{
 							colexectestutils.CallbackMetadataSource{
-								DrainMetaCb: func(_ context.Context) []execinfrapb.ProducerMetadata {
+								DrainMetaCb: func() []execinfrapb.ProducerMetadata {
 									return []execinfrapb.ProducerMetadata{{Err: errors.New(hashRouterMetadataMsg)}}
 								},
 							},
@@ -1137,7 +1137,7 @@ func TestHashRouterRandom(t *testing.T) {
 							if err != nil || b.Length() == 0 || isTerminationScenario(outputRng, 0.5, hashRouterPrematureDrainMeta) {
 								resultsByOp[i].err = err
 								metadataMu.Lock()
-								if meta := outputsAsOps[i].DrainMeta(ctx); meta != nil {
+								if meta := outputsAsOps[i].DrainMeta(); meta != nil {
 									metadataMu.metadata = append(metadataMu.metadata, meta)
 								}
 								metadataMu.Unlock()
@@ -1353,7 +1353,7 @@ func BenchmarkHashRouter(b *testing.B) {
 								oBatch := outputs[j].Next()
 								actualDistribution[j] += oBatch.Length()
 								if oBatch.Length() == 0 {
-									_ = outputs[j].DrainMeta(ctx)
+									_ = outputs[j].DrainMeta()
 									break
 								}
 							}

--- a/pkg/sql/colflow/stats.go
+++ b/pkg/sql/colflow/stats.go
@@ -314,7 +314,7 @@ func (i *statsInvariantChecker) GetStats() *execinfrapb.ComponentStats {
 	return &execinfrapb.ComponentStats{}
 }
 
-func (i *statsInvariantChecker) DrainMeta(context.Context) []execinfrapb.ProducerMetadata {
+func (i *statsInvariantChecker) DrainMeta() []execinfrapb.ProducerMetadata {
 	if !i.statsRetrieved {
 		return []execinfrapb.ProducerMetadata{{Err: errors.New("GetStats wasn't called before DrainMeta")}}
 	}

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -182,7 +182,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 				}
 				createMetadataSourceForID := func(id int) colexecop.MetadataSource {
 					return colexectestutils.CallbackMetadataSource{
-						DrainMetaCb: func(ctx context.Context) []execinfrapb.ProducerMetadata {
+						DrainMetaCb: func() []execinfrapb.ProducerMetadata {
 							return []execinfrapb.ProducerMetadata{{Err: errors.Errorf("%d", id)}}
 						},
 					}

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -250,7 +250,7 @@ func newInvertedJoiner(
 				// We need to generate metadata before closing the processor
 				// because InternalClose() updates ij.Ctx to the "original"
 				// context.
-				trailingMeta := ij.generateMeta(ij.Ctx)
+				trailingMeta := ij.generateMeta()
 				ij.close()
 				return trailingMeta
 			},
@@ -786,13 +786,13 @@ func (ij *invertedJoiner) execStatsForTrace() *execinfrapb.ComponentStats {
 	}
 }
 
-func (ij *invertedJoiner) generateMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
+func (ij *invertedJoiner) generateMeta() []execinfrapb.ProducerMetadata {
 	trailingMeta := make([]execinfrapb.ProducerMetadata, 1, 2)
 	meta := &trailingMeta[0]
 	meta.Metrics = execinfrapb.GetMetricsMeta()
 	meta.Metrics.BytesRead = ij.fetcher.GetBytesRead()
 	meta.Metrics.RowsRead = ij.rowsRead
-	if tfs := execinfra.GetLeafTxnFinalState(ctx, ij.FlowCtx.Txn); tfs != nil {
+	if tfs := execinfra.GetLeafTxnFinalState(ij.Ctx, ij.FlowCtx.Txn); tfs != nil {
 		trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{LeafTxnFinalState: tfs})
 	}
 	return trailingMeta

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -281,7 +281,7 @@ func newJoinReader(
 				// We need to generate metadata before closing the processor
 				// because InternalClose() updates jr.Ctx to the "original"
 				// context.
-				trailingMeta := jr.generateMeta(jr.Ctx)
+				trailingMeta := jr.generateMeta()
 				jr.close()
 				return trailingMeta
 			},
@@ -747,13 +747,13 @@ func (jr *joinReader) execStatsForTrace() *execinfrapb.ComponentStats {
 	}
 }
 
-func (jr *joinReader) generateMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
+func (jr *joinReader) generateMeta() []execinfrapb.ProducerMetadata {
 	trailingMeta := make([]execinfrapb.ProducerMetadata, 1, 2)
 	meta := &trailingMeta[0]
 	meta.Metrics = execinfrapb.GetMetricsMeta()
 	meta.Metrics.RowsRead = jr.rowsRead
 	meta.Metrics.BytesRead = jr.fetcher.GetBytesRead()
-	if tfs := execinfra.GetLeafTxnFinalState(ctx, jr.FlowCtx.Txn); tfs != nil {
+	if tfs := execinfra.GetLeafTxnFinalState(jr.Ctx, jr.FlowCtx.Txn); tfs != nil {
 		trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{LeafTxnFinalState: tfs})
 	}
 	return trailingMeta

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -172,7 +172,7 @@ func newTableReader(
 func (tr *tableReader) generateTrailingMeta() []execinfrapb.ProducerMetadata {
 	// We need to generate metadata before closing the processor because
 	// InternalClose() updates tr.Ctx to the "original" context.
-	trailingMeta := tr.generateMeta(tr.Ctx)
+	trailingMeta := tr.generateMeta()
 	tr.close()
 	return trailingMeta
 }
@@ -301,18 +301,18 @@ func (tr *tableReader) execStatsForTrace() *execinfrapb.ComponentStats {
 	}
 }
 
-func (tr *tableReader) generateMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
+func (tr *tableReader) generateMeta() []execinfrapb.ProducerMetadata {
 	var trailingMeta []execinfrapb.ProducerMetadata
 	if !tr.ignoreMisplannedRanges {
 		nodeID, ok := tr.FlowCtx.NodeID.OptionalNodeID()
 		if ok {
-			ranges := execinfra.MisplannedRanges(ctx, tr.spans, nodeID, tr.FlowCtx.Cfg.RangeCache)
+			ranges := execinfra.MisplannedRanges(tr.Ctx, tr.spans, nodeID, tr.FlowCtx.Cfg.RangeCache)
 			if ranges != nil {
 				trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{Ranges: ranges})
 			}
 		}
 	}
-	if tfs := execinfra.GetLeafTxnFinalState(ctx, tr.FlowCtx.Txn); tfs != nil {
+	if tfs := execinfra.GetLeafTxnFinalState(tr.Ctx, tr.FlowCtx.Txn); tfs != nil {
 		trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{LeafTxnFinalState: tfs})
 	}
 

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -306,7 +306,7 @@ func newZigzagJoiner(
 				// We need to generate metadata before closing the processor
 				// because InternalClose() updates z.Ctx to the "original"
 				// context.
-				trailingMeta := z.generateMeta(z.Ctx)
+				trailingMeta := z.generateMeta()
 				z.close()
 				return trailingMeta
 			},
@@ -1024,13 +1024,13 @@ func (z *zigzagJoiner) getRowsRead() int64 {
 	return rowsRead
 }
 
-func (z *zigzagJoiner) generateMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
+func (z *zigzagJoiner) generateMeta() []execinfrapb.ProducerMetadata {
 	trailingMeta := make([]execinfrapb.ProducerMetadata, 1, 2)
 	meta := &trailingMeta[0]
 	meta.Metrics = execinfrapb.GetMetricsMeta()
 	meta.Metrics.BytesRead = z.getBytesRead()
 	meta.Metrics.RowsRead = z.getRowsRead()
-	if tfs := execinfra.GetLeafTxnFinalState(ctx, z.FlowCtx.Txn); tfs != nil {
+	if tfs := execinfra.GetLeafTxnFinalState(z.Ctx, z.FlowCtx.Txn); tfs != nil {
 		trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{LeafTxnFinalState: tfs})
 	}
 	return trailingMeta


### PR DESCRIPTION
**execinfra: remove ctx argument from DrainMeta**

This commit updates the contract of `DrainMeta` method to use the
context owned by the MetadataSource (the one it received in `Start` or
`Init`) because it is a lot less confusing this way.

Release note: None

**colflow: only drain sources if they were properly initialized**

Previously, in several cases we could have called `DrainMeta` on some
operators even if those weren't properly initialized. Such behavior
should not be allowed, and this commit puts the protection in place in
several "root" components (outboxes, hash routers, parallel unordered
synchronizers; the only other "root" component materializer already had
similar protection in place). The follow up commit will clean up the
MetadataSource interface.

Such misbehavior was never intended to be allowed but was safely ignored
because up until recently the uninitialized operators (at least in most
cases) were able to handle DrainMeta call gracefully. This changed when
we began the effort to centralize the context management.

Fixes: #64288.
Fixes: #64362.
Fixes: #64363.
Fixes: #64364.

Release note: None