### PR TITLE
builtins: add Z and M dimension support for ST_SnapToGrid

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2223,9 +2223,11 @@ The paths themselves are given in the direction of the first geometry.</p>
 Tolerance is used to control where snapping is performed. The result geometry is the input geometry with the vertices snapped.
 If no snapping occurs then the input geometry is returned unchanged.</p>
 </span></td></tr>
+<tr><td><a name="st_snaptogrid"></a><code>st_snaptogrid(geometry: geometry, origin: geometry, size_x: <a href="float.html">float</a>, size_y: <a href="float.html">float</a>, size_z: <a href="float.html">float</a>, size_m: <a href="float.html">float</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Snap a geometry to a grid defined by the given origin and X, Y, Z, and M cell sizes. Any dimension with a 0 cell size will not be snapped.</p>
+</span></td></tr>
 <tr><td><a name="st_snaptogrid"></a><code>st_snaptogrid(geometry: geometry, origin_x: <a href="float.html">float</a>, origin_y: <a href="float.html">float</a>, size_x: <a href="float.html">float</a>, size_y: <a href="float.html">float</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Snap a geometry to a grid of with X coordinates snapped to size_x and Y coordinates snapped to size_y based on an origin of (origin_x, origin_y).</p>
 </span></td></tr>
-<tr><td><a name="st_snaptogrid"></a><code>st_snaptogrid(geometry: geometry, size: <a href="float.html">float</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Snap a geometry to a grid of the given size.</p>
+<tr><td><a name="st_snaptogrid"></a><code>st_snaptogrid(geometry: geometry, size: <a href="float.html">float</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Snap a geometry to a grid of the given size. The specified size is only used to snap X and Y coordinates.</p>
 </span></td></tr>
 <tr><td><a name="st_snaptogrid"></a><code>st_snaptogrid(geometry: geometry, size_x: <a href="float.html">float</a>, size_y: <a href="float.html">float</a>) &rarr; geometry</code></td><td><span class="funcdesc"><p>Snap a geometry to a grid of with X coordinates snapped to size_x and Y coordinates snapped to size_y.</p>
 </span></td></tr>

--- a/pkg/geo/geomfn/snap_to_grid.go
+++ b/pkg/geo/geomfn/snap_to_grid.go
@@ -58,7 +58,10 @@ func snapCoordinateToGrid(
 func snapOrdinateToGrid(
 	ordinate float64, originOrdinate float64, gridSizeOrdinate float64,
 ) float64 {
-	if gridSizeOrdinate == 0 {
+	// A zero grid size ordinate indicates a dimension should not be snapped.
+	// For PostGIS compatibility, a negative grid size ordinate also results
+	// in a dimension not being snapped.
+	if gridSizeOrdinate <= 0 {
 		return ordinate
 	}
 	return math.RoundToEven((ordinate-originOrdinate)/gridSizeOrdinate)*gridSizeOrdinate + originOrdinate

--- a/pkg/geo/geomfn/snap_to_grid_test.go
+++ b/pkg/geo/geomfn/snap_to_grid_test.go
@@ -69,16 +69,69 @@ func TestSnapToGrid(t *testing.T) {
 			expectedEWKT: "LINESTRING(0 0, 1.5 1.5, 2 3)",
 		},
 		{
+			inEWKT:       "POLYGON((0.01 0.01, 1.0 0.01, 1.01 1.11, 0.01 0.01))",
+			origin:       geom.Coord{0, 0, 0, 0},
+			gridSize:     geom.Coord{0.1, 0.1, 0, 0},
+			expectedEWKT: "POLYGON((0 0, 1 0, 1 1.1, 0 0))",
+		},
+		// Geometries with Z and M dimensions
+		{
+			inEWKT:       "POINT(2.5 36.1 2.3 8)",
+			origin:       geom.Coord{0, 0, 0, 0},
+			gridSize:     geom.Coord{2, 2, 1, 10},
+			expectedEWKT: "POINT ZM (2 36 2 10)",
+		},
+		{
+			inEWKT:       "POINT(2.5 36.1 2.3 8)",
+			origin:       geom.Coord{0, 0, 0, 0},
+			gridSize:     geom.Coord{2, 2, 0, 0},
+			expectedEWKT: "POINT ZM (2 36 2.3 8)",
+		},
+		{
+			inEWKT:       "POINT M EMPTY",
+			origin:       geom.Coord{0, 0, 0, 0},
+			gridSize:     geom.Coord{1, 1, 1, 1},
+			expectedEWKT: "POINT M EMPTY",
+		},
+		// Geometries with insufficient points after snapping
+		{
 			inEWKT:       "LINESTRING(1.5 1.5, 1.5 1.5, 1.6 1.6, 1.7 1.7)",
 			origin:       geom.Coord{0, 0, 0, 0},
 			gridSize:     geom.Coord{0.5, 0.5, 0, 0},
 			expectedEWKT: "LINESTRING EMPTY",
 		},
 		{
-			inEWKT:       "POLYGON((0.01 0.01, 1.0 0.01, 1.01 1.11, 0.01 0.01))",
+			inEWKT:       "POLYGON((0 0, 0 0.5, 0.5 0.5, 0.5 0, 0 0))",
 			origin:       geom.Coord{0, 0, 0, 0},
-			gridSize:     geom.Coord{0.1, 0.1, 0, 0},
-			expectedEWKT: "POLYGON((0 0, 1 0, 1 1.1, 0 0))",
+			gridSize:     geom.Coord{2, 2, 2, 2},
+			expectedEWKT: "POLYGON EMPTY",
+		},
+		{
+			inEWKT:       "MULTILINESTRING((1.5 1.5, 1.5 1.5, 1.6 1.6, 1.7 1.7), EMPTY)",
+			origin:       geom.Coord{0, 0, 0, 0},
+			gridSize:     geom.Coord{0.5, 0.5, 0, 0},
+			expectedEWKT: "MULTILINESTRING EMPTY",
+		},
+		{
+			inEWKT:       "MULTIPOLYGON(((0 0, 0 0.5, 0.5 0.5, 0.5 0, 0 0)), ((0 0, 0.5 0, 0.25 0.25, 0 0)))",
+			origin:       geom.Coord{0, 0, 0, 0},
+			gridSize:     geom.Coord{2, 2, 2, 2},
+			expectedEWKT: "MULTIPOLYGON EMPTY",
+		},
+		{
+			inEWKT: `GEOMETRYCOLLECTION(
+LINESTRING(1.5 1.5, 1.5 1.5, 1.6 1.6, 1.7 1.7),
+POLYGON((0 0, 0 0.5, 0.5 0.5, 0.5 0, 0 0)))`,
+			origin:       geom.Coord{0, 0, 0, 0},
+			gridSize:     geom.Coord{2, 2, 2, 2},
+			expectedEWKT: "GEOMETRYCOLLECTION EMPTY",
+		},
+		// Negative grid size ordinates should not snap dimension
+		{
+			inEWKT:       "LINESTRING(1.5 1.5, 1.5 1.5, 1.6 1.6, 1.7 1.7)",
+			origin:       geom.Coord{0, 0, 0, 0},
+			gridSize:     geom.Coord{-0.5, -0.5, 0, 0},
+			expectedEWKT: "LINESTRING(1.5 1.5, 1.6 1.6, 1.7 1.7)",
 		},
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/geospatial_zm
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial_zm
@@ -300,6 +300,48 @@ statement error input geometry must be LINESTRING or MULTILINESTRING
 SELECT st_astext(st_addmeasure('POINT(0 0)'::geometry, 0, 1))
 
 query T
+SELECT distinct(st_astext(geom)) FROM
+( VALUES
+  (st_snaptogrid('LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4)'::geometry, 2, 1)),
+  (st_snaptogrid('LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4)'::geometry, 0, 0, 2, 1)),
+  (st_snaptogrid('LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4)'::geometry, 'POINT EMPTY'::geometry, 2, 1, 0, 0)),
+  (st_snaptogrid('LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4)'::geometry, 'POINT EMPTY'::geometry, 2, 1, 2, 1)),
+  (st_snaptogrid('LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4)'::geometry, 'POINT(0 0)'::geometry, 2, 1, 0, 0)),
+  (st_snaptogrid('LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4)'::geometry, 'POINT(0 0 4 5)'::geometry, 2, 1, 2, 1))
+) AS t(geom)
+----
+LINESTRING (0 0, 0 1, 2 2, 4 3, 4 4)
+
+query T
+SELECT distinct(st_astext(geom)) FROM
+( VALUES
+  (st_snaptogrid('MULTIPOINT(0 0 0, 7 5 5, 6 6 7)'::geometry, 2)),
+  (st_snaptogrid('MULTIPOINT(0 0 0, 7 5 5, 6 6 7)'::geometry, 2, 2)),
+  (st_snaptogrid('MULTIPOINT(0 0 0, 7 5 5, 6 6 7)'::geometry, 0, 0, 2, 2)),
+  (st_snaptogrid('MULTIPOINT(0 0 0, 7 5 5, 6 6 7)'::geometry, 'POINT EMPTY'::geometry, 2, 2, 0, 0)),
+  (st_snaptogrid('MULTIPOINT(0 0 0, 7 5 5, 6 6 7)'::geometry, 'POINT(0 0)'::geometry, 2, 2, 0, 0)),
+  (st_snaptogrid('MULTIPOINT(0 0 0, 7 5 5, 6 6 7)'::geometry, 'POINT(0 0 0 0)'::geometry, 2, 2, 0, 0)),
+  (st_snaptogrid('MULTIPOINT(0 0 0, 7 5 5, 6 6 7)'::geometry, 'POINT(0 0 3 2)'::geometry, 2, 2, 0, 0))
+) AS t(geom)
+----
+MULTIPOINT Z (0 0 0, 8 4 5, 6 6 7)
+
+query T
+SELECT st_astext(st_snaptogrid(geom, 'POINT(2 2)'::geometry, 2, 3, 5, 4)) FROM
+( VALUES
+  ('POINT(2 1)'::geometry),
+  ('LINESTRING(2 1 7 2, 5 6 3 7)'::geometry),
+  ('POLYGON((2 3 1, 3 4 1, 1 3 6, 2 3 1))'::geometry)
+) AS t(geom)
+----
+POINT (2 2)
+LINESTRING ZM (2 2 5 0, 6 5 5 8)
+POLYGON Z ((2 2 0, 2 5 0, 2 2 5, 2 2 0))
+
+statement error origin must be a POINT
+SELECT st_snaptogrid('POINT(0 0 0)'::geometry, 'LINESTRING(0 0 0, 1 1 1)'::geometry, 1, 1, 1, 1)
+
+query T
 SELECT ST_AsEWKT(ST_RotateX(ST_GeomFromEWKT('LINESTRING(1 2 3, 1 1 1)'), pi()/2));
 ----
 LINESTRING Z (1 -3 2, 1 -1 1)


### PR DESCRIPTION
This patch adds support for snapping the Z and M dimension
with `ST_SnapToGrid`.

Resolves #60896.

Release justification: low-risk update to new functionality
Release note (sql change): The `ST_SnapToGrid` function can
now be used to snap Z and M dimensions.