### PR TITLE
colflow: clean up vectorized stats propagation

### DIFF
--- a/pkg/sql/colexec/BUILD.bazel
+++ b/pkg/sql/colexec/BUILD.bazel
@@ -73,6 +73,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/mon",
         "//pkg/util/stringarena",
+        "//pkg/util/tracing",
         "@com_github_cockroachdb_apd_v2//:apd",  # keep
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_marusama_semaphore//:semaphore",

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -94,7 +94,7 @@ func wrapRowSources(
 				nil, /* output */
 				nil, /* metadataSourcesQueue */
 				nil, /* toClose */
-				nil, /* execStatsForTrace */
+				nil, /* getStats */
 				nil, /* cancelFlow */
 			)
 			if err != nil {

--- a/pkg/sql/colexec/colbuilder/execplan_test.go
+++ b/pkg/sql/colexec/colbuilder/execplan_test.go
@@ -128,7 +128,7 @@ func TestNewColOperatorExpectedTypeSchema(t *testing.T) {
 		nil, /* output */
 		nil, /* metadataSourcesQueue */
 		nil, /* toClose */
-		nil, /* execStatsForTrace */
+		nil, /* getStats */
 		nil, /* cancelFlow */
 	)
 	require.NoError(t, err)

--- a/pkg/sql/colexec/materializer_test.go
+++ b/pkg/sql/colexec/materializer_test.go
@@ -70,7 +70,7 @@ func TestColumnarizeMaterialize(t *testing.T) {
 		nil, /* output */
 		nil, /* metadataSourcesQueue */
 		nil, /* toClose */
-		nil, /* execStatsForTrace */
+		nil, /* getStats */
 		nil, /* cancelFlow */
 	)
 	if err != nil {
@@ -154,7 +154,7 @@ func BenchmarkMaterializer(b *testing.B) {
 							nil, /* output */
 							nil, /* metadataSourcesQueue */
 							nil, /* toClose */
-							nil, /* execStatsForTrace */
+							nil, /* getStats */
 							nil, /* cancelFlow */
 						)
 						if err != nil {
@@ -209,7 +209,7 @@ func TestMaterializerNextErrorAfterConsumerDone(t *testing.T) {
 		nil, /* output */
 		[]execinfrapb.MetadataSource{metadataSource},
 		nil, /* toClose */
-		nil, /* execStatsForTrace */
+		nil, /* getStats */
 		nil, /* cancelFlow */
 	)
 	require.NoError(t, err)
@@ -258,7 +258,7 @@ func BenchmarkColumnarizeMaterialize(b *testing.B) {
 			nil, /* output */
 			nil, /* metadataSourcesQueue */
 			nil, /* toClose */
-			nil, /* execStatsForTrace */
+			nil, /* getStats */
 			nil, /* cancelFlow */
 		)
 		if err != nil {

--- a/pkg/sql/colexec/types_integration_test.go
+++ b/pkg/sql/colexec/types_integration_test.go
@@ -94,7 +94,7 @@ func TestSQLTypesIntegration(t *testing.T) {
 				output,
 				nil, /* metadataSourcesQueue */
 				nil, /* toClose */
-				nil, /* execStatsForTrace */
+				nil, /* getStats */
 				nil, /* cancelFlow */
 			)
 			require.NoError(t, err)

--- a/pkg/sql/colflow/BUILD.bazel
+++ b/pkg/sql/colflow/BUILD.bazel
@@ -41,7 +41,6 @@ go_library(
         "//pkg/util/randutil",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
-        "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_marusama_semaphore//:semaphore",

--- a/pkg/sql/colflow/colrpc/BUILD.bazel
+++ b/pkg/sql/colflow/colrpc/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/log/logcrash",
         "//pkg/util/timeutil",
+        "//pkg/util/tracing",
         "@com_github_apache_arrow_go_arrow//array",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",

--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -224,8 +224,10 @@ func TestOutboxInbox(t *testing.T) {
 
 		outboxMemAcc := testMemMonitor.MakeBoundAccount()
 		defer outboxMemAcc.Close(ctx)
-		outbox, err :=
-			NewOutbox(colmem.NewAllocator(ctx, &outboxMemAcc, coldata.StandardColumnFactory), input, typs, nil /* metadataSource */, nil /* toClose */)
+		outbox, err := NewOutbox(
+			colmem.NewAllocator(ctx, &outboxMemAcc, coldata.StandardColumnFactory),
+			input, typs, nil /* metadataSource */, nil /* toClose */, nil, /* getStats */
+		)
 		require.NoError(t, err)
 
 		inboxMemAcc := testMemMonitor.MakeBoundAccount()
@@ -499,13 +501,15 @@ func TestOutboxInboxMetadataPropagation(t *testing.T) {
 			if tc.overrideExpectedMetadata != nil {
 				expectedMetadata = tc.overrideExpectedMetadata
 			}
-			outbox, err := NewOutbox(colmem.NewAllocator(ctx, &outboxMemAcc, coldata.StandardColumnFactory), input, typs, []execinfrapb.MetadataSource{
-				execinfrapb.CallbackMetadataSource{
-					DrainMetaCb: func(context.Context) []execinfrapb.ProducerMetadata {
-						return expectedMetadata
+			outbox, err := NewOutbox(
+				colmem.NewAllocator(ctx, &outboxMemAcc, coldata.StandardColumnFactory),
+				input, typs, []execinfrapb.MetadataSource{
+					execinfrapb.CallbackMetadataSource{
+						DrainMetaCb: func(context.Context) []execinfrapb.ProducerMetadata {
+							return expectedMetadata
+						},
 					},
-				},
-			}, nil /* toClose */)
+				}, nil /* toClose */, nil /* getStats */)
 			require.NoError(t, err)
 
 			inboxMemAcc := testMemMonitor.MakeBoundAccount()
@@ -577,8 +581,10 @@ func BenchmarkOutboxInbox(b *testing.B) {
 
 	outboxMemAcc := testMemMonitor.MakeBoundAccount()
 	defer outboxMemAcc.Close(ctx)
-	outbox, err :=
-		NewOutbox(colmem.NewAllocator(ctx, &outboxMemAcc, coldata.StandardColumnFactory), input, typs, nil /* metadataSources */, nil /* toClose */)
+	outbox, err := NewOutbox(
+		colmem.NewAllocator(ctx, &outboxMemAcc, coldata.StandardColumnFactory),
+		input, typs, nil /* metadataSources */, nil /* toClose */, nil, /* getStats */
+	)
 	require.NoError(b, err)
 
 	inboxMemAcc := testMemMonitor.MakeBoundAccount()
@@ -639,8 +645,10 @@ func TestOutboxStreamIDPropagation(t *testing.T) {
 
 	outboxMemAcc := testMemMonitor.MakeBoundAccount()
 	defer outboxMemAcc.Close(ctx)
-	outbox, err :=
-		NewOutbox(colmem.NewAllocator(ctx, &outboxMemAcc, coldata.StandardColumnFactory), input, typs, nil /* metadataSources */, nil /* toClose */)
+	outbox, err := NewOutbox(
+		colmem.NewAllocator(ctx, &outboxMemAcc, coldata.StandardColumnFactory),
+		input, typs, nil /* metadataSources */, nil /* toClose */, nil, /* getStats */
+	)
 	require.NoError(t, err)
 
 	outboxDone := make(chan struct{})

--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 )
@@ -60,18 +61,28 @@ type Outbox struct {
 		msg *execinfrapb.ProducerMessage
 	}
 
+	span *tracing.Span
+	// getStats, when non-nil, returns all of the execution statistics of the
+	// operators that are in the same tree as this Outbox. The stats will be
+	// added into the span as Structured payload and returned to the gateway as
+	// execinfrapb.ProducerMetadata.
+	getStats func() []*execinfrapb.ComponentStats
+
 	// A copy of Run's caller ctx, with no StreamID tag.
 	// Used to pass a clean context to the input.Next.
 	runnerCtx context.Context
 }
 
 // NewOutbox creates a new Outbox.
+// - getStats, when non-nil, returns all of the execution statistics of the
+//   operators that are in the same tree as this Outbox.
 func NewOutbox(
 	allocator *colmem.Allocator,
 	input colexecop.Operator,
 	typs []*types.T,
 	metadataSources []execinfrapb.MetadataSource,
 	toClose []colexecop.Closer,
+	getStats func() []*execinfrapb.ComponentStats,
 ) (*Outbox, error) {
 	c, err := colserde.NewArrowBatchConverter(typs)
 	if err != nil {
@@ -90,6 +101,7 @@ func NewOutbox(
 		serializer:      s,
 		metadataSources: metadataSources,
 		closers:         toClose,
+		getStats:        getStats,
 	}
 	o.scratch.buf = &bytes.Buffer{}
 	o.scratch.msg = &execinfrapb.ProducerMessage{}
@@ -127,6 +139,11 @@ func (o *Outbox) Run(
 	cancelFn context.CancelFunc,
 	connectionTimeout time.Duration,
 ) {
+	ctx, o.span = execinfra.ProcessorSpan(ctx, "outbox")
+	if o.span != nil {
+		defer o.span.Finish()
+	}
+
 	o.runnerCtx = ctx
 	ctx = logtags.AddTag(ctx, "streamID", streamID)
 	log.VEventf(ctx, 2, "Outbox Dialing %s", nodeID)
@@ -275,6 +292,11 @@ func (o *Outbox) sendMetadata(ctx context.Context, stream flowStreamClient, errT
 		msg.Data.Metadata = append(
 			msg.Data.Metadata, execinfrapb.LocalMetaToRemoteProducerMeta(ctx, execinfrapb.ProducerMetadata{Err: errToSend}),
 		)
+	}
+	if o.span != nil && o.getStats != nil {
+		for _, s := range o.getStats() {
+			o.span.RecordStructured(s)
+		}
 	}
 	if trace := execinfra.GetTraceData(ctx); trace != nil {
 		msg.Data.Metadata = append(msg.Data.Metadata, execinfrapb.RemoteProducerMetadata{

--- a/pkg/sql/colflow/colrpc/outbox_test.go
+++ b/pkg/sql/colflow/colrpc/outbox_test.go
@@ -37,7 +37,7 @@ func TestOutboxCatchesPanics(t *testing.T) {
 		typs     = []*types.T{types.Int}
 		rpcLayer = makeMockFlowStreamRPCLayer()
 	)
-	outbox, err := NewOutbox(testAllocator, input, typs, nil /* metadataSources */, nil /* toClose */)
+	outbox, err := NewOutbox(testAllocator, input, typs, nil /* metadataSources */, nil /* toClose */, nil /* getStats */)
 	require.NoError(t, err)
 
 	// This test relies on the fact that BatchBuffer panics when there are no
@@ -98,7 +98,7 @@ func TestOutboxDrainsMetadataSources(t *testing.T) {
 					return nil
 				},
 			},
-		}, nil /* toClose */)
+		}, nil /* toClose */, nil /* getStats */)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/sql/colflow/stats_test.go
+++ b/pkg/sql/colflow/stats_test.go
@@ -51,7 +51,7 @@ func TestNumBatches(t *testing.T) {
 			break
 		}
 	}
-	s := vsc.(*vectorizedStatsCollectorImpl).finish()
+	s := vsc.(*vectorizedStatsCollectorImpl).getStats()
 	require.Equal(t, nBatches, int(s.Output.NumBatches.Value()))
 }
 
@@ -77,7 +77,7 @@ func TestNumTuples(t *testing.T) {
 				break
 			}
 		}
-		s := vsc.(*vectorizedStatsCollectorImpl).finish()
+		s := vsc.(*vectorizedStatsCollectorImpl).getStats()
 		require.Equal(t, nBatches*batchSize, int(s.Output.NumTuples.Value()))
 	}
 }
@@ -149,7 +149,7 @@ func TestVectorizedStatsCollector(t *testing.T) {
 			batchCount++
 			tupleCount += b.Length()
 		}
-		s := mjStatsCollector.(*vectorizedStatsCollectorImpl).finish()
+		s := mjStatsCollector.(*vectorizedStatsCollectorImpl).getStats()
 
 		require.Equal(t, nBatches*coldata.BatchSize(), int(s.Output.NumTuples.Value()))
 		// Two inputs are advancing the time source for a total of 2 * nBatches

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -254,6 +254,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 							idToClosed.Unlock()
 							return nil
 						}}},
+						nil, /* getStats */
 					)
 
 					require.NoError(t, err)
@@ -360,7 +361,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 						materializerCalledClose = true
 						return nil
 					}}}, /* toClose */
-					nil, /* execStatsForTrace */
+					nil, /* getStats */
 					func() context.CancelFunc { return cancelLocal },
 				)
 				require.NoError(t, err)

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -44,7 +44,8 @@ func (c callbackRemoteComponentCreator) newOutbox(
 	input colexecop.Operator,
 	typs []*types.T,
 	metadataSources []execinfrapb.MetadataSource,
-	toClose []colexecop.Closer,
+	_ []colexecop.Closer,
+	_ func() []*execinfrapb.ComponentStats,
 ) (*colrpc.Outbox, error) {
 	return c.newOutboxFn(allocator, input, typs, metadataSources)
 }
@@ -202,7 +203,7 @@ func TestDrainOnlyInputDAG(t *testing.T) {
 			// expect from the input DAG.
 			require.Len(t, sources, 1)
 			require.Len(t, inboxToNumInputTypes[sources[0].(*colrpc.Inbox)], numInputTypesToOutbox)
-			return colrpc.NewOutbox(allocator, op, typs, sources, nil /* toClose */)
+			return colrpc.NewOutbox(allocator, op, typs, sources, nil /* toClose */, nil /* getStats */)
 		},
 		newInboxFn: func(allocator *colmem.Allocator, typs []*types.T, streamID execinfrapb.StreamID) (*colrpc.Inbox, error) {
 			inbox, err := colrpc.NewInbox(context.Background(), allocator, typs, streamID)

--- a/pkg/sql/colflow/vectorized_meta_propagation_test.go
+++ b/pkg/sql/colflow/vectorized_meta_propagation_test.go
@@ -80,7 +80,7 @@ func TestVectorizedMetaPropagation(t *testing.T) {
 		nil, /* output */
 		[]execinfrapb.MetadataSource{col},
 		nil, /* toClose */
-		nil, /* execStatsForTrace */
+		nil, /* getStats */
 		nil, /* cancelFlow */
 	)
 	if err != nil {

--- a/pkg/sql/colflow/vectorized_panic_propagation_test.go
+++ b/pkg/sql/colflow/vectorized_panic_propagation_test.go
@@ -62,7 +62,7 @@ func TestVectorizedInternalPanic(t *testing.T) {
 		nil, /* output */
 		nil, /* metadataSourceQueue */
 		nil, /* toClose */
-		nil, /* execStatsForTrace */
+		nil, /* getStats */
 		nil, /* cancelFlow */
 	)
 	if err != nil {
@@ -109,7 +109,7 @@ func TestNonVectorizedPanicPropagation(t *testing.T) {
 		nil, /* output */
 		nil, /* metadataSourceQueue */
 		nil, /* toClose */
-		nil, /* execStatsForTrace */
+		nil, /* getStats */
 		nil, /* cancelFlow */
 	)
 	if err != nil {

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -177,7 +177,7 @@ func verifyColOperator(t *testing.T, args verifyColOperatorArgs) error {
 		nil, /* output */
 		result.MetadataSources,
 		result.ToClose,
-		nil, /* execStatsForTrace */
+		nil, /* getStats */
 		nil, /* cancelFlow */
 	)
 	if err != nil {

--- a/pkg/sql/distsql/vectorized_panic_propagation_test.go
+++ b/pkg/sql/distsql/vectorized_panic_propagation_test.go
@@ -62,7 +62,7 @@ func TestNonVectorizedPanicDoesntHangServer(t *testing.T) {
 		&distsqlutils.RowBuffer{},
 		nil, /* metadataSourceQueue */
 		nil, /* toClose */
-		nil, /* execStatsForTrace */
+		nil, /* getStats */
 		nil, /* cancelFlow */
 	)
 	if err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index_geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index_geospatial
@@ -61,14 +61,14 @@ network usage: <hidden>
             │
             └── • scan
                   cluster nodes: <hidden>
-                  actual row count: 2
+                  actual row count: 4
                   KV rows read: 4
                   KV bytes read: 32 B
                   missing stats
                   table: geo_table@geom_index
                   spans: 31 spans
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJzMVdFO20oQfb9fMZoXQNdX2bVNbtiqUgqYNm0hyIlaoTpCxp6CheN1dzeVEcpn9Qf6ZdXaISVEmEaoVfOw0ZydM9k5Z3Zzi_pLjgJHwfvgYAzXcBQOj-GS5LmJL3KCj2-CMABtzrPCkNKUGL29NQoHhy_d7h7vvTgdDk7G2z5jjHlQfzFvZ0uI18HwOBiHZ46tNd2BYXgYhLB_BtfoYCFTOomnpFF8Qo4TB0slE9JaKgvd1gmDtELBHMyKcmYsPHEwkYpQ3KLJTE4ocGzPGFKckuowdDAlE2d5XXbZQt8e4DwrUqrQwVEZF1pAJ8L9KKo-p1FUcRZFFXtqwf825fAIIS5S8BhIc0VK46IZMLMyJy3AXSLaxHkOJpuSAPb9m01992EtTmRhqDCZLNZT65KgKE4F-A12cWOWkOfCPjp4EZvkijTImSlnRoAVbUG9g1yczB1sooXs2sSXhILPnV-3ZlB8JWUoPcpyQ4pUh6_6c7cfVKUCWUCfC9DWHKuFMqIW2_t_N4qYy6KIsacWBCrSTWnWozWThlaGPl-zy2-ziypKZuvWTOMKpjSV6gbiPJdJbCgVwGoz7J5OlLUE0kxfr2c8yy53E7veyqxYXCT3sYtUqmwaq5ufCjl994_NtLs-07xbi_SI8s_SzttEu-WIe6vKNbh4-Hoyzrh9J13mdrt77P7noPuK93zeBD3W4z3fD3y-Je4_qH13Z2VIf0f__ib9j6QypDr-avd9_u9feS12N2ktJF3KQtNKa49VZvOJg5ReUvMnpuVMJXSqZFL_TBMOa14NpKRNs8ubYFA0W_aA98m8ley2k91WstdO9lrJfjvZbyXvPiBP5v_8CAAA__-pQsIe
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJzMVeFO20gQ_n9PMZo_gM6n7NomF_Z0Ug4w17SFICdqheoIGXsKFo7X3d1URiiP1Rfok1Vrh5QQxRBVrZofG8238012vm92c4_6U44CR8Hb4GgMt3ASDk_hmuSlia9ygvevgjAAbS6zwpDSlBi9uzMKB8f_ut0D3vvnfDg4G-_6jDHmQf3FvL0dIf4PhqfBOLxwbK3pHgzD4yCEwwu4RQcLmdJZPCWN4gNynDhYKpmQ1lJZ6L5OGKQVCuZgVpQzY-GJg4lUhOIeTWZyQoFje8aQ4pRUh6GDKZk4y-uyyxb69gCXWZFShQ6OyrjQAjoRHkZR9TGNooqzKKrYcwv-tS2HRwhxkYLHQJobUhoXzYCZlTlpAe4S0SbOczDZlASwr19s6pt3a3EiC0OFyWSxnlqXBEVxKsBvsKs7s4Q8Fw7RwavYJDekQc5MOTMCrGgL6gPk42TuYBMtZNcmviYUfO683JpB8ZmUofQkyw0pUh2-6s_DflCVCmQBfS5AW3OsFsqIWmzv7_0oYi6LIsaeWxCoSLelWY_WTBpaGfp8zS6_zS6qKJmtWzONK5jSVKo7iPNcJrGhVACrzbB7OlHWEkgzfbue8QK73I12udvY9VpmxeIiuZsuUqmyaazuvivk9N1fNtPu-kzzbi3SBuV_SDtvG-2WI-6tKtfg4unryTjj9p10mdvtHrDHn6Puf7zn8ybosR7v-X7g8x3x-EHtu3srQ_oz-ve36X8klSHV8Ve77_M_f8trsb9NayHpUhaaVlrbVJnNJw5Sek3Nn5iWM5XQuZJJ_TNNOKx5NZCSNs0ub4JB0WzZAz4m81ay2052W8leO9lrJfvtZL-VvP-EPJn_8S0AAP__tjbCIA==
 
 statement ok
 DROP TABLE geo_table

--- a/pkg/sql/sem/tree/eval_test/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test/eval_test.go
@@ -196,7 +196,7 @@ func TestEval(t *testing.T) {
 				nil, /* output */
 				result.MetadataSources,
 				nil, /* toClose */
-				nil, /* execStatsForTrace */
+				nil, /* getStats */
 				nil, /* cancelFlow */
 			)
 			require.NoError(t, err)

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -243,7 +243,6 @@ func TestTrace(t *testing.T) {
 				"flow",
 				"materializer",
 				"colbatchscan",
-				"*colexecutils.CancelChecker",
 				"consuming rows",
 				"txn coordinator send",
 				"dist sender send",


### PR DESCRIPTION
Previously, in order to propagate execution statistics we were creating
temporary tracing spans, setting the stats on them, and finishing the
spans right away. This allowed for using (to be more precise, abusing)
the existing infrastructure. The root of the problem is that in the
vectorized engine we do not start per-operator span if stats collection
is enabled at the moment, so we had to get around that limitation.

However, this way is not how tracing spans are intended to be used and
creates some performance slowdown in the hot path, so this commit
refactors the situation. Now we are ensuring that there is always
a tracing span available at the "root" components (either root
materializer or an outbox), so when root components are finishing the
vectorized stats collectors for their subtree of operators, there is
a span to record the stats into.

This required the following minor adjustments:
- in the materializer, we now delegate attachment of the stats to the
tracing span to the drainHelper (which does so on `ConsumerDone`). Note
that the drainHelper doesn't get the recording from the span and leaves
that to the materializer (this is needed in order to avoid collecting
duplicate trace data).
- in the outbox, we now start a "remote child span" (if there is a span
in the parent context) in the beginning of `Run` method, and we attach
that stats in `sendMetadata`.

Addresses: #59379.
Fixes: #59555.

Release justification: low-risk update to existing functionality.

Release note: None