### PR TITLE
kvserver, timeutil: fix some Timer user-after-Stops

### DIFF
--- a/pkg/kv/kvserver/closedts/provider/provider.go
+++ b/pkg/kv/kvserver/closedts/provider/provider.go
@@ -126,7 +126,7 @@ func (p *Provider) runCloser(ctx context.Context) {
 	// Track whether we've ever been live to avoid logging warnings about not
 	// being live during node startup.
 	var everBeenLive bool
-	var t timeutil.Timer
+	t := timeutil.NewTimer()
 	defer t.Stop()
 	for {
 		closeFraction := closedts.CloseFraction.Get(&p.cfg.Settings.SV)
@@ -134,7 +134,9 @@ func (p *Provider) runCloser(ctx context.Context) {
 		if targetDuration > 0 {
 			t.Reset(time.Duration(closeFraction * targetDuration))
 		} else {
-			t.Stop() // disable closing when the target duration is non-positive
+			// Disable closing when the target duration is non-positive.
+			t.Stop()
+			t = timeutil.NewTimer()
 		}
 		select {
 		case <-p.cfg.Stopper.ShouldQuiesce():

--- a/pkg/kv/kvserver/closedts/sidetransport/sender.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/sender.go
@@ -178,15 +178,16 @@ func (s *Sender) Run(ctx context.Context, nodeID roachpb.NodeID) {
 				s.buf.Close()
 			}()
 
-			var timer timeutil.Timer
+			timer := timeutil.NewTimer()
 			defer timer.Stop()
 			for {
 				interval := closedts.SideTransportCloseInterval.Get(&s.st.SV)
 				if interval > 0 {
-					timer.Reset(closedts.SideTransportCloseInterval.Get(&s.st.SV))
+					timer.Reset(interval)
 				} else {
 					// Disable the side-transport.
 					timer.Stop()
+					timer = timeutil.NewTimer()
 				}
 				select {
 				case <-timer.C:


### PR DESCRIPTION
Two guys were continuing to use a Timer after Stop()ing it, which is
illegal.

Release note: None
Release justification: Bug fix.