### PR TITLE
geogen: add support for random generation of geometries with ZM coords

### DIFF
--- a/pkg/geo/geogen/geogen_test.go
+++ b/pkg/geo/geogen/geogen_test.go
@@ -28,7 +28,7 @@ func TestRandomValidLinearRingCoords(t *testing.T) {
 
 	for run := 0; run < numRuns; run++ {
 		t.Run(strconv.Itoa(run), func(t *testing.T) {
-			coords := RandomValidLinearRingCoords(rng, 10, -180, 180, -90, 90)
+			coords := RandomValidLinearRingCoords(rng, 10, MakeRandomGeomBoundsForGeography(), geom.NoLayout)
 			require.Len(t, coords, 10+1)
 			for _, coord := range coords {
 				require.True(t, -180 <= coord.X() && coord.X() <= 180)
@@ -43,10 +43,12 @@ func TestRandomGeomT(t *testing.T) {
 	rng, _ := randutil.NewPseudoRand()
 	for run := 0; run < numRuns; run++ {
 		t.Run(strconv.Itoa(run), func(t *testing.T) {
-			g := RandomGeomT(rng, -180, 180, -90, 90, geopb.SRID(run))
+			g := RandomGeomT(rng, MakeRandomGeomBoundsForGeography(), geopb.SRID(run), geom.NoLayout)
 			require.Equal(t, run, g.SRID())
+			require.True(t, g.Layout() != geom.NoLayout)
 			if gc, ok := g.(*geom.GeometryCollection); ok {
 				for gcIdx := 0; gcIdx < gc.NumGeoms(); gcIdx++ {
+					require.True(t, gc.Geom(gcIdx).Layout() != geom.NoLayout)
 					coords := gc.Geom(gcIdx).FlatCoords()
 					for i := 0; i < len(coords); i += g.Stride() {
 						x := coords[i]


### PR DESCRIPTION
This patch adds support to the geogen package for generating random
geometries that have Z and/or M coordinates.

Release justification: non-production code change
Release note: None