### PR TITLE
workload,roachprod: add zsh completion generation

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -807,6 +807,7 @@ var syncCmd = &cobra.Command{
 var lockFile = os.ExpandEnv("$HOME/.roachprod/LOCK")
 
 var bashCompletion = os.ExpandEnv("$HOME/.roachprod/bash-completion.sh")
+var zshCompletion = os.ExpandEnv("$HOME/.roachprod/zsh-completion.sh")
 
 // syncCloud grabs an exclusive lock on the roachprod state and then proceeds to
 // read the current state from the cloud and write it out to disk. The locking
@@ -886,6 +887,7 @@ func syncCloud(quiet bool) (*cld.Cloud, error) {
 	}
 
 	_ = rootCmd.GenBashCompletionFile(bashCompletion)
+	_ = rootCmd.GenZshCompletionFile(zshCompletion)
 
 	if err := vm.ProvidersSequential(vm.AllProviderNames(), func(p vm.Provider) error {
 		return p.ConfigSSH()

--- a/pkg/workload/cli/bash_complete.go
+++ b/pkg/workload/cli/bash_complete.go
@@ -30,4 +30,21 @@ func init() {
 		bashCmd.Hidden = userFacing
 		return bashCmd
 	})
+	AddSubCmd(func(userFacing bool) *cobra.Command {
+		var bashCmd = SetCmdDefaults(&cobra.Command{
+			Use:   `gen-zsh-completions <output-file>`,
+			Short: `generate zsh completions for workload command`,
+			Args:  cobra.ExactArgs(1),
+		})
+		bashCmd.Run = func(cmd *cobra.Command, args []string) {
+			for parent := cmd.Parent(); parent != nil; parent = cmd.Parent() {
+				cmd = parent
+			}
+			if err := cmd.GenZshCompletionFile(args[0]); err != nil {
+				panic(err)
+			}
+		}
+		bashCmd.Hidden = userFacing
+		return bashCmd
+	})
 }


### PR DESCRIPTION
Release note: none.

Release justification: Non-production code.