### PR TITLE
release-21.1: ui: bump cluster-ui to 0.2.15

### DIFF
--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -15,7 +15,7 @@
     "cypress:update-snapshots": "yarn cypress run --env updateSnapshots=true --spec 'cypress/integration/**/*.visual.spec.ts'"
   },
   "dependencies": {
-    "@cockroachlabs/cluster-ui": "^0.2.12",
+    "@cockroachlabs/cluster-ui": "^0.2.15",
     "analytics-node": "^3.5.0",
     "antd": "^3.25.2",
     "babel-polyfill": "^6.26.0",

--- a/pkg/ui/yarn.lock
+++ b/pkg/ui/yarn.lock
@@ -1813,10 +1813,10 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@cockroachlabs/cluster-ui@^0.2.12":
-  version "0.2.12"
-  resolved "https://registry.yarnpkg.com/@cockroachlabs/cluster-ui/-/cluster-ui-0.2.12.tgz#0dc482bbdc70923f3c52a9e1388f7539b8a4f536"
-  integrity sha512-fnlcLrQL2QJXyiv16EzPc6sDd/mjV53u7OKi7sCTMSMM/fBqF9pNuUaRYG0azMtVPrkpHmaDvRaiDcNJHdF9Ww==
+"@cockroachlabs/cluster-ui@^0.2.15":
+  version "0.2.15"
+  resolved "https://registry.yarnpkg.com/@cockroachlabs/cluster-ui/-/cluster-ui-0.2.15.tgz#4411c126c0d6c8e453e5841d10cebb5604606b2a"
+  integrity sha512-nGsYLA5m2WT5WHMTn5fWJJMuuy3idru6kxtyJ/BqyN97PHZbisQDjMcX1wuLHYhPaQbhXBmfEefyehcn93CpWg==
   dependencies:
     "@babel/runtime" "^7.12.13"
     "@cockroachlabs/crdb-protobuf-client" "^0.0.7"


### PR DESCRIPTION
Backport 1/1 commits from #61843.

/cc @cockroachdb/release

---

Release justification: low-risk DB Console UX improvements (tooltips and
"no samples" help message)

Release note: None (UX improvement of existing feature)

Depends on https://github.com/cockroachdb/yarn-vendored/pull/62
