### PR TITLE
release-21.1: sql: fix span leak in connExecutor.close

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -939,12 +939,6 @@ type ExecutorTestingKnobs struct {
 	// DeterministicExplainAnalyze, if set, will result in overriding fields in
 	// EXPLAIN ANALYZE (PLAN) that can vary between runs (like elapsed times).
 	DeterministicExplainAnalyze bool
-
-	// Pretend59315IsFixed pretends that this issue is fixed:
-	// https://github.com/cockroachdb/cockroach/issues/59315
-	// which means that we don't need the WithBypassRegistry option
-	// in resetForNewSQLTxn.
-	Pretend59315IsFixed bool
 }
 
 // PGWireTestingKnobs contains knobs for the pgwire module.

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -431,8 +431,10 @@ var (
 
 type testClusterConfig struct {
 	// name is the name of the config (used for subtest names).
-	name                string
-	numNodes            int
+	name     string
+	numNodes int
+	// TODO(asubiotto): The fake span resolver does not currently play well with
+	// contention events and tracing (see #61438).
 	useFakeSpanResolver bool
 	// if non-empty, overrides the default distsql mode.
 	overrideDistSQLMode string
@@ -465,8 +467,7 @@ type testClusterConfig struct {
 	isCCLConfig bool
 	// localities is set if nodes should be set to a particular locality.
 	// Nodes are 1-indexed.
-	localities          map[int]roachpb.Locality
-	pretend59315IsFixed bool
+	localities map[int]roachpb.Locality
 }
 
 const threeNodeTenantConfigName = "3node-tenant"
@@ -562,13 +563,6 @@ var logicTestConfigs = []testClusterConfig{
 		numNodes:            5,
 		overrideDistSQLMode: "on",
 		overrideAutoStats:   "false",
-	},
-	{
-		name:                "5node-pretend59315IsFixed",
-		numNodes:            5,
-		overrideDistSQLMode: "on",
-		overrideAutoStats:   "false",
-		pretend59315IsFixed: true,
 	},
 	{
 		name:                       "5node-metadata",
@@ -1340,7 +1334,6 @@ func (t *logicTest) newCluster(serverArgs TestServerArgs) {
 				},
 				SQLExecutor: &sql.ExecutorTestingKnobs{
 					DeterministicExplainAnalyze: true,
-					Pretend59315IsFixed:         t.cfg.pretend59315IsFixed,
 				},
 			},
 			ClusterName:   "testclustername",

--- a/pkg/sql/logictest/testdata/logic_test/contention_event
+++ b/pkg/sql/logictest/testdata/logic_test/contention_event
@@ -1,5 +1,6 @@
-# LogicTest: 5node-pretend59315IsFixed
-#
+# LogicTest: 5node-default-configs
+# This test fails using the fakedist configs due to a testing limitation
+# (see #61438).
 # Verify that ContentionEvents are emitted. This is mostly a sanity check - look
 # for the datadriven tests in `pkg/kv/kvserver/concurrency` for the actual events
 # that do get emitted in various contention scenarios.

--- a/pkg/sql/physicalplan/fake_span_resolver.go
+++ b/pkg/sql/physicalplan/fake_span_resolver.go
@@ -80,6 +80,12 @@ func (fit *fakeSpanResolverIterator) Seek(
 	}
 
 	// Scan the range and keep a list of all potential split keys.
+	// TODO(asubiotto): this scan can have undesired side effects. For example,
+	// it can change when contention occurs and swallows tracing payloads, leading
+	// to unexpected test outcomes as observed in:
+	//
+	// https://github.com/cockroachdb/cockroach/pull/61438
+	// This should use an inconsistent span outside of the txn instead.
 	kvs, err := fit.txn.Scan(ctx, span.Key, span.EndKey, 0)
 	if err != nil {
 		log.Errorf(ctx, "error in fake span resolver scan: %s", err)

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -157,13 +157,7 @@ func (ts *txnState) resetForNewSQLTxn(
 	// TODO(andrei): figure out how to close these spans on server shutdown? Ties
 	// into a larger discussion about how to drain SQL and rollback open txns.
 	opName := sqlTxnName
-	var traceOpts []tracing.SpanOption
-	if !tranCtx.execTestingKnobs.Pretend59315IsFixed {
-		// The surrounding conditional and this option can be removed once #59315
-		// is addressed.
-		traceOpts = append(traceOpts, tracing.WithBypassRegistry())
-	}
-	txnCtx, sp := createRootOrChildSpan(connCtx, opName, tranCtx.tracer, traceOpts...)
+	txnCtx, sp := createRootOrChildSpan(connCtx, opName, tranCtx.tracer)
 	if txnType == implicitTxn {
 		sp.SetTag("implicit", "true")
 	}

--- a/pkg/util/tracing/span_options.go
+++ b/pkg/util/tracing/span_options.go
@@ -20,13 +20,12 @@ import (
 // field comment below are invoked as arguments to `Tracer.StartSpan`.
 // See the SpanOption interface for a synopsis.
 type spanOptions struct {
-	Parent         *Span                         // see WithParentAndAutoCollection
-	RemoteParent   *SpanMeta                     // see WithParentAndManualCollection
-	RefType        opentracing.SpanReferenceType // see WithFollowsFrom
-	LogTags        *logtags.Buffer               // see WithLogTags
-	Tags           map[string]interface{}        // see WithTags
-	ForceRealSpan  bool                          // see WithForceRealSpan
-	BypassRegistry bool                          // See WithBypassRegistry
+	Parent        *Span                         // see WithParentAndAutoCollection
+	RemoteParent  *SpanMeta                     // see WithParentAndManualCollection
+	RefType       opentracing.SpanReferenceType // see WithFollowsFrom
+	LogTags       *logtags.Buffer               // see WithLogTags
+	Tags          map[string]interface{}        // see WithTags
+	ForceRealSpan bool                          // see WithForceRealSpan
 }
 
 func (opts *spanOptions) parentTraceID() uint64 {
@@ -202,24 +201,5 @@ func WithForceRealSpan() SpanOption {
 
 func (forceRealSpanOption) apply(opts spanOptions) spanOptions {
 	opts.ForceRealSpan = true
-	return opts
-}
-
-type bypassRegistryOption struct{}
-
-// WithBypassRegistry instructs StartSpan to no record the span in the top-level
-// registry. Spans started with this option are not inspectable. This was
-// introduced as a stop-gap for long-lived Span objects that are never
-// explicitly Finish()-ed (#58721). Recording these Spans in our registry would
-// cause us to OOM.
-//
-// TODO(irfansharif,asubiotto): Purge all instances of this option; we should be
-// recording all spans.
-func WithBypassRegistry() SpanOption {
-	return bypassRegistryOption{}
-}
-
-func (bypassRegistryOption) apply(opts spanOptions) spanOptions {
-	opts.BypassRegistry = true
 	return opts
 }


### PR DESCRIPTION
Backport 2/2 commits from #61438.

/cc @cockroachdb/release

---

Release justification: high benefit change to existing functionality. This PR fixes a tracing leak that severely reduces the benefit of the new tracing registry for in-flight spans since we previously had to bypass adding these important spans to the regsitry to avoid memory blowups.

PTAL at the individual commits. The first one is the leak fix, the second removes the option to bypass the tracing registry.

Release note: None (no user-observable change)

cc @angelapwen @irfansharif 

Fixes #59315
