### PR TITLE
release-20.2: cloudimpl: fix azure listing missing relative behavior

### DIFF
--- a/pkg/storage/cloudimpl/azure_storage.go
+++ b/pkg/storage/cloudimpl/azure_storage.go
@@ -148,13 +148,21 @@ func (s *azureStorage) ListFiles(ctx context.Context, patternSuffix string) ([]s
 			continue
 		}
 		if matches {
-			azureURL := url.URL{
-				Scheme:   "azure",
-				Host:     strings.TrimPrefix(s.container.URL().Path, "/"),
-				Path:     blob.Name,
-				RawQuery: azureQueryParams(s.conf),
+			if patternSuffix != "" {
+				if !strings.HasPrefix(blob.Name, s.prefix) {
+					// TODO(dt): return a nice rel-path instead of erroring out.
+					return nil, errors.New("pattern matched file outside of path")
+				}
+				fileList = append(fileList, strings.TrimPrefix(strings.TrimPrefix(blob.Name, s.prefix), "/"))
+			} else {
+				azureURL := url.URL{
+					Scheme:   "azure",
+					Host:     strings.TrimPrefix(s.container.URL().Path, "/"),
+					Path:     blob.Name,
+					RawQuery: azureQueryParams(s.conf),
+				}
+				fileList = append(fileList, azureURL.String())
 			}
-			fileList = append(fileList, azureURL.String())
 		}
 	}
 

--- a/pkg/storage/cloudimpl/cloudimpltests/azure_storage_test.go
+++ b/pkg/storage/cloudimpl/cloudimpltests/azure_storage_test.go
@@ -44,8 +44,8 @@ func TestPutAzure(t *testing.T) {
 		t,
 		fmt.Sprintf("azure://%s/%s?%s=%s&%s=%s",
 			bucket, "listing-test",
-			cloudimpl.AzureAccountNameParam, url.QueryEscape(accountName),
 			cloudimpl.AzureAccountKeyParam, url.QueryEscape(accountKey),
+			cloudimpl.AzureAccountNameParam, url.QueryEscape(accountName),
 		),
 		security.RootUser, nil, nil,
 	)


### PR DESCRIPTION
This backports commit 1/2 from #58384.

ListFiles is supposed to return the relative paths that match the glob within the prefix.
For example, list of 'a-*' in '/some/path' is supposed to return 'a-1.txt', 'a-2.txt', etc.
On the otherhand, list of '' in '/some/path/a-*' is has no 'base' path from which its results
are relative, since it just has its pattern. In this case it retuns full URIs for each match.

Previously the azure implemementation of listing was missing the relative behavior and always
returned full paths.

Release note (bug fix): Fix handling of relative paths when listing files on Azure that could cause incremental backups to fail.