### PR TITLE
base,kv: fix two error instantiations in the hot path

### DIFF
--- a/pkg/base/license.go
+++ b/pkg/base/license.go
@@ -19,13 +19,15 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+var errEnterpriseNotEnabled = errors.New("OSS binaries do not include enterprise features")
+
 // CheckEnterpriseEnabled returns a non-nil error if the requested enterprise
 // feature is not enabled, including information or a link explaining how to
 // enable it.
 //
 // This function is overridden by an init hook in CCL builds.
 var CheckEnterpriseEnabled = func(_ *cluster.Settings, _ uuid.UUID, org, feature string) error {
-	return errors.New("OSS binaries do not include enterprise features")
+	return errEnterpriseNotEnabled // nb: this is squarely in the hot path on OSS builds
 }
 
 // TimeToEnterpriseLicenseExpiry returns a duration object that measures the time until

--- a/pkg/kv/kvclient/kvcoord/range_iter.go
+++ b/pkg/kv/kvclient/kvcoord/range_iter.go
@@ -131,11 +131,13 @@ func (ri *RangeIterator) Valid() bool {
 	return ri.Error() == nil
 }
 
+var errRangeIterNotInitialized = errors.New("range iterator not intialized with Seek()")
+
 // Error returns the error the iterator encountered, if any. If
 // the iterator has not been initialized, returns iterator error.
 func (ri *RangeIterator) Error() error {
 	if !ri.init {
-		return errors.New("range iterator not intialized with Seek()")
+		return errRangeIterNotInitialized // hot path
 	}
 	return ri.err
 }


### PR DESCRIPTION
Found as part of the investigation in #61328, where these happened to
jump out at me in the CPU profile's top10 for a simple read-only
workload.

cc @cockroachlabs/kv

Release justification: low-risk perf improvements
Release note: None
