### PR TITLE
kvserver: unskip TestGossipHandlesReplacedNode

### DIFF
--- a/pkg/kv/kvserver/gossip_test.go
+++ b/pkg/kv/kvserver/gossip_test.go
@@ -145,9 +145,6 @@ func TestGossipHandlesReplacedNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// Skipping as part of test-infra-team flaky test cleanup.
-	skip.WithIssue(t, 50024)
-
 	// As of Nov 2018 it takes 3.6s.
 	skip.UnderShort(t)
 	ctx := context.Background()


### PR DESCRIPTION
```
$ caffeinate make stressrace PKG=./pkg/kv/kvserver/ TESTS=TestGossipHandlesReplacedNode
[...]
81182 runs so far, 0 failures, over 21m35s
```

Closes #50024.

cc @irfansharif @erikgrinaker @angelapwen

Release justification: non-production code changes
Release note: None
