### PR TITLE
cliccl: add `load show backups` to display backup collection

### DIFF
--- a/pkg/ccl/backupccl/backup_destination.go
+++ b/pkg/ccl/backupccl/backup_destination.go
@@ -272,7 +272,7 @@ func resolveBackupCollection(
 		chosenSuffix = strings.TrimPrefix(subdir, "/")
 		chosenSuffix = "/" + chosenSuffix
 	} else {
-		chosenSuffix = endTime.GoTime().Format(dateBasedIntoFolderName)
+		chosenSuffix = endTime.GoTime().Format(DateBasedIntoFolderName)
 	}
 	return collectionURI, chosenSuffix, nil
 }

--- a/pkg/ccl/backupccl/backup_destination.go
+++ b/pkg/ccl/backupccl/backup_destination.go
@@ -27,7 +27,7 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// fetchPreviousBackup takes a list of URIs of previous backups and returns
+// fetchPreviousBackups takes a list of URIs of previous backups and returns
 // their manifest as well as the encryption options of the first backup in the
 // chain.
 func fetchPreviousBackups(
@@ -123,7 +123,7 @@ func resolveDest(
 		if exists {
 			// The backup in the auto-append directory is the full backup.
 			prevBackupURIs = append(prevBackupURIs, defaultURI)
-			priors, err := findPriorBackupLocations(ctx, defaultStore)
+			priors, err := FindPriorBackupLocations(ctx, defaultStore)
 			for _, prior := range priors {
 				priorURI, err := url.Parse(defaultURI)
 				if err != nil {
@@ -137,7 +137,7 @@ func resolveDest(
 			}
 
 			// Pick a piece-specific suffix and update the destination path(s).
-			partName := endTime.GoTime().Format(dateBasedIncFolderName)
+			partName := endTime.GoTime().Format(DateBasedIncFolderName)
 			partName = path.Join(chosenSuffix, partName)
 			defaultURI, urisByLocalityKV, err = getURIsByLocalityKV(to, partName)
 			if err != nil {

--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -71,11 +71,15 @@ const (
 const (
 	// BackupFormatDescriptorTrackingVersion added tracking of complete DBs.
 	BackupFormatDescriptorTrackingVersion uint32 = 1
+
 	// DateBasedIncFolderName is the date format used when creating sub-directories
 	// storing incremental backups for auto-appendable backups.
 	// It is exported for testing backup inspection tooling.
-	DateBasedIncFolderName  = "/20060102/150405.00"
-	dateBasedIntoFolderName = "/2006/01/02-150405.00"
+	DateBasedIncFolderName = "/20060102/150405.00"
+	// DateBasedIntoFolderName is the date format used when creating sub-directories
+	// for storing backups in a collection.
+	// Also exported for testing backup inspection tooling.
+	DateBasedIntoFolderName = "/2006/01/02-150405.00"
 	latestFileName          = "LATEST"
 )
 
@@ -1000,4 +1004,19 @@ func checkForPreviousBackup(
 // tempCheckpointFileNameForJob returns temporary filename for backup manifest checkpoint.
 func tempCheckpointFileNameForJob(jobID jobspb.JobID) string {
 	return fmt.Sprintf("%s-%d", backupManifestCheckpointName, jobID)
+}
+
+// ListFullBackupsInCollection lists full backup paths in the collection
+// of an export store
+func ListFullBackupsInCollection(
+	ctx context.Context, store cloud.ExternalStorage,
+) ([]string, error) {
+	backupPaths, err := store.ListFiles(ctx, "/*/*/*/"+backupManifestName)
+	if err != nil {
+		return nil, err
+	}
+	for i, backupPath := range backupPaths {
+		backupPaths[i] = strings.TrimSuffix(backupPath, "/"+backupManifestName)
+	}
+	return backupPaths, nil
 }

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -185,7 +185,7 @@ func showBackupPlanHook(
 		}
 
 		manifests := make([]BackupManifest, len(incPaths)+1)
-		manifests[0], err = readBackupManifestFromStore(ctx, store, encryption)
+		manifests[0], err = ReadBackupManifestFromStore(ctx, store, encryption)
 		if err != nil {
 			return err
 		}

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -532,12 +532,12 @@ func showBackupsInCollectionPlanHook(
 			return errors.Wrapf(err, "connect to external storage")
 		}
 		defer store.Close()
-		res, err := store.ListFiles(ctx, "/*/*/*/"+backupManifestName)
+		res, err := ListFullBackupsInCollection(ctx, store)
 		if err != nil {
 			return err
 		}
 		for _, i := range res {
-			resultsCh <- tree.Datums{tree.NewDString(strings.TrimSuffix(i, "/"+backupManifestName))}
+			resultsCh <- tree.Datums{tree.NewDString(i)}
 		}
 		return nil
 	}

--- a/pkg/ccl/cliccl/BUILD.bazel
+++ b/pkg/ccl/cliccl/BUILD.bazel
@@ -62,14 +62,17 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/build",
+        "//pkg/ccl/backupccl",
         "//pkg/ccl/utilccl",
         "//pkg/cli",
         "//pkg/server",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
+        "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/timeutil",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/ccl/cliccl/load.go
+++ b/pkg/ccl/cliccl/load.go
@@ -11,8 +11,11 @@ package cliccl
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -48,6 +51,14 @@ func init() {
 		RunE:  cli.MaybeDecorateGRPCError(runLoadShowSummary),
 	}
 
+	loadShowIncrementalCmd := &cobra.Command{
+		Use:   "incremental <backup_path>",
+		Short: "show incremental backups",
+		Long:  "Shows incremental chain of a SQL backup.",
+		Args:  cobra.ExactArgs(1),
+		RunE:  cli.MaybeDecorateGRPCError(runLoadShowIncremental),
+	}
+
 	loadShowCmds := &cobra.Command{
 		Use:   "show [command]",
 		Short: "show backups",
@@ -78,7 +89,9 @@ func init() {
 	cli.AddCmd(loadCmds)
 	loadCmds.AddCommand(loadShowCmds)
 	loadShowCmds.AddCommand(loadShowSummaryCmd)
+	loadShowCmds.AddCommand(loadShowIncrementalCmd)
 	loadShowSummaryCmd.Flags().AddFlagSet(loadFlags)
+	loadShowIncrementalCmd.Flags().AddFlagSet(loadFlags)
 }
 
 func newBlobFactory(ctx context.Context, dialing roachpb.NodeID) (blobs.BlobClient, error) {
@@ -118,6 +131,67 @@ func runLoadShowSummary(cmd *cobra.Command, args []string) error {
 	showSpans(desc)
 	showFiles(desc)
 	showDescriptors(desc)
+	return nil
+}
+
+func runLoadShowIncremental(cmd *cobra.Command, args []string) error {
+
+	path := args[0]
+	if !strings.Contains(path, "://") {
+		path = cloudimpl.MakeLocalStorageURI(path)
+	}
+
+	uri, err := url.Parse(path)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	store, err := cloudimpl.ExternalStorageFromURI(ctx, uri.String(), base.ExternalIODirConfig{},
+		cluster.NoSettings, newBlobFactory, security.RootUserName(), nil /*Internal Executor*/, nil /*kvDB*/)
+	if err != nil {
+		return errors.Wrapf(err, "connect to external storage")
+	}
+	defer store.Close()
+
+	incPaths, err := backupccl.FindPriorBackupLocations(ctx, store)
+	if err != nil {
+		return err
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 28, 1, 2, ' ', 0)
+	basepath := uri.Path
+	manifestPaths := append([]string{""}, incPaths...)
+	stores := make([]cloud.ExternalStorage, len(manifestPaths))
+	stores[0] = store
+
+	for i := range manifestPaths {
+
+		if i > 0 {
+			uri.Path = filepath.Join(basepath, manifestPaths[i])
+			stores[i], err = cloudimpl.ExternalStorageFromURI(ctx, uri.String(), base.ExternalIODirConfig{},
+				cluster.NoSettings, newBlobFactory, security.RootUserName(), nil /*Internal Executor*/, nil /*kvDB*/)
+			if err != nil {
+				return errors.Wrapf(err, "connect to external storage")
+			}
+			defer stores[i].Close()
+		}
+
+		manifest, err := backupccl.ReadBackupManifestFromStore(ctx, stores[i], nil)
+		if err != nil {
+			return err
+		}
+		startTime := manifest.StartTime.GoTime().Format(time.RFC3339)
+		endTime := manifest.EndTime.GoTime().Format(time.RFC3339)
+		if i == 0 {
+			startTime = "-"
+		}
+		fmt.Fprintf(w, "%s	%s	%s\n", uri.Path, startTime, endTime)
+	}
+
+	if err := w.Flush(); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/ccl/cliccl/load_test.go
+++ b/pkg/ccl/cliccl/load_test.go
@@ -9,21 +9,28 @@
 package cliccl
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"strings"
 	"testing"
+	"text/tabwriter"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl"
 	"github.com/cockroachdb/cockroach/pkg/cli"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"
 )
 
-func TestLoadShow(t *testing.T) {
+func TestLoadShowSummary(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -101,4 +108,55 @@ Tables:
 			require.Contains(t, out, substr)
 		}
 	})
+}
+
+func TestLoadShowIncremental(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	c := cli.NewCLITest(cli.TestCLIParams{T: t, NoServer: true})
+	defer c.Cleanup()
+
+	ctx := context.Background()
+	dir, cleanFn := testutils.TempDir(t)
+	defer cleanFn()
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{ExternalIODir: dir, Insecure: true})
+	defer srv.Stopper().Stop(ctx)
+
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, `CREATE DATABASE testDB`)
+	sqlDB.Exec(t, `USE testDB`)
+	const backupPath = "nodelocal://0/fooFolder"
+	initTS := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
+	initAOST := initTS.AsOfSystemTime()
+	sqlDB.Exec(t, fmt.Sprintf(`BACKUP DATABASE testDB TO $1 AS OF SYSTEM TIME '%s'`, initAOST), backupPath)
+
+	// We do two more incremental backups on the full backups.
+	incTS := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
+	incAOST := incTS.AsOfSystemTime()
+	sqlDB.Exec(t, fmt.Sprintf(`BACKUP DATABASE testDB TO $1 AS OF SYSTEM TIME '%s'`, incAOST), backupPath)
+	incTS2 := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
+	incAOST2 := incTS2.AsOfSystemTime()
+	sqlDB.Exec(t, fmt.Sprintf(`BACKUP DATABASE testDB TO $1 AS OF SYSTEM TIME '%s'`, incAOST2), backupPath)
+
+	out, err := c.RunWithCapture(fmt.Sprintf("load show incremental %s --external-io-dir=%s", backupPath, dir))
+	require.NoError(t, err)
+	expectedIncFolder := incTS.GoTime().Format(backupccl.DateBasedIncFolderName)
+	expectedIncFolder2 := incTS2.GoTime().Format(backupccl.DateBasedIncFolderName)
+
+	var buf bytes.Buffer
+	w := tabwriter.NewWriter(&buf, 28, 1, 2, ' ', 0)
+	fmt.Fprintf(w, "/fooFolder	-	%s\n", initTS.GoTime().Format(time.RFC3339))
+	fmt.Fprintf(w, "/fooFolder%s	%s	%s\n", expectedIncFolder, initTS.GoTime().Format(time.RFC3339), incTS.GoTime().Format(time.RFC3339))
+	fmt.Fprintf(w, "/fooFolder%s	%s	%s\n", expectedIncFolder2, incTS.GoTime().Format(time.RFC3339), incTS2.GoTime().Format(time.RFC3339))
+	if err := w.Flush(); err != nil {
+		t.Fatalf("TestLoadShowIncremental: flush: %v", err)
+	}
+	checkExpectedOutput(t, buf.String(), out)
+}
+
+func checkExpectedOutput(t *testing.T, expected string, out string) {
+	endOfCmd := strings.Index(out, "\n")
+	output := out[endOfCmd+1:]
+	require.Equal(t, expected, output)
 }

--- a/pkg/ccl/cliccl/load_test.go
+++ b/pkg/ccl/cliccl/load_test.go
@@ -110,6 +110,53 @@ Tables:
 	})
 }
 
+func TestLoadShowBackups(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	c := cli.NewCLITest(cli.TestCLIParams{T: t, NoServer: true})
+	defer c.Cleanup()
+
+	ctx := context.Background()
+	dir, cleanFn := testutils.TempDir(t)
+	defer cleanFn()
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{ExternalIODir: dir, Insecure: true})
+	defer srv.Stopper().Stop(ctx)
+
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, `CREATE DATABASE testDB`)
+	sqlDB.Exec(t, `USE testDB`)
+	const backupPath = "nodelocal://0/fooFolder"
+
+	t.Run("show-backups-without-backups-in-collection", func(t *testing.T) {
+		out, err := c.RunWithCapture(fmt.Sprintf("load show backups %s --external-io-dir=%s", backupPath, dir))
+		require.NoError(t, err)
+		expectedOutput := "no backups found.\n"
+		checkExpectedOutput(t, expectedOutput, out)
+	})
+
+	intoTS := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
+	initAOST := intoTS.AsOfSystemTime()
+	sqlDB.Exec(t, fmt.Sprintf(`BACKUP DATABASE testDB INTO $1 AS OF SYSTEM TIME '%s'`, initAOST), backupPath)
+	intoTS1 := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
+	intoAOST1 := intoTS1.AsOfSystemTime()
+	sqlDB.Exec(t, fmt.Sprintf(`BACKUP DATABASE testDB INTO $1 AS OF SYSTEM TIME '%s'`, intoAOST1), backupPath)
+	intoTS2 := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
+	intoAOST2 := intoTS2.AsOfSystemTime()
+	sqlDB.Exec(t, fmt.Sprintf(`BACKUP DATABASE testDB INTO $1 AS OF SYSTEM TIME '%s'`, intoAOST2), backupPath)
+
+	t.Run("show-backups-with-backups-in-collection", func(t *testing.T) {
+		out, err := c.RunWithCapture(fmt.Sprintf("load show backups %s --external-io-dir=%s", backupPath, dir))
+		require.NoError(t, err)
+
+		expectedOutput := fmt.Sprintf(".%s\n.%s\n.%s\n",
+			intoTS.GoTime().Format(backupccl.DateBasedIntoFolderName),
+			intoTS1.GoTime().Format(backupccl.DateBasedIntoFolderName),
+			intoTS2.GoTime().Format(backupccl.DateBasedIntoFolderName))
+		checkExpectedOutput(t, expectedOutput, out)
+	})
+}
+
 func TestLoadShowIncremental(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)


### PR DESCRIPTION
Previously, users can list backups created by `BACKUP INTO`
with `SHOW BACKUP IN`in a sql session. But this listing task
can be also done offline without a running cluster.

This PR updates `load show` with `backups` subcommand, 
which allows users to list backups in a backup collection 
created by `BACKUP INTO`. 
With the same purpose as other `load show` subcommands, 
this update allows users to list backups without running 
`SHOW BACKUP IN` in a sql session.

see #61131 #61829 to checkout other `load show` subcommand.

Release note (cli change): Add `load show backups` to
display backup collection. Previously, users can list backups
created by `BACKUP INTO` via `SHOW BACKUP IN`in a sql
session. But this listing task can be also done offline without a
running cluster. Now, users are able to list backups in a collection
with `cockroach load show backups <collection_url>.