### PR TITLE
kvnemesis: increase step count during TeamCity nightlies

### DIFF
--- a/pkg/cmd/teamcity-trigger/main.go
+++ b/pkg/cmd/teamcity-trigger/main.go
@@ -81,11 +81,16 @@ func runTC(queueBuild func(string, map[string]string)) {
 		// halve these values.
 		parallelism := 4
 
-		// Conditionally override stressflags.
+		opts := map[string]string{
+			"env.PKG": importPath,
+		}
+
+		// Conditionally override settings.
 		switch importPath {
 		case baseImportPath + "kv/kvnemesis":
 			// Disable -maxruns for kvnemesis. Run for the full 1h.
 			maxRuns = 0
+			opts["env.COCKROACH_KVNEMESIS_STEPS"] = "10000"
 		case baseImportPath + "sql/logictest":
 			// Stress logic tests with reduced parallelism (to avoid overloading the
 			// machine, see https://github.com/cockroachdb/cockroach/pull/10966).
@@ -93,10 +98,6 @@ func runTC(queueBuild func(string, map[string]string)) {
 			// Increase logic test timeout.
 			testTimeout = 2 * time.Hour
 			maxTime = 3 * time.Hour
-		}
-
-		opts := map[string]string{
-			"env.PKG": importPath,
 		}
 
 		opts["env.TESTTIMEOUT"] = testTimeout.String()

--- a/pkg/cmd/teamcity-trigger/main_test.go
+++ b/pkg/cmd/teamcity-trigger/main_test.go
@@ -64,11 +64,13 @@ func Example_runTC() {
 
 	// Output:
 	// github.com/cockroachdb/cockroach/pkg/kv/kvnemesis
+	//   env.COCKROACH_KVNEMESIS_STEPS: 10000
 	//   env.GOFLAGS:     -parallel=4
 	//   env.STRESSFLAGS: -maxruns 0 -maxtime 1h0m0s -maxfails 1 -p 4
 	//   env.TESTTIMEOUT: 40m0s
 	//
 	// github.com/cockroachdb/cockroach/pkg/kv/kvnemesis
+	//   env.COCKROACH_KVNEMESIS_STEPS: 10000
 	//   env.GOFLAGS:     -race -parallel=4
 	//   env.STRESSFLAGS: -maxruns 0 -maxtime 1h0m0s -maxfails 1 -p 1
 	//   env.TESTTIMEOUT: 40m0s

--- a/pkg/kv/kvnemesis/BUILD.bazel
+++ b/pkg/kv/kvnemesis/BUILD.bazel
@@ -67,6 +67,7 @@ go_test(
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
+        "//pkg/util/envutil",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/kv/kvnemesis/kvnemesis.go
+++ b/pkg/kv/kvnemesis/kvnemesis.go
@@ -36,9 +36,13 @@ func RunNemesis(
 	rng *rand.Rand,
 	ct ClosedTimestampTargetInterval,
 	config GeneratorConfig,
+	numSteps int,
 	dbs ...*kv.DB,
 ) ([]error, error) {
-	const concurrency, numSteps = 5, 30
+	const concurrency = 5
+	if numSteps <= 0 {
+		return nil, fmt.Errorf("numSteps must be >0, got %v", numSteps)
+	}
 
 	g, err := MakeGenerator(config, newGetReplicasFn(dbs...))
 	if err != nil {
@@ -57,7 +61,7 @@ func RunNemesis(
 	workerFn := func(ctx context.Context, workerIdx int) error {
 		workerName := fmt.Sprintf(`%d`, workerIdx)
 		var buf strings.Builder
-		for atomic.AddInt64(&stepsStartedAtomic, 1) <= numSteps {
+		for atomic.AddInt64(&stepsStartedAtomic, 1) <= int64(numSteps) {
 			step := g.RandStep(rng)
 
 			recCtx, collect, cancel := tracing.ContextWithRecordingSpan(

--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -22,11 +22,18 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/stretchr/testify/require"
 )
+
+var numSteps int
+
+func init() {
+	numSteps = envutil.EnvOrDefaultInt("COCKROACH_KVNEMESIS_STEPS", 50)
+}
 
 func TestKVNemesisSingleNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -45,7 +52,7 @@ func TestKVNemesisSingleNode(t *testing.T) {
 	config.NumNodes, config.NumReplicas = 1, 1
 	rng, _ := randutil.NewPseudoRand()
 	ct := sqlClosedTimestampTargetInterval{sqlDBs: []*gosql.DB{sqlDB}}
-	failures, err := RunNemesis(ctx, rng, ct, config, db)
+	failures, err := RunNemesis(ctx, rng, ct, config, numSteps, db)
 	require.NoError(t, err, `%+v`, err)
 
 	for _, failure := range failures {
@@ -78,7 +85,7 @@ func TestKVNemesisMultiNode(t *testing.T) {
 	config.NumNodes, config.NumReplicas = numNodes, 3
 	rng, _ := randutil.NewPseudoRand()
 	ct := sqlClosedTimestampTargetInterval{sqlDBs: sqlDBs}
-	failures, err := RunNemesis(ctx, rng, ct, config, dbs...)
+	failures, err := RunNemesis(ctx, rng, ct, config, numSteps, dbs...)
 	require.NoError(t, err, `%+v`, err)
 
 	for _, failure := range failures {


### PR DESCRIPTION
The nightly TeamCity stress tests currently run kvnemesis tests for 1
hour. However, each test run only has 50 steps (operations), which
completes in seconds and has limited complexity.

This commit makes the step count configurable via the environment
variable `COCKROACH_KVNEMESIS_STEPS` (default 50), and sets it to
10000 for the nightly TeamCity tests (takes about 3 minutes to run locally).

Resolves #61054.

Release justification: non-production code changes
Release note: None