### PR TITLE
sql/catalog/lease: make the storedLease format better

### DIFF
--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -64,6 +64,20 @@ type storedLease struct {
 	expiration tree.DTimestamp
 }
 
+var _ redact.SafeFormatter = (*storedLease)(nil)
+
+func (s *storedLease) SafeFormat(sp redact.SafePrinter, verb rune) {
+	sp.Printf("%d@%d:%s", s.id, s.version, s.expirationAsHLC())
+}
+
+func (s *storedLease) String() string {
+	return fmt.Sprintf("%d@%d:%s", s.id, s.version, s.expirationAsHLC())
+}
+
+func (s *storedLease) expirationAsHLC() hlc.Timestamp {
+	return hlc.Timestamp{WallTime: s.expiration.Time.UnixNano()}
+}
+
 // descriptorVersionState holds the state for a descriptor version. This
 // includes the lease information for a descriptor version.
 // TODO(vivek): A node only needs to manage lease information on what it

--- a/pkg/sql/catalog/lease/lease_internal_test.go
+++ b/pkg/sql/catalog/lease/lease_internal_test.go
@@ -27,12 +27,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTableSet(t *testing.T) {
@@ -1023,4 +1026,16 @@ func TestLeaseAcquireAndReleaseConcurrently(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestStoredLeaseFormat(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	v := &storedLease{
+		id:         42,
+		version:    2,
+		expiration: *tree.MustMakeDTimestamp(timeutil.Unix(1, 0), time.Microsecond),
+	}
+	const exp = "42@2:1.000000000,0"
+	require.Equal(t, exp, v.String())
+	require.Equal(t, exp, errors.Redact(errors.Errorf("%s", v)))
 }


### PR DESCRIPTION
Also exposes the timestamp as safe for redaction.

Fixes #61517.

Release justification: low risk, high benefit changes to existing functionality

Release note: None