### PR TITLE
sql: exclude implicit partitioning cols from unique violation error

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -944,8 +944,7 @@ unique_b_a                   crdb_region  true
 statement ok
 INSERT INTO regional_by_row_table (pk, pk2, a, b) VALUES (1000, 1, 1000, 2000)
 
-# TODO(#59504): we should hide crdb_region.
-statement error Key \(crdb_region,pk2\)=\('ap-southeast-2',1\) already exists.
+statement error Key \(pk2\)=\(1\) already exists\.
 ALTER TABLE regional_by_row_table ALTER PRIMARY KEY USING COLUMNS (pk2)
 
 statement ok
@@ -1163,8 +1162,7 @@ vectorized: true
                 └── • scan buffer
                       label: buffer 1
 
-# TODO(mgartner): Update this error message to remove crdb_region (see #59504).
-statement error pq: duplicate key value violates unique constraint "primary"\nDETAIL: Key \(crdb_region_col,pk\)=\('us-east-1',1\) already exists\.
+statement error pq: duplicate key value violates unique constraint "primary"\nDETAIL: Key \(pk\)=\(1\) already exists\.
 INSERT INTO regional_by_row_table_as (pk, a, b) VALUES (1, 1, 1)
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -70,7 +70,7 @@ primary     crdb_internal_a_shard_10  true
 statement ok
 INSERT INTO sharded_primary values (1), (2), (3)
 
-query error pq: duplicate key value violates unique constraint "primary"\nDETAIL: Key \(crdb_internal_a_shard_10,a\)=\(6,1\) already exists\.
+query error pq: duplicate key value violates unique constraint "primary"\nDETAIL: Key \(a\)=\(1\) already exists\.
 INSERT INTO sharded_primary values (1)
 
 # Ensure that the shard column is assigned into the column family of the first column in

--- a/pkg/sql/row/errors.go
+++ b/pkg/sql/row/errors.go
@@ -96,12 +96,17 @@ func NewUniquenessConstraintViolationError(
 			"duplicate key value: decoding err=%s", err)
 	}
 
+	// Exclude implicit partitioning columns and hash sharded index columns from
+	// the error message.
+	skipCols := index.ExplicitColumnStartIdx()
 	return errors.WithDetail(
 		pgerror.WithConstraintName(pgerror.Newf(pgcode.UniqueViolation,
 			"duplicate key value violates unique constraint %q", index.Name,
 		), index.Name),
 		fmt.Sprintf(
-			"Key (%s)=(%s) already exists.", strings.Join(names, ","), strings.Join(values, ","),
+			"Key (%s)=(%s) already exists.",
+			strings.Join(names[skipCols:], ","),
+			strings.Join(values[skipCols:], ","),
 		),
 	)
 }


### PR DESCRIPTION
This commit updates the error message produced in case of a unique constraint
violation to exclude the values for implicit partitioning columns and hash sharded
index columns.

Fixes #59504

Release justification: bug fixes and low-risk updates to new functionality.

Release note (sql change): Updated the error message returned in case of
a unique constraint violation to hide the names and values for implicit
partitioning columns and hash sharded index columns.