### PR TITLE
release-20.2: sql: anonymize custom type names if FmtAnonymize is set

### DIFF
--- a/pkg/sql/sem/tree/type_name.go
+++ b/pkg/sql/sem/tree/type_name.go
@@ -117,6 +117,8 @@ var _ ResolvableTypeReference = &UnresolvedObjectName{}
 var _ ResolvableTypeReference = &ArrayTypeReference{}
 var _ ResolvableTypeReference = &types.T{}
 var _ ResolvableTypeReference = &OIDTypeReference{}
+var _ NodeFormatter = &UnresolvedName{}
+var _ NodeFormatter = &ArrayTypeReference{}
 
 // ResolveType converts a ResolvableTypeReference into a *types.T.
 func ResolveType(
@@ -150,21 +152,34 @@ func ResolveType(
 
 // FormatTypeReference formats a ResolvableTypeReference.
 func (ctx *FmtCtx) FormatTypeReference(ref ResolvableTypeReference) {
-	if ctx.HasFlags(fmtStaticallyFormatUserDefinedTypes) {
-		switch t := ref.(type) {
-		case *types.T:
-			if t.UserDefined() {
+	switch t := ref.(type) {
+	case *types.T:
+		if t.UserDefined() {
+			if ctx.HasFlags(FmtAnonymize) {
+				ctx.WriteByte('_')
+				return
+			} else if ctx.HasFlags(fmtStaticallyFormatUserDefinedTypes) {
 				idRef := OIDTypeReference{OID: t.Oid()}
 				ctx.WriteString(idRef.SQLString())
 				return
 			}
 		}
+		ctx.WriteString(t.SQLString())
+
+	case *OIDTypeReference:
+		if ctx.indexedTypeFormatter != nil {
+			ctx.indexedTypeFormatter(ctx, t)
+			return
+		}
+		ctx.WriteString(ref.SQLString())
+
+	// All other ResolvableTypeReferences must implement NodeFormatter.
+	case NodeFormatter:
+		ctx.FormatNode(t)
+
+	default:
+		panic(errors.AssertionFailedf("type reference must implement NodeFormatter"))
 	}
-	if idRef, ok := ref.(*OIDTypeReference); ok && ctx.indexedTypeFormatter != nil {
-		ctx.indexedTypeFormatter(ctx, idRef)
-		return
-	}
-	ctx.WriteString(ref.SQLString())
 }
 
 // GetStaticallyKnownType possibly promotes a ResolvableTypeReference into a
@@ -201,16 +216,20 @@ type ArrayTypeReference struct {
 	ElementType ResolvableTypeReference
 }
 
-// SQLString implements the ResolvableTypeReference interface.
-func (node *ArrayTypeReference) SQLString() string {
-	var ctx FmtCtx
+// Format implements the NodeFormatter interface.
+func (node *ArrayTypeReference) Format(ctx *FmtCtx) {
 	if typ, ok := GetStaticallyKnownType(node.ElementType); ok {
-		ctx.WriteString(types.MakeArray(typ).SQLString())
+		ctx.FormatTypeReference(types.MakeArray(typ))
 	} else {
-		ctx.WriteString(node.ElementType.SQLString())
+		ctx.FormatTypeReference(node.ElementType)
 		ctx.WriteString("[]")
 	}
-	return ctx.String()
+}
+
+// SQLString implements the ResolvableTypeReference interface.
+func (node *ArrayTypeReference) SQLString() string {
+	// FmtBareIdentifiers prevents the TypeName string from being wrapped in quotations.
+	return AsStringWithFlags(node, FmtBareIdentifiers)
 }
 
 // SQLString implements the ResolvableTypeReference interface.

--- a/pkg/sql/sem/tree/type_name_test.go
+++ b/pkg/sql/sem/tree/type_name_test.go
@@ -1,0 +1,59 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tree_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFmtTypeNameAnonymize(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	var p parser.Parser
+	for _, testCase := range []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    `SELECT 1::int8`,
+			expected: `SELECT 1::INT8`,
+		},
+		{
+			input:    `SELECT 1::integer`,
+			expected: `SELECT 1::INT8`,
+		},
+		{
+			// It would be nice to detect that there's nothing to anonymize here,
+			// but doing so would require a big refactor to FormatTypeReference
+			input:    `SELECT 1::pg_catalog.int8`,
+			expected: `SELECT 1::_._`,
+		},
+		{
+			input:    `SELECT 1::schem.typ`,
+			expected: `SELECT 1::_._`,
+		},
+		{
+			input:    `SELECT 1::schem.typ[];`,
+			expected: `SELECT 1::_._[]`,
+		},
+	} {
+		stmts, _ := p.Parse(testCase.input)
+		actual := stmts.StringWithFlags(tree.FmtAnonymize)
+		require.Equal(t, testCase.expected, actual)
+	}
+}


### PR DESCRIPTION
Backport 1/1 commits from #60806.

/cc @cockroachdb/release

---

fixes #60674 

Release note (bug fix): The names of custom types are no longer sent to
Cockroach Labs in telemetry and crash reports.

Release justification: Low risk, high benefit change that is important
for keeping PII private.
