### PR TITLE
roachtest: bump activerecord adapter tests to 6.1.0beta2

### DIFF
--- a/pkg/cmd/roachtest/activerecord.go
+++ b/pkg/cmd/roachtest/activerecord.go
@@ -20,8 +20,8 @@ import (
 
 var activerecordResultRegex = regexp.MustCompile(`^(?P<test>[^\s]+#[^\s]+) = (?P<timing>\d+\.\d+ s) = (?P<result>.)$`)
 var railsReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)\.?(?P<subpoint>\d*)$`)
-var supportedRailsVersion = "6.0.3.4"
-var adapterVersion = "v6.0.0beta3"
+var supportedRailsVersion = "6.1"
+var adapterVersion = "v6.1.0beta2"
 
 // This test runs activerecord's full test suite against a single cockroach node.
 


### PR DESCRIPTION
Release justification: non-production code change

Release note: None