### PR TITLE
release-20.2: build: install tar in our docker image

### DIFF
--- a/build/deploy/Dockerfile
+++ b/build/deploy/Dockerfile
@@ -4,9 +4,10 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal
 # tzdata - for time zone functions; reinstalled to replace the missing
 #          files in /usr/share/zoneinfo/
 # hostname - used in cockroach k8s manifests
+# tar - used by kubectl cp
 RUN microdnf update -y \
     && rpm --erase --nodeps tzdata \
-    && microdnf install tzdata hostname -y \
+    && microdnf install tzdata hostname tar -y \
     && rm -rf /var/cache/yum
 
 # Install GEOS libraries.


### PR DESCRIPTION
Backport 1/1 commits from #57241.

/cc @cockroachdb/release

---

In the switch to redhat's ubi image, many binaries were excluded in the
container. The loss of tar breaks kubectl cp, a critical tool for
debugging cockroachdb clusters that are running in kubernetes.
This commit includes tar into our docker images such that kubectl cp
will work out of the box.

Release note (general change): Included tar in docker images. This allows users to use kubectl cp on 20.2.x containers.
