### PR TITLE
build: fix a few SQL tests in bazel mode

### DIFF
--- a/pkg/ccl/logictestccl/BUILD.bazel
+++ b/pkg/ccl/logictestccl/BUILD.bazel
@@ -14,10 +14,11 @@ go_test(
         "logic_test.go",
         "main_test.go",
     ],
-    data = glob(["testdata/**"]),
+    data = glob(["testdata/**"]) + ["//pkg/sql/logictest:testdata"],
     embed = [":logictestccl"],
     tags = ["broken_in_bazel"],
     deps = [
+        "//pkg/build/bazel",
         "//pkg/ccl",
         "//pkg/ccl/utilccl",
         "//pkg/security",

--- a/pkg/sql/logictest/BUILD.bazel
+++ b/pkg/sql/logictest/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+filegroup(
+    name = "testdata",
+    srcs = glob(["testdata/**"]),
+    visibility = ["//pkg/ccl/logictestccl:__subpackages__"],
+)
+
 go_library(
     name = "logictest",
     srcs = ["logic.go"],

--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -75,7 +75,6 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":pgwire"],
-    tags = ["broken_in_bazel"],
     deps = [
         "//pkg/base",
         "//pkg/security",

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("//build:STRINGER.bzl", "stringer")
 
+filegroup(
+    name = "testdata",
+    srcs = glob(["testdata/**"]),
+    visibility = ["//pkg/sql/sem/tree/eval_test:__subpackages__"],
+)
+
 go_library(
     name = "tree",
     srcs = [

--- a/pkg/sql/sem/tree/eval_test/BUILD.bazel
+++ b/pkg/sql/sem/tree/eval_test/BUILD.bazel
@@ -7,9 +7,10 @@ go_test(
         "eval_test.go",
         "main_test.go",
     ],
-    tags = ["broken_in_bazel"],
+    data = ["//pkg/sql/sem/tree:testdata"],
     deps = [
         "//pkg/base",
+        "//pkg/build/bazel",
         "//pkg/col/coldata",
         "//pkg/security",
         "//pkg/security/securitytest",

--- a/pkg/sql/sem/tree/eval_test/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test/eval_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/build/bazel"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec"
@@ -45,8 +46,16 @@ func TestEval(t *testing.T) {
 	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(ctx)
 
+	dir := filepath.Join("../testdata", "eval")
+	if bazel.BuiltWithBazel() {
+		runfile, err := bazel.Runfile("pkg/sql/sem/tree/testdata/eval/")
+		if err != nil {
+			t.Fatal(err)
+		}
+		dir = runfile
+	}
 	walk := func(t *testing.T, getExpr func(*testing.T, *datadriven.TestData) string) {
-		datadriven.Walk(t, filepath.Join("../testdata", "eval"), func(t *testing.T, path string) {
+		datadriven.Walk(t, dir, func(t *testing.T, path string) {
 			datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 				if d.Cmd != "eval" {
 					t.Fatalf("unsupported command %s", d.Cmd)

--- a/pkg/util/json/BUILD.bazel
+++ b/pkg/util/json/BUILD.bazel
@@ -39,8 +39,8 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":json"],
-    tags = ["broken_in_bazel"],
     deps = [
+        "//pkg/build/bazel",
         "//pkg/sql/inverted",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/util/encoding",

--- a/pkg/util/json/encode_test.go
+++ b/pkg/util/json/encode_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/build/bazel"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
@@ -67,6 +68,13 @@ func TestFilesEncode(t *testing.T) {
 		t.Fatal("couldn't get directory")
 	}
 	dir := filepath.Join(filepath.Dir(fname), "testdata", "raw")
+	if bazel.BuiltWithBazel() {
+		runfile, err := bazel.Runfile(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		dir = runfile
+	}
 	dirContents, err := ioutil.ReadDir(dir)
 	if err != nil {
 		t.Fatal(err)
@@ -118,6 +126,13 @@ func TestFilesEncode(t *testing.T) {
 					"testdata", "encoded",
 					tc.Name()+".bytes",
 				)
+				if bazel.BuiltWithBazel() {
+					runfile, err := bazel.Runfile(fixtureFilename)
+					if err != nil {
+						t.Fatal(err)
+					}
+					fixtureFilename = runfile
+				}
 
 				if *rewriteResultsInTestfiles {
 					err := ioutil.WriteFile(fixtureFilename, []byte(stringifiedEncoding), 0644)


### PR DESCRIPTION
fixes most of https://github.com/cockroachdb/cockroach/issues/61917

The following tests were fixed:
- pkg/sql/sem/tree/eval_test:eval_test_test
- pkg/util/json:json_test
- pkg/sql/pgwire:pgwire_test

pkg/sql/logictest:logictest_test depends on GEOS libraries, which will
be resolved separately.

I made some changes to pkg/ccl/logictestccl:logictestccl_test to resolve
some of the initial errors, but now the test is timing out. Unclear why,
since it wasn't even running for that long.

Release note: None