### PR TITLE
release-21.1: rsg: don't test st_frechetdistance in randomized test

### DIFF
--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -271,8 +271,11 @@ func TestRandomSyntaxFunctions(t *testing.T) {
 					continue
 				}
 				switch lower {
-				case
-					"pg_sleep":
+				case "pg_sleep":
+					continue
+				case "st_frechetdistance":
+					// Calculating the Frechet distance is slow and testing it here
+					// is not worth it.
 					continue
 				}
 				_, variations := builtins.GetBuiltinProperties(name)


### PR DESCRIPTION
Backport 1/1 commits from #61957.

/cc @cockroachdb/release

---

Release note: None
