### PR TITLE
cli: add user-promo flag to add data in user_promo_codes table

### DIFF
--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -263,7 +263,7 @@ func TestDeterministicInitialData(t *testing.T) {
 		`intro`:      0x81c6a8cfd9c3452a,
 		`json`:       0xcbf29ce484222325,
 		`ledger`:     0xebe27d872d980271,
-		`movr`:       0x4c0da49085e0bc5c,
+		`movr`:       0x79940f4ba5d5e6a3,
 		`queue`:      0xcbf29ce484222325,
 		`rand`:       0xcbf29ce484222325,
 		`roachmart`:  0xda5e73423dbdb2d9,


### PR DESCRIPTION
Resolves: #39603

Release justification: low risk, high benefit changes to existing functionality

Previously, movr dataset dont have a option to populate user_promo_code
table.
This patch adds populating user_promo_code with data.

Release note (cli change): add option in demo movr command to
populate user_promo_code table

Signed-off-by: Tharun <rajendrantharun@live.com>