### PR TITLE
release-20.1: backupccl: correctly manage temp objects during a full cluster restore

### DIFF
--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -74,7 +74,7 @@ func TestFullClusterBackup(t *testing.T) {
 
 	const numAccounts = 10
 	_, _, sqlDB, tempDir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, initNone)
-	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, initNone)
+	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, initNone, base.TestClusterArgs{})
 	defer cleanupFn()
 	defer cleanupEmptyCluster()
 
@@ -263,7 +263,7 @@ func TestFullClusterBackupDroppedTables(t *testing.T) {
 
 	const numAccounts = 10
 	_, _, sqlDB, tempDir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, initNone)
-	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, initNone)
+	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, initNone, base.TestClusterArgs{})
 	defer cleanupFn()
 	defer cleanupEmptyCluster()
 
@@ -284,7 +284,7 @@ func TestIncrementalFullClusterBackup(t *testing.T) {
 	const numAccounts = 10
 	const incrementalBackupLocation = "nodelocal://0/inc-full-backup"
 	_, _, sqlDB, tempDir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, initNone)
-	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, initNone)
+	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, initNone, base.TestClusterArgs{})
 	defer cleanupFn()
 	defer cleanupEmptyCluster()
 
@@ -304,7 +304,7 @@ func TestEmptyFullClusterRestore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	sqlDB, tempDir, cleanupFn := createEmptyCluster(t, singleNode)
-	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, initNone)
+	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, initNone, base.TestClusterArgs{})
 	defer cleanupFn()
 	defer cleanupEmptyCluster()
 
@@ -323,7 +323,7 @@ func TestClusterRestoreEmptyDB(t *testing.T) {
 
 	const numAccounts = 10
 	_, _, sqlDB, tempDir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, initNone)
-	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, initNone)
+	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, initNone, base.TestClusterArgs{})
 	defer cleanupFn()
 	defer cleanupEmptyCluster()
 
@@ -341,7 +341,7 @@ func TestDisallowFullClusterRestoreOnNonFreshCluster(t *testing.T) {
 
 	const numAccounts = 10
 	_, _, sqlDB, tempDir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, initNone)
-	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, initNone)
+	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, initNone, base.TestClusterArgs{})
 	defer cleanupFn()
 	defer cleanupEmptyCluster()
 
@@ -358,7 +358,7 @@ func TestDisallowFullClusterRestoreOfNonFullBackup(t *testing.T) {
 
 	const numAccounts = 10
 	_, _, sqlDB, tempDir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, initNone)
-	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, initNone)
+	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, initNone, base.TestClusterArgs{})
 	defer cleanupFn()
 	defer cleanupEmptyCluster()
 
@@ -520,9 +520,7 @@ func TestClusterRevisionHistory(t *testing.T) {
 
 	for i, testCase := range testCases {
 		t.Run(fmt.Sprintf("t%d", i), func(t *testing.T) {
-			_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(
-				t, singleNode, tempDir, initNone,
-			)
+			_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, initNone, base.TestClusterArgs{})
 			defer cleanupEmptyCluster()
 
 			sqlDBRestore.Exec(t, `RESTORE FROM $1 AS OF SYSTEM TIME `+testCase.ts, localFoo)

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -487,7 +487,8 @@ func WriteTableDescs(
 			// Depending on which cluster version we are restoring to, we decide which
 			// namespace table to write the descriptor into. This may cause wrong
 			// behavior if the cluster version is bumped DURING a restore.
-			tkey := sqlbase.MakePublicTableNameKey(ctx, settings, tables[i].ParentID, tables[i].Name)
+			tkey := sqlbase.MakeObjectNameKey(ctx, settings, tables[i].ParentID,
+				tables[i].GetParentSchemaID(), tables[i].Name)
 			b.CPut(tkey.Key(), tables[i].ID, nil)
 		}
 		for _, kv := range extra {

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -28,7 +29,8 @@ func TestShowBackup(t *testing.T) {
 	const numAccounts = 11
 	_, tc, sqlDB, tempDir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, initNone)
 	kvDB := tc.Server(0).DB()
-	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, initNone)
+	_, _, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir,
+		initNone, base.TestClusterArgs{})
 	defer cleanupFn()
 	defer cleanupEmptyCluster()
 

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -181,7 +181,7 @@ func getTableCreateParams(
 		tempSchemaName := params.p.TemporarySchemaName()
 		sKey := sqlbase.NewSchemaKey(dbID, tempSchemaName)
 		var err error
-		schemaID, err = getDescriptorID(params.ctx, params.p.txn, sKey)
+		schemaID, err = GetDescriptorID(params.ctx, params.p.txn, sKey)
 		if err != nil {
 			return nil, 0, err
 		} else if schemaID == sqlbase.InvalidID {

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -105,7 +105,8 @@ func (p *planner) createDatabase(
 	// be created in every database in >= 20.2.
 	if shouldCreatePublicSchema {
 		// Every database must be initialized with the public schema.
-		if err := p.createSchemaWithID(ctx, sqlbase.NewPublicSchemaKey(id).Key(), keys.PublicSchemaID); err != nil {
+		if err := p.CreateSchemaWithID(ctx, sqlbase.NewPublicSchemaKey(id).Key(),
+			keys.PublicSchemaID); err != nil {
 			return true, err
 		}
 	}
@@ -168,9 +169,9 @@ func (p *planner) createDescriptorWithID(
 	return nil
 }
 
-// getDescriptorID looks up the ID for plainKey.
+// GetDescriptorID looks up the ID for plainKey.
 // InvalidID is returned if the name cannot be resolved.
-func getDescriptorID(
+func GetDescriptorID(
 	ctx context.Context, txn *kv.Txn, plainKey sqlbase.DescriptorKey,
 ) (sqlbase.ID, error) {
 	key := plainKey.Key()
@@ -196,7 +197,7 @@ func resolveSchemaID(
 	}
 
 	sKey := sqlbase.NewSchemaKey(dbID, scName)
-	schemaID, err := getDescriptorID(ctx, txn, sKey)
+	schemaID, err := GetDescriptorID(ctx, txn, sKey)
 	if err != nil || schemaID == sqlbase.InvalidID {
 		return false, sqlbase.InvalidID, err
 	}

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -13,6 +13,7 @@ package sql
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -94,6 +95,8 @@ type PlanHookState interface {
 	ShowCreate(
 		ctx context.Context, dbPrefix string, allDescs []sqlbase.Descriptor, desc *sqlbase.TableDescriptor, displayOptions ShowCreateDisplayOptions,
 	) (string, error)
+	CreateSchemaWithID(ctx context.Context, schemaNameKey roachpb.Key,
+		schemaID sqlbase.ID) error
 }
 
 // AddPlanHook adds a hook used to short-circuit creating a planNode from a

--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -81,12 +81,18 @@ var (
 	}
 )
 
+// TemporarySchemaNameForRestorePrefix is the prefix name of the schema we
+// synthesize during a full cluster restore. All temporary objects being
+// restored are remapped to belong to this schema allowing the reconciliation
+// job to gracefully clean up these objects when it runs.
+const TemporarySchemaNameForRestorePrefix string = "pg_temp_0_"
+
 func createTempSchema(params runParams, sKey sqlbase.DescriptorKey) (sqlbase.ID, error) {
 	id, err := GenerateUniqueDescID(params.ctx, params.extendedEvalCtx.ExecCfg.DB)
 	if err != nil {
 		return sqlbase.InvalidID, err
 	}
-	if err := params.p.createSchemaWithID(params.ctx, sKey.Key(), id); err != nil {
+	if err := params.p.CreateSchemaWithID(params.ctx, sKey.Key(), id); err != nil {
 		return sqlbase.InvalidID, err
 	}
 
@@ -94,7 +100,7 @@ func createTempSchema(params runParams, sKey sqlbase.DescriptorKey) (sqlbase.ID,
 	return id, nil
 }
 
-func (p *planner) createSchemaWithID(
+func (p *planner) CreateSchemaWithID(
 	ctx context.Context, schemaNameKey roachpb.Key, schemaID sqlbase.ID,
 ) error {
 	if p.ExtendedEvalContext().Tracing.KVTracingEnabled() {


### PR DESCRIPTION
Discussion about the design at #56512.

This is a backport of #56956.

Fixes: #56512

Release note: None