### PR TITLE
ui: do not spuriously display warning for non-voters

### DIFF
--- a/pkg/ui/src/views/reports/containers/range/rangeTable.tsx
+++ b/pkg/ui/src/views/reports/containers/range/rangeTable.tsx
@@ -48,7 +48,7 @@ const rangeTableDisplayList: RangeTableRow[] = [
   { variable: "id", display: "ID", compareToLeader: false },
   { variable: "keyRange", display: "Key Range", compareToLeader: true },
   { variable: "problems", display: "Problems", compareToLeader: true },
-  { variable: "replicaType", display: "Replica Type", compareToLeader: true },
+  { variable: "replicaType", display: "Replica Type", compareToLeader: false },
   { variable: "raftState", display: "Raft State", compareToLeader: false },
   { variable: "quiescent", display: "Quiescent", compareToLeader: true },
   { variable: "ticking", display: "Ticking", compareToLeader: true },


### PR DESCRIPTION
Before this commit, we were displaying the replica type of non-voters
with a warning (by highlighting the cell in red). 
This commit fixes the bug.

Before:
<img width="1165" alt="Screen Shot 2021-03-03 at 1 57 55 PM" src="https://user-images.githubusercontent.com/10788754/109858229-8d3caf80-7c29-11eb-81ae-f2d6bccee211.png">


After:
<img width="1119" alt="Screen Shot 2021-03-03 at 2 04 26 PM" src="https://user-images.githubusercontent.com/10788754/109858169-7c8c3980-7c29-11eb-84a8-e46b185591c8.png">


Release justification: fixes UI bug on the range report page
Release note: None