### PR TITLE
sql: Fix panic when transitioning from REGIONAL BY ROW

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -2436,8 +2436,20 @@ func (sc *SchemaChanger) applyZoneConfigChangeForMutation(
 				switch lcSwap.NewLocalityConfig.Locality.(type) {
 				case *descpb.TableDescriptor_LocalityConfig_Global_,
 					*descpb.TableDescriptor_LocalityConfig_RegionalByTable_:
-					// Nothing to do here. The table re-writing the locality config is all
-					// that is required.
+					// The table re-writing the LocalityConfig does most of the work for
+					// us here, but if we're coming from REGIONAL BY ROW, it's also
+					// necessary to drop the zone configurations on the index partitions.
+					if lcSwap.OldLocalityConfig.GetRegionalByRow() != nil {
+						opts = append(
+							opts,
+							dropZoneConfigsForMultiRegionIndexes(
+								append(
+									[]descpb.IndexID{pkSwap.OldPrimaryIndexId},
+									pkSwap.OldIndexes...,
+								)...,
+							),
+						)
+					}
 				case *descpb.TableDescriptor_LocalityConfig_RegionalByRow_:
 					// Apply new zone configurations for all newly partitioned indexes.
 					opts = append(

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -500,6 +500,7 @@ func repartitionRegionalByRowTables(
 		tableDesc, err := localPlanner.Descriptors().GetMutableTableByID(
 			ctx, txn, tbID, tree.ObjectLookupFlags{
 				CommonLookupFlags: tree.CommonLookupFlags{
+					AvoidCached:    true,
 					Required:       true,
 					IncludeDropped: true,
 				},


### PR DESCRIPTION
Before this commit, the transition from REGIONAL BY ROW to REGIONAL
BY TABLE would drop the partitioning on the table not drop the
zone configurations. As a result, when the index GC runs, it would
try and cleanup the zone configurations. This hit an issue though,
as the types are not properly hydrated in the index GC code path.
The end result was that the index GC would panic and bring down the
node. To work around this problem this commit adds code to remove
the zone configs when dropping the table partitioning.

Note: This commit does not solve the root cause of this issue, but
instead, prevent the failure from occurring when transitioning from
REGIONAL BY ROW tables to REGIONAL BY TABLE tables.  A new issue
will be opened for the general problem.

Release note: None

Resolves #61751 .