### PR TITLE
sql: read db descriptor from store when constructing mr zone configs

### DIFF
--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -412,7 +412,10 @@ func performMultiRegionFinalization(
 	descsCol *descs.Collection,
 ) ([]descpb.ID, error) {
 	_, dbDesc, err := descsCol.GetImmutableDatabaseByID(
-		ctx, txn, typeDesc.ParentID, tree.DatabaseLookupFlags{Required: true})
+		ctx, txn, typeDesc.ParentID, tree.DatabaseLookupFlags{
+			AvoidCached: true,
+			Required:    true,
+		})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Previously, when constructing multi-region zone configs for a database
in the type schema changer, we were doing so using a leased version of
the database descriptor. This meant it could be the case that we were
constructing a stale zone configuration, which manifested itself in
some CI failures. This patch fixes that issue by always reading the
database descriptor from the store when constructing zone
configurations in the type schema changer.

Previously, this was failing consistently under stress in ~30s. I have
this thing running perfectly for the last 10 minutes.

Fixes: #61320

Release justification: bug fix to new functionality
Release note: None