### PR TITLE
sql: fix erroneous txn-less usages of job methods

### DIFF
--- a/pkg/jobs/jobsprotectedts/jobs_protected_ts.go
+++ b/pkg/jobs/jobsprotectedts/jobs_protected_ts.go
@@ -46,8 +46,7 @@ func MakeStatusFunc(jr *jobs.Registry) ptreconcile.StatusFunc {
 		if err != nil {
 			return false, err
 		}
-		// TODO: This job update should possibly use the txn (#60690).
-		isTerminal := j.CheckTerminalStatus(ctx, nil /* txn */)
+		isTerminal := j.CheckTerminalStatus(ctx, txn)
 		return isTerminal, nil
 	}
 }

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1269,8 +1269,7 @@ func (sc *SchemaChanger) distBackfill(
 			if nRanges < origNRanges {
 				fractionRangesFinished := float32(origNRanges-nRanges) / float32(origNRanges)
 				fractionCompleted := origFractionCompleted + fractionLeft*fractionRangesFinished
-				// TODO: This job update should possibly use the txn (#60690).
-				if err := sc.job.FractionProgressed(ctx, nil /* txn */, jobs.FractionUpdater(fractionCompleted)); err != nil {
+				if err := sc.job.FractionProgressed(ctx, txn, jobs.FractionUpdater(fractionCompleted)); err != nil {
 					return jobs.SimplifyInvalidStatusError(err)
 				}
 			}

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -535,6 +535,13 @@ func (r *createStatsResumer) Resume(ctx context.Context, execCtx interface{}) er
 				return jobs.NewRetryJobError("node failure")
 			}
 
+			// We can't re-use the txn from above since it has a fixed timestamp set on
+			// it, and our write will be into the behind.
+			txnForJobProgress := txn
+			if details.AsOf != nil {
+				txnForJobProgress = nil
+			}
+
 			// If the job was canceled, any of the distsql processors could have been
 			// the first to encounter the .Progress error. This error's string is sent
 			// through distsql back here, so we can't examine the err type in this case
@@ -542,9 +549,8 @@ func (r *createStatsResumer) Resume(ctx context.Context, execCtx interface{}) er
 			// job progress to coerce out the correct error type. If the update succeeds
 			// then return the original error, otherwise return this error instead so
 			// it can be cleaned up at a higher level.
-			// TODO: This job update should possibly use the txn (#60690).
 			if jobErr := r.job.FractionProgressed(
-				ctx, nil, /* txn */
+				ctx, txnForJobProgress,
 				func(ctx context.Context, _ jobspb.ProgressDetails) float32 {
 					// The job failed so the progress value here doesn't really matter.
 					return 0

--- a/pkg/sql/gcjob/gc_job_utils.go
+++ b/pkg/sql/gcjob/gc_job_utils.go
@@ -117,8 +117,7 @@ func initializeProgress(
 			if err != nil {
 				return err
 			}
-			// TODO: This job update should possibly use the txn (#60690).
-			return job.SetProgress(ctx, nil /* txn */, *progress)
+			return job.SetProgress(ctx, txn, *progress)
 		}); err != nil {
 			return err
 		}
@@ -261,12 +260,11 @@ func persistProgress(
 		if err != nil {
 			return err
 		}
-		// TODO: This job update should possibly use the txn (#60690).
-		if err := job.SetProgress(ctx, nil /* txn */, *progress); err != nil {
+		if err := job.SetProgress(ctx, txn, *progress); err != nil {
 			return err
 		}
 		log.Infof(ctx, "updated progress payload: %+v", progress)
-		err = job.RunningStatus(ctx, nil /* txn */, func(_ context.Context, _ jobspb.Details) (jobs.RunningStatus, error) {
+		err = job.RunningStatus(ctx, txn, func(_ context.Context, _ jobspb.Details) (jobs.RunningStatus, error) {
 			return runningStatus, nil
 		})
 		if err != nil {


### PR DESCRIPTION
Fixes: #60690

Previously, there were multiple code paths were not passing
in a Txn argument into the jobs methods, causing a new
transaction to get created. These usages were erroneous
and could cause a number of issues, since these operations
would be a separate transaction. To address this, this patch
adds explicit Txn arguments in all of these code paths, so
that a new transaction is not needlessly made where it makes
sense.

Release justification: Low risk bug fix addressing potential issues
in various job related code paths.
Release note: None