### PR TITLE
opt: index accelerate <@ expressions for json inverted indexes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -1104,3 +1104,158 @@ SELECT words FROM cb@w WHERE words <@ ARRAY[NULL, 'rat']
 ----
 {}
 {rat}
+
+subtest contained_by_json
+
+statement ok
+CREATE TABLE cb2 (
+  k INT PRIMARY KEY,
+  j JSON,
+  INVERTED INDEX i (j)
+)
+
+statement ok
+INSERT INTO cb2 VALUES
+  (0, '{}'),
+  (1, '[]'),
+  (2, '1'),
+  (3, '"a"'),
+  (4, 'true'),
+  (5, 'null'),
+  (6, '{"a": "b"}'),
+  (7, '{"a": {"b": "c", "d": "e"}}'),
+  (8, '{"a": {"b": "c"}, "d": "e"}'),
+  (9, '{"a": {"b": [1, 2]}}'),
+  (10, '{"a": {"b": {"c": [1, 2, 3]}}}'),
+  (11, '{"a": {"b": {"c": {"d": "e"}}}}'),
+  (12, '{"a": {"b": {"d": 2}}}}'),
+  (13, '{"a": [{"b": {"c": [1, 2]}}]}'),
+  (14, '{"b": {"c": [1, 2]}}'),
+  (15, '{"a": []}'),
+  (16, '{"a": {}}}'),
+  (17, '{"a": [[2]]}'),
+  (18, '[[2]]'),
+  (19, '[1, 2]'),
+  (20, '[1, 2, 3]'),
+  (21, '[{}]'),
+  (22, '[{"a": "b"}]'),
+  (23, '[{"a": "b", "c": ["d", "e"]}]'),
+  (24, '[[1], [2]]'),
+  (25, '[[1, 2]]'),
+  (26, '["a", "b", "b"]'),
+  (27, '[1, 2, {"b": "c"}]'),
+  (28, '[{"a": {"b": "c"}}, "d", "e"]'),
+  (29, '{"a": {"d": null}}'),
+  (30, '{"d": null}'),
+  (31, '[null]'),
+  (32, '[[], null]'),
+  (33, '[null, []]'),
+  (34, '[null, {}]'),
+  (35, '[[null]]'),
+  (36, '[1, 2, null]')
+
+query T
+SELECT j FROM cb2@i WHERE j <@ '{}' ORDER BY k
+----
+{}
+
+query T
+SELECT j FROM cb2@i WHERE j <@ '[]' ORDER BY k
+----
+[]
+
+query T
+SELECT j FROM cb2@i WHERE j <@ '1' ORDER BY k
+----
+1
+
+query T
+SELECT j FROM cb2@i WHERE j <@ '"a"' ORDER BY k
+----
+"a"
+
+query T
+SELECT j FROM cb2@i WHERE j <@ 'null' ORDER BY k
+----
+null
+
+query T
+SELECT j FROM cb2@i WHERE j <@ 'true' ORDER BY k
+----
+true
+
+query T
+SELECT j FROM cb2@i WHERE j <@ '{"a": "b"}' ORDER BY k
+----
+{}
+{"a": "b"}
+
+query T
+SELECT j FROM cb2@i WHERE j <@ '{"a": [1]}' ORDER BY k
+----
+{}
+{"a": []}
+
+query T
+SELECT j FROM cb2@i WHERE j <@ '[null, 1, 2, 3, "d"]' ORDER BY k
+----
+[]
+1
+null
+[1, 2]
+[1, 2, 3]
+[null]
+[1, 2, null]
+
+query T
+SELECT j FROM cb2@i WHERE j <@ '[[1, 2], null]' ORDER BY k
+----
+[]
+null
+[[2]]
+[[1], [2]]
+[[1, 2]]
+[null]
+[[], null]
+[null, []]
+
+query T
+SELECT j FROM cb2@i WHERE j <@ '{"a": {"b": [1, 2], "d": null}}' ORDER BY k
+----
+{}
+{"a": {"b": [1, 2]}}
+{"a": {}}
+{"a": {"d": null}}
+
+query T
+SELECT j FROM cb2@i WHERE j <@ '[[1, 2, {"hello": 3}], {"a": "b"}]' ORDER BY k
+----
+[]
+[[2]]
+[{}]
+[{"a": "b"}]
+[[1], [2]]
+[[1, 2]]
+
+query T
+SELECT j FROM cb2@i WHERE j <@ '[{}, []]' ORDER BY k
+----
+[]
+[{}]
+
+query T
+SELECT j FROM cb2@i WHERE j <@ '[{"a": "b"}, [1, 2]]' ORDER BY k
+----
+[]
+[[2]]
+[{}]
+[{"a": "b"}]
+[[1], [2]]
+[[1, 2]]
+
+query T
+SELECT j FROM cb2@i WHERE j <@ '[[1], [2]]' ORDER BY k
+----
+[]
+[[2]]
+[[1], [2]]

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -977,6 +977,148 @@ vectorized: true
                   table: e@e_b_idx
                   spans: /[]-/"D" /0-/2
 
+query T
+EXPLAIN (VERBOSE) SELECT * FROM d WHERE b <@ '[]'
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b)
+│ estimated row count: 333 (missing stats)
+│ filter: '[]' @> b
+│
+└── • index join
+    │ columns: (a, b)
+    │ estimated row count: 111 (missing stats)
+    │ table: d@primary
+    │ key columns: a
+    │
+    └── • scan
+          columns: (a)
+          estimated row count: 111 (missing stats)
+          table: d@foo_inv
+          spans: /[]-/{}
+
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM d WHERE b <@ '[1, 2]'
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b)
+│ estimated row count: 333 (missing stats)
+│ filter: '[1, 2]' @> b
+│
+└── • index join
+    │ columns: (a, b)
+    │ estimated row count: 111 (missing stats)
+    │ table: d@primary
+    │ key columns: a
+    │
+    └── • project
+        │ columns: (a)
+        │ estimated row count: 111 (missing stats)
+        │
+        └── • inverted filter
+            │ columns: (a, b_inverted_key)
+            │ inverted column: b_inverted_key
+            │ num spans: 5
+            │
+            └── • scan
+                  columns: (a, b_inverted_key)
+                  estimated row count: 111 (missing stats)
+                  table: d@foo_inv
+                  spans: /1-/1/PrefixEnd /2-/2/PrefixEnd /[]-/{} /Arr/1-/Arr/1/PrefixEnd /Arr/2-/Arr/2/PrefixEnd
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM d WHERE b <@ '{}'
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b)
+│ estimated row count: 333 (missing stats)
+│ filter: '{}' @> b
+│
+└── • index join
+    │ columns: (a, b)
+    │ estimated row count: 111 (missing stats)
+    │ table: d@primary
+    │ key columns: a
+    │
+    └── • scan
+          columns: (a)
+          estimated row count: 111 (missing stats)
+          table: d@foo_inv
+          spans: /{}-/{}/PrefixEnd
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM d WHERE b <@ '{"a": "b"}'
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b)
+│ estimated row count: 333 (missing stats)
+│ filter: '{"a": "b"}' @> b
+│
+└── • index join
+    │ columns: (a, b)
+    │ estimated row count: 111 (missing stats)
+    │ table: d@primary
+    │ key columns: a
+    │
+    └── • project
+        │ columns: (a)
+        │ estimated row count: 111 (missing stats)
+        │
+        └── • inverted filter
+            │ columns: (a, b_inverted_key)
+            │ inverted column: b_inverted_key
+            │ num spans: 2
+            │
+            └── • scan
+                  columns: (a, b_inverted_key)
+                  estimated row count: 111 (missing stats)
+                  table: d@foo_inv
+                  spans: /{}-/{}/PrefixEnd /"a"/"b"-/"a"/"b"/PrefixEnd
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM d WHERE b <@ '[{"a": "b"}, {"c": {"d": ["e"]}}, "f"]'
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b)
+│ estimated row count: 333 (missing stats)
+│ filter: '[{"a": "b"}, {"c": {"d": ["e"]}}, "f"]' @> b
+│
+└── • index join
+    │ columns: (a, b)
+    │ estimated row count: 111 (missing stats)
+    │ table: d@primary
+    │ key columns: a
+    │
+    └── • project
+        │ columns: (a)
+        │ estimated row count: 111 (missing stats)
+        │
+        └── • inverted filter
+            │ columns: (a, b_inverted_key)
+            │ inverted column: b_inverted_key
+            │ num spans: 10
+            │
+            └── • scan
+                  columns: (a, b_inverted_key)
+                  estimated row count: 111 (missing stats)
+                  table: d@foo_inv
+                  spans: /"f"-/"f"/PrefixEnd /[]-/{} /Arr/"f"-/Arr/"f"/PrefixEnd /Arr/{}-/Arr/{}/PrefixEnd /Arr/"a"/"b"-/Arr/"a"/"b"/PrefixEnd /Arr/"c"/{}-/Arr/"c"/{}/PrefixEnd /Arr/"c"/{}-/Arr/"c"/{}/PrefixEnd /Arr/"c"/"d"/[]-/Arr/"c"/"d"/{} /Arr/"c"/"d"/[]-/Arr/"c"/"d"/{} /Arr/"c"/"d"/Arr/"e"-/Arr/"c"/"d"/Arr/"e"/PrefixEnd
 
 # Ensure that an inverted index with a composite primary key still encodes
 # the primary key data in the composite value.

--- a/pkg/sql/opt/invertedidx/json_array_test.go
+++ b/pkg/sql/opt/invertedidx/json_array_test.go
@@ -251,10 +251,21 @@ func TestTryFilterJsonOrArrayIndex(t *testing.T) {
 			unique:   true,
 		},
 		{
-			// Contained by is not yet supported for JSON.
-			filters:  "j <@ '1'",
-			indexOrd: jsonOrd,
-			ok:       false,
+			// Contained by is supported for json.
+			filters:          "j <@ '1'",
+			indexOrd:         jsonOrd,
+			ok:               true,
+			tight:            false,
+			unique:           true,
+			remainingFilters: "j <@ '1'",
+		},
+		{
+			filters:          `j <@ '{"a": 1}'`,
+			indexOrd:         jsonOrd,
+			ok:               true,
+			tight:            false,
+			unique:           false,
+			remainingFilters: `j <@ '{"a": 1}'`,
 		},
 		{
 			filters:  "a @> '{1}'",
@@ -342,10 +353,12 @@ func TestTryFilterJsonOrArrayIndex(t *testing.T) {
 		},
 		{
 			// We can constrain the JSON index when the functions are AND-ed.
-			// This will work once JSON is supported for <@.
-			filters:  "j <@ '1' AND a <@ '{1}'",
-			indexOrd: jsonOrd,
-			ok:       false,
+			filters:          "j <@ '1' AND a <@ '{1}'",
+			indexOrd:         jsonOrd,
+			ok:               true,
+			tight:            false,
+			unique:           true,
+			remainingFilters: "j <@ '1' AND a <@ '{1}'",
 		},
 		{
 			// We can guarantee unique primary keys when there are multiple paths

--- a/pkg/sql/opt/memo/testdata/stats/inverted-json
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-json
@@ -266,6 +266,324 @@ index-join t
            ├── key: (1)
            └── fd: (1)-->(4)
 
+# An inverted index scan is preferred for the containment of an indexed column
+# by an empty array. An additional filter is required.
+opt
+SELECT * FROM t WHERE j <@ '[]'
+----
+select
+ ├── columns: k:1(int!null) j:2(jsonb)
+ ├── immutable
+ ├── stats: [rows=666.666667]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── index-join t
+ │    ├── columns: k:1(int!null) j:2(jsonb)
+ │    ├── stats: [rows=10]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    └── scan t@j_idx
+ │         ├── columns: k:1(int!null)
+ │         ├── inverted constraint: /4/1
+ │         │    └── spans: ["7\x00\x018", "7\x00\x018"]
+ │         ├── stats: [rows=10, distinct(4)=1, null(4)=0]
+ │         │   histogram(4)=  0       10       0       0
+ │         │                <--- '\x37000138' --- '\x37000139'
+ │         └── key: (1)
+ └── filters
+      └── '[]' @> j:2 [type=bool, outer=(2), immutable]
+
+# An inverted index scan is preferred for containment of an indexed column
+# by an empty object. An additional filter is required.
+opt
+SELECT * FROM t WHERE j <@ '{}'
+----
+select
+ ├── columns: k:1(int!null) j:2(jsonb)
+ ├── immutable
+ ├── stats: [rows=666.666667]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── index-join t
+ │    ├── columns: k:1(int!null) j:2(jsonb)
+ │    ├── stats: [rows=10]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    └── scan t@j_idx
+ │         ├── columns: k:1(int!null)
+ │         ├── inverted constraint: /4/1
+ │         │    └── spans: ["7\x00\x019", "7\x00\x019"]
+ │         ├── stats: [rows=10, distinct(4)=1, null(4)=0]
+ │         │   histogram(4)=  0       10       0       0
+ │         │                <--- '\x37000139' --- '\x3700013a'
+ │         └── key: (1)
+ └── filters
+      └── '{}' @> j:2 [type=bool, outer=(2), immutable]
+
+# An inverted index scan is preferred for a more selective filter. An
+# additional filter is required.
+opt
+SELECT * FROM t WHERE j <@ '{"c": "d"}'
+----
+select
+ ├── columns: k:1(int!null) j:2(jsonb)
+ ├── immutable
+ ├── stats: [rows=666.666667]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── index-join t
+ │    ├── columns: k:1(int!null) j:2(jsonb)
+ │    ├── stats: [rows=110]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    └── inverted-filter
+ │         ├── columns: k:1(int!null)
+ │         ├── inverted expression: /4
+ │         │    ├── tight: false, unique: false
+ │         │    └── union spans
+ │         │         ├── ["7\x00\x019", "7\x00\x019"]
+ │         │         └── ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
+ │         ├── stats: [rows=110]
+ │         ├── key: (1)
+ │         └── scan t@j_idx
+ │              ├── columns: k:1(int!null) j_inverted_key:4(jsonb!null)
+ │              ├── inverted constraint: /4/1
+ │              │    └── spans
+ │              │         ├── ["7\x00\x019", "7\x00\x019"]
+ │              │         └── ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
+ │              ├── stats: [rows=110, distinct(1)=99.0990991, null(1)=0, distinct(4)=2, null(4)=0]
+ │              │   histogram(4)=  0       10       0          100           0           0
+ │              │                <--- '\x37000139' --- '\x3763000112640001' --- '\x3763000112640002'
+ │              ├── key: (1)
+ │              └── fd: (1)-->(4)
+ └── filters
+      └── '{"c": "d"}' @> j:2 [type=bool, outer=(2), immutable]
+
+# A disjunction requires scanning all entries that match either the left or the
+# right. An additional filter is required.
+opt
+SELECT * FROM t WHERE j <@ '{"c": "d"}' OR j <@ '{"e": "f"}'
+----
+select
+ ├── columns: k:1(int!null) j:2(jsonb)
+ ├── immutable
+ ├── stats: [rows=666.666667]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── index-join t
+ │    ├── columns: k:1(int!null) j:2(jsonb)
+ │    ├── stats: [rows=120]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    └── inverted-filter
+ │         ├── columns: k:1(int!null)
+ │         ├── inverted expression: /4
+ │         │    ├── tight: false, unique: false
+ │         │    └── union spans
+ │         │         ├── ["7\x00\x019", "7\x00\x019"]
+ │         │         ├── ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
+ │         │         └── ["7e\x00\x01\x12f\x00\x01", "7e\x00\x01\x12f\x00\x01"]
+ │         ├── stats: [rows=120]
+ │         ├── key: (1)
+ │         └── scan t@j_idx
+ │              ├── columns: k:1(int!null) j_inverted_key:4(jsonb!null)
+ │              ├── inverted constraint: /4/1
+ │              │    └── spans
+ │              │         ├── ["7\x00\x019", "7\x00\x019"]
+ │              │         ├── ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
+ │              │         └── ["7e\x00\x01\x12f\x00\x01", "7e\x00\x01\x12f\x00\x01"]
+ │              ├── stats: [rows=120, distinct(1)=108.108108, null(1)=0, distinct(4)=3, null(4)=0]
+ │              │   histogram(4)=  0       10       0          100           0           10
+ │              │                <--- '\x37000139' --- '\x3763000112640001' --- '\x3765000112660001'
+ │              ├── key: (1)
+ │              └── fd: (1)-->(4)
+ └── filters
+      └── ('{"c": "d"}' @> j:2) OR ('{"e": "f"}' @> j:2) [type=bool, outer=(2), immutable]
+
+# A conjunction requires scanning all entries that match both the left and the
+# right. An additional filter is required.
+opt
+SELECT * FROM t WHERE j <@ '{"c": "d"}' AND j <@ '{"e": "f"}'
+----
+select
+ ├── columns: k:1(int!null) j:2(jsonb)
+ ├── immutable
+ ├── stats: [rows=222.222222]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── index-join t
+ │    ├── columns: k:1(int!null) j:2(jsonb)
+ │    ├── stats: [rows=120]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    └── inverted-filter
+ │         ├── columns: k:1(int!null)
+ │         ├── inverted expression: /4
+ │         │    ├── tight: false, unique: false
+ │         │    ├── union spans: ["7\x00\x019", "7\x00\x019"]
+ │         │    └── INTERSECTION
+ │         │         ├── span expression
+ │         │         │    ├── tight: false, unique: false
+ │         │         │    └── union spans: ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
+ │         │         └── span expression
+ │         │              ├── tight: false, unique: false
+ │         │              └── union spans: ["7e\x00\x01\x12f\x00\x01", "7e\x00\x01\x12f\x00\x01"]
+ │         ├── stats: [rows=120]
+ │         ├── key: (1)
+ │         └── scan t@j_idx
+ │              ├── columns: k:1(int!null) j_inverted_key:4(jsonb!null)
+ │              ├── inverted constraint: /4/1
+ │              │    └── spans
+ │              │         ├── ["7\x00\x019", "7\x00\x019"]
+ │              │         ├── ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
+ │              │         └── ["7e\x00\x01\x12f\x00\x01", "7e\x00\x01\x12f\x00\x01"]
+ │              ├── stats: [rows=120, distinct(1)=108.108108, null(1)=0, distinct(4)=3, null(4)=0]
+ │              │   histogram(4)=  0       10       0          100           0           10
+ │              │                <--- '\x37000139' --- '\x3763000112640001' --- '\x3765000112660001'
+ │              ├── key: (1)
+ │              └── fd: (1)-->(4)
+ └── filters
+      ├── '{"c": "d"}' @> j:2 [type=bool, outer=(2), immutable]
+      └── '{"e": "f"}' @> j:2 [type=bool, outer=(2), immutable]
+
+# An inverted index scan is preferred for a more selective filter. An
+# additional filter is required.
+opt
+SELECT * FROM t WHERE j <@ '[2]'
+----
+select
+ ├── columns: k:1(int!null) j:2(jsonb)
+ ├── immutable
+ ├── stats: [rows=666.666667]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── index-join t
+ │    ├── columns: k:1(int!null) j:2(jsonb)
+ │    ├── stats: [rows=110]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    └── inverted-filter
+ │         ├── columns: k:1(int!null)
+ │         ├── inverted expression: /4
+ │         │    ├── tight: false, unique: false
+ │         │    └── union spans
+ │         │         ├── ["7\x00\x01*\x04\x00", "7\x00\x01*\x04\x00"]
+ │         │         ├── ["7\x00\x018", "7\x00\x018"]
+ │         │         └── ["7\x00\x03\x00\x01*\x04\x00", "7\x00\x03\x00\x01*\x04\x00"]
+ │         ├── stats: [rows=110]
+ │         ├── key: (1)
+ │         └── scan t@j_idx
+ │              ├── columns: k:1(int!null) j_inverted_key:4(jsonb!null)
+ │              ├── inverted constraint: /4/1
+ │              │    └── spans
+ │              │         ├── ["7\x00\x01*\x04\x00", "7\x00\x01*\x04\x00"]
+ │              │         ├── ["7\x00\x018", "7\x00\x018"]
+ │              │         └── ["7\x00\x03\x00\x01*\x04\x00", "7\x00\x03\x00\x01*\x04\x00"]
+ │              ├── stats: [rows=110, distinct(1)=99.0990991, null(1)=0, distinct(4)=2, null(4)=0]
+ │              │   histogram(4)=  0       10       0          100           0           0
+ │              │                <--- '\x37000138' --- '\x37000300012a0400' --- '\x37000300012a0401'
+ │              ├── key: (1)
+ │              └── fd: (1)-->(4)
+ └── filters
+      └── '[2]' @> j:2 [type=bool, outer=(2), immutable]
+
+# A disjunction requires scanning all entries that match either the left or the
+# right. An additional filter is required.
+opt
+SELECT * FROM t WHERE j <@ '[2]' OR j <@ '[3]'
+----
+select
+ ├── columns: k:1(int!null) j:2(jsonb)
+ ├── immutable
+ ├── stats: [rows=666.666667]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── index-join t
+ │    ├── columns: k:1(int!null) j:2(jsonb)
+ │    ├── stats: [rows=120]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    └── inverted-filter
+ │         ├── columns: k:1(int!null)
+ │         ├── inverted expression: /4
+ │         │    ├── tight: false, unique: false
+ │         │    └── union spans
+ │         │         ├── ["7\x00\x01*\x04\x00", "7\x00\x01*\x04\x00"]
+ │         │         ├── ["7\x00\x01*\x06\x00", "7\x00\x01*\x06\x00"]
+ │         │         ├── ["7\x00\x018", "7\x00\x018"]
+ │         │         ├── ["7\x00\x03\x00\x01*\x04\x00", "7\x00\x03\x00\x01*\x04\x00"]
+ │         │         └── ["7\x00\x03\x00\x01*\x06\x00", "7\x00\x03\x00\x01*\x06\x00"]
+ │         ├── stats: [rows=120]
+ │         ├── key: (1)
+ │         └── scan t@j_idx
+ │              ├── columns: k:1(int!null) j_inverted_key:4(jsonb!null)
+ │              ├── inverted constraint: /4/1
+ │              │    └── spans
+ │              │         ├── ["7\x00\x01*\x04\x00", "7\x00\x01*\x04\x00"]
+ │              │         ├── ["7\x00\x01*\x06\x00", "7\x00\x01*\x06\x00"]
+ │              │         ├── ["7\x00\x018", "7\x00\x018"]
+ │              │         ├── ["7\x00\x03\x00\x01*\x04\x00", "7\x00\x03\x00\x01*\x04\x00"]
+ │              │         └── ["7\x00\x03\x00\x01*\x06\x00", "7\x00\x03\x00\x01*\x06\x00"]
+ │              ├── stats: [rows=120, distinct(1)=108.108108, null(1)=0, distinct(4)=3, null(4)=0]
+ │              │   histogram(4)=  0       10       0          100           0           10           0           0
+ │              │                <--- '\x37000138' --- '\x37000300012a0400' --- '\x37000300012a0600' --- '\x37000300012a0601'
+ │              ├── key: (1)
+ │              └── fd: (1)-->(4)
+ └── filters
+      └── ('[2]' @> j:2) OR ('[3]' @> j:2) [type=bool, outer=(2), immutable]
+
+# A conjunction requires scanning all entries that match both the left and the
+# right. An additional filter is required.
+opt
+SELECT * FROM t WHERE j <@ '[2]' AND j <@ '[3]'
+----
+select
+ ├── columns: k:1(int!null) j:2(jsonb)
+ ├── immutable
+ ├── stats: [rows=222.222222]
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── index-join t
+ │    ├── columns: k:1(int!null) j:2(jsonb)
+ │    ├── stats: [rows=120]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    └── inverted-filter
+ │         ├── columns: k:1(int!null)
+ │         ├── inverted expression: /4
+ │         │    ├── tight: false, unique: false
+ │         │    ├── union spans: ["7\x00\x018", "7\x00\x018"]
+ │         │    └── INTERSECTION
+ │         │         ├── span expression
+ │         │         │    ├── tight: false, unique: false
+ │         │         │    └── union spans
+ │         │         │         ├── ["7\x00\x01*\x04\x00", "7\x00\x01*\x04\x00"]
+ │         │         │         └── ["7\x00\x03\x00\x01*\x04\x00", "7\x00\x03\x00\x01*\x04\x00"]
+ │         │         └── span expression
+ │         │              ├── tight: false, unique: false
+ │         │              └── union spans
+ │         │                   ├── ["7\x00\x01*\x06\x00", "7\x00\x01*\x06\x00"]
+ │         │                   └── ["7\x00\x03\x00\x01*\x06\x00", "7\x00\x03\x00\x01*\x06\x00"]
+ │         ├── stats: [rows=120]
+ │         ├── key: (1)
+ │         └── scan t@j_idx
+ │              ├── columns: k:1(int!null) j_inverted_key:4(jsonb!null)
+ │              ├── inverted constraint: /4/1
+ │              │    └── spans
+ │              │         ├── ["7\x00\x01*\x04\x00", "7\x00\x01*\x04\x00"]
+ │              │         ├── ["7\x00\x01*\x06\x00", "7\x00\x01*\x06\x00"]
+ │              │         ├── ["7\x00\x018", "7\x00\x018"]
+ │              │         ├── ["7\x00\x03\x00\x01*\x04\x00", "7\x00\x03\x00\x01*\x04\x00"]
+ │              │         └── ["7\x00\x03\x00\x01*\x06\x00", "7\x00\x03\x00\x01*\x06\x00"]
+ │              ├── stats: [rows=120, distinct(1)=108.108108, null(1)=0, distinct(4)=3, null(4)=0]
+ │              │   histogram(4)=  0       10       0          100           0           10           0           0
+ │              │                <--- '\x37000138' --- '\x37000300012a0400' --- '\x37000300012a0600' --- '\x37000300012a0601'
+ │              ├── key: (1)
+ │              └── fd: (1)-->(4)
+ └── filters
+      ├── '[2]' @> j:2 [type=bool, outer=(2), immutable]
+      └── '[3]' @> j:2 [type=bool, outer=(2), immutable]
+
 # Histogram boundaries are for JSON values `true`, `"foo"`, `22`, `[]`, and
 # `{}`.
 exec-ddl

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -2148,6 +2148,248 @@ index-join b
       │    └── spans: ["7a\x00\x02\x00\x03\x00\x03b\x00\x02c\x00\x02\x00\x03d\x00\x01\x12e\x00\x01", "7a\x00\x02\x00\x03\x00\x03b\x00\x02c\x00\x02\x00\x03d\x00\x01\x12e\x00\x01"]
       └── key: (1)
 
+# Query using the contained by operator.
+opt expect=GenerateInvertedIndexScans
+SELECT * FROM b WHERE j <@ '1'
+----
+select
+ ├── columns: k:1!null u:2 v:3 j:4
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
+ ├── index-join b
+ │    ├── columns: k:1!null u:2 v:3 j:4
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
+ │    └── scan b@j_inv_idx
+ │         ├── columns: k:1!null
+ │         ├── inverted constraint: /6/1
+ │         │    └── spans: ["7\x00\x01*\x02\x00", "7\x00\x01*\x02\x00"]
+ │         └── key: (1)
+ └── filters
+      └── '1' @> j:4 [outer=(4), immutable]
+
+opt expect=GenerateInvertedIndexScans
+SELECT * FROM b WHERE j <@ '{}'
+----
+select
+ ├── columns: k:1!null u:2 v:3 j:4
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
+ ├── index-join b
+ │    ├── columns: k:1!null u:2 v:3 j:4
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
+ │    └── scan b@j_inv_idx
+ │         ├── columns: k:1!null
+ │         ├── inverted constraint: /6/1
+ │         │    └── spans: ["7\x00\x019", "7\x00\x019"]
+ │         └── key: (1)
+ └── filters
+      └── '{}' @> j:4 [outer=(4), immutable]
+
+opt expect=GenerateInvertedIndexScans
+SELECT * FROM b WHERE j <@ '[]'
+----
+select
+ ├── columns: k:1!null u:2 v:3 j:4
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
+ ├── index-join b
+ │    ├── columns: k:1!null u:2 v:3 j:4
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
+ │    └── scan b@j_inv_idx
+ │         ├── columns: k:1!null
+ │         ├── inverted constraint: /6/1
+ │         │    └── spans: ["7\x00\x018", "7\x00\x018"]
+ │         └── key: (1)
+ └── filters
+      └── '[]' @> j:4 [outer=(4), immutable]
+
+opt expect=GenerateInvertedIndexScans
+SELECT * FROM b WHERE j <@ '{"a": []}'
+----
+select
+ ├── columns: k:1!null u:2 v:3 j:4
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
+ ├── index-join b
+ │    ├── columns: k:1!null u:2 v:3 j:4
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
+ │    └── inverted-filter
+ │         ├── columns: k:1!null
+ │         ├── inverted expression: /6
+ │         │    ├── tight: false, unique: false
+ │         │    └── union spans
+ │         │         ├── ["7\x00\x019", "7\x00\x019"]
+ │         │         └── ["7a\x00\x018", "7a\x00\x018"]
+ │         ├── key: (1)
+ │         └── scan b@j_inv_idx
+ │              ├── columns: k:1!null j_inverted_key:6!null
+ │              ├── inverted constraint: /6/1
+ │              │    └── spans
+ │              │         ├── ["7\x00\x019", "7\x00\x019"]
+ │              │         └── ["7a\x00\x018", "7a\x00\x018"]
+ │              ├── key: (1)
+ │              └── fd: (1)-->(6)
+ └── filters
+      └── '{"a": []}' @> j:4 [outer=(4), immutable]
+
+opt expect=GenerateInvertedIndexScans
+SELECT * FROM b WHERE j <@ '[{"a": {"d": true}}, 1, "b"]'
+----
+select
+ ├── columns: k:1!null u:2 v:3 j:4
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
+ ├── index-join b
+ │    ├── columns: k:1!null u:2 v:3 j:4
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
+ │    └── inverted-filter
+ │         ├── columns: k:1!null
+ │         ├── inverted expression: /6
+ │         │    ├── tight: false, unique: false
+ │         │    └── union spans
+ │         │         ├── ["7\x00\x01\x12b\x00\x01", "7\x00\x01\x12b\x00\x01"]
+ │         │         ├── ["7\x00\x01*\x02\x00", "7\x00\x01*\x02\x00"]
+ │         │         ├── ["7\x00\x018", "7\x00\x018"]
+ │         │         ├── ["7\x00\x03\x00\x01\x12b\x00\x01", "7\x00\x03\x00\x01\x12b\x00\x01"]
+ │         │         ├── ["7\x00\x03\x00\x01*\x02\x00", "7\x00\x03\x00\x01*\x02\x00"]
+ │         │         ├── ["7\x00\x03\x00\x019", "7\x00\x03\x00\x019"]
+ │         │         ├── ["7\x00\x03a\x00\x019", "7\x00\x03a\x00\x019"]
+ │         │         ├── ["7\x00\x03a\x00\x02\x00\x019", "7\x00\x03a\x00\x02\x00\x019"]
+ │         │         └── ["7\x00\x03a\x00\x02d\x00\x01\n", "7\x00\x03a\x00\x02d\x00\x01\n"]
+ │         ├── key: (1)
+ │         └── scan b@j_inv_idx
+ │              ├── columns: k:1!null j_inverted_key:6!null
+ │              ├── inverted constraint: /6/1
+ │              │    └── spans
+ │              │         ├── ["7\x00\x01\x12b\x00\x01", "7\x00\x01\x12b\x00\x01"]
+ │              │         ├── ["7\x00\x01*\x02\x00", "7\x00\x01*\x02\x00"]
+ │              │         ├── ["7\x00\x018", "7\x00\x018"]
+ │              │         ├── ["7\x00\x03\x00\x01\x12b\x00\x01", "7\x00\x03\x00\x01\x12b\x00\x01"]
+ │              │         ├── ["7\x00\x03\x00\x01*\x02\x00", "7\x00\x03\x00\x01*\x02\x00"]
+ │              │         ├── ["7\x00\x03\x00\x019", "7\x00\x03\x00\x019"]
+ │              │         ├── ["7\x00\x03a\x00\x019", "7\x00\x03a\x00\x019"]
+ │              │         ├── ["7\x00\x03a\x00\x02\x00\x019", "7\x00\x03a\x00\x02\x00\x019"]
+ │              │         └── ["7\x00\x03a\x00\x02d\x00\x01\n", "7\x00\x03a\x00\x02d\x00\x01\n"]
+ │              ├── key: (1)
+ │              └── fd: (1)-->(6)
+ └── filters
+      └── '[{"a": {"d": true}}, 1, "b"]' @> j:4 [outer=(4), immutable]
+
+# Disjunction using the contained by operator.
+opt expect=GenerateInvertedIndexScans
+SELECT * FROM b WHERE j <@ '{"a": [3]}' OR j <@ '[1, 2, 3]'
+----
+select
+ ├── columns: k:1!null u:2 v:3 j:4
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
+ ├── index-join b
+ │    ├── columns: k:1!null u:2 v:3 j:4
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
+ │    └── inverted-filter
+ │         ├── columns: k:1!null
+ │         ├── inverted expression: /6
+ │         │    ├── tight: false, unique: false
+ │         │    └── union spans
+ │         │         ├── ["7\x00\x01*\x02\x00", "7\x00\x01*\x02\x00"]
+ │         │         ├── ["7\x00\x01*\x04\x00", "7\x00\x01*\x04\x00"]
+ │         │         ├── ["7\x00\x01*\x06\x00", "7\x00\x01*\x06\x00"]
+ │         │         ├── ["7\x00\x018", "7\x00\x01:")
+ │         │         ├── ["7\x00\x03\x00\x01*\x02\x00", "7\x00\x03\x00\x01*\x02\x00"]
+ │         │         ├── ["7\x00\x03\x00\x01*\x04\x00", "7\x00\x03\x00\x01*\x04\x00"]
+ │         │         ├── ["7\x00\x03\x00\x01*\x06\x00", "7\x00\x03\x00\x01*\x06\x00"]
+ │         │         ├── ["7a\x00\x018", "7a\x00\x018"]
+ │         │         ├── ["7a\x00\x02\x00\x018", "7a\x00\x02\x00\x018"]
+ │         │         └── ["7a\x00\x02\x00\x03\x00\x01*\x06\x00", "7a\x00\x02\x00\x03\x00\x01*\x06\x00"]
+ │         ├── key: (1)
+ │         └── scan b@j_inv_idx
+ │              ├── columns: k:1!null j_inverted_key:6!null
+ │              ├── inverted constraint: /6/1
+ │              │    └── spans
+ │              │         ├── ["7\x00\x01*\x02\x00", "7\x00\x01*\x02\x00"]
+ │              │         ├── ["7\x00\x01*\x04\x00", "7\x00\x01*\x04\x00"]
+ │              │         ├── ["7\x00\x01*\x06\x00", "7\x00\x01*\x06\x00"]
+ │              │         ├── ["7\x00\x018", "7\x00\x01:")
+ │              │         ├── ["7\x00\x03\x00\x01*\x02\x00", "7\x00\x03\x00\x01*\x02\x00"]
+ │              │         ├── ["7\x00\x03\x00\x01*\x04\x00", "7\x00\x03\x00\x01*\x04\x00"]
+ │              │         ├── ["7\x00\x03\x00\x01*\x06\x00", "7\x00\x03\x00\x01*\x06\x00"]
+ │              │         ├── ["7a\x00\x018", "7a\x00\x018"]
+ │              │         ├── ["7a\x00\x02\x00\x018", "7a\x00\x02\x00\x018"]
+ │              │         └── ["7a\x00\x02\x00\x03\x00\x01*\x06\x00", "7a\x00\x02\x00\x03\x00\x01*\x06\x00"]
+ │              ├── key: (1)
+ │              └── fd: (1)-->(6)
+ └── filters
+      └── ('{"a": [3]}' @> j:4) OR ('[1, 2, 3]' @> j:4) [outer=(4), immutable]
+
+# Conjunction using the contained by operator.
+opt expect=GenerateInvertedIndexScans
+SELECT * FROM b WHERE j <@ '{"a": [3]}' AND j <@ '[1, 2, 3]'
+----
+select
+ ├── columns: k:1!null u:2 v:3 j:4
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
+ ├── index-join b
+ │    ├── columns: k:1!null u:2 v:3 j:4
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
+ │    └── inverted-filter
+ │         ├── columns: k:1!null
+ │         ├── inverted expression: /6
+ │         │    ├── tight: false, unique: false
+ │         │    ├── union spans: empty
+ │         │    └── INTERSECTION
+ │         │         ├── span expression
+ │         │         │    ├── tight: false, unique: false
+ │         │         │    └── union spans
+ │         │         │         ├── ["7\x00\x019", "7\x00\x019"]
+ │         │         │         ├── ["7a\x00\x018", "7a\x00\x018"]
+ │         │         │         ├── ["7a\x00\x02\x00\x018", "7a\x00\x02\x00\x018"]
+ │         │         │         └── ["7a\x00\x02\x00\x03\x00\x01*\x06\x00", "7a\x00\x02\x00\x03\x00\x01*\x06\x00"]
+ │         │         └── span expression
+ │         │              ├── tight: false, unique: false
+ │         │              └── union spans
+ │         │                   ├── ["7\x00\x01*\x02\x00", "7\x00\x01*\x02\x00"]
+ │         │                   ├── ["7\x00\x01*\x04\x00", "7\x00\x01*\x04\x00"]
+ │         │                   ├── ["7\x00\x01*\x06\x00", "7\x00\x01*\x06\x00"]
+ │         │                   ├── ["7\x00\x018", "7\x00\x018"]
+ │         │                   ├── ["7\x00\x03\x00\x01*\x02\x00", "7\x00\x03\x00\x01*\x02\x00"]
+ │         │                   ├── ["7\x00\x03\x00\x01*\x04\x00", "7\x00\x03\x00\x01*\x04\x00"]
+ │         │                   └── ["7\x00\x03\x00\x01*\x06\x00", "7\x00\x03\x00\x01*\x06\x00"]
+ │         ├── key: (1)
+ │         └── scan b@j_inv_idx
+ │              ├── columns: k:1!null j_inverted_key:6!null
+ │              ├── inverted constraint: /6/1
+ │              │    └── spans
+ │              │         ├── ["7\x00\x01*\x02\x00", "7\x00\x01*\x02\x00"]
+ │              │         ├── ["7\x00\x01*\x04\x00", "7\x00\x01*\x04\x00"]
+ │              │         ├── ["7\x00\x01*\x06\x00", "7\x00\x01*\x06\x00"]
+ │              │         ├── ["7\x00\x018", "7\x00\x01:")
+ │              │         ├── ["7\x00\x03\x00\x01*\x02\x00", "7\x00\x03\x00\x01*\x02\x00"]
+ │              │         ├── ["7\x00\x03\x00\x01*\x04\x00", "7\x00\x03\x00\x01*\x04\x00"]
+ │              │         ├── ["7\x00\x03\x00\x01*\x06\x00", "7\x00\x03\x00\x01*\x06\x00"]
+ │              │         ├── ["7a\x00\x018", "7a\x00\x018"]
+ │              │         ├── ["7a\x00\x02\x00\x018", "7a\x00\x02\x00\x018"]
+ │              │         └── ["7a\x00\x02\x00\x03\x00\x01*\x06\x00", "7a\x00\x02\x00\x03\x00\x01*\x06\x00"]
+ │              ├── key: (1)
+ │              └── fd: (1)-->(6)
+ └── filters
+      ├── '{"a": [3]}' @> j:4 [outer=(4), immutable]
+      └── '[1, 2, 3]' @> j:4 [outer=(4), immutable]
+
 # Query using the fetch val and equality operators.
 opt expect=GenerateInvertedIndexScans
 SELECT k FROM b WHERE j->'a' = '"b"'

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -864,11 +864,11 @@ func EncodeContainingInvertedIndexSpans(
 
 // EncodeContainedInvertedIndexSpans returns the spans that must be scanned in
 // the inverted index to evaluate a contained by (<@) predicate with the given
-// datum, which should be a container (currently only Arrays, not JSON). These
-// spans should be used to find the objects in the index that could be
-// contained by the given json or array. In other words, if we have a predicate
-// x <@ y, this function should use the value of y to find the spans to scan in
-// an inverted index on x.
+// datum, which should be a container (either an Array or JSON). These spans
+// should be used to find the objects in the index that could be contained by
+// the given json or array. In other words, if we have a predicate x <@ y, this
+// function should use the value of y to find the spans to scan in an inverted
+// index on x.
 //
 // The spans are returned in an inverted.SpanExpression, which represents the
 // set operations that must be applied on the spans read during execution. The
@@ -885,7 +885,7 @@ func EncodeContainedInvertedIndexSpans(
 	case types.ArrayFamily:
 		return encodeContainedArrayInvertedIndexSpans(val.(*tree.DArray), nil /* inKey */)
 	case types.JsonFamily:
-		return inverted.NonInvertedColExpression{}, nil
+		return json.EncodeContainedInvertedIndexSpans(nil /* inKey */, val.(*tree.DJSON).JSON)
 	default:
 		return nil, errors.AssertionFailedf(
 			"trying to apply inverted index to unsupported type %s", datum.ResolvedType(),

--- a/pkg/util/json/encoded.go
+++ b/pkg/util/json/encoded.go
@@ -744,6 +744,16 @@ func (j *jsonEncoded) encodeContainingInvertedIndexSpans(
 	return decoded.encodeContainingInvertedIndexSpans(b, isRoot, isObjectValue)
 }
 
+func (j *jsonEncoded) encodeContainedInvertedIndexSpans(
+	b []byte, isRoot bool,
+) (inverted.Expression, error) {
+	decoded, err := j.decode()
+	if err != nil {
+		return nil, err
+	}
+	return decoded.encodeContainedInvertedIndexSpans(b, isRoot)
+}
+
 // numInvertedIndexEntries implements the JSON interface.
 func (j *jsonEncoded) numInvertedIndexEntries() (int, error) {
 	if j.isScalar() || j.containerLen == 0 {


### PR DESCRIPTION
Previously, we did not support index acceleration when checking if an indexed
column is <@ (contained by) a constant, or in other words, when the indexed
column is on the right side of a @> (contains) expression. We already perform
index acceleration for @> (contains) expressions where an indexed JSON or Array
column is on the left side of the expression, and added support for <@ with
Array columns on the right side.

This change adds support for using the inverted index with <@ expressions on
JSON columns. When there is an inverted index available, a scan will be done on
the JSON column using the spans found from the constant value. An additional
filter will then be applied, as the span expression will never be tight.

Informs: #59763

Release note (performance improvement): Some additional expressions using the
<@ (contained by) and @> (contains) operators now support index-acceleration
with the indexed column on either side of the expression.