### PR TITLE
server: remove unnecessary % escape

### DIFF
--- a/pkg/server/status/runtime.go
+++ b/pkg/server/status/runtime.go
@@ -419,7 +419,7 @@ var statsTemplate = template.Must(template.New("runtime stats").Funcs(template.F
 	`{{iBytes .MS.HeapAlloc}}/{{iBytes .GoTotal}} Go alloc/total{{.StaleMsg}} ` +
 	`(heap fragmentation: {{sub .MS.HeapInuse .MS.HeapAlloc}}, heap reserved: {{sub .MS.HeapIdle .MS.HeapReleased}}, heap released: {{iBytes .MS.HeapReleased}}), ` +
 	`{{iBytes .CS.CGoAllocatedBytes}}/{{iBytes .CS.CGoTotalBytes}} CGO alloc/total ({{oneDecimal .CGORate}} CGO/sec), ` +
-	`{{oneDecimalPercent .URate}}/{{oneDecimalPercent .SRate}} %%(u/s)time, {{oneDecimalPercent .GCPauseRatio}} %%gc ({{.GCCount}}x), ` +
+	`{{oneDecimalPercent .URate}}/{{oneDecimalPercent .SRate}} %(u/s)time, {{oneDecimalPercent .GCPauseRatio}} %gc ({{.GCCount}}x), ` +
 	`{{iBytes .DeltaNet.BytesRecv}}/{{iBytes .DeltaNet.BytesSent}} (r/w)net`))
 
 // SampleEnvironment queries the runtime system for various interesting metrics,


### PR DESCRIPTION
As of 1982047afb366e this log line is now formatted with Go's
templating system, which doesn't require that % is escaped.

Before:

```
I210303 09:56:17.459802 311 2@server/status/runtime.go:553 ⋮ [n1] 76
runtime stats: 106 MiB RSS, 261 goroutines (stacks: 5.0 MiB), 29
MiB/63 MiB Go alloc/total (heap fragmentation: 6.8 MiB, heap reserved:
11 MiB, heap released: 12 MiB), 7.6 MiB/13 MiB CGO alloc/total (0.6
CGO/sec), 1.8/1.2 %%(u/s)time, 0.0 %%gc (0x ), 17 KiB/22 KiB (r/w)net
```

After:

```
I210303 09:59:17.607021 59 2@server/status/runtime.go:553 ⋮ [n1] 71
runtime stats: 92 MiB RSS, 255 goroutines (stacks: 3.7 MiB), 27 MiB/48
MiB Go alloc/total (heap fragmentation: 4.8 MiB, heap reserved: 1.3
MiB, heap released: 27 MiB), 10 MiB/15 MiB CGO alloc/total (0.0
CGO/sec), 0.0/0.0 %(u/s)time, 0.0 %gc (0x), 30 KiB/34 KiB (r/w)net
```

Release justification: Negligible risk.
Release note: None