### PR TITLE
sqlsmith: fix error handling in makeAlter and panic handling

### DIFF
--- a/pkg/internal/sqlsmith/alter.go
+++ b/pkg/internal/sqlsmith/alter.go
@@ -52,7 +52,14 @@ func makeAlter(s *Smither) (tree.Statement, bool) {
 		// up the change). This has the added benefit of leaving
 		// behind old column references for a bit, which should
 		// test some additional logic.
-		_ = s.ReloadSchemas()
+		err := s.ReloadSchemas()
+		if err != nil {
+			// If we fail to load any schema information, then
+			// the actual statement generation could panic, so
+			// fail out here.
+			return nil, false
+		}
+
 		for i := 0; i < retryCount; i++ {
 			stmt, ok := s.alterSampler.Next()(s)
 			if ok {


### PR DESCRIPTION
Fixes: #61775

Previously, the error from ReloadSchemas was ignored
and the statement generator would blindly continue.
This lead to sqlsmith failing completely and panicking
inside roach test. To address this, this patch fixes
the error handling in this case and makes the sqlsmith
error handling more robust to panics.

Release note: None