### PR TITLE
release-20.2: roachtest: install GEOS libraries for activerecord tests

### DIFF
--- a/pkg/cmd/roachtest/activerecord.go
+++ b/pkg/cmd/roachtest/activerecord.go
@@ -37,6 +37,9 @@ func registerActiveRecord(r *testRegistry) {
 		node := c.Node(1)
 		t.Status("setting up cockroach")
 		c.Put(ctx, cockroach, "./cockroach", c.All())
+		if err := c.PutLibraries(ctx, "./lib"); err != nil {
+			t.Fatal(err)
+		}
 		c.Start(ctx, t, c.All())
 
 		version, err := fetchCockroachVersion(ctx, c, node[0])


### PR DESCRIPTION
Backport 1/1 commits from #61424.

/cc @cockroachdb/release

---

Release justification: non-production code change

Release note: None
