### PR TITLE
builtins: run crdb_internal.complete_stream_ingestion_job locally

### DIFF
--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4832,7 +4832,8 @@ may increase either contention or retry errors, or both.`,
 
 	"crdb_internal.complete_stream_ingestion_job": makeBuiltin(
 		tree.FunctionProperties{
-			Category: categoryStreamIngestion,
+			Category:         categoryStreamIngestion,
+			DistsqlBlocklist: true,
 		},
 		tree.Overload{
 			Types: tree.ArgTypes{


### PR DESCRIPTION
We recently introduced `crdb_internal.complete_stream_ingestion_job`
builtin that performs some mutations around the stream ingestion. We
cannot execute the mutations in a distributed environment since we rely
on having access to Root txn. Previously, the builtin wasn't marked as
"DistSQL blocklisted" which allowed for it to be planned in
a distributed fashion which would lead to an error during the execution.

Fixes: #61050.
Fixes: #61534.

Release justification: bug fix.

Release note: None (no release with this bug)