### PR TITLE
storage: fix read behavior for large key-values

### DIFF
--- a/pkg/storage/pebble_mvcc_scanner_test.go
+++ b/pkg/storage/pebble_mvcc_scanner_test.go
@@ -11,6 +11,7 @@
 package storage
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"testing"
@@ -113,4 +114,54 @@ func TestMVCCScanWithManyVersionsAndSeparatedIntents(t *testing.T) {
 		expectedKVs[i].v = []byte("2")
 	}
 	require.Equal(t, expectedKVs, kvs)
+}
+
+func TestMVCCScanWithLargeKeyValue(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	eng := createTestPebbleEngine()
+	defer eng.Close()
+
+	keys := []roachpb.Key{roachpb.Key("a"), roachpb.Key("b"), roachpb.Key("c"), roachpb.Key("d")}
+	largeValue := bytes.Repeat([]byte("l"), 150<<20)
+	// Alternate small and large values.
+	require.NoError(t, eng.PutMVCC(MVCCKey{Key: keys[0], Timestamp: hlc.Timestamp{WallTime: 1}},
+		[]byte("a")))
+	require.NoError(t, eng.PutMVCC(MVCCKey{Key: keys[1], Timestamp: hlc.Timestamp{WallTime: 1}},
+		largeValue))
+	require.NoError(t, eng.PutMVCC(MVCCKey{Key: keys[2], Timestamp: hlc.Timestamp{WallTime: 1}},
+		[]byte("c")))
+	require.NoError(t, eng.PutMVCC(MVCCKey{Key: keys[3], Timestamp: hlc.Timestamp{WallTime: 1}},
+		largeValue))
+
+	reader := eng.NewReadOnly()
+	defer reader.Close()
+	iter := reader.NewMVCCIterator(
+		MVCCKeyAndIntentsIterKind, IterOptions{LowerBound: keys[0], UpperBound: roachpb.Key("e")})
+	defer iter.Close()
+
+	ts := hlc.Timestamp{WallTime: 2}
+	mvccScanner := pebbleMVCCScanner{
+		parent:  iter,
+		reverse: false,
+		start:   keys[0],
+		end:     roachpb.Key("e"),
+		ts:      ts,
+	}
+	mvccScanner.init(nil /* txn */, hlc.Timestamp{})
+	_, err := mvccScanner.scan()
+	require.NoError(t, err)
+
+	kvData := mvccScanner.results.finish()
+	numKeys := mvccScanner.results.count
+	require.Equal(t, 4, int(numKeys))
+	require.Equal(t, 4, len(kvData))
+	require.Equal(t, 20, len(kvData[0]))
+	require.Equal(t, 32, cap(kvData[0]))
+	require.Equal(t, 157286419, len(kvData[1]))
+	require.Equal(t, 157286419, cap(kvData[1]))
+	require.Equal(t, 20, len(kvData[2]))
+	require.Equal(t, 32, cap(kvData[2]))
+	require.Equal(t, 157286419, len(kvData[3]))
+	require.Equal(t, 157286419, cap(kvData[3]))
 }


### PR DESCRIPTION
pebbleMVCCScanner no longer has a 128MB limit on the size
of the key-value pair it can read.

Release justification: Fix for high-severity bug in existing
functionality. The pebbleMVCCScanner change prevents a panic
if a key-value pair larger than 128MB gets written, which
affected a customer cluster.

Release note: None