### PR TITLE
bench/ddl_analysis: fix subtests

### DIFF
--- a/pkg/bench/ddl_analysis/ddl_analysis_bench_test.go
+++ b/pkg/bench/ddl_analysis/ddl_analysis_bench_test.go
@@ -12,7 +12,6 @@ package bench
 
 import (
 	"context"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"strings"
 	"sync"
 	"testing"
@@ -21,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"

--- a/pkg/bench/ddl_analysis/ddl_analysis_bench_test.go
+++ b/pkg/bench/ddl_analysis/ddl_analysis_bench_test.go
@@ -12,6 +12,7 @@ package bench
 
 import (
 	"context"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"strings"
 	"sync"
 	"testing"
@@ -40,6 +41,8 @@ type RoundTripBenchTestCase struct {
 // RunRoundTripBenchmark sets up a db run the RoundTripBenchTestCase test cases
 // and counts how many round trips the stmt specified by the test case performs.
 func RunRoundTripBenchmark(b *testing.B, tests []RoundTripBenchTestCase) {
+	skip.UnderMetamorphic(b, "changes the RTTs")
+
 	expData := readExpectationsFile(b)
 	for _, tc := range tests {
 		b.Run(tc.name, func(b *testing.B) {

--- a/pkg/bench/ddl_analysis/validate_benchmark_data_test.go
+++ b/pkg/bench/ddl_analysis/validate_benchmark_data_test.go
@@ -81,7 +81,6 @@ func TestBenchmarkExpectation(t *testing.T) {
 	skip.UnderStress(t)
 	skip.UnderRace(t)
 	skip.UnderShort(t)
-	skip.UnderMetamorphic(t)
 
 	expecations := readExpectationsFile(t)
 

--- a/pkg/bench/ddl_analysis/validate_benchmark_data_test.go
+++ b/pkg/bench/ddl_analysis/validate_benchmark_data_test.go
@@ -98,9 +98,7 @@ func TestBenchmarkExpectation(t *testing.T) {
 
 	var g sync.WaitGroup
 	run := func(b string) {
-		g.Add(1)
-		go t.Run(b, func(t *testing.T) {
-			defer g.Done()
+		tf := func(t *testing.T) {
 			flags := []string{
 				"--test.run=^$",
 				"--test.bench=" + b,
@@ -125,7 +123,12 @@ func TestBenchmarkExpectation(t *testing.T) {
 						r.name, exp.min, exp.max, r.result)
 				}
 			}
-		})
+		}
+		g.Add(1)
+		go func() {
+			defer g.Done()
+			t.Run(b, tf)
+		}()
 	}
 	benchmarks := getBenchmarks(t)
 	for _, b := range benchmarks {


### PR DESCRIPTION
Before this commit, we'd call `g.Done()` inside the subtest but if the --run
flag did include all subtests, then we'd hang forever. This is solved by
dealing with the wait group above the subtest.

Release note: None