### PR TITLE
geomfn: prevent smaller densifyFrac for ST_{Frechet,Hausdorff}Distance

### DIFF
--- a/pkg/geo/geomfn/distance_test.go
+++ b/pkg/geo/geomfn/distance_test.go
@@ -790,11 +790,8 @@ func TestFrechetDistanceDensify(t *testing.T) {
 		densifyFrac float64
 	}{
 		// Very small densifyFrac causes a SIGFPE in GEOS due to division-by-zero.
-		// The threshold was empirically found to be at 1e-20, while at 1e-19
-		// GEOS instead returns the error "geos error: vector". We explicitly
-		// disallow <1e-19 in the code, and test that both of these error. We do
-		// not test larger values, since very small densify values consume a
-		// large amount of memory causing out-of-memory errors.
+		// We explicitly disallow <1e-6 in the code, and test that both of these error.
+		{"LINESTRING (130 0, 0 0, 0 150)", "LINESTRING (10 10, 10 150, 130 10)", 1e-7},
 		{"LINESTRING (130 0, 0 0, 0 150)", "LINESTRING (10 10, 10 150, 130 10)", 1e-19},
 		{"LINESTRING (130 0, 0 0, 0 150)", "LINESTRING (10 10, 10 150, 130 10)", 1e-20},
 		{"LINESTRING (130 0, 0 0, 0 150)", "LINESTRING (10 10, 10 150, 130 10)", 1e-100},
@@ -867,8 +864,6 @@ func TestHausdorffDistanceDensify(t *testing.T) {
 		{"LINESTRING EMPTY", "LINESTRING EMPTY", 0.5, nil},
 		{"LINESTRING (130 0, 0 0, 0 150)", "LINESTRING EMPTY", 0.5, nil},
 		{"LINESTRING EMPTY", "LINESTRING (10 10, 10 150, 130 10)", 0.5, nil},
-		{"LINESTRING (130 0, 0 0, 0 150)", "LINESTRING (10 10, 10 150, 130 10)", 1e-100, pf(14.142135623730951)},
-		{"LINESTRING (130 0, 0 0, 0 150)", "LINESTRING (10 10, 10 150, 130 10)", 1e-20, pf(14.142135623730951)},
 		{"LINESTRING (130 0, 0 0, 0 150)", "LINESTRING (10 10, 10 150, 130 10)", 0.2, pf(66)},
 		{"LINESTRING (130 0, 0 0, 0 150)", "LINESTRING (10 10, 10 150, 130 10)", 0.4, pf(56.66666666666667)},
 		{"LINESTRING (130 0, 0 0, 0 150)", "LINESTRING (10 10, 10 150, 130 10)", 0.6, pf(70)},
@@ -902,6 +897,7 @@ func TestHausdorffDistanceDensify(t *testing.T) {
 		{"LINESTRING (130 0, 0 0, 0 150)", "LINESTRING (10 10, 10 150, 130 10)", -1},
 		{"LINESTRING (130 0, 0 0, 0 150)", "LINESTRING (10 10, 10 150, 130 10)", -0.1},
 		{"LINESTRING (130 0, 0 0, 0 150)", "LINESTRING (10 10, 10 150, 130 10)", 0.0},
+		{"LINESTRING (130 0, 0 0, 0 150)", "LINESTRING (10 10, 10 150, 130 10)", 0.0000001},
 		{"LINESTRING (130 0, 0 0, 0 150)", "LINESTRING (10 10, 10 150, 130 10)", 1.1},
 	}
 


### PR DESCRIPTION
Release justification: low-risk change to existing functionality

Resolves #61367.

Release note (sql change): Prevent densifyFracs < 1e-6 for
ST_FrechetDistance and ST_HausdorffDistance to protect panics and out of
memory errors.