### PR TITLE
cli: Add --ready-wait and --timeout flag

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1026,6 +1026,12 @@ If zero, the command waits until the last client has disconnected and
 all range leases have been migrated away.`,
 	}
 
+	ReadyWait = FlagInfo{
+		Name: "ready-wait",
+		Description: `
+Specifies whether to wait until the server is ready to accept requests.`,
+	}
+
 	Wait = FlagInfo{
 		Name: "wait",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -474,6 +474,18 @@ var quitCtx struct {
 	drainWait time.Duration
 }
 
+// initCtx captures the command-line parameters of the `init` command.
+// See below for defaults.
+var initCtx struct {
+	// readyWait indicates whether the init command should wait
+	// until the server is ready to accept requests.
+	readyWait bool
+	// readyWaitTimeout is the amount of time that the init
+	// command should wait for the server to be ready to accept
+	// requests.
+	readyWaitTimeout time.Duration
+}
+
 // setQuitContextDefaults set the default values in quitCtx.  This
 // function is called by initCLIDefaults() and thus re-called in every
 // test that exercises command-line parsing.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -807,6 +807,13 @@ func init() {
 		stringFlag(t, &importCtx.ignoreUnsupportedLog, cliflags.ImportLogIgnoredStatements)
 	}
 
+	// init command.
+	{
+		i := initCmd.Flags()
+		boolFlag(i, &initCtx.readyWait, cliflags.ReadyWait)
+		durationFlag(i, &initCtx.readyWaitTimeout, cliflags.Timeout)
+	}
+
 	// sqlfmt command.
 	{
 		f := sqlfmtCmd.Flags()


### PR DESCRIPTION
The `init` command currently returns before the server is in an
operational mode and accepting connections.

This can cause problems for users trying to automate the setup of CRDB
cluster. For example, the following might fail:

```
COMMON="--insecure --join=localhost:26257,localhost:26258,localhost:26259"
cockroach start $COMMON --listen-addr=:26257 --http-addr=:8080 --store store-1 &
cockroach start $COMMON --listen-addr=:26258 --http-addr=:8081 --store store-2 &
cockroach start $COMMON --listen-addr=:26259 --http-addr=:8082 --store store-3 &
cockroach init --insecure
PGCONNECT_TIMEOUT=1 psql -c 'create database foo' 'postgresql://root@localhost:26257?sslmode=disable'
```

In many cases, this poses no problem because cockroach is _listening_
for SQL connections and the client is likely using a longer connect
timeout than provided above.

For automation cases it is valuable to be more confident that the
server is ready in order to avoid adding arbitrarily chosen sleeps and
timeouts. The new flags aim at helping these cases.

Note, however, that there are still some caveats:

1. The --ready-wait flag only tells you about the readiness of the
   node that ran the `init` command.

2. Clients that need very robust automation will still need to handle
   retries and failures since anything can happen between our
   readiness check and the next attempted connection.

Release note (cli change): The `cockroach init` command now accepts
the `ready-wait` and `timeout` flags. The `ready-wait` flag forces the
init command to wait until the server is ready to accept requests. The
`timeout` flag can be used to limit how long `ready-wait` will
wait. The readiness check applies only to the node that the `init`
command connected to; other nodes may not be ready even after the
command exits.