### PR TITLE
bazel: remove `broken_in_bazel` tag from some working tests

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -116,7 +116,6 @@ go_test(
         "validations_test.go",
     ],
     embed = [":changefeedccl"],
-    tags = ["broken_in_bazel"],
     deps = [
         "//pkg/base",
         "//pkg/blobs",

--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -288,7 +288,6 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":cli"],
-    tags = ["broken_in_bazel"],
     deps = [
         "//pkg/base",
         "//pkg/build",

--- a/pkg/geo/BUILD.bazel
+++ b/pkg/geo/BUILD.bazel
@@ -52,7 +52,6 @@ go_test(
         "parse_test.go",
     ],
     embed = [":geo"],
-    tags = ["broken_in_bazel"],
     deps = [
         "//pkg/geo/geopb",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/opt/invertedidx/BUILD.bazel
+++ b/pkg/sql/opt/invertedidx/BUILD.bazel
@@ -44,7 +44,6 @@ go_test(
         "geo_test.go",
         "json_array_test.go",
     ],
-    tags = ["broken_in_bazel"],
     deps = [
         ":invertedidx",
         "//pkg/geo",

--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -110,7 +110,6 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":builtins"],
-    tags = ["broken_in_bazel"],
     deps = [
         "//pkg/base",
         "//pkg/kv",

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -198,7 +198,6 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":tree"],
-    tags = ["broken_in_bazel"],
     deps = [
         "//pkg/internal/rsg",
         "//pkg/kv",

--- a/pkg/util/encoding/BUILD.bazel
+++ b/pkg/util/encoding/BUILD.bazel
@@ -40,7 +40,6 @@ go_test(
         "printer_test.go",
     ],
     embed = [":encoding"],
-    tags = ["broken_in_bazel"],
     deps = [
         "//pkg/geo",
         "//pkg/geo/geopb",


### PR DESCRIPTION
These tests happen to work now (or maybe they were always working?), so
mark them as working so CI can track them.

Release justification: Non-production code changes
Release note: None