### PR TITLE
sql: stop writing trace to statement_diagnostics

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -2710,7 +2710,6 @@ Support status: [reserved](#support-status)
 | id | [int64](#cockroach.server.serverpb.StatementDiagnosticsResponse-int64) |  |  | [reserved](#support-status) |
 | statement_fingerprint | [string](#cockroach.server.serverpb.StatementDiagnosticsResponse-string) |  |  | [reserved](#support-status) |
 | collected_at | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementDiagnosticsResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
-| trace | [string](#cockroach.server.serverpb.StatementDiagnosticsResponse-string) |  |  | [reserved](#support-status) |
 
 
 

--- a/pkg/server/serverpb/status.pb.go
+++ b/pkg/server/serverpb/status.pb.go
@@ -67,7 +67,7 @@ func (x StacksType) String() string {
 	return proto.EnumName(StacksType_name, int32(x))
 }
 func (StacksType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{0}
+	return fileDescriptor_status_d10df09bafa0c627, []int{0}
 }
 
 // Represents the type of file.
@@ -94,7 +94,7 @@ func (x FileType) String() string {
 	return proto.EnumName(FileType_name, int32(x))
 }
 func (FileType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{1}
+	return fileDescriptor_status_d10df09bafa0c627, []int{1}
 }
 
 // We use an enum to allow reporting of client certs and potential others (eg:
@@ -131,7 +131,7 @@ func (x CertificateDetails_CertificateType) String() string {
 	return proto.EnumName(CertificateDetails_CertificateType_name, int32(x))
 }
 func (CertificateDetails_CertificateType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{1, 0}
+	return fileDescriptor_status_d10df09bafa0c627, []int{1, 0}
 }
 
 type ProfileRequest_Type int32
@@ -154,7 +154,7 @@ func (x ProfileRequest_Type) String() string {
 	return proto.EnumName(ProfileRequest_Type_name, int32(x))
 }
 func (ProfileRequest_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{37, 0}
+	return fileDescriptor_status_d10df09bafa0c627, []int{37, 0}
 }
 
 // Enum for phase of execution.
@@ -178,7 +178,7 @@ func (x ActiveQuery_Phase) String() string {
 	return proto.EnumName(ActiveQuery_Phase_name, int32(x))
 }
 func (ActiveQuery_Phase) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{45, 0}
+	return fileDescriptor_status_d10df09bafa0c627, []int{45, 0}
 }
 
 type CertificatesRequest struct {
@@ -191,7 +191,7 @@ func (m *CertificatesRequest) Reset()         { *m = CertificatesRequest{} }
 func (m *CertificatesRequest) String() string { return proto.CompactTextString(m) }
 func (*CertificatesRequest) ProtoMessage()    {}
 func (*CertificatesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{0}
+	return fileDescriptor_status_d10df09bafa0c627, []int{0}
 }
 func (m *CertificatesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -230,7 +230,7 @@ func (m *CertificateDetails) Reset()         { *m = CertificateDetails{} }
 func (m *CertificateDetails) String() string { return proto.CompactTextString(m) }
 func (*CertificateDetails) ProtoMessage()    {}
 func (*CertificateDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{1}
+	return fileDescriptor_status_d10df09bafa0c627, []int{1}
 }
 func (m *CertificateDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -271,7 +271,7 @@ func (m *CertificateDetails_Fields) Reset()         { *m = CertificateDetails_Fi
 func (m *CertificateDetails_Fields) String() string { return proto.CompactTextString(m) }
 func (*CertificateDetails_Fields) ProtoMessage()    {}
 func (*CertificateDetails_Fields) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{1, 0}
+	return fileDescriptor_status_d10df09bafa0c627, []int{1, 0}
 }
 func (m *CertificateDetails_Fields) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -304,7 +304,7 @@ func (m *CertificatesResponse) Reset()         { *m = CertificatesResponse{} }
 func (m *CertificatesResponse) String() string { return proto.CompactTextString(m) }
 func (*CertificatesResponse) ProtoMessage()    {}
 func (*CertificatesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{2}
+	return fileDescriptor_status_d10df09bafa0c627, []int{2}
 }
 func (m *CertificatesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -341,7 +341,7 @@ func (m *DetailsRequest) Reset()         { *m = DetailsRequest{} }
 func (m *DetailsRequest) String() string { return proto.CompactTextString(m) }
 func (*DetailsRequest) ProtoMessage()    {}
 func (*DetailsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{3}
+	return fileDescriptor_status_d10df09bafa0c627, []int{3}
 }
 func (m *DetailsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -378,7 +378,7 @@ func (m *SystemInfo) Reset()         { *m = SystemInfo{} }
 func (m *SystemInfo) String() string { return proto.CompactTextString(m) }
 func (*SystemInfo) ProtoMessage()    {}
 func (*SystemInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{4}
+	return fileDescriptor_status_d10df09bafa0c627, []int{4}
 }
 func (m *SystemInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -415,7 +415,7 @@ func (m *DetailsResponse) Reset()         { *m = DetailsResponse{} }
 func (m *DetailsResponse) String() string { return proto.CompactTextString(m) }
 func (*DetailsResponse) ProtoMessage()    {}
 func (*DetailsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{5}
+	return fileDescriptor_status_d10df09bafa0c627, []int{5}
 }
 func (m *DetailsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -450,7 +450,7 @@ func (m *NodesRequest) Reset()         { *m = NodesRequest{} }
 func (m *NodesRequest) String() string { return proto.CompactTextString(m) }
 func (*NodesRequest) ProtoMessage()    {}
 func (*NodesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{6}
+	return fileDescriptor_status_d10df09bafa0c627, []int{6}
 }
 func (m *NodesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -489,7 +489,7 @@ func (m *NodesResponse) Reset()         { *m = NodesResponse{} }
 func (m *NodesResponse) String() string { return proto.CompactTextString(m) }
 func (*NodesResponse) ProtoMessage()    {}
 func (*NodesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{7}
+	return fileDescriptor_status_d10df09bafa0c627, []int{7}
 }
 func (m *NodesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -524,7 +524,7 @@ func (m *NodeRequest) Reset()         { *m = NodeRequest{} }
 func (m *NodeRequest) String() string { return proto.CompactTextString(m) }
 func (*NodeRequest) ProtoMessage()    {}
 func (*NodeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{8}
+	return fileDescriptor_status_d10df09bafa0c627, []int{8}
 }
 func (m *NodeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -569,7 +569,7 @@ func (m *RaftState) Reset()         { *m = RaftState{} }
 func (m *RaftState) String() string { return proto.CompactTextString(m) }
 func (*RaftState) ProtoMessage()    {}
 func (*RaftState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{9}
+	return fileDescriptor_status_d10df09bafa0c627, []int{9}
 }
 func (m *RaftState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -606,7 +606,7 @@ func (m *RaftState_Progress) Reset()         { *m = RaftState_Progress{} }
 func (m *RaftState_Progress) String() string { return proto.CompactTextString(m) }
 func (*RaftState_Progress) ProtoMessage()    {}
 func (*RaftState_Progress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{9, 0}
+	return fileDescriptor_status_d10df09bafa0c627, []int{9, 0}
 }
 func (m *RaftState_Progress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -651,7 +651,7 @@ func (m *RangeProblems) Reset()         { *m = RangeProblems{} }
 func (m *RangeProblems) String() string { return proto.CompactTextString(m) }
 func (*RangeProblems) ProtoMessage()    {}
 func (*RangeProblems) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{10}
+	return fileDescriptor_status_d10df09bafa0c627, []int{10}
 }
 func (m *RangeProblems) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -687,7 +687,7 @@ func (m *RangeStatistics) Reset()         { *m = RangeStatistics{} }
 func (m *RangeStatistics) String() string { return proto.CompactTextString(m) }
 func (*RangeStatistics) ProtoMessage()    {}
 func (*RangeStatistics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{11}
+	return fileDescriptor_status_d10df09bafa0c627, []int{11}
 }
 func (m *RangeStatistics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -721,7 +721,7 @@ func (m *PrettySpan) Reset()         { *m = PrettySpan{} }
 func (m *PrettySpan) String() string { return proto.CompactTextString(m) }
 func (*PrettySpan) ProtoMessage()    {}
 func (*PrettySpan) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{12}
+	return fileDescriptor_status_d10df09bafa0c627, []int{12}
 }
 func (m *PrettySpan) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -767,7 +767,7 @@ func (m *RangeInfo) Reset()         { *m = RangeInfo{} }
 func (m *RangeInfo) String() string { return proto.CompactTextString(m) }
 func (*RangeInfo) ProtoMessage()    {}
 func (*RangeInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{13}
+	return fileDescriptor_status_d10df09bafa0c627, []int{13}
 }
 func (m *RangeInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -803,7 +803,7 @@ func (m *RangesRequest) Reset()         { *m = RangesRequest{} }
 func (m *RangesRequest) String() string { return proto.CompactTextString(m) }
 func (*RangesRequest) ProtoMessage()    {}
 func (*RangesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{14}
+	return fileDescriptor_status_d10df09bafa0c627, []int{14}
 }
 func (m *RangesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -836,7 +836,7 @@ func (m *RangesResponse) Reset()         { *m = RangesResponse{} }
 func (m *RangesResponse) String() string { return proto.CompactTextString(m) }
 func (*RangesResponse) ProtoMessage()    {}
 func (*RangesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{15}
+	return fileDescriptor_status_d10df09bafa0c627, []int{15}
 }
 func (m *RangesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -871,7 +871,7 @@ func (m *GossipRequest) Reset()         { *m = GossipRequest{} }
 func (m *GossipRequest) String() string { return proto.CompactTextString(m) }
 func (*GossipRequest) ProtoMessage()    {}
 func (*GossipRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{16}
+	return fileDescriptor_status_d10df09bafa0c627, []int{16}
 }
 func (m *GossipRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -906,7 +906,7 @@ func (m *EngineStatsInfo) Reset()         { *m = EngineStatsInfo{} }
 func (m *EngineStatsInfo) String() string { return proto.CompactTextString(m) }
 func (*EngineStatsInfo) ProtoMessage()    {}
 func (*EngineStatsInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{17}
+	return fileDescriptor_status_d10df09bafa0c627, []int{17}
 }
 func (m *EngineStatsInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -941,7 +941,7 @@ func (m *EngineStatsRequest) Reset()         { *m = EngineStatsRequest{} }
 func (m *EngineStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*EngineStatsRequest) ProtoMessage()    {}
 func (*EngineStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{18}
+	return fileDescriptor_status_d10df09bafa0c627, []int{18}
 }
 func (m *EngineStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -974,7 +974,7 @@ func (m *EngineStatsResponse) Reset()         { *m = EngineStatsResponse{} }
 func (m *EngineStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*EngineStatsResponse) ProtoMessage()    {}
 func (*EngineStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{19}
+	return fileDescriptor_status_d10df09bafa0c627, []int{19}
 }
 func (m *EngineStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1008,7 +1008,7 @@ func (m *TraceEvent) Reset()         { *m = TraceEvent{} }
 func (m *TraceEvent) String() string { return proto.CompactTextString(m) }
 func (*TraceEvent) ProtoMessage()    {}
 func (*TraceEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{20}
+	return fileDescriptor_status_d10df09bafa0c627, []int{20}
 }
 func (m *TraceEvent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1042,7 +1042,7 @@ func (m *AllocatorDryRun) Reset()         { *m = AllocatorDryRun{} }
 func (m *AllocatorDryRun) String() string { return proto.CompactTextString(m) }
 func (*AllocatorDryRun) ProtoMessage()    {}
 func (*AllocatorDryRun) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{21}
+	return fileDescriptor_status_d10df09bafa0c627, []int{21}
 }
 func (m *AllocatorDryRun) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1075,7 +1075,7 @@ func (m *AllocatorRangeRequest) Reset()         { *m = AllocatorRangeRequest{} }
 func (m *AllocatorRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*AllocatorRangeRequest) ProtoMessage()    {}
 func (*AllocatorRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{22}
+	return fileDescriptor_status_d10df09bafa0c627, []int{22}
 }
 func (m *AllocatorRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1111,7 +1111,7 @@ func (m *AllocatorRangeResponse) Reset()         { *m = AllocatorRangeResponse{}
 func (m *AllocatorRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*AllocatorRangeResponse) ProtoMessage()    {}
 func (*AllocatorRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{23}
+	return fileDescriptor_status_d10df09bafa0c627, []int{23}
 }
 func (m *AllocatorRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1145,7 +1145,7 @@ func (m *AllocatorRequest) Reset()         { *m = AllocatorRequest{} }
 func (m *AllocatorRequest) String() string { return proto.CompactTextString(m) }
 func (*AllocatorRequest) ProtoMessage()    {}
 func (*AllocatorRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{24}
+	return fileDescriptor_status_d10df09bafa0c627, []int{24}
 }
 func (m *AllocatorRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1178,7 +1178,7 @@ func (m *AllocatorResponse) Reset()         { *m = AllocatorResponse{} }
 func (m *AllocatorResponse) String() string { return proto.CompactTextString(m) }
 func (*AllocatorResponse) ProtoMessage()    {}
 func (*AllocatorResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{25}
+	return fileDescriptor_status_d10df09bafa0c627, []int{25}
 }
 func (m *AllocatorResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1211,7 +1211,7 @@ func (m *JSONResponse) Reset()         { *m = JSONResponse{} }
 func (m *JSONResponse) String() string { return proto.CompactTextString(m) }
 func (*JSONResponse) ProtoMessage()    {}
 func (*JSONResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{26}
+	return fileDescriptor_status_d10df09bafa0c627, []int{26}
 }
 func (m *JSONResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1247,7 +1247,7 @@ func (m *ResponseError) Reset()         { *m = ResponseError{} }
 func (m *ResponseError) String() string { return proto.CompactTextString(m) }
 func (*ResponseError) ProtoMessage()    {}
 func (*ResponseError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{27}
+	return fileDescriptor_status_d10df09bafa0c627, []int{27}
 }
 func (m *ResponseError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1291,7 +1291,7 @@ func (m *LogsRequest) Reset()         { *m = LogsRequest{} }
 func (m *LogsRequest) String() string { return proto.CompactTextString(m) }
 func (*LogsRequest) ProtoMessage()    {}
 func (*LogsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{28}
+	return fileDescriptor_status_d10df09bafa0c627, []int{28}
 }
 func (m *LogsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1324,7 +1324,7 @@ func (m *LogEntriesResponse) Reset()         { *m = LogEntriesResponse{} }
 func (m *LogEntriesResponse) String() string { return proto.CompactTextString(m) }
 func (*LogEntriesResponse) ProtoMessage()    {}
 func (*LogEntriesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{29}
+	return fileDescriptor_status_d10df09bafa0c627, []int{29}
 }
 func (m *LogEntriesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1359,7 +1359,7 @@ func (m *LogFilesListRequest) Reset()         { *m = LogFilesListRequest{} }
 func (m *LogFilesListRequest) String() string { return proto.CompactTextString(m) }
 func (*LogFilesListRequest) ProtoMessage()    {}
 func (*LogFilesListRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{30}
+	return fileDescriptor_status_d10df09bafa0c627, []int{30}
 }
 func (m *LogFilesListRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1392,7 +1392,7 @@ func (m *LogFilesListResponse) Reset()         { *m = LogFilesListResponse{} }
 func (m *LogFilesListResponse) String() string { return proto.CompactTextString(m) }
 func (*LogFilesListResponse) ProtoMessage()    {}
 func (*LogFilesListResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{31}
+	return fileDescriptor_status_d10df09bafa0c627, []int{31}
 }
 func (m *LogFilesListResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1432,7 +1432,7 @@ func (m *LogFileRequest) Reset()         { *m = LogFileRequest{} }
 func (m *LogFileRequest) String() string { return proto.CompactTextString(m) }
 func (*LogFileRequest) ProtoMessage()    {}
 func (*LogFileRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{32}
+	return fileDescriptor_status_d10df09bafa0c627, []int{32}
 }
 func (m *LogFileRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1468,7 +1468,7 @@ func (m *StacksRequest) Reset()         { *m = StacksRequest{} }
 func (m *StacksRequest) String() string { return proto.CompactTextString(m) }
 func (*StacksRequest) ProtoMessage()    {}
 func (*StacksRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{33}
+	return fileDescriptor_status_d10df09bafa0c627, []int{33}
 }
 func (m *StacksRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1504,7 +1504,7 @@ func (m *File) Reset()         { *m = File{} }
 func (m *File) String() string { return proto.CompactTextString(m) }
 func (*File) ProtoMessage()    {}
 func (*File) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{34}
+	return fileDescriptor_status_d10df09bafa0c627, []int{34}
 }
 func (m *File) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1548,7 +1548,7 @@ func (m *GetFilesRequest) Reset()         { *m = GetFilesRequest{} }
 func (m *GetFilesRequest) String() string { return proto.CompactTextString(m) }
 func (*GetFilesRequest) ProtoMessage()    {}
 func (*GetFilesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{35}
+	return fileDescriptor_status_d10df09bafa0c627, []int{35}
 }
 func (m *GetFilesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1581,7 +1581,7 @@ func (m *GetFilesResponse) Reset()         { *m = GetFilesResponse{} }
 func (m *GetFilesResponse) String() string { return proto.CompactTextString(m) }
 func (*GetFilesResponse) ProtoMessage()    {}
 func (*GetFilesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{36}
+	return fileDescriptor_status_d10df09bafa0c627, []int{36}
 }
 func (m *GetFilesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1619,7 +1619,7 @@ func (m *ProfileRequest) Reset()         { *m = ProfileRequest{} }
 func (m *ProfileRequest) String() string { return proto.CompactTextString(m) }
 func (*ProfileRequest) ProtoMessage()    {}
 func (*ProfileRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{37}
+	return fileDescriptor_status_d10df09bafa0c627, []int{37}
 }
 func (m *ProfileRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1654,7 +1654,7 @@ func (m *MetricsRequest) Reset()         { *m = MetricsRequest{} }
 func (m *MetricsRequest) String() string { return proto.CompactTextString(m) }
 func (*MetricsRequest) ProtoMessage()    {}
 func (*MetricsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{38}
+	return fileDescriptor_status_d10df09bafa0c627, []int{38}
 }
 func (m *MetricsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1688,7 +1688,7 @@ func (m *RaftRangeNode) Reset()         { *m = RaftRangeNode{} }
 func (m *RaftRangeNode) String() string { return proto.CompactTextString(m) }
 func (*RaftRangeNode) ProtoMessage()    {}
 func (*RaftRangeNode) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{39}
+	return fileDescriptor_status_d10df09bafa0c627, []int{39}
 }
 func (m *RaftRangeNode) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1721,7 +1721,7 @@ func (m *RaftRangeError) Reset()         { *m = RaftRangeError{} }
 func (m *RaftRangeError) String() string { return proto.CompactTextString(m) }
 func (*RaftRangeError) ProtoMessage()    {}
 func (*RaftRangeError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{40}
+	return fileDescriptor_status_d10df09bafa0c627, []int{40}
 }
 func (m *RaftRangeError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1756,7 +1756,7 @@ func (m *RaftRangeStatus) Reset()         { *m = RaftRangeStatus{} }
 func (m *RaftRangeStatus) String() string { return proto.CompactTextString(m) }
 func (*RaftRangeStatus) ProtoMessage()    {}
 func (*RaftRangeStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{41}
+	return fileDescriptor_status_d10df09bafa0c627, []int{41}
 }
 func (m *RaftRangeStatus) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1789,7 +1789,7 @@ func (m *RaftDebugRequest) Reset()         { *m = RaftDebugRequest{} }
 func (m *RaftDebugRequest) String() string { return proto.CompactTextString(m) }
 func (*RaftDebugRequest) ProtoMessage()    {}
 func (*RaftDebugRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{42}
+	return fileDescriptor_status_d10df09bafa0c627, []int{42}
 }
 func (m *RaftDebugRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1823,7 +1823,7 @@ func (m *RaftDebugResponse) Reset()         { *m = RaftDebugResponse{} }
 func (m *RaftDebugResponse) String() string { return proto.CompactTextString(m) }
 func (*RaftDebugResponse) ProtoMessage()    {}
 func (*RaftDebugResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{43}
+	return fileDescriptor_status_d10df09bafa0c627, []int{43}
 }
 func (m *RaftDebugResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1881,7 +1881,7 @@ func (m *TxnInfo) Reset()         { *m = TxnInfo{} }
 func (m *TxnInfo) String() string { return proto.CompactTextString(m) }
 func (*TxnInfo) ProtoMessage()    {}
 func (*TxnInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{44}
+	return fileDescriptor_status_d10df09bafa0c627, []int{44}
 }
 func (m *TxnInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1929,7 +1929,7 @@ func (m *ActiveQuery) Reset()         { *m = ActiveQuery{} }
 func (m *ActiveQuery) String() string { return proto.CompactTextString(m) }
 func (*ActiveQuery) ProtoMessage()    {}
 func (*ActiveQuery) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{45}
+	return fileDescriptor_status_d10df09bafa0c627, []int{45}
 }
 func (m *ActiveQuery) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1966,7 +1966,7 @@ func (m *ListSessionsRequest) Reset()         { *m = ListSessionsRequest{} }
 func (m *ListSessionsRequest) String() string { return proto.CompactTextString(m) }
 func (*ListSessionsRequest) ProtoMessage()    {}
 func (*ListSessionsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{46}
+	return fileDescriptor_status_d10df09bafa0c627, []int{46}
 }
 func (m *ListSessionsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2025,7 +2025,7 @@ func (m *Session) Reset()         { *m = Session{} }
 func (m *Session) String() string { return proto.CompactTextString(m) }
 func (*Session) ProtoMessage()    {}
 func (*Session) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{47}
+	return fileDescriptor_status_d10df09bafa0c627, []int{47}
 }
 func (m *Session) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2062,7 +2062,7 @@ func (m *ListSessionsError) Reset()         { *m = ListSessionsError{} }
 func (m *ListSessionsError) String() string { return proto.CompactTextString(m) }
 func (*ListSessionsError) ProtoMessage()    {}
 func (*ListSessionsError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{48}
+	return fileDescriptor_status_d10df09bafa0c627, []int{48}
 }
 func (m *ListSessionsError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2099,7 +2099,7 @@ func (m *ListSessionsResponse) Reset()         { *m = ListSessionsResponse{} }
 func (m *ListSessionsResponse) String() string { return proto.CompactTextString(m) }
 func (*ListSessionsResponse) ProtoMessage()    {}
 func (*ListSessionsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{49}
+	return fileDescriptor_status_d10df09bafa0c627, []int{49}
 }
 func (m *ListSessionsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2146,7 +2146,7 @@ func (m *CancelQueryRequest) Reset()         { *m = CancelQueryRequest{} }
 func (m *CancelQueryRequest) String() string { return proto.CompactTextString(m) }
 func (*CancelQueryRequest) ProtoMessage()    {}
 func (*CancelQueryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{50}
+	return fileDescriptor_status_d10df09bafa0c627, []int{50}
 }
 func (m *CancelQueryRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2183,7 +2183,7 @@ func (m *CancelQueryResponse) Reset()         { *m = CancelQueryResponse{} }
 func (m *CancelQueryResponse) String() string { return proto.CompactTextString(m) }
 func (*CancelQueryResponse) ProtoMessage()    {}
 func (*CancelQueryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{51}
+	return fileDescriptor_status_d10df09bafa0c627, []int{51}
 }
 func (m *CancelQueryResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2226,7 +2226,7 @@ func (m *CancelSessionRequest) Reset()         { *m = CancelSessionRequest{} }
 func (m *CancelSessionRequest) String() string { return proto.CompactTextString(m) }
 func (*CancelSessionRequest) ProtoMessage()    {}
 func (*CancelSessionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{52}
+	return fileDescriptor_status_d10df09bafa0c627, []int{52}
 }
 func (m *CancelSessionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2260,7 +2260,7 @@ func (m *CancelSessionResponse) Reset()         { *m = CancelSessionResponse{} }
 func (m *CancelSessionResponse) String() string { return proto.CompactTextString(m) }
 func (*CancelSessionResponse) ProtoMessage()    {}
 func (*CancelSessionResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{53}
+	return fileDescriptor_status_d10df09bafa0c627, []int{53}
 }
 func (m *CancelSessionResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2293,7 +2293,7 @@ func (m *ListContentionEventsRequest) Reset()         { *m = ListContentionEvent
 func (m *ListContentionEventsRequest) String() string { return proto.CompactTextString(m) }
 func (*ListContentionEventsRequest) ProtoMessage()    {}
 func (*ListContentionEventsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{54}
+	return fileDescriptor_status_d10df09bafa0c627, []int{54}
 }
 func (m *ListContentionEventsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2330,7 +2330,7 @@ func (m *ListContentionEventsError) Reset()         { *m = ListContentionEventsE
 func (m *ListContentionEventsError) String() string { return proto.CompactTextString(m) }
 func (*ListContentionEventsError) ProtoMessage()    {}
 func (*ListContentionEventsError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{55}
+	return fileDescriptor_status_d10df09bafa0c627, []int{55}
 }
 func (m *ListContentionEventsError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2367,7 +2367,7 @@ func (m *ListContentionEventsResponse) Reset()         { *m = ListContentionEven
 func (m *ListContentionEventsResponse) String() string { return proto.CompactTextString(m) }
 func (*ListContentionEventsResponse) ProtoMessage()    {}
 func (*ListContentionEventsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{56}
+	return fileDescriptor_status_d10df09bafa0c627, []int{56}
 }
 func (m *ListContentionEventsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2402,7 +2402,7 @@ func (m *SpanStatsRequest) Reset()         { *m = SpanStatsRequest{} }
 func (m *SpanStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*SpanStatsRequest) ProtoMessage()    {}
 func (*SpanStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{57}
+	return fileDescriptor_status_d10df09bafa0c627, []int{57}
 }
 func (m *SpanStatsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2437,7 +2437,7 @@ func (m *SpanStatsResponse) Reset()         { *m = SpanStatsResponse{} }
 func (m *SpanStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*SpanStatsResponse) ProtoMessage()    {}
 func (*SpanStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{58}
+	return fileDescriptor_status_d10df09bafa0c627, []int{58}
 }
 func (m *SpanStatsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2471,7 +2471,7 @@ func (m *ProblemRangesRequest) Reset()         { *m = ProblemRangesRequest{} }
 func (m *ProblemRangesRequest) String() string { return proto.CompactTextString(m) }
 func (*ProblemRangesRequest) ProtoMessage()    {}
 func (*ProblemRangesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{59}
+	return fileDescriptor_status_d10df09bafa0c627, []int{59}
 }
 func (m *ProblemRangesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2506,7 +2506,7 @@ func (m *ProblemRangesResponse) Reset()         { *m = ProblemRangesResponse{} }
 func (m *ProblemRangesResponse) String() string { return proto.CompactTextString(m) }
 func (*ProblemRangesResponse) ProtoMessage()    {}
 func (*ProblemRangesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{60}
+	return fileDescriptor_status_d10df09bafa0c627, []int{60}
 }
 func (m *ProblemRangesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2547,7 +2547,7 @@ func (m *ProblemRangesResponse_NodeProblems) Reset()         { *m = ProblemRange
 func (m *ProblemRangesResponse_NodeProblems) String() string { return proto.CompactTextString(m) }
 func (*ProblemRangesResponse_NodeProblems) ProtoMessage()    {}
 func (*ProblemRangesResponse_NodeProblems) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{60, 0}
+	return fileDescriptor_status_d10df09bafa0c627, []int{60, 0}
 }
 func (m *ProblemRangesResponse_NodeProblems) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2591,7 +2591,7 @@ func (m *HotRangesRequest) Reset()         { *m = HotRangesRequest{} }
 func (m *HotRangesRequest) String() string { return proto.CompactTextString(m) }
 func (*HotRangesRequest) ProtoMessage()    {}
 func (*HotRangesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{61}
+	return fileDescriptor_status_d10df09bafa0c627, []int{61}
 }
 func (m *HotRangesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2634,7 +2634,7 @@ func (m *HotRangesResponse) Reset()         { *m = HotRangesResponse{} }
 func (m *HotRangesResponse) String() string { return proto.CompactTextString(m) }
 func (*HotRangesResponse) ProtoMessage()    {}
 func (*HotRangesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{62}
+	return fileDescriptor_status_d10df09bafa0c627, []int{62}
 }
 func (m *HotRangesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2679,7 +2679,7 @@ func (m *HotRangesResponse_HotRange) Reset()         { *m = HotRangesResponse_Ho
 func (m *HotRangesResponse_HotRange) String() string { return proto.CompactTextString(m) }
 func (*HotRangesResponse_HotRange) ProtoMessage()    {}
 func (*HotRangesResponse_HotRange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{62, 0}
+	return fileDescriptor_status_d10df09bafa0c627, []int{62, 0}
 }
 func (m *HotRangesResponse_HotRange) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2722,7 +2722,7 @@ func (m *HotRangesResponse_StoreResponse) Reset()         { *m = HotRangesRespon
 func (m *HotRangesResponse_StoreResponse) String() string { return proto.CompactTextString(m) }
 func (*HotRangesResponse_StoreResponse) ProtoMessage()    {}
 func (*HotRangesResponse_StoreResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{62, 1}
+	return fileDescriptor_status_d10df09bafa0c627, []int{62, 1}
 }
 func (m *HotRangesResponse_StoreResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2767,7 +2767,7 @@ func (m *HotRangesResponse_NodeResponse) Reset()         { *m = HotRangesRespons
 func (m *HotRangesResponse_NodeResponse) String() string { return proto.CompactTextString(m) }
 func (*HotRangesResponse_NodeResponse) ProtoMessage()    {}
 func (*HotRangesResponse_NodeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{62, 2}
+	return fileDescriptor_status_d10df09bafa0c627, []int{62, 2}
 }
 func (m *HotRangesResponse_NodeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2800,7 +2800,7 @@ func (m *RangeRequest) Reset()         { *m = RangeRequest{} }
 func (m *RangeRequest) String() string { return proto.CompactTextString(m) }
 func (*RangeRequest) ProtoMessage()    {}
 func (*RangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{63}
+	return fileDescriptor_status_d10df09bafa0c627, []int{63}
 }
 func (m *RangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2836,7 +2836,7 @@ func (m *RangeResponse) Reset()         { *m = RangeResponse{} }
 func (m *RangeResponse) String() string { return proto.CompactTextString(m) }
 func (*RangeResponse) ProtoMessage()    {}
 func (*RangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{64}
+	return fileDescriptor_status_d10df09bafa0c627, []int{64}
 }
 func (m *RangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2871,7 +2871,7 @@ func (m *RangeResponse_NodeResponse) Reset()         { *m = RangeResponse_NodeRe
 func (m *RangeResponse_NodeResponse) String() string { return proto.CompactTextString(m) }
 func (*RangeResponse_NodeResponse) ProtoMessage()    {}
 func (*RangeResponse_NodeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{64, 0}
+	return fileDescriptor_status_d10df09bafa0c627, []int{64, 0}
 }
 func (m *RangeResponse_NodeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2907,7 +2907,7 @@ func (m *DiagnosticsRequest) Reset()         { *m = DiagnosticsRequest{} }
 func (m *DiagnosticsRequest) String() string { return proto.CompactTextString(m) }
 func (*DiagnosticsRequest) ProtoMessage()    {}
 func (*DiagnosticsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{65}
+	return fileDescriptor_status_d10df09bafa0c627, []int{65}
 }
 func (m *DiagnosticsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2942,7 +2942,7 @@ func (m *StoresRequest) Reset()         { *m = StoresRequest{} }
 func (m *StoresRequest) String() string { return proto.CompactTextString(m) }
 func (*StoresRequest) ProtoMessage()    {}
 func (*StoresRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{66}
+	return fileDescriptor_status_d10df09bafa0c627, []int{66}
 }
 func (m *StoresRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2985,7 +2985,7 @@ func (m *StoreDetails) Reset()         { *m = StoreDetails{} }
 func (m *StoreDetails) String() string { return proto.CompactTextString(m) }
 func (*StoreDetails) ProtoMessage()    {}
 func (*StoreDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{67}
+	return fileDescriptor_status_d10df09bafa0c627, []int{67}
 }
 func (m *StoreDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3018,7 +3018,7 @@ func (m *StoresResponse) Reset()         { *m = StoresResponse{} }
 func (m *StoresResponse) String() string { return proto.CompactTextString(m) }
 func (*StoresResponse) ProtoMessage()    {}
 func (*StoresResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{68}
+	return fileDescriptor_status_d10df09bafa0c627, []int{68}
 }
 func (m *StoresResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3051,7 +3051,7 @@ func (m *StatementsRequest) Reset()         { *m = StatementsRequest{} }
 func (m *StatementsRequest) String() string { return proto.CompactTextString(m) }
 func (*StatementsRequest) ProtoMessage()    {}
 func (*StatementsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{69}
+	return fileDescriptor_status_d10df09bafa0c627, []int{69}
 }
 func (m *StatementsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3092,7 +3092,7 @@ func (m *StatementsResponse) Reset()         { *m = StatementsResponse{} }
 func (m *StatementsResponse) String() string { return proto.CompactTextString(m) }
 func (*StatementsResponse) ProtoMessage()    {}
 func (*StatementsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{70}
+	return fileDescriptor_status_d10df09bafa0c627, []int{70}
 }
 func (m *StatementsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3130,7 +3130,7 @@ func (m *StatementsResponse_ExtendedStatementStatisticsKey) String() string {
 }
 func (*StatementsResponse_ExtendedStatementStatisticsKey) ProtoMessage() {}
 func (*StatementsResponse_ExtendedStatementStatisticsKey) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{70, 0}
+	return fileDescriptor_status_d10df09bafa0c627, []int{70, 0}
 }
 func (m *StatementsResponse_ExtendedStatementStatisticsKey) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3169,7 +3169,7 @@ func (m *StatementsResponse_CollectedStatementStatistics) String() string {
 }
 func (*StatementsResponse_CollectedStatementStatistics) ProtoMessage() {}
 func (*StatementsResponse_CollectedStatementStatistics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{70, 1}
+	return fileDescriptor_status_d10df09bafa0c627, []int{70, 1}
 }
 func (m *StatementsResponse_CollectedStatementStatistics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3207,7 +3207,7 @@ func (m *StatementsResponse_ExtendedCollectedTransactionStatistics) String() str
 }
 func (*StatementsResponse_ExtendedCollectedTransactionStatistics) ProtoMessage() {}
 func (*StatementsResponse_ExtendedCollectedTransactionStatistics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{70, 2}
+	return fileDescriptor_status_d10df09bafa0c627, []int{70, 2}
 }
 func (m *StatementsResponse_ExtendedCollectedTransactionStatistics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3244,7 +3244,7 @@ func (m *StatementDiagnosticsReport) Reset()         { *m = StatementDiagnostics
 func (m *StatementDiagnosticsReport) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnosticsReport) ProtoMessage()    {}
 func (*StatementDiagnosticsReport) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{71}
+	return fileDescriptor_status_d10df09bafa0c627, []int{71}
 }
 func (m *StatementDiagnosticsReport) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3279,7 +3279,7 @@ func (m *CreateStatementDiagnosticsReportRequest) Reset() {
 func (m *CreateStatementDiagnosticsReportRequest) String() string { return proto.CompactTextString(m) }
 func (*CreateStatementDiagnosticsReportRequest) ProtoMessage()    {}
 func (*CreateStatementDiagnosticsReportRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{72}
+	return fileDescriptor_status_d10df09bafa0c627, []int{72}
 }
 func (m *CreateStatementDiagnosticsReportRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3314,7 +3314,7 @@ func (m *CreateStatementDiagnosticsReportResponse) Reset() {
 func (m *CreateStatementDiagnosticsReportResponse) String() string { return proto.CompactTextString(m) }
 func (*CreateStatementDiagnosticsReportResponse) ProtoMessage()    {}
 func (*CreateStatementDiagnosticsReportResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{73}
+	return fileDescriptor_status_d10df09bafa0c627, []int{73}
 }
 func (m *CreateStatementDiagnosticsReportResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3346,7 +3346,7 @@ func (m *StatementDiagnosticsReportsRequest) Reset()         { *m = StatementDia
 func (m *StatementDiagnosticsReportsRequest) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnosticsReportsRequest) ProtoMessage()    {}
 func (*StatementDiagnosticsReportsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{74}
+	return fileDescriptor_status_d10df09bafa0c627, []int{74}
 }
 func (m *StatementDiagnosticsReportsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3379,7 +3379,7 @@ func (m *StatementDiagnosticsReportsResponse) Reset()         { *m = StatementDi
 func (m *StatementDiagnosticsReportsResponse) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnosticsReportsResponse) ProtoMessage()    {}
 func (*StatementDiagnosticsReportsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{75}
+	return fileDescriptor_status_d10df09bafa0c627, []int{75}
 }
 func (m *StatementDiagnosticsReportsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3408,14 +3408,13 @@ type StatementDiagnostics struct {
 	Id                   int64     `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
 	StatementFingerprint string    `protobuf:"bytes,2,opt,name=statement_fingerprint,json=statementFingerprint,proto3" json:"statement_fingerprint,omitempty"`
 	CollectedAt          time.Time `protobuf:"bytes,3,opt,name=collected_at,json=collectedAt,proto3,stdtime" json:"collected_at"`
-	Trace                string    `protobuf:"bytes,4,opt,name=trace,proto3" json:"trace,omitempty"`
 }
 
 func (m *StatementDiagnostics) Reset()         { *m = StatementDiagnostics{} }
 func (m *StatementDiagnostics) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnostics) ProtoMessage()    {}
 func (*StatementDiagnostics) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{76}
+	return fileDescriptor_status_d10df09bafa0c627, []int{76}
 }
 func (m *StatementDiagnostics) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3448,7 +3447,7 @@ func (m *StatementDiagnosticsRequest) Reset()         { *m = StatementDiagnostic
 func (m *StatementDiagnosticsRequest) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnosticsRequest) ProtoMessage()    {}
 func (*StatementDiagnosticsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{77}
+	return fileDescriptor_status_d10df09bafa0c627, []int{77}
 }
 func (m *StatementDiagnosticsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3481,7 +3480,7 @@ func (m *StatementDiagnosticsResponse) Reset()         { *m = StatementDiagnosti
 func (m *StatementDiagnosticsResponse) String() string { return proto.CompactTextString(m) }
 func (*StatementDiagnosticsResponse) ProtoMessage()    {}
 func (*StatementDiagnosticsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{78}
+	return fileDescriptor_status_d10df09bafa0c627, []int{78}
 }
 func (m *StatementDiagnosticsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3514,7 +3513,7 @@ func (m *JobRegistryStatusRequest) Reset()         { *m = JobRegistryStatusReque
 func (m *JobRegistryStatusRequest) String() string { return proto.CompactTextString(m) }
 func (*JobRegistryStatusRequest) ProtoMessage()    {}
 func (*JobRegistryStatusRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{79}
+	return fileDescriptor_status_d10df09bafa0c627, []int{79}
 }
 func (m *JobRegistryStatusRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3548,7 +3547,7 @@ func (m *JobRegistryStatusResponse) Reset()         { *m = JobRegistryStatusResp
 func (m *JobRegistryStatusResponse) String() string { return proto.CompactTextString(m) }
 func (*JobRegistryStatusResponse) ProtoMessage()    {}
 func (*JobRegistryStatusResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{80}
+	return fileDescriptor_status_d10df09bafa0c627, []int{80}
 }
 func (m *JobRegistryStatusResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3581,7 +3580,7 @@ func (m *JobRegistryStatusResponse_Job) Reset()         { *m = JobRegistryStatus
 func (m *JobRegistryStatusResponse_Job) String() string { return proto.CompactTextString(m) }
 func (*JobRegistryStatusResponse_Job) ProtoMessage()    {}
 func (*JobRegistryStatusResponse_Job) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{80, 0}
+	return fileDescriptor_status_d10df09bafa0c627, []int{80, 0}
 }
 func (m *JobRegistryStatusResponse_Job) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3614,7 +3613,7 @@ func (m *JobStatusRequest) Reset()         { *m = JobStatusRequest{} }
 func (m *JobStatusRequest) String() string { return proto.CompactTextString(m) }
 func (*JobStatusRequest) ProtoMessage()    {}
 func (*JobStatusRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{81}
+	return fileDescriptor_status_d10df09bafa0c627, []int{81}
 }
 func (m *JobStatusRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3647,7 +3646,7 @@ func (m *JobStatusResponse) Reset()         { *m = JobStatusResponse{} }
 func (m *JobStatusResponse) String() string { return proto.CompactTextString(m) }
 func (*JobStatusResponse) ProtoMessage()    {}
 func (*JobStatusResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_status_db02da4c8199186f, []int{82}
+	return fileDescriptor_status_d10df09bafa0c627, []int{82}
 }
 func (m *JobStatusResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8715,12 +8714,6 @@ func (m *StatementDiagnostics) MarshalTo(dAtA []byte) (int, error) {
 		return 0, err
 	}
 	i += n61
-	if len(m.Trace) > 0 {
-		dAtA[i] = 0x22
-		i++
-		i = encodeVarintStatus(dAtA, i, uint64(len(m.Trace)))
-		i += copy(dAtA[i:], m.Trace)
-	}
 	return i, nil
 }
 
@@ -10647,10 +10640,6 @@ func (m *StatementDiagnostics) Size() (n int) {
 	}
 	l = github_com_gogo_protobuf_types.SizeOfStdTime(m.CollectedAt)
 	n += 1 + l + sovStatus(uint64(l))
-	l = len(m.Trace)
-	if l > 0 {
-		n += 1 + l + sovStatus(uint64(l))
-	}
 	return n
 }
 
@@ -22357,35 +22346,6 @@ func (m *StatementDiagnostics) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 4:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Trace", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowStatus
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthStatus
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.Trace = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipStatus(dAtA[iNdEx:])
@@ -23065,17 +23025,17 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("server/serverpb/status.proto", fileDescriptor_status_db02da4c8199186f)
+	proto.RegisterFile("server/serverpb/status.proto", fileDescriptor_status_d10df09bafa0c627)
 }
 
-var fileDescriptor_status_db02da4c8199186f = []byte{
-	// 6328 bytes of a gzipped FileDescriptorProto
+var fileDescriptor_status_d10df09bafa0c627 = []byte{
+	// 6320 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xcc, 0x5c, 0x7d, 0x6c, 0x1b, 0xc9,
 	0x75, 0xf7, 0x8a, 0x14, 0x45, 0x3e, 0xea, 0x83, 0x1a, 0x7d, 0x98, 0xa6, 0x7d, 0x92, 0x6f, 0x7d,
 	0x67, 0xcb, 0x3e, 0x1f, 0x79, 0x67, 0x9f, 0xef, 0x9c, 0x6b, 0xee, 0x72, 0xfa, 0xb2, 0x2d, 0x5b,
 	0x67, 0xcb, 0x2b, 0xa9, 0x29, 0x2e, 0x69, 0xd8, 0x25, 0x77, 0x44, 0xaf, 0x45, 0xee, 0x52, 0xbb,
 	0x4b, 0x55, 0xcc, 0xd5, 0x69, 0x7a, 0xfd, 0x4a, 0xd3, 0x34, 0x9f, 0x2d, 0x90, 0x02, 0x05, 0x1a,
-	0xdc, 0x1f, 0x4d, 0x81, 0xa2, 0x45, 0x8a, 0x02, 0x45, 0x5b, 0xa4, 0x1f, 0x68, 0x8b, 0x36, 0x45,
+	0xdc, 0x1f, 0x4d, 0xd1, 0xa2, 0x45, 0x8a, 0x02, 0x45, 0x0b, 0xa4, 0x1f, 0x68, 0x8b, 0x36, 0x45,
 	0x81, 0x22, 0x40, 0xfb, 0x47, 0xd0, 0x02, 0x4a, 0xab, 0xf4, 0x8f, 0x02, 0xfd, 0xa3, 0xff, 0x07,
 	0x28, 0x50, 0xcc, 0x9b, 0xd9, 0xe5, 0x2c, 0x49, 0x2d, 0x29, 0xe9, 0x7c, 0xe9, 0x1f, 0xb6, 0x76,
 	0xbe, 0xde, 0xfc, 0xe6, 0xcd, 0x9b, 0x37, 0x6f, 0xde, 0xbc, 0x21, 0x9c, 0x73, 0xa9, 0xb3, 0x4b,
@@ -23106,7 +23066,7 @@ var fileDescriptor_status_db02da4c8199186f = []byte{
 	0x71, 0x6c, 0xa7, 0x58, 0xa3, 0xae, 0xab, 0x57, 0x68, 0x76, 0x00, 0x81, 0x0c, 0x63, 0xe6, 0xdb,
 	0x3c, 0x8f, 0x10, 0x88, 0x33, 0x71, 0xce, 0xc6, 0xce, 0x2b, 0x73, 0xc3, 0x1a, 0x7e, 0x13, 0x0d,
 	0x12, 0x5b, 0x26, 0xad, 0x1a, 0x6e, 0x36, 0x7e, 0x3e, 0x36, 0x97, 0xbe, 0xf6, 0xca, 0xd1, 0xd0,
-	0xdc, 0xc2, 0xb6, 0x0b, 0xf1, 0xef, 0xec, 0xcf, 0x9e, 0xd2, 0x04, 0xa5, 0xdc, 0x1f, 0x0d, 0x40,
+	0xdc, 0xc2, 0xb6, 0x0b, 0xf1, 0xef, 0xec, 0xcf, 0x9e, 0xd2, 0x04, 0xa5, 0xdc, 0x1f, 0x0f, 0x40,
 	0x82, 0x17, 0x90, 0x69, 0x48, 0x98, 0xae, 0xdb, 0xa0, 0x8e, 0xcf, 0x19, 0x9e, 0x22, 0x59, 0x18,
 	0x72, 0x1b, 0xa5, 0xc7, 0xb4, 0xec, 0x09, 0xa4, 0x7e, 0x92, 0x3c, 0x03, 0xb0, 0xab, 0x57, 0x4d,
 	0xa3, 0xb8, 0xe5, 0xd8, 0x35, 0x84, 0x1a, 0xd3, 0x52, 0x98, 0x73, 0xcb, 0xb1, 0x6b, 0x64, 0x16,
@@ -23213,7 +23173,7 @@ var fileDescriptor_status_db02da4c8199186f = []byte{
 	0x34, 0xb5, 0x86, 0xc5, 0x84, 0xc2, 0x5f, 0x0b, 0xd8, 0x57, 0x8c, 0x0b, 0x85, 0x90, 0xe8, 0x63,
 	0xaf, 0x84, 0x21, 0xb1, 0x12, 0xc8, 0x1b, 0x90, 0xa0, 0x6c, 0x40, 0xae, 0x38, 0x54, 0x45, 0xed,
 	0xcc, 0xad, 0xe1, 0x6b, 0xa2, 0x91, 0x7a, 0x0d, 0xa6, 0x02, 0xc4, 0x48, 0xdb, 0x9f, 0xa5, 0x33,
-	0xed, 0xb8, 0x83, 0x2e, 0xd5, 0x3f, 0x55, 0x60, 0xba, 0xbd, 0x51, 0xf7, 0x73, 0x7d, 0xec, 0x83,
+	0xed, 0xb8, 0x83, 0x2e, 0xd5, 0x3f, 0x53, 0x60, 0xba, 0xbd, 0x51, 0xf7, 0x73, 0x7d, 0xec, 0x83,
 	0x3c, 0xd7, 0x2f, 0xc2, 0x90, 0xe1, 0x34, 0x8b, 0x4e, 0xc3, 0x12, 0xf2, 0x1e, 0x25, 0x09, 0x6d,
 	0xd3, 0xa0, 0x25, 0x0c, 0xfc, 0xab, 0x7e, 0x51, 0x81, 0x4c, 0x0b, 0xfb, 0xff, 0x03, 0x45, 0xf6,
 	0x0e, 0x8c, 0x4b, 0x78, 0x04, 0x1b, 0x97, 0x21, 0x29, 0x86, 0xda, 0x8f, 0xd4, 0xb7, 0x8f, 0x75,
@@ -23244,7 +23204,7 @@ var fileDescriptor_status_db02da4c8199186f = []byte{
 	0x08, 0x8d, 0x25, 0x1f, 0x79, 0x12, 0x94, 0x29, 0xe6, 0xa5, 0x61, 0x65, 0x61, 0x88, 0x1f, 0x63,
 	0x5d, 0x7e, 0x04, 0xd2, 0xfc, 0xa4, 0x7a, 0x06, 0xe2, 0xe8, 0x67, 0x4f, 0x42, 0xfc, 0xce, 0xf2,
 	0xfc, 0x5a, 0xe6, 0x14, 0x19, 0x82, 0xd8, 0xe2, 0xda, 0x66, 0x46, 0x51, 0x2f, 0xc3, 0xe8, 0xdb,
-	0xd4, 0x73, 0xcc, 0x72, 0x6f, 0x53, 0xe2, 0xf7, 0xd1, 0x58, 0xdd, 0xf2, 0x50, 0xdf, 0xb2, 0x7d,
+	0xd4, 0x73, 0xcc, 0x72, 0x6f, 0x53, 0xe2, 0x0f, 0xd0, 0x58, 0xdd, 0xf2, 0x50, 0xdf, 0xb2, 0x7d,
 	0xe4, 0xa9, 0x7a, 0x9c, 0xdf, 0x82, 0x41, 0xd4, 0xe7, 0x7d, 0x9d, 0x6a, 0xdb, 0x4e, 0xa2, 0xd8,
 	0x50, 0xbd, 0xc2, 0xcc, 0x59, 0x01, 0x97, 0xab, 0x61, 0x49, 0xb9, 0x2a, 0x61, 0x2b, 0xe3, 0xb3,
 	0x03, 0x30, 0x16, 0x54, 0x16, 0x46, 0xfd, 0xd3, 0xb6, 0x32, 0x6e, 0x43, 0x02, 0xf7, 0x01, 0xdf,
@@ -23308,7 +23268,7 @@ var fileDescriptor_status_db02da4c8199186f = []byte{
 	0xbf, 0x29, 0x90, 0x59, 0xaf, 0xeb, 0x56, 0xc8, 0xc9, 0x7d, 0xa1, 0x4d, 0x76, 0x16, 0xa0, 0xc5,
 	0xd0, 0x80, 0x33, 0x9a, 0x7c, 0x3b, 0xcb, 0xc5, 0xe8, 0xc6, 0x0f, 0xf7, 0x67, 0x5f, 0x3e, 0x9a,
 	0xf5, 0x7f, 0x8f, 0x36, 0xa5, 0x4b, 0xdd, 0xfb, 0xad, 0x4b, 0xdd, 0xd8, 0x49, 0x28, 0x8a, 0xbb,
-	0x60, 0xf5, 0x4f, 0x14, 0x18, 0x97, 0x46, 0x27, 0x26, 0x66, 0x15, 0xd2, 0x9e, 0xed, 0xe9, 0xd5,
+	0x60, 0xf5, 0x4f, 0x15, 0x18, 0x97, 0x46, 0x27, 0x26, 0x66, 0x15, 0xd2, 0x9e, 0xed, 0xe9, 0xd5,
 	0xa2, 0xef, 0x99, 0xef, 0xb8, 0x14, 0x6e, 0xbf, 0x22, 0x78, 0xfb, 0xc7, 0x17, 0x17, 0x91, 0x86,
 	0x1f, 0xe7, 0x84, 0xed, 0x31, 0x87, 0x6d, 0x1d, 0xfc, 0xe8, 0x56, 0xb6, 0x1b, 0x96, 0x27, 0x7c,
 	0x8c, 0x80, 0x59, 0x8b, 0x2c, 0x87, 0xbc, 0x02, 0xd3, 0x7a, 0xbd, 0xee, 0xd8, 0x7b, 0x66, 0x4d,
@@ -23319,7 +23279,7 @@ var fileDescriptor_status_db02da4c8199186f = []byte{
 	0xb8, 0x62, 0xed, 0x1e, 0x38, 0xd5, 0x56, 0x7c, 0xfc, 0xc0, 0xa9, 0x7a, 0x5b, 0x3f, 0xb9, 0x7f,
 	0x4a, 0xf1, 0x30, 0xb3, 0x20, 0xae, 0xa4, 0xe3, 0x26, 0x5a, 0xe9, 0x72, 0x13, 0xfd, 0xf3, 0x0a,
 	0x4c, 0x49, 0xa1, 0x26, 0xc5, 0x76, 0xe7, 0xfb, 0x83, 0x83, 0xfd, 0xd9, 0x89, 0xcd, 0x56, 0x85,
-	0x13, 0x9f, 0xed, 0x27, 0x1a, 0xed, 0xc4, 0x0c, 0x97, 0xfc, 0x81, 0x02, 0x17, 0xa5, 0x38, 0x95,
+	0x13, 0x9f, 0xed, 0x27, 0x1a, 0xed, 0xc4, 0x0c, 0x97, 0xfc, 0xa1, 0x02, 0x17, 0xa5, 0x38, 0x95,
 	0x8e, 0x30, 0x17, 0x09, 0x56, 0x0c, 0x61, 0x7d, 0xf2, 0x60, 0x7f, 0xf6, 0x7c, 0x2b, 0x88, 0x25,
 	0x1c, 0xf8, 0x72, 0x62, 0x8c, 0xe7, 0x9d, 0x48, 0xca, 0x86, 0x4b, 0x3e, 0xa7, 0x40, 0x36, 0x1c,
 	0x5b, 0x23, 0x41, 0x8c, 0x23, 0xc4, 0xb5, 0x83, 0xfd, 0xd9, 0xc9, 0xfb, 0x52, 0xa4, 0xcd, 0x89,
@@ -23351,7 +23311,7 @@ var fileDescriptor_status_db02da4c8199186f = []byte{
 	0xf6, 0x16, 0x0c, 0x9a, 0xd6, 0x96, 0xed, 0xdf, 0x8c, 0x1d, 0xe9, 0x12, 0x11, 0x1b, 0xe6, 0xde,
 	0x85, 0xe9, 0xee, 0x2c, 0xe9, 0x22, 0xd2, 0xf7, 0xc2, 0x22, 0x7d, 0xa3, 0x6f, 0xa6, 0x1f, 0x22,
 	0xce, 0xe2, 0xae, 0xff, 0x45, 0x20, 0x4b, 0xad, 0x07, 0x97, 0x3d, 0xaf, 0x69, 0xe7, 0x84, 0x6e,
-	0xeb, 0x5d, 0xf3, 0x0f, 0x07, 0x60, 0x18, 0xab, 0xfa, 0x0f, 0xf6, 0x9e, 0xb6, 0x16, 0x7c, 0x01,
+	0xeb, 0x5d, 0xf3, 0x8f, 0x06, 0x60, 0x18, 0xab, 0xfa, 0x0f, 0xf6, 0x9e, 0xb6, 0x16, 0x7c, 0x01,
 	0xc6, 0xa9, 0x55, 0x76, 0x9a, 0x78, 0xbd, 0xe3, 0x87, 0x60, 0xe2, 0x19, 0x5d, 0xcb, 0xb4, 0x0a,
 	0xc4, 0xf5, 0xeb, 0xac, 0x7f, 0x1c, 0xe6, 0x77, 0xef, 0xfc, 0x50, 0xca, 0x4f, 0xb8, 0x78, 0x3d,
 	0xdf, 0xaa, 0xc0, 0x4f, 0xad, 0x71, 0xa9, 0x02, 0x77, 0x7a, 0xce, 0x41, 0x46, 0x38, 0x2b, 0xb7,
@@ -23383,87 +23343,86 @@ var fileDescriptor_status_db02da4c8199186f = []byte{
 	0x87, 0xf3, 0xc3, 0xd7, 0xcc, 0x87, 0x0e, 0x54, 0x39, 0x7c, 0xa0, 0x6a, 0x13, 0xe6, 0x7a, 0xd3,
 	0x17, 0xea, 0xfb, 0x6d, 0x48, 0x38, 0x98, 0x23, 0x44, 0xe8, 0x46, 0x3f, 0x2b, 0xad, 0x93, 0x9c,
 	0x20, 0xa2, 0x3e, 0x07, 0xea, 0xe1, 0xb5, 0x82, 0x0b, 0x8d, 0x9f, 0x81, 0x0b, 0x91, 0xb5, 0x04,
-	0xb6, 0x4d, 0x18, 0xe2, 0x64, 0xfd, 0x7d, 0xe5, 0x78, 0xe0, 0x7c, 0xb5, 0x26, 0x68, 0xa9, 0x7f,
-	0xa6, 0xc0, 0x64, 0xb7, 0xda, 0x1d, 0x32, 0x78, 0x28, 0xf3, 0x07, 0x22, 0xa4, 0xec, 0x36, 0x0c,
-	0x97, 0xfd, 0x65, 0xc7, 0xa4, 0xe4, 0x28, 0xfb, 0x53, 0x3a, 0x68, 0x39, 0x8f, 0x8f, 0x14, 0x3d,
-	0x47, 0x2f, 0x07, 0x4f, 0x31, 0x31, 0xa1, 0x7e, 0x1c, 0xce, 0x76, 0x1f, 0x29, 0x97, 0x97, 0x9b,
-	0x11, 0x32, 0xce, 0x07, 0x76, 0x88, 0x74, 0xab, 0x3b, 0x70, 0xae, 0x3b, 0x61, 0x31, 0x19, 0x0f,
-	0x21, 0x2d, 0xd1, 0x13, 0xfa, 0xb2, 0x70, 0xd4, 0x09, 0x91, 0x69, 0xa8, 0xd7, 0x21, 0x7b, 0xd7,
-	0x2e, 0x69, 0xb4, 0x62, 0xba, 0x9e, 0xd3, 0x14, 0xc1, 0x45, 0xbd, 0xac, 0xc9, 0xff, 0x56, 0xe0,
-	0x4c, 0x97, 0x56, 0x1f, 0xc2, 0xe1, 0xea, 0x13, 0x30, 0xec, 0x34, 0x2c, 0xcb, 0xb4, 0x2a, 0xc5,
-	0xc7, 0x76, 0xc9, 0x3f, 0xd0, 0x46, 0x45, 0x8c, 0x1d, 0x8a, 0x13, 0x4b, 0xd2, 0x82, 0xda, 0x5d,
-	0xbb, 0xe4, 0xe6, 0xa6, 0x20, 0x76, 0xd7, 0x2e, 0xb5, 0x8b, 0xa0, 0x7a, 0x19, 0x32, 0x77, 0xed,
-	0x52, 0x98, 0x35, 0x53, 0x90, 0x78, 0x6c, 0x97, 0x5a, 0x33, 0x3a, 0xf8, 0xd8, 0x2e, 0xad, 0x18,
-	0xea, 0x32, 0x8c, 0x4b, 0x55, 0x05, 0x3f, 0x5e, 0x82, 0xd8, 0x63, 0xbb, 0x24, 0xd6, 0xf6, 0x4c,
-	0xdb, 0xf6, 0x80, 0xbf, 0xe8, 0xc2, 0x7f, 0xdd, 0x05, 0x01, 0xb1, 0xaa, 0x57, 0x6e, 0x00, 0xb4,
-	0x22, 0x74, 0xc9, 0x24, 0x64, 0x6e, 0x3f, 0xd0, 0x1e, 0x6c, 0x6e, 0xac, 0xdc, 0x5f, 0x2e, 0xae,
-	0x6f, 0xcc, 0x2f, 0xde, 0x5b, 0xcf, 0x9c, 0x22, 0xe3, 0x30, 0xb2, 0x71, 0x47, 0x5b, 0x9e, 0x5f,
-	0xf2, 0xb3, 0x94, 0x2b, 0xcf, 0x41, 0xd2, 0x0f, 0x7f, 0x95, 0xe2, 0x3f, 0x47, 0x01, 0x82, 0xe6,
-	0xeb, 0x19, 0xe5, 0xda, 0xb7, 0xe7, 0x20, 0x21, 0xec, 0xee, 0xaf, 0x2b, 0x30, 0x2c, 0xff, 0x9a,
-	0x02, 0xc9, 0xf7, 0xf7, 0x7b, 0x09, 0x3e, 0x1b, 0x72, 0x85, 0xbe, 0xeb, 0x73, 0x5e, 0xa8, 0x97,
-	0xde, 0xfb, 0xe7, 0xff, 0xfc, 0xda, 0xc0, 0xb3, 0x64, 0xb6, 0x20, 0xce, 0x04, 0x05, 0xf9, 0xc7,
-	0x16, 0x0a, 0xef, 0x0a, 0xc1, 0x79, 0x42, 0x7e, 0x41, 0x81, 0x21, 0xff, 0xac, 0x12, 0x15, 0x80,
-	0x17, 0xfe, 0x6d, 0x86, 0xdc, 0x95, 0x7e, 0xaa, 0x0a, 0x2c, 0x2a, 0x62, 0x39, 0x47, 0x72, 0x01,
-	0x16, 0x11, 0x65, 0x2f, 0xc1, 0x70, 0x60, 0x10, 0x9f, 0xd2, 0x93, 0x4b, 0xbd, 0x1f, 0xdb, 0x73,
-	0x04, 0x73, 0xfd, 0xbe, 0xca, 0x57, 0xa7, 0xb1, 0xff, 0x0c, 0x19, 0x0d, 0xfa, 0xe7, 0xaf, 0xfe,
-	0x3f, 0x03, 0x71, 0x0c, 0xb9, 0xbd, 0xd8, 0x83, 0x92, 0xdf, 0xe3, 0x91, 0x7e, 0x60, 0x40, 0x3d,
-	0x8f, 0xbd, 0xe6, 0x48, 0x36, 0xdc, 0xab, 0x34, 0xe6, 0x27, 0xfc, 0x19, 0x3c, 0x86, 0x59, 0x92,
-	0x17, 0xfa, 0x0b, 0xc6, 0x3c, 0x1c, 0xc9, 0xa1, 0x91, 0x9b, 0xea, 0x14, 0x22, 0x19, 0x23, 0x23,
-	0x01, 0x12, 0x47, 0xdf, 0xf2, 0xc8, 0x67, 0x15, 0x48, 0x70, 0x1f, 0x10, 0xe9, 0xf9, 0x04, 0x32,
-	0xe0, 0xfa, 0xe5, 0x3e, 0x6a, 0x8a, 0x6e, 0x9f, 0xc5, 0x6e, 0xcf, 0x92, 0x33, 0x52, 0xb7, 0xac,
-	0x82, 0xc4, 0x01, 0x17, 0x12, 0xfc, 0x1d, 0x5b, 0x24, 0x82, 0xd0, 0x53, 0xb7, 0x9c, 0xfc, 0x5c,
-	0x40, 0xfc, 0x80, 0xd3, 0x8a, 0xb5, 0x65, 0x0b, 0xae, 0x77, 0x76, 0x2a, 0x7e, 0xeb, 0xa9, 0xd5,
-	0xe9, 0xaf, 0x2b, 0x90, 0x96, 0x1e, 0x60, 0x91, 0x17, 0xfb, 0x7b, 0xa8, 0xe5, 0xf7, 0x9f, 0xef,
-	0xb7, 0xba, 0x60, 0xc3, 0x45, 0x44, 0x74, 0x9e, 0xcc, 0x04, 0x88, 0xf8, 0x5d, 0x33, 0x5a, 0xa2,
-	0x12, 0xac, 0xaf, 0x28, 0x90, 0x0a, 0x5e, 0xc8, 0x44, 0x8a, 0x43, 0xfb, 0xbb, 0xa0, 0x48, 0x71,
-	0xe8, 0x78, 0xb4, 0xa3, 0x5e, 0x46, 0x40, 0x17, 0xc8, 0xb3, 0x01, 0x20, 0xdd, 0xaf, 0x83, 0x22,
-	0x2a, 0x61, 0x7a, 0x5f, 0x81, 0xd1, 0xf0, 0x0b, 0x2a, 0xf2, 0x52, 0x5f, 0x7d, 0x49, 0x0e, 0xc3,
-	0xdc, 0xcb, 0x47, 0x68, 0x21, 0x20, 0xbe, 0x80, 0x10, 0x9f, 0x27, 0x17, 0xba, 0x40, 0x44, 0x21,
-	0x2a, 0xbc, 0xeb, 0xbb, 0xfe, 0x9e, 0x90, 0xcf, 0x2b, 0x30, 0x2c, 0x87, 0xfd, 0x44, 0x2a, 0xd7,
-	0x2e, 0x81, 0x7d, 0x91, 0xca, 0xb5, 0x5b, 0x58, 0x93, 0x7a, 0x06, 0xe1, 0x4d, 0x90, 0xf1, 0x00,
-	0x5e, 0x10, 0xab, 0xf4, 0x1b, 0x22, 0x2c, 0x0b, 0x9f, 0xde, 0x7e, 0x78, 0x88, 0x66, 0x11, 0xd1,
-	0x19, 0x72, 0x3a, 0x40, 0x84, 0x0f, 0x89, 0x8b, 0x01, 0xae, 0xaf, 0x2b, 0x90, 0x96, 0xa2, 0x90,
-	0x22, 0x85, 0xbe, 0x33, 0x40, 0x2a, 0x52, 0xe8, 0xbb, 0x04, 0x37, 0xa9, 0x57, 0x10, 0xcf, 0x73,
-	0xaa, 0xb4, 0xfd, 0x60, 0x2d, 0x1e, 0xe2, 0xd6, 0x92, 0xb0, 0xd7, 0x95, 0x2b, 0xe4, 0xf7, 0x44,
-	0xf4, 0x58, 0x7b, 0x0c, 0x0b, 0x79, 0xf5, 0x88, 0x41, 0x2f, 0x3e, 0xd8, 0xd7, 0x8e, 0xdc, 0xee,
-	0xd0, 0x8d, 0xaa, 0x15, 0xb8, 0x53, 0x14, 0x91, 0x39, 0x7f, 0x2c, 0xe2, 0x93, 0x70, 0x82, 0x7f,
-	0xf4, 0x90, 0xe7, 0x10, 0xb2, 0x4a, 0xce, 0xb7, 0x4d, 0x7c, 0x27, 0xf0, 0x6f, 0x28, 0x30, 0x12,
-	0x8a, 0xe1, 0x22, 0x85, 0x9e, 0x93, 0x1a, 0x0e, 0x34, 0xcb, 0xbd, 0xd4, 0x7f, 0x03, 0x01, 0xef,
-	0x2a, 0xc2, 0xbb, 0xa8, 0x3e, 0xdb, 0x2e, 0x07, 0x42, 0x30, 0xc3, 0x92, 0xf0, 0x59, 0x05, 0x52,
-	0x41, 0x0c, 0x4f, 0xa4, 0x0a, 0x6c, 0x8f, 0x63, 0x8a, 0x54, 0x81, 0x1d, 0x61, 0x41, 0x6a, 0x16,
-	0x61, 0x11, 0xb5, 0xb5, 0x23, 0xba, 0x75, 0xdd, 0x62, 0x10, 0x3e, 0x83, 0x36, 0x5b, 0x79, 0x3b,
-	0x7a, 0x4f, 0x0c, 0xbd, 0x13, 0xcb, 0x45, 0x99, 0x2c, 0xf2, 0xbb, 0xc6, 0x2e, 0x9b, 0x93, 0x8b,
-	0x84, 0x24, 0x8d, 0xfb, 0x73, 0x0a, 0x0c, 0x89, 0xe7, 0x48, 0x91, 0xe6, 0x58, 0xf8, 0xc9, 0x52,
-	0xff, 0x10, 0x3a, 0x45, 0xbc, 0xce, 0x29, 0xb5, 0x61, 0x10, 0x0f, 0x98, 0x22, 0x31, 0x84, 0x1f,
-	0x39, 0x9d, 0x04, 0x43, 0x8d, 0x53, 0x92, 0x30, 0xfc, 0xa2, 0x02, 0x49, 0xff, 0xd1, 0x18, 0x89,
-	0x32, 0x36, 0xdb, 0xde, 0xbd, 0xe5, 0x5e, 0xe8, 0xab, 0xae, 0x40, 0xd2, 0x69, 0xa3, 0xa1, 0x47,
-	0x3b, 0x6c, 0x2c, 0x0c, 0xcb, 0x8f, 0x18, 0xa3, 0x55, 0x79, 0xe7, 0xeb, 0xc8, 0x68, 0x55, 0xde,
-	0xe5, 0x75, 0xa4, 0x7a, 0x01, 0x31, 0x3d, 0x43, 0xce, 0x4a, 0x2b, 0xba, 0xd2, 0x0e, 0xeb, 0x4b,
-	0x0a, 0x0c, 0x89, 0xd6, 0x91, 0x53, 0x14, 0x7e, 0x2d, 0x99, 0x7b, 0x31, 0xba, 0x6a, 0xdb, 0x5b,
-	0x51, 0x5f, 0x8b, 0x13, 0x35, 0x02, 0x4a, 0xe1, 0x5d, 0x96, 0xf1, 0x84, 0x19, 0xd3, 0xab, 0x76,
-	0xc5, 0x8d, 0x34, 0xa6, 0xa5, 0x07, 0xb5, 0x47, 0x85, 0xd2, 0x6d, 0x83, 0xab, 0xc8, 0x1c, 0xf9,
-	0xaa, 0x82, 0x3f, 0x47, 0xd4, 0x0a, 0x52, 0x88, 0x54, 0x6f, 0xdd, 0xe2, 0xed, 0x22, 0xd5, 0x5b,
-	0xd7, 0xf8, 0x07, 0x75, 0x06, 0x51, 0x65, 0xc9, 0xb4, 0xbc, 0x9a, 0x58, 0x3d, 0xf1, 0xc2, 0xe9,
-	0x3d, 0x05, 0x52, 0xc1, 0x4d, 0x6b, 0xa4, 0x42, 0x6b, 0x0f, 0x94, 0x88, 0x54, 0x68, 0x1d, 0x97,
-	0xb7, 0x6a, 0x0e, 0x81, 0x4c, 0x12, 0x12, 0x00, 0x79, 0x64, 0x7b, 0x02, 0xc4, 0x13, 0x18, 0xe4,
-	0xa6, 0xdb, 0xa5, 0xde, 0x97, 0x67, 0xbd, 0x8f, 0x56, 0x61, 0x43, 0xed, 0x10, 0x1b, 0x5f, 0x36,
-	0xcf, 0xde, 0x57, 0x20, 0x2d, 0x3b, 0x9e, 0xa2, 0x26, 0xbe, 0xd3, 0xc9, 0x93, 0xfb, 0x68, 0x67,
-	0x75, 0xf9, 0xa7, 0x52, 0x43, 0x3f, 0xa2, 0x2a, 0xb5, 0xe7, 0xde, 0xb0, 0x2e, 0xc6, 0xb7, 0xfc,
-	0x0b, 0xac, 0x2d, 0xe9, 0x61, 0x67, 0x21, 0x7e, 0x07, 0xd5, 0x43, 0xef, 0x4b, 0x97, 0x80, 0x91,
-	0x67, 0xa1, 0xf0, 0x85, 0x56, 0x57, 0xcd, 0xcf, 0x2a, 0x48, 0x10, 0x7e, 0x49, 0x41, 0x67, 0x84,
-	0x7f, 0xf1, 0x73, 0xb5, 0xcf, 0x5b, 0x80, 0xde, 0xab, 0xa9, 0xf3, 0xce, 0x40, 0x3d, 0x8b, 0x70,
-	0xa6, 0xc8, 0x84, 0xbc, 0x11, 0xf9, 0x3d, 0x7f, 0x57, 0x81, 0xf3, 0xbd, 0x5c, 0xaa, 0x64, 0x21,
-	0xca, 0x14, 0xe8, 0xcf, 0xdf, 0x9b, 0x5b, 0x3c, 0x11, 0x8d, 0xb0, 0xba, 0x54, 0xb3, 0xd2, 0x50,
-	0x6a, 0x1e, 0x9b, 0x65, 0xe1, 0x02, 0x65, 0xbb, 0xfa, 0x5f, 0x2a, 0x87, 0x39, 0xfc, 0x10, 0x89,
-	0x4b, 0xde, 0x38, 0x96, 0xb3, 0x35, 0x60, 0xff, 0x9b, 0xc7, 0x6d, 0x7e, 0xe8, 0x3e, 0xd4, 0x36,
-	0x08, 0xf2, 0xe7, 0x87, 0xf9, 0x71, 0x5f, 0x3d, 0x72, 0xd7, 0xbd, 0x2d, 0xce, 0x28, 0xdf, 0xa8,
-	0xfa, 0x0a, 0x62, 0xcd, 0x93, 0xab, 0x1d, 0x58, 0x0b, 0xef, 0x1e, 0xe6, 0x8e, 0x7d, 0x42, 0xbe,
-	0xa9, 0xa0, 0xc7, 0x2e, 0xec, 0x21, 0x24, 0xd7, 0x8f, 0xe6, 0x4f, 0xe4, 0xc8, 0x5f, 0x39, 0x8e,
-	0x13, 0xb2, 0x8b, 0x43, 0xec, 0xb1, 0x5d, 0x2a, 0x3a, 0xa2, 0x72, 0xd8, 0xf2, 0x48, 0x05, 0xbe,
-	0xc5, 0x48, 0x9d, 0xdd, 0xee, 0xac, 0x8c, 0xd4, 0xd9, 0x1d, 0xee, 0x4a, 0xf5, 0x19, 0x44, 0x74,
-	0x9a, 0x4c, 0xc9, 0x88, 0x0a, 0xef, 0x72, 0x77, 0xe7, 0x93, 0x85, 0x2b, 0xdf, 0xf9, 0x8f, 0x99,
-	0x53, 0xdf, 0x39, 0x98, 0x51, 0xbe, 0x7b, 0x30, 0xa3, 0x7c, 0xef, 0x60, 0x46, 0xf9, 0xf7, 0x83,
-	0x19, 0xe5, 0xcb, 0x3f, 0x98, 0x39, 0xf5, 0xdd, 0x1f, 0xcc, 0x9c, 0xfa, 0xde, 0x0f, 0x66, 0x4e,
-	0xbd, 0x93, 0xf4, 0x89, 0x97, 0x12, 0xe8, 0x69, 0xbf, 0xfe, 0x7f, 0x01, 0x00, 0x00, 0xff, 0xff,
-	0x26, 0x41, 0xa1, 0xb3, 0x24, 0x5b, 0x00, 0x00,
+	0xb6, 0x4d, 0x18, 0xe2, 0x64, 0xfd, 0x7d, 0xe5, 0x78, 0xe0, 0x7c, 0xb5, 0x26, 0x68, 0xa9, 0xbf,
+	0xa7, 0xc0, 0x64, 0xb7, 0xda, 0x1d, 0x32, 0x78, 0x28, 0xf3, 0x07, 0x22, 0xa4, 0xec, 0x36, 0x0c,
+	0x97, 0xfd, 0x65, 0xc7, 0xa4, 0xe4, 0x28, 0xfb, 0x53, 0x3a, 0x68, 0x39, 0xef, 0x47, 0x60, 0x7e,
+	0x1c, 0xce, 0x76, 0x1f, 0x19, 0x97, 0x8f, 0x9b, 0x11, 0x32, 0xcd, 0x07, 0x72, 0x88, 0x34, 0xab,
+	0x3b, 0x70, 0xae, 0x3b, 0x61, 0xc1, 0xfc, 0x87, 0x90, 0x96, 0xe8, 0x09, 0xfd, 0x58, 0x38, 0xea,
+	0x04, 0xc8, 0x34, 0xd4, 0xeb, 0x90, 0xbd, 0x6b, 0x97, 0x34, 0x5a, 0x31, 0x5d, 0xcf, 0x69, 0x8a,
+	0x60, 0xa2, 0x5e, 0xd6, 0xe3, 0x7f, 0x2b, 0x70, 0xa6, 0x4b, 0xab, 0x0f, 0xe1, 0x30, 0xf5, 0x09,
+	0x18, 0x76, 0x1a, 0x96, 0x65, 0x5a, 0x95, 0xe2, 0x63, 0xbb, 0xe4, 0x1f, 0x60, 0xa3, 0x22, 0xc4,
+	0x0e, 0xc5, 0x89, 0x25, 0x69, 0x41, 0xed, 0xae, 0x5d, 0x72, 0x73, 0x53, 0x10, 0xbb, 0x6b, 0x97,
+	0xda, 0x45, 0x4e, 0xbd, 0x0c, 0x99, 0xbb, 0x76, 0x29, 0xcc, 0x9a, 0x29, 0x48, 0x3c, 0xb6, 0x4b,
+	0xad, 0x19, 0x1d, 0x7c, 0x6c, 0x97, 0x56, 0x0c, 0x75, 0x19, 0xc6, 0xa5, 0xaa, 0x82, 0x1f, 0x2f,
+	0x41, 0xec, 0xb1, 0x5d, 0x12, 0x6b, 0x79, 0xa6, 0x6d, 0x3b, 0xc0, 0x5f, 0x70, 0xe1, 0xbf, 0xe6,
+	0x82, 0x80, 0x58, 0xd5, 0x2b, 0x37, 0x00, 0x5a, 0x11, 0xb9, 0x64, 0x12, 0x32, 0xb7, 0x1f, 0x68,
+	0x0f, 0x36, 0x37, 0x56, 0xee, 0x2f, 0x17, 0xd7, 0x37, 0xe6, 0x17, 0xef, 0xad, 0x67, 0x4e, 0x91,
+	0x71, 0x18, 0xd9, 0xb8, 0xa3, 0x2d, 0xcf, 0x2f, 0xf9, 0x59, 0xca, 0x95, 0xe7, 0x20, 0xe9, 0x87,
+	0xbb, 0x4a, 0xf1, 0x9e, 0xa3, 0x00, 0x41, 0xf3, 0xf5, 0x8c, 0x72, 0xed, 0xdb, 0x73, 0x90, 0x10,
+	0x76, 0xf6, 0xd7, 0x15, 0x18, 0x96, 0x7f, 0x3d, 0x81, 0xe4, 0xfb, 0xfb, 0x7d, 0x04, 0x9f, 0x0d,
+	0xb9, 0x42, 0xdf, 0xf5, 0x39, 0x2f, 0xd4, 0x4b, 0xef, 0xfd, 0xf3, 0x7f, 0x7e, 0x6d, 0xe0, 0x59,
+	0x32, 0x5b, 0x10, 0x67, 0x80, 0x82, 0xfc, 0xe3, 0x0a, 0x85, 0x77, 0x85, 0xe0, 0x3c, 0x21, 0xbf,
+	0xa0, 0xc0, 0x90, 0x7f, 0x36, 0x89, 0x0a, 0xb8, 0x0b, 0xff, 0x16, 0x43, 0xee, 0x4a, 0x3f, 0x55,
+	0x05, 0x16, 0x15, 0xb1, 0x9c, 0x23, 0xb9, 0x00, 0x8b, 0x88, 0xaa, 0x97, 0x60, 0x38, 0x30, 0x88,
+	0x4f, 0xe7, 0xc9, 0xa5, 0xde, 0x8f, 0xeb, 0x39, 0x82, 0xb9, 0x7e, 0x5f, 0xe1, 0xab, 0xd3, 0xd8,
+	0x7f, 0x86, 0x8c, 0x06, 0xfd, 0xf3, 0x57, 0xfe, 0x9f, 0x81, 0x38, 0x86, 0xd8, 0x5e, 0xec, 0x41,
+	0xc9, 0xef, 0xf1, 0x48, 0x3f, 0x28, 0xa0, 0x9e, 0xc7, 0x5e, 0x73, 0x24, 0x1b, 0xee, 0x55, 0x1a,
+	0xf3, 0x13, 0xfe, 0xec, 0x1d, 0xc3, 0x2a, 0xc9, 0x0b, 0xfd, 0x05, 0x5f, 0x1e, 0x8e, 0xe4, 0xd0,
+	0x48, 0x4d, 0x75, 0x0a, 0x91, 0x8c, 0x91, 0x91, 0x00, 0x89, 0xa3, 0x6f, 0x79, 0xe4, 0xb3, 0x0a,
+	0x24, 0xb8, 0xcf, 0x87, 0xf4, 0x7c, 0xf2, 0x18, 0x70, 0xfd, 0x72, 0x1f, 0x35, 0x45, 0xb7, 0xcf,
+	0x62, 0xb7, 0x67, 0xc9, 0x19, 0xa9, 0x5b, 0x56, 0x41, 0xe2, 0x80, 0x0b, 0x09, 0xfe, 0x6e, 0x2d,
+	0x12, 0x41, 0xe8, 0x69, 0x5b, 0x4e, 0x7e, 0x1e, 0x20, 0x7e, 0xb0, 0x69, 0xc5, 0xda, 0xb2, 0x05,
+	0xd7, 0x3b, 0x3b, 0x15, 0xbf, 0xed, 0xd4, 0xea, 0xf4, 0xd7, 0x15, 0x48, 0x4b, 0x0f, 0xae, 0xc8,
+	0x8b, 0xfd, 0x3d, 0xcc, 0xf2, 0xfb, 0xcf, 0xf7, 0x5b, 0x5d, 0xb0, 0xe1, 0x22, 0x22, 0x3a, 0x4f,
+	0x66, 0x02, 0x44, 0xfc, 0x6e, 0x19, 0x2d, 0x4f, 0x09, 0xd6, 0x57, 0x14, 0x48, 0x05, 0x2f, 0x62,
+	0x22, 0xc5, 0xa1, 0xfd, 0x1d, 0x50, 0xa4, 0x38, 0x74, 0x3c, 0xd2, 0x51, 0x2f, 0x23, 0xa0, 0x0b,
+	0xe4, 0xd9, 0x00, 0x90, 0xee, 0xd7, 0x41, 0x11, 0x95, 0x30, 0xbd, 0xaf, 0xc0, 0x68, 0xf8, 0xc5,
+	0x14, 0x79, 0xa9, 0xaf, 0xbe, 0x24, 0x07, 0x61, 0xee, 0xe5, 0x23, 0xb4, 0x10, 0x10, 0x5f, 0x40,
+	0x88, 0xcf, 0x93, 0x0b, 0x5d, 0x20, 0xa2, 0x10, 0x15, 0xde, 0xf5, 0x5d, 0x7d, 0x4f, 0xc8, 0xe7,
+	0x15, 0x18, 0x96, 0xc3, 0x7c, 0x22, 0x95, 0x6b, 0x97, 0x40, 0xbe, 0x48, 0xe5, 0xda, 0x2d, 0x8c,
+	0x49, 0x3d, 0x83, 0xf0, 0x26, 0xc8, 0x78, 0x00, 0x2f, 0x88, 0x4d, 0xfa, 0x0d, 0x11, 0x86, 0x85,
+	0x4f, 0x6d, 0x3f, 0x3c, 0x44, 0xb3, 0x88, 0xe8, 0x0c, 0x39, 0x1d, 0x20, 0xc2, 0x87, 0xc3, 0xc5,
+	0x00, 0xd7, 0xd7, 0x15, 0x48, 0x4b, 0x51, 0x47, 0x91, 0x42, 0xdf, 0x19, 0x10, 0x15, 0x29, 0xf4,
+	0x5d, 0x82, 0x99, 0xd4, 0x2b, 0x88, 0xe7, 0x39, 0x55, 0xda, 0x7e, 0xb0, 0x16, 0x0f, 0x69, 0x6b,
+	0x49, 0xd8, 0xeb, 0xca, 0x15, 0xf2, 0xfb, 0x22, 0x5a, 0xac, 0x3d, 0x66, 0x85, 0xbc, 0x7a, 0xc4,
+	0x20, 0x17, 0x1f, 0xec, 0x6b, 0x47, 0x6e, 0x77, 0xe8, 0x46, 0xd5, 0x0a, 0xd4, 0x29, 0x8a, 0x48,
+	0x9c, 0x3f, 0x11, 0xf1, 0x48, 0x38, 0xc1, 0x3f, 0x7a, 0xc8, 0x73, 0x08, 0x59, 0x25, 0xe7, 0xdb,
+	0x26, 0xbe, 0x13, 0xf8, 0x37, 0x14, 0x18, 0x09, 0xc5, 0x6c, 0x91, 0x42, 0xcf, 0x49, 0x0d, 0x07,
+	0x96, 0xe5, 0x5e, 0xea, 0xbf, 0x81, 0x80, 0x77, 0x15, 0xe1, 0x5d, 0x54, 0x9f, 0x6d, 0x97, 0x03,
+	0x21, 0x98, 0x61, 0x49, 0xf8, 0xac, 0x02, 0xa9, 0x20, 0x66, 0x27, 0x52, 0x05, 0xb6, 0xc7, 0x2d,
+	0x45, 0xaa, 0xc0, 0x8e, 0x30, 0x20, 0x35, 0x8b, 0xb0, 0x88, 0xda, 0xda, 0x11, 0xdd, 0xba, 0x6e,
+	0x31, 0x08, 0x9f, 0x41, 0x9b, 0xad, 0xbc, 0x1d, 0xbd, 0x27, 0x86, 0xde, 0x85, 0xe5, 0xa2, 0x4c,
+	0x16, 0xf9, 0x1d, 0x63, 0x97, 0xcd, 0xc9, 0x45, 0x42, 0x92, 0xc6, 0xfd, 0x39, 0x05, 0x86, 0xc4,
+	0xf3, 0xa3, 0x48, 0x73, 0x2c, 0xfc, 0x44, 0xa9, 0x7f, 0x08, 0x9d, 0x22, 0x5e, 0xe7, 0x94, 0xda,
+	0x30, 0x88, 0x07, 0x4b, 0x91, 0x18, 0xc2, 0x8f, 0x9a, 0x4e, 0x82, 0xa1, 0xc6, 0x29, 0x49, 0x18,
+	0x7e, 0x51, 0x81, 0xa4, 0xff, 0x48, 0x8c, 0x44, 0x19, 0x9b, 0x6d, 0xef, 0xdc, 0x72, 0x2f, 0xf4,
+	0x55, 0x57, 0x20, 0xe9, 0xb4, 0xd1, 0xd0, 0x83, 0x1d, 0x36, 0x16, 0x86, 0xe5, 0x47, 0x8b, 0xd1,
+	0xaa, 0xbc, 0xf3, 0x35, 0x64, 0xb4, 0x2a, 0xef, 0xf2, 0x1a, 0x52, 0xbd, 0x80, 0x98, 0x9e, 0x21,
+	0x67, 0xa5, 0x15, 0x5d, 0x69, 0x87, 0xf5, 0x25, 0x05, 0x86, 0x44, 0xeb, 0xc8, 0x29, 0x0a, 0xbf,
+	0x8e, 0xcc, 0xbd, 0x18, 0x5d, 0xb5, 0xed, 0x6d, 0xa8, 0xaf, 0xc5, 0x89, 0x1a, 0x01, 0xa5, 0xf0,
+	0x2e, 0xcb, 0x78, 0xc2, 0x8c, 0xe9, 0x55, 0xbb, 0xe2, 0x46, 0x1a, 0xd3, 0xd2, 0x03, 0xda, 0xa3,
+	0x42, 0xe9, 0xb6, 0xc1, 0x55, 0x64, 0x8e, 0x7c, 0x55, 0xc1, 0x9f, 0x1f, 0x6a, 0x05, 0x25, 0x44,
+	0xaa, 0xb7, 0x6e, 0xf1, 0x75, 0x91, 0xea, 0xad, 0x6b, 0xbc, 0x83, 0x3a, 0x83, 0xa8, 0xb2, 0x64,
+	0x5a, 0x5e, 0x4d, 0xac, 0x9e, 0x78, 0xd1, 0xf4, 0x9e, 0x02, 0xa9, 0xe0, 0x66, 0x35, 0x52, 0xa1,
+	0xb5, 0x07, 0x46, 0x44, 0x2a, 0xb4, 0x8e, 0xcb, 0x5a, 0x35, 0x87, 0x40, 0x26, 0x09, 0x09, 0x80,
+	0x3c, 0xb2, 0x3d, 0x01, 0xe2, 0x09, 0x0c, 0x72, 0xd3, 0xed, 0x52, 0xef, 0xcb, 0xb2, 0xde, 0x47,
+	0xab, 0xb0, 0xa1, 0x76, 0x88, 0x8d, 0x2f, 0x9b, 0x67, 0xef, 0x2b, 0x90, 0x96, 0x1d, 0x4d, 0x51,
+	0x13, 0xdf, 0xe9, 0xe4, 0xc9, 0x7d, 0xb4, 0xb3, 0xba, 0xfc, 0xd3, 0xa8, 0xa1, 0x1f, 0x4d, 0x95,
+	0xda, 0x73, 0xef, 0x57, 0x17, 0xe3, 0x5b, 0xfe, 0xc5, 0xd5, 0x96, 0xf4, 0xb0, 0xb3, 0x10, 0xbf,
+	0x73, 0xea, 0xa1, 0xf7, 0xa5, 0x4b, 0xbf, 0xc8, 0xb3, 0x50, 0xf8, 0x02, 0xab, 0xab, 0xe6, 0x67,
+	0x15, 0x24, 0x08, 0xbf, 0xa4, 0xa0, 0x33, 0xc2, 0xbf, 0xe8, 0xb9, 0xda, 0xa7, 0xd7, 0xbf, 0xf7,
+	0x6a, 0xea, 0xbc, 0x23, 0x50, 0xcf, 0x22, 0x9c, 0x29, 0x32, 0x21, 0x6f, 0x44, 0x7e, 0xcf, 0xdf,
+	0x55, 0xe0, 0x7c, 0x2f, 0x17, 0x2a, 0x59, 0x88, 0x32, 0x05, 0xfa, 0xf3, 0xef, 0xe6, 0x16, 0x4f,
+	0x44, 0x23, 0xac, 0x2e, 0xd5, 0xac, 0x34, 0x94, 0x9a, 0xc7, 0x66, 0x59, 0xb8, 0x3c, 0xd9, 0xae,
+	0xfe, 0x97, 0xca, 0x61, 0x0e, 0x3f, 0x44, 0xe2, 0x92, 0x37, 0x8e, 0xe5, 0x5c, 0x0d, 0xd8, 0xff,
+	0xe6, 0x71, 0x9b, 0x1f, 0xba, 0x0f, 0xb5, 0x0d, 0x82, 0xfc, 0xf9, 0x61, 0x7e, 0xdb, 0x57, 0x8f,
+	0xdc, 0x75, 0x6f, 0x8b, 0x33, 0xca, 0x37, 0xaa, 0xbe, 0x82, 0x58, 0xf3, 0xe4, 0x6a, 0x07, 0xd6,
+	0xc2, 0xbb, 0x87, 0xb9, 0x63, 0x9f, 0x90, 0x6f, 0x2a, 0xe8, 0xb1, 0x0b, 0x7b, 0x08, 0xc9, 0xf5,
+	0xa3, 0xf9, 0x13, 0x39, 0xf2, 0x57, 0x8e, 0xe3, 0x84, 0xec, 0xe2, 0x10, 0x7b, 0x6c, 0x97, 0x8a,
+	0x8e, 0xa8, 0x1c, 0xb6, 0x3c, 0x52, 0x81, 0x6f, 0x31, 0x52, 0x67, 0xb7, 0x3b, 0x2b, 0x23, 0x75,
+	0x76, 0x87, 0xbb, 0x52, 0x7d, 0x06, 0x11, 0x9d, 0x26, 0x53, 0x32, 0xa2, 0xc2, 0xbb, 0xdc, 0xdd,
+	0xf9, 0x64, 0xe1, 0xca, 0x77, 0xfe, 0x63, 0xe6, 0xd4, 0x77, 0x0e, 0x66, 0x94, 0xef, 0x1e, 0xcc,
+	0x28, 0xdf, 0x3b, 0x98, 0x51, 0xfe, 0xfd, 0x60, 0x46, 0xf9, 0xf2, 0x0f, 0x66, 0x4e, 0x7d, 0xf7,
+	0x07, 0x33, 0xa7, 0xbe, 0xf7, 0x83, 0x99, 0x53, 0xef, 0x24, 0x7d, 0xe2, 0xa5, 0x04, 0x7a, 0xd6,
+	0xaf, 0xff, 0x5f, 0x00, 0x00, 0x00, 0xff, 0xff, 0x88, 0x0c, 0xb2, 0xa6, 0x14, 0x5b, 0x00, 0x00,
 }

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -974,7 +974,7 @@ message StatementDiagnostics {
   string statement_fingerprint = 2;
   google.protobuf.Timestamp collected_at = 3
     [ (gogoproto.nullable) = false, (gogoproto.stdtime) = true ];
-  string trace = 4;
+  reserved 4;
 }
 
 message StatementDiagnosticsRequest {

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -2070,13 +2070,6 @@ func TestStatementDiagnosticsCompleted(t *testing.T) {
 	if err := getStatusJSONProto(s, diagPath, &diagRespGet); err != nil {
 		t.Fatal(err)
 	}
-
-	json := diagRespGet.Diagnostics.Trace
-	if json == "" ||
-		!strings.Contains(json, "traced statement") ||
-		!strings.Contains(json, "statement execution committed the txn") {
-		t.Fatal("statement diagnostics did not capture a trace")
-	}
 }
 
 func TestJobStatusResponse(t *testing.T) {

--- a/pkg/sql/catalog/systemschema/system.go
+++ b/pkg/sql/catalog/systemschema/system.go
@@ -1593,6 +1593,7 @@ var (
 			{Name: "statement_fingerprint", ID: 2, Type: types.String, Nullable: false},
 			{Name: "statement", ID: 3, Type: types.String, Nullable: false},
 			{Name: "collected_at", ID: 4, Type: types.TimestampTZ, Nullable: false},
+			// TODO(radu): remove this column; it is no longer used.
 			{Name: "trace", ID: 5, Type: types.Jsonb, Nullable: true},
 			{Name: "bundle_chunks", ID: 6, Type: types.IntArray, Nullable: true},
 			{Name: "error", ID: 7, Type: types.String, Nullable: true},

--- a/pkg/sql/stmtdiagnostics/statement_diagnostics.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics.go
@@ -401,9 +401,9 @@ func (r *Registry) InsertStatementDiagnostics(
 			ctx, "stmt-diag-insert", txn,
 			sessiondata.InternalExecutorOverride{User: security.RootUserName()},
 			"INSERT INTO system.statement_diagnostics "+
-				"(statement_fingerprint, statement, collected_at, trace, bundle_chunks, error) "+
-				"VALUES ($1, $2, $3, $4, $5, $6) RETURNING id",
-			stmtFingerprint, stmt, collectionTime, traceJSON, bundleChunksVal, errorVal,
+				"(statement_fingerprint, statement, collected_at, bundle_chunks, error) "+
+				"VALUES ($1, $2, $3, $4, $5) RETURNING id",
+			stmtFingerprint, stmt, collectionTime, bundleChunksVal, errorVal,
 		)
 		if err != nil {
 			return err

--- a/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
@@ -66,13 +66,6 @@ func TestDiagnosticsRequest(t *testing.T) {
 
 	checkCompleted(reqID)
 
-	// Check the trace.
-	row := db.QueryRow("SELECT jsonb_pretty(trace) FROM system.statement_diagnostics WHERE ID = $1", traceID.Int64)
-	var json string
-	require.NoError(t, row.Scan(&json))
-	require.Contains(t, json, "traced statement")
-	require.Contains(t, json, "statement execution committed the txn")
-
 	// Verify that we can handle multiple requests at the same time.
 	id1, err := registry.InsertRequestInternal(ctx, "INSERT INTO test VALUES (_)")
 	require.NoError(t, err)
@@ -139,13 +132,6 @@ func TestDiagnosticsRequestDifferentNode(t *testing.T) {
 			return nil
 		})
 		require.True(t, traceID.Valid)
-
-		// Check the trace.
-		row := db0.QueryRow(`SELECT jsonb_pretty(trace) FROM system.statement_diagnostics
-                         WHERE ID = $1`, traceID.Int64)
-		var json string
-		require.NoError(t, row.Scan(&json))
-		require.Contains(t, json, "traced statement")
 	}
 	runUntilTraced("INSERT INTO test VALUES (1)", reqID)
 

--- a/pkg/ui/src/views/reports/containers/statementDiagnosticsHistory/index.tsx
+++ b/pkg/ui/src/views/reports/containers/statementDiagnosticsHistory/index.tsx
@@ -13,14 +13,12 @@ import { Helmet } from "react-helmet";
 import { connect } from "react-redux";
 import moment from "moment";
 import { Action, Dispatch } from "redux";
-import Long from "long";
 import { Link } from "react-router-dom";
 import { isUndefined } from "lodash";
 
 import { Anchor, Button, Text, TextTypes, Tooltip } from "src/components";
 import HeaderSection from "src/views/shared/components/headerSection";
 import { AdminUIState } from "src/redux/state";
-import { getStatementDiagnostics } from "src/util/api";
 import { trustIcon } from "src/util/trust";
 import DownloadIcon from "!!raw-loader!assets/download.svg";
 import {
@@ -36,7 +34,6 @@ import { DiagnosticStatusBadge } from "src/views/statements/diagnostics/diagnost
 import "./statementDiagnosticsHistoryView.styl";
 import { cockroach } from "src/js/protos";
 import IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosticsReport;
-import StatementDiagnosticsRequest = cockroach.server.serverpb.StatementDiagnosticsRequest;
 import {
   SortedTable,
   ColumnDescriptor,
@@ -202,19 +199,6 @@ class StatementDiagnosticsHistoryView extends React.Component<
       <div className="diagnostics-history-view__table-header">
         <Text>{`${this.tablePageSize} of ${totalCount} traces`}</Text>
       </div>
-    );
-  };
-
-  getStatementDiagnostics = async (diagnosticsId: Long) => {
-    const request = new StatementDiagnosticsRequest({
-      statement_diagnostics_id: diagnosticsId,
-    });
-    const response = await getStatementDiagnostics(request);
-    const trace = response.diagnostics?.trace;
-    this.downloadRef.current?.download(
-      "statement-diagnostics.json",
-      "application/json",
-      trace,
     );
   };
 


### PR DESCRIPTION
The trace JSON stored in the statement_diagnostics table can be
arbitrarily large which causes problems for very large queries. This
trace is not currently used, and is contained in the bundle itself.
We stop writing it to the table in this commit. We can remove the
column altogether in a separate change (it will require a migration).

Fixes #61874.

Release note (bug fix): Fixed "command is too large" errors in some
cases when using EXPLAIN ANALYZE (DEBUG) or statement diagnostics on
complex queries.