### PR TITLE
bazel: make `pkg/internal/rsg/yacc` test runnable in Bazel

### DIFF
--- a/pkg/internal/rsg/yacc/BUILD.bazel
+++ b/pkg/internal/rsg/yacc/BUILD.bazel
@@ -16,7 +16,10 @@ go_test(
     name = "yacc_test",
     size = "small",
     srcs = ["parse_test.go"],
+    data = ["//pkg/sql/parser:sql.y"],
     embed = [":yacc"],
-    tags = ["broken_in_bazel"],
-    deps = ["//pkg/util/log"],
+    deps = [
+        "//pkg/build/bazel",
+        "//pkg/util/log",
+    ],
 )

--- a/pkg/internal/rsg/yacc/parse_test.go
+++ b/pkg/internal/rsg/yacc/parse_test.go
@@ -14,11 +14,24 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/build/bazel"
 	// Needed for the -verbosity flag on circleci tests.
 	_ "github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
-const sqlYPath = "../../../sql/parser/sql.y"
+var sqlYPath string
+
+func init() {
+	if bazel.BuiltWithBazel() {
+		runfile, err := bazel.Runfile("pkg/sql/parser/sql.y")
+		if err != nil {
+			panic(err)
+		}
+		sqlYPath = runfile
+	} else {
+		sqlYPath = "../../../sql/parser/sql.y"
+	}
+}
 
 func TestLex(t *testing.T) {
 	b, err := ioutil.ReadFile(sqlYPath)


### PR DESCRIPTION
This test was missing a dependency on `sql.y`.

Release note: None