### PR TITLE
sql: fix display of idle_in_*session_timeout

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -312,6 +312,34 @@ SHOW statement_timeout
 ----
 0
 
+statement ok
+SET idle_in_session_timeout = 10000
+
+query T
+SHOW idle_in_session_timeout
+----
+10000
+
+statement ok
+SET idle_in_session_timeout = 10000
+
+query T
+SHOW idle_in_session_timeout
+----
+10000
+
+statement ok
+SET idle_in_session_timeout = 0;
+SET idle_in_transaction_session_timeout = 123456
+
+query T
+SHOW idle_in_transaction_session_timeout
+----
+123456
+
+statement ok
+SET idle_in_transaction_session_timeout = 0
+
 # Test that composite variable names get rejected properly, especially
 # when "tracing" is used as prefix.
 

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -982,7 +982,7 @@ var varGen = map[string]sessionVar{
 		GetStringVal: makeTimeoutVarGetter(`idle_in_session_timeout`),
 		Set:          idleInSessionTimeoutVarSet,
 		Get: func(evalCtx *extendedEvalContext) string {
-			ms := evalCtx.SessionData.StmtTimeout.Nanoseconds() / int64(time.Millisecond)
+			ms := evalCtx.SessionData.IdleInSessionTimeout.Nanoseconds() / int64(time.Millisecond)
 			return strconv.FormatInt(ms, 10)
 		},
 		GlobalDefault: func(sv *settings.Values) string {
@@ -994,7 +994,7 @@ var varGen = map[string]sessionVar{
 		GetStringVal: makeTimeoutVarGetter(`idle_in_transaction_session_timeout`),
 		Set:          idleInTransactionSessionTimeoutVarSet,
 		Get: func(evalCtx *extendedEvalContext) string {
-			ms := evalCtx.SessionData.StmtTimeout.Nanoseconds() / int64(time.Millisecond)
+			ms := evalCtx.SessionData.IdleInTransactionSessionTimeout.Nanoseconds() / int64(time.Millisecond)
 			return strconv.FormatInt(ms, 10)
 		},
 		GlobalDefault: func(sv *settings.Values) string { return "0" },


### PR DESCRIPTION
Release note (bug fix): Previously the idle_in_session_timeout and
idle_in_transaction_session_timeout settings would show the wrong value
when using SHOW. They would instead show the value of the
statement_timeout setting. This is now fixed. The functionality was
already working correctly; this just fixes a display bug.