### PR TITLE
release-20.1: sql: disallow creation of interleaved partitioned indexes

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_index
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_index
@@ -150,3 +150,14 @@ indexes  CREATE TABLE indexes (
          FAMILY "primary" (a, b)
 )
 -- Warning: Partitioned table with no zone configurations.
+
+# Regression test for #60699. Do not allow creation of interleaved partitioned
+# indexes.
+statement ok
+CREATE TABLE t60699_a (a INT PRIMARY KEY);
+CREATE TABLE t60699_b (b INT PRIMARY KEY, a INT REFERENCES t60699_a (a));
+
+statement error interleaved indexes cannot be partitioned
+CREATE INDEX i ON t60699_b (a) INTERLEAVE IN PARENT t60699_a (a) PARTITION BY LIST (a) (
+  partition part1 VALUES IN (1)
+)

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -320,6 +320,10 @@ func (n *createIndexNode) startExec(params runParams) error {
 		)
 	}
 
+	if n.n.Interleave != nil && n.n.PartitionBy != nil {
+		return pgerror.New(pgcode.FeatureNotSupported, "interleaved indexes cannot be partitioned")
+	}
+
 	indexDesc, err := MakeIndexDescriptor(params, n.n, n.tableDesc)
 	if err != nil {
 		return err


### PR DESCRIPTION
Backport 1/1 commits from #61106.

/cc @cockroachdb/release

---

Previously, creating interleaved partitioned indexes panicked. This
commit disallows their creation to prevent panicking.

Fixes #60699

Release justification: This is a low risk change that prevents panics
when attempting to create interleaved partitioned tables.

Release note (bug fix): Creating interleaved partitioned indexes is now
disallowed. Previously, the database would crash when trying to create
one.
