### PR TITLE
release-21.1: opt: require column type for computed column expressions

### DIFF
--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -680,7 +680,7 @@ func (b *Builder) addComputedColsForTable(tabMeta *opt.TableMeta) {
 			tableScope.appendOrdinaryColumnsFromTable(tabMeta, &tabMeta.Alias)
 		}
 
-		if texpr := tableScope.resolveAndRequireType(expr, types.Any); texpr != nil {
+		if texpr := tableScope.resolveAndRequireType(expr, tabCol.DatumType()); texpr != nil {
 			colID := tabMeta.MetaID.ColumnID(i)
 			var scalar opt.ScalarExpr
 			b.factory.FoldingControl().TemporarilyDisallowStableFolds(func() {

--- a/pkg/sql/opt/optbuilder/testdata/virtual-columns
+++ b/pkg/sql/opt/optbuilder/testdata/virtual-columns
@@ -1237,3 +1237,50 @@ upsert t_idx2
            ├── CASE WHEN a:12 IS NULL THEN column3:9 ELSE c_new:18 END [as=upsert_c:23]
            ├── CASE WHEN a:12 IS NULL THEN column10:10 ELSE v:15 END [as=upsert_v:24]
            └── CASE WHEN a:12 IS NULL THEN column11:11 ELSE column20:20 END [as=upsert_w:25]
+
+# Test that virtual column expressions are forced to have the column type.
+exec-ddl
+CREATE TABLE coltyp (
+  k INT,
+  v INT AS (NULL) VIRTUAL,
+  w STRING AS (IF(k IS NULL, NULL, NULL)) VIRTUAL
+)
+----
+
+build format=(show-types,show-scalars)
+SELECT * FROM coltyp
+----
+project
+ ├── columns: k:1(int) v:2(int) w:3(string)
+ └── project
+      ├── columns: v:2(int) w:3(string) k:1(int) rowid:4(int!null) crdb_internal_mvcc_timestamp:5(decimal)
+      ├── scan coltyp
+      │    ├── columns: k:1(int) rowid:4(int!null) crdb_internal_mvcc_timestamp:5(decimal)
+      │    └── computed column expressions
+      │         ├── v:2
+      │         │    └── cast: INT8 [type=int]
+      │         │         └── null [type=unknown]
+      │         └── w:3
+      │              └── case [type=string]
+      │                   ├── is [type=bool]
+      │                   │    ├── variable: k:1 [type=int]
+      │                   │    └── null [type=unknown]
+      │                   ├── when [type=string]
+      │                   │    ├── true [type=bool]
+      │                   │    └── cast: STRING [type=string]
+      │                   │         └── null [type=unknown]
+      │                   └── cast: STRING [type=string]
+      │                        └── null [type=unknown]
+      └── projections
+           ├── cast: INT8 [as=v:2, type=int]
+           │    └── null [type=unknown]
+           └── case [as=w:3, type=string]
+                ├── is [type=bool]
+                │    ├── variable: k:1 [type=int]
+                │    └── null [type=unknown]
+                ├── when [type=string]
+                │    ├── true [type=bool]
+                │    └── cast: STRING [type=string]
+                │         └── null [type=unknown]
+                └── cast: STRING [type=string]
+                     └── null [type=unknown]

--- a/pkg/sql/opt/xform/testdata/rules/computed
+++ b/pkg/sql/opt/xform/testdata/rules/computed
@@ -20,14 +20,6 @@ CREATE TABLE t_float (
 ----
 
 exec-ddl
-CREATE TABLE t_now (
-    k_interval INTERVAL,
-    c_ts TIMESTAMP AS (now() + k_interval) STORED,
-    INDEX c_ts_index (c_ts, k_interval)
-)
-----
-
-exec-ddl
 CREATE TABLE t_rand (
     k_int INT,
     c_int INT AS ((random()*100)::INT + k_int) STORED,
@@ -150,18 +142,6 @@ select
  │              └── k_float:1 + 1.0
  └── filters
       └── k_float:1 = 5.0 [outer=(1), constraints=(/1: [/5.0 - /5.0]; tight), fd=()-->(1)]
-
-# Don't constrain the index when the computed column has a stable function.
-opt
-SELECT k_interval FROM t_now WHERE k_interval = '3 hours'
-----
-select
- ├── columns: k_interval:1!null
- ├── fd: ()-->(1)
- ├── scan t_now
- │    └── columns: k_interval:1
- └── filters
-      └── k_interval:1 = '03:00:00' [outer=(1), constraints=(/1: [/'03:00:00' - /'03:00:00']; tight), fd=()-->(1)]
 
 # Don't constrain the index when the computed column has a volatile function.
 opt


### PR DESCRIPTION
Backport 1/1 commits from #61806.

/cc @cockroachdb/release

---

When building computed column expression, the optbuilder was not
requiring the column type. This leads to user observable problems with
virtual columns (which are effectively replaced with the expression in
a query).

Fixes #61768.

Release justification: fix for new feature.

Release note: None
