### PR TITLE
sql: add missing log.Scopes

### DIFF
--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -848,6 +848,7 @@ func TestTrimFlushedStatements(t *testing.T) {
 
 func TestShowLastQueryStatistics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	params := base.TestServerArgs{}

--- a/pkg/sql/copy_file_upload_test.go
+++ b/pkg/sql/copy_file_upload_test.go
@@ -302,6 +302,7 @@ func TestNodelocalNotAdmin(t *testing.T) {
 // interact with the FileTable ExternalStorage.
 func TestUserfileNotAdmin(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	params, _ := tests.CreateTestServerParams()
 	localExternalDir, cleanup := testutils.TempDir(t)

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -1337,6 +1337,7 @@ WHERE
 // entire database.
 func TestDropDatabaseWithForeignKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 	params, _ := tests.CreateTestServerParams()
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.Background())

--- a/pkg/sql/indexbackfiller_test.go
+++ b/pkg/sql/indexbackfiller_test.go
@@ -186,6 +186,7 @@ func queryPairs(t *testing.T, sqlDB *gosql.DB, query string) []pair {
 // and ensures that the data was backfilled properly.
 func TestIndexBackfillerComputedAndGeneratedColumns(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	// A test case exists to exercise the behavior of an index backfill.
 	// The case gets to do arbitrary things to the table (which is created with

--- a/pkg/sql/pg_metadata_test.go
+++ b/pkg/sql/pg_metadata_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors/oserror"
 )
 
@@ -176,6 +177,7 @@ func rewriteDiffs(t *testing.T, diffs PGMetadataTables, diffsFile string) {
 // TestPGCatalog is the pg_catalog diff tool test which compares pg_catalog with postgres and cockroach
 func TestPGCatalog(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 	pgTables := loadTestData(t)
 	crdbTables := loadCockroachPgCatalog(t)
 	diffs := loadExpectedDiffs(t)

--- a/pkg/sql/revert_test.go
+++ b/pkg/sql/revert_test.go
@@ -131,6 +131,7 @@ func TestRevertTable(t *testing.T) {
 
 func TestRevertGCThreshold(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})

--- a/pkg/sql/run_control_test.go
+++ b/pkg/sql/run_control_test.go
@@ -654,6 +654,7 @@ func isClientsideQueryCanceledErr(err error) bool {
 
 func TestIdleInSessionTimeout(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
 	numNodes := 1
@@ -714,6 +715,7 @@ func TestIdleInSessionTimeout(t *testing.T) {
 
 func TestIdleInTransactionSessionTimeout(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
 	numNodes := 1
@@ -774,6 +776,7 @@ func TestIdleInTransactionSessionTimeout(t *testing.T) {
 
 func TestIdleInTransactionSessionTimeoutAbortedState(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
 	numNodes := 1
@@ -838,6 +841,7 @@ func TestIdleInTransactionSessionTimeoutAbortedState(t *testing.T) {
 
 func TestIdleInTransactionSessionTimeoutCommitWaitState(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
 	numNodes := 1


### PR DESCRIPTION
I think these are all the tests missing it in the sql pkg.

Release note: None
Release justification: None