### PR TITLE
kv: permit merge transactions to refresh after subsumption

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -211,7 +211,7 @@ const (
 	ReplicationAuto TestClusterReplicationMode = iota
 	// ReplicationManual means that the split, merge and replication queues of all
 	// servers are stopped, and the test must manually control splitting, merging
-	// and  replication through the TestServer.
+	// and replication through the TestServer.
 	// Note that the server starts with a number of system ranges,
 	// all with a single replica on node 1.
 	ReplicationManual

--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -221,6 +221,12 @@ func (ba *BatchRequest) IsSingleAbortTxnRequest() bool {
 	return false
 }
 
+// IsSingleRefreshRequest returns true iff the batch contains a single request,
+// and that request is a RefreshRequest.
+func (ba *BatchRequest) IsSingleRefreshRequest() bool {
+	return ba.isSingleRequestWithMethod(Refresh)
+}
+
 // IsSingleSubsumeRequest returns true iff the batch contains a single request,
 // and that request is an SubsumeRequest.
 func (ba *BatchRequest) IsSingleSubsumeRequest() bool {


### PR DESCRIPTION
Fixes #59308.

This commit adds support for range merge transactions to refresh. This
is necessary to allow the merge transaction to have its write timestamp
be bumped and still commit without retrying. In such cases, the
transaction must refresh its reads, including its original read on the
RHS's local range descriptor. If we were to block this refresh on the
frozen RHS range, the merge would deadlock.

On the surface, it seems unsafe to permit Refresh requests on an already
subsumed RHS range, because the refresh's effect on the timestamp cache
will never make it to the LHS leaseholder. This risks the future joint
range serving a write that invalidates the Refresh. However, in this
specific situation, we can be sure that such a serializability violation
will not occur because the Range merge also writes to (deletes) this
key. This means that if the Range merge transaction commits, its intent
on the key will be resolved to the timestamp of the refresh and no
future write will ever be able to violate the refresh. Conversely, if the
Range merge transaction does not commit, then the merge will fail and
the update to the RHS's timestamp cache will not be lost (not that this
particularly matters in cases of aborted transactions).

The same line of reasoning as the one above has motivated us to explore
removing keys from a transaction's refresh spans when they are written
to by the transaction, as the intents written by the transaction act as
a form of pessimistic lock that obviate the need for the optimistic
refresh. Such an improvement would eliminate the need for this special
case, but until we generalize the mechanism to prune refresh spans based
on intent spans, we're forced to live with this.

See https://github.com/cockroachdb/cockroach/issues/59308#issuecomment-786162869
for why the original fix, which attempted to manually refresh the range
merge transaction before it entered its critical phase, was not sufficient.

Release justification: needed for new functionality.