### PR TITLE
sql: fixing information_schema.columns.is_identity

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -497,13 +497,14 @@ https://www.postgresql.org/docs/9.5/infoschema-columns.html`,
 					dbNameStr,                                                 // udt_catalog
 					udtSchema,                                                 // udt_schema
 					tree.NewDString(column.GetType().PGName()), // udt_name
-					tree.DNull,                        // scope_catalog
-					tree.DNull,                        // scope_schema
-					tree.DNull,                        // scope_name
-					tree.DNull,                        // maximum_cardinality
-					tree.DNull,                        // dtd_identifier
-					tree.DNull,                        // is_self_referencing
-					tree.DNull,                        // is_identity
+					tree.DNull, // scope_catalog
+					tree.DNull, // scope_schema
+					tree.DNull, // scope_name
+					tree.DNull, // maximum_cardinality
+					tree.DNull, // dtd_identifier
+					tree.DNull, // is_self_referencing
+					//TODO: Need to update when supporting identiy columns (Issue #48532)
+					noString,                          // is_identity
 					tree.DNull,                        // identity_generation
 					tree.DNull,                        // identity_start
 					tree.DNull,                        // identity_increment

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4301,3 +4301,13 @@ udt_schema  udt_name
 sh          d
 public      e
 pg_catalog  int8
+
+# Testing information_schema.columns.is_identity which for now is False for every column
+statement ok
+SET DATABASE = "";
+
+query T colnames
+SELECT distinct is_identity FROM information_schema.columns
+----
+is_identity
+NO


### PR DESCRIPTION
Previously, information_schema.columns.is_identity was set to null
This was inadequate because is incorrect value
To address this, this patch sets column to NO as identity columns
are not yet supported

Release justification: bug fixes and low-risk updates to new functionality
Release note (sql change): fixed information_schema.columns.is_identity to
display the correct value

Fixes #61011