### PR TITLE
kv: add TestTxnClearRangeIntents to verify ClearRange intent behavior

### DIFF
--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -1922,6 +1922,15 @@ func gcArgs(startKey []byte, endKey []byte, keys ...roachpb.GCRequest_GCKey) roa
 	}
 }
 
+func clearRangeArgs(startKey, endKey roachpb.Key) roachpb.ClearRangeRequest {
+	return roachpb.ClearRangeRequest{
+		RequestHeader: roachpb.RequestHeader{
+			Key:    startKey,
+			EndKey: endKey,
+		},
+	}
+}
+
 // TestOptimizePuts verifies that contiguous runs of puts and
 // conditional puts are marked as "blind" if they're written
 // to a virgin keyspace.


### PR DESCRIPTION
This adds a test case verifying that a `ClearRange()` call can remove a
write intent belonging to an implicitly committed `STAGING` transaction.
This will cause subsequent txn recovery to roll back the entire txn,
even though it has already been committed.

`ClearRange()` does require the caller to ensure there are no intents in
the cleared range, but this is a bit of a footgun, and it should ideally
ensure that txn invariants are enforced itself -- this will be addressed
separately.

Touches #46764.

Release justification: non-production code changes
Release note: None