### PR TITLE
sql: add drop type to the prepared statement generator

### DIFF
--- a/pkg/sql/explain_test.go
+++ b/pkg/sql/explain_test.go
@@ -37,6 +37,7 @@ func TestStatementReuses(t *testing.T) {
 		`CREATE SEQUENCE s`,
 		`CREATE INDEX woo ON a(b)`,
 		`CREATE USER woo`,
+		`CREATE TYPE test as ENUM('a')`,
 	}
 
 	for _, s := range initStmts {
@@ -54,6 +55,7 @@ func TestStatementReuses(t *testing.T) {
 		`DROP SEQUENCE s`,
 		`DROP VIEW v`,
 		`DROP USER woo`,
+		`DROP TYPE test`,
 
 		// Ditto ALTER first, so that erroneous side effects bork what's
 		// below.

--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -1355,6 +1355,10 @@ CREATE TABLE greeting_table (x greeting NOT NULL, y INT, INDEX (x, y))
 statement ok
 PREPARE enum_query AS SELECT x, y FROM greeting_table WHERE y = 2
 
+# Create prepared statement to drop type.
+statement ok
+PREPARE enum_drop AS DROP TYPE greeting
+
 # Now alter the enum to have a new value.
 statement ok
 ALTER TYPE greeting ADD VALUE 'howdy'
@@ -1368,3 +1372,11 @@ query TI
 EXECUTE enum_query
 ----
 howdy 2
+
+# drop table
+statement ok
+DROP TABLE greeting_table
+
+# drop the type using prepared statement.
+statement ok
+EXECUTE enum_drop

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -61,7 +61,7 @@ func (p *planner) prepareUsingOptimizer(ctx context.Context) (planFlags, error) 
 		*tree.CreateSequence,
 		*tree.CreateStats,
 		*tree.Deallocate, *tree.Discard, *tree.DropDatabase, *tree.DropIndex,
-		*tree.DropTable, *tree.DropView, *tree.DropSequence,
+		*tree.DropTable, *tree.DropView, *tree.DropSequence, *tree.DropType,
 		*tree.Execute,
 		*tree.Grant, *tree.GrantRole,
 		*tree.Prepare,


### PR DESCRIPTION
Release justification: fixes for high-priority or high-severity bugs in existing functionality

Previously, prepare statement doesn't have support for drop type
in the optimizer, so it panics during execution as no flags are generated.

This patch fixes this by adding `dropType` to the optimizer.

Resolves #61226

Release note: none

Signed-off-by: Tharun <rajendrantharun@live.com>

<img width="454" alt="Screen Shot 2021-03-03 at 2 39 29 PM" src="https://user-images.githubusercontent.com/14926492/109781995-6c2a8d80-7c2e-11eb-902e-e596aa4f2bb3.png">
