### PR TITLE
Add a SQL helper for determining the validity of upgrading to a new CRDB version

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2724,6 +2724,8 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.trace_id"></a><code>crdb_internal.trace_id() &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the current trace ID or an error if no trace is open.</p>
 </span></td></tr>
+<tr><td><a name="crdb_internal.version_upgrade_type"></a><code>crdb_internal.version_upgrade_type(to_version: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns a string describing the version change that will occur when moving to a different cockroachdbbinary. Possible return values are MinorUpgrade, MinorDowngrade, MajorUpgrade, MajorRollback, Unsupported, and None. version_upgrade_type does not take into account the preserve_downgrade_option when returning MajorRollback.</p>
+</span></td></tr>
 <tr><td><a name="current_database"></a><code>current_database() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the current database.</p>
 </span></td></tr>
 <tr><td><a name="current_schema"></a><code>current_schema() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the current schema.</p>

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -854,3 +854,11 @@ query B
 SELECT is_temporary FROM crdb_internal.create_statements WHERE descriptor_name = 'temp'
 ----
 true
+
+query T
+SELECT crdb_internal.version_upgrade_type('v0.0.0');
+----
+Unsupported
+
+query error unable to parse version
+SELECT crdb_internal.version_upgrade_type('not a version');

--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -83,6 +83,7 @@ go_library(
         "//pkg/util/tracing",
         "//pkg/util/unaccent",
         "//pkg/util/uuid",
+        "//pkg/util/version",
         "@com_github_cockroachdb_apd_v2//:apd",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_gogo_protobuf//types",

--- a/pkg/util/version/BUILD.bazel
+++ b/pkg/util/version/BUILD.bazel
@@ -13,4 +13,5 @@ go_test(
     size = "small",
     srcs = ["version_test.go"],
     embed = [":version"],
+    deps = ["@com_github_stretchr_testify//assert"],
 )


### PR DESCRIPTION
Both CC and the cockroach operator have had to write code to determine the type of upgrade between two versions of cockroachdb in order to tell what steps need to be taken for the upgrade and if the upgrade is possible at all. 
Both have also encountered issues with the logic and acquiring the versions.

This PR adds a helper, exposed over SQL, to push all of this logic into CRDB itself. It allows a user to pass in a version they would like to upgrade the cluster to and receive a string indicating if the upgrade is possible and what steps must be take to perform said upgrade.