### PR TITLE
server,gossip: Store generated join tokens in gossip

### DIFF
--- a/pkg/gossip/keys.go
+++ b/pkg/gossip/keys.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 )
 
@@ -91,6 +92,11 @@ const (
 	// stmtDiagnosticsRequestRegistry listens for notifications and responds by
 	// polling for new requests.
 	KeyGossipStatementDiagnosticsRequest = "stmt-diag-req"
+
+	// KeyJoinTokenPrefix is the prefix for keys that indicate a join token, as
+	// part of the node join TLS handshake process. The key for a join token
+	// is overwritten once it's used.
+	KeyJoinTokenPrefix = "join-token"
 )
 
 // MakeKey creates a canonical key under which to gossip a piece of
@@ -210,4 +216,10 @@ func removePrefixFromKey(key, prefix string) (string, error) {
 		return "", errors.Errorf("%q does not have expected prefix %q%s", key, prefix, separator)
 	}
 	return trimmedKey, nil
+}
+
+// MakeJoinTokenKey returns the gossip key for a join token, based on the join
+// token's ID (a UUID).
+func MakeJoinTokenKey(id uuid.UUID) string {
+	return MakeKey(KeyJoinTokenPrefix, id.String())
 }

--- a/pkg/server/join_token.go
+++ b/pkg/server/join_token.go
@@ -18,6 +18,7 @@ import (
 	"hash/crc32"
 	"io/ioutil"
 	"math/rand"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -30,6 +31,9 @@ import (
 const (
 	// Length of the join token shared secret.
 	joinTokenSecretLen = 16
+
+	// Default TTL for join tokens.
+	joinTokenDefaultTTL = 10 * time.Minute
 )
 
 // joinToken is a container for a tokenID and associated sharedSecret for use
@@ -71,8 +75,7 @@ func (j *joinToken) sign(caCert []byte) {
 func (j *joinToken) verifySignature(caCert []byte) bool {
 	signer := hmac.New(sha256.New, j.sharedSecret)
 	_, _ = signer.Write(caCert)
-	// TODO(aaron-crl): Avoid timing attacks here.
-	return bytes.Equal(signer.Sum(nil), j.fingerprint)
+	return hmac.Equal(signer.Sum(nil), j.fingerprint)
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2559,5 +2559,9 @@ func (s *statusServer) GenerateJoinToken(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "error when marshaling join token")
 	}
+	if err := s.gossip.AddInfo(
+		gossip.MakeJoinTokenKey(jt.tokenID), token, joinTokenDefaultTTL); err != nil {
+		return "", errors.Wrap(err, "error when gossiping join token")
+	}
 	return string(token), nil
 }


### PR DESCRIPTION
When a join token is generated, gossip it among other connected
nodes with a short TTL. This allows that join token to be used
when connecting to any node in the cluster, and not necessarily
to the same node where the join token was generated.

Also add an isValid function to the join token to confirm (on
the receiver end) that the join token matches what was stored
in gossip.

First commit is #61505. Part of #60632.

Release justification: Changes to new code paths, gated behind
experimental feature flag.
Release note: None.