### PR TITLE
bazel: add infrastructure to run tests w/ bazel in CI

### DIFF
--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -60,3 +60,4 @@ RUN rm -rf /tmp/* /var/lib/apt/lists/*
 RUN ln -s /usr/bin/bazel-3.6.0 /usr/bin/bazel
 
 COPY bazelbuild.sh /usr/local/bin
+COPY bazeltest.sh /usr/local/bin

--- a/build/bazelbuilder/bazeltest.sh
+++ b/build/bazelbuilder/bazeltest.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -xuo pipefail
+
+bazel test //pkg:small_tests //pkg:medium_tests //pkg:large_tests //pkg:enormous_tests
+EXIT_CODE=$?
+# Stage artifacts.
+cp -r $(bazel info bazel-testlogs) /artifacts/bazel-testlogs
+find /artifacts/bazel-testlogs -type f -exec chmod 666 {} +
+find /artifacts/bazel-testlogs -type d -exec chmod 777 {} +
+exit $EXIT_CODE

--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -1,1 +1,1 @@
-BAZEL_IMAGE=cockroachdb/bazel:20210301-143622
+BAZEL_IMAGE=cockroachdb/bazel:20210302-163751

--- a/build/teamcity-bazel-test.sh
+++ b/build/teamcity-bazel-test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "${0}")/teamcity-support.sh"
+source "$(dirname "${0}")/teamcity-bazel-support.sh"  # For BAZEL_IMAGE
+
+tc_prepare
+
+# NB: $root is set by teamcity-support.sh.
+export TMPDIR=$root/artifacts
+mkdir -p "$TMPDIR"
+
+# Bazel configuration for CI.
+cp $root/.bazelrc.ci $root/.bazelrc.user
+
+tc_start_block "Run Bazel test"
+docker run -i ${tty-} --rm --init \
+       --workdir="/go/src/github.com/cockroachdb/cockroach" \
+       -v "$root:/go/src/github.com/cockroachdb/cockroach:ro" \
+       -v "$TMPDIR:/artifacts" \
+       $BAZEL_IMAGE bazeltest.sh
+tc_end_block "Run Bazel test"

--- a/pkg/base/BUILD.bazel
+++ b/pkg/base/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
         "node_id_test.go",
         "store_spec_test.go",
     ],
+    tags = ["broken_in_bazel"],
     deps = [
         ":base",
         "//pkg/roachpb",

--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
         "regional_by_row_test.go",
         "show_test.go",
     ],
+    tags = ["broken_in_bazel"],
     deps = [
         "//pkg/base",
         "//pkg/ccl/multiregionccl/multiregionccltestutils",

--- a/pkg/cmd/cockroach-oss/BUILD.bazel
+++ b/pkg/cmd/cockroach-oss/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
     size = "medium",
     srcs = ["dep_test.go"],
     embed = [":cockroach-oss_lib"],
+    tags = ["broken_in_bazel"],
     deps = [
         "//pkg/testutils/buildutil",
         "//pkg/util/leaktest",

--- a/pkg/internal/codeowners/BUILD.bazel
+++ b/pkg/internal/codeowners/BUILD.bazel
@@ -18,6 +18,7 @@ go_test(
     size = "small",
     srcs = ["codeowners_test.go"],
     embed = [":codeowners"],
+    tags = ["broken_in_bazel"],
     deps = [
         "//pkg/internal/team",
         "@com_github_stretchr_testify//require",

--- a/pkg/internal/team/BUILD.bazel
+++ b/pkg/internal/team/BUILD.bazel
@@ -16,5 +16,6 @@ go_test(
     size = "small",
     srcs = ["team_test.go"],
     embed = [":team"],
+    tags = ["broken_in_bazel"],
     deps = ["@com_github_stretchr_testify//require"],
 )

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -285,6 +285,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":kvserver"],
     shard_count = 16,
+    tags = ["broken_in_bazel"],
     deps = [
         "//pkg/base",
         "//pkg/cli/exit",


### PR DESCRIPTION
Copy and tweak the existing stuff that allows us to perform Bazel builds
in CI to additionally build the `small` and `medium` tests. This will
help us ensure they don't break under our feet.

Release justification: Non-production code changes
Release note: None