### PR TITLE
kvprober: add metrics to the registry & catalog

### DIFF
--- a/pkg/kv/kvprober/kvprober_integration_test.go
+++ b/pkg/kv/kvprober/kvprober_integration_test.go
@@ -53,8 +53,8 @@ func TestProberDoesReads(t *testing.T) {
 
 		time.Sleep(100 * time.Millisecond)
 
-		require.Zero(t, p.Metrics.ProbePlanAttempts.Count())
-		require.Zero(t, p.Metrics.ReadProbeAttempts.Count())
+		require.Zero(t, p.Metrics().ProbePlanAttempts.Count())
+		require.Zero(t, p.Metrics().ReadProbeAttempts.Count())
 	})
 
 	t.Run("happy path", func(t *testing.T) {
@@ -67,13 +67,13 @@ func TestProberDoesReads(t *testing.T) {
 		require.NoError(t, p.Start(ctx, s.Stopper()))
 
 		testutils.SucceedsSoon(t, func() error {
-			if p.Metrics.ReadProbeAttempts.Count() < int64(50) {
-				return errors.Newf("probe count too low: %v", p.Metrics.ReadProbeAttempts.Count())
+			if p.Metrics().ReadProbeAttempts.Count() < int64(50) {
+				return errors.Newf("probe count too low: %v", p.Metrics().ReadProbeAttempts.Count())
 			}
 			return nil
 		})
-		require.Zero(t, p.Metrics.ReadProbeFailures.Count())
-		require.Zero(t, p.Metrics.ProbePlanFailures.Count())
+		require.Zero(t, p.Metrics().ReadProbeFailures.Count())
+		require.Zero(t, p.Metrics().ProbePlanFailures.Count())
 	})
 
 	t.Run("a single range is unavailable", func(t *testing.T) {
@@ -101,12 +101,12 @@ func TestProberDoesReads(t *testing.T) {
 		// TODO(josh): Once structured logging is in, can check that failures
 		// involved only the time-series range.
 		testutils.SucceedsSoon(t, func() error {
-			if p.Metrics.ReadProbeFailures.Count() < int64(2) {
-				return errors.Newf("error count too low: %v", p.Metrics.ReadProbeFailures.Count())
+			if p.Metrics().ReadProbeFailures.Count() < int64(2) {
+				return errors.Newf("error count too low: %v", p.Metrics().ReadProbeFailures.Count())
 			}
 			return nil
 		})
-		require.Zero(t, p.Metrics.ProbePlanFailures.Count())
+		require.Zero(t, p.Metrics().ProbePlanFailures.Count())
 	})
 
 	t.Run("all ranges are unavailable for Gets", func(t *testing.T) {
@@ -148,9 +148,9 @@ func TestProberDoesReads(t *testing.T) {
 		}
 
 		// Expect all probes to fail but planning to succeed.
-		require.Equal(t, int64(10), p.Metrics.ReadProbeAttempts.Count())
-		require.Equal(t, int64(10), p.Metrics.ReadProbeFailures.Count())
-		require.Zero(t, p.Metrics.ProbePlanFailures.Count())
+		require.Equal(t, int64(10), p.Metrics().ReadProbeAttempts.Count())
+		require.Equal(t, int64(10), p.Metrics().ReadProbeFailures.Count())
+		require.Zero(t, p.Metrics().ProbePlanFailures.Count())
 	})
 }
 

--- a/pkg/kv/kvprober/kvprober_test.go
+++ b/pkg/kv/kvprober/kvprober_test.go
@@ -40,10 +40,10 @@ func TestProbe(t *testing.T) {
 
 		p.probe(ctx, m)
 
-		require.Zero(t, p.Metrics.ProbePlanAttempts.Count())
-		require.Zero(t, p.Metrics.ReadProbeAttempts.Count())
-		require.Zero(t, p.Metrics.ProbePlanFailures.Count())
-		require.Zero(t, p.Metrics.ReadProbeFailures.Count())
+		require.Zero(t, p.Metrics().ProbePlanAttempts.Count())
+		require.Zero(t, p.Metrics().ReadProbeAttempts.Count())
+		require.Zero(t, p.Metrics().ProbePlanFailures.Count())
+		require.Zero(t, p.Metrics().ReadProbeFailures.Count())
 	})
 
 	t.Run("happy path", func(t *testing.T) {
@@ -53,10 +53,10 @@ func TestProbe(t *testing.T) {
 
 		p.probe(ctx, m)
 
-		require.Equal(t, int64(1), p.Metrics.ProbePlanAttempts.Count())
-		require.Equal(t, int64(1), p.Metrics.ReadProbeAttempts.Count())
-		require.Zero(t, p.Metrics.ProbePlanFailures.Count())
-		require.Zero(t, p.Metrics.ReadProbeFailures.Count())
+		require.Equal(t, int64(1), p.Metrics().ProbePlanAttempts.Count())
+		require.Equal(t, int64(1), p.Metrics().ReadProbeAttempts.Count())
+		require.Zero(t, p.Metrics().ProbePlanFailures.Count())
+		require.Zero(t, p.Metrics().ReadProbeFailures.Count())
 	})
 
 	t.Run("planning fails", func(t *testing.T) {
@@ -70,10 +70,10 @@ func TestProbe(t *testing.T) {
 
 		p.probe(ctx, m)
 
-		require.Equal(t, int64(1), p.Metrics.ProbePlanAttempts.Count())
-		require.Zero(t, p.Metrics.ReadProbeAttempts.Count())
-		require.Equal(t, int64(1), p.Metrics.ProbePlanFailures.Count())
-		require.Zero(t, p.Metrics.ReadProbeFailures.Count())
+		require.Equal(t, int64(1), p.Metrics().ProbePlanAttempts.Count())
+		require.Zero(t, p.Metrics().ReadProbeAttempts.Count())
+		require.Equal(t, int64(1), p.Metrics().ProbePlanFailures.Count())
+		require.Zero(t, p.Metrics().ReadProbeFailures.Count())
 	})
 
 	t.Run("get fails", func(t *testing.T) {
@@ -86,10 +86,10 @@ func TestProbe(t *testing.T) {
 
 		p.probe(ctx, m)
 
-		require.Equal(t, int64(1), p.Metrics.ProbePlanAttempts.Count())
-		require.Equal(t, int64(1), p.Metrics.ReadProbeAttempts.Count())
-		require.Zero(t, p.Metrics.ProbePlanFailures.Count())
-		require.Equal(t, int64(1), p.Metrics.ReadProbeFailures.Count())
+		require.Equal(t, int64(1), p.Metrics().ProbePlanAttempts.Count())
+		require.Equal(t, int64(1), p.Metrics().ReadProbeAttempts.Count())
+		require.Zero(t, p.Metrics().ProbePlanFailures.Count())
+		require.Equal(t, int64(1), p.Metrics().ReadProbeFailures.Count())
 	})
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -652,6 +652,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		Settings:                st,
 		HistogramWindowInterval: cfg.HistogramWindowInterval(),
 	})
+	registry.AddMetricStruct(kvProber.Metrics())
 
 	sqlServer, err := newSQLServer(ctx, sqlServerArgs{
 		sqlServerOptionalKVArgs: sqlServerOptionalKVArgs{

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -576,6 +576,26 @@ var charts = []sectionDescription{
 		},
 	},
 	{
+		Organization: [][]string{{KVTransactionLayer, "Prober"}}, Charts: []chartDescription{
+			{
+				Title: "Availability",
+				Metrics: []string{
+					"kv.prober.planning_attempts",
+					"kv.prober.planning_failures",
+					"kv.prober.read.attempts",
+					"kv.prober.read.failures",
+				},
+				AxisLabel: "Probes",
+			},
+			{
+				Title: "Latency",
+				Metrics: []string{
+					"kv.prober.read.latency",
+				},
+			},
+		},
+	},
+	{
 		Organization: [][]string{
 			{KVTransactionLayer, "Clocks"},
 			{Process, "Clocks"},


### PR DESCRIPTION
https://github.com/cockroachdb/cockroach/issues/61074

**kvprober: add metrics to the registry & catalog**

This commit adds the kvprober metrics to the registry so they are
exported at the prometheus endpoint and tracked in CRDB's time-series
DB. This commit also adds the kvprober metrics to the catalog since
that is required by a unit test.

Release justification: Auxiliary system that is off by default.
Release note: None.