### PR TITLE
kvserver: detect and return intents in ClearRange

### DIFF
--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -6245,6 +6245,7 @@ func TestRangeStatsComputation(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 	tc.Start(t, stopper)
+	ctx := context.Background()
 
 	baseStats := initialStats()
 	// The initial stats contain an empty lease and no prior read summary, but
@@ -6311,7 +6312,7 @@ func TestRangeStatsComputation(t *testing.T) {
 		// Account for TxnDidNotUpdateMeta
 		expMS.LiveBytes += 2
 		expMS.ValBytes += 2
-		if tc.engine.IsSeparatedIntentsEnabledForTesting() {
+		if tc.engine.IsSeparatedIntentsEnabledForTesting(ctx) {
 			expMS.SeparatedIntentCount++
 		}
 	}

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -715,7 +715,7 @@ type Engine interface {
 	// IsSeparatedIntentsEnabledForTesting is a test only method used in tests
 	// that know that this enabled setting is not changing and need the value to
 	// adjust their expectations.
-	IsSeparatedIntentsEnabledForTesting() bool
+	IsSeparatedIntentsEnabledForTesting(ctx context.Context) bool
 }
 
 // Batch is the interface for batch specific operations.

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -11,11 +11,13 @@
 package storage
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -859,6 +861,53 @@ func Scan(reader Reader, start, end roachpb.Key, max int64) ([]MVCCKeyValue, err
 		return nil
 	})
 	return kvs, err
+}
+
+// ScanSeparatedIntents scans intents using only the separated intents lock
+// table. It does not take interleaved intents into account at all.
+//
+// TODO(erikgrinaker): When we are fully migrated to separated intents, this
+// should be renamed ScanIntents.
+func ScanSeparatedIntents(
+	reader Reader, start, end roachpb.Key, max int64, targetBytes int64,
+) ([]roachpb.Intent, error) {
+	if bytes.Compare(start, end) >= 0 {
+		return []roachpb.Intent{}, nil
+	}
+
+	ltStart, _ := keys.LockTableSingleKey(start, nil)
+	ltEnd, _ := keys.LockTableSingleKey(end, nil)
+	iter := reader.NewEngineIterator(IterOptions{LowerBound: ltStart, UpperBound: ltEnd})
+	defer iter.Close()
+
+	var (
+		intents     = []roachpb.Intent{}
+		intentBytes int64
+		meta        enginepb.MVCCMetadata
+	)
+	valid, err := iter.SeekEngineKeyGE(EngineKey{Key: ltStart})
+	for ; valid; valid, err = iter.NextEngineKey() {
+		if max != 0 && int64(len(intents)) >= max {
+			break
+		}
+		key, err := iter.EngineKey()
+		if err != nil {
+			return nil, err
+		}
+		lockedKey, err := keys.DecodeLockTableSingleKey(key.Key)
+		if err != nil {
+			return nil, err
+		}
+		if err = protoutil.Unmarshal(iter.UnsafeValue(), &meta); err != nil {
+			return nil, err
+		}
+		intents = append(intents, roachpb.MakeIntent(meta.Txn, lockedKey))
+		intentBytes += int64(len(lockedKey)) + int64(len(iter.Value()))
+		if (max > 0 && int64(len(intents)) >= max) || (targetBytes > 0 && intentBytes >= targetBytes) {
+			break
+		}
+	}
+	return intents, err
 }
 
 // WriteSyncNoop carries out a synchronous no-op write to the engine.

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -1589,3 +1589,67 @@ func TestFS(t *testing.T) {
 		})
 	}
 }
+
+func TestScanSeparatedIntents(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	maxKey := keys.MaxKey
+
+	keys := []roachpb.Key{
+		roachpb.Key("a"),
+		roachpb.Key("b"),
+		roachpb.Key("c"),
+	}
+	testcases := map[string]struct {
+		from          roachpb.Key
+		to            roachpb.Key
+		max           int64
+		targetBytes   int64
+		expectIntents []roachpb.Key
+	}{
+		"no keys":         {keys[0], keys[0], 0, 0, keys[:0]},
+		"one key":         {keys[0], keys[1], 0, 0, keys[0:1]},
+		"two keys":        {keys[0], keys[2], 0, 0, keys[0:2]},
+		"all keys":        {keys[0], maxKey, 0, 0, keys},
+		"offset mid":      {keys[1], keys[2], 0, 0, keys[1:2]},
+		"offset last":     {keys[2], maxKey, 0, 0, keys[2:]},
+		"offset post":     {roachpb.Key("x"), maxKey, 0, 0, []roachpb.Key{}},
+		"nil end":         {keys[0], nil, 0, 0, []roachpb.Key{}},
+		"limit keys":      {keys[0], maxKey, 2, 0, keys[0:2]},
+		"one byte":        {keys[0], maxKey, 0, 1, keys[0:1]},
+		"80 bytes":        {keys[0], maxKey, 0, 80, keys[0:2]},
+		"80 bytes or one": {keys[0], maxKey, 1, 80, keys[0:1]},
+		"1000 bytes":      {keys[0], maxKey, 0, 1000, keys},
+	}
+
+	for name, enableSeparatedIntents := range map[string]bool{"interleaved": false, "separated": true} {
+		t.Run(name, func(t *testing.T) {
+			settings := makeSettingsForSeparatedIntents(false, enableSeparatedIntents)
+			eng := newPebbleInMem(ctx, roachpb.Attributes{}, 1<<20, settings)
+			defer eng.Close()
+
+			for _, key := range keys {
+				err := MVCCPut(ctx, eng, nil, key, txn1.ReadTimestamp, roachpb.Value{RawBytes: key}, txn1)
+				require.NoError(t, err)
+			}
+
+			for name, tc := range testcases {
+				tc := tc
+				t.Run(name, func(t *testing.T) {
+					intents, err := ScanSeparatedIntents(eng, tc.from, tc.to, tc.max, tc.targetBytes)
+					require.NoError(t, err)
+					if enableSeparatedIntents {
+						require.Len(t, intents, len(tc.expectIntents), "unexpected number of separated intents")
+						for i, intent := range intents {
+							require.Equal(t, tc.expectIntents[i], intent.Key)
+						}
+					} else {
+						require.Empty(t, intents)
+					}
+				})
+			}
+		})
+	}
+}

--- a/pkg/storage/mvcc_stats_test.go
+++ b/pkg/storage/mvcc_stats_test.go
@@ -200,7 +200,7 @@ func TestMVCCStatsPutCommitMovesTimestamp(t *testing.T) {
 			if accountForTxnDidNotUpdateMeta(t, engine) {
 				// Account for TxnDidNotUpdateMeta
 				mValSize += 2
-				if engine.IsSeparatedIntentsEnabledForTesting() {
+				if engine.IsSeparatedIntentsEnabledForTesting(ctx) {
 					separatedIntentCount = 1
 				}
 			}
@@ -289,7 +289,7 @@ func TestMVCCStatsPutPushMovesTimestamp(t *testing.T) {
 			if accountForTxnDidNotUpdateMeta(t, engine) {
 				// Account for TxnDidNotUpdateMeta
 				mValSize += 2
-				if engine.IsSeparatedIntentsEnabledForTesting() {
+				if engine.IsSeparatedIntentsEnabledForTesting(ctx) {
 					separatedIntentCount = 1
 				}
 			}
@@ -391,7 +391,7 @@ func TestMVCCStatsDeleteMovesTimestamp(t *testing.T) {
 			if accountForTxnDidNotUpdateMeta(t, engine) {
 				// Account for TxnDidNotUpdateMeta
 				mVal1Size += 2
-				if engine.IsSeparatedIntentsEnabledForTesting() {
+				if engine.IsSeparatedIntentsEnabledForTesting(ctx) {
 					separatedIntentCount = 1
 				}
 			}
@@ -521,7 +521,7 @@ func TestMVCCStatsPutMovesDeletionTimestamp(t *testing.T) {
 			if accountForTxnDidNotUpdateMeta(t, engine) {
 				// Account for TxnDidNotUpdateMeta
 				mVal1Size += 2
-				if engine.IsSeparatedIntentsEnabledForTesting() {
+				if engine.IsSeparatedIntentsEnabledForTesting(ctx) {
 					separatedIntentCount = 1
 				}
 			}
@@ -657,7 +657,7 @@ func TestMVCCStatsDelDelCommitMovesTimestamp(t *testing.T) {
 			if accountForTxnDidNotUpdateMeta(t, engine) {
 				// Account for TxnDidNotUpdateMeta
 				mValSize += 2
-				if engine.IsSeparatedIntentsEnabledForTesting() {
+				if engine.IsSeparatedIntentsEnabledForTesting(ctx) {
 					separatedIntentCount = 1
 				}
 			}
@@ -813,7 +813,7 @@ func TestMVCCStatsPutDelPutMovesTimestamp(t *testing.T) {
 			if accountForTxnDidNotUpdateMeta(t, engine) {
 				// Account for TxnDidNotUpdateMeta
 				mValSize += 2
-				if engine.IsSeparatedIntentsEnabledForTesting() {
+				if engine.IsSeparatedIntentsEnabledForTesting(ctx) {
 					separatedIntentCount = 1
 				}
 			}
@@ -1040,7 +1040,7 @@ func TestMVCCStatsPutIntentTimestampNotPutTimestamp(t *testing.T) {
 			if accountForTxnDidNotUpdateMeta(t, engine) {
 				// Account for TxnDidNotUpdateMeta
 				m1ValSize += 2
-				if engine.IsSeparatedIntentsEnabledForTesting() {
+				if engine.IsSeparatedIntentsEnabledForTesting(ctx) {
 					separatedIntentCount = 1
 				}
 			}

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -900,8 +901,9 @@ func (p *Pebble) SafeToWriteSeparatedIntents(ctx context.Context) (bool, error) 
 }
 
 // IsSeparatedIntentsEnabledForTesting implements the Engine interface.
-func (p *Pebble) IsSeparatedIntentsEnabledForTesting() bool {
-	return SeparatedIntentsEnabled.Get(&p.settings.SV)
+func (p *Pebble) IsSeparatedIntentsEnabledForTesting(ctx context.Context) bool {
+	return !p.settings.Version.ActiveVersionOrEmpty(ctx).Less(
+		clusterversion.ByKey(clusterversion.SeparatedIntents)) && SeparatedIntentsEnabled.Get(&p.settings.SV)
 }
 
 func (p *Pebble) put(key MVCCKey, value []byte) error {


### PR DESCRIPTION
Previously, `ClearRange` would blindly remove a key range. This could
cause it to remove write intents belonging to an implicitly committed
`STAGING` transaction. When that transaction was later recovered, some
intents would be missing, and the entire transaction would be aborted
and rolled back (even writes outside of the cleared range).

This patch changes `ClearRange` to check for any intents and return
them to the caller as a `WriteIntentError` to be resolved. However, it
only does this for separated intents (disabled by default until 21.2),
since a full scan for interleaved intents would be too expensive.

Resolves #46764.

Also fixes a false positive with `Engine.IsSeparatedIntentsEnabledForTesting()`
in a separate commit.

Release note (bug fix): Fixed a bug that in rare circumstances could
cause an implicitly committed (`STAGING`) transaction to be uncommitted
if any unresolved intents were removed by a range clear (e.g. when
cleaning up a dropped table). This bug fix is only effective with
separated intents, which are disabled by default.