### PR TITLE
sql: show time since table stats were collected in EXPLAIN

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -357,13 +357,17 @@ func (ex *connExecutor) execStmtInOpenState(
 		case tree.ExplainPlan:
 			telemetry.Inc(sqltelemetry.ExplainAnalyzeUseCounter)
 			flags := explain.MakeFlags(&e.ExplainOptions)
-			flags.MakeDeterministic = ex.server.cfg.TestingKnobs.DeterministicExplainAnalyze
+			if ex.server.cfg.TestingKnobs.DeterministicExplainAnalyze {
+				flags.Redact = explain.RedactAll
+			}
 			ih.SetOutputMode(explainAnalyzePlanOutput, flags)
 
 		case tree.ExplainDistSQL:
 			telemetry.Inc(sqltelemetry.ExplainAnalyzeDistSQLUseCounter)
 			flags := explain.MakeFlags(&e.ExplainOptions)
-			flags.MakeDeterministic = ex.server.cfg.TestingKnobs.DeterministicExplainAnalyze
+			if ex.server.cfg.TestingKnobs.DeterministicExplainAnalyze {
+				flags.Redact = explain.RedactAll
+			}
 			ih.SetOutputMode(explainAnalyzeDistSQLOutput, flags)
 
 		default:

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -357,7 +357,7 @@ func (ex *connExecutor) execStmtInOpenState(
 		case tree.ExplainPlan:
 			telemetry.Inc(sqltelemetry.ExplainAnalyzeUseCounter)
 			flags := explain.MakeFlags(&e.ExplainOptions)
-			if ex.server.cfg.TestingKnobs.DeterministicExplainAnalyze {
+			if ex.server.cfg.TestingKnobs.DeterministicExplain {
 				flags.Redact = explain.RedactAll
 			}
 			ih.SetOutputMode(explainAnalyzePlanOutput, flags)
@@ -365,7 +365,7 @@ func (ex *connExecutor) execStmtInOpenState(
 		case tree.ExplainDistSQL:
 			telemetry.Inc(sqltelemetry.ExplainAnalyzeDistSQLUseCounter)
 			flags := explain.MakeFlags(&e.ExplainOptions)
-			if ex.server.cfg.TestingKnobs.DeterministicExplainAnalyze {
+			if ex.server.cfg.TestingKnobs.DeterministicExplain {
 				flags.Redact = explain.RedactAll
 			}
 			ih.SetOutputMode(explainAnalyzeDistSQLOutput, flags)

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -685,7 +685,7 @@ func (p *PlanningCtx) getDefaultSaveFlowsFunc(
 		var diagram execinfrapb.FlowDiagram
 		if planner.instrumentation.shouldSaveDiagrams() {
 			diagramFlags := execinfrapb.DiagramFlags{
-				MakeDeterministic: planner.execCfg.TestingKnobs.DeterministicExplainAnalyze,
+				MakeDeterministic: planner.execCfg.TestingKnobs.DeterministicExplain,
 			}
 			var err error
 			diagram, err = p.flowSpecsToDiagram(ctx, flows, diagramFlags)

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -941,9 +941,16 @@ type ExecutorTestingKnobs struct {
 	// unsupported and will lead to a panic.
 	TestingSaveFlows func(stmt string) func(map[roachpb.NodeID]*execinfrapb.FlowSpec) error
 
-	// DeterministicExplainAnalyze, if set, will result in overriding fields in
-	// EXPLAIN ANALYZE (PLAN) that can vary between runs (like elapsed times).
-	DeterministicExplainAnalyze bool
+	// DeterministicExplain, if set, will result in overriding fields in EXPLAIN
+	// and EXPLAIN ANALYZE that can vary between runs (like elapsed times).
+	//
+	// TODO(radu): this flag affects EXPLAIN and EXPLAIN ANALYZE differently. It
+	// hides the vectorization, distribution, and cluster nodes in EXPLAIN ANALYZE
+	// but not in EXPLAIN. This is just a consequence of how the tests we have are
+	// written. We should replace this knob with a session setting that allows
+	// exact control of the redaction flags (and have each test set it as
+	// necessary).
+	DeterministicExplain bool
 }
 
 // PGWireTestingKnobs contains knobs for the pgwire module.

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -241,7 +241,7 @@ func (ih *instrumentationHelper) Finish(
 			ih.explainPlan,
 			p.curPlan.distSQLFlowInfos,
 			trace,
-			cfg.TestingKnobs.DeterministicExplainAnalyze,
+			cfg.TestingKnobs.DeterministicExplain,
 		)
 	}
 
@@ -250,7 +250,7 @@ func (ih *instrumentationHelper) Finish(
 	for _, flowInfo := range p.curPlan.distSQLFlowInfos {
 		flowsMetadata = append(flowsMetadata, flowInfo.flowsMetadata)
 	}
-	queryLevelStats, err := execstats.GetQueryLevelStats(trace, cfg.TestingKnobs.DeterministicExplainAnalyze, flowsMetadata)
+	queryLevelStats, err := execstats.GetQueryLevelStats(trace, cfg.TestingKnobs.DeterministicExplain, flowsMetadata)
 	if err != nil {
 		const msg = "error getting query level stats for statement: %s: %+v"
 		if util.CrdbTestBuild {

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1333,7 +1333,7 @@ func (t *logicTest) newCluster(serverArgs TestServerArgs) {
 					ForceProductionBatchSizes:       serverArgs.forceProductionBatchSizes,
 				},
 				SQLExecutor: &sql.ExecutorTestingKnobs{
-					DeterministicExplainAnalyze: true,
+					DeterministicExplain: true,
 				},
 			},
 			ClusterName:   "testclustername",
@@ -1440,7 +1440,7 @@ func (t *logicTest) newCluster(serverArgs TestServerArgs) {
 			AllowSettingClusterSettings: true,
 			TestingKnobs: base.TestingKnobs{
 				SQLExecutor: &sql.ExecutorTestingKnobs{
-					DeterministicExplainAnalyze: true,
+					DeterministicExplain: true,
 				},
 			},
 		}

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_local
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_local
@@ -81,7 +81,7 @@ network usage: <hidden>
       actual row count: 2
       KV rows read: 2
       KV bytes read: 16 B
-      estimated row count: 1 (100% of the table)
+      estimated row count: 1 (100% of the table; stats collected <hidden> ago)
       table: c@sec
       spans: FULL SCAN
 ·
@@ -155,7 +155,7 @@ network usage: <hidden>
 │         actual row count: 2
 │         KV rows read: 2
 │         KV bytes read: 16 B
-│         estimated row count: 1 (100% of the table)
+│         estimated row count: 1 (100% of the table; stats collected <hidden> ago)
 │         table: c@sec
 │         spans: FULL SCAN
 │

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_threshold
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_threshold
@@ -69,7 +69,7 @@ vectorized: false
 │ estimated row count: 1
 │
 └── • scan
-      estimated row count: 100 (100% of the table)
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
       table: small@primary
       spans: FULL SCAN
 
@@ -88,7 +88,7 @@ vectorized: true
 │ estimated row count: 1
 │
 └── • scan
-      estimated row count: 100 (100% of the table)
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
       table: small@primary
       spans: FULL SCAN
 
@@ -119,7 +119,7 @@ vectorized: true
 │ estimated row count: 1
 │
 └── • scan
-      estimated row count: 100,000 (100% of the table)
+      estimated row count: 100,000 (100% of the table; stats collected <hidden> ago)
       table: large@primary
       spans: FULL SCAN
 
@@ -138,7 +138,7 @@ vectorized: false
 │ estimated row count: 1
 │
 └── • scan
-      estimated row count: 100,000 (100% of the table)
+      estimated row count: 100,000 (100% of the table; stats collected <hidden> ago)
       table: large@primary
       spans: FULL SCAN
 
@@ -160,11 +160,11 @@ vectorized: true
 │ right cols are key
 │
 ├── • scan
-│     estimated row count: 100 (100% of the table)
+│     estimated row count: 100 (100% of the table; stats collected <hidden> ago)
 │     table: small@primary
 │     spans: FULL SCAN
 │
 └── • scan
-      estimated row count: 100,000 (100% of the table)
+      estimated row count: 100,000 (100% of the table; stats collected <hidden> ago)
       table: large@primary
       spans: FULL SCAN

--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -91,6 +91,8 @@ type Table interface {
 	StatisticCount() int
 
 	// Statistic returns the ith statistic, where i < StatisticCount.
+	// The statistics must be ordered from new to old, according to the
+	// CreatedAt() times.
 	Statistic(i int) TableStatistic
 
 	// CheckCount returns the number of check constraints present on the table.

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_misc
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_misc
@@ -120,7 +120,7 @@ vectorized: true
 ·
 • scan
   columns: (a int, b int, c float, d decimal)
-  estimated row count: 1,000 (100% of the table)
+  estimated row count: 1,000 (100% of the table; stats collected <hidden> ago)
   table: data@primary
   spans: FULL SCAN
 ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -1476,7 +1476,7 @@ distribution: local
 vectorized: true
 ·
 • scan
-  estimated row count: 1,000,000 (100% of the table)
+  estimated row count: 1,000,000 (100% of the table; stats collected <hidden> ago)
   table: percent@primary
   spans: FULL SCAN
 
@@ -1487,7 +1487,7 @@ distribution: local
 vectorized: true
 ·
 • scan
-  estimated row count: 150,000 (15% of the table)
+  estimated row count: 150,000 (15% of the table; stats collected <hidden> ago)
   table: percent@primary
   spans: [/1 - /150000]
 
@@ -1498,7 +1498,7 @@ distribution: local
 vectorized: true
 ·
 • scan
-  estimated row count: 20,000 (2.0% of the table)
+  estimated row count: 20,000 (2.0% of the table; stats collected <hidden> ago)
   table: percent@primary
   spans: [/1 - /20000]
 
@@ -1509,7 +1509,7 @@ distribution: local
 vectorized: true
 ·
 • scan
-  estimated row count: 1,234 (0.12% of the table)
+  estimated row count: 1,234 (0.12% of the table; stats collected <hidden> ago)
   table: percent@primary
   spans: [/1 - /1234]
 
@@ -1520,7 +1520,7 @@ distribution: local
 vectorized: true
 ·
 • scan
-  estimated row count: 980 (0.10% of the table)
+  estimated row count: 980 (0.10% of the table; stats collected <hidden> ago)
   table: percent@primary
   spans: [/1 - /980]
 
@@ -1531,7 +1531,7 @@ distribution: local
 vectorized: true
 ·
 • scan
-  estimated row count: 100 (0.01% of the table)
+  estimated row count: 100 (0.01% of the table; stats collected <hidden> ago)
   table: percent@primary
   spans: [/1 - /100]
 
@@ -1542,7 +1542,7 @@ distribution: local
 vectorized: true
 ·
 • scan
-  estimated row count: 99 (<0.01% of the table)
+  estimated row count: 99 (<0.01% of the table; stats collected <hidden> ago)
   table: percent@primary
   spans: [/1 - /99]
 
@@ -1553,7 +1553,7 @@ distribution: local
 vectorized: true
 ·
 • scan
-  estimated row count: 1 (<0.01% of the table)
+  estimated row count: 1 (<0.01% of the table; stats collected <hidden> ago)
   table: percent@primary
   spans: [/1 - /1]
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -1235,7 +1235,7 @@ vectorized: true
             │     label: buffer 1
             │
             └── • scan
-                  estimated row count: 1 (100% of the table)
+                  estimated row count: 1 (100% of the table; stats collected <hidden> ago)
                   table: p@primary
                   spans: FULL SCAN
 
@@ -1258,7 +1258,7 @@ vectorized: true
 │           │ estimated row count: 33
 │           │
 │           └── • scan
-│                 estimated row count: 33 (33% of the table)
+│                 estimated row count: 33 (33% of the table; stats collected <hidden> ago)
 │                 table: c@primary
 │                 spans: [/1 - ]
 │                 locking strength: for update
@@ -1280,7 +1280,7 @@ vectorized: true
             │         label: buffer 1
             │
             └── • scan
-                  estimated row count: 1 (100% of the table)
+                  estimated row count: 1 (100% of the table; stats collected <hidden> ago)
                   table: p@primary
                   spans: FULL SCAN
 
@@ -1300,7 +1300,7 @@ vectorized: true
 │       │ label: buffer 1
 │       │
 │       └── • scan
-│             estimated row count: 1 (100% of the table)
+│             estimated row count: 1 (100% of the table; stats collected <hidden> ago)
 │             table: p@primary
 │             spans: [/1 - ]
 │
@@ -1352,7 +1352,7 @@ vectorized: true
 │           │ estimated row count: 33
 │           │
 │           └── • scan
-│                 estimated row count: 33 (33% of the table)
+│                 estimated row count: 33 (33% of the table; stats collected <hidden> ago)
 │                 table: c@primary
 │                 spans: [/1 - ]
 │                 locking strength: for update
@@ -1389,7 +1389,7 @@ vectorized: true
 │       │ label: buffer 1
 │       │
 │       └── • scan
-│             estimated row count: 1 (100% of the table)
+│             estimated row count: 1 (100% of the table; stats collected <hidden> ago)
 │             table: p@primary
 │             spans: [/1 - ]
 │
@@ -1461,7 +1461,7 @@ vectorized: true
             │     label: buffer 1
             │
             └── • scan
-                  estimated row count: 10 (100% of the table)
+                  estimated row count: 10 (100% of the table; stats collected <hidden> ago)
                   table: small_parent@primary
                   spans: FULL SCAN
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -437,49 +437,49 @@ vectorized: true
         │   │   │   │   │   │   │ estimated row count: 10
         │   │   │   │   │   │   │
         │   │   │   │   │   │   ├── • scan
-        │   │   │   │   │   │   │     estimated row count: 5 (0.05% of the table)
+        │   │   │   │   │   │   │     estimated row count: 5 (0.05% of the table; stats collected <hidden> ago)
         │   │   │   │   │   │   │     table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
         │   │   │   │   │   │   │     spans: [/0/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /0/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
         │   │   │   │   │   │   │     limit: 5
         │   │   │   │   │   │   │
         │   │   │   │   │   │   └── • scan
-        │   │   │   │   │   │         estimated row count: 5 (0.05% of the table)
+        │   │   │   │   │   │         estimated row count: 5 (0.05% of the table; stats collected <hidden> ago)
         │   │   │   │   │   │         table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
         │   │   │   │   │   │         spans: [/1/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /1/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
         │   │   │   │   │   │         limit: 5
         │   │   │   │   │   │
         │   │   │   │   │   └── • scan
-        │   │   │   │   │         estimated row count: 5 (0.05% of the table)
+        │   │   │   │   │         estimated row count: 5 (0.05% of the table; stats collected <hidden> ago)
         │   │   │   │   │         table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
         │   │   │   │   │         spans: [/2/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /2/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
         │   │   │   │   │         limit: 5
         │   │   │   │   │
         │   │   │   │   └── • scan
-        │   │   │   │         estimated row count: 5 (0.05% of the table)
+        │   │   │   │         estimated row count: 5 (0.05% of the table; stats collected <hidden> ago)
         │   │   │   │         table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
         │   │   │   │         spans: [/3/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /3/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
         │   │   │   │         limit: 5
         │   │   │   │
         │   │   │   └── • scan
-        │   │   │         estimated row count: 5 (0.05% of the table)
+        │   │   │         estimated row count: 5 (0.05% of the table; stats collected <hidden> ago)
         │   │   │         table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
         │   │   │         spans: [/4/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /4/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
         │   │   │         limit: 5
         │   │   │
         │   │   └── • scan
-        │   │         estimated row count: 5 (0.05% of the table)
+        │   │         estimated row count: 5 (0.05% of the table; stats collected <hidden> ago)
         │   │         table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
         │   │         spans: [/5/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /5/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
         │   │         limit: 5
         │   │
         │   └── • scan
-        │         estimated row count: 5 (0.05% of the table)
+        │         estimated row count: 5 (0.05% of the table; stats collected <hidden> ago)
         │         table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
         │         spans: [/6/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /6/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
         │         limit: 5
         │
         └── • scan
-              estimated row count: 5 (0.05% of the table)
+              estimated row count: 5 (0.05% of the table; stats collected <hidden> ago)
               table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
               spans: [/7/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /7/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
               limit: 5

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -42,7 +42,7 @@ vectorized: true
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 100 (100% of the table)
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
       table: abc@primary
       spans: FULL SCAN
 
@@ -61,7 +61,7 @@ vectorized: true
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 100 (100% of the table)
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
       table: abc@primary
       spans: FULL SCAN
 
@@ -80,7 +80,7 @@ vectorized: true
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 33 (33% of the table)
+      estimated row count: 33 (33% of the table; stats collected <hidden> ago)
       table: abc@primary
       spans: /2-
 
@@ -99,7 +99,7 @@ vectorized: true
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 33 (33% of the table)
+      estimated row count: 33 (33% of the table; stats collected <hidden> ago)
       table: abc@primary
       spans: /2-
 
@@ -118,7 +118,7 @@ vectorized: true
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 100 (100% of the table)
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
       table: abc@primary
       spans: FULL SCAN
 
@@ -137,7 +137,7 @@ vectorized: true
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 100 (100% of the table)
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
       table: abc@primary
       spans: FULL SCAN
 
@@ -208,7 +208,7 @@ vectorized: true
         │
         └── • scan
               columns: (a, b, c, d)
-              estimated row count: 100,000 (100% of the table)
+              estimated row count: 100,000 (100% of the table; stats collected <hidden> ago)
               table: data@primary
               spans: FULL SCAN
 
@@ -233,7 +233,7 @@ vectorized: true
     │ filter: c = 1
     │
     └── • scan
-          estimated row count: 100,000 (100% of the table)
+          estimated row count: 100,000 (100% of the table; stats collected <hidden> ago)
           table: data@primary
           spans: FULL SCAN
 ·
@@ -292,7 +292,7 @@ vectorized: true
         └── • scan
               columns: (title, shelf)
               ordering: +title
-              estimated row count: 100 (100% of the table)
+              estimated row count: 100 (100% of the table; stats collected <hidden> ago)
               table: books@primary
               spans: FULL SCAN
 
@@ -337,13 +337,13 @@ vectorized: true
             │
             ├── • scan
             │     columns: (title, shelf)
-            │     estimated row count: 100 (100% of the table)
+            │     estimated row count: 100 (100% of the table; stats collected <hidden> ago)
             │     table: books@primary
             │     spans: FULL SCAN
             │
             └── • scan
                   columns: (name, book)
-                  estimated row count: 100 (100% of the table)
+                  estimated row count: 100 (100% of the table; stats collected <hidden> ago)
                   table: authors@primary
                   spans: FULL SCAN
 
@@ -375,12 +375,12 @@ vectorized: true
         │ equality: (title) = (book)
         │
         ├── • scan
-        │     estimated row count: 100 (100% of the table)
+        │     estimated row count: 100 (100% of the table; stats collected <hidden> ago)
         │     table: books@primary
         │     spans: FULL SCAN
         │
         └── • scan
-              estimated row count: 100 (100% of the table)
+              estimated row count: 100 (100% of the table; stats collected <hidden> ago)
               table: authors@primary
               spans: FULL SCAN
 ·
@@ -412,7 +412,7 @@ vectorized: true
         │
         └── • scan
               columns: (name, book)
-              estimated row count: 100 (100% of the table)
+              estimated row count: 100 (100% of the table; stats collected <hidden> ago)
               table: authors@primary
               spans: FULL SCAN
 
@@ -429,13 +429,13 @@ vectorized: true
 │
 ├── • scan
 │     columns: (title, edition, shelf)
-│     estimated row count: 10,000 (100% of the table)
+│     estimated row count: 10,000 (100% of the table; stats collected <hidden> ago)
 │     table: books2@primary
 │     spans: FULL SCAN
 │
 └── • scan
       columns: (title, edition, shelf)
-      estimated row count: 100 (100% of the table)
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
       table: books@primary
       spans: FULL SCAN
 
@@ -454,7 +454,7 @@ vectorized: true
     │ estimated row count: 100
     │
     └── • scan
-          estimated row count: 100 (100% of the table)
+          estimated row count: 100 (100% of the table; stats collected <hidden> ago)
           table: authors@primary
           spans: FULL SCAN
 ·
@@ -520,7 +520,7 @@ vectorized: true
     │
     └── • scan
           columns: (a)
-          estimated row count: 100 (100% of the table)
+          estimated row count: 100 (100% of the table; stats collected <hidden> ago)
           table: small@primary
           spans: FULL SCAN
 
@@ -553,7 +553,7 @@ vectorized: true
             │
             └── • scan
                   columns: (a)
-                  estimated row count: 100 (100% of the table)
+                  estimated row count: 100 (100% of the table; stats collected <hidden> ago)
                   table: small@primary
                   spans: FULL SCAN
 
@@ -576,7 +576,7 @@ vectorized: true
 │
 └── • scan
       columns: (b)
-      estimated row count: 100 (100% of the table)
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
       table: small@primary
       spans: FULL SCAN
 
@@ -603,7 +603,7 @@ vectorized: true
     └── • scan
           columns: (a)
           ordering: +a
-          estimated row count: 100 (100% of the table)
+          estimated row count: 100 (100% of the table; stats collected <hidden> ago)
           table: small@primary
           spans: FULL SCAN
 
@@ -620,7 +620,7 @@ vectorized: true
 │ pred: (b % 6) = 0
 │
 └── • scan
-      estimated row count: 100 (100% of the table)
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
       table: small@primary
       spans: FULL SCAN
 ·
@@ -645,7 +645,7 @@ vectorized: true
     │
     └── • scan
           columns: (c)
-          estimated row count: 100 (100% of the table)
+          estimated row count: 100 (100% of the table; stats collected <hidden> ago)
           table: small@primary
           spans: FULL SCAN
 
@@ -678,7 +678,7 @@ vectorized: true
             │
             └── • scan
                   columns: (c)
-                  estimated row count: 100 (100% of the table)
+                  estimated row count: 100 (100% of the table; stats collected <hidden> ago)
                   table: small@primary
                   spans: FULL SCAN
 
@@ -702,7 +702,7 @@ vectorized: true
     │
     └── • scan
           columns: (c)
-          estimated row count: 100 (100% of the table)
+          estimated row count: 100 (100% of the table; stats collected <hidden> ago)
           table: small@primary
           spans: FULL SCAN
 
@@ -731,13 +731,13 @@ vectorized: true
     │   │
     │   └── • scan
     │         columns: (b, d)
-    │         estimated row count: 10,000 (100% of the table)
+    │         estimated row count: 10,000 (100% of the table; stats collected <hidden> ago)
     │         table: large@primary
     │         spans: FULL SCAN
     │
     └── • scan
           columns: (c)
-          estimated row count: 100 (100% of the table)
+          estimated row count: 100 (100% of the table; stats collected <hidden> ago)
           table: small@primary
           spans: FULL SCAN
 
@@ -937,7 +937,7 @@ vectorized: true
 └── • scan
       columns: (a, b, c)
       ordering: +a
-      estimated row count: 100 (100% of the table)
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
       table: abc@primary
       spans: FULL SCAN
 
@@ -958,14 +958,14 @@ vectorized: true
 ├── • scan
 │     columns: (d, e, f)
 │     ordering: +f
-│     estimated row count: 10,000 (100% of the table)
+│     estimated row count: 10,000 (100% of the table; stats collected <hidden> ago)
 │     table: def@primary
 │     spans: FULL SCAN
 │
 └── • scan
       columns: (a, b, c)
       ordering: +a
-      estimated row count: 100 (100% of the table)
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
       table: abc@primary
       spans: FULL SCAN
 
@@ -989,13 +989,13 @@ vectorized: true
     │
     ├── • scan
     │     columns: (d, e, f)
-    │     estimated row count: 10,000 (100% of the table)
+    │     estimated row count: 10,000 (100% of the table; stats collected <hidden> ago)
     │     table: def@primary
     │     spans: FULL SCAN
     │
     └── • scan
           columns: (a, b, c)
-          estimated row count: 100 (100% of the table)
+          estimated row count: 100 (100% of the table; stats collected <hidden> ago)
           table: abc@primary
           spans: FULL SCAN
 
@@ -1014,7 +1014,7 @@ vectorized: true
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 100 (100% of the table)
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
       table: abc@primary
       spans: FULL SCAN
 
@@ -1032,7 +1032,7 @@ vectorized: true
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 100 (100% of the table)
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
       table: abc@primary
       spans: FULL SCAN
 
@@ -1051,7 +1051,7 @@ vectorized: true
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 100 (100% of the table)
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
       table: abc@primary
       spans: FULL SCAN
 
@@ -1070,7 +1070,7 @@ vectorized: true
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 100 (100% of the table)
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
       table: abc@primary
       spans: FULL SCAN
 
@@ -1089,7 +1089,7 @@ vectorized: true
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 100 (100% of the table)
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
       table: abc@primary
       spans: FULL SCAN
 
@@ -1108,7 +1108,7 @@ vectorized: true
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 100 (100% of the table)
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
       table: abc@primary
       spans: FULL SCAN
 
@@ -1125,7 +1125,7 @@ vectorized: true
 │ equality: (a) = (a)
 │
 └── • scan
-      estimated row count: 100 (100% of the table)
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
       table: small@primary
       spans: FULL SCAN
 ·
@@ -1149,7 +1149,7 @@ vectorized: true
     │ filter: (a + b) < 20
     │
     └── • scan
-          estimated row count: 100 (100% of the table)
+          estimated row count: 100 (100% of the table; stats collected <hidden> ago)
           table: small@primary
           spans: FULL SCAN
 ·
@@ -1767,7 +1767,7 @@ vectorized: true
                                         │ filter: n_name = 'SAUDI ARABIA'
                                         │
                                         └── • scan
-                                              estimated row count: 25 (100% of the table)
+                                              estimated row count: 25 (100% of the table; stats collected <hidden> ago)
                                               table: nation@primary
                                               spans: FULL SCAN
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare
@@ -99,6 +99,6 @@ vectorized: true
 │ equality cols are key
 │
 └── • scan
-      estimated row count: 1 (100% of the table)
+      estimated row count: 1 (100% of the table; stats collected <hidden> ago)
       table: ab@primary
       spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -1576,7 +1576,7 @@ vectorized: true
     │
     └── • scan
           columns: (a, b, c)
-          estimated row count: 3 (3.3% of the table)
+          estimated row count: 3 (3.3% of the table; stats collected <hidden> ago)
           table: t2@bc
           spans: /2-/3
 
@@ -1612,7 +1612,7 @@ vectorized: true
 │
 └── • scan
       columns: (a, b, c)
-      estimated row count: 3 (3.1% of the table)
+      estimated row count: 3 (3.1% of the table; stats collected <hidden> ago)
       table: t2@bc
       spans: /2/!NULL-/2/2 /2/3-/3
 
@@ -1723,7 +1723,7 @@ vectorized: true
 │
 └── • scan
       columns: (a, b)
-      estimated row count: 3 (3.3% of the table)
+      estimated row count: 3 (3.3% of the table; stats collected <hidden> ago)
       table: t2@bc
       spans: /2-/3
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/stats
@@ -47,7 +47,7 @@ vectorized: true
 │
 └── • scan
       columns: (u, v)
-      estimated row count: 1 (12% of the table)
+      estimated row count: 1 (12% of the table; stats collected <hidden> ago)
       table: uv@uv_v_idx
       spans: /1-/2
 
@@ -81,7 +81,7 @@ vectorized: true
 │
 └── • scan
       columns: (u, v)
-      estimated row count: 1 (1.0% of the table)
+      estimated row count: 1 (1.0% of the table; stats collected <hidden> ago)
       table: uv@uv_u_idx
       spans: /1-/2
 
@@ -118,7 +118,7 @@ vectorized: true
 │
 └── • scan
       columns: (u, v)
-      estimated row count: 5 (5.0% of the table)
+      estimated row count: 5 (5.0% of the table; stats collected <hidden> ago)
       table: uv@uv_u_idx
       spans: /1-/2
 
@@ -153,7 +153,7 @@ vectorized: true
 │
 └── • scan
       columns: (u, v)
-      estimated row count: 1 (1.1% of the table)
+      estimated row count: 1 (1.1% of the table; stats collected <hidden> ago)
       table: uv@uv_v_idx
       spans: /1-/2
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -2505,7 +2505,7 @@ vectorized: true
 │               │
 │               └── • scan
 │                     columns: (r, a, b, c)
-│                     estimated row count: 1 (0.10% of the table)
+│                     estimated row count: 1 (0.10% of the table; stats collected <hidden> ago)
 │                     table: uniq_partial_enum@primary
 │                     spans: /"@"/2/0-/"@"/2/1 /"@"/2/2/1-/"@"/2/3/2 /"\x80"/2/0-/"\x80"/2/1 /"\x80"/2/2/1-/"\x80"/2/3/2 /"\xc0"/2/0-/"\xc0"/2/1 /"\xc0"/2/2/1-/"\xc0"/2/3/2
 │                     parallel

--- a/pkg/sql/opt/exec/explain/BUILD.bazel
+++ b/pkg/sql/opt/exec/explain/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/util",
         "//pkg/util/errorutil",
         "//pkg/util/humanizeutil",
+        "//pkg/util/timeutil",
         "//pkg/util/treeprinter",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_dustin_go_humanize//:go-humanize",

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -332,7 +332,7 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 	if stats, ok := n.annotations[exec.ExecutionStatsID]; ok {
 		s := stats.(*exec.ExecutionStats)
 		if len(s.Nodes) > 0 {
-			e.ob.AddNonDeterministicField("cluster nodes", strings.Join(s.Nodes, ", "))
+			e.ob.AddRedactableField(RedactNodes, "cluster nodes", strings.Join(s.Nodes, ", "))
 		}
 		if s.RowCount.HasValue() {
 			e.ob.AddField("actual row count", humanizeutil.Count(s.RowCount.Value()))

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/dustin/go-humanize"
 )
@@ -352,8 +353,8 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 		if n.op != valuesOp {
 			count := uint64(math.Round(s.RowCount))
 			if s.TableStatsAvailable {
-				if n.op == scanOp && s.TableRowCount != 0 {
-					percentage := s.RowCount / s.TableRowCount * 100
+				if n.op == scanOp && s.TableStatsRowCount != 0 {
+					percentage := s.RowCount / float64(s.TableStatsRowCount) * 100
 					// We want to print the percentage in a user-friendly way; we include
 					// decimals depending on how small the value is.
 					var percentageStr string
@@ -368,8 +369,20 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 						percentageStr = "<0.01"
 					}
 
+					var duration string
+					if e.ob.flags.Redact.Has(RedactVolatile) {
+						duration = "<hidden>"
+					} else {
+						timeSinceStats := timeutil.Since(s.TableStatsCreatedAt)
+						if timeSinceStats < 0 {
+							timeSinceStats = 0
+						}
+						duration = humanizeutil.LongDuration(timeSinceStats)
+					}
 					e.ob.AddField("estimated row count", fmt.Sprintf(
-						"%s (%s%% of the table)", humanizeutil.Count(count), percentageStr,
+						"%s (%s%% of the table; stats collected %s ago)",
+						humanizeutil.Count(count), percentageStr,
+						duration,
 					))
 				} else {
 					e.ob.AddField("estimated row count", humanizeutil.Count(count))

--- a/pkg/sql/opt/exec/explain/flags.go
+++ b/pkg/sql/opt/exec/explain/flags.go
@@ -25,9 +25,38 @@ type Flags struct {
 	// If HideValues is true, then Verbose must be false.
 	HideValues bool
 
-	// MakeDeterministic edits values that are not suitable for testing, such as
-	// planning time.
-	MakeDeterministic bool
+	// Redaction control (for testing purposes).
+	Redact RedactFlags
+}
+
+// RedactFlags control the redacting of various field values. They are used to
+// guarantee deterministic results for testing purposes.
+type RedactFlags uint8
+
+const (
+	// RedactDistribution hides the value of the "distribution" field.
+	RedactDistribution RedactFlags = (1 << iota)
+
+	// RedactVectorized hides the value of the "vectorized" field.
+	RedactVectorized
+
+	// RedactNodes hides cluster nodes involved.
+	RedactNodes
+
+	// RedactVolatile hides any values that can vary from one query run to the
+	// other, even without changes to the configuration or data distribution (e.g.
+	// timings).
+	RedactVolatile
+)
+
+const (
+	// RedactAll has all redact flags set.
+	RedactAll RedactFlags = RedactDistribution | RedactVectorized | RedactNodes | RedactVolatile
+)
+
+// Has returns true if the receiver has the given flag set.
+func (f RedactFlags) Has(flag RedactFlags) bool {
+	return (f & flag) != 0
 }
 
 // MakeFlags crates Flags from ExplainOptions.

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -12,6 +12,7 @@ package exec
 
 import (
 	"context"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/inverted"
@@ -291,9 +292,12 @@ type EstimatedStats struct {
 	TableStatsAvailable bool
 	// RowCount is the estimated number of rows produced by the operator.
 	RowCount float64
-	// TableRowCount is set only for scans; it is the estimated total number of
-	// rows in the table we are scanning.
-	TableRowCount float64
+	// TableStatsRowCount is set only for scans; it is the estimated total number
+	// of rows in the table we are scanning.
+	TableStatsRowCount uint64
+	// TableStatsCreatedAt is set only for scans; it is the time when the latest
+	// table statistics were collected.
+	TableStatsCreatedAt time.Time
 	// Cost is the estimated cost of the operator. This cost includes the costs of
 	// the child operators.
 	Cost float64

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -611,13 +611,6 @@ func (sb *statisticsBuilder) colStatTable(
 	return sb.colStatLeaf(colSet, tableStats, tableFD, tableNotNullCols)
 }
 
-// GetCachedTableStatistics returns the statistics for the given table, if they
-// were calculated already.
-func (m *Memo) GetCachedTableStatistics(tabID opt.TableID) (_ *props.Statistics, ok bool) {
-	stats, ok := m.metadata.TableAnnotation(tabID, statsAnnID).(*props.Statistics)
-	return stats, ok
-}
-
 // +------+
 // | Scan |
 // +------+

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1918,6 +1918,9 @@ func (ef *execFactory) ConstructExplain(
 		}, nil
 	}
 	flags := explain.MakeFlags(options)
+	if ef.planner.execCfg.TestingKnobs.DeterministicExplain {
+		flags.Redact = explain.RedactVolatile
+	}
 	n := &explainPlanNode{
 		options: options,
 		flags:   flags,

--- a/pkg/util/humanizeutil/duration.go
+++ b/pkg/util/humanizeutil/duration.go
@@ -10,7 +10,10 @@
 
 package humanizeutil
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 // Duration formats a duration in a user-friendly way. The result is not exact
 // and the granularity is no smaller than microseconds.
@@ -42,4 +45,45 @@ func Duration(val time.Duration) string {
 
 	// Everything larger is rounded to the nearest second.
 	return val.Round(time.Second).String()
+}
+
+// LongDuration formats a duration that is expected to be on the order of
+// minutes / hours / days in a user-friendly way. The result is not exact and
+// the granularity is no smaller than seconds.
+//
+// Examples:
+//  - 0 seconds
+//  - 1 second
+//  - 3 minutes
+//  - 1 hour
+//  - 5 days
+//  - 1000 days
+func LongDuration(val time.Duration) string {
+	var round time.Duration
+	var unit string
+
+	switch {
+	case val < time.Minute:
+		round = time.Second
+		unit = "second"
+
+	case val < time.Hour:
+		round = time.Minute
+		unit = "minute"
+
+	case val < 24*time.Hour:
+		round = time.Hour
+		unit = "hour"
+
+	default:
+		round = 24 * time.Hour
+		unit = "day"
+	}
+
+	n := int64(val.Round(round) / round)
+	s := ""
+	if n != 1 {
+		s = "s"
+	}
+	return fmt.Sprintf("%d %s%s", n, unit, s)
 }

--- a/pkg/util/humanizeutil/duration_test.go
+++ b/pkg/util/humanizeutil/duration_test.go
@@ -52,3 +52,34 @@ func TestDuration(t *testing.T) {
 		})
 	}
 }
+
+func TestLongDuration(t *testing.T) {
+	testCases := []struct {
+		val time.Duration
+		exp string
+	}{
+		{val: 0, exp: "0 seconds"},
+		{val: time.Second, exp: "1 second"},
+		{val: time.Second + 500*time.Millisecond, exp: "2 seconds"},
+		{val: 50 * time.Second, exp: "50 seconds"},
+		{val: time.Minute, exp: "1 minute"},
+		{val: time.Minute + 20*time.Second, exp: "1 minute"},
+		{val: time.Minute + 30*time.Second, exp: "2 minutes"},
+		{val: 50 * time.Minute, exp: "50 minutes"},
+		{val: time.Hour, exp: "1 hour"},
+		{val: time.Hour + 10*time.Minute, exp: "1 hour"},
+		{val: time.Hour + 30*time.Minute, exp: "2 hours"},
+		{val: 24 * time.Hour, exp: "1 day"},
+		{val: 24*time.Hour + 10*time.Hour, exp: "1 day"},
+		{val: 24*time.Hour + 12*time.Hour, exp: "2 days"},
+		{val: 1234 * 24 * time.Hour, exp: "1234 days"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.val.String(), func(t *testing.T) {
+			res := LongDuration(tc.val)
+			if res != tc.exp {
+				t.Errorf("expected '%s', got '%s'", tc.exp, res)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### opt: more granular redaction of EXPLAIN

This change replaces the MakeDeterministic explain flag with a more
granular bitfield, which can control various types of redactions.

Release note: None

#### sql: show time since table stats were collected in EXPLAIN

Example:
```
EXPLAIN SELECT * FROM rides JOIN vehicles ON rides.vehicle_id = vehicles.id;
                                         info
--------------------------------------------------------------------------------------
  distribution: full
  vectorized: true

  • hash join
  │ estimated row count: 500
  │ equality: (vehicle_id) = (id)
  │
  ├── • scan
  │     estimated row count: 500 (100% of the table; stats collected 15 seconds ago)
  │     table: rides@primary
  │     spans: FULL SCAN
  │
  └── • scan
        estimated row count: 15 (100% of the table; stats collected 11 seconds ago)
        table: vehicles@primary
        spans: FULL SCAN
(16 rows)
```

Durations are rounded to the nearest unit (second, minute, hour, day).

Fixes #57517.

Release note (sql change): EXPLAIN and EXPLAIN ANALYZE now show how
long ago table statistics were collected.

CC @awoods187 