### PR TITLE
builtins: fix json_extract_path_text NULL bug

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/json_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/json_builtins
@@ -615,6 +615,11 @@ SELECT json_extract_path('{"a": {"b": 2}}', 'a', 'b', 'c')
 NULL
 
 query T
+SELECT json_extract_path('null')
+----
+null
+
+query T
 SELECT json_extract_path_text('{"a": 1}', 'a')
 ----
 1
@@ -646,6 +651,11 @@ SELECT jsonb_extract_path_text('{"a": {"b": 2}}', 'a', 'b')
 
 query T
 SELECT json_extract_path_text('{"a": {"b": 2}}', 'a', 'b', 'c')
+----
+NULL
+
+query T
+SELECT json_extract_path_text('null')
 ----
 NULL
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -5588,6 +5588,9 @@ var jsonExtractPathTextImpl = tree.Overload{
 		if err != nil {
 			return nil, err
 		}
+		if text == nil {
+			return tree.DNull, nil
+		}
 		return tree.NewDString(*text), nil
 	},
 	Info:       "Returns the JSON value as text pointed to by the variadic arguments.",


### PR DESCRIPTION
If a null JSON is returned, then the text representation is a nil
pointer, which was not handled correctly.

No release note since this bug only exists in non-released versions.

Release note: None