### PR TITLE
release-21.1: geogen: reduce range of randomly generated points

### DIFF
--- a/pkg/geo/geogen/geogen.go
+++ b/pkg/geo/geogen/geogen.go
@@ -185,8 +185,8 @@ func RandomGeomT(
 
 // RandomGeometry generates a random Geometry with the given SRID.
 func RandomGeometry(rng *rand.Rand, srid geopb.SRID) geo.Geometry {
-	minX, maxX := -math.MaxFloat32, math.MaxFloat32
-	minY, maxY := -math.MaxFloat32, math.MaxFloat32
+	minX, maxX := -10e9, 10e9
+	minY, maxY := -10e9, 10e9
 	proj, ok := geoprojbase.Projections[srid]
 	if ok {
 		minX, maxX = proj.Bounds.MinX, proj.Bounds.MaxX


### PR DESCRIPTION
Backport 1/1 commits from #61636.

/cc @cockroachdb/release

---

This patch reduces the range of randomly generated points
to [-10e9, 10e9].

Resolves #61367.

Release justification: non-production code change
Release note: None
