### PR TITLE
internal/sqlsmith: do not crash in an edge case with merge join

### DIFF
--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -289,6 +289,12 @@ func makeMergeJoinExpr(s *Smither, _ colRefs, forJoin bool) (tree.TableExpr, col
 					if rightColElem.Direction != leftColElem.Direction {
 						break
 					}
+					if leftCol == nil || rightCol == nil {
+						// TODO(yuzefovich): there are some cases here where
+						// column references are nil, but we aren't yet sure
+						// why. Rather than panicking, just break.
+						break
+					}
 					if !tree.MustBeStaticallyKnownType(rightCol.Type).Equivalent(tree.MustBeStaticallyKnownType(leftCol.Type)) {
 						break
 					}

--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -117,8 +117,8 @@ func (s *Smither) getRandTableIndex(
 	for _, col := range idx.Columns {
 		ref := s.columns[table][col.Column]
 		if ref == nil {
-			// TODO (rohany): There are some cases here where colRef is nil, but we
-			//  aren't yet sure why. Rather than panicking, just return.
+			// TODO(yuzefovich): there are some cases here where colRef is nil,
+			// but we aren't yet sure why. Rather than panicking, just return.
 			return nil, nil, nil, false
 		}
 		refs = append(refs, &colRef{


### PR DESCRIPTION
I tried running `workload/sqlsmith` manually, and it crashed pretty
quickly due to a nil pointer. In other place in the code we already had
a TODO left to investigate and protected ourselves from the crash, but
not when generating a merge join.

Release note: None