### PR TITLE
roachprod: don't swallow error when failing to fetch subscription

### DIFF
--- a/pkg/cmd/roachprod/vm/azure/azure.go
+++ b/pkg/cmd/roachprod/vm/azure/azure.go
@@ -1266,7 +1266,8 @@ func (p *Provider) getSubscription(
 		return
 	}
 
-	if page, err := sc.List(ctx); err == nil {
+	page, err := sc.List(ctx)
+	if err == nil {
 		if len(page.Values()) == 0 {
 			err = errors.New("did not find Azure subscription")
 			return sub, err


### PR DESCRIPTION
Previously, if there was an error listing Azure subscriptions, we would
return an empty subscription with no error. This lead to roachprod
panicing occationally on `roachprod list`.

Release note: None