### PR TITLE
sql: set default sample_rate to 0.1

### DIFF
--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -201,7 +201,15 @@ func (ex *connExecutor) prepare(
 	prepare := func(ctx context.Context, txn *kv.Txn) (err error) {
 		ex.statsCollector.reset(&ex.server.sqlStats, ex.appStats, &ex.phaseTimes)
 		p := &ex.planner
-		ex.resetPlanner(ctx, p, txn, ex.server.cfg.Clock.PhysicalTime() /* stmtTS */)
+		if origin != PreparedStatementOriginSQL {
+			// If the PREPARE command was issued as a SQL statement, then we
+			// have already reset the planner at the very beginning of the
+			// execution (in execStmtInOpenState). We might have also
+			// instrumented the planner to collect execution statistics, and
+			// resetting the planner here would break the assumptions of the
+			// instrumentation.
+			ex.resetPlanner(ctx, p, txn, ex.server.cfg.Clock.PhysicalTime() /* stmtTS */)
+		}
 		p.stmt = stmt
 		p.semaCtx.Annotations = tree.MakeAnnotations(stmt.NumAnnotations)
 		flags, err = ex.populatePrepared(ctx, txn, placeholderHints, p)

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -38,7 +38,7 @@ import (
 var collectTxnStatsSampleRate = settings.RegisterFloatSetting(
 	"sql.txn_stats.sample_rate",
 	"the probability that a given transaction will collect execution statistics (displayed in the DB Console)",
-	0,
+	0.1,
 	func(f float64) error {
 		if f < 0 || f > 1 {
 			return errors.New("value must be between 0 and 1 inclusive")


### PR DESCRIPTION
**sql: do not reset planner if PREPARE is executed as a stmt**

Previously, when executing a PREPARE command, we would always reset the
planner. This is not necessary when the origin of the command is SQL
because in that case we properly reset the planner before starting the
statement's execution. This change fixes a problem when PREPARE
statements are chosen to be sampled for execution statistics (without
the fix, we would encounter a nil pointer).

Release note: None

**sql: set default sample_rate to 0.1**

Fixes: #59379.

Release note (sql change): Default value for `sql.txn_stats.sample_rate`
cluster setting has been increased from 0 to 0.1. This means that from
now on every statement has 10% probability of being sampled for the
purposes of execution statistics. Note that no other criteria for
sampling (like the query latencies) are currently being utilized to
decide whether to sample a statement or not.