### PR TITLE
sql: add a regression test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -746,3 +746,7 @@ SELECT * FROM crdb_internal.jobs
 # Cleanup
 statement ok
 SET disallow_full_table_scans = false
+
+# Regression test for #58104.
+statement ok
+SELECT * FROM pg_catalog.pg_attrdef WHERE (adnum = 1 AND adrelid = 1) OR (adbin = 'foo' AND adrelid = 2)


### PR DESCRIPTION
This commit adds a regression test for #58104 (the problem was already
fixed).

Resolves #58104.

Release justification: non-production code change.

Release note: None