### PR TITLE
sql: add back references for user defined types in expressions

### DIFF
--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -132,7 +132,11 @@ func rewriteSequencesInExpr(expr string, rewrites DescRewriteMap) (string, error
 		return "", err
 	}
 	rewriteFunc := func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
-		annotateTypeExpr, id, ok := schemaexpr.GetTypeExprAndSeqID(expr)
+		newExpr, id, ok := schemaexpr.GetTypeExprAndSeqID(expr)
+		if !ok {
+			return true, expr, nil
+		}
+		annotateTypeExpr, ok := newExpr.(*tree.AnnotateTypeExpr)
 		if !ok {
 			return true, expr, nil
 		}

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -5668,7 +5668,7 @@ func TestImportPgDump(t *testing.T) {
 			if c.expected == expectAll {
 				sqlDB.CheckQueryResults(t, `SHOW CREATE TABLE seqtable`, [][]string{{
 					"seqtable", `CREATE TABLE public.seqtable (
-	a INT8 NULL DEFAULT nextval('public.a_seq':::STRING::REGCLASS),
+	a INT8 NULL DEFAULT nextval('public.a_seq'::REGCLASS),
 	b INT8 NULL,
 	rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
 	CONSTRAINT "primary" PRIMARY KEY (rowid ASC),

--- a/pkg/sql/catalog/schemaexpr/column.go
+++ b/pkg/sql/catalog/schemaexpr/column.go
@@ -286,10 +286,10 @@ func columnDescriptorsToPtrs(cols []descpb.ColumnDescriptor) []*descpb.ColumnDes
 	return ptrs
 }
 
-// replaceIDsWithFQNames walks the given expr and replaces occurrences
+// ReplaceIDsWithFQNames walks the given expr and replaces occurrences
 // of regclass IDs in the expr with the descriptor's fully qualified name.
 // For example, nextval(12345::REGCLASS) => nextval('foo.public.seq').
-func replaceIDsWithFQNames(
+func ReplaceIDsWithFQNames(
 	ctx context.Context, rootExpr tree.Expr, semaCtx *tree.SemaContext,
 ) (tree.Expr, error) {
 	replaceFn := func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
@@ -324,30 +324,29 @@ func replaceIDsWithFQNames(
 
 // GetTypeExprAndSeqID takes an expr and looks for a sequence ID in
 // this expr. If it finds one, it will return that ID as well as the
-// AnnotateTypeExpr that contains it.
-func GetTypeExprAndSeqID(expr tree.Expr) (*tree.AnnotateTypeExpr, int64, bool) {
-	// If it's not an AnnotateTypeExpr, skip this node.
-	annotateTypeExpr, ok := expr.(*tree.AnnotateTypeExpr)
-	if !ok {
+// Expr that contains it.
+func GetTypeExprAndSeqID(expr tree.Expr) (tree.Expr, int64, bool) {
+	// Depending on if the given expr is typed checked, we're looking
+	// for either a *tree.AnnotateTypeExpr (if not typed checked), or
+	// a *tree.DOid (if type checked).
+	switch n := expr.(type) {
+	case *tree.AnnotateTypeExpr:
+		if typ, safe := tree.GetStaticallyKnownType(n.Type); !safe || typ.Oid() != oid.T_regclass {
+			return nil, 0, false
+		}
+		// If it's not a constant int, skip this node.
+		numVal, ok := n.Expr.(*tree.NumVal)
+		if !ok {
+			return nil, 0, false
+		}
+		id, err := numVal.AsInt64()
+		if err != nil {
+			return nil, 0, false
+		}
+		return n, id, true
+	case *tree.DOid:
+		return n, int64(n.DInt), true
+	default:
 		return nil, 0, false
 	}
-
-	// If it's not a regclass, skip this node.
-	if typ, safe := tree.GetStaticallyKnownType(
-		annotateTypeExpr.Type,
-	); !safe || typ.Oid() != oid.T_regclass {
-		return nil, 0, false
-	}
-
-	// If it's not a constant int, skip this node.
-	numVal, ok := annotateTypeExpr.Expr.(*tree.NumVal)
-	if !ok {
-		return nil, 0, false
-	}
-	id, err := numVal.AsInt64()
-	if err != nil {
-		return nil, 0, false
-	}
-
-	return annotateTypeExpr, id, true
 }

--- a/pkg/sql/catalog/schemaexpr/expr.go
+++ b/pkg/sql/catalog/schemaexpr/expr.go
@@ -174,7 +174,12 @@ func FormatExprForDisplay(
 	if err != nil {
 		return "", err
 	}
-	return tree.AsStringWithFlags(expr, fmtFlags), nil
+	// Replace any IDs in the expr with their fully qualified names.
+	seqReplacedExpr, err := ReplaceIDsWithFQNames(ctx, expr, semaCtx)
+	if err != nil {
+		return "", err
+	}
+	return tree.AsStringWithFlags(seqReplacedExpr, fmtFlags), nil
 }
 
 func deserializeExprForFormatting(
@@ -189,15 +194,9 @@ func deserializeExprForFormatting(
 		return nil, err
 	}
 
-	// Replace any IDs in the expr with their fully qualified names.
-	seqReplacedExpr, err := replaceIDsWithFQNames(ctx, expr, semaCtx)
-	if err != nil {
-		return nil, err
-	}
-
 	// Replace the column variables with dummyColumns so that they can be
 	// type-checked.
-	replacedExpr, _, err := replaceColumnVars(desc, seqReplacedExpr)
+	replacedExpr, _, err := replaceColumnVars(desc, expr)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1960,7 +1960,7 @@ CREATE TABLE crdb_internal.create_statements (
 		var err error
 		if table.IsView() {
 			descType = typeView
-			stmt, err = ShowCreateView(ctx, &name, table)
+			stmt, err = ShowCreateView(ctx, &p.semaCtx, &name, table)
 		} else if table.IsSequence() {
 			descType = typeSequence
 			stmt, err = ShowCreateSequence(ctx, &name, table)

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -18,11 +18,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/docs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
@@ -33,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
+	"github.com/cockroachdb/cockroach/pkg/util/sequence"
 	"github.com/cockroachdb/errors"
 )
 
@@ -155,7 +159,13 @@ func (n *createViewNode) startExec(params runParams) error {
 	// the name for our view. So instead of creating a new view, replace
 	// the existing one.
 	if replacingDesc != nil {
-		newDesc, err = params.p.replaceViewDesc(params.ctx, n, replacingDesc, backRefMutables)
+		newDesc, err = params.p.replaceViewDesc(
+			params.ctx,
+			params.p.ExecCfg().Settings,
+			params.p,
+			n, replacingDesc,
+			backRefMutables,
+		)
 		if err != nil {
 			return err
 		}
@@ -173,6 +183,7 @@ func (n *createViewNode) startExec(params runParams) error {
 		var creationTime hlc.Timestamp
 		desc, err := makeViewTableDesc(
 			params.ctx,
+			params.p.ExecCfg().Settings,
 			viewName,
 			n.viewQuery,
 			n.dbDesc.GetID(),
@@ -184,6 +195,7 @@ func (n *createViewNode) startExec(params runParams) error {
 			&params.p.semaCtx,
 			params.p.EvalContext(),
 			n.persistence,
+			params.p,
 		)
 		if err != nil {
 			return err
@@ -225,6 +237,13 @@ func (n *createViewNode) startExec(params runParams) error {
 		newDesc = &desc
 	}
 
+	// Used to determine if we want users to be allowed to rename
+	// sequences used in views.
+	st := params.p.ExecCfg().Settings
+	version := st.Version.ActiveVersionOrEmpty(params.ctx)
+	byID := version != (clusterversion.ClusterVersion{}) &&
+		version.IsActive(clusterversion.SequencesRegclass)
+
 	// Persist the back-references in all referenced table descriptors.
 	for id, updated := range n.planDeps {
 		backRefMutable := backRefMutables[id]
@@ -242,6 +261,7 @@ func (n *createViewNode) startExec(params runParams) error {
 			// yet known.
 			// We need to do it here.
 			dep.ID = newDesc.ID
+			dep.ByID = byID && updated.desc.IsSequence()
 			backRefMutable.DependedOnBy = append(backRefMutable.DependedOnBy, dep)
 		}
 		if err := params.p.writeSchemaChange(
@@ -288,6 +308,7 @@ func (n *createViewNode) Close(ctx context.Context)  {}
 // include the back-references.
 func makeViewTableDesc(
 	ctx context.Context,
+	st *cluster.Settings,
 	viewName string,
 	viewQuery string,
 	parentID descpb.ID,
@@ -299,6 +320,7 @@ func makeViewTableDesc(
 	semaCtx *tree.SemaContext,
 	evalCtx *tree.EvalContext,
 	persistence tree.Persistence,
+	sc resolver.SchemaResolver,
 ) (tabledesc.Mutable, error) {
 	desc := tabledesc.InitTableDescriptor(
 		id,
@@ -310,11 +332,76 @@ func makeViewTableDesc(
 		persistence,
 	)
 	desc.ViewQuery = viewQuery
+
+	// If we're in 21.1, then sequences in views should be referenced
+	// by IDs, so walk the tree and replace sequence names with IDs.
+	version := st.Version.ActiveVersionOrEmpty(ctx)
+	byID := version != (clusterversion.ClusterVersion{}) &&
+		version.IsActive(clusterversion.SequencesRegclass)
+
+	if sc != nil && byID {
+		updatedQuery, err := startViewWalk(ctx, sc, viewQuery)
+		if err != nil {
+			return tabledesc.Mutable{}, err
+		}
+		desc.ViewQuery = updatedQuery
+	}
+
 	if err := addResultColumns(ctx, semaCtx, evalCtx, &desc, resultColumns); err != nil {
 		return tabledesc.Mutable{}, err
 	}
 
 	return desc, nil
+}
+
+// startViewWalk prepares to walk the given viewQuery by defining the
+// function used to replace sequence names with IDs, and parsing the
+// viewQuery into a statement.
+func startViewWalk(
+	ctx context.Context, sc resolver.SchemaResolver, viewQuery string,
+) (string, error) {
+	replaceSeqFunc := func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
+		seqIdentifiers, err := sequence.GetUsedSequences(expr)
+		if err != nil {
+			return false, expr, err
+		}
+		seqNameToID := make(map[string]int64)
+		for _, seqIdentifier := range seqIdentifiers {
+			seqDesc, err := GetSequenceDescFromIdentifier(ctx, sc, seqIdentifier)
+			if err != nil {
+				return false, expr, err
+			}
+			seqNameToID[seqIdentifier.SeqName] = int64(seqDesc.ID)
+		}
+		newExpr, err = sequence.ReplaceSequenceNamesWithIDs(expr, seqNameToID)
+		if err != nil {
+			return false, expr, err
+		}
+		return false, newExpr, nil
+	}
+
+	stmt, err := parser.ParseOne(viewQuery)
+	if err != nil {
+		return "", err
+	}
+
+	return WalkViewQuery(stmt.AST, replaceSeqFunc)
+}
+
+// WalkViewQuery takes in a tree.Statement and walks the
+// statement, applying the given function to expressions.
+// This function is used during both encoding and
+// decoding, passing in a different replaceFunc.
+func WalkViewQuery(
+	stmt tree.Statement,
+	replaceFunc func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error),
+) (string, error) {
+	v := tree.SimpleVisitor{Fn: replaceFunc}
+	newStmt, changed := tree.WalkStmt(&v, stmt)
+	if changed {
+		return newStmt.String(), nil
+	}
+	return stmt.String(), nil
 }
 
 // replaceViewDesc modifies and returns the input view descriptor changed
@@ -324,12 +411,29 @@ func makeViewTableDesc(
 // on that the new view no longer depends on.
 func (p *planner) replaceViewDesc(
 	ctx context.Context,
+	st *cluster.Settings,
+	sc resolver.SchemaResolver,
 	n *createViewNode,
 	toReplace *tabledesc.Mutable,
 	backRefMutables map[descpb.ID]*tabledesc.Mutable,
 ) (*tabledesc.Mutable, error) {
 	// Set the query to the new query.
 	toReplace.ViewQuery = n.viewQuery
+
+	// If we're in 21.1, then sequences in views should be referenced
+	// by IDs, so walk the tree and replace sequence names with IDs.
+	version := st.Version.ActiveVersionOrEmpty(ctx)
+	byID := version != (clusterversion.ClusterVersion{}) &&
+		version.IsActive(clusterversion.SequencesRegclass)
+
+	if sc != nil && byID {
+		updatedQuery, err := startViewWalk(ctx, sc, n.viewQuery)
+		if err != nil {
+			return nil, err
+		}
+		toReplace.ViewQuery = updatedQuery
+	}
+
 	// Reset the columns to add the new result columns onto.
 	toReplace.Columns = make([]descpb.ColumnDescriptor, 0, len(n.columns))
 	toReplace.NextColumnID = 0

--- a/pkg/sql/logictest/testdata/logic_test/drop_sequence
+++ b/pkg/sql/logictest/testdata/logic_test/drop_sequence
@@ -31,7 +31,7 @@ query TT
 SHOW CREATE TABLE t1
 ----
 t1  CREATE TABLE public.t1 (
-    i INT8 NOT NULL DEFAULT nextval('public.drop_test':::STRING::REGCLASS),
+    i INT8 NOT NULL DEFAULT nextval('public.drop_test'::REGCLASS),
     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
     CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
     FAMILY "primary" (i, rowid)
@@ -92,8 +92,8 @@ query TT
 SHOW CREATE TABLE foo
 ----
 foo  CREATE TABLE public.foo (
-     i INT8 NOT NULL DEFAULT nextval('other_db.public.s':::STRING::REGCLASS),
-     j INT8 NOT NULL DEFAULT nextval('public.s':::STRING::REGCLASS),
+     i INT8 NOT NULL DEFAULT nextval('other_db.public.s'::REGCLASS),
+     j INT8 NOT NULL DEFAULT nextval('public.s'::REGCLASS),
      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
      CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
      FAMILY fam_0_i_j_rowid (i, j, rowid)
@@ -115,7 +115,7 @@ SHOW CREATE TABLE foo
 ----
 foo  CREATE TABLE public.foo (
      i INT8 NOT NULL,
-     j INT8 NOT NULL DEFAULT nextval('public.s':::STRING::REGCLASS),
+     j INT8 NOT NULL DEFAULT nextval('public.s'::REGCLASS),
      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
      CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
      FAMILY fam_0_i_j_rowid (i, j, rowid)
@@ -151,8 +151,8 @@ query TT
 SHOW CREATE TABLE bar
 ----
 bar  CREATE TABLE public.bar (
-     i INT8 NOT NULL DEFAULT nextval('other_sc.s':::STRING::REGCLASS),
-     j INT8 NOT NULL DEFAULT nextval('public.s':::STRING::REGCLASS),
+     i INT8 NOT NULL DEFAULT nextval('other_sc.s'::REGCLASS),
+     j INT8 NOT NULL DEFAULT nextval('public.s'::REGCLASS),
      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
      CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
      FAMILY fam_0_i_j_rowid (i, j, rowid)
@@ -174,7 +174,7 @@ SHOW CREATE TABLE bar
 ----
 bar  CREATE TABLE public.bar (
      i INT8 NOT NULL,
-     j INT8 NOT NULL DEFAULT nextval('public.s':::STRING::REGCLASS),
+     j INT8 NOT NULL DEFAULT nextval('public.s'::REGCLASS),
      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
      CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
      FAMILY fam_0_i_j_rowid (i, j, rowid)

--- a/pkg/sql/logictest/testdata/logic_test/drop_type
+++ b/pkg/sql/logictest/testdata/logic_test/drop_type
@@ -398,3 +398,13 @@ DROP TYPE sc2.typ;
 # This is just cleanup.
 statement ok
 DROP SCHEMA sc2 CASCADE;
+
+
+statement ok
+CREATE TYPE typ2 AS ENUM('a')
+
+statement ok
+CREATE VIEW v AS (SELECT 'a'::typ2 < 'a'::typ2)
+
+statement error pq: cannot drop type "typ2" because other objects \(\[test.public.v\]\) still depend on it
+drop type typ2

--- a/pkg/sql/logictest/testdata/logic_test/int_size
+++ b/pkg/sql/logictest/testdata/logic_test/int_size
@@ -134,7 +134,7 @@ query TT
 SHOW CREATE TABLE i4_sql_sequence
 ----
 i4_sql_sequence  CREATE TABLE public.i4_sql_sequence (
-                 a INT4 NOT NULL DEFAULT nextval('public.i4_sql_sequence_a_seq':::STRING::REGCLASS),
+                 a INT4 NOT NULL DEFAULT nextval('public.i4_sql_sequence_a_seq'::REGCLASS),
                  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
                  CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                  FAMILY "primary" (a, rowid)
@@ -150,7 +150,7 @@ query TT
 SHOW CREATE TABLE i8_sql_sequence
 ----
 i8_sql_sequence  CREATE TABLE public.i8_sql_sequence (
-                 a INT8 NOT NULL DEFAULT nextval('public.i8_sql_sequence_a_seq':::STRING::REGCLASS),
+                 a INT8 NOT NULL DEFAULT nextval('public.i8_sql_sequence_a_seq'::REGCLASS),
                  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
                  CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                  FAMILY "primary" (a, rowid)
@@ -170,7 +170,7 @@ query TT
 SHOW CREATE TABLE i4_virtual_sequence
 ----
 i4_virtual_sequence  CREATE TABLE public.i4_virtual_sequence (
-                     a INT8 NOT NULL DEFAULT nextval('public.i4_virtual_sequence_a_seq':::STRING::REGCLASS),
+                     a INT8 NOT NULL DEFAULT nextval('public.i4_virtual_sequence_a_seq'::REGCLASS),
                      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
                      CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                      FAMILY "primary" (a, rowid)
@@ -186,7 +186,7 @@ query TT
 SHOW CREATE TABLE i8_virtual_sequence
 ----
 i8_virtual_sequence  CREATE TABLE public.i8_virtual_sequence (
-                     a INT8 NOT NULL DEFAULT nextval('public.i8_virtual_sequence_a_seq':::STRING::REGCLASS),
+                     a INT8 NOT NULL DEFAULT nextval('public.i8_virtual_sequence_a_seq'::REGCLASS),
                      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
                      CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                      FAMILY "primary" (a, rowid)

--- a/pkg/sql/logictest/testdata/logic_test/sequences_regclass
+++ b/pkg/sql/logictest/testdata/logic_test/sequences_regclass
@@ -38,10 +38,10 @@ query TT
 SHOW CREATE TABLE foo
 ----
 foo  CREATE TABLE public.foo (
-     i INT8 NOT NULL DEFAULT nextval('public.foo_i_seq':::STRING::REGCLASS),
-     j INT8 NOT NULL DEFAULT nextval('public.test_seq':::STRING::REGCLASS),
-     k INT8 NOT NULL DEFAULT nextval('public.foo_k_seq':::STRING::REGCLASS),
-     l INT8 NOT NULL DEFAULT currval('diff_db.public.test_seq':::STRING::REGCLASS),
+     i INT8 NOT NULL DEFAULT nextval('public.foo_i_seq'::REGCLASS),
+     j INT8 NOT NULL DEFAULT nextval('public.test_seq'::REGCLASS),
+     k INT8 NOT NULL DEFAULT nextval('public.foo_k_seq'::REGCLASS),
+     l INT8 NOT NULL DEFAULT currval('diff_db.public.test_seq'::REGCLASS),
      CONSTRAINT "primary" PRIMARY KEY (i ASC),
      FAMILY "primary" (i, j, k, l)
 )
@@ -130,9 +130,9 @@ query TT
 SHOW CREATE TABLE bar
 ----
 bar  CREATE TABLE public.bar (
-     i INT8 NOT NULL DEFAULT nextval('public.new_bar_i_seq':::STRING::REGCLASS),
-     j INT8 NOT NULL DEFAULT currval('public.new_s1':::STRING::REGCLASS),
-     k INT8 NOT NULL DEFAULT nextval('public.new_s2':::STRING::REGCLASS),
+     i INT8 NOT NULL DEFAULT nextval('public.new_bar_i_seq'::REGCLASS),
+     j INT8 NOT NULL DEFAULT currval('public.new_s1'::REGCLASS),
+     k INT8 NOT NULL DEFAULT nextval('public.new_s2'::REGCLASS),
      CONSTRAINT "primary" PRIMARY KEY (i ASC),
      FAMILY fam_0_i_j_k (i, j, k)
 )
@@ -187,8 +187,8 @@ query TT
 SHOW CREATE TABLE new_other_db.t
 ----
 new_other_db.public.t  CREATE TABLE public.t (
-                       i INT8 NOT NULL DEFAULT nextval('new_other_db.public.s':::STRING::REGCLASS),
-                       j INT8 NOT NULL DEFAULT currval('new_other_db.public.s2':::STRING::REGCLASS),
+                       i INT8 NOT NULL DEFAULT nextval('new_other_db.public.s'::REGCLASS),
+                       j INT8 NOT NULL DEFAULT currval('new_other_db.public.s2'::REGCLASS),
                        rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
                        CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                        FAMILY fam_0_i_j_rowid (i, j, rowid)
@@ -251,9 +251,9 @@ query TT
 SHOW CREATE TABLE tb
 ----
 tb  CREATE TABLE public.tb (
-    i INT8 NOT NULL DEFAULT nextval('test_schema.tb_i_seq':::STRING::REGCLASS),
-    j INT8 NOT NULL DEFAULT nextval('test_schema.sc_s1':::STRING::REGCLASS),
-    k INT8 NOT NULL DEFAULT currval('test_schema.sc_s2':::STRING::REGCLASS),
+    i INT8 NOT NULL DEFAULT nextval('test_schema.tb_i_seq'::REGCLASS),
+    j INT8 NOT NULL DEFAULT nextval('test_schema.sc_s1'::REGCLASS),
+    k INT8 NOT NULL DEFAULT currval('test_schema.sc_s2'::REGCLASS),
     CONSTRAINT "primary" PRIMARY KEY (i ASC),
     FAMILY fam_0_i_j_k (i, j, k)
 )
@@ -306,9 +306,9 @@ query TT
 SHOW CREATE TABLE new_test_schema.foo
 ----
 new_test_schema.foo  CREATE TABLE new_test_schema.foo (
-                     i INT8 NOT NULL DEFAULT nextval('new_test_schema.foo_i_seq':::STRING::REGCLASS),
-                     j INT8 NOT NULL DEFAULT nextval('new_test_schema.s3':::STRING::REGCLASS),
-                     k INT8 NOT NULL DEFAULT currval('new_test_schema.s4':::STRING::REGCLASS),
+                     i INT8 NOT NULL DEFAULT nextval('new_test_schema.foo_i_seq'::REGCLASS),
+                     j INT8 NOT NULL DEFAULT nextval('new_test_schema.s3'::REGCLASS),
+                     k INT8 NOT NULL DEFAULT currval('new_test_schema.s4'::REGCLASS),
                      CONSTRAINT "primary" PRIMARY KEY (i ASC),
                      FAMILY fam_0_i_j_k (i, j, k)
 )
@@ -348,3 +348,139 @@ USE other_db
 
 statement ok
 INSERT INTO t (i) VALUES (2)
+
+statement ok
+USE test
+
+
+# Test that sequences used in views are encoded
+# properly and can be renamed.
+subtest view_sequence
+
+statement ok
+CREATE TABLE t3 (i INT NOT NULL, j INT NOT NULL)
+
+statement ok
+CREATE TABLE t4 (i INT NOT NULL, j INT NOT NULL)
+
+# Basic view.
+statement ok
+CREATE SEQUENCE view_seq
+
+statement ok
+CREATE VIEW v AS (SELECT i, nextval('view_seq') FROM t3)
+
+query TT
+SHOW CREATE VIEW v
+----
+v  CREATE VIEW public.v (i, nextval) AS (SELECT i, nextval('public.view_seq'::REGCLASS) FROM test.public.t3)
+
+# Subquery in FROM clause.
+statement ok
+CREATE VIEW v2 AS SELECT currval FROM (SELECT currval('view_seq') FROM t3)
+
+query TT
+SHOW CREATE VIEW v2
+----
+v2  CREATE VIEW public.v2 (currval) AS SELECT currval FROM (SELECT currval('public.view_seq'::REGCLASS) FROM test.public.t3)
+
+# Union containing sequences.
+statement ok
+CREATE VIEW v3 AS SELECT nextval('view_seq'), i FROM t3 UNION SELECT nextval('view_seq'), i FROM t4
+
+query TT
+SHOW CREATE VIEW v3
+----
+v3  CREATE VIEW public.v3 (nextval, i) AS SELECT nextval('public.view_seq'::REGCLASS), i FROM test.public.t3 UNION SELECT nextval('public.view_seq'::REGCLASS), i FROM test.public.t4
+
+statement ok
+CREATE VIEW v4 AS SELECT t3.i, nextval('view_seq') FROM t3 INNER JOIN (SELECT j, currval('view_seq') FROM t4) as t5 ON t3.i = t5.j
+
+# Join containing sequences.
+query TT
+SHOW CREATE VIEW v4
+----
+v4  CREATE VIEW public.v4 (i, nextval) AS SELECT t3.i, nextval('public.view_seq'::REGCLASS) FROM test.public.t3 INNER JOIN (SELECT j, currval('public.view_seq'::REGCLASS) FROM test.public.t4) AS t5 ON t3.i = t5.j
+
+# Materialized view containing sequences.
+statement ok
+CREATE MATERIALIZED VIEW v5 AS SELECT currval('view_seq'), i FROM t3
+
+query TT
+SHOW CREATE VIEW v5
+----
+v5  CREATE VIEW public.v5 (currval, i, rowid) AS SELECT currval('public.view_seq'::REGCLASS), i FROM test.public.t3
+
+# Replacing an existing view.
+statement ok
+CREATE view v6 AS SELECT nextval('view_seq') AS i
+
+statement ok
+CREATE OR REPLACE VIEW v6 AS SELECT currval('view_seq') AS i
+
+query TT
+SHOW CREATE VIEW v6
+----
+v6  CREATE VIEW public.v6 (i) AS SELECT currval('public.view_seq'::REGCLASS) AS i
+
+# Subquery in the SELECT expr.
+statement ok
+CREATE VIEW v7 AS (SELECT i, (SELECT nextval('view_seq')) FROM t3)
+
+query TT
+SHOW CREATE VIEW v7
+----
+v7  CREATE VIEW public.v7 (i, nextval) AS (SELECT i, (SELECT nextval('public.view_seq'::REGCLASS)) FROM test.public.t3)
+
+# Sequence in the WHERE clause.
+statement ok
+CREATE VIEW v8 AS SELECT i FROM t3 WHERE i = nextval('view_seq')
+
+query TT
+SHOW CREATE VIEW v8
+----
+v8  CREATE VIEW public.v8 (i) AS SELECT i FROM test.public.t3 WHERE i = nextval('public.view_seq'::REGCLASS)
+
+# Sequence in the CTE.
+statement ok
+CREATE VIEW v9 AS (WITH w AS (SELECT nextval('view_seq')) SELECT nextval FROM w)
+
+query TT
+SHOW CREATE VIEW v9
+----
+v9  CREATE VIEW public.v9 (nextval) AS (WITH w AS (SELECT nextval('public.view_seq'::REGCLASS)) SELECT nextval FROM w)
+
+# Sequence in the LIMIT clause.
+statement ok
+CREATE VIEW v10 AS (SELECT i FROM t3 LIMIT nextval('view_seq'))
+
+query TT
+SHOW CREATE VIEW v10
+----
+v10  CREATE VIEW public.v10 (i) AS (SELECT i FROM test.public.t3 LIMIT nextval('public.view_seq'::REGCLASS))
+
+# Test renaming sequences is fine and tables are not corrupted.
+statement ok
+ALTER SEQUENCE view_seq RENAME TO view_seq2
+
+query TT
+SHOW CREATE VIEW v7
+----
+v7  CREATE VIEW public.v7 (i, nextval) AS (SELECT i, (SELECT nextval('public.view_seq2'::REGCLASS)) FROM test.public.t3)
+
+statement ok
+INSERT INTO t3 VALUES (8, 2)
+
+statement ok
+INSERT INTO t4 VALUES (35, 6)
+
+query II
+SELECT * FROM v
+----
+8  1
+
+query II
+SELECT * FROM v3 ORDER BY nextval
+----
+2  8
+3  35

--- a/pkg/sql/logictest/testdata/logic_test/serial
+++ b/pkg/sql/logictest/testdata/logic_test/serial
@@ -117,9 +117,9 @@ query TT
 SHOW CREATE TABLE serial
 ----
 serial  CREATE TABLE public.serial (
-        a INT8 NOT NULL DEFAULT nextval('public.serial_a_seq':::STRING::REGCLASS),
+        a INT8 NOT NULL DEFAULT nextval('public.serial_a_seq'::REGCLASS),
         b INT8 NULL DEFAULT 7:::INT8,
-        c INT8 NOT NULL DEFAULT nextval('public.serial_c_seq2':::STRING::REGCLASS),
+        c INT8 NOT NULL DEFAULT nextval('public.serial_c_seq2'::REGCLASS),
         CONSTRAINT "primary" PRIMARY KEY (a ASC),
         UNIQUE INDEX serial_c_key (c ASC),
         FAMILY "primary" (a, b, c)
@@ -160,8 +160,8 @@ query TT
 SHOW CREATE TABLE smallbig
 ----
 smallbig  CREATE TABLE public.smallbig (
-          a INT8 NOT NULL DEFAULT nextval('public.smallbig_a_seq':::STRING::REGCLASS),
-          b INT8 NOT NULL DEFAULT nextval('public.smallbig_b_seq':::STRING::REGCLASS),
+          a INT8 NOT NULL DEFAULT nextval('public.smallbig_a_seq'::REGCLASS),
+          b INT8 NOT NULL DEFAULT nextval('public.smallbig_b_seq'::REGCLASS),
           c INT8 NULL,
           rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
           CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
@@ -183,9 +183,9 @@ query TT
 SHOW CREATE TABLE serials
 ----
 serials  CREATE TABLE public.serials (
-         a INT8 NOT NULL DEFAULT nextval('public.serials_a_seq':::STRING::REGCLASS),
-         b INT8 NOT NULL DEFAULT nextval('public.serials_b_seq':::STRING::REGCLASS),
-         c INT8 NOT NULL DEFAULT nextval('public.serials_c_seq':::STRING::REGCLASS),
+         a INT8 NOT NULL DEFAULT nextval('public.serials_a_seq'::REGCLASS),
+         b INT8 NOT NULL DEFAULT nextval('public.serials_b_seq'::REGCLASS),
+         c INT8 NOT NULL DEFAULT nextval('public.serials_c_seq'::REGCLASS),
          d INT8 NULL,
          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
          CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
@@ -222,9 +222,9 @@ query TT
 SHOW CREATE TABLE serial
 ----
 serial  CREATE TABLE public.serial (
-        a INT8 NOT NULL DEFAULT nextval('public.serial_a_seq1':::STRING::REGCLASS),
+        a INT8 NOT NULL DEFAULT nextval('public.serial_a_seq1'::REGCLASS),
         b INT8 NULL DEFAULT 7:::INT8,
-        c INT8 NOT NULL DEFAULT nextval('public.serial_c_seq3':::STRING::REGCLASS),
+        c INT8 NOT NULL DEFAULT nextval('public.serial_c_seq3'::REGCLASS),
         CONSTRAINT "primary" PRIMARY KEY (a ASC),
         UNIQUE INDEX serial_c_key (c ASC),
         FAMILY "primary" (a, b, c)
@@ -278,9 +278,9 @@ query TT
 SHOW CREATE TABLE "serial_MixedCase"
 ----
 "serial_MixedCase"  CREATE TABLE public."serial_MixedCase" (
-                    a INT8 NOT NULL DEFAULT nextval('public."serial_MixedCase_a_seq"':::STRING::REGCLASS),
+                    a INT8 NOT NULL DEFAULT nextval('public."serial_MixedCase_a_seq"'::REGCLASS),
                     b INT8 NULL DEFAULT 7:::INT8,
-                    c INT8 NOT NULL DEFAULT nextval('public."serial_MixedCase_c_seq"':::STRING::REGCLASS),
+                    c INT8 NOT NULL DEFAULT nextval('public."serial_MixedCase_c_seq"'::REGCLASS),
                     CONSTRAINT "primary" PRIMARY KEY (a ASC),
                     UNIQUE INDEX "serial_MixedCase_c_key" (c ASC),
                     FAMILY "primary" (a, b, c)
@@ -305,8 +305,8 @@ query TT
 SHOW CREATE TABLE smallbig
 ----
 smallbig  CREATE TABLE public.smallbig (
-          a INT2 NOT NULL DEFAULT nextval('public.smallbig_a_seq1':::STRING::REGCLASS),
-          b INT8 NOT NULL DEFAULT nextval('public.smallbig_b_seq1':::STRING::REGCLASS),
+          a INT2 NOT NULL DEFAULT nextval('public.smallbig_a_seq1'::REGCLASS),
+          b INT8 NOT NULL DEFAULT nextval('public.smallbig_b_seq1'::REGCLASS),
           c INT8 NULL,
           rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
           CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
@@ -328,9 +328,9 @@ query TT
 SHOW CREATE TABLE serials
 ----
 serials  CREATE TABLE public.serials (
-         a INT2 NOT NULL DEFAULT nextval('public.serials_a_seq1':::STRING::REGCLASS),
-         b INT4 NOT NULL DEFAULT nextval('public.serials_b_seq1':::STRING::REGCLASS),
-         c INT8 NOT NULL DEFAULT nextval('public.serials_c_seq1':::STRING::REGCLASS),
+         a INT2 NOT NULL DEFAULT nextval('public.serials_a_seq1'::REGCLASS),
+         b INT4 NOT NULL DEFAULT nextval('public.serials_b_seq1'::REGCLASS),
+         c INT8 NOT NULL DEFAULT nextval('public.serials_c_seq1'::REGCLASS),
          d INT8 NULL,
          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
          CONSTRAINT "primary" PRIMARY KEY (rowid ASC),

--- a/pkg/sql/logictest/testdata/logic_test/show_create_all_tables
+++ b/pkg/sql/logictest/testdata/logic_test/show_create_all_tables
@@ -208,7 +208,7 @@ CREATE TABLE public.c (
 );
 CREATE SEQUENCE public.s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
 CREATE TABLE public.s_tbl (
-    id INT8 NOT NULL DEFAULT nextval('public.s':::STRING::REGCLASS),
+    id INT8 NOT NULL DEFAULT nextval('public.s'::REGCLASS),
     v INT8 NULL,
     CONSTRAINT "primary" PRIMARY KEY (id ASC),
     FAMILY f1 (id, v)

--- a/pkg/sql/logictest/testdata/logic_test/show_create_all_tables_builtin
+++ b/pkg/sql/logictest/testdata/logic_test/show_create_all_tables_builtin
@@ -202,7 +202,7 @@ CREATE TABLE public.c (
 );
 CREATE SEQUENCE public.s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
 CREATE TABLE public.s_tbl (
-    id INT8 NOT NULL DEFAULT nextval('public.s':::STRING::REGCLASS),
+    id INT8 NOT NULL DEFAULT nextval('public.s'::REGCLASS),
     v INT8 NULL,
     CONSTRAINT "primary" PRIMARY KEY (id ASC),
     FAMILY f1 (id, v)

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -238,6 +238,7 @@ func (node *TableExprs) Format(ctx *FmtCtx) {
 type TableExpr interface {
 	NodeFormatter
 	tableExpr()
+	WalkTableExpr(Visitor) TableExpr
 }
 
 func (*AliasedTableExpr) tableExpr() {}

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -2630,7 +2630,7 @@ func ProcessPlaceholderAnnotations(
 		}
 	}
 
-	walkStmt(&v, stmt)
+	WalkStmt(&v, stmt)
 	return v.err
 }
 

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -248,7 +248,7 @@ func (p *planner) ShowCreate(
 	var err error
 	tn := tree.MakeUnqualifiedTableName(tree.Name(desc.GetName()))
 	if desc.IsView() {
-		stmt, err = ShowCreateView(ctx, &tn, desc)
+		stmt, err = ShowCreateView(ctx, &p.RunParams(ctx).p.semaCtx, &tn, desc)
 	} else if desc.IsSequence() {
 		stmt, err = ShowCreateSequence(ctx, &tn, desc)
 	} else {

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -86,7 +87,7 @@ func selectComment(ctx context.Context, p PlanHookState, tableID descpb.ID) (tc 
 // statement used to create the given view. It is used in the implementation of
 // the crdb_internal.create_statements virtual table.
 func ShowCreateView(
-	ctx context.Context, tn *tree.TableName, desc catalog.TableDescriptor,
+	ctx context.Context, semaCtx *tree.SemaContext, tn *tree.TableName, desc catalog.TableDescriptor,
 ) (string, error) {
 	f := tree.NewFmtCtx(tree.FmtSimple)
 	f.WriteString("CREATE ")
@@ -104,8 +105,38 @@ func ShowCreateView(
 		f.FormatNameP(&name)
 	}
 	f.WriteString(") AS ")
-	f.WriteString(desc.GetViewQuery())
+
+	// Convert sequences referenced by ID in the view back to their names.
+	decodedViewQuery, err := formatViewQueryForDisplay(ctx, semaCtx, desc)
+	if err != nil {
+		f.WriteString(desc.GetViewQuery())
+	} else {
+		f.WriteString(decodedViewQuery)
+	}
 	return f.CloseAndGetString(), nil
+}
+
+// formatViewQueryForDisplay formats the given viewQuery by
+// parsing it into a statement, walking the statement and
+// looking for any IDs in the statement, and replacing the
+// IDs with the descriptor's fully qualified name.
+func formatViewQueryForDisplay(
+	ctx context.Context, semaCtx *tree.SemaContext, desc catalog.TableDescriptor,
+) (string, error) {
+	replaceFunc := func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
+		newExpr, err = schemaexpr.ReplaceIDsWithFQNames(ctx, expr, semaCtx)
+		if err != nil {
+			return false, expr, err
+		}
+		return false, newExpr, nil
+	}
+
+	viewQuery := desc.GetViewQuery()
+	stmt, err := parser.ParseOne(viewQuery)
+	if err != nil {
+		return "", err
+	}
+	return WalkViewQuery(stmt.AST, replaceFunc)
 }
 
 // showComments prints out the COMMENT statements sufficient to populate a

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -241,6 +241,7 @@ func (v virtualSchemaView) initVirtualTableDesc(
 	}
 	mutDesc, err := makeViewTableDesc(
 		ctx,
+		st,
 		create.Name.Table(),
 		tree.AsStringWithFlags(create.AsSource, tree.FmtParsable),
 		0, /* parentID */
@@ -252,6 +253,7 @@ func (v virtualSchemaView) initVirtualTableDesc(
 		nil, /* semaCtx */
 		nil, /* evalCtx */
 		tree.PersistencePermanent,
+		nil, /* sc */
 	)
 	return mutDesc.TableDescriptor, err
 }


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/59019.

Previously, we tracked back references for user-defined types
when they appear as the type for columns (or used in array
or alias types). However, we did not track them when they
occur inside of expressions or view statements.
This patch addresses this by tracking user-defined types
inside of expressions and view statements.

This is rebased on https://github.com/cockroachdb/cockroach/pull/61439/ since it shares the same
view query walking logic implemented in that PR, which is 
why it's massive right now.

Release note: None