### PR TITLE
colexec: fully support distinct spec

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -189,12 +189,6 @@ func supportedNatively(spec *execinfrapb.ProcessorSpec) error {
 		return nil
 
 	case spec.Core.Distinct != nil:
-		if spec.Core.Distinct.NullsAreDistinct {
-			return errors.Newf("distinct with unique nulls not supported")
-		}
-		if spec.Core.Distinct.ErrorOnDup != "" {
-			return errors.Newf("distinct with error on duplicates not supported")
-		}
 		return nil
 
 	case spec.Core.Ordinality != nil:
@@ -954,7 +948,10 @@ func NewColOperator(
 			result.ColumnTypes = make([]*types.T, len(spec.Input[0].ColumnTypes))
 			copy(result.ColumnTypes, spec.Input[0].ColumnTypes)
 			if len(core.Distinct.OrderedColumns) == len(core.Distinct.DistinctColumns) {
-				result.Root, err = colexecbase.NewOrderedDistinct(inputs[0].Root, core.Distinct.OrderedColumns, result.ColumnTypes)
+				result.Root, err = colexecbase.NewOrderedDistinct(
+					inputs[0].Root, core.Distinct.OrderedColumns, result.ColumnTypes,
+					core.Distinct.NullsAreDistinct, core.Distinct.ErrorOnDup,
+				)
 			} else {
 				// We have separate unit tests that instantiate in-memory
 				// distinct operators, so we don't need to look at
@@ -970,6 +967,7 @@ func NewColOperator(
 				allocator := colmem.NewAllocator(ctx, distinctMemAccount, factory)
 				inMemoryUnorderedDistinct := colexec.NewUnorderedDistinct(
 					allocator, inputs[0].Root, core.Distinct.DistinctColumns, result.ColumnTypes,
+					core.Distinct.NullsAreDistinct, core.Distinct.ErrorOnDup,
 				)
 				edOpName := "external-distinct"
 				diskAccount := result.createDiskAccount(ctx, flowCtx, edOpName, spec.ProcessorID)

--- a/pkg/sql/colexec/colexecbase/BUILD.bazel
+++ b/pkg/sql/colexec/colexecbase/BUILD.bazel
@@ -21,6 +21,8 @@ go_library(
         "//pkg/sql/colexecerror",
         "//pkg/sql/colexecop",
         "//pkg/sql/colmem",  # keep
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/tree",  # keep
         "//pkg/sql/types",
         "//pkg/util/duration",  # keep

--- a/pkg/sql/colexec/colexecbase/distinct.go
+++ b/pkg/sql/colexec/colexecbase/distinct.go
@@ -11,10 +11,14 @@
 package colexecbase
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
 )
@@ -23,7 +27,7 @@ import (
 // a slice of columns, creates a chain of distinct operators and returns the
 // last distinct operator in that chain as well as its output column.
 func OrderedDistinctColsToOperators(
-	input colexecop.Operator, distinctCols []uint32, typs []*types.T,
+	input colexecop.Operator, distinctCols []uint32, typs []*types.T, nullsAreDistinct bool,
 ) (colexecop.ResettableOperator, []bool, error) {
 	distinctCol := make([]bool, coldata.BatchSize())
 	// zero the boolean column on every iteration.
@@ -37,7 +41,7 @@ func OrderedDistinctColsToOperators(
 		ok  bool
 	)
 	for i := range distinctCols {
-		input, err = newSingleDistinct(input, int(distinctCols[i]), distinctCol, typs[distinctCols[i]])
+		input, err = newSingleDistinct(input, int(distinctCols[i]), distinctCol, typs[distinctCols[i]], nullsAreDistinct)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -61,14 +65,99 @@ var _ colexecop.ResettableOperator = &distinctChainOps{}
 // NewOrderedDistinct creates a new ordered distinct operator on the given
 // input columns with the given types.
 func NewOrderedDistinct(
-	input colexecop.Operator, distinctCols []uint32, typs []*types.T,
+	input colexecop.Operator,
+	distinctCols []uint32,
+	typs []*types.T,
+	nullsAreDistinct bool,
+	errorOnDup string,
 ) (colexecop.ResettableOperator, error) {
-	op, outputCol, err := OrderedDistinctColsToOperators(input, distinctCols, typs)
+	od := &orderedDistinct{
+		OneInputNode:         colexecop.NewOneInputNode(input),
+		UpsertDistinctHelper: UpsertDistinctHelper{ErrorOnDup: errorOnDup},
+	}
+	op, outputCol, err := OrderedDistinctColsToOperators(&od.distinctChainInput, distinctCols, typs, nullsAreDistinct)
 	if err != nil {
 		return nil, err
 	}
-	return &colexecutils.BoolVecToSelOp{
+	op = &colexecutils.BoolVecToSelOp{
 		OneInputHelper: colexecop.MakeOneInputHelper(op),
 		OutputCol:      outputCol,
-	}, nil
+		// orderedDistinct is responsible for feeding the distinct chain with
+		// input batches (this is needed to support emitting errors on
+		// duplicates), so we want BoolVecToSelOp to emit a batch for each of
+		// its input batches, even if no rows are selected (i.e. a zero-length
+		// output batch).
+		ProcessOnlyOneBatch: true,
+	}
+	od.distinctChain = op
+	return od, nil
+}
+
+type orderedDistinct struct {
+	colexecop.InitHelper
+	colexecop.OneInputNode
+	UpsertDistinctHelper
+
+	distinctChain      colexecop.ResettableOperator
+	distinctChainInput colexecop.FeedOperator
+}
+
+var _ colexecop.ResettableOperator = &orderedDistinct{}
+
+// Init implements the colexecop.Operator interface.
+func (d *orderedDistinct) Init(ctx context.Context) {
+	if !d.InitHelper.Init(ctx) {
+		return
+	}
+	d.Input.Init(ctx)
+	d.distinctChain.Init(ctx)
+}
+
+// Next implements the colexecop.Operator interface.
+func (d *orderedDistinct) Next() coldata.Batch {
+	for {
+		b := d.Input.Next()
+		origLen := b.Length()
+		if origLen == 0 {
+			return coldata.ZeroBatch
+		}
+		d.distinctChainInput.SetBatch(b)
+		b = d.distinctChain.Next()
+		updatedLength := b.Length()
+		d.MaybeEmitErrorOnDup(origLen, updatedLength)
+		if updatedLength > 0 {
+			return b
+		}
+	}
+}
+
+// Reset implements the colexecop.Resetter interface.
+func (d *orderedDistinct) Reset(ctx context.Context) {
+	if r, ok := d.Input.(colexecop.Resetter); ok {
+		r.Reset(ctx)
+	}
+	d.distinctChain.Reset(ctx)
+}
+
+// UpsertDistinctHelper is a utility that helps distinct operators emit errors
+// when they observe duplicate tuples. This behavior is needed by UPSERT
+// operations.
+type UpsertDistinctHelper struct {
+	ErrorOnDup string
+}
+
+// MaybeEmitErrorOnDup might emit an error when it detects duplicates. It takes
+// in two arguments - one representing the original length of the batch (before
+// performing distinct operation on it) and another for the updated length
+// (after the distinct operation).
+// TODO(yuzefovich): consider templating out the distinct operators to have and
+// to omit this helper based on the distinct spec.
+func (h *UpsertDistinctHelper) MaybeEmitErrorOnDup(origLen, updatedLen int) {
+	if h.ErrorOnDup != "" && origLen > updatedLen {
+		// At least one duplicate row was removed from the batch, so we raise an
+		// error.
+		// TODO(yuzefovich): ErrorOnDup could be passed via log.Safe() if there
+		// was a guarantee that it does not contain PII.
+		colexecerror.ExpectedError(pgerror.Newf(pgcode.CardinalityViolation, "%s", h.ErrorOnDup))
+	}
 }

--- a/pkg/sql/colexec/colexecbase/distinct.go
+++ b/pkg/sql/colexec/colexecbase/distinct.go
@@ -53,6 +53,7 @@ func OrderedDistinctColsToOperators(
 
 type distinctChainOps struct {
 	colexecop.ResettableOperator
+	colexecop.NonExplainable
 }
 
 var _ colexecop.ResettableOperator = &distinctChainOps{}

--- a/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
@@ -83,7 +83,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -143,7 +144,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -205,7 +207,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -264,7 +267,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -327,7 +331,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -385,7 +390,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -445,7 +451,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -502,7 +509,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -582,7 +590,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -634,7 +643,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -688,7 +698,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -739,7 +750,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -794,7 +806,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -844,7 +857,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -896,7 +910,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -945,7 +960,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1017,7 +1033,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1069,7 +1086,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1123,7 +1141,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1174,7 +1193,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1229,7 +1249,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1279,7 +1300,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1331,7 +1353,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1380,7 +1403,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1450,7 +1474,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1513,7 +1538,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1578,7 +1604,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1640,7 +1667,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1706,7 +1734,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1767,7 +1796,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1830,7 +1860,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1890,7 +1921,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1968,7 +2000,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2031,7 +2064,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2096,7 +2130,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2158,7 +2193,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2224,7 +2260,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2285,7 +2322,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2348,7 +2386,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2408,7 +2447,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2488,7 +2528,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2551,7 +2592,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2616,7 +2658,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2678,7 +2721,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2744,7 +2788,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2805,7 +2850,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2868,7 +2914,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2928,7 +2975,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3011,7 +3059,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3082,7 +3131,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3155,7 +3205,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3225,7 +3276,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3299,7 +3351,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3368,7 +3421,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3439,7 +3493,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3507,7 +3562,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3598,7 +3654,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3657,7 +3714,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3718,7 +3776,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3776,7 +3835,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3838,7 +3898,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3895,7 +3956,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3954,7 +4016,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4010,7 +4073,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4089,7 +4153,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4141,7 +4206,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4195,7 +4261,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4246,7 +4313,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4301,7 +4369,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4351,7 +4420,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4403,7 +4473,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4452,7 +4523,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4524,7 +4596,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4582,7 +4655,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4642,7 +4716,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4699,7 +4774,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4760,7 +4836,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4816,7 +4893,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4874,7 +4952,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4929,7 +5008,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5007,7 +5087,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5061,7 +5142,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5117,7 +5199,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5170,7 +5253,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5227,7 +5311,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5279,7 +5364,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5333,7 +5419,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5384,7 +5471,8 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5463,7 +5551,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5524,7 +5613,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5587,7 +5677,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5647,7 +5738,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5714,7 +5806,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5775,7 +5868,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5838,7 +5932,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5898,7 +5993,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5980,7 +6076,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6033,7 +6130,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6088,7 +6186,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6140,7 +6239,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6199,7 +6299,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6252,7 +6353,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6307,7 +6409,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6359,7 +6462,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6439,7 +6543,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6492,7 +6597,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6547,7 +6653,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6599,7 +6706,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6658,7 +6766,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6711,7 +6820,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6766,7 +6876,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6818,7 +6929,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6890,7 +7002,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6954,7 +7067,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7020,7 +7134,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7083,7 +7198,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7153,7 +7269,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7217,7 +7334,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7283,7 +7401,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7346,7 +7465,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7432,7 +7552,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7496,7 +7617,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7562,7 +7684,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7625,7 +7748,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7695,7 +7819,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7759,7 +7884,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7825,7 +7951,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7888,7 +8015,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7976,7 +8104,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8040,7 +8169,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8106,7 +8236,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8169,7 +8300,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8239,7 +8371,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8303,7 +8436,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8369,7 +8503,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8432,7 +8567,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8526,7 +8662,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8598,7 +8735,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8672,7 +8810,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8743,7 +8882,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8821,7 +8961,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8893,7 +9034,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8967,7 +9109,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9038,7 +9181,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9134,7 +9278,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9194,7 +9339,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9256,7 +9402,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9315,7 +9462,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9381,7 +9529,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9441,7 +9590,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9503,7 +9653,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9562,7 +9713,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9643,7 +9795,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9696,7 +9849,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9751,7 +9905,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9803,7 +9958,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9862,7 +10018,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9915,7 +10072,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9970,7 +10128,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10022,7 +10181,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10096,7 +10256,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10155,7 +10316,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10216,7 +10378,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10274,7 +10437,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10339,7 +10503,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10398,7 +10563,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10459,7 +10625,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10517,7 +10684,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10597,7 +10765,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10652,7 +10821,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10709,7 +10879,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10763,7 +10934,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10824,7 +10996,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10879,7 +11052,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10936,7 +11110,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10990,7 +11165,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 											}
 										}
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
+											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -11035,6 +11211,10 @@ func (ht *HashTable) CheckProbeForDistinct(vecs []coldata.Vec, nToCheck uint64, 
 	for toCheckPos := uint64(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
 		//gcassert:bce
 		toCheck := toCheckSlice[toCheckPos]
+		if ht.ProbeScratch.distinct[toCheck] {
+			ht.ProbeScratch.HeadID[toCheck] = ht.ProbeScratch.GroupID[toCheck]
+			continue
+		}
 		if !ht.ProbeScratch.differs[toCheck] {
 			// If the current key matches with the probe key, we want to update HeadID
 			// with the current key if it has not been set yet.

--- a/pkg/sql/colexec/colexechash/hashtable_tmpl.go
+++ b/pkg/sql/colexec/colexechash/hashtable_tmpl.go
@@ -65,8 +65,6 @@ func _ASSIGN_NE(_, _, _, _, _, _ interface{}) int {
 // probe vector might have NULL values.
 // _BUILD_HAS_NULLS - a boolean as .BuildHasNulls that determines whether the
 // build vector might have NULL values.
-// _ALLOW_NULL_EQUALITY - a boolean as .AllowNullEquality that determines
-// whether NULL values should be treated as equal.
 // _SELECT_DISTINCT - a boolean as .SelectDistinct that determines whether a
 // probe tuple should be marked as "distinct" if its GroupID is zero (meaning
 // that there is no tuple in the hash table with the same hash code).
@@ -84,7 +82,6 @@ func _ASSIGN_NE(_, _, _, _, _, _ interface{}) int {
 func _CHECK_COL_BODY(
 	_PROBE_HAS_NULLS bool,
 	_BUILD_HAS_NULLS bool,
-	_ALLOW_NULL_EQUALITY bool,
 	_SELECT_DISTINCT bool,
 	_USE_PROBE_SEL bool,
 	_PROBING_AGAINST_ITSELF bool,
@@ -138,21 +135,21 @@ func _CHECK_COL_BODY(
 			// {{if .BuildHasNulls}}
 			buildIsNull = buildVec.Nulls().NullAt(buildIdx)
 			// {{end}}
-			// {{if .AllowNullEquality}}
-			if probeIsNull && buildIsNull {
-				// Both values are NULLs, and since we're allowing null equality, we
-				// proceed to the next value to check.
-				continue
-			} else if probeIsNull {
-				// Only probing value is NULL, so it is different from the build value
-				// (which is non-NULL). We mark it as "different" and proceed to the
-				// next value to check. This behavior is special in case of allowing
-				// null equality because we don't want to reset the GroupID of the
-				// current probing tuple.
-				ht.ProbeScratch.differs[toCheck] = true
-				continue
+			if ht.allowNullEquality {
+				if probeIsNull && buildIsNull {
+					// Both values are NULLs, and since we're allowing null equality, we
+					// proceed to the next value to check.
+					continue
+				} else if probeIsNull {
+					// Only probing value is NULL, so it is different from the build value
+					// (which is non-NULL). We mark it as "different" and proceed to the
+					// next value to check. This behavior is special in case of allowing
+					// null equality because we don't want to reset the GroupID of the
+					// current probing tuple.
+					ht.ProbeScratch.differs[toCheck] = true
+					continue
+				}
 			}
-			// {{end}}
 			if probeIsNull {
 				ht.ProbeScratch.GroupID[toCheck] = 0
 			} else if buildIsNull {
@@ -183,23 +180,15 @@ func _CHECK_COL_WITH_NULLS(
 	// {{$deletingProbeMode := .DeletingProbeMode}}
 	if probeVec.MaybeHasNulls() {
 		if buildVec.MaybeHasNulls() {
-			if ht.allowNullEquality {
-				// {{/*
-				// The allowNullEquality flag only matters if both vectors have nulls.
-				// This lets us avoid writing all 2^3 conditional branches.
-				// */}}
-				_CHECK_COL_BODY(true, true, true, false, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
-			} else {
-				_CHECK_COL_BODY(true, true, false, false, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
-			}
+			_CHECK_COL_BODY(true, true, false, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
 		} else {
-			_CHECK_COL_BODY(true, false, false, false, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
+			_CHECK_COL_BODY(true, false, false, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
 		}
 	} else {
 		if buildVec.MaybeHasNulls() {
-			_CHECK_COL_BODY(false, true, false, false, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
+			_CHECK_COL_BODY(false, true, false, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
 		} else {
-			_CHECK_COL_BODY(false, false, false, false, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
+			_CHECK_COL_BODY(false, false, false, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
 		}
 	}
 	// {{end}}
@@ -320,15 +309,15 @@ func _CHECK_COL_FOR_DISTINCT_WITH_NULLS(_USE_PROBE_SEL bool) { // */}}
 	// {{define "checkColForDistinctWithNulls" -}}
 	if probeVec.MaybeHasNulls() {
 		if buildVec.MaybeHasNulls() {
-			_CHECK_COL_BODY(true, true, true, true, _USE_PROBE_SEL, false, false)
+			_CHECK_COL_BODY(true, true, true, _USE_PROBE_SEL, false, false)
 		} else {
-			_CHECK_COL_BODY(true, false, true, true, _USE_PROBE_SEL, false, false)
+			_CHECK_COL_BODY(true, false, true, _USE_PROBE_SEL, false, false)
 		}
 	} else {
 		if buildVec.MaybeHasNulls() {
-			_CHECK_COL_BODY(false, true, true, true, _USE_PROBE_SEL, false, false)
+			_CHECK_COL_BODY(false, true, true, _USE_PROBE_SEL, false, false)
 		} else {
-			_CHECK_COL_BODY(false, false, true, true, _USE_PROBE_SEL, false, false)
+			_CHECK_COL_BODY(false, false, true, _USE_PROBE_SEL, false, false)
 		}
 	}
 

--- a/pkg/sql/colexec/colexecjoin/mergejoiner.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner.go
@@ -443,13 +443,15 @@ func newMergeJoinBase(
 	var err error
 	base.left.distincterInput = &colexecop.FeedOperator{}
 	base.left.distincter, base.left.distinctOutput, err = colexecbase.OrderedDistinctColsToOperators(
-		base.left.distincterInput, lEqCols, leftTypes)
+		base.left.distincterInput, lEqCols, leftTypes, false, /* nullsAreDistinct */
+	)
 	if err != nil {
 		return base, err
 	}
 	base.right.distincterInput = &colexecop.FeedOperator{}
 	base.right.distincter, base.right.distinctOutput, err = colexecbase.OrderedDistinctColsToOperators(
-		base.right.distincterInput, rEqCols, rightTypes)
+		base.right.distincterInput, rEqCols, rightTypes, false, /* nullsAreDistinct */
+	)
 	if err != nil {
 		return base, err
 	}

--- a/pkg/sql/colexec/colexecutils/bool_vec_to_sel.go
+++ b/pkg/sql/colexec/colexecutils/bool_vec_to_sel.go
@@ -46,6 +46,10 @@ type BoolVecToSelOp struct {
 	// OutputCol is the boolean output column. It should be shared by other
 	// operators that write to it.
 	OutputCol []bool
+	// ProcessOnlyOneBatch indicates whether BoolVecToSelOp should always return
+	// a batch after it has processed the input batch (even if all tuples are
+	// deselected).
+	ProcessOnlyOneBatch bool
 }
 
 var _ colexecop.ResettableOperator = &BoolVecToSelOp{}
@@ -95,12 +99,10 @@ func (p *BoolVecToSelOp) Next() coldata.Batch {
 			}
 		}
 
-		if idx == 0 {
-			continue
+		if idx > 0 || p.ProcessOnlyOneBatch {
+			batch.SetLength(idx)
+			return batch
 		}
-
-		batch.SetLength(idx)
-		return batch
 	}
 }
 

--- a/pkg/sql/colexec/colexecwindow/partitioner.go
+++ b/pkg/sql/colexec/colexecwindow/partitioner.go
@@ -45,7 +45,7 @@ func NewWindowSortingPartitioner(
 	}
 
 	var distinctCol []bool
-	input, distinctCol, err = colexecbase.OrderedDistinctColsToOperators(input, partitionIdxs, inputTyps)
+	input, distinctCol, err = colexecbase.OrderedDistinctColsToOperators(input, partitionIdxs, inputTyps, false /* nullsAreDistinct */)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/colexec/colexecwindow/window_peer_grouper.eg.go
+++ b/pkg/sql/colexec/colexecwindow/window_peer_grouper.eg.go
@@ -44,7 +44,7 @@ func NewWindowPeerGrouper(
 			orderIdxs[i] = ordCol.ColIdx
 		}
 		input, distinctCol, err = colexecbase.OrderedDistinctColsToOperators(
-			input, orderIdxs, typs,
+			input, orderIdxs, typs, false, /* nullsAreDistinct */
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/sql/colexec/colexecwindow/window_peer_grouper_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/window_peer_grouper_tmpl.go
@@ -54,7 +54,7 @@ func NewWindowPeerGrouper(
 			orderIdxs[i] = ordCol.ColIdx
 		}
 		input, distinctCol, err = colexecbase.OrderedDistinctColsToOperators(
-			input, orderIdxs, typs,
+			input, orderIdxs, typs, false, /* nullsAreDistinct */
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/sql/colexec/distinct_test.go
+++ b/pkg/sql/colexec/distinct_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -28,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
 )
 
 type distinctTestCase struct {
@@ -37,6 +39,12 @@ type distinctTestCase struct {
 	expected                []colexectestutils.Tuple
 	isOrderedOnDistinctCols bool
 	nullsAreDistinct        bool
+	// errorOnDup indicates the message that should be emitted if any duplicates
+	// are observed by the distinct operator.
+	errorOnDup string
+	// noError indicates whether no error should actually occur. It should only
+	// be used in conjunction with errorOnDup.
+	noError bool
 }
 
 var distinctTestCases = []distinctTestCase{
@@ -240,6 +248,56 @@ var distinctTestCases = []distinctTestCase{
 		isOrderedOnDistinctCols: true,
 		nullsAreDistinct:        true,
 	},
+	{
+		distinctCols: []uint32{0},
+		typs:         []*types.T{types.Int},
+		tuples: colexectestutils.Tuples{
+			{1},
+			{2},
+			{2},
+			{3},
+		},
+		isOrderedOnDistinctCols: true,
+		errorOnDup:              "duplicate twos",
+	},
+	{
+		distinctCols: []uint32{0, 1},
+		typs:         []*types.T{types.Int, types.Int},
+		tuples: colexectestutils.Tuples{
+			{1, 1},
+			{1, 2},
+			{1, 2},
+			{1, 3},
+		},
+		isOrderedOnDistinctCols: true,
+		errorOnDup:              "duplicates in the second column",
+	},
+	{
+		distinctCols: []uint32{0},
+		typs:         []*types.T{types.Int},
+		tuples: colexectestutils.Tuples{
+			{nil},
+			{nil},
+		},
+		isOrderedOnDistinctCols: true,
+		errorOnDup:              "duplicate nulls",
+	},
+	{
+		distinctCols: []uint32{0},
+		typs:         []*types.T{types.Int},
+		tuples: colexectestutils.Tuples{
+			{nil},
+			{nil},
+		},
+		expected: colexectestutils.Tuples{
+			{nil},
+			{nil},
+		},
+		isOrderedOnDistinctCols: true,
+		nullsAreDistinct:        true,
+		errorOnDup:              "\"duplicate\" distinct nulls",
+		noError:                 true,
+	},
 }
 
 func mustParseJSON(s string) json.JSON {
@@ -250,18 +308,72 @@ func mustParseJSON(s string) json.JSON {
 	return j
 }
 
+func (tc *distinctTestCase) runTests(
+	t *testing.T,
+	verifier colexectestutils.VerifierType,
+	constructor func(inputs []colexecop.Operator) (colexecop.Operator, error),
+) {
+	if tc.errorOnDup == "" {
+		colexectestutils.RunTestsWithTyps(
+			t, testAllocator, []colexectestutils.Tuples{tc.tuples}, [][]*types.T{tc.typs},
+			tc.expected, verifier, constructor,
+		)
+	} else {
+		var numErrorRuns int
+		errorHandler := func(err error) {
+			if strings.Contains(err.Error(), tc.errorOnDup) {
+				numErrorRuns++
+				return
+			}
+			t.Fatal(err)
+		}
+		// numConstructorCalls is incremented every time the operator to test is
+		// constructed and is a lower bound on the number of test runs. It is a
+		// lower bound because in some cases we will reset the operator chain
+		// for a second run, and the constructor won't get called then.
+		var numConstructorCalls int
+		instrumentedConstructor := func(inputs []colexecop.Operator) (colexecop.Operator, error) {
+			numConstructorCalls++
+			return constructor(inputs)
+		}
+		colexectestutils.RunTestsWithoutAllNullsInjectionWithErrorHandler(
+			t, testAllocator, []colexectestutils.Tuples{tc.tuples}, [][]*types.T{tc.typs},
+			tc.expected, verifier, instrumentedConstructor, errorHandler,
+		)
+		if tc.noError {
+			require.Zero(t, numErrorRuns)
+		} else {
+			// RunTests test harness runs two scenarios in which the error might
+			// not be encountered:
+			// 1) verifySelAndNullResets - because it exits once two batches are
+			//    returned. Note that in this scenario the constructor is called
+			//    up to two times;
+			// 2) randomNullsInjection - because the input data set is modified;
+			// so we subtract three runs from the lower bound on the number of
+			// expected errors.
+			numConstructorCalls -= 3
+			// Because numConstructorCalls is a lower bound on the number of
+			// the test runs, we expect numErrorRuns to be no less than
+			// numConstructorCalls.
+			require.GreaterOrEqual(
+				t, numErrorRuns, numConstructorCalls,
+				"expected to have no less erroneous runs than the total number of constructor calls",
+			)
+		}
+	}
+}
+
 func TestDistinct(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	rng, _ := randutil.NewPseudoRand()
 	for _, tc := range distinctTestCases {
 		log.Infof(context.Background(), "unordered")
-		colexectestutils.RunTestsWithTyps(t, testAllocator, []colexectestutils.Tuples{tc.tuples}, [][]*types.T{tc.typs}, tc.expected, colexectestutils.OrderedVerifier,
-			func(input []colexecop.Operator) (colexecop.Operator, error) {
-				return NewUnorderedDistinct(
-					testAllocator, input[0], tc.distinctCols, tc.typs, tc.nullsAreDistinct, "", /* errorOnDup */
-				), nil
-			})
+		tc.runTests(t, colexectestutils.OrderedVerifier, func(input []colexecop.Operator) (colexecop.Operator, error) {
+			return NewUnorderedDistinct(
+				testAllocator, input[0], tc.distinctCols, tc.typs, tc.nullsAreDistinct, tc.errorOnDup,
+			), nil
+		})
 		if tc.isOrderedOnDistinctCols {
 			for numOrderedCols := 1; numOrderedCols < len(tc.distinctCols); numOrderedCols++ {
 				log.Infof(context.Background(), "partiallyOrdered/ordCols=%d", numOrderedCols)
@@ -269,18 +381,16 @@ func TestDistinct(t *testing.T) {
 				for i, j := range rng.Perm(len(tc.distinctCols))[:numOrderedCols] {
 					orderedCols[i] = tc.distinctCols[j]
 				}
-				colexectestutils.RunTestsWithTyps(t, testAllocator, []colexectestutils.Tuples{tc.tuples}, [][]*types.T{tc.typs}, tc.expected, colexectestutils.OrderedVerifier,
-					func(input []colexecop.Operator) (colexecop.Operator, error) {
-						return newPartiallyOrderedDistinct(
-							testAllocator, input[0], tc.distinctCols, orderedCols, tc.typs, tc.nullsAreDistinct, "", /* errorOnDup */
-						)
-					})
+				tc.runTests(t, colexectestutils.OrderedVerifier, func(input []colexecop.Operator) (colexecop.Operator, error) {
+					return newPartiallyOrderedDistinct(
+						testAllocator, input[0], tc.distinctCols, orderedCols, tc.typs, tc.nullsAreDistinct, tc.errorOnDup,
+					)
+				})
 			}
 			log.Info(context.Background(), "ordered")
-			colexectestutils.RunTestsWithTyps(t, testAllocator, []colexectestutils.Tuples{tc.tuples}, [][]*types.T{tc.typs}, tc.expected, colexectestutils.OrderedVerifier,
-				func(input []colexecop.Operator) (colexecop.Operator, error) {
-					return colexecbase.NewOrderedDistinct(input[0], tc.distinctCols, tc.typs, tc.nullsAreDistinct, "" /* errorOnDup */)
-				})
+			tc.runTests(t, colexectestutils.OrderedVerifier, func(input []colexecop.Operator) (colexecop.Operator, error) {
+				return colexecbase.NewOrderedDistinct(input[0], tc.distinctCols, tc.typs, tc.nullsAreDistinct, tc.errorOnDup)
+			})
 		}
 	}
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/hashtable_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/hashtable_gen.go
@@ -116,9 +116,9 @@ func genHashTable(inputFileContents string, wr io.Writer, htm hashTableMode) err
 		`{{template "checkColForDistinctWithNulls" buildDict "Global" . "UseProbeSel" $1}}`,
 	)
 
-	checkBody := makeFunctionRegex("_CHECK_BODY", 2)
+	checkBody := makeFunctionRegex("_CHECK_BODY", 3)
 	s = checkBody.ReplaceAllString(s,
-		`{{template "checkBody" buildDict "Global" . "SelectSameTuples" $1 "DeletingProbeMode" $2}}`,
+		`{{template "checkBody" buildDict "Global" . "SelectSameTuples" $1 "DeletingProbeMode" $2 "SelectDistinct" $3}}`,
 	)
 
 	updateSelBody := makeFunctionRegex("_UPDATE_SEL_BODY", 1)

--- a/pkg/sql/colexec/execgen/cmd/execgen/hashtable_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/hashtable_gen.go
@@ -96,9 +96,9 @@ func genHashTable(inputFileContents string, wr io.Writer, htm hashTableMode) err
 	assignNeRe := makeFunctionRegex("_ASSIGN_NE", 6)
 	s = assignNeRe.ReplaceAllString(s, makeTemplateFunctionCall("Global.Right.Assign", 6))
 
-	checkColBody := makeFunctionRegex("_CHECK_COL_BODY", 7)
+	checkColBody := makeFunctionRegex("_CHECK_COL_BODY", 6)
 	s = checkColBody.ReplaceAllString(s,
-		`{{template "checkColBody" buildDict "Global" .Global "ProbeHasNulls" $1 "BuildHasNulls" $2 "AllowNullEquality" $3 "SelectDistinct" $4 "UseProbeSel" $5 "ProbingAgainstItself" $6 "DeletingProbeMode" $7}}`,
+		`{{template "checkColBody" buildDict "Global" .Global "ProbeHasNulls" $1 "BuildHasNulls" $2 "SelectDistinct" $3 "UseProbeSel" $4 "ProbingAgainstItself" $5 "DeletingProbeMode" $6}}`,
 	)
 
 	checkColWithNulls := makeFunctionRegex("_CHECK_COL_WITH_NULLS", 3)

--- a/pkg/sql/colexec/external_distinct.go
+++ b/pkg/sql/colexec/external_distinct.go
@@ -44,7 +44,8 @@ func NewExternalDistinct(
 		// limit, so we use an unlimited allocator.
 		// TODO(yuzefovich): it might be worth increasing the number of buckets.
 		return NewUnorderedDistinct(
-			unlimitedAllocator, partitionedInputs[0], distinctCols, inputTypes,
+			unlimitedAllocator, partitionedInputs[0], distinctCols,
+			inputTypes, distinctSpec.NullsAreDistinct, distinctSpec.ErrorOnDup,
 		)
 	}
 	diskBackedFallbackOpConstructor := func(
@@ -73,7 +74,10 @@ func NewExternalDistinct(
 			projection[i] = uint32(i)
 		}
 		diskBackedWithoutOrdinality := colexecbase.NewSimpleProjectOp(diskBackedSorter, len(sortTypes), projection)
-		diskBackedFallbackOp, err := colexecbase.NewOrderedDistinct(diskBackedWithoutOrdinality, distinctCols, inputTypes)
+		diskBackedFallbackOp, err := colexecbase.NewOrderedDistinct(
+			diskBackedWithoutOrdinality, distinctCols, inputTypes,
+			distinctSpec.NullsAreDistinct, distinctSpec.ErrorOnDup,
+		)
 		if err != nil {
 			colexecerror.InternalError(err)
 		}

--- a/pkg/sql/colexec/external_distinct_test.go
+++ b/pkg/sql/colexec/external_distinct_test.go
@@ -79,31 +79,29 @@ func TestExternalDistinct(t *testing.T) {
 				// Closer.
 				numExpectedClosers++
 			}
-			colexectestutils.RunTestsWithTyps(
-				t,
-				testAllocator,
-				[]colexectestutils.Tuples{tc.tuples},
-				[][]*types.T{tc.typs},
-				tc.expected,
-				verifier,
-				func(input []colexecop.Operator) (colexecop.Operator, error) {
-					// A sorter should never exceed ExternalSorterMinPartitions, even
-					// during repartitioning. A panic will happen if a sorter requests
-					// more than this number of file descriptors.
-					sem := colexecop.NewTestingSemaphore(colexecop.ExternalSorterMinPartitions)
-					semsToCheck = append(semsToCheck, sem)
-					distinct, newAccounts, newMonitors, closers, err := createExternalDistinct(
-						ctx, flowCtx, input, tc.typs, tc.distinctCols, tc.nullsAreDistinct,
-						outputOrdering, queueCfg, sem, nil /* spillingCallbackFn */, numForcedRepartitions,
-					)
-					require.Equal(t, numExpectedClosers, len(closers))
-					accounts = append(accounts, newAccounts...)
-					monitors = append(monitors, newMonitors...)
-					return distinct, err
-				},
-			)
-			for i, sem := range semsToCheck {
-				require.Equal(t, 0, sem.GetCount(), "sem still reports open FDs at index %d", i)
+			tc.runTests(t, verifier, func(input []colexecop.Operator) (colexecop.Operator, error) {
+				// A sorter should never exceed ExternalSorterMinPartitions, even
+				// during repartitioning. A panic will happen if a sorter requests
+				// more than this number of file descriptors.
+				sem := colexecop.NewTestingSemaphore(colexecop.ExternalSorterMinPartitions)
+				semsToCheck = append(semsToCheck, sem)
+				distinct, newAccounts, newMonitors, closers, err := createExternalDistinct(
+					ctx, flowCtx, input, tc.typs, tc.distinctCols, tc.nullsAreDistinct, tc.errorOnDup,
+					outputOrdering, queueCfg, sem, nil /* spillingCallbackFn */, numForcedRepartitions,
+				)
+				require.Equal(t, numExpectedClosers, len(closers))
+				accounts = append(accounts, newAccounts...)
+				monitors = append(monitors, newMonitors...)
+				return distinct, err
+			})
+			if tc.errorOnDup == "" || tc.noError {
+				// We don't check that all FDs were released if an error is
+				// expected to be returned because our utility closeIfCloser()
+				// doesn't handle multiple closers (which is always the case for
+				// the external distinct).
+				for i, sem := range semsToCheck {
+					require.Equal(t, 0, sem.GetCount(), "sem still reports open FDs at index %d", i)
+				}
 			}
 		}
 	}
@@ -205,7 +203,7 @@ func TestExternalDistinctSpilling(t *testing.T) {
 			semsToCheck = append(semsToCheck, sem)
 			var outputOrdering execinfrapb.Ordering
 			distinct, newAccounts, newMonitors, closers, err := createExternalDistinct(
-				ctx, flowCtx, input, typs, distinctCols, false, /* nullsAreDistinct */
+				ctx, flowCtx, input, typs, distinctCols, false /* nullsAreDistinct */, "", /* errorOnDup */
 				outputOrdering, queueCfg, sem, func() { numSpills++ }, numForcedRepartitions,
 			)
 			require.NoError(t, err)
@@ -322,7 +320,7 @@ func BenchmarkExternalDistinct(b *testing.B) {
 					}
 					op, accs, mons, _, err := createExternalDistinct(
 						ctx, flowCtx, []colexecop.Operator{input}, typs,
-						distinctCols, false, /* nullsAreDistinct */
+						distinctCols, false /* nullsAreDistinct */, "", /* errorOnDup */
 						outputOrdering, queueCfg, &colexecop.TestingSemaphore{},
 						nil /* spillingCallbackFn */, 0, /* numForcedRepartitions */
 					)
@@ -357,6 +355,7 @@ func createExternalDistinct(
 	typs []*types.T,
 	distinctCols []uint32,
 	nullsAreDistinct bool,
+	errorOnDup string,
 	outputOrdering execinfrapb.Ordering,
 	diskQueueCfg colcontainer.DiskQueueCfg,
 	testingSemaphore semaphore.Semaphore,
@@ -366,6 +365,7 @@ func createExternalDistinct(
 	distinctSpec := &execinfrapb.DistinctSpec{
 		DistinctColumns:  distinctCols,
 		NullsAreDistinct: nullsAreDistinct,
+		ErrorOnDup:       errorOnDup,
 		OutputOrdering:   outputOrdering,
 	}
 	spec := &execinfrapb.ProcessorSpec{

--- a/pkg/sql/colexec/ordered_aggregator.go
+++ b/pkg/sql/colexec/ordered_aggregator.go
@@ -149,7 +149,9 @@ func NewOrderedAggregator(
 			return nil, errors.AssertionFailedf("filtering ordered aggregation is not supported")
 		}
 	}
-	op, groupCol, err := colexecbase.OrderedDistinctColsToOperators(args.Input, args.Spec.GroupCols, args.InputTypes)
+	op, groupCol, err := colexecbase.OrderedDistinctColsToOperators(
+		args.Input, args.Spec.GroupCols, args.InputTypes, false, /* nullsAreDistinct */
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/colexec/partially_ordered_distinct.go
+++ b/pkg/sql/colexec/partially_ordered_distinct.go
@@ -31,13 +31,15 @@ func newPartiallyOrderedDistinct(
 	distinctCols []uint32,
 	orderedCols []uint32,
 	typs []*types.T,
+	nullsAreDistinct bool,
+	errorOnDup string,
 ) (colexecop.Operator, error) {
 	if len(orderedCols) == 0 || len(orderedCols) == len(distinctCols) {
 		return nil, errors.AssertionFailedf(
 			"partially ordered distinct wrongfully planned: numDistinctCols=%d "+
 				"numOrderedCols=%d", len(distinctCols), len(orderedCols))
 	}
-	chunker, err := newChunker(allocator, input, typs, orderedCols)
+	chunker, err := newChunker(allocator, input, typs, orderedCols, nullsAreDistinct)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +61,7 @@ func newPartiallyOrderedDistinct(
 			distinctUnorderedCols = append(distinctUnorderedCols, distinctCol)
 		}
 	}
-	distinct := NewUnorderedDistinct(allocator, chunkerOperator, distinctUnorderedCols, typs)
+	distinct := NewUnorderedDistinct(allocator, chunkerOperator, distinctUnorderedCols, typs, nullsAreDistinct, errorOnDup)
 	return &partiallyOrderedDistinct{
 		input:    chunkerOperator,
 		distinct: distinct.(colexecop.ResettableOperator),

--- a/pkg/sql/colexec/sort.go
+++ b/pkg/sql/colexec/sort.go
@@ -51,7 +51,7 @@ func newSorter(
 			return nil, errors.Errorf("sorter for type: %s and direction: %s not supported", inputTypes[ord.ColIdx], ord.Direction)
 		}
 		if i < len(orderingCols)-1 {
-			partitioners[i], err = newPartitioner(inputTypes[ord.ColIdx])
+			partitioners[i], err = newPartitioner(inputTypes[ord.ColIdx], false /* nullsAreDistinct */)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/colexec/values_differ.eg.go
+++ b/pkg/sql/colexec/values_differ.eg.go
@@ -31,9 +31,10 @@ var (
 )
 
 // valuesDiffer takes in two ColVecs as well as values indices to check whether
-// the values differ. This function pays attention to NULLs, and two NULL
-// values do *not* differ.
-func valuesDiffer(aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValueIdx int) bool {
+// the values differ. This function pays attention to NULLs.
+func valuesDiffer(
+	aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValueIdx int, nullsAreDistinct bool,
+) bool {
 	switch aColVec.CanonicalTypeFamily() {
 	case types.BoolFamily:
 		switch aColVec.Type().Width() {
@@ -46,7 +47,7 @@ func valuesDiffer(aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValu
 			aNull := aNulls.MaybeHasNulls() && aNulls.NullAt(aValueIdx)
 			bNull := bNulls.MaybeHasNulls() && bNulls.NullAt(bValueIdx)
 			if aNull && bNull {
-				return false
+				return nullsAreDistinct
 			} else if aNull || bNull {
 				return true
 			}
@@ -81,7 +82,7 @@ func valuesDiffer(aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValu
 			aNull := aNulls.MaybeHasNulls() && aNulls.NullAt(aValueIdx)
 			bNull := bNulls.MaybeHasNulls() && bNulls.NullAt(bValueIdx)
 			if aNull && bNull {
-				return false
+				return nullsAreDistinct
 			} else if aNull || bNull {
 				return true
 			}
@@ -108,7 +109,7 @@ func valuesDiffer(aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValu
 			aNull := aNulls.MaybeHasNulls() && aNulls.NullAt(aValueIdx)
 			bNull := bNulls.MaybeHasNulls() && bNulls.NullAt(bValueIdx)
 			if aNull && bNull {
-				return false
+				return nullsAreDistinct
 			} else if aNull || bNull {
 				return true
 			}
@@ -134,7 +135,7 @@ func valuesDiffer(aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValu
 			aNull := aNulls.MaybeHasNulls() && aNulls.NullAt(aValueIdx)
 			bNull := bNulls.MaybeHasNulls() && bNulls.NullAt(bValueIdx)
 			if aNull && bNull {
-				return false
+				return nullsAreDistinct
 			} else if aNull || bNull {
 				return true
 			}
@@ -168,7 +169,7 @@ func valuesDiffer(aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValu
 			aNull := aNulls.MaybeHasNulls() && aNulls.NullAt(aValueIdx)
 			bNull := bNulls.MaybeHasNulls() && bNulls.NullAt(bValueIdx)
 			if aNull && bNull {
-				return false
+				return nullsAreDistinct
 			} else if aNull || bNull {
 				return true
 			}
@@ -203,7 +204,7 @@ func valuesDiffer(aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValu
 			aNull := aNulls.MaybeHasNulls() && aNulls.NullAt(aValueIdx)
 			bNull := bNulls.MaybeHasNulls() && bNulls.NullAt(bValueIdx)
 			if aNull && bNull {
-				return false
+				return nullsAreDistinct
 			} else if aNull || bNull {
 				return true
 			}
@@ -241,7 +242,7 @@ func valuesDiffer(aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValu
 			aNull := aNulls.MaybeHasNulls() && aNulls.NullAt(aValueIdx)
 			bNull := bNulls.MaybeHasNulls() && bNulls.NullAt(bValueIdx)
 			if aNull && bNull {
-				return false
+				return nullsAreDistinct
 			} else if aNull || bNull {
 				return true
 			}
@@ -287,7 +288,7 @@ func valuesDiffer(aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValu
 			aNull := aNulls.MaybeHasNulls() && aNulls.NullAt(aValueIdx)
 			bNull := bNulls.MaybeHasNulls() && bNulls.NullAt(bValueIdx)
 			if aNull && bNull {
-				return false
+				return nullsAreDistinct
 			} else if aNull || bNull {
 				return true
 			}
@@ -321,7 +322,7 @@ func valuesDiffer(aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValu
 			aNull := aNulls.MaybeHasNulls() && aNulls.NullAt(aValueIdx)
 			bNull := bNulls.MaybeHasNulls() && bNulls.NullAt(bValueIdx)
 			if aNull && bNull {
-				return false
+				return nullsAreDistinct
 			} else if aNull || bNull {
 				return true
 			}
@@ -348,7 +349,7 @@ func valuesDiffer(aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValu
 			aNull := aNulls.MaybeHasNulls() && aNulls.NullAt(aValueIdx)
 			bNull := bNulls.MaybeHasNulls() && bNulls.NullAt(bValueIdx)
 			if aNull && bNull {
-				return false
+				return nullsAreDistinct
 			} else if aNull || bNull {
 				return true
 			}
@@ -381,7 +382,7 @@ func valuesDiffer(aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValu
 			aNull := aNulls.MaybeHasNulls() && aNulls.NullAt(aValueIdx)
 			bNull := bNulls.MaybeHasNulls() && bNulls.NullAt(bValueIdx)
 			if aNull && bNull {
-				return false
+				return nullsAreDistinct
 			} else if aNull || bNull {
 				return true
 			}

--- a/pkg/sql/colexec/values_differ_tmpl.go
+++ b/pkg/sql/colexec/values_differ_tmpl.go
@@ -59,9 +59,10 @@ func _ASSIGN_NE(_, _, _, _, _, _ string) bool {
 // */}}
 
 // valuesDiffer takes in two ColVecs as well as values indices to check whether
-// the values differ. This function pays attention to NULLs, and two NULL
-// values do *not* differ.
-func valuesDiffer(aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValueIdx int) bool {
+// the values differ. This function pays attention to NULLs.
+func valuesDiffer(
+	aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValueIdx int, nullsAreDistinct bool,
+) bool {
 	switch aColVec.CanonicalTypeFamily() {
 	// {{range .}}
 	case _CANONICAL_TYPE_FAMILY:
@@ -75,7 +76,7 @@ func valuesDiffer(aColVec coldata.Vec, aValueIdx int, bColVec coldata.Vec, bValu
 			aNull := aNulls.MaybeHasNulls() && aNulls.NullAt(aValueIdx)
 			bNull := bNulls.MaybeHasNulls() && bNulls.NullAt(bValueIdx)
 			if aNull && bNull {
-				return false
+				return nullsAreDistinct
 			} else if aNull || bNull {
 				return true
 			}

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -763,7 +763,7 @@ DELETE FROM u WHERE b IN (-10, -100, -1000)
 # Inserting multiple rows that conflict with each other inserts some of the
 # rows.
 statement ok
-INSERT INTO u VALUES (2, 2), (2, 20), (2, -2) ON CONFLICT DO NOTHING
+INSERT INTO u VALUES (2, 2), (2, 2), (2, -2) ON CONFLICT DO NOTHING
 
 query II rowsort
 SELECT * FROM u

--- a/pkg/sql/logictest/testdata/logic_test/tpch_vec
+++ b/pkg/sql/logictest/testdata/logic_test/tpch_vec
@@ -630,13 +630,12 @@ EXPLAIN (VEC) SELECT sum(l_extendedprice * l_discount) AS revenue FROM lineitem 
 │
 └ Node 1
   └ *colexec.orderedAggregator
-    └ *colexecbase.distinctChainOps
-      └ *colexecproj.projMultFloat64Float64Op
-        └ *colexecsel.selLTFloat64Float64ConstOp
-          └ *colexecsel.selLEFloat64Float64ConstOp
-            └ *colexecsel.selGEFloat64Float64ConstOp
-              └ *rowexec.joinReader
-                └ *colfetcher.ColBatchScan
+    └ *colexecproj.projMultFloat64Float64Op
+      └ *colexecsel.selLTFloat64Float64ConstOp
+        └ *colexecsel.selLEFloat64Float64ConstOp
+          └ *colexecsel.selGEFloat64Float64ConstOp
+            └ *rowexec.joinReader
+              └ *colfetcher.ColBatchScan
 
 # Query 7
 query T
@@ -808,21 +807,20 @@ EXPLAIN (VEC) SELECT 100.00 * sum(CASE WHEN p_type LIKE 'PROMO%' THEN l_extended
   └ *colexecproj.projDivFloat64Float64Op
     └ *colexecproj.projMultFloat64Float64ConstOp
       └ *colexec.orderedAggregator
-        └ *colexecbase.distinctChainOps
-          └ *colexecproj.projMultFloat64Float64Op
-            └ *colexecproj.projMinusFloat64ConstFloat64Op
-              └ *colexec.caseOp
-                ├ *colexec.bufferOp
-                │ └ *colexecjoin.hashJoiner
-                │   ├ *colfetcher.ColBatchScan
-                │   └ *rowexec.joinReader
-                │     └ *colfetcher.ColBatchScan
-                ├ *colexecproj.projMultFloat64Float64Op
-                │ └ *colexecproj.projMinusFloat64ConstFloat64Op
-                │   └ *colexecproj.projPrefixBytesBytesConstOp
-                │     └ *colexec.bufferOp
-                └ *colexecbase.constFloat64Op
-                  └ *colexec.bufferOp
+        └ *colexecproj.projMultFloat64Float64Op
+          └ *colexecproj.projMinusFloat64ConstFloat64Op
+            └ *colexec.caseOp
+              ├ *colexec.bufferOp
+              │ └ *colexecjoin.hashJoiner
+              │   ├ *colfetcher.ColBatchScan
+              │   └ *rowexec.joinReader
+              │     └ *colfetcher.ColBatchScan
+              ├ *colexecproj.projMultFloat64Float64Op
+              │ └ *colexecproj.projMinusFloat64ConstFloat64Op
+              │   └ *colexecproj.projPrefixBytesBytesConstOp
+              │     └ *colexec.bufferOp
+              └ *colexecbase.constFloat64Op
+                └ *colexec.bufferOp
 
 # Query 15
 statement ok
@@ -872,17 +870,15 @@ EXPLAIN (VEC) SELECT sum(l_extendedprice) / 7.0 AS avg_yearly FROM lineitem, par
 └ Node 1
   └ *colexecproj.projDivFloat64Float64ConstOp
     └ *colexec.orderedAggregator
-      └ *colexecbase.distinctChainOps
+      └ *rowexec.joinReader
         └ *rowexec.joinReader
-          └ *rowexec.joinReader
-            └ *colexecproj.projMultFloat64Float64ConstOp
-              └ *colexec.orderedAggregator
-                └ *colexecbase.distinctChainOps
-                  └ *rowexec.joinReader
-                    └ *rowexec.joinReader
-                      └ *colexecsel.selEQBytesBytesConstOp
-                        └ *colexecsel.selEQBytesBytesConstOp
-                          └ *colfetcher.ColBatchScan
+          └ *colexecproj.projMultFloat64Float64ConstOp
+            └ *colexec.orderedAggregator
+              └ *rowexec.joinReader
+                └ *rowexec.joinReader
+                  └ *colexecsel.selEQBytesBytesConstOp
+                    └ *colexecsel.selEQBytesBytesConstOp
+                      └ *colfetcher.ColBatchScan
 
 # Query 18
 query T
@@ -900,8 +896,7 @@ EXPLAIN (VEC) SELECT c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, s
             │ ├ *colfetcher.ColBatchScan
             │ └ *colexecsel.selGTFloat64Float64ConstOp
             │   └ *colexec.orderedAggregator
-            │     └ *colexecbase.distinctChainOps
-            │       └ *colfetcher.ColBatchScan
+            │     └ *colfetcher.ColBatchScan
             └ *colfetcher.ColBatchScan
 
 # Query 19
@@ -911,51 +906,50 @@ EXPLAIN (VEC) SELECT sum(l_extendedprice* (1 - l_discount)) AS revenue FROM line
 │
 └ Node 1
   └ *colexec.orderedAggregator
-    └ *colexecbase.distinctChainOps
-      └ *colexecproj.projMultFloat64Float64Op
-        └ *colexecproj.projMinusFloat64ConstFloat64Op
-          └ *colexec.caseOp
-            ├ *colexec.bufferOp
-            │ └ *colexecjoin.hashJoiner
-            │   ├ *colexecsel.selEQBytesBytesConstOp
-            │   │ └ *colexec.selectInOpBytes
-            │   │   └ *colfetcher.ColBatchScan
-            │   └ *colexecsel.selGEInt64Int64ConstOp
-            │     └ *colfetcher.ColBatchScan
-            ├ *colexecbase.constBoolOp
-            │ └ *colexec.orProjOp
-            │   ├ *colexec.bufferOp
-            │   ├ *colexec.andProjOp
-            │   │ ├ *colexec.andProjOp
-            │   │ │ ├ *colexec.andProjOp
-            │   │ │ │ ├ *colexec.andProjOp
-            │   │ │ │ │ ├ *colexecproj.projEQBytesBytesConstOp
-            │   │ │ │ │ └ *colexec.projectInOpBytes
-            │   │ │ │ └ *colexecproj.projGEFloat64Float64ConstOp
-            │   │ │ └ *colexecproj.projLEFloat64Float64ConstOp
-            │   │ └ *colexecproj.projLEInt64Int64ConstOp
-            │   └ *colexec.andProjOp
-            │     ├ *colexec.andProjOp
-            │     │ ├ *colexec.andProjOp
-            │     │ │ ├ *colexec.andProjOp
-            │     │ │ │ ├ *colexecproj.projEQBytesBytesConstOp
-            │     │ │ │ └ *colexec.projectInOpBytes
-            │     │ │ └ *colexecproj.projGEFloat64Float64ConstOp
-            │     │ └ *colexecproj.projLEFloat64Float64ConstOp
-            │     └ *colexecproj.projLEInt64Int64ConstOp
-            ├ *colexecbase.constBoolOp
-            │ └ *colexec.andProjOp
-            │   ├ *colexec.bufferOp
-            │   ├ *colexec.andProjOp
-            │   │ ├ *colexec.andProjOp
-            │   │ │ ├ *colexec.andProjOp
-            │   │ │ │ ├ *colexecproj.projEQBytesBytesConstOp
-            │   │ │ │ └ *colexec.projectInOpBytes
-            │   │ │ └ *colexecproj.projGEFloat64Float64ConstOp
-            │   │ └ *colexecproj.projLEFloat64Float64ConstOp
-            │   └ *colexecproj.projLEInt64Int64ConstOp
-            └ *colexecbase.constBoolOp
-              └ *colexec.bufferOp
+    └ *colexecproj.projMultFloat64Float64Op
+      └ *colexecproj.projMinusFloat64ConstFloat64Op
+        └ *colexec.caseOp
+          ├ *colexec.bufferOp
+          │ └ *colexecjoin.hashJoiner
+          │   ├ *colexecsel.selEQBytesBytesConstOp
+          │   │ └ *colexec.selectInOpBytes
+          │   │   └ *colfetcher.ColBatchScan
+          │   └ *colexecsel.selGEInt64Int64ConstOp
+          │     └ *colfetcher.ColBatchScan
+          ├ *colexecbase.constBoolOp
+          │ └ *colexec.orProjOp
+          │   ├ *colexec.bufferOp
+          │   ├ *colexec.andProjOp
+          │   │ ├ *colexec.andProjOp
+          │   │ │ ├ *colexec.andProjOp
+          │   │ │ │ ├ *colexec.andProjOp
+          │   │ │ │ │ ├ *colexecproj.projEQBytesBytesConstOp
+          │   │ │ │ │ └ *colexec.projectInOpBytes
+          │   │ │ │ └ *colexecproj.projGEFloat64Float64ConstOp
+          │   │ │ └ *colexecproj.projLEFloat64Float64ConstOp
+          │   │ └ *colexecproj.projLEInt64Int64ConstOp
+          │   └ *colexec.andProjOp
+          │     ├ *colexec.andProjOp
+          │     │ ├ *colexec.andProjOp
+          │     │ │ ├ *colexec.andProjOp
+          │     │ │ │ ├ *colexecproj.projEQBytesBytesConstOp
+          │     │ │ │ └ *colexec.projectInOpBytes
+          │     │ │ └ *colexecproj.projGEFloat64Float64ConstOp
+          │     │ └ *colexecproj.projLEFloat64Float64ConstOp
+          │     └ *colexecproj.projLEInt64Int64ConstOp
+          ├ *colexecbase.constBoolOp
+          │ └ *colexec.andProjOp
+          │   ├ *colexec.bufferOp
+          │   ├ *colexec.andProjOp
+          │   │ ├ *colexec.andProjOp
+          │   │ │ ├ *colexec.andProjOp
+          │   │ │ │ ├ *colexecproj.projEQBytesBytesConstOp
+          │   │ │ │ └ *colexec.projectInOpBytes
+          │   │ │ └ *colexecproj.projGEFloat64Float64ConstOp
+          │   │ └ *colexecproj.projLEFloat64Float64ConstOp
+          │   └ *colexecproj.projLEInt64Int64ConstOp
+          └ *colexecbase.constBoolOp
+            └ *colexec.bufferOp
 
 # Query 20
 query T

--- a/pkg/sql/logictest/testdata/logic_test/unique
+++ b/pkg/sql/logictest/testdata/logic_test/unique
@@ -329,9 +329,9 @@ statement ok
 INSERT INTO uniq_partial VALUES (7, 7), (7, 8), (7, -7) ON CONFLICT (a) WHERE b > 0 DO NOTHING
 
 # On conflict do nothing with constant input, no conflict columns.
-# Only rows (9, 9) and (9, -9) are inserted.
+# Only one row (9, 9) and (9, -9) are inserted.
 statement ok
-INSERT INTO uniq_partial VALUES (1, 9), (9, 9), (9, 10), (9, -9) ON CONFLICT DO NOTHING
+INSERT INTO uniq_partial VALUES (1, 9), (9, 9), (9, 9), (9, -9) ON CONFLICT DO NOTHING
 
 # On conflict do nothing with non-constant input.
 # The (1, 10) row is not inserted because of a conflict with (1, 1).

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_local
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_local
@@ -235,10 +235,9 @@ EXPLAIN (VEC) SELECT stddev(0) FROM t46123 WHERE ('' COLLATE en)::BOOL
 │
 └ Node 1
   └ *colexec.orderedAggregator
-    └ *colexecbase.distinctChainOps
-      └ *colexecbase.constInt64Op
-        └ *rowexec.filtererProcessor
-          └ *colfetcher.ColBatchScan
+    └ *colexecbase.constInt64Op
+      └ *rowexec.filtererProcessor
+        └ *colfetcher.ColBatchScan
 
 # Regression test for #46122.
 statement ok
@@ -294,8 +293,7 @@ EXPLAIN (VEC) SELECT max(c) FROM a
 │
 └ Node 1
   └ *colexec.orderedAggregator
-    └ *colexecbase.distinctChainOps
-      └ *colfetcher.ColBatchScan
+    └ *colfetcher.ColBatchScan
 
 # Verify that binary operations on integers of any width return INT8.
 statement ok
@@ -365,8 +363,7 @@ EXPLAIN (VEC) SELECT concat_agg(_bytes), concat_agg(_string) FROM bytes_string
 │
 └ Node 1
   └ *colexec.orderedAggregator
-    └ *colexecbase.distinctChainOps
-      └ *colfetcher.ColBatchScan
+    └ *colfetcher.ColBatchScan
 
 statement ok
 CREATE TABLE t63792 (c INT);


### PR DESCRIPTION
**colexechash: do not template on AllowNullEquality in the hash table**

Previously, we would generate different code based on AllowNullEquality
value. However, for the upcoming work on supporting distinct nulls in
the unordered distinct, it is a big burden to make the templating work
(namely, it would result in a lot of basically duplicated code). This
commit removes the template based on this value which reduces the amount
of the generated code and - to be confirmed - doesn't give us noticeable
performance hit.

Release note: None

**colexecbase: mark distinctChainOps as unexplainable**

`distinctChainOps` is a utility operator that converts a series of
single column distincters into an "ordered distinct" resettable
operator. It is also used by several other components (like ordered
aggregator to know the boundaries of the aggregation groups). This
commit marks this utility operator as "non-explainable", so it'll be
omitted from the EXPLAIN (VEC) diagrams (in non-verbose setting). The
follow up commit will introduce separate `orderedDistinct` operator that
will be "explainable".

Release note: None

**colexec: fully support distinct spec**

This commit adds the remaining support of Distinct spec to the
vectorized engine. Previously, we couldn't support cases when nulls
should be treated as distinct or when an error should be returned when
a duplicate is detected. These cases are needed for UPSERT queries.

This change required some modifications to treat nulls as distinct in
several components (the hash table used by the unordered distinct, sort
partitioners since they are used by the fallback strategy of the
external sort, valuesDiffer used by sort chunks). This commit also
introduced a helper struct to emit an error on duplicates. This also
required some changes to track whether duplicates were detected in
a batch.

Fixes: #61411.

Release note (sql change): Previously, in some special cases (UPSERTs,
as documented by cockroachdb/docs#9922), the
support of the distinct operations was missing in the vectorized
engine. Now it is added, and such operations will be able to spill to
disk if necessary.

**colexec: add a unit test for errorOnDup for distinct operator**

This commit adds some unit tests for `errorOnDup` case of the distinct
operators. That required a bit of plumbing because the expected error is
propagated as a panic, so we augment `RunTests` test harness with
special error handler functions and panic catchers.

Release note: None