### PR TITLE
release-21.1: opt: detect invalid tuple comparison with ANY

### DIFF
--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -2255,3 +2255,24 @@ build
 SELECT 1 FROM (VALUES (1)) AS a(x) HAVING (SELECT true FROM (VALUES (a.x)) AS b(y))
 ----
 error (42803): subquery uses ungrouped column "x" from outer query
+
+build
+SELECT ((1, 2), (3, 4)) = ANY (VALUES (('foo', 'bar')))
+----
+error (22023): unsupported comparison operator: <tuple{tuple{int, int}, tuple{int, int}}> = ANY <tuple{tuple{string, string}}>
+
+# Regression test for #61229 - detect uncomparable tuple types.
+build
+SELECT (1, 1) = ANY (VALUES ('foo', 'bar'))
+----
+error (22023): unsupported comparison operator: <tuple{int, int}> = ANY <tuple{tuple{string AS column1, string AS column2}}>
+
+build
+SELECT ARRAY[1, 2] = ANY (VALUES (ARRAY['foo', 'bar']))
+----
+error (22023): unsupported comparison operator: <int[]> = ANY <tuple{string[]}>
+
+build
+SELECT (1, 1) = ANY (VALUES (1, 2, 3))
+----
+error (22023): unsupported comparison operator: <tuple{int, int}> = ANY <tuple{tuple{int AS column1, int AS column2, int AS column3}}>

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1872,10 +1872,31 @@ func typeCheckComparisonOpWithSubOperator(
 		}
 	}
 	fn, ok := ops.LookupImpl(cmpTypeLeft, cmpTypeRight)
-	if !ok {
+	if !ok || !deepCheckValidCmpOp(ops, cmpTypeLeft, cmpTypeRight) {
 		return nil, nil, nil, false, subOpCompError(cmpTypeLeft, rightTyped.ResolvedType(), subOp, op)
 	}
 	return leftTyped, rightTyped, fn, false, nil
+}
+
+// deepCheckValidCmpOp performs extra checks that a given operation is valid
+// when the types are tuples.
+func deepCheckValidCmpOp(ops cmpOpOverload, leftType, rightType *types.T) bool {
+	if leftType.Family() == types.TupleFamily && rightType.Family() == types.TupleFamily {
+		l := leftType.TupleContents()
+		r := rightType.TupleContents()
+		if len(l) != len(r) {
+			return false
+		}
+		for i := range l {
+			if _, ok := ops.LookupImpl(l[i], r[i]); !ok {
+				return false
+			}
+			if !deepCheckValidCmpOp(ops, l[i], r[i]) {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func subOpCompError(leftType, rightType *types.T, subOp, op ComparisonOperator) error {


### PR DESCRIPTION
Backport 1/1 commits from #61574.

/cc @cockroachdb/release

---

Fixes #61229.

Release justification: backportable bug fix.

Release note (bug fix): fixed a case where an invalid tuple comparison using
ANY was causing an internal error; we now return "unsupported
comparison operator".
