### PR TITLE
[release-21.1] vendor: Bump pebble to 958290ba5bd6

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -525,8 +525,8 @@ def go_deps():
         name = "com_github_cockroachdb_pebble",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/pebble",
-        sum = "h1:XdZUrLbpSS/DuvlJNlQh7ihh0OgrkxeR/bHKYaHXrKk=",
-        version = "v0.0.0-20210302221659-e755a0512369",
+        sum = "h1:eDPZb4vP/jcgEAh/IRShMewRVlwqAUNv73BBZnhw/yI=",
+        version = "v0.0.0-20210310192349-958290ba5bd6",
     )
     go_repository(
         name = "com_github_cockroachdb_redact",

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20210302221659-e755a0512369
+	github.com/cockroachdb/pebble v0.0.0-20210310192349-958290ba5bd6
 	github.com/cockroachdb/redact v1.0.9
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249 h1:pZu
 github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249/go.mod h1:UJ0EZAp832vCd54Wev9N1BMKEyvcZ5+IM0AwDrnlkEc=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20210302221659-e755a0512369 h1:XdZUrLbpSS/DuvlJNlQh7ihh0OgrkxeR/bHKYaHXrKk=
-github.com/cockroachdb/pebble v0.0.0-20210302221659-e755a0512369/go.mod h1:1XpB4cLQcF189RAcWi4gUc110zJgtOfT7SVNGY8sOe0=
+github.com/cockroachdb/pebble v0.0.0-20210310192349-958290ba5bd6 h1:eDPZb4vP/jcgEAh/IRShMewRVlwqAUNv73BBZnhw/yI=
+github.com/cockroachdb/pebble v0.0.0-20210310192349-958290ba5bd6/go.mod h1:1XpB4cLQcF189RAcWi4gUc110zJgtOfT7SVNGY8sOe0=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.0.9 h1:sjlUvGorKMIVQfo+w2RqDi5eewCHn453C/vdIXMzjzI=
 github.com/cockroachdb/redact v1.0.9/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=


### PR DESCRIPTION
Changes pulled in:
```
3cc0c971bcb7b976952bf5f0f0e3b12708599e85 db: workaround SetFinalizer(*DB) memory leak
0fbd278c1fe1f9810f1b04240c96e11991fe34cb *: don't use SetFinalizer in race builds
00685e9c29917447add6d44a12068ab6d176240e db: mergingIter.SeekPrefixGE stops early if prefix cannot match
3c37882d2ac826bf9a38fe1d1ca1d253bdd0a505 meta: add SingleDelete to metamorphic test
070a80fcca6f9a90381811238f94ee2f726d5fe4 db: reduce allocations of Iterator.prefixOrFullSeekKey
```

Release note: None.