### PR TITLE
bazel: upgrade to latest version of `rules_go`

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,10 +12,10 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 # Load go bazel tools. This gives us access to the go bazel SDK/toolchains.
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "81eff5df9077783b18e93d0c7ff990d8ad7a3b8b3ca5b785e1c483aacdb342d7",
+    sha256 = "7c10271940c6bce577d51a075ae77728964db285dac0a46614a7934dc34303e6",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.24.9/rules_go-v0.24.9.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.24.9/rules_go-v0.24.9.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.26.0/rules_go-v0.26.0.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.26.0/rules_go-v0.26.0.tar.gz",
     ],
 )
 

--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -121,6 +121,7 @@ go_test(
         "version_test.go",
     ],
     embed = [":roachpb"],
+    tags = ["broken_in_bazel"],
     deps = [
         "//pkg/cli/exit",
         "//pkg/keys",


### PR DESCRIPTION
Among other improvements, this fixes a bug which prevented building w/
Bazel 4.0 unless you set a specific command-line flag.

Mark `pkg/roachpb:roachpb_test` as broken -- the dependencies were
already broken (see #61357), and this just manifests the breakage as a
compile error instead of a simple warning as before. This will take more
work.

Release note: None