### PR TITLE
geomfn: simplify InEpsilon checks in tests

### DIFF
--- a/pkg/geo/geomfn/affine_transforms_test.go
+++ b/pkg/geo/geomfn/affine_transforms_test.go
@@ -423,14 +423,7 @@ func TestRotate(t *testing.T) {
 			actual, err := Rotate(geometry, tc.rotRadians)
 			require.NoError(t, err)
 
-			// Compare FlatCoords and assert they are within epsilon.
-			// This is because they exact matches may encounter rounding issues.
-			actualGeomT, err := actual.AsGeomT()
-			require.NoError(t, err)
-			require.Equal(t, tc.expected.SRID(), actualGeomT.SRID())
-			require.Equal(t, tc.expected.Layout(), actualGeomT.Layout())
-			require.IsType(t, tc.expected, actualGeomT)
-			require.InEpsilonSlice(t, tc.expected.FlatCoords(), actualGeomT.FlatCoords(), 0.00001)
+			requireGeometryWithinEpsilon(t, requireGeometryFromGeomT(t, tc.expected), actual, 1e-5)
 		})
 	}
 }
@@ -530,15 +523,8 @@ func TestRotateWithPointOrigin(t *testing.T) {
 				require.EqualError(t, err, tt.wantErrStr)
 			} else {
 				require.NoError(t, err)
+				requireGeometryWithinEpsilon(t, requireGeometryFromGeomT(t, tt.wantGeom), got, 1e-5)
 			}
-			// Compare FlatCoords and assert they are within epsilon.
-			// This is because they exact matches may encounter rounding issues.
-			actualGeomT, err := got.AsGeomT()
-			require.NoError(t, err)
-			require.Equal(t, tt.wantGeom.SRID(), actualGeomT.SRID())
-			require.Equal(t, tt.wantGeom.Layout(), actualGeomT.Layout())
-			require.IsType(t, tt.wantGeom, actualGeomT)
-			require.InEpsilonSlice(t, tt.wantGeom.FlatCoords(), actualGeomT.FlatCoords(), 0.00001)
 		})
 	}
 }
@@ -683,14 +669,7 @@ func TestRotateX(t *testing.T) {
 			actual, err := RotateX(geometry, tc.rotRadians)
 			require.NoError(t, err)
 
-			// Compare FlatCoords and assert they are within epsilon.
-			// This is because they exact matches may encounter rounding issues.
-			actualGeomT, err := actual.AsGeomT()
-			require.NoError(t, err)
-			require.Equal(t, tc.expected.SRID(), actualGeomT.SRID())
-			require.Equal(t, tc.expected.Layout(), actualGeomT.Layout())
-			require.IsType(t, tc.expected, actualGeomT)
-			require.InEpsilonSlice(t, tc.expected.FlatCoords(), actualGeomT.FlatCoords(), 0.00001)
+			requireGeometryWithinEpsilon(t, requireGeometryFromGeomT(t, tc.expected), actual, 1e-5)
 		})
 	}
 }
@@ -765,15 +744,7 @@ func TestRotateY(t *testing.T) {
 
 			actual, err := RotateY(geometry, tc.rotRadians)
 			require.NoError(t, err)
-
-			// Compare FlatCoords and assert they are within epsilon.
-			// This is because they exact matches may encounter rounding issues.
-			actualGeomT, err := actual.AsGeomT()
-			require.NoError(t, err)
-			require.Equal(t, tc.expected.SRID(), actualGeomT.SRID())
-			require.Equal(t, tc.expected.Layout(), actualGeomT.Layout())
-			require.IsType(t, tc.expected, actualGeomT)
-			require.InEpsilonSlice(t, tc.expected.FlatCoords(), actualGeomT.FlatCoords(), 0.00001)
+			requireGeometryWithinEpsilon(t, requireGeometryFromGeomT(t, tc.expected), actual, 1e-5)
 		})
 	}
 }
@@ -848,15 +819,7 @@ func TestRotateZ(t *testing.T) {
 
 			actual, err := RotateZ(geometry, tc.rotRadians)
 			require.NoError(t, err)
-
-			// Compare FlatCoords and assert they are within epsilon.
-			// This is because they exact matches may encounter rounding issues.
-			actualGeomT, err := actual.AsGeomT()
-			require.NoError(t, err)
-			require.Equal(t, tc.expected.SRID(), actualGeomT.SRID())
-			require.Equal(t, tc.expected.Layout(), actualGeomT.Layout())
-			require.IsType(t, tc.expected, actualGeomT)
-			require.InEpsilonSlice(t, tc.expected.FlatCoords(), actualGeomT.FlatCoords(), 0.00001)
+			requireGeometryWithinEpsilon(t, requireGeometryFromGeomT(t, tc.expected), actual, 1e-5)
 		})
 	}
 }

--- a/pkg/geo/geomfn/distance_test.go
+++ b/pkg/geo/geomfn/distance_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/geo"
 	"github.com/cockroachdb/cockroach/pkg/geo/geos"
 	"github.com/stretchr/testify/require"
-	"github.com/twpayne/go-geom"
 )
 
 var distanceTestCases = []struct {
@@ -979,18 +978,12 @@ func TestClosestPoint(t *testing.T) {
 			gB, err := geo.ParseGeometry(tc.geomB)
 			require.NoError(t, err)
 
-			ret, err := ClosestPoint(gA, gB)
-			require.NoError(t, err)
-			retAsGeomT, err := ret.AsGeomT()
-			require.NoError(t, err)
-
 			expected, err := geo.ParseGeometry(tc.expected)
 			require.NoError(t, err)
-			expectedAsGeomT, err := expected.AsGeomT()
+			ret, err := ClosestPoint(gA, gB)
 			require.NoError(t, err)
 
-			require.InEpsilon(t, expectedAsGeomT.(*geom.Point).X(), retAsGeomT.(*geom.Point).X(), 2e-10)
-			require.InEpsilon(t, expectedAsGeomT.(*geom.Point).Y(), retAsGeomT.(*geom.Point).Y(), 2e-10)
+			requireGeometryWithinEpsilon(t, expected, ret, 2e-10)
 		})
 	}
 

--- a/pkg/geo/geomfn/geomfn_test.go
+++ b/pkg/geo/geomfn/geomfn_test.go
@@ -14,7 +14,9 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
+	"github.com/twpayne/go-geom"
 )
 
 var mismatchingSRIDGeometryA = geo.MustParseGeometry("SRID=4004;POINT(1.0 1.0)")
@@ -125,5 +127,52 @@ func TestRemoveConsecutivePointsFromGeomT(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, expectedT, actual)
 		})
+	}
+}
+
+func requireGeometryFromGeomT(t *testing.T, g geom.T) geo.Geometry {
+	ret, err := geo.MakeGeometryFromGeomT(g)
+	require.NoError(t, err)
+	return ret
+}
+
+// requireGeometryWithinEpsilon and ensures the geometry shape and SRID are equal,
+// and that each coordinate is within the provided epsilon.
+func requireGeometryWithinEpsilon(t *testing.T, expected, got geo.Geometry, epsilon float64) {
+	expectedT, err := expected.AsGeomT()
+	require.NoError(t, err)
+	gotT, err := got.AsGeomT()
+	require.NoError(t, err)
+	requireGeomTWithinEpsilon(t, expectedT, gotT, epsilon)
+}
+
+func requireGeomTWithinEpsilon(t *testing.T, expectedT, gotT geom.T, epsilon float64) {
+	require.Equal(t, expectedT.SRID(), gotT.SRID())
+	require.Equal(t, expectedT.Layout(), gotT.Layout())
+	require.IsType(t, expectedT, gotT)
+	switch lhs := expectedT.(type) {
+	case *geom.Point, *geom.LineString:
+		require.InEpsilonSlice(t, expectedT.FlatCoords(), gotT.FlatCoords(), epsilon)
+	case *geom.MultiPoint, *geom.Polygon, *geom.MultiLineString:
+		require.Equal(t, expectedT.Ends(), gotT.Ends())
+		require.InEpsilonSlice(t, expectedT.FlatCoords(), gotT.FlatCoords(), epsilon)
+	case *geom.MultiPolygon:
+		require.Equal(t, expectedT.Ends(), gotT.Ends())
+		require.Equal(t, expectedT.Endss(), gotT.Endss())
+		require.InEpsilonSlice(t, expectedT.FlatCoords(), gotT.FlatCoords(), epsilon)
+	case *geom.GeometryCollection:
+		rhs, ok := gotT.(*geom.GeometryCollection)
+		require.True(t, ok)
+		require.Len(t, rhs.Geoms(), len(lhs.Geoms()))
+		for i := range lhs.Geoms() {
+			requireGeomTWithinEpsilon(
+				t,
+				lhs.Geom(i),
+				rhs.Geom(i),
+				epsilon,
+			)
+		}
+	default:
+		panic(errors.AssertionFailedf("unknown geometry type: %T", expectedT))
 	}
 }

--- a/pkg/geo/geomfn/linestring_test.go
+++ b/pkg/geo/geomfn/linestring_test.go
@@ -571,15 +571,7 @@ func TestLineSubstring(t *testing.T) {
 				require.Equal(t, tt.wantErrString, err.Error())
 				return
 			}
-
-			// match the shape
-			gWantGeom, err := geo.MakeGeometryFromGeomT(tt.wantGeomT)
-			require.NoError(t, err)
-			require.Equal(t, gWantGeom.ShapeType().String(), got.ShapeType().String())
-
-			geomT, err := got.AsGeomT()
-			require.NoError(t, err)
-			require.InEpsilonSlice(t, tt.wantGeomT.FlatCoords(), geomT.FlatCoords(), 0.0001)
+			requireGeometryWithinEpsilon(t, requireGeometryFromGeomT(t, tt.wantGeomT), got, 1e-4)
 		})
 	}
 }

--- a/pkg/geo/geomfn/snap_test.go
+++ b/pkg/geo/geomfn/snap_test.go
@@ -59,7 +59,13 @@ func TestSnap(t *testing.T) {
 			input:     geom.NewMultiPolygonFlat(geom.XY, []float64{1, 1, 2, 2, 3, 3, 1, 1, 4, 4, 5, 5, 6, 6, 4, 4}, [][]int{{8}, {16}}),
 			target:    geom.NewLineStringFlat(geom.XY, []float64{5, 107, 54, 84, 101, 100}),
 			tolerance: 200,
-			expected:  geom.NewMultiPolygonFlat(geom.XY, []float64{1, 1, 2, 2, 5, 107, 54, 84, 101, 100, 1, 1, 4, 4, 5, 5, 5, 107, 54, 84, 101, 100, 4, 4}, [][]int{{8}, {16}}),
+			expected: geom.NewMultiPolygonFlat(
+				geom.XY,
+				[]float64{
+					1, 1, 2, 2, 5, 107, 54, 84, 101, 100, 1, 1, 4, 4, 5, 5, 5, 107, 54, 84, 101, 100, 4, 4,
+				},
+				[][]int{{12}, {24}},
+			),
 		},
 	}
 
@@ -73,15 +79,7 @@ func TestSnap(t *testing.T) {
 			actual, err := Snap(input, target, tc.tolerance)
 			require.NoError(t, err)
 
-			// Compare FlatCoords and assert they are within epsilon.
-			// This is because they exact matches may encounter rounding issues.
-			actualGeomT, err := actual.AsGeomT()
-
-			require.NoError(t, err)
-			require.Equal(t, tc.expected.SRID(), actualGeomT.SRID())
-			require.Equal(t, tc.expected.Layout(), actualGeomT.Layout())
-			require.IsType(t, tc.expected, actualGeomT)
-			require.InEpsilonSlice(t, tc.expected.FlatCoords(), actualGeomT.FlatCoords(), 0.00001)
+			requireGeometryWithinEpsilon(t, requireGeometryFromGeomT(t, tc.expected), actual, 1e-5)
 		})
 	}
 }

--- a/pkg/geo/geomfn/topology_operations_test.go
+++ b/pkg/geo/geomfn/topology_operations_test.go
@@ -73,19 +73,9 @@ func TestCentroid(t *testing.T) {
 			require.NoError(t, err)
 			ret, err := Centroid(g)
 			require.NoError(t, err)
-
-			retAsGeomT, err := ret.AsGeomT()
-			require.NoError(t, err)
-
 			expected, err := geo.ParseGeometry(tc.expected)
 			require.NoError(t, err)
-			expectedAsGeomT, err := expected.AsGeomT()
-			require.NoError(t, err)
-
-			// Ensure points are close in terms of precision.
-			require.InEpsilon(t, expectedAsGeomT.(*geom.Point).X(), retAsGeomT.(*geom.Point).X(), 2e-10)
-			require.InEpsilon(t, expectedAsGeomT.(*geom.Point).Y(), retAsGeomT.(*geom.Point).Y(), 2e-10)
-			require.Equal(t, expected.SRID(), ret.SRID())
+			requireGeometryWithinEpsilon(t, expected, ret, 2e-10)
 		})
 	}
 }
@@ -293,19 +283,9 @@ func TestPointOnSurface(t *testing.T) {
 			require.NoError(t, err)
 			ret, err := PointOnSurface(g)
 			require.NoError(t, err)
-
-			retAsGeomT, err := ret.AsGeomT()
-			require.NoError(t, err)
-
 			expected, err := geo.ParseGeometry(tc.expected)
 			require.NoError(t, err)
-			expectedAsGeomT, err := expected.AsGeomT()
-			require.NoError(t, err)
-
-			// Ensure points are close in terms of precision.
-			require.InEpsilon(t, expectedAsGeomT.(*geom.Point).X(), retAsGeomT.(*geom.Point).X(), 2e-10)
-			require.InEpsilon(t, expectedAsGeomT.(*geom.Point).Y(), retAsGeomT.(*geom.Point).Y(), 2e-10)
-			require.Equal(t, expected.SRID(), ret.SRID())
+			requireGeometryWithinEpsilon(t, expected, ret, 2e-10)
 		})
 	}
 }


### PR DESCRIPTION
These checks were used repeatedly and copy-pasta'd, why not simplify
them into the one.

Release justification: non-production code change

Release note: None