### PR TITLE
ui: add contention graph to SQL metrics overview page

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -124,6 +124,20 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
+      title="SQL Statement Contention"
+      sources={nodeSources}
+      tooltip={`The total number of SQL statements that experienced contention ${tooltipSelection}.`}
+    >
+      <Axis label="queries">
+        <Metric
+          name="cr.node.sql.distsql.contended_queries.count"
+          title="Contention"
+          nonNegativeRate
+        />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
       title="Active Flows for Distributed SQL Statements"
       tooltip="The number of flows on each node contributing to currently running distributed SQL statements."
     >


### PR DESCRIPTION
Release justification: low-risk, high-benefit change to existing functionality.
Exposes a very useful graph that was hidden away.

Release note (sql change): a statement contention timeseries is now displayed
in the SQL metrics overview dashboard.

Closes #60156

Screenshot:
![image](https://user-images.githubusercontent.com/10560359/110498965-cb245280-80c5-11eb-9f2e-276b6575e2bb.png)
