### PR TITLE
roachtest: bump activerecord version

### DIFF
--- a/pkg/cmd/roachtest/activerecord.go
+++ b/pkg/cmd/roachtest/activerecord.go
@@ -21,9 +21,9 @@ import (
 var activerecordResultRegex = regexp.MustCompile(`^(?P<test>[^\s]+#[^\s]+) = (?P<timing>\d+\.\d+ s) = (?P<result>.)$`)
 var railsReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)\.?(?P<subpoint>\d*)$`)
 var supportedRailsVersion = "6.0.3.4"
-var adapterVersion = "v6.0.0beta2"
+var adapterVersion = "v6.0.0beta3"
 
-// This test runs pgjdbc's full test suite against a single cockroach node.
+// This test runs activerecord's full test suite against a single cockroach node.
 
 func registerActiveRecord(r *testRegistry) {
 	runActiveRecord := func(


### PR DESCRIPTION
6.0.0beta2 seems to have tests we don't pass, so let's bump it!

Release justification: non-production code change

Release note: None