### PR TITLE
release-21.1: sql: report correct schema name in pg_indexes.indexdef

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3126,6 +3126,24 @@ select * from pg_indexes where indexname = 'regression_46450_idx'
 ----
 1136917443  public  regression_46450  regression_46450_idx  NULL  CREATE INDEX regression_46450_idx ON test.public.regression_46450 USING gin (json ASC)
 
+# Make sure indexdef uses user-defined schemas.
+
+statement ok
+CREATE SCHEMA test_schema;
+CREATE TABLE test_schema.test (
+  a INT PRIMARY KEY,
+  b INT
+);
+CREATE index on test_schema.test(b)
+
+query TTTT colnames
+SELECT schemaname, tablename, indexname, indexdef
+FROM pg_indexes WHERE schemaname='test_schema' and tablename='test'
+----
+schemaname   tablename  indexname   indexdef
+test_schema  test       primary     CREATE UNIQUE INDEX "primary" ON test.test_schema.test USING btree (a ASC)
+test_schema  test       test_b_idx  CREATE INDEX test_b_idx ON test.test_schema.test USING btree (b ASC)
+
 # Make sure that selecting from vtables with indexes in other dbs properly
 # hides descriptors that should be hidden.
 
@@ -3237,13 +3255,13 @@ CREATE TABLE jt (a INT PRIMARY KEY); INSERT INTO jt VALUES(1); INSERT INTO jt VA
 query ITT
 SELECT a, oid, relname FROM jt INNER LOOKUP JOIN pg_class ON a::oid=oid
 ----
-100  100  jt
+102  102  jt
 
 query ITT
 SELECT a, oid, relname FROM jt LEFT OUTER LOOKUP JOIN pg_class ON a::oid=oid
 ----
 1    NULL  NULL
-100  100   jt
+102  102   jt
 
 subtest regression_49207
 statement ok

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1817,7 +1817,7 @@ https://www.postgresql.org/docs/9.5/view-pg-indexes.html`,
 				scNameName := tree.NewDName(scName)
 				tblName := tree.NewDName(table.GetName())
 				return catalog.ForEachIndex(table, catalog.IndexOpts{}, func(index catalog.Index) error {
-					def, err := indexDefFromDescriptor(ctx, p, db, table, index.IndexDesc(), tableLookup)
+					def, err := indexDefFromDescriptor(ctx, p, db, scName, table, index.IndexDesc(), tableLookup)
 					if err != nil {
 						return err
 					}
@@ -1841,6 +1841,7 @@ func indexDefFromDescriptor(
 	ctx context.Context,
 	p *planner,
 	db *dbdesc.Immutable,
+	schemaName string,
 	table catalog.TableDescriptor,
 	index *descpb.IndexDescriptor,
 	tableLookup tableLookupFn,
@@ -1848,7 +1849,7 @@ func indexDefFromDescriptor(
 	colNames := index.ColumnNames[index.ExplicitColumnStartIdx():]
 	indexDef := tree.CreateIndex{
 		Name:     tree.Name(index.Name),
-		Table:    tree.MakeTableName(tree.Name(db.GetName()), tree.Name(table.GetName())),
+		Table:    tree.MakeTableNameWithSchema(tree.Name(db.GetName()), tree.Name(schemaName), tree.Name(table.GetName())),
 		Unique:   index.Unique,
 		Columns:  make(tree.IndexElemList, len(colNames)),
 		Storing:  make(tree.NameList, len(index.StoreColumnNames)),


### PR DESCRIPTION
Backport 1/1 commits from #61722.

/cc @cockroachdb/release

---

Release note (bug fix): The indexdef column in the pg_indexes table
would always report that the index belonged to the public schema. Now it
correctly reports user-defined schemas if necessary.
