### PR TITLE
release-20.2: importccl: support exporting to userfile

### DIFF
--- a/pkg/ccl/importccl/exportcsv_test.go
+++ b/pkg/ccl/importccl/exportcsv_test.go
@@ -75,7 +75,7 @@ func TestExportImportBank(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	db, dir, cleanup := setupExportableBank(t, 3, 100)
+	db, _, cleanup := setupExportableBank(t, 3, 100)
 	defer cleanup()
 
 	// Add some unicode to prove FmtExport works as advertised.
@@ -83,6 +83,7 @@ func TestExportImportBank(t *testing.T) {
 	db.Exec(t, "UPDATE bank SET payload = NULL WHERE id % 2 = 0")
 
 	chunkSize := 13
+	baseExportDir := "userfile:///t/"
 	for _, null := range []string{"", "NULL"} {
 		nullAs, nullIf := "", ", nullif = ''"
 		if null != "" {
@@ -90,27 +91,19 @@ func TestExportImportBank(t *testing.T) {
 			nullIf = fmt.Sprintf(", nullif = '%s'", null)
 		}
 		t.Run("null="+null, func(t *testing.T) {
-			var files []string
-
+			exportDir := filepath.Join(baseExportDir, t.Name())
 			var asOf string
 			db.QueryRow(t, "SELECT cluster_logical_timestamp()").Scan(&asOf)
 
-			for _, row := range db.QueryStr(t,
-				fmt.Sprintf(`EXPORT INTO CSV 'nodelocal://0/t'
-					WITH chunk_rows = $1, delimiter = '|' %s
-					FROM SELECT * FROM bank AS OF SYSTEM TIME %s`, nullAs, asOf), chunkSize,
-			) {
-				files = append(files, row[0])
-				f, err := ioutil.ReadFile(filepath.Join(dir, "t", row[0]))
-				if err != nil {
-					t.Fatal(err)
-				}
-				t.Log(string(f))
-			}
+			db.Exec(t,
+				fmt.Sprintf(`EXPORT INTO CSV $1 
+					WITH chunk_rows = $2, delimiter = '|' %s
+					FROM SELECT * FROM bank AS OF SYSTEM TIME %s`, nullAs, asOf), exportDir, chunkSize,
+			)
 
 			schema := bank.FromRows(1).Tables()[0].Schema
-			fileList := "'nodelocal://0/t/" + strings.Join(files, "', 'nodelocal://0/t/") + "'"
-			db.Exec(t, fmt.Sprintf(`IMPORT TABLE bank2 %s CSV DATA (%s) WITH delimiter = '|'%s`, schema, fileList, nullIf))
+			exportedFiles := filepath.Join(exportDir, "*")
+			db.Exec(t, fmt.Sprintf(`IMPORT TABLE bank2 %s CSV DATA ($1) WITH delimiter = '|'%s`, schema, nullIf), exportedFiles)
 
 			db.CheckQueryResults(t,
 				fmt.Sprintf(`SELECT * FROM bank AS OF SYSTEM TIME %s ORDER BY id`, asOf), db.QueryStr(t, `SELECT * FROM bank2 ORDER BY id`),

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -3444,6 +3444,7 @@ func (dsp *DistSQLPlanner) createPlanForExport(
 		Options:          n.csvOpts,
 		ChunkRows:        int64(n.chunkRows),
 		CompressionCodec: n.fileCompression,
+		User:             planCtx.planner.User(),
 	}}
 
 	resTypes := make([]*types.T, len(colinfo.ExportColumns))


### PR DESCRIPTION
Previously, exporting to userfile would result in a error reading: `user
creating the FileTable ExternalStorage must be specified`. This was
because the user was not plumbed through to the export processor.

Release note (bug fix): Exporting to userfile locations was previously
not working, and now it is.