### PR TITLE
ccl,server: error.Wrap on previously handled errors

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -1034,7 +1034,7 @@ func backupPlanHook(
 				return errors.Wrap(err, "invalid previous backups")
 			}
 			if coveredTime != startTime {
-				return errors.Wrapf(err, "expected previous backups to cover until time %v, got %v", startTime, coveredTime)
+				return errors.Errorf("expected previous backups to cover until time %v, got %v", startTime, coveredTime)
 			}
 		}
 

--- a/pkg/ccl/importccl/read_import_workload.go
+++ b/pkg/ccl/importccl/read_import_workload.go
@@ -157,7 +157,7 @@ func (w *workloadReader) readFiles(
 			}
 		}
 		if t.Name == `` {
-			return errors.Wrapf(err, `unknown table %s for generator %s`, conf.Table, meta.Name)
+			return errors.Errorf(`unknown table %s for generator %s`, conf.Table, meta.Name)
 		}
 
 		wc := NewWorkloadKVConverter(

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -233,7 +233,7 @@ func bootstrapCluster(
 		if i == 0 {
 			bootstrapVersion = cv
 		} else if bootstrapVersion != cv {
-			return nil, errors.Wrapf(err, "found cluster versions %s and %s", bootstrapVersion, cv)
+			return nil, errors.Errorf("found cluster versions %s and %s", bootstrapVersion, cv)
 		}
 
 		sIdent := roachpb.StoreIdent{


### PR DESCRIPTION
These errors.Wrap calls are wrapping errors that are nil and thus will
always return a nil error.

Release justification: Minor error handling fixes
Release note: None