### PR TITLE
sql: alter primary key is not idempotent

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -828,7 +828,6 @@ func TestBackupRestoreNegativePrimaryKey(t *testing.T) {
 	backupAndRestore(ctx, t, tc, []string{LocalFoo}, []string{LocalFoo}, numAccounts)
 
 	sqlDB.Exec(t, `CREATE UNIQUE INDEX id2 ON data.bank (id)`)
-	sqlDB.Exec(t, `ALTER TABLE data.bank ALTER PRIMARY KEY USING COLUMNS(id)`)
 
 	var unused string
 	var exportedRows, exportedIndexEntries int
@@ -838,7 +837,7 @@ func TestBackupRestoreNegativePrimaryKey(t *testing.T) {
 	if exportedRows != numAccounts {
 		t.Fatalf("expected %d rows, got %d", numAccounts, exportedRows)
 	}
-	expectedIndexEntries := numAccounts * 3 // old PK, new and old secondary idx
+	expectedIndexEntries := numAccounts * 2 // Indexes id2 and balance_idx
 	if exportedIndexEntries != expectedIndexEntries {
 		t.Fatalf("expected %d index entries, got %d", expectedIndexEntries, exportedIndexEntries)
 	}

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -143,6 +144,19 @@ func (p *planner) AlterPrimaryKey(
 			tableDesc.Name,
 			sb.String(),
 		)
+	}
+
+	// Validate if the end result is the same as the current
+	// primary index, which would mean nothing needs to be modified
+	// here.
+	{
+		requiresIndexChange, err := p.shouldCreateIndexes(ctx, tableDesc, alterPKNode, alterPrimaryKeyLocalitySwap)
+		if err != nil {
+			return err
+		}
+		if !requiresIndexChange {
+			return nil
+		}
 	}
 
 	nameExists := func(name string) bool {
@@ -506,6 +520,101 @@ func (p *planner) AlterPrimaryKey(
 	)
 
 	return nil
+}
+
+// Given the current table descriptor and the new primary keys
+// index descriptor  this function determines if the two are
+// equivalent and if any index creation operations are needed
+// by comparing properties.
+func (p *planner) shouldCreateIndexes(
+	ctx context.Context,
+	desc *tabledesc.Mutable,
+	alterPKNode *tree.AlterTableAlterPrimaryKey,
+	alterPrimaryKeyLocalitySwap *alterPrimaryKeyLocalitySwap,
+) (requiresIndexChange bool, err error) {
+	oldPK := desc.GetPrimaryIndex()
+
+	// Validate if basic properties between the two match.
+	if len(oldPK.IndexDesc().ColumnIDs) != len(alterPKNode.Columns) ||
+		oldPK.IsSharded() != (alterPKNode.Sharded != nil) ||
+		oldPK.IsInterleaved() != (alterPKNode.Interleave != nil) {
+		return true, nil
+	}
+
+	// Validate if sharding properties are the same.
+	if alterPKNode.Sharded != nil {
+		shardBuckets, err := tabledesc.EvalShardBucketCount(ctx, &p.semaCtx, p.EvalContext(), alterPKNode.Sharded.ShardBuckets)
+		if err != nil {
+			return true, err
+		}
+		if oldPK.IndexDesc().Sharded.ShardBuckets != shardBuckets {
+			return true, nil
+		}
+	}
+
+	// Validate if interleaving properties match,
+	// specifically the parent table, and the index
+	// involved.
+	if alterPKNode.Interleave != nil {
+		parentTable, err := resolver.ResolveExistingTableObject(
+			ctx, p, &alterPKNode.Interleave.Parent, tree.ObjectLookupFlagsWithRequiredTableKind(tree.ResolveRequireTableDesc),
+		)
+		if err != nil {
+			return true, err
+		}
+
+		ancestors := oldPK.IndexDesc().Interleave.Ancestors
+		if len(ancestors) == 0 {
+			return true, nil
+		}
+		if ancestors[len(ancestors)-1].TableID !=
+			parentTable.GetID() {
+			return true, nil
+		}
+		if ancestors[len(ancestors)-1].IndexID !=
+			parentTable.GetPrimaryIndexID() {
+			return true, nil
+		}
+	}
+
+	// If the old primary key is dropped, then recreation
+	// is required.
+	if oldPK.IndexDesc().Disabled {
+		return true, nil
+	}
+
+	// Validate the columns on the indexes
+	for idx, elem := range alterPKNode.Columns {
+		col, err := desc.FindColumnWithName(elem.Column)
+		if err != nil {
+			return true, err
+		}
+
+		if col.GetID() != oldPK.IndexDesc().ColumnIDs[idx] {
+			return true, nil
+		}
+		if (elem.Direction == tree.Ascending &&
+			oldPK.IndexDesc().ColumnDirections[idx] != descpb.IndexDescriptor_ASC) ||
+			(elem.Direction == tree.Descending &&
+				oldPK.IndexDesc().ColumnDirections[idx] != descpb.IndexDescriptor_DESC) {
+			return true, nil
+		}
+	}
+
+	// Check partitioning changes based on primary key locality,
+	// either the config changes, or the region column is changed
+	// then recreate indexes.
+	if alterPrimaryKeyLocalitySwap != nil {
+		localitySwapConfig := alterPrimaryKeyLocalitySwap.localityConfigSwap
+		if !localitySwapConfig.NewLocalityConfig.Equal(localitySwapConfig.OldLocalityConfig) {
+			return true, nil
+		}
+		if localitySwapConfig.NewRegionalByRowColumnID != nil &&
+			*localitySwapConfig.NewRegionalByRowColumnID != oldPK.IndexDesc().ColumnIDs[0] {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // We only recreate the old primary key of the table as a unique secondary

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1240,3 +1240,167 @@ ALTER TABLE t54629 ALTER PRIMARY KEY USING COLUMNS (c);
 DROP INDEX t54629_a_key CASCADE;
 INSERT INTO t54629 VALUES (1, 1);
 DELETE FROM t54629 WHERE c = 1;
+
+# Validate ALTER ADD PRIMARY KEY idempotence for #59307
+statement ok
+create table t1(id integer not null, id2 integer not null, name varchar(32));
+
+query TTT
+select index_name,column_name,direction from [show indexes from t1] where index_name like 'primary%';
+----
+primary  rowid  ASC
+
+statement ok
+alter table t1 alter primary key using columns(id, id2);
+
+
+query TTT
+select index_name,column_name,direction from [show indexes from t1];
+----
+primary  id  ASC
+primary  id2  ASC
+
+
+statement ok
+alter table t1 alter primary key using columns(id, id2);
+
+
+query TTT
+select index_name,column_name,direction from [show indexes from t1];
+----
+primary  id  ASC
+primary  id2  ASC
+
+# Validate drop and recreate
+statement ok
+alter table t1 drop constraint "primary", alter primary key using columns(id, id2);
+
+
+query TTT
+select index_name,column_name,direction from [show indexes from t1];
+----
+primary  id  ASC
+primary  id2  ASC
+
+statement ok
+alter table t1 alter primary key using columns(id);
+
+
+query TTT
+select index_name,column_name,direction from [show indexes from t1];
+----
+primary  id  ASC
+t1_id_id2_key  id  ASC
+t1_id_id2_key  id2  ASC
+
+statement ok
+alter table t1 alter primary key using columns(id desc);
+
+
+query TTT
+select index_name,column_name,direction from [show indexes from t1];
+----
+primary        id   DESC
+t1_id_id2_key  id   ASC
+t1_id_id2_key  id2  ASC
+t1_id_key      id   ASC
+
+
+statement ok
+alter table t1 alter primary key using columns(id desc);
+
+query TTT
+select index_name,column_name,direction from [show indexes from t1];
+----
+primary  id  DESC
+t1_id_id2_key  id  ASC
+t1_id_id2_key  id2  ASC
+t1_id_key id  ASC
+
+statement ok
+alter table t1 alter primary key using columns(id desc);
+
+query TTT
+select index_name,column_name,direction from [show indexes from t1];
+----
+primary  id  DESC
+t1_id_id2_key  id  ASC
+t1_id_id2_key  id2  ASC
+t1_id_key id  ASC
+
+statement ok
+alter table t1 alter primary key using columns(id) USING HASH WITH BUCKET_COUNT = 10
+
+query TTT
+select index_name,column_name,direction from [show indexes from t1];
+----
+primary        crdb_internal_id_shard_10  ASC
+primary        id                         ASC
+t1_id_key1     id                         DESC
+t1_id_key1     crdb_internal_id_shard_10  ASC
+t1_id_id2_key  id                         ASC
+t1_id_id2_key  id2                        ASC
+t1_id_id2_key  crdb_internal_id_shard_10  ASC
+t1_id_key      id                         ASC
+t1_id_key      crdb_internal_id_shard_10  ASC
+
+statement ok
+CREATE TABLE parent3 (x INT, y INT, PRIMARY KEY (x, y), FAMILY (x, y));
+
+statement ok
+CREATE TABLE child3 (x INT PRIMARY KEY, y INT NOT NULL, z INT NOT NULL, FAMILY (x, y, z));
+
+statement ok
+INSERT INTO parent3 VALUES (1, 2), (4, 5);
+
+statement ok
+INSERT INTO child3 VALUES (1, 2, 3), (4, 5, 6);
+
+statement ok
+ALTER TABLE child3 ALTER PRIMARY KEY USING COLUMNS (x, y, z) INTERLEAVE IN PARENT parent3(x, y)
+
+query TTT
+select index_name,column_name,direction from [show indexes from child3];
+----
+primary       x  ASC
+primary       y  ASC
+primary       z  ASC
+child3_x_key  x  ASC
+child3_x_key  y  ASC
+child3_x_key  z  ASC
+
+statement ok
+ALTER TABLE child3 ALTER PRIMARY KEY USING COLUMNS (x, y, z) INTERLEAVE IN PARENT parent3(x, y)
+
+query TTT
+select index_name,column_name,direction from [show indexes from child3];
+----
+primary       x  ASC
+primary       y  ASC
+primary       z  ASC
+child3_x_key  x  ASC
+child3_x_key  y  ASC
+child3_x_key  z  ASC
+
+statement ok
+ALTER TABLE child3 ALTER PRIMARY KEY USING COLUMNS (x, y) INTERLEAVE IN PARENT parent3(x, y)
+
+query TTT
+select index_name,column_name,direction from [show indexes from child3];
+----
+primary           x  ASC
+primary           y  ASC
+child3_x_key      x  ASC
+child3_x_key      y  ASC
+child3_x_y_z_key  x  ASC
+child3_x_y_z_key  y  ASC
+child3_x_y_z_key  z  ASC
+
+statement ok
+drop table t1;
+
+statement ok
+drop table child3;
+
+statement ok
+drop table parent3;


### PR DESCRIPTION
Fixes: #59307

Previously, issuing an alter primary key with the exact same
definition as the current primary key would cause expensive
indexes to be recreated even when there was no logical change.
There was overhead involved in creating these indexes and as
a side effect existing indexes for the primary key would also
get needlessly renamed. To address this, this patch uses the
AST node for alter primary key to determine if the requested
change is logically the same before any operation is executed.
If its logically the same then it becomes a no-op.

Release justification: This is a low risk change with good benefit
to the user base by reducing extra indexes getting made and rename
operations.

Release note (bug fix): Alter primary key was not idempotent, so
logical equivalent changes to primary keys would unnecessarily
create new indexes.