### PR TITLE
sql: move `ALTER TYPE ... DROP VALUE` behind a feature flag

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -2749,6 +2749,8 @@ func TestBackupRestoreDuringUserDefinedTypeChange(t *testing.T) {
 
 			// Create a database with a type.
 			sqlDB.Exec(t, `
+SET CLUSTER SETTING sql.defaults.drop_enum_value.enabled = true;
+SET enable_drop_enum_value = true;
 CREATE DATABASE d;
 CREATE TYPE d.greeting AS ENUM ('hello', 'howdy', 'hi');
 `)

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -231,6 +231,12 @@ var implicitColumnPartitioningEnabledClusterMode = settings.RegisterBoolSetting(
 	false,
 )
 
+var dropEnumValueEnabledClusterMode = settings.RegisterBoolSetting(
+	"sql.defaults.drop_enum_value.enabled",
+	"default value for enable_drop_enum_value; allows for dropping enum values",
+	false,
+)
+
 var hashShardedIndexesEnabledClusterMode = settings.RegisterBoolSetting(
 	"sql.defaults.experimental_hash_sharded_indexes.enabled",
 	"default value for experimental_enable_hash_sharded_indexes; allows for creation of hash sharded indexes by default",
@@ -2314,6 +2320,10 @@ func (m *sessionDataMutator) SetTempTablesEnabled(val bool) {
 
 func (m *sessionDataMutator) SetImplicitColumnPartitioningEnabled(val bool) {
 	m.data.ImplicitColumnPartitioningEnabled = val
+}
+
+func (m *sessionDataMutator) SetDropEnumValueEnabled(val bool) {
+	m.data.DropEnumValueEnabled = val
 }
 
 func (m *sessionDataMutator) SetHashShardedIndexesEnabled(val bool) {

--- a/pkg/sql/logictest/testdata/logic_test/alter_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type
@@ -269,6 +269,12 @@ SELECT 'lru'::store
 statement ok
 CREATE TYPE greetings AS ENUM('hi', 'hello', 'howdy', 'yo')
 
+statement error pq: ALTER TYPE ... DROP VALUE ... is only supported as an alpha feature
+ALTER TYPE greetings DROP VALUE 'hi'
+
+statement ok
+SET enable_drop_enum_value = true;
+
 statement ok
 ALTER TYPE greetings DROP VALUE 'hi'
 
@@ -280,16 +286,6 @@ CREATE TABLE use_greetings(k INT PRIMARY KEY, v greetings)
 
 statement ok
 INSERT INTO use_greetings VALUES(1, 'yo')
-
-statement ok
-SET sql_safe_updates = true;
-
-# ALTER TYPE DROP VALUE is gated behind sql_safe_updates
-statement error pq: rejected \(sql_safe_updates = true\)
-ALTER TYPE greetings DROP VALUE 'yo'
-
-statement ok
-SET sql_safe_updates = false
 
 statement error pq: could not remove enum value "yo" as it is being used by "use_greetings"
 ALTER TYPE greetings DROP VALUE 'yo'

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4182,6 +4182,7 @@ default_transaction_read_only                         off
 default_transaction_use_follower_reads                off
 disable_partially_distributed_plans                   off
 disallow_full_table_scans                             off
+enable_drop_enum_value                                off
 enable_experimental_alter_column_type_general         off
 enable_experimental_stream_replication                off
 enable_implicit_select_for_update                     on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2438,6 +2438,7 @@ default_transaction_use_follower_reads                off                 NULL  
 disable_partially_distributed_plans                   off                 NULL      NULL        NULL        string
 disallow_full_table_scans                             off                 NULL      NULL        NULL        string
 distsql                                               off                 NULL      NULL        NULL        string
+enable_drop_enum_value                                off                 NULL      NULL        NULL        string
 enable_experimental_alter_column_type_general         off                 NULL      NULL        NULL        string
 enable_experimental_stream_replication                off                 NULL      NULL        NULL        string
 enable_implicit_select_for_update                     on                  NULL      NULL        NULL        string
@@ -2516,6 +2517,7 @@ default_transaction_use_follower_reads                off                 NULL  
 disable_partially_distributed_plans                   off                 NULL  user     NULL      off                 off
 disallow_full_table_scans                             off                 NULL  user     NULL      off                 off
 distsql                                               off                 NULL  user     NULL      off                 off
+enable_drop_enum_value                                off                 NULL  user     NULL      off                 off
 enable_experimental_alter_column_type_general         off                 NULL  user     NULL      off                 off
 enable_experimental_stream_replication                off                 NULL  user     NULL      off                 off
 enable_implicit_select_for_update                     on                  NULL  user     NULL      on                  on
@@ -2590,6 +2592,7 @@ default_transaction_use_follower_reads                NULL    NULL     NULL     
 disable_partially_distributed_plans                   NULL    NULL     NULL     NULL        NULL
 disallow_full_table_scans                             NULL    NULL     NULL     NULL        NULL
 distsql                                               NULL    NULL     NULL     NULL        NULL
+enable_drop_enum_value                                NULL    NULL     NULL     NULL        NULL
 enable_experimental_alter_column_type_general         NULL    NULL     NULL     NULL        NULL
 enable_experimental_stream_replication                NULL    NULL     NULL     NULL        NULL
 enable_implicit_select_for_update                     NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -41,6 +41,7 @@ default_transaction_use_follower_reads                off
 disable_partially_distributed_plans                   off
 disallow_full_table_scans                             off
 distsql                                               off
+enable_drop_enum_value                                off
 enable_experimental_alter_column_type_general         off
 enable_experimental_stream_replication                off
 enable_implicit_select_for_update                     on

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -206,9 +206,11 @@ type LocalOnlySessionData struct {
 	AllowPrepareAsOptPlan bool
 	// TempTablesEnabled indicates whether temporary tables can be created or not.
 	TempTablesEnabled bool
-	// ImplicitPartitioningEnabled indicates whether implicit column partitioning can
-	// be created.
+	// ImplicitPartitioningEnabled indicates whether implicit column partitioning
+	// can be created.
 	ImplicitColumnPartitioningEnabled bool
+	// DropEnumValueEnabled indicates whether enum values can be dropped.
+	DropEnumValueEnabled bool
 	// HashShardedIndexesEnabled indicates whether hash sharded indexes can be created.
 	HashShardedIndexesEnabled bool
 	// DisallowFullTableScans indicates whether queries that plan full table scans

--- a/pkg/sql/type_change_test.go
+++ b/pkg/sql/type_change_test.go
@@ -198,6 +198,8 @@ func TestFailedTypeSchemaChangeRetriesTransparently(t *testing.T) {
 
 	// Create a type.
 	_, err := sqlDB.Exec(`
+SET CLUSTER SETTING sql.defaults.drop_enum_value.enabled = true;
+SET enable_drop_enum_value = true;
 CREATE DATABASE d;
 CREATE TYPE d.t AS ENUM();
 `)
@@ -237,6 +239,8 @@ func TestAddDropValuesInTransaction(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 
 	if _, err := sqlDB.Exec(`
+SET CLUSTER SETTING sql.defaults.drop_enum_value.enabled = true;
+SET enable_drop_enum_value = true;
 CREATE DATABASE d;
 USE d;
 CREATE TYPE greetings AS ENUM('hi', 'hello', 'yo');
@@ -397,8 +401,12 @@ func TestEnumMemberTransitionIsolation(t *testing.T) {
 	ctx := context.Background()
 	defer s.Stopper().Stop(ctx)
 
-	// Create a database with a type.
-	if _, err := sqlDB.Exec(`CREATE TYPE ab AS ENUM ('a', 'b')`); err != nil {
+	// Setup.
+	if _, err := sqlDB.Exec(`
+SET CLUSTER SETTING sql.defaults.drop_enum_value.enabled = true;
+SET enable_drop_enum_value = true;
+CREATE TYPE ab AS ENUM ('a', 'b')`,
+	); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -1142,6 +1142,25 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`enable_drop_enum_value`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`enable_drop_enum_value`),
+		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("enable_drop_enum_value", s)
+			if err != nil {
+				return err
+			}
+			m.SetDropEnumValueEnabled(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) string {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData.DropEnumValueEnabled)
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return formatBoolAsPostgresSetting(dropEnumValueEnabledClusterMode.Get(sv))
+		},
+	},
+
+	// CockroachDB extension.
 	`experimental_enable_hash_sharded_indexes`: {
 		GetStringVal: makePostgresBoolGetStringValFn(`experimental_enable_hash_sharded_indexes`),
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {


### PR DESCRIPTION
Previously, `ALTER TYPE ... DROP VALUE` was behind `sql_safe_updates`.
This patch moves it instead behind a feature flag. The session setting
is `enable_drop_enum_value` and the cluster setting is
`sql.defaults.drop_enum_value.enabled`.

Resolves #61519

Release justification: Low risk patch that gates new functionality
behind a feature flag.
Release note (sql change): `ALTER TYPE ... DROP VALUE` is gated behind
a feature flag. The session setting is called `enable_drop_enum_value`
and the corresponding cluster setting is called
`sql.defaults.drop_enum_value.enabled`.