### PR TITLE
[dnm] roachprod: start crdb in a container

### DIFF
--- a/pkg/cmd/roachprod/install/cockroach.go
+++ b/pkg/cmd/roachprod/install/cockroach.go
@@ -149,13 +149,14 @@ func (r Cockroach) Start(c *SyncedCluster, extraArgs []string) {
 
 	fmt.Printf("%s: starting nodes\n", c.Name)
 	c.Parallel("", len(nodes), parallelism, func(nodeIdx int) ([]byte, error) {
-		vers, err := getCockroachVersion(c, nodes[nodeIdx])
-		if err != nil {
-			return nil, err
-		}
+		//vers, err := getCockroachVersion(c, nodes[nodeIdx])
+		//if err != nil {
+		//	return nil, err
+		//}
 
 		// NB: if cockroach started successfully, we ignore the output as it is
 		// some harmless start messaging.
+		vers := version.MustParse("v21.1.0")
 		if _, err := h.startNode(nodeIdx, extraArgs, vers); err != nil {
 			return nil, err
 		}
@@ -216,14 +217,14 @@ func (r Cockroach) Start(c *SyncedCluster, extraArgs []string) {
 		// We're sure to set cluster settings after having initialized the
 		// cluster.
 
-		fmt.Printf("%s: setting cluster settings\n", h.c.Name)
-		clusterSettingsOut, err := h.setClusterSettings(nodeIdx)
-		if err != nil {
-			log.Fatalf("unable to set cluster settings: %v", err)
-		}
-		if clusterSettingsOut != "" {
-			fmt.Println(clusterSettingsOut)
-		}
+		//fmt.Printf("%s: setting cluster settings\n", h.c.Name)
+		//clusterSettingsOut, err := h.setClusterSettings(nodeIdx)
+		//if err != nil {
+		//	log.Fatalf("unable to set cluster settings: %v", err)
+		//}
+		//if clusterSettingsOut != "" {
+		//	fmt.Println(clusterSettingsOut)
+		//}
 		return nil, nil
 	})
 }
@@ -396,6 +397,8 @@ func (h *crdbInstallHelper) generateStartCmd(
 	binary := cockroachNodeBinary(h.c, nodes[nodeIdx])
 	keyCmd := h.generateKeyCmd(nodeIdx, extraArgs)
 
+	// NB hard-coding uid/gid 1000 is no good
+	binary = "docker run -d -u 1000:1000 -v /mnt:/mnt -v /home/ubuntu/logs:/home/ubuntu/logs -p 0.0.0.0:26257:26257 -p 0.0.0.0:26258:26258 -p 0.0.0.0:8080:8080 cockroachdb/cockroach"
 	// NB: this is awkward as when the process fails, the test runner will show an
 	// unhelpful empty error (since everything has been redirected away). This is
 	// unfortunately equally awkward to address.
@@ -427,7 +430,7 @@ func (h *crdbInstallHelper) generateStartArgs(
 	var args []string
 	nodes := h.c.ServerNodes()
 
-	args = append(args, "--background")
+	// args = append(args, "--background")
 	if h.c.Secure {
 		args = append(args, "--certs-dir="+h.c.Impl.CertsDir(h.c, nodes[nodeIdx]))
 	} else {


### PR DESCRIPTION
This isn't something I am planning to finish, but I wanted to see if I
would immediately run into any snags when trying to get `roachprod
start` to spin up a Docker container instead of running bare-metal.

The motivation is twofold:

- I'm generally interested in how we involve roachprod over time.
  Specifically, the question is whether in the long run systems testing
  should be done in k8s and which, if any, stepping stones there are to
  evolve what we currently do into that direction.
- The current bare-metal setup goes [unresponsive] when CRDB goes into
  overdrive, and tests fail in the most opaque ways. We then incur a
  large tax for debugging these situations since we can't access the
  cluster in that state.

Work that would need to be done to really finish this:

- maintain ubuntu images that come with docker installed (right now
  needs to be manually set up) and the `ubuntu` user set up and the images
  we need cached
- we hit the old problem of having to pass the uid/gid to the container
  to avoid creating files as root, I hacked around it by hard-coding
  them
- Setting the cluster settings, etc, is all done via the `./cockroach`
  binary but that is no longer a thing. Ideally that should use SQL
- The whole premise of uploading binaries is out of the window, we
  need to deal in CRDB containers exclusively, though we could
  conceivably use a wrapper container running the uploaded binary
  if we wanted to retain how roachprod/test work.

cc @irfansharif

[unresponsive]: https://github.com/cockroachdb/cockroach/issues/59424#issuecomment-795436509

Release note: None
