### PR TITLE
bazel: make `pkg/sql/parser` test runnable in Bazel

### DIFF
--- a/pkg/sql/parser/BUILD.bazel
+++ b/pkg/sql/parser/BUILD.bazel
@@ -51,7 +51,6 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":parser"],
-    tags = ["broken_in_bazel"],
     deps = [
         "//pkg/sql/lex",
         "//pkg/sql/pgwire/pgerror",
@@ -108,7 +107,7 @@ genrule(
     ],
     outs = ["helpmap_test.go"],
     cmd = """
-      $(location :help-gen-test) < $< >$@
+      $(location :help-gen-test) < $< >$@.tmp
       mv -f $@.tmp $@
     """,
     tools = [


### PR DESCRIPTION
There was a typo in the `genrule` definition here.

Release note: None