### PR TITLE
sql: Require FORCE to modify protected zone config fields

### DIFF
--- a/docs/generated/sql/bnf/alter_zone_database_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_zone_database_stmt.bnf
@@ -1,4 +1,4 @@
 alter_zone_database_stmt ::=
-	'ALTER' 'DATABASE' database_name 'CONFIGURE' 'ZONE' 'USING' variable '=' 'COPY' 'FROM' 'PARENT' ( ( ',' variable '=' value | ',' variable '=' 'COPY' 'FROM' 'PARENT' ) )*
-	| 'ALTER' 'DATABASE' database_name 'CONFIGURE' 'ZONE' 'USING' variable '=' value ( ( ',' variable '=' value | ',' variable '=' 'COPY' 'FROM' 'PARENT' ) )*
-	| 'ALTER' 'DATABASE' database_name 'CONFIGURE' 'ZONE' 'DISCARD'
+	'ALTER' 'DATABASE' database_name 'CONFIGURE' 'ZONE' 'USING' variable '=' 'COPY' 'FROM' 'PARENT' ( ( ',' variable '=' value | ',' variable '=' 'COPY' 'FROM' 'PARENT' ) )* opt_force
+	| 'ALTER' 'DATABASE' database_name 'CONFIGURE' 'ZONE' 'USING' variable '=' value ( ( ',' variable '=' value | ',' variable '=' 'COPY' 'FROM' 'PARENT' ) )* opt_force
+	| 'ALTER' 'DATABASE' database_name 'CONFIGURE' 'ZONE' 'DISCARD' opt_force

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -876,6 +876,7 @@ unreserved_keyword ::=
 	| 'FILTER'
 	| 'FIRST'
 	| 'FOLLOWING'
+	| 'FORCE'
 	| 'FORCE_INDEX'
 	| 'FUNCTION'
 	| 'GENERATED'
@@ -1728,7 +1729,7 @@ alter_rename_database_stmt ::=
 	'ALTER' 'DATABASE' database_name 'RENAME' 'TO' database_name
 
 alter_zone_database_stmt ::=
-	'ALTER' 'DATABASE' database_name set_zone_config
+	'ALTER' 'DATABASE' database_name set_zone_config opt_force
 
 alter_database_owner ::=
 	'ALTER' 'DATABASE' database_name 'OWNER' 'TO' role_spec
@@ -1737,16 +1738,16 @@ alter_database_to_schema_stmt ::=
 	'ALTER' 'DATABASE' database_name 'CONVERT' 'TO' 'SCHEMA' 'WITH' 'PARENT' database_name
 
 alter_database_add_region_stmt ::=
-	'ALTER' 'DATABASE' database_name 'ADD' 'REGION' region_name
+	'ALTER' 'DATABASE' database_name 'ADD' 'REGION' region_name opt_force
 
 alter_database_drop_region_stmt ::=
-	'ALTER' 'DATABASE' database_name 'DROP' 'REGION' region_name
+	'ALTER' 'DATABASE' database_name 'DROP' 'REGION' region_name opt_force
 
 alter_database_survival_goal_stmt ::=
-	'ALTER' 'DATABASE' database_name survival_goal_clause
+	'ALTER' 'DATABASE' database_name survival_goal_clause opt_force
 
 alter_database_primary_region_stmt ::=
-	'ALTER' 'DATABASE' database_name primary_region_clause
+	'ALTER' 'DATABASE' database_name primary_region_clause opt_force
 
 alter_zone_range_stmt ::=
 	'ALTER' 'RANGE' zone_name set_zone_config
@@ -2236,6 +2237,10 @@ alter_index_cmds ::=
 
 sequence_option_list ::=
 	( sequence_option_elem ) ( ( sequence_option_elem ) )*
+
+opt_force ::=
+	'FORCE'
+	| 
 
 region_name ::=
 	name

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -1084,10 +1084,14 @@ txn_database_drop_regions  ca-central-1    true     {ca-az1,ca-az2,ca-az3}
 txn_database_drop_regions  ap-southeast-2  false    {ap-az1,ap-az2,ap-az3}
 txn_database_drop_regions  us-east-1       false    {us-az1,us-az2,us-az3}
 
+# Adding a FORCE to this second statement until we get a fix for #60620. When
+# that fix is ready, we can construct the view of the zone config as it was at
+# the beginning of the transaction, and the checks for FORCE should work again,
+# and we won't require the explicit force here.
 statement ok
 BEGIN;
 ALTER DATABASE txn_database_drop_regions DROP REGION "us-east-1";
-ALTER DATABASE txn_database_drop_regions DROP REGION "ap-southeast-2";
+ALTER DATABASE txn_database_drop_regions DROP REGION "ap-southeast-2" FORCE;
 COMMIT;
 
 query TTBT colnames

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
@@ -1,0 +1,241 @@
+# LogicTest: multiregion-9node-3region-3azs
+
+query TTTT
+SHOW REGIONS
+----
+ap-southeast-2  {ap-az1,ap-az2,ap-az3}  {}  {}
+ca-central-1    {ca-az1,ca-az2,ca-az3}  {}  {}
+us-east-1       {us-az1,us-az2,us-az3}  {}  {}
+
+statement ok
+CREATE DATABASE "mr-zone-configs" primary region "ca-central-1" regions "ap-southeast-2", "us-east-1"
+
+statement ok
+use "mr-zone-configs"
+
+statement ok
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING gc.ttlseconds = 5
+
+statement ok
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING range_min_bytes = 1000, range_max_bytes = 100000
+
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
+----
+DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
+                            range_min_bytes = 1000,
+                            range_max_bytes = 100000,
+                            gc.ttlseconds = 5,
+                            num_replicas = 5,
+                            num_voters = 3,
+                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                            voter_constraints = '[+region=ca-central-1]',
+                            lease_preferences = '[[+region=ca-central-1]]'
+
+statement error attempting to modify protected field "num_voters" of a multi-region database zone configuration
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING num_voters = 5
+
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
+----
+DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
+                            range_min_bytes = 1000,
+                            range_max_bytes = 100000,
+                            gc.ttlseconds = 5,
+                            num_replicas = 5,
+                            num_voters = 3,
+                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                            voter_constraints = '[+region=ca-central-1]',
+                            lease_preferences = '[[+region=ca-central-1]]'
+
+statement ok
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING num_voters = 5 FORCE
+
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
+----
+DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
+                            range_min_bytes = 1000,
+                            range_max_bytes = 100000,
+                            gc.ttlseconds = 5,
+                            num_replicas = 5,
+                            num_voters = 5,
+                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                            voter_constraints = '[+region=ca-central-1]',
+                            lease_preferences = '[[+region=ca-central-1]]'
+
+# Ensure all fields are blocked
+statement error attempting to modify protected field "global_reads" of a multi-region database zone configuration
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING global_reads = true
+
+statement error attempting to modify protected field "num_replicas" of a multi-region database zone configuration
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING num_replicas = 7
+
+statement error attempting to modify protected field "constraints" of a multi-region database zone configuration
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING constraints = '{+region=ap-southeast-2: 1}'
+
+statement error attempting to modify protected field "voter_constraints" of a multi-region database zone configuration
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING voter_constraints = '[+region=ap-southeast-2]'
+
+statement error attempting to modify protected field "lease_preferences" of a multi-region database zone configuration
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING lease_preferences = '[[+region=ap-southeast-2]]'
+
+# With above modified zone config, try and drop a region to get warning again
+statement error attempting to update zone configuration for database "mr-zone-configs" which contains modified field "num_voters"
+ALTER DATABASE "mr-zone-configs" DROP REGION "ap-southeast-2"
+
+statement ok
+ALTER DATABASE "mr-zone-configs" DROP REGION "ap-southeast-2" FORCE
+
+statement ok
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING global_reads = true force
+
+statement error attempting to update zone configuration for database "mr-zone-configs" which contains modified field "global_reads"
+ALTER DATABASE "mr-zone-configs" ADD REGION "ap-southeast-2"
+
+statement ok
+ALTER DATABASE "mr-zone-configs" ADD REGION "ap-southeast-2" force
+
+# Zone config is unmodified now. We don't need force.
+statement ok
+ALTER DATABASE "mr-zone-configs" DROP REGION "ap-southeast-2"
+
+statement ok
+ALTER DATABASE "mr-zone-configs" ADD REGION "ap-southeast-2" force
+
+statement ok
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING num_replicas = 7 force
+
+statement error attempting to update zone configuration for database "mr-zone-configs" which contains modified field "num_replicas"
+ALTER DATABASE "mr-zone-configs" SET PRIMARY REGION "us-east-1"
+
+statement ok
+ALTER DATABASE "mr-zone-configs" SET PRIMARY REGION "us-east-1" FORCE
+
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
+----
+DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
+                            range_min_bytes = 134217728,
+                            range_max_bytes = 536870912,
+                            gc.ttlseconds = 90000,
+                            num_replicas = 5,
+                            num_voters = 3,
+                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                            voter_constraints = '[+region=us-east-1]',
+                            lease_preferences = '[[+region=us-east-1]]'
+
+# Alter with one protected field and one unprotected field.
+statement error attempting to modify protected field "num_replicas" of a multi-region database zone configuration
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING num_replicas = 7, gc.ttlseconds = 100000
+
+statement ok
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING num_replicas = 7, gc.ttlseconds = 100000 force
+
+statement error attempting to update zone configuration for database "mr-zone-configs" which contains modified field "num_replicas"
+ALTER DATABASE "mr-zone-configs" SURVIVE REGION FAILURE
+
+statement ok
+ALTER DATABASE "mr-zone-configs" SURVIVE REGION FAILURE FORCE
+
+statement error attempting to modify protected field "constraints" of a multi-region database zone configuration
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING constraints = '{+region=us-east-1: 3}'
+
+statement ok
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING constraints = '{+region=us-east-1: 3}' FORCE
+
+statement error attempting to update zone configuration for database "mr-zone-configs" which contains modified field "constraints"
+ALTER DATABASE "mr-zone-configs" DROP REGION "ap-southeast-2"
+
+statement ok
+ALTER DATABASE "mr-zone-configs" DROP REGION "ap-southeast-2" FORCE
+
+statement error attempting to modify protected field "voter_constraints" of a multi-region database zone configuration
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING voter_constraints = '[+region=ap-southeast-2]'
+
+statement ok
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING voter_constraints = '[+region=ap-southeast-2]' FORCE
+
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
+----
+DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
+                            range_min_bytes = 134217728,
+                            range_max_bytes = 536870912,
+                            gc.ttlseconds = 90000,
+                            num_replicas = 5,
+                            num_voters = 5,
+                            constraints = '{+region=ca-central-1: 1, +region=us-east-1: 1}',
+                            voter_constraints = '[+region=ap-southeast-2]',
+                            lease_preferences = '[[+region=us-east-1]]'
+
+statement error attempting to update zone configuration for database "mr-zone-configs" which contains modified field "voter_constraints"
+ALTER DATABASE "mr-zone-configs" DROP REGION "ca-central-1"
+
+statement ok
+ALTER DATABASE "mr-zone-configs" DROP REGION "ca-central-1" FORCE
+
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
+----
+DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
+                            range_min_bytes = 134217728,
+                            range_max_bytes = 536870912,
+                            gc.ttlseconds = 90000,
+                            num_replicas = 5,
+                            num_voters = 5,
+                            constraints = '{+region=us-east-1: 1}',
+                            voter_constraints = '{+region=us-east-1: 2}',
+                            lease_preferences = '[[+region=us-east-1]]'
+
+statement error attempting to modify protected field "lease_preferences" of a multi-region database zone configuration
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING lease_preferences = '[[+region=ap-southeast-2]]'
+
+statement ok
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING lease_preferences = '[[+region=ap-southeast-2]]' FORCE
+
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
+----
+DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
+                            range_min_bytes = 134217728,
+                            range_max_bytes = 536870912,
+                            gc.ttlseconds = 90000,
+                            num_replicas = 5,
+                            num_voters = 5,
+                            constraints = '{+region=us-east-1: 1}',
+                            voter_constraints = '{+region=us-east-1: 2}',
+                            lease_preferences = '[[+region=ap-southeast-2]]'
+
+statement error attempting to update zone configuration for database "mr-zone-configs" which contains modified field "lease_preferences"
+ALTER DATABASE "mr-zone-configs" DROP REGION "us-east-1"
+
+statement ok
+ALTER DATABASE "mr-zone-configs" DROP REGION "us-east-1" FORCE
+
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
+----
+DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
+                            range_min_bytes = 134217728,
+                            range_max_bytes = 536870912,
+                            gc.ttlseconds = 90000,
+                            num_replicas = 5,
+                            num_voters = 5,
+                            constraints = '{+region=us-east-1: 1}',
+                            voter_constraints = '{+region=us-east-1: 2}',
+                            lease_preferences = '[[+region=ap-southeast-2]]'
+
+query TTTTT colnames
+SHOW DATABASES
+----
+database_name    owner  primary_region  regions  survival_goal
+defaultdb        root   NULL            {}       NULL
+mr-zone-configs  root   NULL            {}       NULL
+postgres         root   NULL            {}       NULL
+system           node   NULL            {}       NULL
+test             root   NULL            {}       NULL
+
+# FIXME: Write some more testcases here which test constraints which are longer to ensure
+# that slice checking is working (e.g. a constraints list which is much longer than what
+# the MR zone config would generate).

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -1805,10 +1805,14 @@ CREATE TABLE regional_by_row_as (
   FAMILY (cr, pk, i)
 ) LOCALITY REGIONAL BY ROW AS "cr";
 
+# Adding a FORCE to this second statement until we get a fix for #60620. When
+# that fix is ready, we can construct the view of the zone config as it was at
+# the beginning of the transaction, and the checks for FORCE should work again,
+# and we won't require the explicit force here.
 statement ok
 BEGIN;
 ALTER DATABASE add_regions_in_txn ADD REGION "us-east-1";
-ALTER DATABASE add_regions_in_txn ADD REGION "ap-southeast-2";
+ALTER DATABASE add_regions_in_txn ADD REGION "ap-southeast-2" FORCE;
 COMMIT;
 
 
@@ -2058,11 +2062,15 @@ regional_by_row_as                CREATE TABLE public.regional_by_row_as (
 ) LOCALITY REGIONAL BY ROW AS cr
 
 
+# Adding a FORCE to this second statement until we get a fix for #60620. When
+# that fix is ready, we can construct the view of the zone config as it was at
+# the beginning of the transaction, and the checks for FORCE should work again,
+# and we won't require the explicit force here.
 # Add and remove a region in the same txn.
 statement ok
 BEGIN;
 ALTER DATABASE drop_regions ADD REGION "us-east-1";
-ALTER DATABASE drop_regions DROP REGION "ap-southeast-2";
+ALTER DATABASE drop_regions DROP REGION "ap-southeast-2" FORCE;
 COMMIT;
 
 query TTT

--- a/pkg/ccl/multiregionccl/regional_by_row_test.go
+++ b/pkg/ccl/multiregionccl/regional_by_row_test.go
@@ -516,19 +516,27 @@ CREATE TABLE db.t(k INT PRIMARY KEY) LOCALITY REGIONAL BY ROW`)
 		t.Error(err)
 	}
 
+	// Adding a FORCE to this second statement until we get a fix for #60620. When
+	// that fix is ready, we can construct the view of the zone config as it was at
+	// the beginning of the transaction, and the checks for FORCE should work again,
+	// and we won't require the explicit force here.
 	_, err = sqlDB.Exec(`BEGIN;
 ALTER DATABASE db ADD REGION "us-east3";
-ALTER DATABASE db DROP REGION "us-east2";
+ALTER DATABASE db DROP REGION "us-east2" FORCE;
 COMMIT;`)
 	require.Error(t, err, "boom")
 
 	// The cleanup job should kick in and revert the changes that happened to the
 	// type descriptor in the user txn. We should eventually be able to add
 	// "us-east3" and remove "us-east2".
+	// Adding a FORCE to this second statement until we get a fix for #60620. When
+	// that fix is ready, we can construct the view of the zone config as it was at
+	// the beginning of the transaction, and the checks for FORCE should work again,
+	// and we won't require the explicit force here.
 	testutils.SucceedsSoon(t, func() error {
 		_, err = sqlDB.Exec(`BEGIN;
 	ALTER DATABASE db ADD REGION "us-east3";
-	ALTER DATABASE db DROP REGION "us-east2";
+	ALTER DATABASE db DROP REGION "us-east2" FORCE;
 	COMMIT;`)
 		return err
 	})

--- a/pkg/config/zonepb/zone.go
+++ b/pkg/config/zonepb/zone.go
@@ -597,6 +597,114 @@ func (z *ZoneConfig) CopyFromZone(other ZoneConfig, fieldList []tree.Name) {
 	}
 }
 
+// DiffWithZone diffs all specified fields of the supplied ZoneConfig, with the
+// receiver ZoneConfig. Returns true if all are equal, and false if there is a
+// difference (along with a string which represents the first difference found).
+func (z *ZoneConfig) DiffWithZone(other ZoneConfig, fieldList []tree.Name) (bool, string, error) {
+	for _, fieldName := range fieldList {
+		switch fieldName {
+		case "num_replicas":
+			if other.NumReplicas == nil && z.NumReplicas == nil {
+				continue
+			}
+			if z.NumReplicas == nil || other.NumReplicas == nil ||
+				*z.NumReplicas != *other.NumReplicas {
+				return false, "num_replicas", nil
+			}
+		case "num_voters":
+			if other.NumVoters == nil && z.NumVoters == nil {
+				continue
+			}
+			if z.NumVoters == nil || other.NumVoters == nil ||
+				*z.NumVoters != *other.NumVoters {
+				return false, "num_voters", nil
+			}
+		case "range_min_bytes":
+			if other.RangeMinBytes == nil && z.RangeMinBytes == nil {
+				continue
+			}
+			if z.RangeMinBytes == nil || other.RangeMinBytes == nil ||
+				*z.RangeMinBytes != *other.RangeMinBytes {
+				return false, "range_min_bytes", nil
+			}
+		case "range_max_bytes":
+			if other.RangeMaxBytes == nil && z.RangeMaxBytes == nil {
+				continue
+			}
+			if z.RangeMaxBytes == nil || other.RangeMaxBytes == nil ||
+				*z.RangeMaxBytes != *other.RangeMaxBytes {
+				return false, "range_max_bytes", nil
+			}
+		case "global_reads":
+			if other.GlobalReads == nil && z.GlobalReads == nil {
+				continue
+			}
+			if z.GlobalReads == nil || other.GlobalReads == nil ||
+				*z.GlobalReads != *other.GlobalReads {
+				return false, "global_reads", nil
+			}
+		case "gc.ttlseconds":
+			if other.GC == nil && z.GC == nil {
+				continue
+			}
+			if z.GC == nil || other.GC == nil || *z.GC != *other.GC {
+				return false, "gc.ttlseconds", nil
+			}
+		case "constraints":
+			if other.Constraints == nil && z.Constraints == nil {
+				continue
+			}
+			if z.Constraints == nil || other.Constraints == nil {
+				return false, "constraints", nil
+			}
+			for i, c := range z.Constraints {
+				for j, constraint := range c.Constraints {
+					if len(other.Constraints) <= i ||
+						len(other.Constraints[i].Constraints) <= j ||
+						constraint != other.Constraints[i].Constraints[j] {
+						return false, "constraints", nil
+					}
+				}
+			}
+		case "voter_constraints":
+			if other.VoterConstraints == nil && z.VoterConstraints == nil {
+				continue
+			}
+			if z.VoterConstraints == nil || other.VoterConstraints == nil {
+				return false, "voter_constraints", nil
+			}
+			for i, c := range z.VoterConstraints {
+				for j, constraint := range c.Constraints {
+					if len(other.VoterConstraints) <= i ||
+						len(other.VoterConstraints[i].Constraints) <= j ||
+						constraint != other.VoterConstraints[i].Constraints[j] {
+						return false, "voter_constraints", nil
+					}
+				}
+			}
+		case "lease_preferences":
+			if other.LeasePreferences == nil && z.LeasePreferences == nil {
+				continue
+			}
+			if z.LeasePreferences == nil || other.LeasePreferences == nil {
+				return false, "voter_constraints", nil
+			}
+			for i, c := range z.LeasePreferences {
+				for j, constraint := range c.Constraints {
+					if len(other.LeasePreferences) <= i ||
+						len(other.LeasePreferences[i].Constraints) <= j ||
+						constraint != other.LeasePreferences[i].Constraints[j] {
+						return false, "lease_preferences", nil
+					}
+				}
+			}
+		default:
+			return false, "", errors.AssertionFailedf("unknown zone configuration field %q", fieldName)
+		}
+	}
+	return true, "", nil
+}
+
 // StoreSatisfiesConstraint checks whether a store satisfies the given constraint.
 // If the constraint is of the PROHIBITED type, satisfying it means the store
 // not matching the constraint's spec.

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1385,9 +1385,13 @@ func TestParse(t *testing.T) {
 
 		{`ALTER DATABASE a RENAME TO b`},
 		{`ALTER DATABASE a ADD REGION "us-west-1"`},
+		{`ALTER DATABASE a ADD REGION "us-west-1 FORCE"`},
 		{`ALTER DATABASE a DROP REGION "us-west-1"`},
+		{`ALTER DATABASE a DROP REGION "us-west-1 FORCE"`},
 		{`ALTER DATABASE a SURVIVE REGION FAILURE`},
+		{`ALTER DATABASE a SURVIVE REGION FAILURE FORCE`},
 		{`ALTER DATABASE a PRIMARY REGION "us-west-3"`},
+		{`ALTER DATABASE a PRIMARY REGION "us-west-3 FORCE"`},
 		{`EXPLAIN ALTER DATABASE a RENAME TO b`},
 
 		{`ALTER DATABASE a OWNER TO foo`},
@@ -1540,6 +1544,7 @@ func TestParse(t *testing.T) {
 		{`ALTER RANGE meta CONFIGURE ZONE = 'foo'`},
 
 		{`ALTER DATABASE db CONFIGURE ZONE = 'foo'`},
+		{`ALTER DATABASE db CONFIGURE ZONE = 'foo' FORCE`},
 		{`EXPLAIN ALTER DATABASE db CONFIGURE ZONE = 'foo'`},
 
 		{`ALTER TABLE db.t CONFIGURE ZONE = 'foo'`},
@@ -1565,6 +1570,7 @@ func TestParse(t *testing.T) {
 		{`ALTER RANGE default CONFIGURE ZONE USING foo = bar, baz = yay`},
 		{`ALTER RANGE meta CONFIGURE ZONE USING foo = bar, baz = yay`},
 		{`ALTER DATABASE db CONFIGURE ZONE USING foo = bar, baz = yay`},
+		{`ALTER DATABASE db CONFIGURE ZONE USING foo = bar, baz = yay FORCE`},
 		{`ALTER TABLE db.t CONFIGURE ZONE USING foo = bar, baz = yay`},
 		{`ALTER PARTITION p OF TABLE db.t CONFIGURE ZONE USING foo = bar, baz = yay`},
 		{`ALTER TABLE t CONFIGURE ZONE USING foo = bar, baz = yay`},
@@ -2460,6 +2466,8 @@ $function$`,
 			`ALTER RANGE meta CONFIGURE ZONE USING "foo.bar" = yay`},
 		{`ALTER DATABASE db CONFIGURE ZONE USING foo.bar = yay`,
 			`ALTER DATABASE db CONFIGURE ZONE USING "foo.bar" = yay`},
+		{`ALTER DATABASE db CONFIGURE ZONE USING foo.bar = yay FORCE`,
+			`ALTER DATABASE db CONFIGURE ZONE USING "foo.bar" = yay FORCE`},
 		{`ALTER TABLE db.t CONFIGURE ZONE USING foo.bar = yay`,
 			`ALTER TABLE db.t CONFIGURE ZONE USING "foo.bar" = yay`},
 		{`ALTER PARTITION p OF TABLE db.t CONFIGURE ZONE USING foo.bar = yay`,

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -635,7 +635,7 @@ func (u *sqlSymUnion) objectNamePrefixList() tree.ObjectNamePrefixList {
 
 %token <str> FAILURE FALSE FAMILY FETCH FETCHVAL FETCHTEXT FETCHVAL_PATH FETCHTEXT_PATH
 %token <str> FILES FILTER
-%token <str> FIRST FLOAT FLOAT4 FLOAT8 FLOORDIV FOLLOWING FOR FORCE_INDEX FOREIGN FROM FULL FUNCTION
+%token <str> FIRST FLOAT FLOAT4 FLOAT8 FLOORDIV FOLLOWING FOR FORCE FORCE_INDEX FOREIGN FROM FULL FUNCTION
 
 %token <str> GENERATED GEOGRAPHY GEOMETRY GEOMETRYM GEOMETRYZ GEOMETRYZM
 %token <str> GEOMETRYCOLLECTION GEOMETRYCOLLECTIONM GEOMETRYCOLLECTIONZ GEOMETRYCOLLECTIONZM
@@ -1079,6 +1079,8 @@ func (u *sqlSymUnion) objectNamePrefixList() tree.ObjectNamePrefixList {
 %type <bool> opt_unique opt_concurrently opt_cluster opt_without_index
 %type <bool> opt_index_access_method
 
+%type <bool> opt_force
+
 %type <*tree.Limit> limit_clause offset_clause opt_limit_clause
 %type <tree.Expr> select_fetch_first_value
 %type <empty> row_or_rows
@@ -1508,46 +1510,51 @@ alter_database_owner:
   }
 
 alter_database_add_region_stmt:
-  ALTER DATABASE database_name ADD REGION region_name
+  ALTER DATABASE database_name ADD REGION region_name opt_force
   {
     $$.val = &tree.AlterDatabaseAddRegion{
       Name: tree.Name($3),
       Region: tree.Name($6),
+      Force: $7.bool(),
     }
   }
 
 alter_database_drop_region_stmt:
-  ALTER DATABASE database_name DROP REGION region_name
+  ALTER DATABASE database_name DROP REGION region_name opt_force
   {
     $$.val = &tree.AlterDatabaseDropRegion{
       Name: tree.Name($3),
       Region: tree.Name($6),
+      Force: $7.bool(),
     }
   }
 
 alter_database_survival_goal_stmt:
-  ALTER DATABASE database_name survival_goal_clause
+  ALTER DATABASE database_name survival_goal_clause opt_force
   {
     $$.val = &tree.AlterDatabaseSurvivalGoal{
       Name: tree.Name($3),
       SurvivalGoal: $4.survivalGoal(),
+      Force: $5.bool(),
     }
   }
 
 alter_database_primary_region_stmt:
-  ALTER DATABASE database_name primary_region_clause
+  ALTER DATABASE database_name primary_region_clause opt_force
   {
     $$.val = &tree.AlterDatabasePrimaryRegion{
       Name: tree.Name($3),
       PrimaryRegion: tree.Name($4),
+      Force: $5.bool(),
     }
   }
-| ALTER DATABASE database_name SET primary_region_clause
+| ALTER DATABASE database_name SET primary_region_clause opt_force
   {
     /* SKIP DOC */
     $$.val = &tree.AlterDatabasePrimaryRegion{
       Name: tree.Name($3),
       PrimaryRegion: tree.Name($5),
+      Force: $6.bool(),
     }
   }
 
@@ -1750,10 +1757,11 @@ set_zone_config:
   }
 
 alter_zone_database_stmt:
-  ALTER DATABASE database_name set_zone_config
+  ALTER DATABASE database_name set_zone_config opt_force
   {
      s := $4.setZoneConfig()
      s.ZoneSpecifier = tree.ZoneSpecifier{Database: tree.Name($3)}
+     s.Force = $5.bool()
      $$.val = s
   }
 
@@ -1821,6 +1829,17 @@ alter_zone_partition_stmt:
     err = errors.WithHint(err, "try ALTER PARTITION <partition> OF INDEX <tablename>@*")
     return setErr(sqllex, err)
   }
+
+opt_force:
+  FORCE
+  {
+    $$.val = true
+  }
+| /* EMPTY */
+  {
+    $$.val = false
+  }
+
 
 var_set_list:
   var_name '=' COPY FROM PARENT
@@ -12467,6 +12486,7 @@ unreserved_keyword:
 | FILTER
 | FIRST
 | FOLLOWING
+| FORCE
 | FORCE_INDEX
 | FUNCTION
 | GENERATED

--- a/pkg/sql/sem/tree/alter_database.go
+++ b/pkg/sql/sem/tree/alter_database.go
@@ -32,6 +32,7 @@ func (node *AlterDatabaseOwner) Format(ctx *FmtCtx) {
 type AlterDatabaseAddRegion struct {
 	Name   Name
 	Region Name
+	Force  bool
 }
 
 var _ Statement = &AlterDatabaseAddRegion{}
@@ -42,12 +43,16 @@ func (node *AlterDatabaseAddRegion) Format(ctx *FmtCtx) {
 	ctx.FormatNode(&node.Name)
 	ctx.WriteString(" ADD REGION ")
 	ctx.FormatNode(&node.Region)
+	if node.Force {
+		ctx.WriteString(" FORCE")
+	}
 }
 
 // AlterDatabaseDropRegion represents a ALTER DATABASE DROP REGION statement.
 type AlterDatabaseDropRegion struct {
 	Name   Name
 	Region Name
+	Force  bool
 }
 
 var _ Statement = &AlterDatabaseDropRegion{}
@@ -58,12 +63,16 @@ func (node *AlterDatabaseDropRegion) Format(ctx *FmtCtx) {
 	ctx.FormatNode(&node.Name)
 	ctx.WriteString(" DROP REGION ")
 	ctx.FormatNode(&node.Region)
+	if node.Force {
+		ctx.WriteString(" FORCE")
+	}
 }
 
 // AlterDatabasePrimaryRegion represents a ALTER DATABASE PRIMARY REGION ... statement.
 type AlterDatabasePrimaryRegion struct {
 	Name          Name
 	PrimaryRegion Name
+	Force         bool
 }
 
 var _ Statement = &AlterDatabasePrimaryRegion{}
@@ -74,12 +83,16 @@ func (node *AlterDatabasePrimaryRegion) Format(ctx *FmtCtx) {
 	ctx.FormatNode(&node.Name)
 	ctx.WriteString(" PRIMARY REGION ")
 	node.PrimaryRegion.Format(ctx)
+	if node.Force {
+		ctx.WriteString(" FORCE")
+	}
 }
 
 // AlterDatabaseSurvivalGoal represents a ALTER DATABASE SURVIVE ... statement.
 type AlterDatabaseSurvivalGoal struct {
 	Name         Name
 	SurvivalGoal SurvivalGoal
+	Force        bool
 }
 
 var _ Statement = &AlterDatabaseSurvivalGoal{}
@@ -90,4 +103,7 @@ func (node *AlterDatabaseSurvivalGoal) Format(ctx *FmtCtx) {
 	ctx.FormatNode(&node.Name)
 	ctx.WriteString(" ")
 	node.SurvivalGoal.Format(ctx)
+	if node.Force {
+		ctx.WriteString(" FORCE")
+	}
 }

--- a/pkg/sql/sem/tree/zone.go
+++ b/pkg/sql/sem/tree/zone.go
@@ -21,6 +21,8 @@ type ZoneSpecifier struct {
 
 	// Partition is only respected when Table is set.
 	Partition Name
+
+	Force bool
 }
 
 // TelemetryName returns a name fitting for telemetry purposes.
@@ -141,5 +143,8 @@ func (node *SetZoneConfig) Format(ctx *FmtCtx) {
 				ctx.WriteString(` = COPY FROM PARENT`)
 			}
 		}
+	}
+	if node.Force {
+		ctx.WriteString(" FORCE")
 	}
 }

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -131,6 +131,17 @@ func (p *planner) SetZoneConfig(ctx context.Context, n *tree.SetZoneConfig) (pla
 		return nil, errorutil.UnsupportedWithMultiTenancy(multitenancyZoneCfgIssueNo)
 	}
 
+	if n.Database != "" {
+		if err := p.CheckZoneConfigChangePermittedForMultiRegionDatabase(
+			ctx,
+			n.Database,
+			n.Options,
+			n.Force,
+		); err != nil {
+			return nil, err
+		}
+	}
+
 	var yamlConfig tree.TypedExpr
 
 	if n.YAMLConfig != nil {


### PR DESCRIPTION
With the introduction of the multi-region simplification in 21.1, there
are a set of fields in the zone configurations which are protected by the
system. These fields are transparently modified by the system when
certain multi-region abstractions are used (e.g. when a region is added
to the database, the constraints field is modified to add the new
region). Due the protected status of these field, we want to prevent
users from setting them if they're not aware of the impact in doing so
(that they could be overwritten by the system, and that they could
result in sub-optimal performance). To make this more explicit to users,
we block modifications to these fields and if the users wish to modify
them anyway, they must provide a FORCE argument along with the
modification statement. This impacts both the setting of the field in
the zone configuration, as well as any eventual multi-region statement
which follows and will result in over-writing the user's zone
configuration update.

Release justification: Prevent bad user experience with new feature.

Release note (sql change): Updates to certain fields in the zone
configurations are blocked for multi-region enabled databases. This
block can be overridden through the use of the FORCE keyword on the
blocked statement.

Resolves #60447 