### PR TITLE
release-20.2: geomfn: require at least 1 quad seg for st_buffer

### DIFF
--- a/pkg/geo/geomfn/buffer.go
+++ b/pkg/geo/geomfn/buffer.go
@@ -113,6 +113,13 @@ func ParseBufferParams(s string, distance float64) (BufferParams, float64, error
 
 // Buffer buffers a given Geometry by the supplied parameters.
 func Buffer(g geo.Geometry, params BufferParams, distance float64) (geo.Geometry, error) {
+	if params.p.QuadrantSegments < 1 {
+		return geo.Geometry{}, errors.Newf(
+			"must request at least 1 quadrant segment, requested %d quadrant segments",
+			params.p.QuadrantSegments,
+		)
+
+	}
 	if params.p.QuadrantSegments > geo.MaxAllowedSplitPoints {
 		return geo.Geometry{}, errors.Newf(
 			"attempting to split buffered geometry into too many quadrant segments; requested %d quadrant segments, max %d",

--- a/pkg/geo/geomfn/buffer_test.go
+++ b/pkg/geo/geomfn/buffer_test.go
@@ -102,4 +102,20 @@ func TestBuffer(t *testing.T) {
 			),
 		)
 	})
+
+	t.Run("too little quadrant segements", func(t *testing.T) {
+		for _, num := range []int{0, -1} {
+			t.Run(fmt.Sprintf("%d", num), func(t *testing.T) {
+				g := geo.MustParseGeometry("LINESTRING(0 0, 100 100)")
+				params, distance, err := ParseBufferParams(fmt.Sprintf("quad_segs=%d", num), 1000)
+				require.NoError(t, err)
+				_, err = Buffer(g, params, distance)
+				require.EqualError(
+					t,
+					err,
+					fmt.Sprintf("must request at least 1 quadrant segment, requested %d quadrant segments", num),
+				)
+			})
+		}
+	})
 }


### PR DESCRIPTION
Backport 1/1 commits from #61315.

/cc @cockroachdb/release

---

Release justification: low-risk, high benefit changes to existing
functionality

Resolves #61314 

Release note (sql change): ST_Buffer now requires at least 1 quadrant
segment.
