### PR TITLE
release-21.1: sql: Fix panic when transitioning from REGIONAL BY ROW

### DIFF
--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -975,14 +975,29 @@ func RemoveIndexZoneConfigs(
 		return nil
 	}
 
+	// Look through all of the subzones and determine if we need to remove any
+	// of them. We only want to rewrite the zone config below if there's actual
+	// work to be done here.
+	zcRewriteNecessary := false
 	for _, indexDesc := range indexDescs {
-		zone.DeleteIndexSubzones(uint32(indexDesc.ID))
+		for _, s := range zone.Subzones {
+			if s.IndexID == uint32(indexDesc.ID) {
+				// We've found an subzone that matches the given indexID. Delete all of
+				// this index's subzones and move on to the next index.
+				zone.DeleteIndexSubzones(uint32(indexDesc.ID))
+				zcRewriteNecessary = true
+				break
+			}
+		}
 	}
 
-	// Ignore CCL required error to allow schema change to progress.
-	_, err = writeZoneConfig(ctx, txn, tableDesc.GetID(), tableDesc, zone, execCfg, false /* hasNewSubzones */)
-	if err != nil && !sqlerrors.IsCCLRequiredError(err) {
-		return err
+	if zcRewriteNecessary {
+		// Ignore CCL required error to allow schema change to progress.
+		_, err = writeZoneConfig(ctx, txn, tableDesc.GetID(), tableDesc, zone, execCfg, false /* hasNewSubzones */)
+		if err != nil && !sqlerrors.IsCCLRequiredError(err) {
+			return err
+		}
 	}
+
 	return nil
 }

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -500,6 +500,7 @@ func repartitionRegionalByRowTables(
 		tableDesc, err := localPlanner.Descriptors().GetMutableTableByID(
 			ctx, txn, tbID, tree.ObjectLookupFlags{
 				CommonLookupFlags: tree.CommonLookupFlags{
+					AvoidCached:    true,
 					Required:       true,
 					IncludeDropped: true,
 				},


### PR DESCRIPTION
Backport 1/1 commits from #61889.

/cc @cockroachdb/release

---

Before this commit, the transition from REGIONAL BY ROW to REGIONAL
BY TABLE would drop the partitioning on the table not drop the
zone configurations. As a result, when the index GC runs, it would
try and cleanup the zone configurations. This hit an issue though,
as the types are not properly hydrated in the index GC code path.
The end result was that the index GC would panic and bring down the
node. To work around this problem this commit adds code to remove
the zone configs when dropping the table partitioning.

Note: This commit does not solve the root cause of this issue, but
instead, prevent the failure from occurring when transitioning from
REGIONAL BY ROW tables to REGIONAL BY TABLE tables.  A new issue
will be opened for the general problem.

Release note: None

Resolves #61751 .
