### PR TITLE
cliccl: add `load show` subcommand `incremental` to display incremental backups

### DIFF
--- a/pkg/ccl/backupccl/backup_destination.go
+++ b/pkg/ccl/backupccl/backup_destination.go
@@ -27,7 +27,7 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// fetchPreviousBackup takes a list of URIs of previous backups and returns
+// fetchPreviousBackups takes a list of URIs of previous backups and returns
 // their manifest as well as the encryption options of the first backup in the
 // chain.
 func fetchPreviousBackups(
@@ -123,7 +123,7 @@ func resolveDest(
 		if exists {
 			// The backup in the auto-append directory is the full backup.
 			prevBackupURIs = append(prevBackupURIs, defaultURI)
-			priors, err := findPriorBackupLocations(ctx, defaultStore)
+			priors, err := FindPriorBackupLocations(ctx, defaultStore)
 			for _, prior := range priors {
 				priorURI, err := url.Parse(defaultURI)
 				if err != nil {
@@ -137,7 +137,7 @@ func resolveDest(
 			}
 
 			// Pick a piece-specific suffix and update the destination path(s).
-			partName := endTime.GoTime().Format(dateBasedIncFolderName)
+			partName := endTime.GoTime().Format(DateBasedIncFolderName)
 			partName = path.Join(chosenSuffix, partName)
 			defaultURI, urisByLocalityKV, err = getURIsByLocalityKV(to, partName)
 			if err != nil {

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -185,7 +185,7 @@ func showBackupPlanHook(
 		}
 
 		manifests := make([]BackupManifest, len(incPaths)+1)
-		manifests[0], err = readBackupManifestFromStore(ctx, store, encryption)
+		manifests[0], err = ReadBackupManifestFromStore(ctx, store, encryption)
 		if err != nil {
 			return err
 		}

--- a/pkg/ccl/cliccl/BUILD.bazel
+++ b/pkg/ccl/cliccl/BUILD.bazel
@@ -62,14 +62,17 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/build",
+        "//pkg/ccl/backupccl",
         "//pkg/ccl/utilccl",
         "//pkg/cli",
         "//pkg/server",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
+        "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/timeutil",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/ccl/cliccl/load.go
+++ b/pkg/ccl/cliccl/load.go
@@ -11,8 +11,11 @@ package cliccl
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -48,6 +51,14 @@ func init() {
 		RunE:  cli.MaybeDecorateGRPCError(runLoadShowSummary),
 	}
 
+	loadShowIncrementalCmd := &cobra.Command{
+		Use:   "incremental <backup_path>",
+		Short: "show incremental backups",
+		Long:  "Shows incremental chain of a SQL backup.",
+		Args:  cobra.ExactArgs(1),
+		RunE:  cli.MaybeDecorateGRPCError(runLoadShowIncremental),
+	}
+
 	loadShowCmds := &cobra.Command{
 		Use:   "show [command]",
 		Short: "show backups",
@@ -78,7 +89,9 @@ func init() {
 	cli.AddCmd(loadCmds)
 	loadCmds.AddCommand(loadShowCmds)
 	loadShowCmds.AddCommand(loadShowSummaryCmd)
+	loadShowCmds.AddCommand(loadShowIncrementalCmd)
 	loadShowSummaryCmd.Flags().AddFlagSet(loadFlags)
+	loadShowIncrementalCmd.Flags().AddFlagSet(loadFlags)
 }
 
 func newBlobFactory(ctx context.Context, dialing roachpb.NodeID) (blobs.BlobClient, error) {
@@ -118,6 +131,67 @@ func runLoadShowSummary(cmd *cobra.Command, args []string) error {
 	showSpans(desc)
 	showFiles(desc)
 	showDescriptors(desc)
+	return nil
+}
+
+func runLoadShowIncremental(cmd *cobra.Command, args []string) error {
+
+	path := args[0]
+	if !strings.Contains(path, "://") {
+		path = cloudimpl.MakeLocalStorageURI(path)
+	}
+
+	uri, err := url.Parse(path)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	store, err := cloudimpl.ExternalStorageFromURI(ctx, uri.String(), base.ExternalIODirConfig{},
+		cluster.NoSettings, newBlobFactory, security.RootUserName(), nil /*Internal Executor*/, nil /*kvDB*/)
+	if err != nil {
+		return errors.Wrapf(err, "connect to external storage")
+	}
+	defer store.Close()
+
+	incPaths, err := backupccl.FindPriorBackupLocations(ctx, store)
+	if err != nil {
+		return err
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 28, 1, 2, ' ', 0)
+	basepath := uri.Path
+	manifestPaths := append([]string{""}, incPaths...)
+	stores := make([]cloud.ExternalStorage, len(manifestPaths))
+	stores[0] = store
+
+	for i := range manifestPaths {
+
+		if i > 0 {
+			uri.Path = filepath.Join(basepath, manifestPaths[i])
+			stores[i], err = cloudimpl.ExternalStorageFromURI(ctx, uri.String(), base.ExternalIODirConfig{},
+				cluster.NoSettings, newBlobFactory, security.RootUserName(), nil /*Internal Executor*/, nil /*kvDB*/)
+			if err != nil {
+				return errors.Wrapf(err, "connect to external storage")
+			}
+			defer stores[i].Close()
+		}
+
+		manifest, err := backupccl.ReadBackupManifestFromStore(ctx, stores[i], nil)
+		if err != nil {
+			return err
+		}
+		startTime := manifest.StartTime.GoTime().Format(time.RFC3339)
+		endTime := manifest.EndTime.GoTime().Format(time.RFC3339)
+		if i == 0 {
+			startTime = "-"
+		}
+		fmt.Fprintf(w, "%s	%s	%s\n", uri.Path, startTime, endTime)
+	}
+
+	if err := w.Flush(); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/ccl/cliccl/load_test.go
+++ b/pkg/ccl/cliccl/load_test.go
@@ -9,21 +9,28 @@
 package cliccl
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"strings"
 	"testing"
+	"text/tabwriter"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl"
 	"github.com/cockroachdb/cockroach/pkg/cli"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"
 )
 
-func TestLoadShow(t *testing.T) {
+func TestLoadShowSummary(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -101,4 +108,55 @@ Tables:
 			require.Contains(t, out, substr)
 		}
 	})
+}
+
+func TestLoadShowIncremental(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	c := cli.NewCLITest(cli.TestCLIParams{T: t, NoServer: true})
+	defer c.Cleanup()
+
+	ctx := context.Background()
+	dir, cleanFn := testutils.TempDir(t)
+	defer cleanFn()
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{ExternalIODir: dir, Insecure: true})
+	defer srv.Stopper().Stop(ctx)
+
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, `CREATE DATABASE testDB`)
+	sqlDB.Exec(t, `USE testDB`)
+	const backupPath = "nodelocal://0/fooFolder"
+	initTS := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
+	initAOST := initTS.AsOfSystemTime()
+	sqlDB.Exec(t, fmt.Sprintf(`BACKUP DATABASE testDB TO $1 AS OF SYSTEM TIME '%s'`, initAOST), backupPath)
+
+	// We do two more incremental backups on the full backups.
+	incTS := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
+	incAOST := incTS.AsOfSystemTime()
+	sqlDB.Exec(t, fmt.Sprintf(`BACKUP DATABASE testDB TO $1 AS OF SYSTEM TIME '%s'`, incAOST), backupPath)
+	incTS2 := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
+	incAOST2 := incTS2.AsOfSystemTime()
+	sqlDB.Exec(t, fmt.Sprintf(`BACKUP DATABASE testDB TO $1 AS OF SYSTEM TIME '%s'`, incAOST2), backupPath)
+
+	out, err := c.RunWithCapture(fmt.Sprintf("load show incremental %s --external-io-dir=%s", backupPath, dir))
+	require.NoError(t, err)
+	expectedIncFolder := incTS.GoTime().Format(backupccl.DateBasedIncFolderName)
+	expectedIncFolder2 := incTS2.GoTime().Format(backupccl.DateBasedIncFolderName)
+
+	var buf bytes.Buffer
+	w := tabwriter.NewWriter(&buf, 28, 1, 2, ' ', 0)
+	fmt.Fprintf(w, "/fooFolder	-	%s\n", initTS.GoTime().Format(time.RFC3339))
+	fmt.Fprintf(w, "/fooFolder%s	%s	%s\n", expectedIncFolder, initTS.GoTime().Format(time.RFC3339), incTS.GoTime().Format(time.RFC3339))
+	fmt.Fprintf(w, "/fooFolder%s	%s	%s\n", expectedIncFolder2, incTS.GoTime().Format(time.RFC3339), incTS2.GoTime().Format(time.RFC3339))
+	if err := w.Flush(); err != nil {
+		t.Fatalf("TestLoadShowIncremental: flush: %v", err)
+	}
+	checkExpectedOutput(t, buf.String(), out)
+}
+
+func checkExpectedOutput(t *testing.T, expected string, out string) {
+	endOfCmd := strings.Index(out, "\n")
+	output := out[endOfCmd+1:]
+	require.Equal(t, expected, output)
 }


### PR DESCRIPTION
Previously, `load show` only supports showing metadata of a single backup
manifest. Users are ignorant of the incremental backups and have no ways to
inspect the incremental backup manifests unless they know the incremental paths
beforehand (by running `show backup` in a sql session).

This PR updates `load show` with `incremental` subcommand to display
incremental backups, i.e. displaying the auto appended incremental backup
paths of a backup. After listing the incremental paths, users are able to
inspect an incremental backup manifest with `load show summary`.

see #61131

Release note (cli change): Update `load show` with `incremental` subcommand to display 
incremental backups. User can inspect incremental backup chain by running
`cockroach load show incremental <backup_url>.` After listing the incremental paths, 
users are able to inspect an incremental backup manifest with `load show summary`.

```
$ ./cockroach load show incremental "nodelocal://0/test_inc"
./                          -                           2021-03-10T15:48:07Z
./20210310/154947.85        2021-03-10T15:48:07Z        2021-03-10T15:49:47Z
./20210310/155910.43        2021-03-10T15:49:47Z        2021-03-10T15:59:10Z
```