### PR TITLE
sql: create schema if not exists see's dropped schemas as existing

### DIFF
--- a/pkg/sql/alter_schema.go
+++ b/pkg/sql/alter_schema.go
@@ -184,7 +184,7 @@ func (p *planner) renameSchema(
 	ctx context.Context, db *dbdesc.Mutable, desc *schemadesc.Mutable, newName string, jobDesc string,
 ) error {
 	// Check that there isn't a name collision with the new name.
-	found, err := schemaExists(ctx, p.txn, p.ExecCfg().Codec, db.ID, newName)
+	found, _, err := schemaExists(ctx, p.txn, p.ExecCfg().Codec, db.ID, newName)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -816,3 +816,22 @@ query TT
 SELECT schema_name, table_name FROM [SHOW TABLES FROM for_show.sc1]
 ----
 sc1    t1
+
+# Unit test for #61149
+statement ok
+CREATE SCHEMA sc2
+
+statement ok
+CREATE TYPE sc3 as enum('foo')
+
+statement ok
+BEGIN
+
+statement ok
+DROP SCHEMA sc2
+
+statement error pgcode 55000 schema "sc2" is being dropped, try again later
+CREATE SCHEMA IF NOT EXISTS sc2
+
+statement ok
+END

--- a/pkg/sql/reparent_database.go
+++ b/pkg/sql/reparent_database.go
@@ -81,7 +81,7 @@ func (p *planner) ReparentDatabase(
 	}
 
 	// Ensure that this database wouldn't collide with a name under the new database.
-	exists, err := schemaExists(ctx, p.txn, p.ExecCfg().Codec, parent.ID, db.Name)
+	exists, _, err := schemaExists(ctx, p.txn, p.ExecCfg().Codec, parent.ID, db.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/schema.go
+++ b/pkg/sql/schema.go
@@ -26,22 +26,22 @@ import (
 
 func schemaExists(
 	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec, parentID descpb.ID, schema string,
-) (bool, error) {
+) (bool, descpb.ID, error) {
 	// Check statically known schemas.
 	if schema == tree.PublicSchema {
-		return true, nil
+		return true, descpb.InvalidID, nil
 	}
 	for _, s := range virtualSchemas {
 		if s.name == schema {
-			return true, nil
+			return true, descpb.InvalidID, nil
 		}
 	}
 	// Now lookup in the namespace for other schemas.
-	exists, _, err := catalogkv.LookupObjectID(ctx, txn, codec, parentID, keys.RootNamespaceID, schema)
+	exists, schemaID, err := catalogkv.LookupObjectID(ctx, txn, codec, parentID, keys.RootNamespaceID, schema)
 	if err != nil {
-		return false, err
+		return false, descpb.InvalidID, err
 	}
-	return exists, nil
+	return exists, schemaID, nil
 }
 
 func (p *planner) writeSchemaDesc(ctx context.Context, desc *schemadesc.Mutable) error {


### PR DESCRIPTION
Fixes: #61149

Previously, the CREATE SCHEMA IF NOT EXISTS statement would detect
existing schemas, but never checked if they were in a dropping state.
So, the creation process would be skipped and the drop would still
continue leading to unexpected behaviour (i.e. the new schema to
replace it would not get created). To address this, this patch
returns an error if a schema is found in a dropping state.

Release note (bug fix): Dropping and recreating a schema
in a transaction will now correctly error out if an object
in a dropped state is detected.

Release justification: Low risk change to address a high severity
issue where users could have failures due to incorrect behaviour.