### PR TITLE
release-20.2: sql: don't save memo unnecessarily

### DIFF
--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -279,7 +279,7 @@ type planTop struct {
 	planComponents
 
 	// mem/catalog retains the memo and catalog that were used to create the
-	// plan.
+	// plan. Only set if savePlanForStats or savePlanString is true.
 	mem     *memo.Memo
 	catalog *optCatalog
 

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -598,8 +598,6 @@ func (opc *optPlanningCtx) runExecBuilder(
 
 	planTop.planComponents = *result
 	planTop.explainPlan = explainPlan
-	planTop.mem = mem
-	planTop.catalog = &opc.catalog
 	planTop.codec = codec
 	planTop.stmt = stmt
 	planTop.flags = opc.flags
@@ -611,6 +609,10 @@ func (opc *optPlanningCtx) runExecBuilder(
 	}
 	if containsFullIndexScan {
 		planTop.flags.Set(planFlagContainsFullIndexScan)
+	}
+	if planTop.savePlanString || planTop.savePlanForStats {
+		planTop.mem = mem
+		planTop.catalog = &opc.catalog
 	}
 	return nil
 }


### PR DESCRIPTION
Backport 1/1 commits from #61863.

/cc @cockroachdb/release

---

We save a reference to the Memo, which is useful for explaining plans.
However, this means that we're holding on to the memory used by the
entire explored memo during execution of the query. This change makes
it so that we only save it only if we're building an explain plan.

Fixes #59065.

Release note: None
