### PR TITLE
sql: formatting of `TableIndexName` can be wrong in certain contexts

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -940,7 +940,7 @@ SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
 FROM system.eventlog
 WHERE "eventType" = 'comment_on_index'
 ----
-1  {"Comment": "This is an index.", "EventType": "comment_on_index", "IndexName": "b_index", "Statement": "COMMENT ON INDEX \"\".\"\".b_index IS 'This is an index.'", "TableName": "defaultdb.public.a", "User": "root"}
+1  {"Comment": "This is an index.", "EventType": "comment_on_index", "IndexName": "b_index", "Statement": "COMMENT ON INDEX defaultdb.public.a@b_index IS 'This is an index.'", "TableName": "defaultdb.public.a", "User": "root"}
 
 statement ok
 COMMENT ON TABLE a IS 'This is a table.'

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -712,7 +712,7 @@ func (p *planner) getTableAndIndex(
 	catalog.init(p)
 	catalog.reset()
 
-	idx, _, err := cat.ResolveTableIndex(
+	idx, qualifiedName, err := cat.ResolveTableIndex(
 		ctx, &catalog, cat.Flags{AvoidDescriptorCaches: true}, tableWithIndex,
 	)
 	if err != nil {
@@ -722,6 +722,13 @@ func (p *planner) getTableAndIndex(
 		return nil, nil, err
 	}
 	optIdx := idx.(*optIndex)
+
+	// Resolve the object name for logging if
+	// its missing.
+	if tableWithIndex.Table.ObjectName == "" {
+		tableWithIndex.Table = tree.MakeTableNameFromPrefix(qualifiedName.ObjectNamePrefix, qualifiedName.ObjectName)
+	}
+
 	return tabledesc.NewExistingMutable(*optIdx.tab.desc.TableDesc()), optIdx.desc, nil
 }
 


### PR DESCRIPTION
Fixes: #58496

Previously, the object name information for TableIndexName,
was not populated in multiple contexts leading to incorrect
formatting of index names in event log messages. To address
this, this patch modifies code paths for resolving table
indexes to add this information during the planning phase.

Release note: None