### PR TITLE
tracing: limit number of imported remote spans

### DIFF
--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -47,6 +47,8 @@ const (
 	maxStructuredBytesPerSpan = 10 * (1 << 10)  // 10 KiB
 	// maxChildrenPerSpan limits the number of (direct) child spans in a Span.
 	maxChildrenPerSpan = 1000
+	// maxRemoteSpansPerSpan limits the number of imported remote spans per Span.
+	maxRemoteSpansPerSpan = 1000
 	// maxSpanRegistrySize limits the number of local root spans tracked in
 	// a Tracer's registry.
 	maxSpanRegistrySize = 5000


### PR DESCRIPTION
In #59560 we've seen that this can grow unboundedly. Set a limit out of
an abundance of caution. Fixes #59188.

Release note: None

---

+cc @cockroachdb/kv-east 