### PR TITLE
lint/forbiddenmethod: improve linter hint

### DIFF
--- a/pkg/testutils/lint/passes/forbiddenmethod/analyzers.go
+++ b/pkg/testutils/lint/passes/forbiddenmethod/analyzers.go
@@ -30,7 +30,8 @@ var grpcClientConnCloseOptions = Options{
 	Package:  "google.golang.org/grpc",
 	Type:     "ClientConn",
 	Method:   "Close",
-	Hint:     "must elide the call to Close() if the ClientConn is from an *rpc.Context",
+	Hint: "must elide the call to Close() if the ClientConn is from an *rpc.Context. " +
+		"Do `grpcConn.Close() // nolint:grpcconnclose` when the conn does not come from an rpc.Context.",
 }
 
 // DescriptorMarshalAnalyzer checks for correct unmarshaling of descpb


### PR DESCRIPTION
Tell people how to bypass the linter, since in tests you probably want
to bypass it.

Release note: None
Release justification: Test only.