### PR TITLE
storage: bump pebble

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -525,8 +525,8 @@ def go_deps():
         name = "com_github_cockroachdb_pebble",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/pebble",
-        sum = "h1:1OofRBEfi6kh5Iym7Qzl5uOSoaGLX8p2TM+6MzELbLc=",
-        version = "v0.0.0-20210302170351-6eee4f6b45b1",
+        sum = "h1:XdZUrLbpSS/DuvlJNlQh7ihh0OgrkxeR/bHKYaHXrKk=",
+        version = "v0.0.0-20210302221659-e755a0512369",
     )
     go_repository(
         name = "com_github_cockroachdb_redact",

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20210302170351-6eee4f6b45b1
+	github.com/cockroachdb/pebble v0.0.0-20210302221659-e755a0512369
 	github.com/cockroachdb/redact v1.0.9
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249 h1:pZu
 github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249/go.mod h1:UJ0EZAp832vCd54Wev9N1BMKEyvcZ5+IM0AwDrnlkEc=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20210302170351-6eee4f6b45b1 h1:1OofRBEfi6kh5Iym7Qzl5uOSoaGLX8p2TM+6MzELbLc=
-github.com/cockroachdb/pebble v0.0.0-20210302170351-6eee4f6b45b1/go.mod h1:1XpB4cLQcF189RAcWi4gUc110zJgtOfT7SVNGY8sOe0=
+github.com/cockroachdb/pebble v0.0.0-20210302221659-e755a0512369 h1:XdZUrLbpSS/DuvlJNlQh7ihh0OgrkxeR/bHKYaHXrKk=
+github.com/cockroachdb/pebble v0.0.0-20210302221659-e755a0512369/go.mod h1:1XpB4cLQcF189RAcWi4gUc110zJgtOfT7SVNGY8sOe0=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.0.9 h1:sjlUvGorKMIVQfo+w2RqDi5eewCHn453C/vdIXMzjzI=
 github.com/cockroachdb/redact v1.0.9/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=


### PR DESCRIPTION
Bumping pebble to incorporate
https://github.com/cockroachdb/pebble/pull/1076. This is the only
change since the last bump.

Release justification: fixes for high-priority or high-severity bugs
in existing functionality.

Release note: None