### PR TITLE
bazel: add way to run lint unit tests with `bazel run`

### DIFF
--- a/build/bazelutil/BUILD.bazel
+++ b/build/bazelutil/BUILD.bazel
@@ -1,0 +1,47 @@
+load(":lint.bzl", "lint_binary")
+
+# These tests can be run with `bazel run`, e.g.
+#   bazel run //build/bazelutil:fmtsafe_lint
+# (We use `bazel run` over `bazel test` because the lint needs access to the
+#  entire source tree, which is problematic to link wholesale into the Bazel
+#  sandbox.)
+
+lint_binary(
+    name = "fmtsafe_lint",
+    test = "//pkg/testutils/lint/passes/fmtsafe:fmtsafe_test",
+)
+
+lint_binary(
+    name = "forbiddenmethod_lint",
+    test = "//pkg/testutils/lint/passes/forbiddenmethod:forbiddenmethod_test",
+)
+
+lint_binary(
+    name = "hash_lint",
+    test = "//pkg/testutils/lint/passes/hash:hash_test",
+)
+
+lint_binary(
+    name = "nocopy_lint",
+    test = "//pkg/testutils/lint/passes/nocopy:nocopy_test",
+)
+
+lint_binary(
+    name = "passesutil_lint",
+    test = "//pkg/testutils/lint/passes/passesutil:passesutil_test",
+)
+
+lint_binary(
+    name = "returnerrcheck_lint",
+    test = "//pkg/testutils/lint/passes/returnerrcheck:returnerrcheck_test",
+)
+
+lint_binary(
+    name = "timer_lint",
+    test = "//pkg/testutils/lint/passes/timer:timer_test",
+)
+
+lint_binary(
+    name = "unconvert_lint",
+    test = "//pkg/testutils/lint/passes/unconvert:unconvert_test",
+)

--- a/build/bazelutil/lint.bzl
+++ b/build/bazelutil/lint.bzl
@@ -1,0 +1,41 @@
+load("@bazel_skylib//lib:shell.bzl", "shell")
+
+def _gen_script_impl(ctx):
+    subs = {
+        "@@PACKAGE@@": shell.quote(ctx.attr.test.label.package),
+        "@@NAME@@": shell.quote(ctx.attr.test.label.name),
+    }
+    out_file = ctx.actions.declare_file(ctx.label.name)
+    ctx.actions.expand_template(
+        template = ctx.file._template,
+        output = out_file,
+        substitutions = subs,
+    )
+    return [
+        DefaultInfo(files = depset([out_file])),
+    ]
+
+_gen_script = rule(
+    implementation = _gen_script_impl,
+    attrs = {
+        "test": attr.label(mandatory = True),
+        "_template": attr.label(
+            default = "@cockroach//build/bazelutil:lint.sh.in",
+            allow_single_file = True,
+        ),
+    },
+)
+
+def lint_binary(name, test):
+    script_name = name+".sh"
+    _gen_script(test=test, name=script_name, testonly=1)
+    native.sh_binary(
+        name=name,
+        srcs=[script_name],
+        data = [
+            test,
+            "@go_sdk//:bin/go",
+        ],
+        deps = ["@bazel_tools//tools/bash/runfiles"],
+        testonly = 1,
+    )

--- a/build/bazelutil/lint.sh.in
+++ b/build/bazelutil/lint.sh.in
@@ -1,0 +1,29 @@
+# This is boilerplate taken directly from
+#  https://github.com/bazelbuild/bazel/blob/master/tools/bash/runfiles/runfiles.bash
+# See that page for an explanation of what this is and why it's necessary.
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+PACKAGE=@@PACKAGE@@
+NAME=@@NAME@@
+test_bin="$(rlocation cockroach/$PACKAGE/${NAME}_/$NAME)"
+go_bin="$(rlocation go_sdk/bin/go)"
+
+if [ -z "${BUILD_WORKSPACE_DIRECTORY-}" ]; then
+  echo "error: BUILD_WORKSPACE_DIRECTORY not set" >&2
+  exit 1
+fi
+
+cd "$BUILD_WORKSPACE_DIRECTORY/$PACKAGE"
+
+PATH="$(dirname $go_bin):$PATH" \
+    GOROOT="$(dirname $(dirname $go_bin))" \
+    $test_bin $@

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -361,6 +361,7 @@ test_suite(
     name = "small_tests",
     tags = [
         "-broken_in_bazel",
+        "-lint",
         "small",
     ],
     tests = ALL_TESTS,
@@ -370,6 +371,7 @@ test_suite(
     name = "medium_tests",
     tags = [
         "-broken_in_bazel",
+        "-lint",
         "medium",
     ],
     tests = ALL_TESTS,
@@ -379,6 +381,7 @@ test_suite(
     name = "large_tests",
     tags = [
         "-broken_in_bazel",
+        "-lint",
         "large",
     ],
     tests = ALL_TESTS,
@@ -388,6 +391,7 @@ test_suite(
     name = "enormous_tests",
     tags = [
         "-broken_in_bazel",
+        "-lint",
         "enormous",
     ],
     tests = ALL_TESTS,

--- a/pkg/cmd/generate-test-suites/main.go
+++ b/pkg/cmd/generate-test-suites/main.go
@@ -54,6 +54,7 @@ test_suite(
     name = "%[1]s_tests",
     tags = [
         "-broken_in_bazel",
+        "-lint",
         "%[1]s",
     ],
     tests = ALL_TESTS,

--- a/pkg/testutils/lint/passes/fmtsafe/BUILD.bazel
+++ b/pkg/testutils/lint/passes/fmtsafe/BUILD.bazel
@@ -23,7 +23,8 @@ go_test(
     size = "small",
     srcs = ["fmtsafe_test.go"],
     data = glob(["testdata/**"]),
-    tags = ["broken_in_bazel"],
+    tags = ["lint"],
+    visibility = ["//build/bazelutil:__subpackages__"],
     deps = [
         ":fmtsafe",
         "//pkg/testutils/skip",

--- a/pkg/testutils/lint/passes/forbiddenmethod/BUILD.bazel
+++ b/pkg/testutils/lint/passes/forbiddenmethod/BUILD.bazel
@@ -21,7 +21,8 @@ go_test(
     size = "small",
     srcs = ["descriptormarshal_test.go"],
     data = glob(["testdata/**"]),
-    tags = ["broken_in_bazel"],
+    tags = ["lint"],
+    visibility = ["//build/bazelutil:__subpackages__"],
     deps = [
         ":forbiddenmethod",
         "//pkg/testutils/skip",

--- a/pkg/testutils/lint/passes/hash/BUILD.bazel
+++ b/pkg/testutils/lint/passes/hash/BUILD.bazel
@@ -16,7 +16,8 @@ go_test(
     size = "small",
     srcs = ["hash_test.go"],
     data = glob(["testdata/**"]),
-    tags = ["broken_in_bazel"],
+    tags = ["lint"],
+    visibility = ["//build/bazelutil:__subpackages__"],
     deps = [
         ":hash",
         "//pkg/testutils/skip",

--- a/pkg/testutils/lint/passes/nocopy/BUILD.bazel
+++ b/pkg/testutils/lint/passes/nocopy/BUILD.bazel
@@ -17,7 +17,8 @@ go_test(
     size = "small",
     srcs = ["nocopy_test.go"],
     data = glob(["testdata/**"]),
-    tags = ["broken_in_bazel"],
+    tags = ["lint"],
+    visibility = ["//build/bazelutil:__subpackages__"],
     deps = [
         ":nocopy",
         "//pkg/testutils/skip",

--- a/pkg/testutils/lint/passes/passesutil/BUILD.bazel
+++ b/pkg/testutils/lint/passes/passesutil/BUILD.bazel
@@ -15,7 +15,8 @@ go_test(
     name = "passesutil_test",
     size = "small",
     srcs = ["passes_util_test.go"],
-    tags = ["broken_in_bazel"],
+    tags = ["lint"],
+    visibility = ["//build/bazelutil:__subpackages__"],
     deps = [
         "//pkg/testutils/lint/passes/forbiddenmethod",
         "//pkg/testutils/lint/passes/unconvert",

--- a/pkg/testutils/lint/passes/returnerrcheck/BUILD.bazel
+++ b/pkg/testutils/lint/passes/returnerrcheck/BUILD.bazel
@@ -19,7 +19,8 @@ go_test(
     size = "small",
     srcs = ["returnerrcheck_test.go"],
     data = glob(["testdata/**"]),
-    tags = ["broken_in_bazel"],
+    tags = ["lint"],
+    visibility = ["//build/bazelutil:__subpackages__"],
     deps = [
         ":returnerrcheck",
         "//pkg/testutils/skip",

--- a/pkg/testutils/lint/passes/timer/BUILD.bazel
+++ b/pkg/testutils/lint/passes/timer/BUILD.bazel
@@ -17,7 +17,8 @@ go_test(
     size = "small",
     srcs = ["timer_test.go"],
     data = glob(["testdata/**"]),
-    tags = ["broken_in_bazel"],
+    tags = ["lint"],
+    visibility = ["//build/bazelutil:__subpackages__"],
     deps = [
         ":timer",
         "//pkg/testutils/skip",

--- a/pkg/testutils/lint/passes/unconvert/BUILD.bazel
+++ b/pkg/testutils/lint/passes/unconvert/BUILD.bazel
@@ -18,7 +18,8 @@ go_test(
     size = "small",
     srcs = ["unconvert_test.go"],
     data = glob(["testdata/**"]),
-    tags = ["broken_in_bazel"],
+    tags = ["lint"],
+    visibility = ["//build/bazelutil:__subpackages__"],
     deps = [
         ":unconvert",
         "//pkg/testutils/skip",


### PR DESCRIPTION
    I tried to get these tests working in the Bazel sandbox (for posterity:
    https://github.com/rickystewart/cockroach/tree/lint_take2), but it's
    pretty difficult IMO -- I don't really think it's feasible, and if it
    can be done, we'll have to resort to a bunch of ugly hacks that I think
    will end up being pretty troublesome for remote execution. So just mark
    these tests as decisively not working in Bazel, and provide an alternate
    way to run them. Notably, this will mean that they can't be in the
    normal unit test suites, can't be cached, etc. Over time we'll have more
    than a few tests that can't just be run with `bazel test`, so that's not
    *necessarily* concerning.
    
    We implement this as a series of thin `sh_binary` rules that wrap the
    test targets proper. The shell scripts set an appropriate `PATH` and
    `GOROOT`, `cd` to a subdirectory of `$BUILD_WORKSPACE_DIRECTORY`, and
    then just run the test binary with the passed-in arguments, as in:
    
        bazel run //build/bazelutil:fmtsafe_lint_tester -- -test.v
    
    Also remove the `broken_in_bazel` tag from these tests and replace them
    with a bespoke `lint` tag (they're not "broken", they just need to be
    run in this special way from now on -- this will help distinguish the
    tests that are really still broken), and deleted some useless files that
    Gazelle generated at some point in the past but don't serve a purpose.
    
    Next steps from here will include running the linter itself from a Bazel
    build.
    
    Release justification: Non-production code change
    Release note: None