### PR TITLE
storage: coordinated iteration with limits in intentInterleavin…

### DIFF
--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -290,6 +290,48 @@ func (i *EngineIterator) PrevEngineKey() (valid bool, err error) {
 	return i.checkKeyAllowed()
 }
 
+// SeekEngineKeyGEWithLimit is part of the storage.EngineIterator interface.
+func (i *EngineIterator) SeekEngineKeyGEWithLimit(
+	key storage.EngineKey, limit roachpb.Key,
+) (state pebble.IterValidityState, err error) {
+	state, err = i.i.SeekEngineKeyGEWithLimit(key, limit)
+	if state != pebble.IterValid {
+		return state, err
+	}
+	if err = i.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: key.Key}); err != nil {
+		return pebble.IterExhausted, err
+	}
+	return state, err
+}
+
+// SeekEngineKeyLTWithLimit is part of the storage.EngineIterator interface.
+func (i *EngineIterator) SeekEngineKeyLTWithLimit(
+	key storage.EngineKey, limit roachpb.Key,
+) (state pebble.IterValidityState, err error) {
+	state, err = i.i.SeekEngineKeyLTWithLimit(key, limit)
+	if state != pebble.IterValid {
+		return state, err
+	}
+	if err = i.spans.CheckAllowed(SpanReadOnly, roachpb.Span{EndKey: key.Key}); err != nil {
+		return pebble.IterExhausted, err
+	}
+	return state, err
+}
+
+// NextEngineKeyWithLimit is part of the storage.EngineIterator interface.
+func (i *EngineIterator) NextEngineKeyWithLimit(
+	limit roachpb.Key,
+) (state pebble.IterValidityState, err error) {
+	return i.i.NextEngineKeyWithLimit(limit)
+}
+
+// PrevEngineKeyWithLimit is part of the storage.EngineIterator interface.
+func (i *EngineIterator) PrevEngineKeyWithLimit(
+	limit roachpb.Key,
+) (state pebble.IterValidityState, err error) {
+	return i.i.PrevEngineKeyWithLimit(limit)
+}
+
 func (i *EngineIterator) checkKeyAllowed() (valid bool, err error) {
 	key, err := i.i.UnsafeEngineKey()
 	if err != nil {

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -235,6 +235,26 @@ type EngineIterator interface {
 	// GetRawIter is a low-level method only for use in the storage package,
 	// that returns the underlying pebble Iterator.
 	GetRawIter() *pebble.Iterator
+	// SeekEngineKeyGEWithLimit is similar to SeekEngineKeyGE, but takes an
+	// additional exclusive upper limit parameter. The limit is semantically
+	// best-effort, and is an optimization to avoid O(n^2) iteration behavior in
+	// some pathological situations (uncompacted deleted locks).
+	SeekEngineKeyGEWithLimit(key EngineKey, limit roachpb.Key) (state pebble.IterValidityState, err error)
+	// SeekEngineKeyLTWithLimit is similar to SeekEngineKeyLT, but takes an
+	// additional inclusive lower limit parameter. The limit is semantically
+	// best-effort, and is an optimization to avoid O(n^2) iteration behavior in
+	// some pathological situations (uncompacted deleted locks).
+	SeekEngineKeyLTWithLimit(key EngineKey, limit roachpb.Key) (state pebble.IterValidityState, err error)
+	// NextEngineKeyWithLimit is similar to NextEngineKey, but takes an
+	// additional exclusive upper limit parameter. The limit is semantically
+	// best-effort, and is an optimization to avoid O(n^2) iteration behavior in
+	// some pathological situations (uncompacted deleted locks).
+	NextEngineKeyWithLimit(limit roachpb.Key) (state pebble.IterValidityState, err error)
+	// PrevEngineKeyWithLimit is similar to PrevEngineKey, but takes an
+	// additional inclusive lower limit parameter. The limit is semantically
+	// best-effort, and is an optimization to avoid O(n^2) iteration behavior in
+	// some pathological situations (uncompacted deleted locks).
+	PrevEngineKeyWithLimit(limit roachpb.Key) (state pebble.IterValidityState, err error)
 }
 
 // IterOptions contains options used to create an {MVCC,Engine}Iterator.

--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble"
 )
 
 type intentInterleavingIterConstraint int8
@@ -95,7 +96,8 @@ type intentInterleavingIter struct {
 
 	// intentIter is for iterating over separated intents, so that
 	// intentInterleavingIter can make them look as if they were interleaved.
-	intentIter EngineIterator
+	intentIter      EngineIterator
+	intentIterState pebble.IterValidityState
 	// The decoded key from the lock table. This is an unsafe key
 	// in that it is only valid when intentIter has not been
 	// repositioned. It is nil if the intentIter is considered to be
@@ -241,6 +243,57 @@ func newIntentInterleavingIterator(reader Reader, opts IterOptions) MVCCIterator
 	return iiIter
 }
 
+// TODO(sumeer): the limits generated below are tight for the current value of
+// i.iterKey.Key. And the semantics of the underlying *WithLimit methods in
+// pebble.Iterator are best-effort, but the implementation is not. Consider
+// strengthening the semantics and using the tightness of these limits to
+// avoid comparisons between iterKey and intentKey.
+
+// makeUpperLimitKey uses the current value of i.iterKey.Key (and assumes
+// i.iterValid=true), to construct an exclusive upper limit roachpb.Key that
+// will include the intent for i.iterKey.Key.
+func (i *intentInterleavingIter) makeUpperLimitKey() roachpb.Key {
+	key := i.iterKey.Key
+	// The +2 is to account for the call to BytesNext and the need to append a
+	// '\x00' in the implementation of the *WithLimit function. The rest is the
+	// same as in the implementation of LockTableSingleKey. The BytesNext is to
+	// construct the exclusive roachpb.Key as mentioned earlier. The
+	// implementation of *WithLimit (in pebbleIterator), has to additionally
+	// append '\x00' (the sentinel byte) to construct an encoded EngineKey with
+	// an empty version.
+	keyLen :=
+		len(keys.LocalRangeLockTablePrefix) + len(keys.LockTableSingleKeyInfix) + len(key) + 3 + 2
+	if cap(i.intentLimitKeyBuf) < keyLen {
+		i.intentLimitKeyBuf = make([]byte, 0, keyLen)
+	}
+	_, i.intentLimitKeyBuf = keys.LockTableSingleKey(key, i.intentLimitKeyBuf)
+	// To construct the exclusive limitKey, roachpb.BytesNext gives us a
+	// tight limit. Since it appends \x00, this is not decodable, except at
+	// the Pebble level, which is all we need here. We don't actually use
+	// BytesNext since it tries not to overwrite the slice.
+	i.intentLimitKeyBuf = append(i.intentLimitKeyBuf, '\x00')
+	return i.intentLimitKeyBuf
+}
+
+// makeLowerLimitKey uses the current value of i.iterKey.Key (and assumes
+// i.iterValid=true), to construct an inclusive lower limit roachpb.Key that
+// will include the intent for i.iterKey.Key.
+func (i *intentInterleavingIter) makeLowerLimitKey() roachpb.Key {
+	key := i.iterKey.Key
+	// The +1 is to account for the need to append a '\x00' in the
+	// implementation of the *WithLimit function. The rest is the same as in the
+	// implementation of LockTableSingleKey.  The implementation of *WithLimit
+	// (in pebbleIterator), has to additionally append '\x00' (the sentinel
+	// byte) to construct an encoded EngineKey with an empty version.
+	keyLen :=
+		len(keys.LocalRangeLockTablePrefix) + len(keys.LockTableSingleKeyInfix) + len(key) + 3 + 1
+	if cap(i.intentLimitKeyBuf) < keyLen {
+		i.intentLimitKeyBuf = make([]byte, 0, keyLen)
+	}
+	_, i.intentLimitKeyBuf = keys.LockTableSingleKey(key, i.intentLimitKeyBuf)
+	return i.intentLimitKeyBuf
+}
+
 func (i *intentInterleavingIter) SeekGE(key MVCCKey) {
 	i.dir = +1
 	i.valid = true
@@ -248,6 +301,10 @@ func (i *intentInterleavingIter) SeekGE(key MVCCKey) {
 
 	if i.constraint != notConstrained {
 		i.checkConstraint(key.Key, false)
+	}
+	i.iter.SeekGE(key)
+	if err := i.tryDecodeKey(); err != nil {
+		return
 	}
 	var intentSeekKey roachpb.Key
 	if key.Timestamp.IsEmpty() {
@@ -261,19 +318,16 @@ func (i *intentInterleavingIter) SeekGE(key MVCCKey) {
 		// so don't expect to ever see the intent. NB: intentSeekKey is nil.
 		i.intentKey = nil
 	}
-
 	if intentSeekKey != nil {
-		valid, err := i.intentIter.SeekEngineKeyGE(EngineKey{Key: intentSeekKey})
-		if err != nil {
-			i.err = err
-			i.valid = false
-			return
+		var limitKey roachpb.Key
+		if i.iterValid && !i.prefix {
+			limitKey = i.makeUpperLimitKey()
 		}
-		if err := i.tryDecodeLockKey(valid); err != nil {
+		iterState, err := i.intentIter.SeekEngineKeyGEWithLimit(EngineKey{Key: intentSeekKey}, limitKey)
+		if err = i.tryDecodeLockKey(iterState, err); err != nil {
 			return
 		}
 	}
-	i.iter.SeekGE(key)
 	i.computePos()
 }
 
@@ -284,22 +338,24 @@ func (i *intentInterleavingIter) SeekIntentGE(key roachpb.Key, txnUUID uuid.UUID
 	if i.constraint != notConstrained {
 		i.checkConstraint(key, false)
 	}
+	i.iter.SeekGE(MVCCKey{Key: key})
+	if err := i.tryDecodeKey(); err != nil {
+		return
+	}
 	var engineKey EngineKey
 	engineKey, i.intentKeyBuf = LockTableKey{
 		Key:      key,
 		Strength: lock.Exclusive,
 		TxnUUID:  txnUUID[:],
 	}.ToEngineKey(i.intentKeyBuf)
-	valid, err := i.intentIter.SeekEngineKeyGE(engineKey)
-	if err != nil {
-		i.err = err
-		i.valid = false
+	var limitKey roachpb.Key
+	if i.iterValid && !i.prefix {
+		limitKey = i.makeUpperLimitKey()
+	}
+	iterState, err := i.intentIter.SeekEngineKeyGEWithLimit(engineKey, limitKey)
+	if err = i.tryDecodeLockKey(iterState, err); err != nil {
 		return
 	}
-	if err := i.tryDecodeLockKey(valid); err != nil {
-		return
-	}
-	i.iter.SeekGE(MVCCKey{Key: key})
 	i.computePos()
 }
 
@@ -321,20 +377,28 @@ func (i *intentInterleavingIter) checkConstraint(k roachpb.Key, isExclusiveUpper
 	}
 }
 
+func (i *intentInterleavingIter) tryDecodeKey() error {
+	i.iterValid, i.err = i.iter.Valid()
+	if i.iterValid {
+		i.iterKey = i.iter.UnsafeKey()
+	}
+	if i.err != nil {
+		i.valid = false
+	}
+	return i.err
+}
+
+// Assumes that i.err != nil. And i.iterValid and i.iterKey are up to date.
 func (i *intentInterleavingIter) computePos() {
-	var err error
-	i.iterValid, err = i.iter.Valid()
-	if err != nil || (!i.iterValid && i.intentKey == nil) {
-		i.err = err
+	if !i.iterValid && i.intentKey == nil {
 		i.valid = false
 		return
 	}
-	// INVARIANT: err == nil && (i.iterValid || i.intentKey != nil)
+	// INVARIANT: i.iterValid || i.intentKey != nil
 	if !i.iterValid {
 		i.intentCmp = -i.dir
 		return
 	}
-	i.iterKey = i.iter.UnsafeKey()
 	if i.intentKey == nil {
 		i.intentCmp = i.dir
 	} else {
@@ -342,8 +406,16 @@ func (i *intentInterleavingIter) computePos() {
 	}
 }
 
-func (i *intentInterleavingIter) tryDecodeLockKey(valid bool) error {
-	if !valid {
+func (i *intentInterleavingIter) tryDecodeLockKey(
+	iterState pebble.IterValidityState, err error,
+) error {
+	if err != nil {
+		i.err = err
+		i.valid = false
+		return err
+	}
+	i.intentIterState = iterState
+	if iterState != pebble.IterValid {
 		// NB: this does not set i.valid = false, since this method does not care
 		// about the state of i.iter, which may be valid. It is the caller's
 		// responsibility to additionally use the state of i.iter to appropriately
@@ -405,16 +477,18 @@ func (i *intentInterleavingIter) Next() {
 			// Both iterators are exhausted, since intentKey is synchronized with
 			// intentIter for non-prefix iteration, so step both forward.
 			i.valid = true
-			valid, err := i.intentIter.NextEngineKey()
-			if err != nil {
-				i.err = err
-				i.valid = false
-				return
-			}
-			if err := i.tryDecodeLockKey(valid); err != nil {
-				return
-			}
 			i.iter.Next()
+			if err := i.tryDecodeKey(); err != nil {
+				return
+			}
+			var limitKey roachpb.Key
+			if i.iterValid && !i.prefix {
+				limitKey = i.makeUpperLimitKey()
+			}
+			iterState, err := i.intentIter.NextEngineKeyWithLimit(limitKey)
+			if err = i.tryDecodeLockKey(iterState, err); err != nil {
+				return
+			}
 			i.computePos()
 			return
 		}
@@ -430,17 +504,15 @@ func (i *intentInterleavingIter) Next() {
 			// provisional value, but it does care that iter is pointing to some
 			// version of that key.
 			i.iter.Next()
+			if err := i.tryDecodeKey(); err != nil {
+				return
+			}
 			i.intentCmp = 0
-			var err error
-			if i.iterValid, err = i.iter.Valid(); err != nil || !i.iterValid {
-				if err == nil {
-					err = errors.Errorf("intent has no provisional value")
-				}
-				i.err = err
+			if !i.iterValid {
+				i.err = errors.Errorf("intent has no provisional value")
 				i.valid = false
 				return
 			}
-			i.iterKey = i.iter.UnsafeKey()
 			if util.RaceEnabled {
 				cmp := i.intentKey.Compare(i.iterKey.Key)
 				if cmp != 0 {
@@ -456,17 +528,16 @@ func (i *intentInterleavingIter) Next() {
 			// could also be positioned at an intent. We are assuming that there
 			// isn't a bug (external to this code) that has caused two intents to be
 			// present for the same key.
-			valid, err := i.intentIter.NextEngineKey()
-			if err != nil {
-				i.err = err
-				i.valid = false
+			var limitKey roachpb.Key
+			if !i.prefix {
+				limitKey = i.makeUpperLimitKey()
+			}
+			iterState, err := i.intentIter.NextEngineKeyWithLimit(limitKey)
+			if err = i.tryDecodeLockKey(iterState, err); err != nil {
 				return
 			}
 			i.intentCmp = +1
-			if err := i.tryDecodeLockKey(valid); err != nil {
-				return
-			}
-			if util.RaceEnabled && valid {
+			if util.RaceEnabled && iterState == pebble.IterValid {
 				cmp := i.intentKey.Compare(i.iterKey.Key)
 				if cmp <= 0 {
 					i.err = errors.Errorf("intentIter incorrectly positioned, cmp: %d", cmp)
@@ -490,18 +561,17 @@ func (i *intentInterleavingIter) Next() {
 			i.valid = false
 			return
 		}
-		valid, err := i.intentIter.NextEngineKey()
-		if err != nil {
-			i.err = err
-			i.valid = false
-			return
-		}
-		if err := i.tryDecodeLockKey(valid); err != nil {
-			return
-		}
 		if !i.iterValid {
 			i.err = errors.Errorf("iter expected to be at provisional value, but is exhausted")
 			i.valid = false
+			return
+		}
+		var limitKey roachpb.Key
+		if !i.prefix {
+			limitKey = i.makeUpperLimitKey()
+		}
+		iterState, err := i.intentIter.NextEngineKeyWithLimit(limitKey)
+		if err = i.tryDecodeLockKey(iterState, err); err != nil {
 			return
 		}
 		i.intentCmp = +1
@@ -518,6 +588,18 @@ func (i *intentInterleavingIter) Next() {
 		// The iterator is positioned at iter. It could be a value or an intent,
 		// though usually it will be a value.
 		i.iter.Next()
+		if err := i.tryDecodeKey(); err != nil {
+			return
+		}
+		if i.intentIterState == pebble.IterAtLimit && i.iterValid && !i.prefix {
+			// TODO(sumeer): could avoid doing this if i.iter has stepped to
+			// different version of same key.
+			limitKey := i.makeUpperLimitKey()
+			iterState, err := i.intentIter.NextEngineKeyWithLimit(limitKey)
+			if err = i.tryDecodeLockKey(iterState, err); err != nil {
+				return
+			}
+		}
 		i.computePos()
 	}
 }
@@ -541,25 +623,37 @@ func (i *intentInterleavingIter) NextKey() {
 			i.valid = false
 			return
 		}
-		valid, err := i.intentIter.NextEngineKey()
-		if err != nil {
-			i.err = err
-			i.valid = false
-			return
-		}
-		if err := i.tryDecodeLockKey(valid); err != nil {
-			return
-		}
 		// Step the iter to NextKey(), i.e., past all the versions of this key.
 		i.iter.NextKey()
+		if err := i.tryDecodeKey(); err != nil {
+			return
+		}
+		var limitKey roachpb.Key
+		if i.iterValid && !i.prefix {
+			limitKey = i.makeUpperLimitKey()
+		}
+		iterState, err := i.intentIter.NextEngineKeyWithLimit(limitKey)
+		if err := i.tryDecodeLockKey(iterState, err); err != nil {
+			return
+		}
 		i.computePos()
-	} else {
-		// The iterator is positioned at iter. It could be a value or an intent,
-		// though usually it will be a value.
-		// Step the iter to NextKey(), i.e., past all the versions of this key.
-		i.iter.NextKey()
-		i.computePos()
+		return
 	}
+	// The iterator is positioned at iter. It could be a value or an intent,
+	// though usually it will be a value.
+	// Step the iter to NextKey(), i.e., past all the versions of this key.
+	i.iter.NextKey()
+	if err := i.tryDecodeKey(); err != nil {
+		return
+	}
+	if i.intentIterState == pebble.IterAtLimit && i.iterValid && !i.prefix {
+		limitKey := i.makeUpperLimitKey()
+		iterState, err := i.intentIter.NextEngineKeyWithLimit(limitKey)
+		if err = i.tryDecodeLockKey(iterState, err); err != nil {
+			return
+		}
+	}
+	i.computePos()
 }
 
 func (i *intentInterleavingIter) isCurAtIntentIter() bool {
@@ -649,6 +743,10 @@ func (i *intentInterleavingIter) SeekLT(key MVCCKey) {
 		}
 	}
 
+	i.iter.SeekLT(key)
+	if err := i.tryDecodeKey(); err != nil {
+		return
+	}
 	var intentSeekKey roachpb.Key
 	if key.Timestamp.IsEmpty() {
 		// Common case.
@@ -659,16 +757,14 @@ func (i *intentInterleavingIter) SeekLT(key MVCCKey) {
 		// the key before doing SeekLT.
 		intentSeekKey, i.intentKeyBuf = keys.LockTableSingleKey(key.Key.Next(), i.intentKeyBuf)
 	}
-	valid, err := i.intentIter.SeekEngineKeyLT(EngineKey{Key: intentSeekKey})
-	if err != nil {
-		i.err = err
-		i.valid = false
+	var limitKey roachpb.Key
+	if i.iterValid {
+		limitKey = i.makeLowerLimitKey()
+	}
+	iterState, err := i.intentIter.SeekEngineKeyLTWithLimit(EngineKey{Key: intentSeekKey}, limitKey)
+	if err = i.tryDecodeLockKey(iterState, err); err != nil {
 		return
 	}
-	if err := i.tryDecodeLockKey(valid); err != nil {
-		return
-	}
-	i.iter.SeekLT(key)
 	i.computePos()
 }
 
@@ -683,16 +779,18 @@ func (i *intentInterleavingIter) Prev() {
 		if !i.valid {
 			// Both iterators are exhausted, so step both backward.
 			i.valid = true
-			valid, err := i.intentIter.PrevEngineKey()
-			if err != nil {
-				i.err = err
-				i.valid = false
-				return
-			}
-			if err := i.tryDecodeLockKey(valid); err != nil {
-				return
-			}
 			i.iter.Prev()
+			if err := i.tryDecodeKey(); err != nil {
+				return
+			}
+			var limitKey roachpb.Key
+			if i.iterValid {
+				limitKey = i.makeLowerLimitKey()
+			}
+			iterState, err := i.intentIter.PrevEngineKeyWithLimit(limitKey)
+			if err = i.tryDecodeLockKey(iterState, err); err != nil {
+				return
+			}
 			i.computePos()
 			return
 		}
@@ -712,17 +810,10 @@ func (i *intentInterleavingIter) Prev() {
 				return
 			}
 			i.iter.Prev()
-			i.intentCmp = +1
-			var err error
-			i.iterValid, err = i.iter.Valid()
-			if err != nil {
-				i.err = err
-				i.valid = false
+			if err := i.tryDecodeKey(); err != nil {
 				return
 			}
-			if i.iterValid {
-				i.iterKey = i.iter.UnsafeKey()
-			}
+			i.intentCmp = +1
 			if util.RaceEnabled && i.iterValid {
 				cmp := i.intentKey.Compare(i.iterKey.Key)
 				if cmp <= 0 {
@@ -735,13 +826,9 @@ func (i *intentInterleavingIter) Prev() {
 			// The intentIter is after the iter. We don't know whether the iter key
 			// has an intent. Note that the iter could itself be positioned at an
 			// intent.
-			valid, err := i.intentIter.PrevEngineKey()
-			if err != nil {
-				i.err = err
-				i.valid = false
-				return
-			}
-			if err := i.tryDecodeLockKey(valid); err != nil {
+			limitKey := i.makeLowerLimitKey()
+			iterState, err := i.intentIter.PrevEngineKeyWithLimit(limitKey)
+			if err = i.tryDecodeLockKey(iterState, err); err != nil {
 				return
 			}
 			if i.intentKey == nil {
@@ -759,18 +846,18 @@ func (i *intentInterleavingIter) Prev() {
 		// exhausted or positioned at a versioned value of a preceding key.
 		// Stepping intentIter backward will ensure that intentKey is <= the key
 		// of iter (when neither is exhausted).
-		intentIterValid, err := i.intentIter.PrevEngineKey()
-		if err != nil {
-			i.err = err
-			i.valid = false
-			return
+		var limitKey roachpb.Key
+		if i.iterValid {
+			limitKey = i.makeLowerLimitKey()
 		}
-		if err := i.tryDecodeLockKey(intentIterValid); err != nil {
+		intentIterState, err := i.intentIter.PrevEngineKeyWithLimit(limitKey)
+		if err = i.tryDecodeLockKey(intentIterState, err); err != nil {
 			return
 		}
 		if !i.iterValid {
 			// It !i.iterValid, the intentIter can no longer be valid either.
-			if intentIterValid {
+			// Note that limitKey is nil in this case.
+			if intentIterState != pebble.IterExhausted {
 				i.err = errors.Errorf("reverse iteration discovered intent without provisional value")
 			}
 			i.valid = false
@@ -791,6 +878,18 @@ func (i *intentInterleavingIter) Prev() {
 		// The iterator is positioned at iter. It could be a value or an intent,
 		// though usually it will be a value.
 		i.iter.Prev()
+		if err := i.tryDecodeKey(); err != nil {
+			return
+		}
+		if i.intentIterState == pebble.IterAtLimit && i.iterValid {
+			// TODO(sumeer): could avoid doing this if i.iter has stepped to
+			// different version of same key.
+			limitKey := i.makeLowerLimitKey()
+			iterState, err := i.intentIter.PrevEngineKeyWithLimit(limitKey)
+			if err = i.tryDecodeLockKey(iterState, err); err != nil {
+				return
+			}
+		}
 		i.computePos()
 	}
 }

--- a/pkg/storage/intent_interleaving_iter_test.go
+++ b/pkg/storage/intent_interleaving_iter_test.go
@@ -813,6 +813,8 @@ func intentInterleavingIterBench(b *testing.B, runFunc func(b *testing.B, state 
 }
 
 func BenchmarkIntentInterleavingIterNext(b *testing.B) {
+	defer log.Scope(b).Close(b)
+
 	intentInterleavingIterBench(b, func(b *testing.B, state benchState) {
 		b.Run(state.benchPrefix,
 			func(b *testing.B) {
@@ -848,6 +850,8 @@ func BenchmarkIntentInterleavingIterNext(b *testing.B) {
 }
 
 func BenchmarkIntentInterleavingIterPrev(b *testing.B) {
+	defer log.Scope(b).Close(b)
+
 	intentInterleavingIterBench(b, func(b *testing.B, state benchState) {
 		b.Run(state.benchPrefix,
 			func(b *testing.B) {
@@ -883,6 +887,8 @@ func BenchmarkIntentInterleavingIterPrev(b *testing.B) {
 }
 
 func BenchmarkIntentInterleavingSeekGEAndIter(b *testing.B) {
+	defer log.Scope(b).Close(b)
+
 	intentInterleavingIterBench(b, func(b *testing.B, state benchState) {
 		for _, seekStride := range []int{1, 10} {
 			b.Run(fmt.Sprintf("%s/seekStride=%d", state.benchPrefix, seekStride),


### PR DESCRIPTION
…gIter

intentInterleavingIter uses the *WithLimit() functions exposed
by pebble.Iterator.

This is motivated by the O(N^2) complexity we observe when doing
coordinated iteration over the lock table and MVCC keys where
all the intents in the lock table are deleted but have not yet
been compacted away. The O(N^2) complexity arises in two cases:
- Limited scans: the extreme is a limited scan with a
  limit of 1. Each successive scan traverses N, N-1, ...
  deleted locks.
- Mix of forward/reverse iteration in a single scan: A Next/SeekGE
  will incur a cost of N and the Prev/SeekLT another cost of N.
  This situation could be potentially fixed with a narrower
  solution, given the constrained way that the combination of
  forward and backward iteration is used in pebbleMVCCScanner
  (forward iteration using Next and SeekGE when doing a reverse
  scan), however the solution is likely to be fragile since it
  would require the code in intentInterleavingIter to know how
  it is used in pebbleMVCCScanner. The limited iteration mode
  solves it in a more general way.

By placing a limit when doing such coordinated iteration, we
restore iteration to O(N) for N keys.

Some preliminary benchmark numbers are included -- old is master.
Note the speedup in the `ScanOneAllIntentsResolved/separated=true`
cases which were taking many ms. The remaining are effectively
unchanged (these are from single runs, so some of the deltas
there may be noise).

Note that there is a shift
in where comparisons get performed in some of these benchmarks:
the comparison i.intentKey.Compare(i.iterKey.Key) in
intentInterleavingIter is replaced (when there is a live intent
for a different key) with a corresponding comparison in
pebble.Iterator's find{Next,Prev}Entry comparing with the limit
parameter. However we are still paying the cost for extra
comparisons when there are only dead intents within the iterator
bounds: say there are N keys each with M versions, so N\*M dead
intents each with a SINGLEDEL,SET pair (so 2\*N\*M keys in Pebble,
of which N\*M are considered distinct UserKeys). There will
eventually be N calls to pebble.Iterator.findNextEntry (when
iterating forward), each of which will call Iterator.nextUserKey
M times, after each of which it will do a comparison with the
limit key. So a total of N\*M extra comparisons to iterate over
these 2\*N\*M keys in Pebble. The cost of these seems negligible
based on the performance numbers below, which are not with
a deep mergingIter stack in Pebble -- a more realistic setting
with a deep mergingIter stack will have more comparisons for
merging across iterators, which should further decrease the
relative performance effect of the N\*M comparisons we are
paying in the top-level pebble.Iterator.

```
name                                                                           old time/op    new time/op    delta
ScanOneAllIntentsResolved/separated=false/versions=200/percent-flushed=0-16      51.1µs ± 0%    49.9µs ± 0%    -2.26%
ScanOneAllIntentsResolved/separated=false/versions=200/percent-flushed=50-16     21.9µs ± 0%    24.2µs ± 0%   +10.52%
ScanOneAllIntentsResolved/separated=false/versions=200/percent-flushed=90-16     5.52µs ± 0%    5.50µs ± 0%    -0.36%
ScanOneAllIntentsResolved/separated=false/versions=200/percent-flushed=100-16    2.37µs ± 0%    2.15µs ± 0%    -9.04%
ScanOneAllIntentsResolved/separated=true/versions=200/percent-flushed=0-16       47.4ms ± 0%     0.1ms ± 0%   -99.88%
ScanOneAllIntentsResolved/separated=true/versions=200/percent-flushed=50-16      11.1ms ± 0%     0.0ms ± 0%   -99.81%
ScanOneAllIntentsResolved/separated=true/versions=200/percent-flushed=90-16      1.07ms ± 0%    0.01ms ± 0%   -99.48%
ScanOneAllIntentsResolved/separated=true/versions=200/percent-flushed=100-16     2.08µs ± 0%    2.04µs ± 0%    -1.88%

IntentScan/separated=false/versions=10/percent-flushed=0-16                      2.96µs ± 0%    2.80µs ± 0%    -5.67%
IntentScan/separated=false/versions=10/percent-flushed=50-16                     1.93µs ± 0%    1.80µs ± 0%    -6.78%
IntentScan/separated=false/versions=10/percent-flushed=80-16                     1.55µs ± 0%    1.46µs ± 0%    -5.73%
IntentScan/separated=false/versions=10/percent-flushed=90-16                     1.22µs ± 0%    1.20µs ± 0%    -2.05%
IntentScan/separated=false/versions=10/percent-flushed=100-16                     937ns ± 0%     864ns ± 0%    -7.79%
IntentScan/separated=false/versions=100/percent-flushed=0-16                     27.0µs ± 0%    19.8µs ± 0%   -26.65%
IntentScan/separated=false/versions=100/percent-flushed=50-16                    13.3µs ± 0%     9.2µs ± 0%   -31.13%
IntentScan/separated=false/versions=100/percent-flushed=80-16                    4.06µs ± 0%    3.71µs ± 0%    -8.72%
IntentScan/separated=false/versions=100/percent-flushed=90-16                    2.69µs ± 0%    2.59µs ± 0%    -3.93%
IntentScan/separated=false/versions=100/percent-flushed=100-16                    985ns ± 0%     931ns ± 0%    -5.48%
IntentScan/separated=false/versions=200/percent-flushed=0-16                     50.1µs ± 0%    50.9µs ± 0%    +1.76%
IntentScan/separated=false/versions=200/percent-flushed=50-16                    26.7µs ± 0%    19.7µs ± 0%   -26.19%
IntentScan/separated=false/versions=200/percent-flushed=80-16                    8.76µs ± 0%    6.30µs ± 0%   -28.06%
IntentScan/separated=false/versions=200/percent-flushed=90-16                    4.18µs ± 0%    3.83µs ± 0%    -8.33%
IntentScan/separated=false/versions=200/percent-flushed=100-16                   1.04µs ± 0%    0.95µs ± 0%    -8.47%
IntentScan/separated=false/versions=400/percent-flushed=0-16                     22.2µs ± 0%    15.5µs ± 0%   -30.26%
IntentScan/separated=false/versions=400/percent-flushed=50-16                    9.76µs ± 0%    6.91µs ± 0%   -29.22%
IntentScan/separated=false/versions=400/percent-flushed=80-16                    20.4µs ± 0%    12.3µs ± 0%   -39.94%
IntentScan/separated=false/versions=400/percent-flushed=90-16                    9.09µs ± 0%    6.29µs ± 0%   -30.87%
IntentScan/separated=false/versions=400/percent-flushed=100-16                   1.79µs ± 0%    1.68µs ± 0%    -6.35%
IntentScan/separated=true/versions=10/percent-flushed=0-16                       3.47µs ± 0%    3.33µs ± 0%    -4.21%
IntentScan/separated=true/versions=10/percent-flushed=50-16                      1.93µs ± 0%    1.83µs ± 0%    -5.17%
IntentScan/separated=true/versions=10/percent-flushed=80-16                      1.38µs ± 0%    1.49µs ± 0%    +8.15%
IntentScan/separated=true/versions=10/percent-flushed=90-16                      1.20µs ± 0%    1.36µs ± 0%   +13.36%
IntentScan/separated=true/versions=10/percent-flushed=100-16                      923ns ± 0%    1002ns ± 0%    +8.56%
IntentScan/separated=true/versions=100/percent-flushed=0-16                      25.3µs ± 0%    28.9µs ± 0%   +14.20%
IntentScan/separated=true/versions=100/percent-flushed=50-16                     6.74µs ± 0%    7.27µs ± 0%    +7.88%
IntentScan/separated=true/versions=100/percent-flushed=80-16                     3.43µs ± 0%    3.69µs ± 0%    +7.43%
IntentScan/separated=true/versions=100/percent-flushed=90-16                     2.31µs ± 0%    2.60µs ± 0%   +12.38%
IntentScan/separated=true/versions=100/percent-flushed=100-16                     973ns ± 0%    1056ns ± 0%    +8.53%
IntentScan/separated=true/versions=200/percent-flushed=0-16                      46.9µs ± 0%    51.8µs ± 0%   +10.41%
IntentScan/separated=true/versions=200/percent-flushed=50-16                     14.7µs ± 0%    13.8µs ± 0%    -6.30%
IntentScan/separated=true/versions=200/percent-flushed=80-16                     5.70µs ± 0%    6.04µs ± 0%    +6.02%
IntentScan/separated=true/versions=200/percent-flushed=90-16                     3.47µs ± 0%    3.69µs ± 0%    +6.52%
IntentScan/separated=true/versions=200/percent-flushed=100-16                    0.99µs ± 0%    1.06µs ± 0%    +6.83%
IntentScan/separated=true/versions=400/percent-flushed=0-16                      32.4µs ± 0%    26.3µs ± 0%   -18.79%
IntentScan/separated=true/versions=400/percent-flushed=50-16                     37.4µs ± 0%    38.9µs ± 0%    +4.03%
IntentScan/separated=true/versions=400/percent-flushed=80-16                     12.7µs ± 0%    11.8µs ± 0%    -6.98%
IntentScan/separated=true/versions=400/percent-flushed=90-16                     5.56µs ± 0%    6.19µs ± 0%   +11.30%
IntentScan/separated=true/versions=400/percent-flushed=100-16                    1.73µs ± 0%    1.87µs ± 0%    +8.23%
ScanAllIntentsResolved/separated=false/versions=200/percent-flushed=0-16         46.7µs ± 0%    47.9µs ± 0%    +2.62%
ScanAllIntentsResolved/separated=false/versions=200/percent-flushed=50-16        19.8µs ± 0%    19.2µs ± 0%    -3.20%
ScanAllIntentsResolved/separated=false/versions=200/percent-flushed=90-16        3.83µs ± 0%    3.89µs ± 0%    +1.62%
ScanAllIntentsResolved/separated=false/versions=200/percent-flushed=100-16        972ns ± 0%     993ns ± 0%    +2.16%
ScanAllIntentsResolved/separated=true/versions=200/percent-flushed=0-16          63.1µs ± 0%    59.6µs ± 0%    -5.55%
ScanAllIntentsResolved/separated=true/versions=200/percent-flushed=50-16         17.0µs ± 0%    15.1µs ± 0%   -10.87%
ScanAllIntentsResolved/separated=true/versions=200/percent-flushed=90-16         3.26µs ± 0%    3.61µs ± 0%   +10.73%
ScanAllIntentsResolved/separated=true/versions=200/percent-flushed=100-16         918ns ± 0%     945ns ± 0%    +2.94%
IntentResolution/separated=false/versions=10/percent-flushed=0-16                2.25µs ± 0%    2.23µs ± 0%    -1.15%
IntentResolution/separated=false/versions=10/percent-flushed=50-16               3.09µs ± 0%    2.89µs ± 0%    -6.53%
IntentResolution/separated=false/versions=10/percent-flushed=80-16               2.73µs ± 0%    2.44µs ± 0%   -10.64%
IntentResolution/separated=false/versions=10/percent-flushed=90-16               1.90µs ± 0%    1.88µs ± 0%    -0.95%
IntentResolution/separated=false/versions=10/percent-flushed=100-16              2.45µs ± 0%    2.41µs ± 0%    -1.59%
IntentResolution/separated=false/versions=100/percent-flushed=0-16               4.59µs ± 0%    4.70µs ± 0%    +2.42%
IntentResolution/separated=false/versions=100/percent-flushed=50-16              3.83µs ± 0%    3.91µs ± 0%    +2.01%
IntentResolution/separated=false/versions=100/percent-flushed=80-16              3.18µs ± 0%    3.14µs ± 0%    -1.23%
IntentResolution/separated=false/versions=100/percent-flushed=90-16              3.19µs ± 0%    3.06µs ± 0%    -4.20%
IntentResolution/separated=false/versions=100/percent-flushed=100-16             2.65µs ± 0%    2.34µs ± 0%   -11.71%
IntentResolution/separated=false/versions=200/percent-flushed=0-16               5.76µs ± 0%    5.70µs ± 0%    -1.04%
IntentResolution/separated=false/versions=200/percent-flushed=50-16              4.09µs ± 0%    4.01µs ± 0%    -2.05%
IntentResolution/separated=false/versions=200/percent-flushed=80-16              3.22µs ± 0%    3.15µs ± 0%    -2.05%
IntentResolution/separated=false/versions=200/percent-flushed=90-16              3.14µs ± 0%    3.17µs ± 0%    +0.67%
IntentResolution/separated=false/versions=200/percent-flushed=100-16             2.54µs ± 0%    2.50µs ± 0%    -1.81%
IntentResolution/separated=false/versions=400/percent-flushed=0-16               2.83µs ± 0%    2.94µs ± 0%    +3.74%
IntentResolution/separated=false/versions=400/percent-flushed=50-16              2.75µs ± 0%    2.71µs ± 0%    -1.74%
IntentResolution/separated=false/versions=400/percent-flushed=80-16              2.84µs ± 0%    2.83µs ± 0%    -0.14%
IntentResolution/separated=false/versions=400/percent-flushed=90-16              2.78µs ± 0%    2.72µs ± 0%    -2.09%
IntentResolution/separated=false/versions=400/percent-flushed=100-16             2.04µs ± 0%    2.03µs ± 0%    -0.39%
IntentResolution/separated=true/versions=10/percent-flushed=0-16                 3.03µs ± 0%    3.07µs ± 0%    +1.15%
IntentResolution/separated=true/versions=10/percent-flushed=50-16                3.21µs ± 0%    3.24µs ± 0%    +0.84%
IntentResolution/separated=true/versions=10/percent-flushed=80-16                2.88µs ± 0%    2.77µs ± 0%    -3.81%
IntentResolution/separated=true/versions=10/percent-flushed=90-16                2.67µs ± 0%    2.67µs ± 0%    -0.04%
IntentResolution/separated=true/versions=10/percent-flushed=100-16               2.21µs ± 0%    2.22µs ± 0%    +0.32%
IntentResolution/separated=true/versions=100/percent-flushed=0-16                8.16µs ± 0%    8.36µs ± 0%    +2.44%
IntentResolution/separated=true/versions=100/percent-flushed=50-16               4.18µs ± 0%    3.98µs ± 0%    -4.69%
IntentResolution/separated=true/versions=100/percent-flushed=80-16               4.03µs ± 0%    4.10µs ± 0%    +1.76%
IntentResolution/separated=true/versions=100/percent-flushed=90-16               3.74µs ± 0%    3.78µs ± 0%    +1.23%
IntentResolution/separated=true/versions=100/percent-flushed=100-16              2.20µs ± 0%    2.26µs ± 0%    +2.77%
IntentResolution/separated=true/versions=200/percent-flushed=0-16                13.2µs ± 0%    12.8µs ± 0%    -3.25%
IntentResolution/separated=true/versions=200/percent-flushed=50-16               4.37µs ± 0%    4.28µs ± 0%    -1.90%
IntentResolution/separated=true/versions=200/percent-flushed=80-16               4.23µs ± 0%    4.38µs ± 0%    +3.62%
IntentResolution/separated=true/versions=200/percent-flushed=90-16               3.98µs ± 0%    4.08µs ± 0%    +2.44%
IntentResolution/separated=true/versions=200/percent-flushed=100-16              2.35µs ± 0%    2.28µs ± 0%    -3.15%
IntentResolution/separated=true/versions=400/percent-flushed=0-16                4.64µs ± 0%    4.59µs ± 0%    -0.93%
IntentResolution/separated=true/versions=400/percent-flushed=50-16               5.06µs ± 0%    4.77µs ± 0%    -5.74%
IntentResolution/separated=true/versions=400/percent-flushed=80-16               3.91µs ± 0%    3.78µs ± 0%    -3.32%
IntentResolution/separated=true/versions=400/percent-flushed=90-16               3.54µs ± 0%    3.50µs ± 0%    -1.05%
IntentResolution/separated=true/versions=400/percent-flushed=100-16              2.24µs ± 0%    2.28µs ± 0%    +2.01%
IntentRangeResolution/separated=false/versions=10/percent-flushed=0-16            265µs ± 0%     277µs ± 0%    +4.64%
IntentRangeResolution/separated=false/versions=10/percent-flushed=50-16           211µs ± 0%     217µs ± 0%    +3.19%
IntentRangeResolution/separated=false/versions=10/percent-flushed=80-16           202µs ± 0%     209µs ± 0%    +3.61%
IntentRangeResolution/separated=false/versions=10/percent-flushed=90-16           197µs ± 0%     201µs ± 0%    +1.87%
IntentRangeResolution/separated=false/versions=10/percent-flushed=100-16          150µs ± 0%     154µs ± 0%    +3.07%
IntentRangeResolution/separated=false/versions=100/percent-flushed=0-16           528µs ± 0%     531µs ± 0%    +0.52%
IntentRangeResolution/separated=false/versions=100/percent-flushed=50-16          311µs ± 0%     302µs ± 0%    -2.88%
IntentRangeResolution/separated=false/versions=100/percent-flushed=80-16          232µs ± 0%     230µs ± 0%    -0.94%
IntentRangeResolution/separated=false/versions=100/percent-flushed=90-16          227µs ± 0%     226µs ± 0%    -0.35%
IntentRangeResolution/separated=false/versions=100/percent-flushed=100-16         164µs ± 0%     161µs ± 0%    -2.31%
IntentRangeResolution/separated=false/versions=200/percent-flushed=0-16           980µs ± 0%     616µs ± 0%   -37.09%
IntentRangeResolution/separated=false/versions=200/percent-flushed=50-16          396µs ± 0%     323µs ± 0%   -18.36%
IntentRangeResolution/separated=false/versions=200/percent-flushed=80-16          263µs ± 0%     249µs ± 0%    -5.28%
IntentRangeResolution/separated=false/versions=200/percent-flushed=90-16          287µs ± 0%     236µs ± 0%   -17.86%
IntentRangeResolution/separated=false/versions=200/percent-flushed=100-16         161µs ± 0%     164µs ± 0%    +2.08%
IntentRangeResolution/separated=false/versions=400/percent-flushed=0-16           263µs ± 0%     267µs ± 0%    +1.67%
IntentRangeResolution/separated=false/versions=400/percent-flushed=50-16          254µs ± 0%     257µs ± 0%    +1.37%
IntentRangeResolution/separated=false/versions=400/percent-flushed=80-16          257µs ± 0%     259µs ± 0%    +0.94%
IntentRangeResolution/separated=false/versions=400/percent-flushed=90-16          246µs ± 0%     256µs ± 0%    +4.22%
IntentRangeResolution/separated=false/versions=400/percent-flushed=100-16         172µs ± 0%     175µs ± 0%    +1.46%
IntentRangeResolution/separated=true/versions=10/percent-flushed=0-16             443µs ± 0%     447µs ± 0%    +0.77%
IntentRangeResolution/separated=true/versions=10/percent-flushed=50-16            295µs ± 0%     287µs ± 0%    -2.64%
IntentRangeResolution/separated=true/versions=10/percent-flushed=80-16            241µs ± 0%     254µs ± 0%    +5.27%
IntentRangeResolution/separated=true/versions=10/percent-flushed=90-16            238µs ± 0%     240µs ± 0%    +0.82%
IntentRangeResolution/separated=true/versions=10/percent-flushed=100-16           220µs ± 0%     225µs ± 0%    +2.17%
IntentRangeResolution/separated=true/versions=100/percent-flushed=0-16           1.84ms ± 0%    2.04ms ± 0%   +10.39%
IntentRangeResolution/separated=true/versions=100/percent-flushed=50-16           554µs ± 0%     583µs ± 0%    +5.11%
IntentRangeResolution/separated=true/versions=100/percent-flushed=80-16           377µs ± 0%     389µs ± 0%    +3.31%
IntentRangeResolution/separated=true/versions=100/percent-flushed=90-16           309µs ± 0%     316µs ± 0%    +2.30%
IntentRangeResolution/separated=true/versions=100/percent-flushed=100-16          225µs ± 0%     235µs ± 0%    +4.27%
IntentRangeResolution/separated=true/versions=200/percent-flushed=0-16           3.59ms ± 0%    3.84ms ± 0%    +7.21%
IntentRangeResolution/separated=true/versions=200/percent-flushed=50-16           875µs ± 0%     998µs ± 0%   +14.00%
IntentRangeResolution/separated=true/versions=200/percent-flushed=80-16           508µs ± 0%     525µs ± 0%    +3.33%
IntentRangeResolution/separated=true/versions=200/percent-flushed=90-16           382µs ± 0%     391µs ± 0%    +2.22%
IntentRangeResolution/separated=true/versions=200/percent-flushed=100-16          266µs ± 0%     240µs ± 0%    -9.75%
IntentRangeResolution/separated=true/versions=400/percent-flushed=0-16           1.54ms ± 0%    1.69ms ± 0%    +9.22%
IntentRangeResolution/separated=true/versions=400/percent-flushed=50-16          1.93ms ± 0%    2.13ms ± 0%   +10.45%
IntentRangeResolution/separated=true/versions=400/percent-flushed=80-16           769µs ± 0%     829µs ± 0%    +7.84%
IntentRangeResolution/separated=true/versions=400/percent-flushed=90-16           506µs ± 0%     535µs ± 0%    +5.61%
IntentRangeResolution/separated=true/versions=400/percent-flushed=100-16          248µs ± 0%     252µs ± 0%    +1.52%
```

Release justification: Change is localized to intentInterleavingIter
and pebble.Iterator. It may be risky given it is involved in all reads
of MVCC data. One possibility would be to adopt the change since it
only really affects separated intents (the intentIter is the only one
using the limited iteration), which would unblock turning on separated
intents in a randomized manner for SQL tests and roachtests, while leaving
it off by default for 21.1. This would reduce the possibility of code
rot for separated intents.

Release note: None