### PR TITLE
nightly build: add missing license files

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -30,9 +30,9 @@ executable.
 ### Deployment
 
 The deploy image is a downsized image containing a minimal environment for
-running CockroachDB. It is based on Debian Jessie and contains only the main
-CockroachDB binary. To fetch this image, run `docker pull
-cockroachdb/cockroach` in the usual fashion.
+running CockroachDB. It is based on RedHat's `ubi8/ubi-minimal` image and
+contains only the main CockroachDB binary, libgeos libraries, and licenses. To
+fetch this image, run `docker pull cockroachdb/cockroach` in the usual fashion.
 
 To build the image yourself, use the Dockerfile in the `deploy` directory after
 building a release version of the binary with the development image described in
@@ -45,6 +45,7 @@ usual fashion. To be more specific, the steps to do this are:
 go/src/github.com/cockroachdb/cockroach $ ./build/builder.sh mkrelease linux-gnu
 go/src/github.com/cockroachdb/cockroach $ cp ./cockroach-linux-2.6.32-gnu-amd64 build/deploy/cockroach
 go/src/github.com/cockroachdb/cockroach $ cp ./lib.docker_amd64/libgeos_c.so ./lib.docker_amd64/libgeos.so build/deploy/
+go/src/github.com/cockroachdb/cockroach $ cp -r licenses build/deploy/
 go/src/github.com/cockroachdb/cockroach $ cd build/deploy && docker build -t cockroachdb/cockroach .
 ```
 

--- a/build/release/teamcity-make-and-publish-build.sh
+++ b/build/release/teamcity-make-and-publish-build.sh
@@ -68,6 +68,7 @@ docker_login_with_google
 # curl unhappy, so passing `i` will cause it to read to the end.
 curl -f -s -S -o- "https://${bucket}.s3.amazonaws.com/cockroach-${build_name}.linux-amd64.tgz" | tar ixfz - --strip-components 1
 cp cockroach lib/libgeos.so lib/libgeos_c.so build/deploy
+cp -r licenses build/deploy/
 
 docker build --no-cache --tag="${gcr_repository}:${build_name}" build/deploy
 docker push "${gcr_repository}:${build_name}"


### PR DESCRIPTION
In #60007 we included the `licenses` directory to the release docker
images, but forgot to reflect the change to the nightly docker builds.

This patch fixes the missing directory issue by copying all needed files
under the `build/deploy` directory.

Release justification: non-production code changes

Release note: None