### PR TITLE
sql: add is_temporary and is_virtual columns to crdb_internal.create_statements

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1935,7 +1935,9 @@ CREATE TABLE crdb_internal.create_statements (
   alter_statements              STRING[] NOT NULL,
   validate_statements           STRING[] NOT NULL,
   has_partitions                BOOL NOT NULL,
-	is_multi_region               BOOL NOT NULL,
+  is_multi_region               BOOL NOT NULL,
+  is_virtual                    BOOL NOT NULL,
+  is_temporary                  BOOL NOT NULL,
   INDEX(descriptor_id)
 )
 `, virtualCurrentDB, false, /* includesIndexEntries */
@@ -2004,6 +2006,8 @@ CREATE TABLE crdb_internal.create_statements (
 			validateStmts,
 			tree.MakeDBool(tree.DBool(hasPartitions)),
 			tree.MakeDBool(tree.DBool(db != nil && db.IsMultiRegion())),
+			tree.MakeDBool(tree.DBool(table.IsVirtualTable())),
+			tree.MakeDBool(tree.DBool(table.IsTemporary())),
 		)
 	})
 

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -226,10 +226,10 @@ SELECT * FROM crdb_internal.builtin_functions WHERE function = ''
 ----
 function  signature  category  details
 
-query ITTITTTTTTTBB colnames
+query ITTITTTTTTTBBBB colnames
 SELECT * FROM crdb_internal.create_statements WHERE database_name = ''
 ----
-database_id  database_name  schema_name  descriptor_id  descriptor_type  descriptor_name  create_statement  state  create_nofks  alter_statements  validate_statements  has_partitions  is_multi_region
+database_id  database_name  schema_name  descriptor_id  descriptor_type  descriptor_name  create_statement  state  create_nofks  alter_statements  validate_statements  has_partitions  is_multi_region  is_virtual  is_temporary
 
 query ITITTBTB colnames
 SELECT * FROM crdb_internal.table_columns WHERE descriptor_name = ''
@@ -825,3 +825,32 @@ testdb         root      ALL
 
 statement ok
 SET DATABASE = test
+
+# Test crdb_internal.create_statements functionality.
+
+statement ok
+CREATE TABLE normal_table()
+
+query B
+SELECT is_virtual FROM crdb_internal.create_statements WHERE descriptor_name = 'normal_table'
+----
+false
+
+query B
+SELECT is_virtual FROM crdb_internal.create_statements WHERE descriptor_name = 'pg_views'
+----
+true
+
+query B
+SELECT is_temporary FROM crdb_internal.create_statements WHERE descriptor_name = 'normal_table'
+----
+false
+
+statement ok
+SET experimental_enable_temp_tables = 'on';
+CREATE TEMPORARY TABLE temp()
+
+query B
+SELECT is_temporary FROM crdb_internal.create_statements WHERE descriptor_name = 'temp'
+----
+true

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
@@ -238,10 +238,10 @@ SELECT * FROM crdb_internal.builtin_functions WHERE function = ''
 ----
 function  signature  category  details
 
-query ITTITTTTTTTBB colnames
+query ITTITTTTTTTBBBB colnames
 SELECT * FROM crdb_internal.create_statements WHERE database_name = ''
 ----
-database_id  database_name  schema_name  descriptor_id  descriptor_type  descriptor_name  create_statement  state  create_nofks  alter_statements  validate_statements  has_partitions  is_multi_region
+database_id  database_name  schema_name  descriptor_id  descriptor_type  descriptor_name  create_statement  state  create_nofks  alter_statements  validate_statements  has_partitions  is_multi_region  is_virtual  is_temporary
 
 query ITITTBTB colnames
 SELECT * FROM crdb_internal.table_columns WHERE descriptor_name = ''

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -190,7 +190,9 @@ CREATE TABLE crdb_internal.create_statements (
    validate_statements STRING[] NOT NULL,
    has_partitions BOOL NOT NULL,
    is_multi_region BOOL NOT NULL,
-   INDEX create_statements_descriptor_id_idx (descriptor_id ASC) STORING (database_id, database_name, schema_name, descriptor_type, descriptor_name, create_statement, state, create_nofks, alter_statements, validate_statements, has_partitions, is_multi_region)
+   is_virtual BOOL NOT NULL,
+   is_temporary BOOL NOT NULL,
+   INDEX create_statements_descriptor_id_idx (descriptor_id ASC) STORING (database_id, database_name, schema_name, descriptor_type, descriptor_name, create_statement, state, create_nofks, alter_statements, validate_statements, has_partitions, is_multi_region, is_virtual, is_temporary)
 )  CREATE TABLE crdb_internal.create_statements (
    database_id INT8 NULL,
    database_name STRING NULL,
@@ -205,7 +207,9 @@ CREATE TABLE crdb_internal.create_statements (
    validate_statements STRING[] NOT NULL,
    has_partitions BOOL NOT NULL,
    is_multi_region BOOL NOT NULL,
-   INDEX create_statements_descriptor_id_idx (descriptor_id ASC) STORING (database_id, database_name, schema_name, descriptor_type, descriptor_name, create_statement, state, create_nofks, alter_statements, validate_statements, has_partitions, is_multi_region)
+   is_virtual BOOL NOT NULL,
+   is_temporary BOOL NOT NULL,
+   INDEX create_statements_descriptor_id_idx (descriptor_id ASC) STORING (database_id, database_name, schema_name, descriptor_type, descriptor_name, create_statement, state, create_nofks, alter_statements, validate_statements, has_partitions, is_multi_region, is_virtual, is_temporary)
 )  {}  {}
 CREATE TABLE crdb_internal.create_type_statements (
    database_id INT8 NULL,

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -133,11 +133,11 @@ CREATE SEQUENCE ignored_options_test NO CYCLE
 statement ok
 CREATE SEQUENCE show_create_test
 
-query ITTITTTTTTTBB colnames
+query ITTITTTTTTTBBBB colnames
 SELECT * FROM crdb_internal.create_statements WHERE descriptor_name = 'show_create_test'
 ----
-database_id  database_name  schema_name  descriptor_id  descriptor_type  descriptor_name   create_statement                                                                                     state   create_nofks                                                                                         alter_statements  validate_statements  has_partitions  is_multi_region
-52           test           public       63             sequence         show_create_test  CREATE SEQUENCE public.show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1  PUBLIC  CREATE SEQUENCE public.show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1  {}                {}                   false           false
+database_id  database_name  schema_name  descriptor_id  descriptor_type  descriptor_name   create_statement                                                                                     state   create_nofks                                                                                         alter_statements  validate_statements  has_partitions  is_multi_region  is_virtual  is_temporary
+52           test           public       63             sequence         show_create_test  CREATE SEQUENCE public.show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1  PUBLIC  CREATE SEQUENCE public.show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1  {}                {}                   false           false            false       false
 
 query TT colnames
 SHOW CREATE SEQUENCE show_create_test


### PR DESCRIPTION
These columns are useful for filtering for generating output for
SHOW CREATE ALL TABLES.

Release justification: None, change to internal table.
Release note: None