### PR TITLE
sql: save flow diagrams only when needed

### DIFF
--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -304,9 +304,16 @@ func (ih *instrumentationHelper) ShouldDiscardRows() bool {
 }
 
 // ShouldSaveFlows is true if we should save the flow specifications (to be able
-// to generate diagrams).
+// to generate diagrams - when shouldSaveDiagrams() returns true - and to get
+// query level stats when sampling statements).
 func (ih *instrumentationHelper) ShouldSaveFlows() bool {
 	return ih.collectBundle || ih.outputMode == explainAnalyzeDistSQLOutput || ih.collectExecStats
+}
+
+// shouldSaveDiagrams returns whether saveFlows() function should also be saving
+// diagrams in flowInfo objects.
+func (ih *instrumentationHelper) shouldSaveDiagrams() bool {
+	return ih.collectBundle || ih.outputMode != unmodifiedOutput
 }
 
 // ShouldUseJobForCreateStats indicates if we should run CREATE STATISTICS as a


### PR DESCRIPTION
Previously, whenever we needed to save flows information, we would
always generate flow diagrams. However, those are not used when we are
sampling statements and become unnecessary work. This commit updates the
default `saveFlows` function to only generate flow diagrams when needed
(when we're collecting a stmt bundle or when we're running EXPLAIN
ANALYZE stmt).

Addresses: #59379.

Release justification: low-risk update to new functionality.

Release note: None