### PR TITLE
release-21.1: sqlsmith: add complete_stream_ingestion_job to sqlsmith blocklist

### DIFF
--- a/pkg/ccl/streamingccl/streamingutils/utils_test.go
+++ b/pkg/ccl/streamingccl/streamingutils/utils_test.go
@@ -90,6 +90,14 @@ func TestCutoverBuiltin(t *testing.T) {
 		job.ID(), cutoverTime)
 	require.Error(t, err, "cannot cutover to a timestamp")
 
+	// Ensure that the builtin runs locally.
+	var explain string
+	err = db.QueryRowContext(ctx,
+		`EXPLAIN SELECT crdb_internal.complete_stream_ingestion_job($1, $2)`, job.ID(),
+		highWater).Scan(&explain)
+	require.NoError(t, err)
+	require.Equal(t, "distribution: local", explain)
+
 	// This should succeed since the highwatermark is equal to the cutover time.
 	var jobID int64
 	err = db.QueryRowContext(

--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -435,6 +435,12 @@ var functions = func() map[tree.FunctionClass]map[oid.Oid][]function {
 		case "pg_sleep":
 			continue
 		}
+		if strings.Contains(def.Name, "stream_ingestion") {
+			// crdb_internal.complete_stream_ingestion_job is a stateful function that
+			// requires a running stream ingestion job. Invoking this against random
+			// parameters is likely to fail and so we skip it.
+			continue
+		}
 		if strings.Contains(def.Name, "crdb_internal.force_") ||
 			strings.Contains(def.Name, "crdb_internal.unsafe_") {
 			continue

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4892,7 +4892,8 @@ may increase either contention or retry errors, or both.`,
 
 	"crdb_internal.complete_stream_ingestion_job": makeBuiltin(
 		tree.FunctionProperties{
-			Category: categoryStreamIngestion,
+			Category:         categoryStreamIngestion,
+			DistsqlBlocklist: true,
 		},
 		tree.Overload{
 			Types: tree.ArgTypes{


### PR DESCRIPTION
Backport 1/1 commits from #61720.

/cc @cockroachdb/release

---

crdb_internal.complete_stream_ingestion is stateful builtin that
requires a running stream ingestion job to run without throwing an
error. Running it with random parameter values is likely to always fail
and so we skip it.

This internal should also not be planned in a distributed manner since
it relies on having a root txn to mutate the stream ingestion job state.
Previously, the builtin wasn't marked as "DistSQL blocklisted", now it
is.

Fixes: #61050.
Fixes: #61534.

Release note: None (no release with this bug)
