### PR TITLE
bench/ddl_analysis: skip because it's flakey

### DIFF
--- a/pkg/bench/ddl_analysis/validate_benchmark_data_test.go
+++ b/pkg/bench/ddl_analysis/validate_benchmark_data_test.go
@@ -68,6 +68,7 @@ func TestBenchmarkExpectation(t *testing.T) {
 	skip.UnderRace(t)
 	skip.UnderShort(t)
 	skip.UnderMetamorphic(t)
+	skip.WithIssue(t, 61856)
 
 	expecations := readExpectationsFile(t)
 


### PR DESCRIPTION
I stressed this thing a lot. I guess not enough.

Touch #61856. 

Release note: None