### PR TITLE
tracing: don't return an error from ImportRemoteSpans

### DIFF
--- a/pkg/kv/kvclient/kvcoord/transport.go
+++ b/pkg/kv/kvclient/kvcoord/transport.go
@@ -206,9 +206,7 @@ func (gt *grpcTransport) sendBatch(
 				return nil, errors.Errorf(
 					"trying to ingest remote spans but there is no recording span set up")
 			}
-			if err := span.ImportRemoteSpans(reply.CollectedSpans); err != nil {
-				return nil, errors.Wrap(err, "error ingesting remote spans")
-			}
+			span.ImportRemoteSpans(reply.CollectedSpans)
 		}
 	}
 	return reply, err
@@ -346,9 +344,7 @@ func (s *senderTransport) SendNext(
 		if span == nil {
 			panic("trying to ingest remote spans but there is no recording span set up")
 		}
-		if err := span.ImportRemoteSpans(br.CollectedSpans); err != nil {
-			panic(err)
-		}
+		span.ImportRemoteSpans(br.CollectedSpans)
 	}
 
 	return br, nil

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -651,11 +651,8 @@ func (r *DistSQLReceiver) Push(
 			r.rangeCache.Insert(r.ctx, meta.Ranges...)
 		}
 		if len(meta.TraceData) > 0 {
-			span := tracing.SpanFromContext(r.ctx)
-			if span == nil {
-				// Nothing to do.
-			} else if err := span.ImportRemoteSpans(meta.TraceData); err != nil {
-				r.resultWriter.SetError(errors.Errorf("error ingesting remote spans: %s", err))
+			if span := tracing.SpanFromContext(r.ctx); span != nil {
+				span.ImportRemoteSpans(meta.TraceData)
 			}
 			var ev roachpb.ContentionEvent
 			for i := range meta.TraceData {

--- a/pkg/sql/rowexec/tablereader_test.go
+++ b/pkg/sql/rowexec/tablereader_test.go
@@ -413,9 +413,7 @@ func TestLimitScans(t *testing.T) {
 
 		// Simulate what the DistSQLReceiver does and ingest the trace.
 		if meta != nil && len(meta.TraceData) > 0 {
-			if err := sp.ImportRemoteSpans(meta.TraceData); err != nil {
-				t.Fatal(err)
-			}
+			sp.ImportRemoteSpans(meta.TraceData)
 		}
 
 		if row == nil && meta == nil {

--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -217,16 +217,15 @@ func (s *crdbSpan) getRecording(everyoneIsV211 bool, wantTags bool) Recording {
 	return result
 }
 
-func (s *crdbSpan) importRemoteSpans(remoteSpans []tracingpb.RecordedSpan) error {
+func (s *crdbSpan) importRemoteSpans(remoteSpans []tracingpb.RecordedSpan) {
 	// Change the root of the remote recording to be a child of this Span. This is
 	// usually already the case, except with DistSQL traces where remote
 	// processors run in spans that FollowFrom an RPC Span that we don't collect.
 	remoteSpans[0].ParentSpanID = s.spanID
 
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.mu.recording.remoteSpans = append(s.mu.recording.remoteSpans, remoteSpans...)
-	s.mu.Unlock()
-	return nil
 }
 
 func (s *crdbSpan) setTagLocked(key string, value interface{}) {

--- a/pkg/util/tracing/grpc_interceptor_test.go
+++ b/pkg/util/tracing/grpc_interceptor_test.go
@@ -192,7 +192,7 @@ func TestGRPCInterceptors(t *testing.T) {
 			var rec tracingpb.RecordedSpan
 			require.NoError(t, types.UnmarshalAny(recAny, &rec))
 			require.Len(t, rec.InternalStructured, 1)
-			require.NoError(t, sp.ImportRemoteSpans([]tracingpb.RecordedSpan{rec}))
+			sp.ImportRemoteSpans([]tracingpb.RecordedSpan{rec})
 			sp.Finish()
 			var n int
 			sp.SetVerbose(true) // to get the tags

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -103,11 +103,10 @@ func (sp *Span) GetRecording() Recording {
 // ImportRemoteSpans adds RecordedSpan data to the recording of the given Span;
 // these spans will be part of the result of GetRecording. Used to import
 // recorded traces from other nodes.
-func (sp *Span) ImportRemoteSpans(remoteSpans []tracingpb.RecordedSpan) error {
-	if sp.done() {
-		return nil
+func (sp *Span) ImportRemoteSpans(remoteSpans []tracingpb.RecordedSpan) {
+	if !sp.done() {
+		sp.i.ImportRemoteSpans(remoteSpans)
 	}
-	return sp.i.ImportRemoteSpans(remoteSpans)
 }
 
 // Meta returns the information which needs to be propagated across process

--- a/pkg/util/tracing/span_inner.go
+++ b/pkg/util/tracing/span_inner.go
@@ -79,8 +79,8 @@ func (s *spanInner) GetRecording() Recording {
 	return s.crdb.getRecording(s.tracer.TracingVerbosityIndependentSemanticsIsActive(), wantTags)
 }
 
-func (s *spanInner) ImportRemoteSpans(remoteSpans []tracingpb.RecordedSpan) error {
-	return s.crdb.importRemoteSpans(remoteSpans)
+func (s *spanInner) ImportRemoteSpans(remoteSpans []tracingpb.RecordedSpan) {
+	s.crdb.importRemoteSpans(remoteSpans)
 }
 
 func (s *spanInner) Finish() {

--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -60,7 +60,7 @@ func TestRecordingString(t *testing.T) {
 	remoteChild.Finish()
 
 	remoteRec := remoteChild.GetRecording()
-	require.NoError(t, root.ImportRemoteSpans(remoteRec))
+	root.ImportRemoteSpans(remoteRec)
 
 	root.Record("root 3")
 
@@ -153,7 +153,7 @@ func TestRecordingInRecording(t *testing.T) {
 	// code at the RPC boundaries).
 	grandChild := tr.StartSpan("grandchild", WithParentAndManualCollection(child.Meta()))
 	grandChild.Finish()
-	require.NoError(t, child.ImportRemoteSpans(grandChild.GetRecording()))
+	child.ImportRemoteSpans(grandChild.GetRecording())
 	child.Finish()
 	root.Finish()
 
@@ -191,7 +191,7 @@ func TestSpan_ImportRemoteSpans(t *testing.T) {
 	ch.Record("foo")
 	ch.SetVerbose(false)
 	ch.Finish()
-	require.NoError(t, sp.ImportRemoteSpans(ch.GetRecording()))
+	sp.ImportRemoteSpans(ch.GetRecording())
 	sp.Finish()
 
 	require.NoError(t, TestingCheckRecordedSpans(sp.GetRecording(), `

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -290,9 +290,7 @@ func TestTracerInjectExtract(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := s1.ImportRemoteSpans(rec); err != nil {
-		t.Fatal(err)
-	}
+	s1.ImportRemoteSpans(rec)
 	s1.Finish()
 
 	if err := TestingCheckRecordedSpans(s1.GetRecording(), `
@@ -517,7 +515,7 @@ func TestTracer_VisitSpans(t *testing.T) {
 	childChildFinished := tr2.StartSpan("root.child.remotechilddone", WithParentAndManualCollection(child.Meta()))
 	require.Len(t, tr2.activeSpans.m, 2)
 
-	require.NoError(t, child.ImportRemoteSpans(childChildFinished.GetRecording()))
+	child.ImportRemoteSpans(childChildFinished.GetRecording())
 
 	childChildFinished.Finish()
 	require.Len(t, tr2.activeSpans.m, 1)
@@ -551,7 +549,7 @@ func TestSpanRecordingFinished(t *testing.T) {
 
 	tr2 := NewTracer()
 	remoteChildChild := tr2.StartSpan("root.child.remotechild", WithParentAndManualCollection(child.Meta()))
-	require.NoError(t, child.ImportRemoteSpans(remoteChildChild.GetRecording()))
+	child.ImportRemoteSpans(remoteChildChild.GetRecording())
 
 	// All spans are un-finished.
 	sortedSpanOps := getSortedSpanOps(t, tr1)
@@ -582,7 +580,7 @@ func TestSpanRecordingFinished(t *testing.T) {
 	remoteChildChild.Finish()
 	// NB: importing a span twice is essentially a bad idea. It's ok in
 	// this test though.
-	require.NoError(t, child.ImportRemoteSpans(remoteChildChild.GetRecording()))
+	child.ImportRemoteSpans(remoteChildChild.GetRecording())
 	child.Finish()
 	spanOpsWithFinished = getSpanOpsWithFinished(t, tr1)
 


### PR DESCRIPTION
We no longer return errors from ImportRemoteSpans, and we saw in the
[past] that it is not a good idea to do so - it's easy to mess up
cross-version behavior.

[past]: https://github.com/cockroachdb/cockroach/pull/59992#issuecomment-778146715

Release justification: low-risk code clarification
Release note: None
