### PR TITLE
jobs: fix rare flake

### DIFF
--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -902,22 +902,38 @@ func (sj *StartableJob) ReportExecutionResults(
 }
 
 // CleanupOnRollback will unregister the job in the case that the creating
-// transaction has been rolled back.
+// transaction has been rolled back. It will return an assertion failure if
+// the transaction used to create this job is committed. It will return an
+// error but proceed with cleanup if the transaction is still open under
+// the assumption that this is being called due to an unrecoverable error
+// that prevented the transaction from being cleaned up.
 func (sj *StartableJob) CleanupOnRollback(ctx context.Context) error {
-	if sj.txn.IsCommitted() {
+
+	if sj.txn.IsCommitted() && ctx.Err() == nil {
 		return errors.AssertionFailedf(
 			"cannot call CleanupOnRollback for a StartableJob created by a committed transaction")
 	}
-	if !sj.txn.Sender().TxnStatus().IsFinalized() {
-		return errors.AssertionFailedf(
-			"cannot call CleanupOnRollback for a StartableJob with a non-finalized transaction")
-	}
+
+	// Note that we check the context error because when a context is canceled in
+	// (*kv.DB).Txn() we move the cleanup to async. That async cleanup may not
+	// have happened either due to a race or due to the server shutting down.
+	// Another issue is that the cleanup may fail with an ambiguous error due to
+	// networking problems leading the transaction in an undefined state.
+	// Given that, proceed to clean up regardless.
+
 	sj.registry.unregister(sj.ID())
 	if sj.span != nil {
 		sj.span.Finish()
 	}
 	if sj.cancel != nil {
 		sj.cancel()
+	}
+
+	// This is an error, but it's likely due to some shutdown behavior so do not
+	// mark it as an assertion failure.
+	if !sj.txn.Sender().TxnStatus().IsFinalized() && ctx.Err() == nil {
+		return errors.New(
+			"cannot call CleanupOnRollback for a StartableJob with a non-finalized transaction")
 	}
 	return nil
 }


### PR DESCRIPTION
When the server is shutting down we can get a combination of behaviors that
leads to a span being leaked. Namely, when a context is canceled, code to
cleanup a transaction becomes async and then may not run because the stopper
is shutting down. That means that attempts to clean up the span would fail.

```
W210304 13:36:53.486245 46608 sql/create_stats.go:146  [intExec=create-stats] 13285  failed to cleanup StartableJob: cannot call CleanupOnRollback for a StartableJob with a non-finalized transaction
```

This change makes sure we always clean up the spans if the context has
been canceled.

Release justification: bug fixes to new functionality

Release note: None