### PR TITLE
release-21.1: storageccl: use chunked encryption for new backups

### DIFF
--- a/pkg/ccl/storageccl/BUILD.bazel
+++ b/pkg/ccl/storageccl/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     deps = [
         "//pkg/base",
         "//pkg/ccl/storageccl/engineccl",
+        "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/kv/bulk",


### PR DESCRIPTION
Backport 1/1 commits from #61841.

/cc @cockroachdb/release

---

Release note: none.
