### PR TITLE
kvserver: don't double WallPrev for closedts target

### DIFF
--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -730,7 +730,7 @@ func (b *propBuf) assignClosedTimestampToProposalLocked(
 			closedTSTarget.Backward(lb.FloorPrev())
 		}
 		// We can't close timestamps above the current lease's expiration.
-		closedTSTarget.Backward(p.leaseStatus.ClosedTimestampUpperBound().WallPrev())
+		closedTSTarget.Backward(p.leaseStatus.ClosedTimestampUpperBound())
 	}
 
 	// We're about to close closedTSTarget. The propBuf needs to remember that in


### PR DESCRIPTION
WallPrev was applied both inside and outside of
ClosedTimestampUpperBound, by mistake.

Release note: None
Release justification: Low risk rationalization of a previous patch.