### PR TITLE
release-21.1: kvserver: don't let closed timestamps squeeze writes

### DIFF
--- a/pkg/kv/kvserver/kvserverpb/lease_status.go
+++ b/pkg/kv/kvserver/kvserverpb/lease_status.go
@@ -37,3 +37,30 @@ func (st LeaseStatus) Expiration() hlc.Timestamp {
 		panic("unexpected")
 	}
 }
+
+// ClosedTimestampUpperBound represents the highest timestamp that can be closed
+// under this lease.
+//
+// We can't close timestamps above the current lease's expiration. This is in
+// order to keep the monotonic property of closed timestamps carried by
+// commands, which makes for straight-forward closed timestamp management on the
+// command application side: if we allowed requests to close timestamps above
+// the lease's expiration, then a future LeaseRequest proposed by another node
+// might carry a lower closed timestamp (i.e. the lease start time).
+//
+// Note that the stasis period doesn't affect closed timestamps; a request is
+// only server under a particular closed timestamp if its read frontier is below
+// the closed timestamp.
+//
+// We don't want to close timestamps within the same nanosecond as the lease
+// expiration; we want to always leave some space between the closed timestamp
+// and the lease expiration. To see why, check the comments on the similar
+// logic in propBuf.assignClosedTimestampToProposalLocked.
+func (st LeaseStatus) ClosedTimestampUpperBound() hlc.Timestamp {
+	// HACK(andrei): We declare the lease expiration to be synthetic by fiat,
+	// because it frequently is synthetic even though currently it's not marked
+	// as such. See the TODO in Timestamp.Add() about the work remaining to
+	// properly mark these timestamps as synthetic. We need to make sure it's
+	// synthetic here so that the results of Backwards() can be synthetic.
+	return st.Expiration().WithSynthetic(true).WallPrev()
+}

--- a/pkg/kv/kvserver/replica_closedts_test.go
+++ b/pkg/kv/kvserver/replica_closedts_test.go
@@ -51,10 +51,15 @@ func TestBumpSideTransportClosed(t *testing.T) {
 	}
 	testCases := []struct {
 		name string
-		exp  bool
+		// exp controls whether the BumpSideTransportClosed is expected to succeed.
+		exp bool
+		// computeTarget controls what timestamp the test will try to close. If not
+		// set, the test will try to close the current time.
+		computeTarget func(r *kvserver.Replica) (target hlc.Timestamp, exp bool)
+
 		// Optional, to configure testing filters.
 		knobs func() (_ *kvserver.StoreTestingKnobs, filterC chan chan struct{})
-		// Configures the replica to test different situtations.
+		// Configures the replica to test different situations.
 		setup func(_ setupArgs) (unblockFilterC chan struct{}, asyncErrC chan error, _ error)
 	}{
 		{
@@ -296,6 +301,34 @@ func TestBumpSideTransportClosed(t *testing.T) {
 				})
 			},
 		},
+		{
+			// We can't close all the way up to the lease expiration. See
+			// propBuf.assignClosedTimestampToProposalLocked.
+			name: "close lease expiration",
+			computeTarget: func(r *kvserver.Replica) (target hlc.Timestamp, exp bool) {
+				ls := r.LeaseStatusAt(context.Background(), r.Clock().NowAsClockTimestamp())
+				return ls.Expiration(), false
+			},
+		},
+		{
+			// Like above, but we can't even close in the same nanosecond as the lease
+			// expiration (or previous nanosecond with Logical: MaxInt32).
+			name: "close lease expiration prev",
+			computeTarget: func(r *kvserver.Replica) (target hlc.Timestamp, exp bool) {
+				ls := r.LeaseStatusAt(context.Background(), r.Clock().NowAsClockTimestamp())
+				return ls.Expiration().Prev(), false
+			},
+		},
+		{
+			// Differently from above, we can close up to leaseExpiration.WallPrev.
+			// Notably, we can close timestamps that fall inside the lease's stasis
+			// period.
+			name: "close lease expiration WallPrev",
+			computeTarget: func(r *kvserver.Replica) (target hlc.Timestamp, exp bool) {
+				ls := r.LeaseStatusAt(context.Background(), r.Clock().NowAsClockTimestamp())
+				return ls.Expiration().WallPrev(), true
+			},
+		},
 	}
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
@@ -325,27 +358,40 @@ func TestBumpSideTransportClosed(t *testing.T) {
 			require.NotNil(t, repl)
 
 			now := tc.Server(0).Clock().NowAsClockTimestamp()
+			var target hlc.Timestamp
+			var exp bool
+			if test.computeTarget == nil {
+				// We'll attempt to close `now`.
+				target = now.ToTimestamp()
+				exp = test.exp
+			} else {
+				target, exp = test.computeTarget(repl)
+			}
 			var targets [roachpb.MAX_CLOSED_TIMESTAMP_POLICY]hlc.Timestamp
-			target := now.ToTimestamp()
 			targets[roachpb.LAG_BY_CLUSTER_SETTING] = target
 
 			// Run the setup function to get the replica in the desired state.
-			unblockFilterC, asyncErrC, err := test.setup(setupArgs{
-				tc:        tc,
-				leftDesc:  leftDesc,
-				rightDesc: rightDesc,
-				repl:      repl,
-				now:       now,
-				target:    target,
-				filterC:   filterC,
-			})
-			require.NoError(t, err)
+			var unblockFilterC chan struct{}
+			var asyncErrC chan error
+			if test.setup != nil {
+				var err error
+				unblockFilterC, asyncErrC, err = test.setup(setupArgs{
+					tc:        tc,
+					leftDesc:  leftDesc,
+					rightDesc: rightDesc,
+					repl:      repl,
+					now:       now,
+					target:    target,
+					filterC:   filterC,
+				})
+				require.NoError(t, err)
+			}
 
 			// Try to bump the closed timestamp. Use succeeds soon if we are
 			// expecting the call to succeed, to avoid any flakiness. Don't do
 			// so if we expect the call to fail, in which case any flakiness
 			// would be a serious bug.
-			if test.exp {
+			if exp {
 				testutils.SucceedsSoon(t, func() error {
 					ok, _, _ := repl.BumpSideTransportClosed(ctx, now, targets)
 					if !ok {

--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -730,7 +730,7 @@ func (b *propBuf) assignClosedTimestampToProposalLocked(
 			closedTSTarget.Backward(lb.FloorPrev())
 		}
 		// We can't close timestamps above the current lease's expiration.
-		closedTSTarget.Backward(p.leaseStatus.ClosedTimestampUpperBound().WallPrev())
+		closedTSTarget.Backward(p.leaseStatus.ClosedTimestampUpperBound())
 	}
 
 	// We're about to close closedTSTarget. The propBuf needs to remember that in

--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -729,16 +729,13 @@ func (b *propBuf) assignClosedTimestampToProposalLocked(
 			// logical ticks when there's no good reason for them.
 			closedTSTarget.Backward(lb.FloorPrev())
 		}
-		// We can't close timestamps above the current lease's expiration(*). This is
+		// We can't close timestamps above the current lease's expiration. This is
 		// in order to keep the monotonic property of closed timestamps carried by
 		// commands, which makes for straight-forward closed timestamp management on
 		// the command application side: if we allowed requests to close timestamps
 		// above the lease's expiration, then a future LeaseRequest proposed by
 		// another node might carry a lower closed timestamp (i.e. the lease start
 		// time).
-		// (*) If we've previously closed a higher timestamp under a previous lease
-		// with a higher expiration, then requests will keep carrying that closed
-		// timestamp; we won't regress the closed timestamp.
 		//
 		// HACK(andrei): We declare the lease expiration to be synthetic by fiat,
 		// because it frequently is synthetic even though currently it's not marked

--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -729,21 +729,8 @@ func (b *propBuf) assignClosedTimestampToProposalLocked(
 			// logical ticks when there's no good reason for them.
 			closedTSTarget.Backward(lb.FloorPrev())
 		}
-		// We can't close timestamps above the current lease's expiration. This is
-		// in order to keep the monotonic property of closed timestamps carried by
-		// commands, which makes for straight-forward closed timestamp management on
-		// the command application side: if we allowed requests to close timestamps
-		// above the lease's expiration, then a future LeaseRequest proposed by
-		// another node might carry a lower closed timestamp (i.e. the lease start
-		// time).
-		//
-		// HACK(andrei): We declare the lease expiration to be synthetic by fiat,
-		// because it frequently is synthetic even though currently it's not marked
-		// as such. See the TODO in Timestamp.Add() about the work remaining to
-		// properly mark these timestamps as synthetic. We need to make sure it's
-		// synthetic here so that the results of Backwards() can be synthetic.
-		leaseExpiration := p.leaseStatus.Expiration().WithSynthetic(true)
-		closedTSTarget.Backward(leaseExpiration)
+		// We can't close timestamps above the current lease's expiration.
+		closedTSTarget.Backward(p.leaseStatus.ClosedTimestampUpperBound().WallPrev())
 	}
 
 	// We're about to close closedTSTarget. The propBuf needs to remember that in

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -103,10 +103,6 @@ func (r *Replica) executeWriteBatch(
 	defer tok.DoneIfNotMoved(ctx)
 	minTS.Forward(minTS2)
 
-	if !ba.IsSingleSkipLeaseCheckRequest() && st.Expiration().Less(minTS) {
-		log.Fatalf(ctx, "closed timestamp above lease expiration (%s vs %s): %s", minTS, st.Expiration(), ba)
-	}
-
 	// Examine the timestamp cache for preceding commands which require this
 	// command to move its timestamp forward. Or, in the case of a transactional
 	// write, the txn timestamp and possible write-too-old bool.

--- a/pkg/util/hlc/timestamp.go
+++ b/pkg/util/hlc/timestamp.go
@@ -274,6 +274,15 @@ func (t Timestamp) FloorPrev() Timestamp {
 	panic("cannot take the previous value to a zero timestamp")
 }
 
+// WallPrev subtracts 1 from the WallTime and resets Logical.
+func (t Timestamp) WallPrev() Timestamp {
+	return Timestamp{
+		WallTime:  t.WallTime - 1,
+		Logical:   0,
+		Synthetic: t.Synthetic,
+	}
+}
+
 // Forward replaces the receiver with the argument, if that moves it forwards in
 // time. Returns true if the timestamp was adjusted to a larger time and false
 // otherwise.

--- a/pkg/util/hlc/timestamp_test.go
+++ b/pkg/util/hlc/timestamp_test.go
@@ -130,18 +130,18 @@ func TestTimestampPrev(t *testing.T) {
 	}
 }
 
-func TestTimestampFloorPrev(t *testing.T) {
+func TestTimestampFloorPrevWallPrev(t *testing.T) {
 	testCases := []struct {
-		ts, expPrev Timestamp
+		ts, expPrev, expWallPrev Timestamp
 	}{
-		{makeTS(2, 0), makeTS(1, 0)},
-		{makeTS(1, 2), makeTS(1, 1)},
-		{makeTS(1, 1), makeTS(1, 0)},
-		{makeTS(1, 0), makeTS(0, 0)},
-		{makeSynTS(2, 0), makeSynTS(1, 0)},
-		{makeSynTS(1, 2), makeSynTS(1, 1)},
-		{makeSynTS(1, 1), makeSynTS(1, 0)},
-		{makeSynTS(1, 0), makeSynTS(0, 0)},
+		{makeTS(2, 0), makeTS(1, 0), makeTS(1, 0)},
+		{makeTS(1, 2), makeTS(1, 1), makeTS(0, 0)},
+		{makeTS(1, 1), makeTS(1, 0), makeTS(0, 0)},
+		{makeTS(1, 0), makeTS(0, 0), makeTS(0, 0)},
+		{makeSynTS(2, 0), makeSynTS(1, 0), makeSynTS(1, 0)},
+		{makeSynTS(1, 2), makeSynTS(1, 1), makeSynTS(0, 0)},
+		{makeSynTS(1, 1), makeSynTS(1, 0), makeSynTS(0, 0)},
+		{makeSynTS(1, 0), makeSynTS(0, 0), makeSynTS(0, 0)},
 	}
 	for _, c := range testCases {
 		assert.Equal(t, c.expPrev, c.ts.FloorPrev())

--- a/pkg/util/hlc/timestamp_test.go
+++ b/pkg/util/hlc/timestamp_test.go
@@ -145,6 +145,7 @@ func TestTimestampFloorPrevWallPrev(t *testing.T) {
 	}
 	for _, c := range testCases {
 		assert.Equal(t, c.expPrev, c.ts.FloorPrev())
+		assert.Equal(t, c.expWallPrev, c.ts.WallPrev())
 	}
 }
 


### PR DESCRIPTION
Backport 3/3 commits from #61559.
Also backport and #61660 and #61716 as small fixes.

/cc @cockroachdb/release

---

Before this patch, we'd close up to the lease expiration. This is
particularly relevant for leading ranges, where the closed timestamp is
in the future of present time. On these ranges, it can easily happen
that, when either the Raft transport or the side transport wants to
close a timestamp, the lease is currently valid (relative to present
time), but the target closed is above the lease expiration. Before this
patch, this would result in closing up to the lease expiration.

This patch makes it so that we never close within the last (full)
nanosecond of the lease. If the lease expires at (10,20), we'll close at
most (9.0). This ensures that there's infinite (logical) time left for
writes to be pushed into, while staying within the lease validity.
Before this patch, writes would have been pushed above the lease
expiration. They would have executed there, which is not ok.

Release note: None
Release justification: Bug fix for new functionality.
