### PR TITLE
kvserver/closedts: improve Sender streaming

### DIFF
--- a/pkg/kv/kvserver/closedts/sidetransport/BUILD.bazel
+++ b/pkg/kv/kvserver/closedts/sidetransport/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+        "@org_golang_google_grpc//:go_default_library",
     ],
 )
 
@@ -30,10 +31,13 @@ go_test(
         "//pkg/kv/kvserver/closedts",
         "//pkg/kv/kvserver/closedts/ctpb",
         "//pkg/roachpb",
+        "//pkg/rpc",
         "//pkg/settings/cluster",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/stop",
+        "//pkg/util/syncutil",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//:go_default_library",
     ],
 )


### PR DESCRIPTION
This patch improves the Sender in two ways:

1) after RPC errors, it more convincingly avoids spinning on tripped
Dialer breakers. Before, if the stream hit an error, the connection
goroutine would loop around, generate a snapshot and try to send it. If
this attempt encoutered a tripped breaker, we'd loop again. This patch
adds a sleep to space attempts apart.

2) A stream.Send could block (when the receiver is not reading or
delivering network-level acks), and this would prevent the stopper
quiescing process (stopper.Stop would block). This patch hooks up the
stopper quiescing to the stream's context, such that the Send gets
interrupted.

Release note: None
Release justification: Bug fix in new functionality.