### PR TITLE
release-20.2: opt: fix fetch scope in UPDATE..FROM statements

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -1456,3 +1456,17 @@ VALUES (1, 'a', 2)
 ON CONFLICT (a, b) DO UPDATE SET a = excluded.a
 WHERE t61414_b.a = 'x'
 RETURNING k
+
+# Regression test for #61284. When building partial index DEL column
+# expressions, there should not be ambiguous column errors if there exists
+# columns in an UPDATE FROM clause that match column names in the partial index
+# predicate.
+
+statement ok
+CREATE TABLE t61284 (
+  a INT,
+  INDEX (a) WHERE a > 0
+)
+
+statement ok
+UPDATE t61284 SET a = v.a FROM (VALUES (1), (2)) AS v(a) WHERE t61284.a = v.a

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -1778,3 +1778,52 @@ update t
       └── projections
            ├── (partial_index_put1_new:9 > 0) AND (partial_index_del1_new:10 > 0) [as=partial_index_put1:11]
            └── (t.partial_index_put1:5 > 0) AND (t.partial_index_del1:6 > 0) [as=partial_index_del1:12]
+
+build
+UPDATE partial_indexes SET a = v.a FROM (VALUES (1), (2)) AS v(a) WHERE partial_indexes.a = v.a
+----
+update partial_indexes
+ ├── columns: <none>
+ ├── fetch columns: a:5 b:6 c:7
+ ├── update-mapping:
+ │    └── column1:9 => a:1
+ ├── partial index put columns: partial_index_put1:10 partial_index_put2:11 partial_index_put3:13 partial_index_put4:14
+ ├── partial index del columns: partial_index_put1:10 partial_index_del2:12 partial_index_put3:13 partial_index_put4:14
+ └── project
+      ├── columns: partial_index_put1:10 partial_index_put2:11 partial_index_del2:12 partial_index_put3:13 partial_index_put4:14 a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8 column1:9!null
+      ├── distinct-on
+      │    ├── columns: a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8 column1:9!null
+      │    ├── grouping columns: a:5!null
+      │    ├── select
+      │    │    ├── columns: a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8 column1:9!null
+      │    │    ├── inner-join (cross)
+      │    │    │    ├── columns: a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8 column1:9!null
+      │    │    │    ├── scan partial_indexes
+      │    │    │    │    ├── columns: a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8
+      │    │    │    │    └── partial index predicates
+      │    │    │    │         ├── secondary: filters
+      │    │    │    │         │    └── c:7 = 'foo'
+      │    │    │    │         └── secondary: filters
+      │    │    │    │              └── (a:5 > b:6) AND (c:7 = 'bar')
+      │    │    │    ├── values
+      │    │    │    │    ├── columns: column1:9!null
+      │    │    │    │    ├── (1,)
+      │    │    │    │    └── (2,)
+      │    │    │    └── filters (true)
+      │    │    └── filters
+      │    │         └── a:5 = column1:9
+      │    └── aggregations
+      │         ├── first-agg [as=b:6]
+      │         │    └── b:6
+      │         ├── first-agg [as=c:7]
+      │         │    └── c:7
+      │         ├── first-agg [as=crdb_internal_mvcc_timestamp:8]
+      │         │    └── crdb_internal_mvcc_timestamp:8
+      │         └── first-agg [as=column1:9]
+      │              └── column1:9
+      └── projections
+           ├── c:7 = 'foo' [as=partial_index_put1:10]
+           ├── (column1:9 > b:6) AND (c:7 = 'bar') [as=partial_index_put2:11]
+           ├── (a:5 > b:6) AND (c:7 = 'bar') [as=partial_index_del2:12]
+           ├── c:7 = 'delete-only' [as=partial_index_put3:13]
+           └── c:7 = 'write-only' [as=partial_index_put4:14]


### PR DESCRIPTION
Backport 1/1 commits from #61522.

/cc @cockroachdb/release

---

Previously, the fetch scope incorrectly included columns in the FROM
clause of an UPDATE..FROM statement. As a result, column names shared by
the FROM clause and the mutating table lead to ambiguity when resolving
partial index DEL column expressions. This commit ensures that the fetch
scope does not include columns in the FROM clause.

Fixes #61284

Release justification: This is a low-risk bug fix to existing
functionality.

Release note (bug fix): An UPDATE..FROM statement where the FROM clause
contained column names that match table column names erred if the table
had a partial index predicate referencing those columns. This bug,
present since partial indexes were released in version 20.2.0, has been
fixed.
