### PR TITLE
release-20.2: opt: fix non-existent columns due to mutation rounding

### DIFF
--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -696,6 +696,20 @@ func (mb *mutationBuilder) roundDecimalValues(colIDs opt.ColList, roundComputedC
 		// Overwrite the input column ID with the new synthesized column ID.
 		colIDs[i] = scopeCol.id
 		mb.roundedDecimalCols.Add(scopeCol.id)
+
+		// When building an UPDATE..FROM expression the projectionScope may have
+		// two columns with different names but the same ID. As a result, the
+		// scope column with the correct name (the name of the target column)
+		// may not be returned from projectionScope.getColumn. We set the name
+		// of the new scope column to the target column name to ensure it is
+		// in-scope when building CHECK constraint and partial index PUT
+		// expressions. See #61520.
+		// TODO(mgartner): Find a less brittle way to manage the scopes of
+		// mutations so that this isn't necessary. Ideally the scope produced by
+		// addUpdateColumns would not include columns in the FROM clause. Those
+		// columns are only in-scope in the RETURNING clause via
+		// mb.extraAccessibleCols.
+		scopeCol.name = mb.tab.Column(i).ColName()
 	}
 
 	if projectionsScope != nil {

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -1827,3 +1827,51 @@ update partial_indexes
            ├── (a:5 > b:6) AND (c:7 = 'bar') [as=partial_index_del2:12]
            ├── c:7 = 'delete-only' [as=partial_index_put3:13]
            └── c:7 = 'write-only' [as=partial_index_put4:14]
+
+# Regression test for #61520. The new value for column a (project as b:8) should
+# be in-scope when building the partial index PUT expression when the value in
+# the FROM clause must be rounded.
+
+exec-ddl
+CREATE TABLE t61520 (
+  a DECIMAL(10, 2),
+  INDEX (a) WHERE a > 0
+)
+----
+
+build
+UPDATE t61520 t SET a = v.b FROM (VALUES (1.0)) v(b) WHERE t.a = v.b RETURNING a, b
+----
+project
+ ├── columns: a:1 b:7
+ └── update t
+      ├── columns: a:1 rowid:2!null column1:7
+      ├── fetch columns: a:4 rowid:5
+      ├── update-mapping:
+      │    └── b:8 => a:1
+      ├── partial index put columns: partial_index_put1:9
+      ├── partial index del columns: partial_index_del1:10
+      └── project
+           ├── columns: partial_index_put1:9 partial_index_del1:10!null a:4!null rowid:5!null crdb_internal_mvcc_timestamp:6 column1:7!null b:8
+           ├── project
+           │    ├── columns: b:8 a:4!null rowid:5!null crdb_internal_mvcc_timestamp:6 column1:7!null
+           │    ├── select
+           │    │    ├── columns: a:4!null rowid:5!null crdb_internal_mvcc_timestamp:6 column1:7!null
+           │    │    ├── inner-join (cross)
+           │    │    │    ├── columns: a:4 rowid:5!null crdb_internal_mvcc_timestamp:6 column1:7!null
+           │    │    │    ├── scan t
+           │    │    │    │    ├── columns: a:4 rowid:5!null crdb_internal_mvcc_timestamp:6
+           │    │    │    │    └── partial index predicates
+           │    │    │    │         └── secondary: filters
+           │    │    │    │              └── a:4 > 0
+           │    │    │    ├── values
+           │    │    │    │    ├── columns: column1:7!null
+           │    │    │    │    └── (1.0,)
+           │    │    │    └── filters (true)
+           │    │    └── filters
+           │    │         └── a:4 = column1:7
+           │    └── projections
+           │         └── crdb_internal.round_decimal_values(column1:7, 2) [as=b:8]
+           └── projections
+                ├── b:8 > 0 [as=partial_index_put1:9]
+                └── a:4 > 0 [as=partial_index_del1:10]

--- a/pkg/sql/opt/optbuilder/testdata/update_from
+++ b/pkg/sql/opt/optbuilder/testdata/update_from
@@ -350,3 +350,47 @@ update abc
            │    └── ac.c:14
            └── first-agg [as=ac.rowid:15]
                 └── ac.rowid:15
+
+
+# Regression test for #61520. The new value for column a (projected as b:8)
+# should be in-scope when building the partial index PUT expression when the
+# value in the FROM clause must be rounded.
+
+exec-ddl
+CREATE TABLE t61520 (
+  a DECIMAL(10, 2),
+  CHECK (a > 0)
+)
+----
+
+build
+UPDATE t61520 t SET a = v.b FROM (VALUES (1.0)) v(b) WHERE t.a = v.b RETURNING a, b
+----
+project
+ ├── columns: a:1 b:7
+ └── update t
+      ├── columns: a:1 rowid:2!null column1:7
+      ├── fetch columns: a:4 rowid:5
+      ├── update-mapping:
+      │    └── b:8 => a:1
+      ├── check columns: check1:9
+      └── project
+           ├── columns: check1:9 a:4!null rowid:5!null crdb_internal_mvcc_timestamp:6 column1:7!null b:8
+           ├── project
+           │    ├── columns: b:8 a:4!null rowid:5!null crdb_internal_mvcc_timestamp:6 column1:7!null
+           │    ├── select
+           │    │    ├── columns: a:4!null rowid:5!null crdb_internal_mvcc_timestamp:6 column1:7!null
+           │    │    ├── inner-join (cross)
+           │    │    │    ├── columns: a:4 rowid:5!null crdb_internal_mvcc_timestamp:6 column1:7!null
+           │    │    │    ├── scan t
+           │    │    │    │    └── columns: a:4 rowid:5!null crdb_internal_mvcc_timestamp:6
+           │    │    │    ├── values
+           │    │    │    │    ├── columns: column1:7!null
+           │    │    │    │    └── (1.0,)
+           │    │    │    └── filters (true)
+           │    │    └── filters
+           │    │         └── a:4 = column1:7
+           │    └── projections
+           │         └── crdb_internal.round_decimal_values(column1:7, 2) [as=b:8]
+           └── projections
+                └── b:8 > 0 [as=check1:9]


### PR DESCRIPTION
Backport 1/1 commits from #61578.

/cc @cockroachdb/release

---

This commit fixes a bug that caused "column does not exist" errors when
building `CHECK` constraint expressions and partial index PUT
expressions in `UPDATE..FROM` statements.

This is an intentionally minimal fix so that it can be backported to
previous versions. This code is brittle for several reasons, and ideally
we can find a better long-term fix.

Fixes #61520

Release justification: This is a low-risk bug fix.

Release note (bug fix): A bug has been fixed that caused "column does
not exist errors" in specific cases of `UPDATE..FROM` statements. The
error only occurred when updating a `DECIMAL` column to a column in the
`FROM` clause, and the column had a CHECK constraint or was referenced
by a partial index predicate.
