### PR TITLE
hlc: fix WallPrev test

### DIFF
--- a/pkg/util/hlc/timestamp_test.go
+++ b/pkg/util/hlc/timestamp_test.go
@@ -145,6 +145,7 @@ func TestTimestampFloorPrevWallPrev(t *testing.T) {
 	}
 	for _, c := range testCases {
 		assert.Equal(t, c.expPrev, c.ts.FloorPrev())
+		assert.Equal(t, c.expWallPrev, c.ts.WallPrev())
 	}
 }
 


### PR DESCRIPTION
The test was not actually checking the expected WallPrev's.

Release note: None