### PR TITLE
release-20.2: colexec: call StartInternal in Columnarizer

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -60,8 +60,10 @@ func wrapRowSources(
 		// Optimization: if the input is a Columnarizer, its input is necessarily a
 		// execinfra.RowSource, so remove the unnecessary conversion.
 		if c, ok := input.(*colexec.Columnarizer); ok {
-			// TODO(asubiotto): We might need to do some extra work to remove references
-			// to this operator (e.g. streamIDToOp).
+			// Since this Columnarizer has been previously added to Closers and
+			// MetadataSources, this call ensures that all future calls are noops.
+			// Modifying the slices at this stage is difficult.
+			c.MarkAsRemovedFromFlow()
 			toWrapInputs = append(toWrapInputs, c.Input())
 		} else {
 			toWrapInput, err := colexec.NewMaterializer(

--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -42,6 +42,11 @@ type Columnarizer struct {
 	accumulatedMeta []execinfrapb.ProducerMetadata
 	ctx             context.Context
 	typs            []*types.T
+
+	// removedFromFlow marks this Columnarizer as having been removed from the
+	// flow. This renders all future calls to Init, Next, Close, and DrainMeta
+	// noops.
+	removedFromFlow bool
 }
 
 var _ colexecbase.Operator = &Columnarizer{}
@@ -85,6 +90,9 @@ func NewColumnarizer(
 
 // Init is part of the Operator interface.
 func (c *Columnarizer) Init() {
+	if c.removedFromFlow {
+		return
+	}
 	// We don't want to call Start on the input to columnarizer and allocating
 	// internal objects several times if Init method is called more than once, so
 	// we have this check in place.
@@ -98,6 +106,9 @@ func (c *Columnarizer) Init() {
 
 // Next is part of the Operator interface.
 func (c *Columnarizer) Next(context.Context) coldata.Batch {
+	if c.removedFromFlow {
+		return coldata.ZeroBatch
+	}
 	var reallocated bool
 	c.batch, reallocated = c.allocator.ResetMaybeReallocate(
 		c.typs, c.batch, 1 /* minCapacity */, c.maxBatchMemSize,
@@ -169,6 +180,9 @@ var (
 
 // DrainMeta is part of the MetadataSource interface.
 func (c *Columnarizer) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
+	if c.removedFromFlow {
+		return nil
+	}
 	c.MoveToDraining(nil /* err */)
 	for {
 		meta := c.DrainHelper()
@@ -182,6 +196,9 @@ func (c *Columnarizer) DrainMeta(ctx context.Context) []execinfrapb.ProducerMeta
 
 // Close is part of the Operator interface.
 func (c *Columnarizer) Close(ctx context.Context) error {
+	if c.removedFromFlow {
+		return nil
+	}
 	c.InternalClose()
 	return nil
 }
@@ -210,4 +227,14 @@ func (c *Columnarizer) Child(nth int, verbose bool) execinfra.OpNode {
 // Input returns the input of this columnarizer.
 func (c *Columnarizer) Input() execinfra.RowSource {
 	return c.input
+}
+
+// MarkAsRemovedFromFlow is called by planning code to make all future calls on
+// this columnarizer noops. It exists to support an execution optimization where
+// a Columnarizer is removed from a flow in cases where it would be the input to
+// a Materializer (which is redundant). Simply bypassing the Columnarizer is not
+// enough because it is added to a slice of Closers and MetadataSources that are
+// difficult to change once physical planning moves on from the Columnarizer.
+func (c *Columnarizer) MarkAsRemovedFromFlow() {
+	c.removedFromFlow = true
 }

--- a/pkg/sql/colexec/columnarizer_test.go
+++ b/pkg/sql/colexec/columnarizer_test.go
@@ -80,34 +80,53 @@ func TestColumnarizerDrainsAndClosesInput(t *testing.T) {
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
 
-	rb := distsqlutils.NewRowBuffer([]*types.T{types.Int}, nil /* rows */, distsqlutils.RowBufferArgs{})
 	flowCtx := &execinfra.FlowCtx{
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
 	}
 
-	const errMsg = "artificial error"
-	rb.Push(nil, &execinfrapb.ProducerMetadata{Err: errors.New(errMsg)})
-	c, err := NewColumnarizer(ctx, testAllocator, flowCtx, 0 /* processorID */, rb)
-	require.NoError(t, err)
+	for _, tc := range []struct {
+		name           string
+		consumerClosed bool
+	}{
+		{
+			name:           "ConsumerClosed",
+			consumerClosed: true,
+		}, {
+			name:           "ConsumerDone",
+			consumerClosed: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			const errMsg = "artificial error"
+			rb := distsqlutils.NewRowBuffer([]*types.T{types.Int}, nil /* rows */, distsqlutils.RowBufferArgs{})
+			rb.Push(nil, &execinfrapb.ProducerMetadata{Err: errors.New(errMsg)})
+			c, err := NewColumnarizer(ctx, testAllocator, flowCtx, 0 /* processorID */, rb)
+			require.NoError(t, err)
 
-	c.Init()
+			c.Init()
 
-	// If the metadata is obtained through this Next call, the Columnarizer still
-	// returns it in DrainMeta.
-	err = colexecerror.CatchVectorizedRuntimeError(func() { c.Next(ctx) })
-	require.True(t, testutils.IsError(err, errMsg), "unexpected error %v", err)
+			// If the metadata is obtained through this Next call, the Columnarizer still
+			// returns it in DrainMeta.
+			err = colexecerror.CatchVectorizedRuntimeError(func() { c.Next(ctx) })
+			require.True(t, testutils.IsError(err, errMsg), "unexpected error %v", err)
 
-	// Calling DrainMeta from the vectorized execution engine should propagate to
-	// non-vectorized components as calling ConsumerDone and then draining their
-	// metadata.
-	meta := c.DrainMeta(ctx)
-	require.True(t, len(meta) == 0)
-	require.True(t, rb.Done)
-	require.Equal(t, execinfra.DrainRequested, rb.ConsumerStatus, "unexpected consumer status %d", rb.ConsumerStatus)
-	// Closing the Columnarizer should call ConsumerClosed on the processor.
-	require.NoError(t, c.Close(ctx))
-	require.Equal(t, execinfra.ConsumerClosed, rb.ConsumerStatus, "unexpected consumer status %d", rb.ConsumerStatus)
+			if tc.consumerClosed {
+				// Closing the Columnarizer should call ConsumerClosed on the processor.
+				require.NoError(t, c.Close(ctx))
+				require.Equal(t, execinfra.ConsumerClosed, rb.ConsumerStatus, "unexpected consumer status %d", rb.ConsumerStatus)
+			} else {
+				// Calling DrainMeta from the vectorized execution engine should propagate to
+				// non-vectorized components as calling ConsumerDone and then draining their
+				// metadata.
+				meta := c.DrainMeta(ctx)
+				require.True(t, len(meta) == 0)
+				require.True(t, rb.Done)
+				require.Equal(t, execinfra.DrainRequested, rb.ConsumerStatus, "unexpected consumer status %d", rb.ConsumerStatus)
+			}
+			require.True(t, c.Closed, "the ProcessorBase.Closed bool should be set in either case")
+		})
+	}
 }
 
 func BenchmarkColumnarize(b *testing.B) {

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -115,9 +115,7 @@ func (p *planNodeToRowSource) SetInput(ctx context.Context, input execinfra.RowS
 }
 
 func (p *planNodeToRowSource) Start(ctx context.Context) context.Context {
-	// We do not call p.StartInternal to avoid creating a span. Only the context
-	// needs to be set.
-	p.Ctx = ctx
+	ctx = p.StartInternalNoSpan(ctx)
 	p.params.ctx = ctx
 	if !p.started {
 		p.started = true


### PR DESCRIPTION
Backport 2/2 commits from #61124.

/cc @cockroachdb/release

---

Fixes #60994 
Fixes #58366

Release justification: fixes a possible crash.

Release note (bug fix): fixed an npe observed with a SpanFromContext call in
the stack trace.
