### PR TITLE
execinfra: clean up ProcessorBase

### DIFF
--- a/pkg/ccl/backupccl/split_and_scatter_processor.go
+++ b/pkg/ccl/backupccl/split_and_scatter_processor.go
@@ -191,7 +191,7 @@ func newSplitAndScatterProcessor(
 	if err := ssp.Init(ssp, post, splitAndScatterOutputTypes, flowCtx, processorID, output, nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			InputsToDrain: nil, // there are no inputs to drain
-			TrailingMetaCallback: func(context.Context) []execinfrapb.ProducerMetadata {
+			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
 				ssp.close()
 				return nil
 			},

--- a/pkg/ccl/importccl/import_processor.go
+++ b/pkg/ccl/importccl/import_processor.go
@@ -146,11 +146,6 @@ func (idp *readImportDataProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Pro
 	}, nil
 }
 
-// ConsumerDone is part of the RowSource interface.
-func (idp *readImportDataProcessor) ConsumerDone() {
-	idp.MoveToDraining(nil /* err */)
-}
-
 // ConsumerClosed is part of the RowSource interface.
 func (idp *readImportDataProcessor) ConsumerClosed() {
 	// The consumer is done, Next() will not be called again.

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -171,7 +171,7 @@ func newStreamIngestionDataProcessor(
 	if err := sip.Init(sip, post, streamIngestionResultTypes, flowCtx, processorID, output, nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{},
-			TrailingMetaCallback: func(context.Context) []execinfrapb.ProducerMetadata {
+			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
 				sip.close()
 				return nil
 			},

--- a/pkg/sql/colexec/materializer.go
+++ b/pkg/sql/colexec/materializer.go
@@ -198,7 +198,9 @@ func NewMaterializer(
 		execinfra.ProcStateOpts{
 			// We append drainHelper to inputs to drain below in order to reuse
 			// the same underlying slice from the pooled materializer.
-			TrailingMetaCallback: func(ctx context.Context) []execinfrapb.ProducerMetadata {
+			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
+				// Note that we delegate draining all of the metadata sources
+				// to drainHelper which is added as an input to drain below.
 				m.close()
 				return nil
 			},

--- a/pkg/sql/execinfra/metadata_test_receiver.go
+++ b/pkg/sql/execinfra/metadata_test_receiver.go
@@ -71,7 +71,7 @@ func NewMetadataTestReceiver(
 		nil, /* memMonitor */
 		ProcStateOpts{
 			InputsToDrain: []RowSource{input},
-			TrailingMetaCallback: func(context.Context) []execinfrapb.ProducerMetadata {
+			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
 				var trailingMeta []execinfrapb.ProducerMetadata
 				if mtr.rowCounts != nil {
 					if meta := mtr.checkRowNumMetadata(); meta != nil {
@@ -235,10 +235,4 @@ func (mtr *MetadataTestReceiver) Next() (rowenc.EncDatumRow, *execinfrapb.Produc
 
 		return outRow, nil
 	}
-}
-
-// ConsumerClosed is part of the RowSource interface.
-func (mtr *MetadataTestReceiver) ConsumerClosed() {
-	// The consumer is done, Next() will not be called again.
-	mtr.InternalClose()
 }

--- a/pkg/sql/execinfra/metadata_test_sender.go
+++ b/pkg/sql/execinfra/metadata_test_sender.go
@@ -54,7 +54,7 @@ func NewMetadataTestSender(
 		nil, /* memMonitor */
 		ProcStateOpts{
 			InputsToDrain: []RowSource{mts.input},
-			TrailingMetaCallback: func(context.Context) []execinfrapb.ProducerMetadata {
+			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
 				mts.InternalClose()
 				// Send a final record with LastMsg set.
 				meta := execinfrapb.ProducerMetadata{
@@ -113,10 +113,4 @@ func (mts *MetadataTestSender) Next() (rowenc.EncDatumRow, *execinfrapb.Producer
 		}
 	}
 	return nil, mts.DrainHelper()
-}
-
-// ConsumerClosed is part of the RowSource interface.
-func (mts *MetadataTestSender) ConsumerClosed() {
-	// The consumer is done, Next() will not be called again.
-	mts.InternalClose()
 }

--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -89,7 +89,7 @@ func (ag *aggregatorBase) init(
 	input execinfra.RowSource,
 	post *execinfrapb.PostProcessSpec,
 	output execinfra.RowReceiver,
-	trailingMetaCallback func(context.Context) []execinfrapb.ProducerMetadata,
+	trailingMetaCallback func() []execinfrapb.ProducerMetadata,
 ) error {
 	ctx := flowCtx.EvalCtx.Ctx()
 	memMonitor := execinfra.NewMonitor(ctx, flowCtx.EvalCtx.Mon, "aggregator-mem")
@@ -278,7 +278,7 @@ func newAggregator(
 		input,
 		post,
 		output,
-		func(context.Context) []execinfrapb.ProducerMetadata {
+		func() []execinfrapb.ProducerMetadata {
 			ag.close()
 			return nil
 		},
@@ -311,7 +311,7 @@ func newOrderedAggregator(
 		input,
 		post,
 		output,
-		func(context.Context) []execinfrapb.ProducerMetadata {
+		func() []execinfrapb.ProducerMetadata {
 			ag.close()
 			return nil
 		},

--- a/pkg/sql/rowexec/bulk_row_writer.go
+++ b/pkg/sql/rowexec/bulk_row_writer.go
@@ -236,9 +236,3 @@ func (sp *bulkRowWriter) convertLoop(
 
 	return nil
 }
-
-// ConsumerClosed is part of the RowSource interface.
-func (sp *bulkRowWriter) ConsumerClosed() {
-	// The consumer is done, Next() will not be called again.
-	sp.InternalClose()
-}

--- a/pkg/sql/rowexec/countrows.go
+++ b/pkg/sql/rowexec/countrows.go
@@ -100,10 +100,6 @@ func (ag *countAggregator) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMeta
 	return nil, ag.DrainHelper()
 }
 
-func (ag *countAggregator) ConsumerClosed() {
-	ag.InternalClose()
-}
-
 // execStatsForTrace implements ProcessorBase.ExecStatsForTrace.
 func (ag *countAggregator) execStatsForTrace() *execinfrapb.ComponentStats {
 	is, ok := getInputStats(ag.input)

--- a/pkg/sql/rowexec/distinct.go
+++ b/pkg/sql/rowexec/distinct.go
@@ -118,7 +118,7 @@ func newDistinct(
 		d, post, d.types, flowCtx, processorID, output, memMonitor, /* memMonitor */
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{d.input},
-			TrailingMetaCallback: func(context.Context) []execinfrapb.ProducerMetadata {
+			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
 				d.close()
 				return nil
 			},

--- a/pkg/sql/rowexec/filterer.go
+++ b/pkg/sql/rowexec/filterer.go
@@ -106,12 +106,6 @@ func (f *filtererProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMet
 	return nil, f.DrainHelper()
 }
 
-// ConsumerClosed is part of the RowSource interface.
-func (f *filtererProcessor) ConsumerClosed() {
-	// The consumer is done, Next() will not be called again.
-	f.InternalClose()
-}
-
 // execStatsForTrace implements ProcessorBase.ExecStatsForTrace.
 func (f *filtererProcessor) execStatsForTrace() *execinfrapb.ComponentStats {
 	is, ok := getInputStats(f.input)

--- a/pkg/sql/rowexec/hashjoiner.go
+++ b/pkg/sql/rowexec/hashjoiner.go
@@ -122,7 +122,7 @@ func newHashJoiner(
 		output,
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{h.leftSource, h.rightSource},
-			TrailingMetaCallback: func(context.Context) []execinfrapb.ProducerMetadata {
+			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
 				h.close()
 				return nil
 			},

--- a/pkg/sql/rowexec/inverted_filterer.go
+++ b/pkg/sql/rowexec/inverted_filterer.go
@@ -101,7 +101,7 @@ func newInvertedFilterer(
 		ifr, post, outputColTypes, flowCtx, processorID, output, nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{ifr.input},
-			TrailingMetaCallback: func(ctx context.Context) []execinfrapb.ProducerMetadata {
+			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
 				ifr.close()
 				return nil
 			},

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -282,9 +282,13 @@ func newJoinReader(
 		output,
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{jr.input},
-			TrailingMetaCallback: func(ctx context.Context) []execinfrapb.ProducerMetadata {
+			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
+				// We need to generate metadata before closing the processor
+				// because InternalClose() updates jr.Ctx to the "original"
+				// context.
+				trailingMeta := jr.generateMeta(jr.Ctx)
 				jr.close()
-				return jr.generateMeta(ctx)
+				return trailingMeta
 			},
 		},
 	); err != nil {

--- a/pkg/sql/rowexec/mergejoiner.go
+++ b/pkg/sql/rowexec/mergejoiner.go
@@ -86,7 +86,7 @@ func newMergeJoiner(
 		post, output,
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{leftSource, rightSource},
-			TrailingMetaCallback: func(context.Context) []execinfrapb.ProducerMetadata {
+			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
 				m.close()
 				return nil
 			},
@@ -259,9 +259,8 @@ func (m *mergeJoiner) nextRow() (rowenc.EncDatumRow, *execinfrapb.ProducerMetada
 
 func (m *mergeJoiner) close() {
 	if m.InternalClose() {
-		ctx := m.Ctx
-		m.streamMerger.close(ctx)
-		m.MemMonitor.Stop(ctx)
+		m.streamMerger.close(m.Ctx)
+		m.MemMonitor.Stop(m.Ctx)
 	}
 }
 

--- a/pkg/sql/rowexec/noop.go
+++ b/pkg/sql/rowexec/noop.go
@@ -91,12 +91,6 @@ func (n *noopProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadat
 	return nil, n.DrainHelper()
 }
 
-// ConsumerClosed is part of the RowSource interface.
-func (n *noopProcessor) ConsumerClosed() {
-	// The consumer is done, Next() will not be called again.
-	n.InternalClose()
-}
-
 // execStatsForTrace implements ProcessorBase.ExecStatsForTrace.
 func (n *noopProcessor) execStatsForTrace() *execinfrapb.ComponentStats {
 	is, ok := getInputStats(n.input)

--- a/pkg/sql/rowexec/ordinality.go
+++ b/pkg/sql/rowexec/ordinality.go
@@ -58,10 +58,7 @@ func newOrdinalityProcessor(
 		nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{o.input},
-			TrailingMetaCallback: func(context.Context) []execinfrapb.ProducerMetadata {
-				o.ConsumerClosed()
-				return nil
-			}},
+		},
 	); err != nil {
 		return nil, err
 	}
@@ -105,12 +102,6 @@ func (o *ordinalityProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerM
 	}
 	return nil, o.DrainHelper()
 
-}
-
-// ConsumerClosed is part of the RowSource interface.
-func (o *ordinalityProcessor) ConsumerClosed() {
-	// The consumer is done, Next() will not be called again.
-	o.InternalClose()
 }
 
 // execStatsForTrace implements ProcessorBase.ExecStatsForTrace.

--- a/pkg/sql/rowexec/project_set.go
+++ b/pkg/sql/rowexec/project_set.go
@@ -278,12 +278,6 @@ func (ps *projectSetProcessor) toEncDatum(d tree.Datum, colIdx int) rowenc.EncDa
 	return rowenc.DatumToEncDatum(ctyp, d)
 }
 
-// ConsumerClosed is part of the RowSource interface.
-func (ps *projectSetProcessor) ConsumerClosed() {
-	// The consumer is done, Next() will not be called again.
-	ps.InternalClose()
-}
-
 // ChildCount is part of the execinfra.OpNode interface.
 func (ps *projectSetProcessor) ChildCount(verbose bool) int {
 	if _, ok := ps.input.(execinfra.OpNode); ok {

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -164,7 +164,7 @@ func newSampleAggregator(
 	if err := s.Init(
 		nil, post, input.OutputTypes(), flowCtx, processorID, output, memMonitor,
 		execinfra.ProcStateOpts{
-			TrailingMetaCallback: func(context.Context) []execinfrapb.ProducerMetadata {
+			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
 				s.close()
 				return nil
 			},

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -201,7 +201,7 @@ func newSamplerProcessor(
 	if err := s.Init(
 		nil, post, outTypes, flowCtx, processorID, output, memMonitor,
 		execinfra.ProcStateOpts{
-			TrailingMetaCallback: func(context.Context) []execinfrapb.ProducerMetadata {
+			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
 				s.close()
 				return nil
 			},

--- a/pkg/sql/rowexec/sorter.go
+++ b/pkg/sql/rowexec/sorter.go
@@ -116,11 +116,10 @@ func (s *sorterBase) close() {
 		if s.i != nil {
 			s.i.Close()
 		}
-		ctx := s.Ctx
-		s.rows.Close(ctx)
-		s.MemMonitor.Stop(ctx)
+		s.rows.Close(s.Ctx)
+		s.MemMonitor.Stop(s.Ctx)
 		if s.diskMonitor != nil {
-			s.diskMonitor.Stop(ctx)
+			s.diskMonitor.Stop(s.Ctx)
 		}
 	}
 }
@@ -214,7 +213,7 @@ func newSortAllProcessor(
 		spec.OrderingMatchLen,
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{input},
-			TrailingMetaCallback: func(context.Context) []execinfrapb.ProducerMetadata {
+			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
 				proc.close()
 				return nil
 			},
@@ -326,7 +325,7 @@ func newSortTopKProcessor(
 		ordering, spec.OrderingMatchLen,
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{input},
-			TrailingMetaCallback: func(context.Context) []execinfrapb.ProducerMetadata {
+			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
 				proc.close()
 				return nil
 			},
@@ -423,7 +422,7 @@ func newSortChunksProcessor(
 		proc, flowCtx, processorID, sortChunksProcName, input, post, out, ordering, spec.OrderingMatchLen,
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{input},
-			TrailingMetaCallback: func(context.Context) []execinfrapb.ProducerMetadata {
+			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
 				proc.close()
 				return nil
 			},

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -169,8 +169,10 @@ func newTableReader(
 	return tr, nil
 }
 
-func (tr *tableReader) generateTrailingMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
-	trailingMeta := tr.generateMeta(ctx)
+func (tr *tableReader) generateTrailingMeta() []execinfrapb.ProducerMetadata {
+	// We need to generate metadata before closing the processor because
+	// InternalClose() updates tr.Ctx to the "original" context.
+	trailingMeta := tr.generateMeta(tr.Ctx)
 	tr.close()
 	return trailingMeta
 }

--- a/pkg/sql/rowexec/values.go
+++ b/pkg/sql/rowexec/values.go
@@ -131,12 +131,6 @@ func (v *valuesProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetad
 
 }
 
-// ConsumerClosed is part of the RowSource interface.
-func (v *valuesProcessor) ConsumerClosed() {
-	// The consumer is done, Next() will not be called again.
-	v.InternalClose()
-}
-
 // ChildCount is part of the execinfra.OpNode interface.
 func (v *valuesProcessor) ChildCount(verbose bool) int {
 	return 0

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -168,7 +168,7 @@ func newWindower(
 		output,
 		limitedMon,
 		execinfra.ProcStateOpts{InputsToDrain: []execinfra.RowSource{w.input},
-			TrailingMetaCallback: func(context.Context) []execinfrapb.ProducerMetadata {
+			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
 				w.close()
 				return nil
 			}},

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -309,9 +309,13 @@ func newZigzagJoiner(
 		post,
 		output,
 		execinfra.ProcStateOpts{
-			TrailingMetaCallback: func(ctx context.Context) []execinfrapb.ProducerMetadata {
+			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
+				// We need to generate metadata before closing the processor
+				// because InternalClose() updates z.Ctx to the "original"
+				// context.
+				trailingMeta := z.generateMeta(z.Ctx)
 				z.close()
-				return z.generateMeta(ctx)
+				return trailingMeta
 			},
 		},
 	)


### PR DESCRIPTION
This commit removes redundant context argument from
`trailingMetaCallback` in favor of just using `ProcessorBase.Ctx` when
needed. This was already actually the case since the callback was always
called with `ProcessorBase.Ctx`. We also had the wrong sequences of
actions when collecting trailing metadata in inverted joiner, join
reader, and zigzag joiner, where we first called `InternalClose` and
then generated the metadata. That is wrong because `InternalClose`
replaces the context used throughout the operation of a processor with
the "original" context (the one passed into `StartInternal`). This is
now fixed.

Additionally, a few unnecessary method overwrites are removed and
`ProcessorBase` now provides the default implementation of
`ConsumerClosed` (which simply calls `InternalClose`).

This commit also makes a slight adjustment to context management of the
change aggregator.

Release justification: low-risk cleanup.

Release note: None