### PR TITLE
*: fix or untag a few broken_in_bazel tests

### DIFF
--- a/.github/BUILD.bazel
+++ b/.github/BUILD.bazel
@@ -1,0 +1,3 @@
+exports_files([
+    "CODEOWNERS",
+])

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -188,3 +188,7 @@ gazelle(
     name = "gazelle",
     prefix = "github.com/cockroachdb/cockroach",
 )
+
+exports_files([
+    "TEAMS.yaml",
+])

--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update \
     libncurses-dev \
     libtinfo-dev \
     make \
+    netbase \
     python3 \
     unzip \
  && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100 \

--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -1,1 +1,1 @@
-BAZEL_IMAGE=cockroachdb/bazel:20210311-171107
+BAZEL_IMAGE=cockroachdb/bazel:20210315-115417

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -351,8 +351,8 @@ ALL_TESTS = [
 ]
 
 # These suites run only the tests with the appropriate "size" (excepting those
-# tagged "broken_in_bazel") [1]. Note that tests have a default timeout
-# depending on the size [2].
+# tagged "broken_in_bazel" or "flaky") [1]. Note that tests have a default
+# timeout depending on the size [2].
 
 # [1] https://docs.bazel.build/versions/master/be/general.html#test_suite
 # [2] https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes-tests
@@ -361,6 +361,7 @@ test_suite(
     name = "small_tests",
     tags = [
         "-broken_in_bazel",
+        "-flaky",
         "small",
     ],
     tests = ALL_TESTS,
@@ -370,6 +371,7 @@ test_suite(
     name = "medium_tests",
     tags = [
         "-broken_in_bazel",
+        "-flaky",
         "medium",
     ],
     tests = ALL_TESTS,
@@ -379,6 +381,7 @@ test_suite(
     name = "large_tests",
     tags = [
         "-broken_in_bazel",
+        "-flaky",
         "large",
     ],
     tests = ALL_TESTS,
@@ -388,6 +391,7 @@ test_suite(
     name = "enormous_tests",
     tags = [
         "-broken_in_bazel",
+        "-flaky",
         "enormous",
     ],
     tests = ALL_TESTS,

--- a/pkg/base/BUILD.bazel
+++ b/pkg/base/BUILD.bazel
@@ -53,7 +53,6 @@ go_test(
         "node_id_test.go",
         "store_spec_test.go",
     ],
-    tags = ["broken_in_bazel"],
     deps = [
         ":base",
         "//pkg/roachpb",

--- a/pkg/cmd/generate-test-suites/main.go
+++ b/pkg/cmd/generate-test-suites/main.go
@@ -42,8 +42,8 @@ ALL_TESTS = [`)
 	fmt.Println(`]
 
 # These suites run only the tests with the appropriate "size" (excepting those
-# tagged "broken_in_bazel") [1]. Note that tests have a default timeout
-# depending on the size [2].
+# tagged "broken_in_bazel" or "flaky") [1]. Note that tests have a default
+# timeout depending on the size [2].
 
 # [1] https://docs.bazel.build/versions/master/be/general.html#test_suite
 # [2] https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes-tests`)
@@ -54,6 +54,7 @@ test_suite(
     name = "%[1]s_tests",
     tags = [
         "-broken_in_bazel",
+        "-flaky",
         "%[1]s",
     ],
     tests = ALL_TESTS,

--- a/pkg/internal/codeowners/BUILD.bazel
+++ b/pkg/internal/codeowners/BUILD.bazel
@@ -17,9 +17,13 @@ go_test(
     name = "codeowners_test",
     size = "small",
     srcs = ["codeowners_test.go"],
+    data = [
+        "//:TEAMS.yaml",
+        "//.github:CODEOWNERS",
+    ],
     embed = [":codeowners"],
-    tags = ["broken_in_bazel"],
     deps = [
+        "//pkg/build/bazel",
         "//pkg/internal/team",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/internal/codeowners/codeowners_test.go
+++ b/pkg/internal/codeowners/codeowners_test.go
@@ -11,12 +11,30 @@
 package codeowners
 
 import (
+	"log"
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/build/bazel"
 	"github.com/cockroachdb/cockroach/pkg/internal/team"
 	"github.com/stretchr/testify/require"
 )
+
+func init() {
+	if bazel.BuiltWithBazel() {
+		codeOwnersFile, err := bazel.Runfile(".github/CODEOWNERS")
+		if err != nil {
+			log.Fatal(err)
+		}
+		DefaultCodeOwnersLocation = codeOwnersFile
+
+		teamFile, err := bazel.Runfile("TEAMS.yaml")
+		if err != nil {
+			log.Fatal(err)
+		}
+		team.DefaultTeamsYAMLLocation = teamFile
+	}
+}
 
 func TestMatch(t *testing.T) {
 	owners := `

--- a/pkg/internal/team/BUILD.bazel
+++ b/pkg/internal/team/BUILD.bazel
@@ -15,7 +15,12 @@ go_test(
     name = "team_test",
     size = "small",
     srcs = ["team_test.go"],
+    data = [
+        "//:TEAMS.yaml",
+    ],
     embed = [":team"],
-    tags = ["broken_in_bazel"],
-    deps = ["@com_github_stretchr_testify//require"],
+    deps = [
+        "//pkg/build/bazel",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/pkg/internal/team/team_test.go
+++ b/pkg/internal/team/team_test.go
@@ -12,10 +12,22 @@ package team
 
 import (
 	"bytes"
+	"log"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/build/bazel"
 	"github.com/stretchr/testify/require"
 )
+
+func init() {
+	if bazel.BuiltWithBazel() {
+		teamFile, err := bazel.Runfile("TEAMS.yaml")
+		if err != nil {
+			log.Fatal(err)
+		}
+		DefaultTeamsYAMLLocation = teamFile
+	}
+}
 
 func TestLoadTeams(t *testing.T) {
 	yamlFile := []byte(`

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -285,7 +285,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":kvserver"],
     shard_count = 16,
-    tags = ["broken_in_bazel"],
+    tags = ["flaky"],
     deps = [
         "//pkg/base",
         "//pkg/cli/exit",

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -275,7 +275,6 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":server"],
     shard_count = 16,
-    tags = ["broken_in_bazel"],
     deps = [
         "//pkg/base",
         "//pkg/build",

--- a/pkg/server/debug/goroutineui/BUILD.bazel
+++ b/pkg/server/debug/goroutineui/BUILD.bazel
@@ -15,9 +15,10 @@ go_test(
     name = "goroutineui_test",
     size = "small",
     srcs = ["dump_test.go"],
+    data = ["@go_sdk//:files"],
     embed = [":goroutineui"],
-    tags = ["broken_in_bazel"],
     deps = [
+        "//pkg/build/bazel",
         "//pkg/util/leaktest",
         "@com_github_stretchr_testify//assert",
     ],

--- a/pkg/server/debug/goroutineui/dump_test.go
+++ b/pkg/server/debug/goroutineui/dump_test.go
@@ -15,9 +15,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/build/bazel"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/stretchr/testify/assert"
 )
+
+func init() {
+	if bazel.BuiltWithBazel() {
+		bazel.SetGoEnv()
+	}
+}
 
 func TestDumpHTML(t *testing.T) {
 	defer leaktest.AfterTest(t)()


### PR DESCRIPTION
Three commits:

* codeowners,team: fix Bazel test builds

  The default locations for the `CODEOWNERS` and `TEAMS.yaml` files were
  not correct when built with `bazel test`. This commit updates the
  default locations to the proper ones for Bazel-based test builds.

* server,kvserver: fix or untag broken_in_bazel tests

  This patch addresses a few tests tagged `broken_in_bazel`:

  * `goroutineui.TestDumpHTML` needed the Go toolchain to be installed in
    the sandbox, to reliably detect stdlib functions in stack traces.

  * `pkg/server:server_test` appears to work under Bazel, and was untagged
    `broken_in_bazel`.

  * `pkg/kv/kvserver:kvserver_test` is generally flaky (see #60025), and
    was untagged `broken_in_bazel` as it's not Bazel-specific.

* bazelbuilder: install netbase in Docker image 

  `TestValidateAddrs` in `pkg/base` relies on the operating system having
  the named ports `postgresql` and `http`. These are provided by
  `/etc/services`, but this file was not present in the Bazel Docker
  image, causing the test to fail.

  This patch installs the `netbase` package, providing the necessary
  `/etc/services` file, and removes the `broken_in_bazel` tag.

Resolves #61914.

@rickystewart We'll need to build and push a new `cockroachdb/bazel` image after this is merged.

Release note: None