### PR TITLE
sql: create database if not exists see's dropped database's as existing

### DIFF
--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -72,8 +72,19 @@ func (p *planner) createDatabase(
 		shouldCreatePublicSchema = false
 	}
 
-	if exists, _, err := catalogkv.LookupDatabaseID(ctx, p.txn, p.ExecCfg().Codec, dbName); err == nil && exists {
+	if exists, databaseID, err := catalogkv.LookupDatabaseID(ctx, p.txn, p.ExecCfg().Codec, dbName); err == nil && exists {
 		if database.IfNotExists {
+			// Check if the database is in a dropping state
+			desc, err := catalogkv.GetDescriptorByID(ctx, p.txn, p.ExecCfg().Codec, databaseID, catalogkv.Immutable,
+				catalogkv.DatabaseDescriptorKind, true)
+			if err != nil {
+				return nil, false, err
+			}
+			if desc.Dropped() {
+				return nil, false, pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+					"database %q is being dropped, try again later",
+					dbName)
+			}
 			// Noop.
 			return nil, false, nil
 		}

--- a/pkg/sql/logictest/testdata/logic_test/database
+++ b/pkg/sql/logictest/testdata/logic_test/database
@@ -218,3 +218,24 @@ user testuser
 
 statement error permission denied to create database
 CREATE DATABASE privs
+
+# Unit test for #61150
+user root
+
+statement ok
+CREATE DATABASE d1
+
+statement ok
+BEGIN
+
+statement ok
+DROP DATABASE d1
+
+statement error pgcode 55000 database "d1" is being dropped, try again later
+CREATE DATABASE IF NOT EXISTS d1
+
+statement ok
+END
+
+statement ok
+DROP DATABASE d1


### PR DESCRIPTION
Fixes: #61150

Previously, the CREATE DATABASE IF NOT EXISTS statement would detect
existing databases, but never checked if they were in a dropping state.
So, the creation process would be skipped and the drop would still
continue leading to unexpected behaviour (i.e. the new database to
replace it would not get created). To address this, this patch
returns an error if a database is found in a dropping state.

Release note (bug fix): Dropping and recreating a database
in a transaction will now correctly error out if an object
in a dropped state is detected.

Release justification: Low risk change to address a high severity
issue where users could have failures due to incorrect behaviour.