### PR TITLE
sql: remove connect privilege warning

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/connect_privilege
+++ b/pkg/sql/logictest/testdata/logic_test/connect_privilege
@@ -8,9 +8,6 @@ public  a  root
 
 user testuser
 
-statement notice NOTICE: CONNECT privilege will be required to connect to databases in a future release\nHINT: .*59875.*
-use test
-
 query TTT
 SELECT schemaname, tablename, tableowner FROM pg_catalog.pg_tables WHERE tablename = 'a'
 ----

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
-	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -239,27 +238,6 @@ var varGen = map[string]sessionVar{
 		},
 		SetWithPlanner: func(
 			_ context.Context, p *planner, dbName string) error {
-			// Check if the user has connect privilege on the database.
-			// If the dbName is empty string, skip the privilege check.
-			if dbName != "" {
-				_, dbDesc, err := p.Descriptors().GetImmutableDatabaseByName(
-					p.EvalContext().Context, p.Txn(), dbName, tree.DatabaseLookupFlags{Required: true},
-				)
-				if err != nil {
-					return err
-				}
-				// Give a warning if the user does not have CONNECT privilege on the database.
-				connectPrivilegeMissingWarning := errors.WithIssueLink(
-					pgnotice.Newf("CONNECT privilege will be required to connect to databases in a future release"),
-					errors.IssueLink{IssueURL: build.MakeIssueURL(59875)},
-				)
-				if err := p.CheckPrivilege(p.EvalContext().Context, dbDesc, privilege.CONNECT); err != nil {
-					p.BufferClientNotice(
-						p.EvalContext().Context,
-						connectPrivilegeMissingWarning,
-					)
-				}
-			}
 			p.sessionDataMutator.SetDatabase(dbName)
 			return nil
 		},


### PR DESCRIPTION
sql: remove connect privilege warning

Release justification: No functionality, removing warning
Release note: None

Resolves #61560