### PR TITLE
Revert bsl license change applied to the wrong branch

### DIFF
--- a/licenses/BSL.txt
+++ b/licenses/BSL.txt
@@ -3,7 +3,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Cockroach Labs, Inc.
-Licensed Work:        CockroachDB 21.2
+Licensed Work:        CockroachDB 21.1
                       The Licensed Work is (c) 2021 Cockroach Labs, Inc.
 Additional Use Grant: You may make use of the Licensed Work, provided that
                       you may not use the Licensed Work for a Database
@@ -15,7 +15,7 @@ Additional Use Grant: You may make use of the Licensed Work, provided that
                       Licensed Work by creating tables whose schemas are
                       controlled by such third parties.
 
-Change Date:          2024-10-01
+Change Date:          2024-04-01
 
 Change License:       Apache License, Version 2.0
 


### PR DESCRIPTION
Updated BSL.txt to 21.2 in the release-21.1 branch rather than on master.  This undoes the change to release-21.1