### PR TITLE
release-20.2: changefeedccl: remove unnecessary and/or impossible privilege checks

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -174,14 +174,13 @@ func changefeedPlanHook(
 		if err != nil {
 			return errors.Wrap(err, "failed to resolve targets in the CHANGEFEED stmt")
 		}
-		for _, desc := range targetDescs {
-			if err := p.CheckPrivilege(ctx, desc, privilege.SELECT); err != nil {
-				return err
-			}
-		}
+
 		targets := make(jobspb.ChangefeedTargets, len(targetDescs))
 		for _, desc := range targetDescs {
 			if table, isTable := desc.(catalog.TableDescriptor); isTable {
+				if err := p.CheckPrivilege(ctx, desc, privilege.SELECT); err != nil {
+					return err
+				}
 				targets[table.GetID()] = jobspb.ChangefeedTarget{
 					StatementTimeName: table.GetName(),
 				}


### PR DESCRIPTION
Backport 1/1 commits from #61031.

/cc @cockroachdb/release

---

Changefeeds were checking the SELECT privilege on every descriptor associated
with targeted tables, including the database (should not be required) and
custom types (not possible to assign granularly).
They now only check SELECT on the targeted tables itself.

Release note (bug fix): Better privilege checks when creating a changefeed

Closes #61006
