### PR TITLE
kv: configure leading closed timestamp target for global_read ranges

### DIFF
--- a/pkg/ccl/multiregionccl/regional_by_row_test.go
+++ b/pkg/ccl/multiregionccl/regional_by_row_test.go
@@ -365,6 +365,15 @@ func TestAlterTableLocalityRegionalByRowError(t *testing.T) {
 							// TTL into the system with AddImmediateGCZoneConfig.
 							defer sqltestutils.DisableGCTTLStrictEnforcement(t, sqlDB)()
 
+							// Drop the closed timestamp target lead for GLOBAL tables.
+							// The test passes with it configured to its default, but it
+							// is very slow due to #61444 (2.5s vs. 35s).
+							// TODO(nvanbenschoten): We can remove this when that issue
+							// is addressed.
+							if _, err := sqlDB.Exec(`SET CLUSTER SETTING kv.closed_timestamp.lead_for_global_reads_override = '5ms'`); err != nil {
+								t.Fatal(err)
+							}
+
 							if _, err := sqlDB.Exec(fmt.Sprintf(`
 CREATE DATABASE t PRIMARY REGION "ajstorm-1";
 USE t;

--- a/pkg/kv/kvserver/closedts/policy.go
+++ b/pkg/kv/kvserver/closedts/policy.go
@@ -23,19 +23,105 @@ func TargetForPolicy(
 	now hlc.ClockTimestamp,
 	maxClockOffset time.Duration,
 	lagTargetDuration time.Duration,
+	leadTargetOverride time.Duration,
+	sideTransportCloseInterval time.Duration,
 	policy roachpb.RangeClosedTimestampPolicy,
 ) hlc.Timestamp {
 	switch policy {
-	case roachpb.LAG_BY_CLUSTER_SETTING, roachpb.LEAD_FOR_GLOBAL_READS:
-		return hlc.Timestamp{WallTime: now.WallTime - lagTargetDuration.Nanoseconds()}
-		// TODO(andrei,nvanbenschoten): Resolve all the issues preventing us from closing
-		// timestamps in the future (which, in turn, forces future-time writes on
-		// global ranges), and enable the proper logic below.
-		//case roachpb.LEAD_FOR_GLOBAL_READS:
-		//	closedTSTarget = hlc.Timestamp{
-		//		WallTime:  now + 2*maxClockOffset.Nanoseconds(),
-		//		Synthetic: true,
-		//	}
+	case roachpb.LAG_BY_CLUSTER_SETTING:
+		// Simple calculation: lag now by desired duration.
+		return now.ToTimestamp().Add(-lagTargetDuration.Nanoseconds(), 0)
+	case roachpb.LEAD_FOR_GLOBAL_READS:
+		// The LEAD_FOR_GLOBAL_READS calculation is more complex. Instead of the
+		// policy defining an offset from the publisher's perspective, the
+		// policy defines a goal from the consumer's perspective - the goal
+		// being that present time reads (with a possible uncertainty interval)
+		// can be served from all followers. To accomplish this, we must work
+		// backwards to establish a lead time to publish closed timestamps at.
+		//
+		// The calculation looks something like the following:
+		//
+		//  # This should be sufficient for any present-time transaction,
+		//  # because its global uncertainty limit should be <= this time.
+		//  # For more, see (*Transaction).RequiredFrontier.
+		//  closed_ts_at_follower = now + max_offset
+		//
+		//  # The sender must account for the time it takes to propagate a
+		//  # closed timestamp update to its followers.
+		//  closed_ts_at_sender = closed_ts_at_follower + propagation_time
+		//
+		//  # Closed timestamps propagate in two ways. Both need to make it to
+		//  # followers in time.
+		//  propagation_time = max(raft_propagation_time, side_propagation_time)
+		//
+		//  # Raft propagation takes 3 network hops to go from a leader proposing
+		//  # a write (with a closed timestamp update) to the write being applied.
+		//  # 1. leader sends MsgProp with entry
+		//  # 2. followers send MsgPropResp with vote
+		//  # 3. leader sends MsgProp with higher commit index
+		//  #
+		//  # We also add on a small bit of overhead for request evaluation, log
+		//  # sync, and state machine apply latency.
+		//  raft_propagation_time = max_network_rtt * 1.5 + raft_overhead
+		//
+		//  # Side-transport propagation takes 1 network hop, as there is no voting.
+		//  # However, it is delayed by the full side_transport_close_interval in
+		//  # the worst-case.
+		//  side_propagation_time = max_network_rtt * 0.5 + side_transport_close_interval
+		//
+		//  # Combine, we get the following result
+		//  closed_ts_at_sender = now + max_offset + max(
+		//    max_network_rtt * 1.5 + raft_overhead,
+		//    max_network_rtt * 0.5 + side_transport_close_interval,
+		//  )
+		//
+		// By default, this leads to a closed timestamp target that leads the
+		// senders current clock by 800ms.
+		//
+		// NOTE: this calculation takes into consideration maximum clock skew as
+		// it relates to a transaction's uncertainty interval, but it does not
+		// take into consideration "effective" clock skew as it relates to a
+		// follower replica having a faster clock than a leaseholder and
+		// therefore needing the leaseholder to publish even further into the
+		// future. Since the effect of getting this wrong is reduced performance
+		// (i.e. missed follower reads) and not a correctness violation (i.e.
+		// stale reads), we can be less strict here. We also expect that even
+		// when two nodes have skewed physical clocks, the "stability" property
+		// of HLC propagation when nodes are communicating should reduce the
+		// effective HLC clock skew.
+
+		// TODO(nvanbenschoten): make this dynamic, based on the measured
+		// network latencies recorded by the RPC context. This isn't trivial and
+		// brings up a number of questions. For instance, how far into the tail
+		// do we care about? Do we place upper and lower bounds on this value?
+		const maxNetworkRTT = 150 * time.Millisecond
+
+		// See raft_propagation_time.
+		const raftTransportOverhead = 20 * time.Millisecond
+		raftTransportPropTime := (maxNetworkRTT*3)/2 + raftTransportOverhead
+
+		// See side_propagation_time.
+		sideTransportPropTime := maxNetworkRTT/2 + sideTransportCloseInterval
+
+		// See propagation_time.
+		maxTransportPropTime := sideTransportPropTime
+		if maxTransportPropTime < raftTransportPropTime {
+			maxTransportPropTime = raftTransportPropTime
+		}
+
+		// Include a small amount of extra margin to smooth out temporary
+		// network blips or anything else that slows down closed timestamp
+		// propagation momentarily.
+		const bufferTime = 25 * time.Millisecond
+		leadTimeAtSender := maxTransportPropTime + maxClockOffset + bufferTime
+
+		// Override entirely with cluster setting, if necessary.
+		if leadTargetOverride != 0 {
+			leadTimeAtSender = leadTargetOverride
+		}
+
+		// Mark as synthetic, because this time is in the future.
+		return now.ToTimestamp().Add(leadTimeAtSender.Nanoseconds(), 0).WithSynthetic(true)
 	default:
 		panic("unexpected RangeClosedTimestampPolicy")
 	}

--- a/pkg/kv/kvserver/closedts/setting.go
+++ b/pkg/kv/kvserver/closedts/setting.go
@@ -46,3 +46,14 @@ var SideTransportCloseInterval = settings.RegisterDurationSetting(
 	200*time.Millisecond,
 	settings.NonNegativeDuration,
 )
+
+// LeadForGlobalReadsOverride overrides the lead time that ranges with the
+// LEAD_FOR_GLOBAL_READS closed timestamp policy use to publish close timestamps
+// (see TargetForPolicy), if it is set to a non-zero value. Meant as an escape
+// hatch.
+var LeadForGlobalReadsOverride = settings.RegisterDurationSetting(
+	"kv.closed_timestamp.lead_for_global_reads_override",
+	"if nonzero, overrides the lead time that global_read ranges use to publish closed timestamps",
+	0,
+	settings.NonNegativeDuration,
+)

--- a/pkg/kv/kvserver/closedts/sidetransport/sender.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/sender.go
@@ -266,9 +266,18 @@ func (s *Sender) publish(ctx context.Context) hlc.ClockTimestamp {
 	now := s.clock.NowAsClockTimestamp()
 	maxClockOffset := s.clock.MaxOffset()
 	lagTargetDuration := closedts.TargetDuration.Get(&s.st.SV)
+	leadTargetOverride := closedts.LeadForGlobalReadsOverride.Get(&s.st.SV)
+	sideTransportCloseInterval := closedts.SideTransportCloseInterval.Get(&s.st.SV)
 	for i := range s.trackedMu.lastClosed {
 		pol := roachpb.RangeClosedTimestampPolicy(i)
-		target := closedts.TargetForPolicy(now, maxClockOffset, lagTargetDuration, pol)
+		target := closedts.TargetForPolicy(
+			now,
+			maxClockOffset,
+			lagTargetDuration,
+			leadTargetOverride,
+			sideTransportCloseInterval,
+			pol,
+		)
 		s.trackedMu.lastClosed[pol] = target
 		msg.ClosedTimestamps[pol] = ctpb.Update_GroupUpdate{
 			Policy:          pol,

--- a/pkg/kv/kvserver/replica_closedts.go
+++ b/pkg/kv/kvserver/replica_closedts.go
@@ -144,9 +144,12 @@ func (r *Replica) BumpSideTransportClosed(
 // this range. Note that we might not be able to ultimately close this timestamp
 // if there are requests in flight.
 func (r *Replica) closedTimestampTargetRLocked() hlc.Timestamp {
-	now := r.Clock().NowAsClockTimestamp()
-	maxClockOffset := r.Clock().MaxOffset()
-	lagTargetDuration := closedts.TargetDuration.Get(&r.ClusterSettings().SV)
-	policy := r.closedTimestampPolicyRLocked()
-	return closedts.TargetForPolicy(now, maxClockOffset, lagTargetDuration, policy)
+	return closedts.TargetForPolicy(
+		r.Clock().NowAsClockTimestamp(),
+		r.Clock().MaxOffset(),
+		closedts.TargetDuration.Get(&r.ClusterSettings().SV),
+		closedts.LeadForGlobalReadsOverride.Get(&r.ClusterSettings().SV),
+		closedts.SideTransportCloseInterval.Get(&r.ClusterSettings().SV),
+		r.closedTimestampPolicyRLocked(),
+	)
 }

--- a/pkg/sql/as_of_test.go
+++ b/pkg/sql/as_of_test.go
@@ -122,8 +122,18 @@ func TestAsOfTime(t *testing.T) {
 		}
 	})
 
-	// Future queries shouldn't work.
+	// Future queries shouldn't work if not marked as synthetic.
 	if err := db.QueryRow("SELECT a FROM d.t AS OF SYSTEM TIME '2200-01-01'").Scan(&i); !testutils.IsError(err, "pq: AS OF SYSTEM TIME: cannot specify timestamp in the future") {
+		t.Fatal(err)
+	}
+
+	// Future queries shouldn't work if too far in the future.
+	if err := db.QueryRow("SELECT a FROM d.t AS OF SYSTEM TIME '+10h?'").Scan(&i); !testutils.IsError(err, "pq: request timestamp .* too far in future") {
+		t.Fatal(err)
+	}
+
+	// Future queries work if marked as synthetic and only slightly in future.
+	if err := db.QueryRow("SELECT a FROM d.t AS OF SYSTEM TIME '+10ms?'").Scan(&i); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -400,7 +400,7 @@ func CountLeases(
 		)
 	}
 
-	stmt := fmt.Sprintf(`SELECT count(1) FROM system.public.lease AS OF SYSTEM TIME %s WHERE `,
+	stmt := fmt.Sprintf(`SELECT count(1) FROM system.public.lease AS OF SYSTEM TIME '%s' WHERE `,
 		at.AsOfSystemTime()) +
 		strings.Join(whereClauses, " OR ")
 	values, err := executor.QueryRowEx(

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1222,7 +1222,7 @@ func (p *planner) EvalAsOfTimestamp(
 	if err != nil {
 		return hlc.Timestamp{}, err
 	}
-	if now := p.execCfg.Clock.Now(); now.Less(ts) {
+	if now := p.execCfg.Clock.Now(); now.Less(ts) && !ts.Synthetic {
 		return hlc.Timestamp{}, errors.Errorf(
 			"AS OF SYSTEM TIME: cannot specify timestamp in the future (%s > %s)", ts, now)
 	}

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -105,6 +105,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
+        "//pkg/clusterversion",
         "//pkg/geo",
         "//pkg/geo/geopb",
         "//pkg/keys",

--- a/pkg/sql/sem/tree/as_of.go
+++ b/pkg/sql/sem/tree/as_of.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/apd/v2"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -106,14 +107,24 @@ func DatumToHLC(evalCtx *EvalContext, stmtTimestamp time.Time, d Datum) (hlc.Tim
 	switch d := d.(type) {
 	case *DString:
 		s := string(*d)
+		// Parse synthetic flag.
+		syn := false
+		if strings.HasSuffix(s, "?") && evalCtx.Settings.Version.IsActive(evalCtx.Context, clusterversion.PriorReadSummaries) {
+			// NOTE: we don't parse this in mixed-version clusters because v20.2
+			// nodes will not know how to handle synthetic timestamps.
+			s = s[:len(s)-1]
+			syn = true
+		}
 		// Attempt to parse as timestamp.
 		if dt, _, err := ParseDTimestamp(evalCtx, s, time.Nanosecond); err == nil {
 			ts.WallTime = dt.Time.UnixNano()
+			ts.Synthetic = syn
 			break
 		}
 		// Attempt to parse as a decimal.
 		if dec, _, err := apd.NewFromString(s); err == nil {
 			ts, convErr = DecimalToHLC(dec)
+			ts.Synthetic = syn
 			break
 		}
 		// Attempt to parse as an interval.
@@ -122,6 +133,7 @@ func DatumToHLC(evalCtx *EvalContext, stmtTimestamp time.Time, d Datum) (hlc.Tim
 				convErr = errors.Errorf("interval value %v too small, absolute value must be >= %v", d, time.Microsecond)
 			}
 			ts.WallTime = duration.Add(stmtTimestamp, iv.Duration).UnixNano()
+			ts.Synthetic = syn
 			break
 		}
 		convErr = errors.Errorf("value is neither timestamp, decimal, nor interval")

--- a/pkg/util/hlc/timestamp.go
+++ b/pkg/util/hlc/timestamp.go
@@ -168,7 +168,11 @@ func ParseTimestamp(str string) (_ Timestamp, err error) {
 
 // AsOfSystemTime returns a string to be used in an AS OF SYSTEM TIME query.
 func (t Timestamp) AsOfSystemTime() string {
-	return fmt.Sprintf("%d.%010d", t.WallTime, t.Logical)
+	syn := ""
+	if t.Synthetic {
+		syn = "?"
+	}
+	return fmt.Sprintf("%d.%010d%s", t.WallTime, t.Logical, syn)
 }
 
 // IsEmpty retruns true if t is an empty Timestamp.

--- a/pkg/util/hlc/timestamp.go
+++ b/pkg/util/hlc/timestamp.go
@@ -368,15 +368,6 @@ func (t Timestamp) UnsafeToClockTimestamp() ClockTimestamp {
 	return ClockTimestamp(t)
 }
 
-// MustToClockTimestamp casts a Timestamp to a ClockTimestamp. Panics if the
-// timestamp is synthetic. See TryToClockTimestamp if you don't want to panic.
-func (t Timestamp) MustToClockTimestamp() ClockTimestamp {
-	if t.Synthetic {
-		panic(fmt.Sprintf("can't convert synthetic timestamp to ClockTimestamp: %s", t))
-	}
-	return ClockTimestamp(t)
-}
-
 // ToTimestamp upcasts a ClockTimestamp into a Timestamp.
 func (t ClockTimestamp) ToTimestamp() Timestamp {
 	if t.Synthetic {

--- a/pkg/util/hlc/timestamp_test.go
+++ b/pkg/util/hlc/timestamp_test.go
@@ -222,6 +222,9 @@ func TestAsOfSystemTime(t *testing.T) {
 		{makeTS(145, 0), "145.0000000000"},
 		{makeTS(145, 123), "145.0000000123"},
 		{makeTS(145, 1123456789), "145.1123456789"},
+		{makeSynTS(145, 0), "145.0000000000?"},
+		{makeSynTS(145, 123), "145.0000000123?"},
+		{makeSynTS(145, 1123456789), "145.1123456789?"},
 	}
 	for _, c := range testCases {
 		assert.Equal(t, c.exp, c.ts.AsOfSystemTime())


### PR DESCRIPTION
Informs #59680.
Informs #52745.

This commit updates `closedts.TargetForPolicy` to calculate a target closed
timestamp that leads present time for ranges with the LEAD_FOR_GLOBAL_READS
closed timestamp policy. This is needed for non-blocking transactions, which
require ranges to closed time in the future.

TargetForPolicy's LEAD_FOR_GLOBAL_READS calculation is more complex than its
LAG_BY_CLUSTER_SETTING calculation. Instead of the policy defining an offset
from the publisher's perspective, the policy defines a goal from the consumer's
perspective - the goal being that present time reads (with a possible
uncertainty interval) can be served from all followers. To accomplish this, we
must work backwards to establish a lead time to publish closed timestamps at.

The calculation looks something like the following:
```
// this should be sufficient for any present-time transaction,
// because its global uncertainty limit should be <= this time.
// For more, see (*Transaction).RequiredFrontier.
closed_ts_at_follower = now + max_offset

// the sender must account for the time it takes to propagate a
// closed timestamp update to its followers.
closed_ts_at_sender = closed_ts_at_follower + propagation_time

// closed timestamps propagate in two ways. Both need to make it to
// followers in time.
propagation_time = max(raft_propagation_time, side_propagation_time)

// raft propagation takes 3 network hops to go from a leader proposing
// a write (with a closed timestamp update) to the write being applied.
// 1. leader sends MsgProp with entry
// 2. followers send MsgPropResp with vote
// 3. leader sends MsgProp with higher commit index
//
// we also add on a small bit of overhead for request evaluation, log
// sync, and state machine apply latency.
raft_propagation_time = max_network_rtt * 1.5 + raft_overhead

// side-transport propagation takes 1 network hop, as there is no voting.
// However, it is delayed by the full side_transport_close_interval in
// the worst-case.
side_propagation_time = max_network_rtt * 0.5 + side_transport_close_interval

// put together, we get the following result
closed_ts_at_sender = now + max_offset + max(
	max_network_rtt * 1.5 + raft_overhead,
	max_network_rtt * 0.5 + side_transport_close_interval,
)
```

While writing this, I explored what it would take to use dynamic network latency
measurements in this calculation to complete #59680. The code for that wasn't
too bad, but brought up a number of questions, including how far into the tail
we care about and whether we place upper and lower bounds on this value. To
avoid needing to immediately answer these questions, the commit hardcodes a
maximum network RTT of 150ms, which should be an overestimate for almost any
cluster we expect to run on.

The commit also adds a new `kv.closed_timestamp.lead_for_global_reads_override`
cluster setting, which, if nonzero, overrides the lead time that global_read
ranges use to publish closed timestamps. The cluster setting is hidden, but
should provide an escape hatch for cases where we get the calculation
(especially when it becomes dynamic) wrong.

Release justification: needed for new functionality