### PR TITLE
bazel: install libtinfo5 in bazel docker image

### DIFF
--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update \
     git \
     gnupg2 \
     libncurses-dev \
+    libtinfo-dev \
     make \
     python3 \
     unzip \

--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -1,1 +1,1 @@
-BAZEL_IMAGE=cockroachdb/bazel:20210302-163751
+BAZEL_IMAGE=cockroachdb/bazel:20210311-171107


### PR DESCRIPTION
This doesn't necessarily fix anything at `HEAD`, but in my experiments
I've found that depending on how you configure your build, you can get
it to fail due to being unable to link to `libtinfo.so.5`; this package
installs that library. If nothing else this will minimize the chances
someone consults this Dockerfile for guidance on how to configure a
working Ubuntu build, and then is confused by the error.

Release note: None