### PR TITLE
util/tracing: modify span registry to track all local spans

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1196,6 +1196,7 @@ CREATE TABLE crdb_internal.node_inflight_trace_spans (
 					tree.NewDInt(tree.DInt(parentSpanID)),
 					tree.NewDInt(tree.DInt(spanID)),
 					tree.NewDInt(tree.DInt(goroutineID)),
+					// TODO(angelapwen): Stop surfacing finished bool. All inflight spans will be un-Finish'ed.
 					tree.MakeDBool(tree.DBool(finished)),
 					startTime,
 					tree.NewDInterval(

--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -393,8 +393,8 @@ func TestNonVerboseChildSpanRegisteredWithParent(t *testing.T) {
 	defer sp.Finish()
 	ch := tr.StartSpan("child", WithParentAndAutoCollection(sp))
 	defer ch.Finish()
-	require.Len(t, sp.i.crdb.mu.recording.children, 1)
-	require.Equal(t, ch.i.crdb, sp.i.crdb.mu.recording.children[0])
+	require.Len(t, sp.i.crdb.mu.recording.childrenIDs, 1)
+	require.Equal(t, ch.i.crdb.spanID, sp.i.crdb.mu.recording.childrenIDs[0])
 	ch.RecordStructured(&types.Int32Value{Value: 5})
 	// Check that the child span (incl its payload) is in the recording.
 	rec := sp.GetRecording()
@@ -415,7 +415,7 @@ func TestSpanMaxChildren(t *testing.T) {
 		if exp > maxChildrenPerSpan {
 			exp = maxChildrenPerSpan
 		}
-		require.Len(t, sp.i.crdb.mu.recording.children, exp)
+		require.Len(t, sp.i.crdb.mu.recording.childrenIDs, exp)
 	}
 }
 

--- a/pkg/util/tracing/tracingpb/recorded_span.proto
+++ b/pkg/util/tracing/tracingpb/recorded_span.proto
@@ -75,6 +75,7 @@ message RecordedSpan {
   // The ID of the goroutine on which the span was created.
   uint64 goroutine_id = 12 [(gogoproto.customname) = "GoroutineID"];
 
+  // TODO(angelapwen): Remove and reserve if registry is for unFinish'ed spans.
   // True if the span has been Finish()ed, false otherwise.
   bool finished = 13;
 


### PR DESCRIPTION
Resolves #61407 
cc @cockroachdb/kv-east 👀 

Previously the `activeSpans` registry in a `Tracer` only tracked
local root Spans. To access local child Spans, we needed to
perform a tree traversal from the associated root Span. This was
inconvenient because we found use cases for accessing a specific
non-root Span, including toggling a specific span's verbosity.

This commit changes `activeSpans` to track all local Spans, not
just local root Spans. Also, a `crdbSpan` object no longer needs
to keep track of its children Spans in memory and instead only
tracks its local children Spans' IDs.

Release justification: Low risk change because we are limiting
the number of spans tracked.
Release note: None