### PR TITLE
WIP build: run generate and buildshort together in teamcity-check

### DIFF
--- a/build/teamcity-check.sh
+++ b/build/teamcity-check.sh
@@ -38,18 +38,15 @@ fi
 
 tc_start_block "Ensure generated code is up-to-date"
 # Buffer noisy output and only print it on failure.
-run build/builder.sh make generate &> artifacts/generate.log || (cat artifacts/generate.log && false)
+run build/builder.sh make buildshort generate &> artifacts/generate.log || (cat artifacts/generate.log && false)
 rm artifacts/generate.log
-check_clean "Run \`make generate\` to automatically regenerate these."
-run build/builder.sh make buildshort &> artifacts/buildshort.log || (cat artifacts/buildshort.log && false)
-rm artifacts/buildshort.log
-check_clean "Run \`make buildshort\` to automatically regenerate these."
+check_clean "Run \`make buildshort generate\` to automatically regenerate these."
 # NB: $root is set by teamcity-support.sh.
 run docker run -i ${tty-} --rm --init \
        --workdir="/go/src/github.com/cockroachdb/cockroach" \
        -v "$root:/go/src/github.com/cockroachdb/cockroach" \
-       $BAZEL_IMAGE build/bazelutil/bazel-generate.sh &> artifacts/buildshort.log || (cat artifacts/buildshort.log && false)
-rm artifacts/buildshort.log
+       $BAZEL_IMAGE build/bazelutil/bazel-generate.sh &> artifacts/bazel-generate.log || (cat artifacts/bazel-generate.log && false)
+rm artifacts/bazel-generate.log
 check_clean "Run \`make bazel-generate\` to automatically regenerate these."
 tc_end_block "Ensure generated code is up-to-date"
 

--- a/build/teamcity-check.sh
+++ b/build/teamcity-check.sh
@@ -39,7 +39,7 @@ fi
 tc_start_block "Ensure generated code is up-to-date"
 # Buffer noisy output and only print it on failure.
 run build/builder.sh make buildshort generate &> artifacts/generate.log || (cat artifacts/generate.log && false)
-rm artifacts/generate.log
+# rm artifacts/generate.log
 check_clean "Run \`make buildshort generate\` to automatically regenerate these."
 # NB: $root is set by teamcity-support.sh.
 run docker run -i ${tty-} --rm --init \


### PR DESCRIPTION
In 05cd2595371, `make generate` was split off from `make buildshort`. 
I imagine this might have been to have better logging around generation.

I think an unfortunate side-effect of this is that the `generate`
target then depends on the `cockroach` target, which then builds the
UI, which takes substantially more time.  When they are run together,
we have the following Make logic to depends on the cockroach-short
target instead:

     980 settings-doc-gen = $(if $(filter buildshort,$(MAKECMDGOALS)),$(COCKROACHSHORT),$(COCKROACH))

My hope is that this speeds up the `lint` phase of our CI builds a
little bit.

Release note: None