### PR TITLE
release-20.2: colexec: propagate disk full error as expected

### DIFF
--- a/pkg/sql/colexec/external_hash_joiner.go
+++ b/pkg/sql/colexec/external_hash_joiner.go
@@ -461,7 +461,7 @@ func (hj *externalHashJoiner) partitionBatch(
 				scratchBatch.SetLength(len(sel))
 			})
 			if err := partitioner.Enqueue(ctx, partitionIdx, scratchBatch); err != nil {
-				colexecerror.InternalError(err)
+				handleErrorFromDiskQueue(err)
 			}
 			partitionInfo, ok := hj.partitionsToJoinUsingInMemHash[partitionIdx]
 			if !ok {

--- a/pkg/sql/colexec/external_sort.go
+++ b/pkg/sql/colexec/external_sort.go
@@ -272,7 +272,7 @@ func (s *externalSorter) Next(ctx context.Context) coldata.Batch {
 				s.partitioner = s.partitionerCreator()
 			}
 			if err := s.partitioner.Enqueue(ctx, newPartitionIdx, b); err != nil {
-				colexecerror.InternalError(err)
+				handleErrorFromDiskQueue(err)
 			}
 			s.state = externalSorterSpillPartition
 			continue
@@ -305,7 +305,7 @@ func (s *externalSorter) Next(ctx context.Context) coldata.Batch {
 				s.fdState.acquiredFDs = toAcquire
 			}
 			if err := s.partitioner.Enqueue(ctx, curPartitionIdx, b); err != nil {
-				colexecerror.InternalError(err)
+				handleErrorFromDiskQueue(err)
 			}
 			continue
 		case externalSorterRepeatedMerging:
@@ -330,7 +330,7 @@ func (s *externalSorter) Next(ctx context.Context) coldata.Batch {
 			newPartitionIdx := s.firstPartitionIdx + s.numPartitions
 			for b := merger.Next(ctx); b.Length() > 0; b = merger.Next(ctx) {
 				if err := s.partitioner.Enqueue(ctx, newPartitionIdx, b); err != nil {
-					colexecerror.InternalError(err)
+					handleErrorFromDiskQueue(err)
 				}
 			}
 			// We are now done with the merger, so we can release the memory

--- a/pkg/sql/colexec/mergejoiner.go
+++ b/pkg/sql/colexec/mergejoiner.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexecbase/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -622,9 +621,7 @@ func (o *mergeJoinBase) appendToBufferedGroup(
 	})
 	scratchBatch.SetSelection(false)
 	scratchBatch.SetLength(groupLength)
-	if err := bufferedGroup.enqueue(ctx, scratchBatch); err != nil {
-		colexecerror.InternalError(err)
-	}
+	bufferedGroup.enqueue(ctx, scratchBatch)
 }
 
 // setBuilderSourceToBatch sets the builder state to use groups from the

--- a/pkg/sql/colexec/relative_rank.eg.go
+++ b/pkg/sql/colexec/relative_rank.eg.go
@@ -223,9 +223,7 @@ func (r *percentRankNoPartitionOp) Next(ctx context.Context) coldata.Batch {
 			batch := r.Input().Next(ctx)
 			n := batch.Length()
 			if n == 0 {
-				if err := r.bufferedTuples.enqueue(ctx, coldata.ZeroBatch); err != nil {
-					colexecerror.InternalError(err)
-				}
+				r.bufferedTuples.enqueue(ctx, coldata.ZeroBatch)
 				// We have fully consumed the input, so now we can populate the output.
 				r.state = relativeRankEmitting
 				continue
@@ -254,9 +252,7 @@ func (r *percentRankNoPartitionOp) Next(ctx context.Context) coldata.Batch {
 				}
 				r.scratch.SetLength(n)
 			})
-			if err := r.bufferedTuples.enqueue(ctx, r.scratch); err != nil {
-				colexecerror.InternalError(err)
-			}
+			r.bufferedTuples.enqueue(ctx, r.scratch)
 
 			// Then, we need to update the sizes of the partitions.
 			// There is a single partition in the whole input.
@@ -423,9 +419,7 @@ func (r *percentRankWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 			batch := r.Input().Next(ctx)
 			n := batch.Length()
 			if n == 0 {
-				if err := r.bufferedTuples.enqueue(ctx, coldata.ZeroBatch); err != nil {
-					colexecerror.InternalError(err)
-				}
+				r.bufferedTuples.enqueue(ctx, coldata.ZeroBatch)
 				// We need to flush the last vector of the running partitions
 				// sizes, including the very last partition.
 				if r.partitionsState.runningSizes == nil {
@@ -438,12 +432,8 @@ func (r *percentRankWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 				runningPartitionsSizesCol[r.partitionsState.idx] = r.numTuplesInPartition
 				r.partitionsState.idx++
 				r.partitionsState.runningSizes.SetLength(r.partitionsState.idx)
-				if err := r.partitionsState.enqueue(ctx, r.partitionsState.runningSizes); err != nil {
-					colexecerror.InternalError(err)
-				}
-				if err := r.partitionsState.enqueue(ctx, coldata.ZeroBatch); err != nil {
-					colexecerror.InternalError(err)
-				}
+				r.partitionsState.enqueue(ctx, r.partitionsState.runningSizes)
+				r.partitionsState.enqueue(ctx, coldata.ZeroBatch)
 				// We have fully consumed the input, so now we can populate the output.
 				r.state = relativeRankEmitting
 				continue
@@ -474,9 +464,7 @@ func (r *percentRankWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 				}
 				r.scratch.SetLength(n)
 			})
-			if err := r.bufferedTuples.enqueue(ctx, r.scratch); err != nil {
-				colexecerror.InternalError(err)
-			}
+			r.bufferedTuples.enqueue(ctx, r.scratch)
 
 			// Then, we need to update the sizes of the partitions.
 			partitionCol := batch.ColVec(r.partitionColIdx).Bool()
@@ -504,9 +492,7 @@ func (r *percentRankWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 							if r.partitionsState.idx == coldata.BatchSize() {
 								// We need to flush the vector of partitions sizes.
 								r.partitionsState.runningSizes.SetLength(coldata.BatchSize())
-								if err := r.partitionsState.enqueue(ctx, r.partitionsState.runningSizes); err != nil {
-									colexecerror.InternalError(err)
-								}
+								r.partitionsState.enqueue(ctx, r.partitionsState.runningSizes)
 								r.partitionsState.runningSizes = nil
 								r.partitionsState.idx = 0
 							}
@@ -534,9 +520,7 @@ func (r *percentRankWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 							if r.partitionsState.idx == coldata.BatchSize() {
 								// We need to flush the vector of partitions sizes.
 								r.partitionsState.runningSizes.SetLength(coldata.BatchSize())
-								if err := r.partitionsState.enqueue(ctx, r.partitionsState.runningSizes); err != nil {
-									colexecerror.InternalError(err)
-								}
+								r.partitionsState.enqueue(ctx, r.partitionsState.runningSizes)
 								r.partitionsState.runningSizes = nil
 								r.partitionsState.idx = 0
 							}
@@ -727,9 +711,7 @@ func (r *cumeDistNoPartitionOp) Next(ctx context.Context) coldata.Batch {
 			batch := r.Input().Next(ctx)
 			n := batch.Length()
 			if n == 0 {
-				if err := r.bufferedTuples.enqueue(ctx, coldata.ZeroBatch); err != nil {
-					colexecerror.InternalError(err)
-				}
+				r.bufferedTuples.enqueue(ctx, coldata.ZeroBatch)
 				// We need to flush the last vector of the running peer groups
 				// sizes, including the very last peer group.
 				if r.peerGroupsState.runningSizes == nil {
@@ -742,12 +724,8 @@ func (r *cumeDistNoPartitionOp) Next(ctx context.Context) coldata.Batch {
 				runningPeerGroupsSizesCol[r.peerGroupsState.idx] = r.numPeers
 				r.peerGroupsState.idx++
 				r.peerGroupsState.runningSizes.SetLength(r.peerGroupsState.idx)
-				if err := r.peerGroupsState.enqueue(ctx, r.peerGroupsState.runningSizes); err != nil {
-					colexecerror.InternalError(err)
-				}
-				if err := r.peerGroupsState.enqueue(ctx, coldata.ZeroBatch); err != nil {
-					colexecerror.InternalError(err)
-				}
+				r.peerGroupsState.enqueue(ctx, r.peerGroupsState.runningSizes)
+				r.peerGroupsState.enqueue(ctx, coldata.ZeroBatch)
 				// We have fully consumed the input, so now we can populate the output.
 				r.state = relativeRankEmitting
 				continue
@@ -776,9 +754,7 @@ func (r *cumeDistNoPartitionOp) Next(ctx context.Context) coldata.Batch {
 				}
 				r.scratch.SetLength(n)
 			})
-			if err := r.bufferedTuples.enqueue(ctx, r.scratch); err != nil {
-				colexecerror.InternalError(err)
-			}
+			r.bufferedTuples.enqueue(ctx, r.scratch)
 
 			// Then, we need to update the sizes of the partitions.
 			// There is a single partition in the whole input.
@@ -810,9 +786,7 @@ func (r *cumeDistNoPartitionOp) Next(ctx context.Context) coldata.Batch {
 							if r.peerGroupsState.idx == coldata.BatchSize() {
 								// We need to flush the vector of peer group sizes.
 								r.peerGroupsState.runningSizes.SetLength(coldata.BatchSize())
-								if err := r.peerGroupsState.enqueue(ctx, r.peerGroupsState.runningSizes); err != nil {
-									colexecerror.InternalError(err)
-								}
+								r.peerGroupsState.enqueue(ctx, r.peerGroupsState.runningSizes)
 								r.peerGroupsState.runningSizes = nil
 								r.peerGroupsState.idx = 0
 							}
@@ -840,9 +814,7 @@ func (r *cumeDistNoPartitionOp) Next(ctx context.Context) coldata.Batch {
 							if r.peerGroupsState.idx == coldata.BatchSize() {
 								// We need to flush the vector of peer group sizes.
 								r.peerGroupsState.runningSizes.SetLength(coldata.BatchSize())
-								if err := r.peerGroupsState.enqueue(ctx, r.peerGroupsState.runningSizes); err != nil {
-									colexecerror.InternalError(err)
-								}
+								r.peerGroupsState.enqueue(ctx, r.peerGroupsState.runningSizes)
 								r.peerGroupsState.runningSizes = nil
 								r.peerGroupsState.idx = 0
 							}
@@ -1030,9 +1002,7 @@ func (r *cumeDistWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 			batch := r.Input().Next(ctx)
 			n := batch.Length()
 			if n == 0 {
-				if err := r.bufferedTuples.enqueue(ctx, coldata.ZeroBatch); err != nil {
-					colexecerror.InternalError(err)
-				}
+				r.bufferedTuples.enqueue(ctx, coldata.ZeroBatch)
 				// We need to flush the last vector of the running partitions
 				// sizes, including the very last partition.
 				if r.partitionsState.runningSizes == nil {
@@ -1045,12 +1015,8 @@ func (r *cumeDistWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 				runningPartitionsSizesCol[r.partitionsState.idx] = r.numTuplesInPartition
 				r.partitionsState.idx++
 				r.partitionsState.runningSizes.SetLength(r.partitionsState.idx)
-				if err := r.partitionsState.enqueue(ctx, r.partitionsState.runningSizes); err != nil {
-					colexecerror.InternalError(err)
-				}
-				if err := r.partitionsState.enqueue(ctx, coldata.ZeroBatch); err != nil {
-					colexecerror.InternalError(err)
-				}
+				r.partitionsState.enqueue(ctx, r.partitionsState.runningSizes)
+				r.partitionsState.enqueue(ctx, coldata.ZeroBatch)
 				// We need to flush the last vector of the running peer groups
 				// sizes, including the very last peer group.
 				if r.peerGroupsState.runningSizes == nil {
@@ -1063,12 +1029,8 @@ func (r *cumeDistWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 				runningPeerGroupsSizesCol[r.peerGroupsState.idx] = r.numPeers
 				r.peerGroupsState.idx++
 				r.peerGroupsState.runningSizes.SetLength(r.peerGroupsState.idx)
-				if err := r.peerGroupsState.enqueue(ctx, r.peerGroupsState.runningSizes); err != nil {
-					colexecerror.InternalError(err)
-				}
-				if err := r.peerGroupsState.enqueue(ctx, coldata.ZeroBatch); err != nil {
-					colexecerror.InternalError(err)
-				}
+				r.peerGroupsState.enqueue(ctx, r.peerGroupsState.runningSizes)
+				r.peerGroupsState.enqueue(ctx, coldata.ZeroBatch)
 				// We have fully consumed the input, so now we can populate the output.
 				r.state = relativeRankEmitting
 				continue
@@ -1099,9 +1061,7 @@ func (r *cumeDistWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 				}
 				r.scratch.SetLength(n)
 			})
-			if err := r.bufferedTuples.enqueue(ctx, r.scratch); err != nil {
-				colexecerror.InternalError(err)
-			}
+			r.bufferedTuples.enqueue(ctx, r.scratch)
 
 			// Then, we need to update the sizes of the partitions.
 			partitionCol := batch.ColVec(r.partitionColIdx).Bool()
@@ -1129,9 +1089,7 @@ func (r *cumeDistWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 							if r.partitionsState.idx == coldata.BatchSize() {
 								// We need to flush the vector of partitions sizes.
 								r.partitionsState.runningSizes.SetLength(coldata.BatchSize())
-								if err := r.partitionsState.enqueue(ctx, r.partitionsState.runningSizes); err != nil {
-									colexecerror.InternalError(err)
-								}
+								r.partitionsState.enqueue(ctx, r.partitionsState.runningSizes)
 								r.partitionsState.runningSizes = nil
 								r.partitionsState.idx = 0
 							}
@@ -1159,9 +1117,7 @@ func (r *cumeDistWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 							if r.partitionsState.idx == coldata.BatchSize() {
 								// We need to flush the vector of partitions sizes.
 								r.partitionsState.runningSizes.SetLength(coldata.BatchSize())
-								if err := r.partitionsState.enqueue(ctx, r.partitionsState.runningSizes); err != nil {
-									colexecerror.InternalError(err)
-								}
+								r.partitionsState.enqueue(ctx, r.partitionsState.runningSizes)
 								r.partitionsState.runningSizes = nil
 								r.partitionsState.idx = 0
 							}
@@ -1197,9 +1153,7 @@ func (r *cumeDistWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 							if r.peerGroupsState.idx == coldata.BatchSize() {
 								// We need to flush the vector of peer group sizes.
 								r.peerGroupsState.runningSizes.SetLength(coldata.BatchSize())
-								if err := r.peerGroupsState.enqueue(ctx, r.peerGroupsState.runningSizes); err != nil {
-									colexecerror.InternalError(err)
-								}
+								r.peerGroupsState.enqueue(ctx, r.peerGroupsState.runningSizes)
 								r.peerGroupsState.runningSizes = nil
 								r.peerGroupsState.idx = 0
 							}
@@ -1227,9 +1181,7 @@ func (r *cumeDistWithPartitionOp) Next(ctx context.Context) coldata.Batch {
 							if r.peerGroupsState.idx == coldata.BatchSize() {
 								// We need to flush the vector of peer group sizes.
 								r.peerGroupsState.runningSizes.SetLength(coldata.BatchSize())
-								if err := r.peerGroupsState.enqueue(ctx, r.peerGroupsState.runningSizes); err != nil {
-									colexecerror.InternalError(err)
-								}
+								r.peerGroupsState.enqueue(ctx, r.peerGroupsState.runningSizes)
 								r.peerGroupsState.runningSizes = nil
 								r.peerGroupsState.idx = 0
 							}

--- a/pkg/sql/colexec/relative_rank_tmpl.go
+++ b/pkg/sql/colexec/relative_rank_tmpl.go
@@ -154,9 +154,7 @@ func _COMPUTE_PARTITIONS_SIZES() { // */}}
 			if r.partitionsState.idx == coldata.BatchSize() {
 				// We need to flush the vector of partitions sizes.
 				r.partitionsState.runningSizes.SetLength(coldata.BatchSize())
-				if err := r.partitionsState.enqueue(ctx, r.partitionsState.runningSizes); err != nil {
-					colexecerror.InternalError(err)
-				}
+				r.partitionsState.enqueue(ctx, r.partitionsState.runningSizes)
 				r.partitionsState.runningSizes = nil
 				r.partitionsState.idx = 0
 			}
@@ -192,9 +190,7 @@ func _COMPUTE_PEER_GROUPS_SIZES() { // */}}
 			if r.peerGroupsState.idx == coldata.BatchSize() {
 				// We need to flush the vector of peer group sizes.
 				r.peerGroupsState.runningSizes.SetLength(coldata.BatchSize())
-				if err := r.peerGroupsState.enqueue(ctx, r.peerGroupsState.runningSizes); err != nil {
-					colexecerror.InternalError(err)
-				}
+				r.peerGroupsState.enqueue(ctx, r.peerGroupsState.runningSizes)
 				r.peerGroupsState.runningSizes = nil
 				r.peerGroupsState.idx = 0
 			}
@@ -348,9 +344,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 			batch := r.Input().Next(ctx)
 			n := batch.Length()
 			if n == 0 {
-				if err := r.bufferedTuples.enqueue(ctx, coldata.ZeroBatch); err != nil {
-					colexecerror.InternalError(err)
-				}
+				r.bufferedTuples.enqueue(ctx, coldata.ZeroBatch)
 				// {{if .HasPartition}}
 				// We need to flush the last vector of the running partitions
 				// sizes, including the very last partition.
@@ -364,12 +358,8 @@ func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 				runningPartitionsSizesCol[r.partitionsState.idx] = r.numTuplesInPartition
 				r.partitionsState.idx++
 				r.partitionsState.runningSizes.SetLength(r.partitionsState.idx)
-				if err := r.partitionsState.enqueue(ctx, r.partitionsState.runningSizes); err != nil {
-					colexecerror.InternalError(err)
-				}
-				if err := r.partitionsState.enqueue(ctx, coldata.ZeroBatch); err != nil {
-					colexecerror.InternalError(err)
-				}
+				r.partitionsState.enqueue(ctx, r.partitionsState.runningSizes)
+				r.partitionsState.enqueue(ctx, coldata.ZeroBatch)
 				// {{end}}
 				// {{if .IsCumeDist}}
 				// We need to flush the last vector of the running peer groups
@@ -384,12 +374,8 @@ func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 				runningPeerGroupsSizesCol[r.peerGroupsState.idx] = r.numPeers
 				r.peerGroupsState.idx++
 				r.peerGroupsState.runningSizes.SetLength(r.peerGroupsState.idx)
-				if err := r.peerGroupsState.enqueue(ctx, r.peerGroupsState.runningSizes); err != nil {
-					colexecerror.InternalError(err)
-				}
-				if err := r.peerGroupsState.enqueue(ctx, coldata.ZeroBatch); err != nil {
-					colexecerror.InternalError(err)
-				}
+				r.peerGroupsState.enqueue(ctx, r.peerGroupsState.runningSizes)
+				r.peerGroupsState.enqueue(ctx, coldata.ZeroBatch)
 				// {{end}}
 				// We have fully consumed the input, so now we can populate the output.
 				r.state = relativeRankEmitting
@@ -426,9 +412,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Next(ctx context.Context) coldata.Batch {
 				}
 				r.scratch.SetLength(n)
 			})
-			if err := r.bufferedTuples.enqueue(ctx, r.scratch); err != nil {
-				colexecerror.InternalError(err)
-			}
+			r.bufferedTuples.enqueue(ctx, r.scratch)
 
 			// Then, we need to update the sizes of the partitions.
 			// {{if .HasPartition}}

--- a/pkg/sql/colexec/routers.go
+++ b/pkg/sql/colexec/routers.go
@@ -381,12 +381,11 @@ func (o *routerOutputOp) addBatch(ctx context.Context, batch coldata.Batch, sele
 
 	if batch.Length() == 0 {
 		if o.mu.pendingBatch != nil {
-			err := o.mu.data.enqueue(ctx, o.mu.pendingBatch)
-			if err == nil && o.testingKnobs.addBatchTestInducedErrorCb != nil {
-				err = o.testingKnobs.addBatchTestInducedErrorCb()
-			}
-			if err != nil {
-				colexecerror.InternalError(err)
+			o.mu.data.enqueue(ctx, o.mu.pendingBatch)
+			if o.testingKnobs.addBatchTestInducedErrorCb != nil {
+				if err := o.testingKnobs.addBatchTestInducedErrorCb(); err != nil {
+					colexecerror.InternalError(err)
+				}
 			}
 		} else if o.testingKnobs.addBatchTestInducedErrorCb != nil {
 			// This is the last chance to run addBatchTestInducedErorCb if it has
@@ -436,12 +435,11 @@ func (o *routerOutputOp) addBatch(ctx context.Context, batch coldata.Batch, sele
 		o.mu.pendingBatch.SetLength(newLength)
 		if o.testingKnobs.alwaysFlush || newLength >= o.mu.pendingBatch.Capacity() {
 			// The capacity in o.mu.pendingBatch has been filled.
-			err := o.mu.data.enqueue(ctx, o.mu.pendingBatch)
-			if err == nil && o.testingKnobs.addBatchTestInducedErrorCb != nil {
-				err = o.testingKnobs.addBatchTestInducedErrorCb()
-			}
-			if err != nil {
-				colexecerror.InternalError(err)
+			o.mu.data.enqueue(ctx, o.mu.pendingBatch)
+			if o.testingKnobs.addBatchTestInducedErrorCb != nil {
+				if err := o.testingKnobs.addBatchTestInducedErrorCb(); err != nil {
+					colexecerror.InternalError(err)
+				}
 			}
 			o.mu.pendingBatch = nil
 		}

--- a/pkg/sql/colexec/spilling_queue_test.go
+++ b/pkg/sql/colexec/spilling_queue_test.go
@@ -96,7 +96,7 @@ func TestSpillingQueue(t *testing.T) {
 			ctx := context.Background()
 			for {
 				b = op.Next(ctx)
-				require.NoError(t, q.enqueue(ctx, b))
+				q.enqueue(ctx, b)
 				if b.Length() == 0 {
 					break
 				}

--- a/pkg/sql/sqlerrors/errors.go
+++ b/pkg/sql/sqlerrors/errors.go
@@ -218,6 +218,11 @@ func IsOutOfMemoryError(err error) bool {
 	return errHasCode(err, pgcode.OutOfMemory)
 }
 
+// IsDiskFullError checks whether this is a disk full error.
+func IsDiskFullError(err error) bool {
+	return errHasCode(err, pgcode.DiskFull)
+}
+
 // IsUndefinedColumnError checks whether this is an undefined column error.
 func IsUndefinedColumnError(err error) bool {
 	return errHasCode(err, pgcode.UndefinedColumn)


### PR DESCRIPTION
Backport 1/1 commits from #61790.

/cc @cockroachdb/release

---

Previously, we would always propagate the errors emitted by the spilling
queues and disk queues as "internal" which resulted in errors being
annotated. However, "disk full" errors are expected to occur, so this
commit cleans that up. Additionally, it plumbs the propagation into the
spilling queue's `Enqueue` method itself to remove some of the
duplicated code.

Fixes: #61769.

Release note: None
