### PR TITLE
release 20.2: roachtest: fix import/mixed-version

### DIFF
--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -169,15 +169,17 @@ func registerImportTPCH(r *testRegistry) {
 	}
 }
 
-func successfulImportStep(warehouses, nodeID int) versionStep {
-	return func(ctx context.Context, t *test, u *versionUpgradeTest) {
-		u.c.Run(ctx, u.c.Node(nodeID), tpccImportCmd(warehouses))
-	}
-}
-
 func runImportMixedVersion(
 	ctx context.Context, t *test, c *cluster, warehouses int, predecessorVersion string,
 ) {
+	successfulImportStep := func(warehouses, nodeID int) versionStep {
+		// Even though this is a 20.2 test, since it's run in a mixed-version
+		// cluster test so we need to support 20.1 nodes, so include the deprecated
+		// fk indexes.
+		return func(ctx context.Context, t *test, u *versionUpgradeTest) {
+			u.c.Run(ctx, u.c.Node(nodeID), tpccImportCmd(warehouses, "--deprecated-fk-indexes"))
+		}
+	}
 	// An empty string means that the cockroach binary specified by flag
 	// `cockroach` will be used.
 	const mainVersion = ""


### PR DESCRIPTION
This commit fixes the import/mixed-version roachtest. Previously it did
not include the --deprecated-fk-indexes flag that was required since the
import was running with older 20.1 nodes in the cluster.

Fixes https://github.com/cockroachdb/cockroach/issues/57939

Release note: None