### PR TITLE
sql/catalog/lease: revert fallback change and fallback also when doing by-id lookups

### DIFF
--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -224,10 +224,12 @@ type Collection struct {
 }
 
 // getLeasedDescriptorByName return a leased descriptor valid for the
-// transaction, acquiring one if necessary.
+// transaction, acquiring one if necessary. Due to a bug in lease acquisition
+// for dropped descriptors, the descriptor may have to be read from the store,
+// in which case shouldReadFromStore will be true.
 func (tc *Collection) getLeasedDescriptorByName(
 	ctx context.Context, txn *kv.Txn, parentID descpb.ID, parentSchemaID descpb.ID, name string,
-) (desc catalog.Descriptor, err error) {
+) (desc catalog.Descriptor, shouldReadFromStore bool, err error) {
 	// First, look to see if we already have the descriptor.
 	// This ensures that, once a SQL transaction resolved name N to id X, it will
 	// continue to use N to refer to X even if N is renamed during the
@@ -236,15 +238,22 @@ func (tc *Collection) getLeasedDescriptorByName(
 		if log.V(2) {
 			log.Eventf(ctx, "found descriptor in collection for '%s'", name)
 		}
-		return desc, nil
+		return desc, false, nil
 	}
 
 	readTimestamp := txn.ReadTimestamp()
 	desc, expiration, err := tc.leaseMgr.AcquireByName(ctx, readTimestamp, parentID, parentSchemaID, name)
 	if err != nil {
+		// Read the descriptor from the store in the face of some specific errors
+		// because of a known limitation of AcquireByName. See the known
+		// limitations of AcquireByName for details.
+		if catalog.HasInactiveDescriptorError(err) ||
+			errors.Is(err, catalog.ErrDescriptorNotFound) {
+			return nil, true, nil
+		}
 		// Lease acquisition failed with some other error. This we don't
 		// know how to deal with, so propagate the error.
-		return nil, err
+		return nil, false, err
 	}
 
 	if expiration.LessEq(readTimestamp) {
@@ -261,7 +270,7 @@ func (tc *Collection) getLeasedDescriptorByName(
 	// timestamp, so we need to set a deadline on the transaction to prevent it
 	// from committing beyond the version's expiration time.
 	txn.UpdateDeadlineMaybe(ctx, expiration)
-	return desc, nil
+	return desc, false, nil
 }
 
 // getLeasedDescriptorByID return a leased descriptor valid for the transaction,
@@ -409,14 +418,14 @@ func (tc *Collection) getDatabaseByName(
 				ctx, txn, tc.codec(), keys.RootNamespaceID, keys.RootNamespaceID, name, mutable)
 		}
 
-		desc, err := tc.getLeasedDescriptorByName(
+		desc, shouldReadFromStore, err := tc.getLeasedDescriptorByName(
 			ctx, txn, keys.RootNamespaceID, keys.RootNamespaceID, name)
 		if err != nil {
-			if errors.Is(err, catalog.ErrDescriptorNotFound) ||
-				errors.Is(err, catalog.ErrDescriptorDropped) {
-				err = nil
-			}
 			return false, nil, err
+		}
+		if shouldReadFromStore {
+			return tc.getDescriptorFromStore(
+				ctx, txn, tc.codec(), keys.RootNamespaceID, keys.RootNamespaceID, name, mutable)
 		}
 		return true, desc, nil
 	}
@@ -511,14 +520,14 @@ func (tc *Collection) getObjectByName(
 			ctx, txn, tc.codec(), dbID, schemaID, objectName, mutable)
 	}
 
-	desc, err := tc.getLeasedDescriptorByName(
+	desc, shouldReadFromStore, err := tc.getLeasedDescriptorByName(
 		ctx, txn, dbID, schemaID, objectName)
 	if err != nil {
-		if errors.Is(err, catalog.ErrDescriptorNotFound) ||
-			errors.Is(err, catalog.ErrDescriptorDropped) {
-			err = nil
-		}
 		return false, nil, err
+	}
+	if shouldReadFromStore {
+		return tc.getDescriptorFromStore(
+			ctx, txn, tc.codec(), dbID, schemaID, objectName, mutable)
 	}
 	return true, desc, nil
 }
@@ -719,8 +728,7 @@ func (tc *Collection) getUserDefinedSchemaByName(
 		// before the schema change has returned results.
 		desc, err := tc.getDescriptorByID(ctx, txn, schemaInfo.ID, flags, mutable)
 		if err != nil {
-			if errors.Is(err, catalog.ErrDescriptorNotFound) ||
-				errors.Is(err, catalog.ErrDescriptorDropped) {
+			if errors.Is(err, catalog.ErrDescriptorNotFound) {
 				return false, nil, nil
 			}
 			return false, nil, err

--- a/pkg/sql/catalog/errors.go
+++ b/pkg/sql/catalog/errors.go
@@ -72,6 +72,12 @@ func NewInactiveDescriptorError(err error) error {
 	return &inactiveDescriptorError{err}
 }
 
+// HasInactiveDescriptorError returns true if the error contains an
+// inactiveDescriptorError.
+func HasInactiveDescriptorError(err error) bool {
+	return errors.HasType(err, (*inactiveDescriptorError)(nil))
+}
+
 // ErrDescriptorNotFound is returned to signal that a descriptor could not be
 // found with the given id.
 var ErrDescriptorNotFound = errors.New("descriptor not found")

--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -83,7 +83,6 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/randutil",
         "//pkg/util/retry",
-        "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",

--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -83,6 +83,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/randutil",
         "//pkg/util/retry",
+        "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -185,24 +185,6 @@ func (s storage) jitteredLeaseDuration() time.Duration {
 		2*s.leaseJitterFraction*rand.Float64()))
 }
 
-// nonPublicDescriptorError is returned from the attempt to acquire a lease
-// when the descriptor is found to be in a non-public state. This means that
-// it cannot be leased, however, the Manager can utilize this to update
-// the descriptorState and to also guide calls to Acquire with a timestamp
-// preceding the drop.
-type nonPublicDescriptorError struct {
-	cause error
-	desc  catalog.Descriptor
-}
-
-func (e *nonPublicDescriptorError) Error() string {
-	return e.cause.Error()
-}
-
-func (e *nonPublicDescriptorError) Cause() error {
-	return e.cause
-}
-
 // acquire a lease on the most recent version of a descriptor. If the lease
 // cannot be obtained because the descriptor is in the process of being dropped
 // or offline (currently only applicable to tables), the error will be of type
@@ -240,7 +222,7 @@ func (s storage) acquire(
 		if err := catalog.FilterDescriptorState(
 			desc, tree.CommonLookupFlags{}, // filter all non-public state
 		); err != nil {
-			return &nonPublicDescriptorError{cause: err, desc: desc}
+			return err
 		}
 		// Once the descriptor is set it is immutable and care must be taken
 		// to not modify it.
@@ -879,21 +861,7 @@ func (t *descriptorState) removeInactiveVersions() []*storedLease {
 // The boolean returned is true if this call was actually responsible for the
 // lease acquisition.
 func acquireNodeLease(ctx context.Context, m *Manager, id descpb.ID) (bool, error) {
-	upsertDescriptorAndMaybeDropLease := func(ctx context.Context, desc *descriptorVersionState, takenOffline bool) error {
-		t := m.findDescriptorState(id, false /* create */)
-		t.mu.Lock()
-		defer t.mu.Unlock()
-		t.mu.takenOffline = takenOffline
-		toRelease, err := t.upsertLocked(ctx, desc)
-		if err != nil {
-			return err
-		}
-		m.names.insert(desc)
-		if toRelease != nil {
-			releaseLease(toRelease, m)
-		}
-		return nil
-	}
+	var toRelease *storedLease
 	resultChan, didAcquire := m.storage.group.DoChan(fmt.Sprintf("acquire%d", id), func() (interface{}, error) {
 		// Note that we use a new `context` here to avoid a situation where a cancellation
 		// of the first context cancels other callers to the `acquireNodeLease()` method,
@@ -910,27 +878,20 @@ func acquireNodeLease(ctx context.Context, m *Manager, id descpb.ID) (bool, erro
 			minExpiration = newest.expiration
 		}
 		desc, err := m.storage.acquire(newCtx, minExpiration, id)
-		// Deal with the case where the descriptor has been taken offline.
-		// Queries attempting to use this descriptor at a historical timestamp
-		// prior to its having been dropped would not be able to if we just surfaced
-		// this error alone.
-		if e := new(nonPublicDescriptorError); errors.As(err, &e) {
-			if err := upsertDescriptorAndMaybeDropLease(ctx, &descriptorVersionState{
-				Descriptor: e.desc,
-				expiration: e.desc.GetModificationTime(),
-			}, true /* takenOffline */); err != nil {
-				return nil, errors.CombineErrors(e,
-					errors.Wrapf(err, "upserting non-public descriptor"))
-			}
-			return nil, err
-		}
 		if err != nil {
 			return nil, err
 		}
-		if err := upsertDescriptorAndMaybeDropLease(
-			ctx, desc, false, /* takenOffline */
-		); err != nil {
+		t := m.findDescriptorState(id, false /* create */)
+		t.mu.Lock()
+		t.mu.takenOffline = false
+		defer t.mu.Unlock()
+		toRelease, err = t.upsertLocked(newCtx, desc)
+		if err != nil {
 			return nil, err
+		}
+		m.names.insert(desc)
+		if toRelease != nil {
+			releaseLease(toRelease, m)
 		}
 		return leaseToken(desc), nil
 	})
@@ -1429,6 +1390,17 @@ func (m *Manager) findNewest(id descpb.ID) *descriptorVersionState {
 // the returned descriptor. Renewal of a lease may begin in the
 // background. Renewal is done in order to prevent blocking on future
 // acquisitions.
+//
+// Known limitation: AcquireByName() calls Acquire() and therefore suffers
+// from the same limitation as Acquire (See Acquire). AcquireByName() is
+// unable to function correctly on a timestamp less than the timestamp
+// of a transaction with a DROP/TRUNCATE on the descriptor. The limitation in
+// the face of a DROP follows directly from the limitation on Acquire().
+// A TRUNCATE is implemented by changing the name -> id mapping
+// and by dropping the descriptor with the old id. While AcquireByName
+// can use the timestamp and get the correct name->id  mapping at a
+// timestamp, it uses Acquire() to get a descriptor with the corresponding
+// id and fails because the id has been dropped by the TRUNCATE.
 func (m *Manager) AcquireByName(
 	ctx context.Context,
 	timestamp hlc.Timestamp,
@@ -1577,6 +1549,12 @@ func (m *Manager) resolveName(
 // A transaction using this descriptor must ensure that its
 // commit-timestamp < expiration-time. Care must be taken to not modify
 // the returned descriptor.
+//
+// Known limitation: Acquire() can return an error after the descriptor with
+// the ID has been dropped. This is true even when using a timestamp
+// less than the timestamp of the DROP command. This is because Acquire
+// can only return an older version of a descriptor if the latest version
+// can be leased; as it stands a dropped descriptor cannot be leased.
 func (m *Manager) Acquire(
 	ctx context.Context, timestamp hlc.Timestamp, id descpb.ID,
 ) (catalog.Descriptor, hlc.Timestamp, error) {
@@ -1604,11 +1582,6 @@ func (m *Manager) Acquire(
 				_, errLease := acquireNodeLease(ctx, m, id)
 				return errLease
 			}(); err != nil {
-				// Go back around because now we know about a dropped descriptor.
-				if e := new(nonPublicDescriptorError); errors.As(err, &e) &&
-					timestamp.Less(e.desc.GetModificationTime()) {
-					continue
-				}
 				return nil, hlc.Timestamp{}, err
 			}
 

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -1929,9 +1929,8 @@ INSERT INTO t.kv VALUES ('a', 'b');
 	}
 
 	// Not sure whether run in the past and so sees clock uncertainty push.
-	// Must be a DDL as a regular DML would use the lease and not get pushed.
 	if _, err := tx1.Exec(`
-ALTER TABLE t.kv RENAME COLUMN v TO vv;
+INSERT INTO t.kv VALUES ('c', 'd');
 `); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -230,10 +230,7 @@ func checkPrivilegeForSetZoneConfig(ctx context.Context, p *planner, zs tree.Zon
 			return p.RequireAdminRole(ctx, "alter the system database")
 		}
 		_, dbDesc, err := p.Descriptors().GetImmutableDatabaseByName(ctx, p.txn,
-			string(zs.Database), tree.DatabaseLookupFlags{
-				Required:    true,
-				AvoidCached: true,
-			})
+			string(zs.Database), tree.DatabaseLookupFlags{Required: true})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR reverts https://github.com/cockroachdb/cockroach/pull/59606 and then adds the parallel fallback logic to the `ByID` resolution path. It was uncovered by the schema change workload. In particular, we were missing out on the ability to do AS OF SYSTEM TIME reads on dropped schemas or types after they had been fully dropped. 

Fixes https://github.com/cockroachdb/cockroach/issues/57487. 

Release justification: bug fixes and low-risk updates to new functionality
    
Release note: None
