### PR TITLE
release-20.2: roachtest: update tag of ActiveRecord version to test

### DIFF
--- a/pkg/cmd/roachtest/activerecord.go
+++ b/pkg/cmd/roachtest/activerecord.go
@@ -21,7 +21,7 @@ import (
 var activerecordResultRegex = regexp.MustCompile(`^(?P<test>[^\s]+#[^\s]+) = (?P<timing>\d+\.\d+ s) = (?P<result>.)$`)
 var railsReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)\.?(?P<subpoint>\d*)$`)
 var supportedRailsVersion = "6.1"
-var adapterVersion = "v6.1.0beta2"
+var adapterVersion = "v6.1.0-beta.2"
 
 // This test runs activerecord's full test suite against a single cockroach node.
 


### PR DESCRIPTION
Backport 1/1 commits from #61653.

/cc @cockroachdb/release

---

fixes https://github.com/cockroachdb/cockroach/issues/61687

I changed the tag format in the activerecord adapter repo.

Release justification: test only change.
Release note: None
