### PR TITLE
WIP changefeedccl: avoid out of bounds access

### DIFF
--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -528,6 +528,10 @@ func (r *avroDataRecord) RowFromBinary(buf []byte) (rowenc.EncDatumRow, error) {
 }
 
 func (r *avroDataRecord) nativeFromRow(row rowenc.EncDatumRow) (interface{}, error) {
+	if len(row) < len(r.Fields) {
+		return nil, errors.Errorf(
+			`expected row with at least %d columns got %d`, len(r.Fields), len(row))
+	}
 	avroDatums := make(map[string]interface{}, len(row))
 	for fieldIdx, field := range r.Fields {
 		d := row[r.colIdxByFieldIdx[fieldIdx]]


### PR DESCRIPTION
In #50745 we saw a panic because of an out-of-bounds array
access. This PR guards against that situation and returns an error
instead.

I haven't yet reproduced how we got into a state where the avro schema
was out of sync with the row we were encoding.

Note that we cannot do an exact length match like we do in
rowFromNative because `nativeFromRow` is also called in cases where
the columns in the row is expected to be larger than the fields in the
schema. Namely, when we are encoding just the key.

Release note: None