### PR TITLE
release-21.1: backupccl: make backup and restore more defensive to stats collections failures

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -161,6 +161,7 @@ go_test(
         "//pkg/sql/rowflow",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
+        "//pkg/sql/stats",
         "//pkg/storage",
         "//pkg/storage/cloud",
         "//pkg/storage/cloudimpl",

--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -331,7 +331,16 @@ func backup(
 			// Collect all the table stats for this table.
 			tableStatisticsAcc, err := statsCache.GetTableStats(ctx, tableDesc.GetID())
 			if err != nil {
-				return RowCount{}, err
+				// Successfully backed up data is more valuable than table stats that can
+				// be recomputed on restore, and so if we fail to collect the stats of a
+				// table we do not want to mark the job as failed.
+				// The lack of stats on restore could lead to suboptimal performance when
+				// reading/writing to this table until the stats have been recomputed.
+				wrappedErr := errors.Wrap(err,
+					fmt.Sprintf("failed to collect stats for table %d during a backup",
+						tableDesc.GetID()))
+				log.Warningf(ctx, wrappedErr.Error())
+				continue
 			}
 			for _, stat := range tableStatisticsAcc {
 				tableStatistics = append(tableStatistics, &stat.TableStatisticProto)

--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -332,14 +332,13 @@ func backup(
 			tableStatisticsAcc, err := statsCache.GetTableStats(ctx, tableDesc.GetID())
 			if err != nil {
 				// Successfully backed up data is more valuable than table stats that can
-				// be recomputed on restore, and so if we fail to collect the stats of a
+				// be recomputed after restore, and so if we fail to collect the stats of a
 				// table we do not want to mark the job as failed.
 				// The lack of stats on restore could lead to suboptimal performance when
 				// reading/writing to this table until the stats have been recomputed.
-				wrappedErr := errors.Wrap(err,
-					fmt.Sprintf("failed to collect stats for table %d during a backup",
-						tableDesc.GetID()))
-				log.Warningf(ctx, wrappedErr.Error())
+				log.Warningf(ctx, "failed to collect stats for table: %s, "+
+					"table ID: %d during a backup: %s", tableDesc.GetName(), tableDesc.GetID(),
+					err.Error())
 				continue
 			}
 			for _, stat := range tableStatisticsAcc {

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -5601,6 +5601,39 @@ func TestBackupRestoreSubsetCreatedStats(t *testing.T) {
 	sqlDB.CheckQueryResults(t, getStatsQuery(`"data 2".foo`), [][]string{})
 }
 
+// This test is a reproduction of a scenario that caused backup jobs to fail
+// during stats collection because the stats cache would attempt to resolve a
+// descriptor that had been dropped. Stats collection was made more resilient to
+// such errors in #61222.
+func TestBackupHandlesDroppedTypeStatsCollection(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const dest = "userfile:///basefoo"
+	const numAccounts = 1
+	_, _, sqlDB, _, cleanupFn := BackupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
+	defer cleanupFn()
+
+	sqlDB.Exec(t, `CREATE TYPE greeting as ENUM ('hello')`)
+	sqlDB.Exec(t, `CREATE TABLE foo (t greeting)`)
+	sqlDB.Exec(t, `INSERT INTO foo VALUES ('hello')`)
+	sqlDB.Exec(t, `SET sql_safe_updates=false`)
+	sqlDB.Exec(t, `ALTER TABLE foo RENAME COLUMN t to t_old`)
+	sqlDB.Exec(t, `ALTER TABLE foo ADD COLUMN t VARCHAR`)
+	sqlDB.Exec(t, `ALTER TABLE foo DROP COLUMN t_old`)
+	sqlDB.Exec(t, `DROP TYPE greeting`)
+
+	// Prior to the fix mentioned above, the stats cache would attempt to resolve
+	// the dropped type when computing the stats for foo at the end of the backup
+	// job. This would result in a `descriptor not found` error.
+
+	// Ensure a full backup completes successfully.
+	sqlDB.Exec(t, `BACKUP foo TO $1`, dest)
+
+	// Ensure an incremental backup completes successfully.
+	sqlDB.Exec(t, `BACKUP foo TO $1`, dest)
+}
+
 // Ensure that statistics are restored from correct backup.
 func TestBackupCreatedStatsFromIncrementalBackup(t *testing.T) {
 	defer leaktest.AfterTest(t)()


### PR DESCRIPTION
Backport 2/2 commits from #61420.

/cc @cockroachdb/release

---

Release justification: low risk, high benefit change to existing functionality.

Release note: None

Fixes: #61199
