### PR TITLE
kv/kvserver: skip TestEagerReplication

### DIFF
--- a/pkg/kv/kvserver/replicate_test.go
+++ b/pkg/kv/kvserver/replicate_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -29,6 +30,7 @@ import (
 
 func TestEagerReplication(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 54646, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()


### PR DESCRIPTION
Refs: #54646

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None