### PR TITLE
release-21.1: colexec: make vectorized stats concurrency safe

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -575,9 +575,6 @@ func (r opResult) createAndWrapRowSource(
 			if err != nil {
 				return nil, err
 			}
-			if kvReader, ok := proc.(execinfra.KVReader); ok {
-				r.KVReader = kvReader
-			}
 			var (
 				rs execinfra.RowSource
 				ok bool

--- a/pkg/sql/colexec/colexecargs/op_creation.go
+++ b/pkg/sql/colexec/colexecargs/op_creation.go
@@ -83,7 +83,7 @@ type NewColOperatorArgs struct {
 // values of NewColOperator call.
 type NewColOperatorResult struct {
 	Op              colexecop.Operator
-	KVReader        execinfra.KVReader
+	KVReader        colexecop.KVReader
 	ColumnTypes     []*types.T
 	MetadataSources []execinfrapb.MetadataSource
 	// ToClose is a slice of components that need to be Closed.

--- a/pkg/sql/colexecop/operator.go
+++ b/pkg/sql/colexecop/operator.go
@@ -66,13 +66,17 @@ type DrainableOperator interface {
 }
 
 // KVReader is an operator that performs KV reads.
+// TODO(yuzefovich): consider changing the contract to remove the mention of
+// concurrency safety once stats are only retrieved from Next goroutines.
 type KVReader interface {
 	// GetBytesRead returns the number of bytes read from KV by this operator.
+	// It must be safe for concurrent use.
 	GetBytesRead() int64
 	// GetRowsRead returns the number of rows read from KV by this operator.
+	// It must be safe for concurrent use.
 	GetRowsRead() int64
 	// GetCumulativeContentionTime returns the amount of time KV reads spent
-	// contending.
+	// contending. It must be safe for concurrent use.
 	GetCumulativeContentionTime() time.Duration
 }
 

--- a/pkg/sql/colexecop/operator.go
+++ b/pkg/sql/colexecop/operator.go
@@ -12,6 +12,7 @@ package colexecop
 
 import (
 	"context"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
@@ -62,6 +63,17 @@ type Operator interface {
 type DrainableOperator interface {
 	Operator
 	execinfrapb.MetadataSource
+}
+
+// KVReader is an operator that performs KV reads.
+type KVReader interface {
+	// GetBytesRead returns the number of bytes read from KV by this operator.
+	GetBytesRead() int64
+	// GetRowsRead returns the number of rows read from KV by this operator.
+	GetRowsRead() int64
+	// GetCumulativeContentionTime returns the amount of time KV reads spent
+	// contending.
+	GetCumulativeContentionTime() time.Duration
 }
 
 // ZeroInputNode is an execinfra.OpNode with no inputs.

--- a/pkg/sql/colfetcher/BUILD.bazel
+++ b/pkg/sql/colfetcher/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//pkg/util/encoding",
         "//pkg/util/hlc",
         "//pkg/util/log",
+        "//pkg/util/syncutil",
         "//pkg/util/tracing",
         "@com_github_cockroachdb_apd_v2//:apd",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -66,7 +66,7 @@ type ColBatchScan struct {
 	ResultTypes []*types.T
 }
 
-var _ execinfra.KVReader = &ColBatchScan{}
+var _ colexecop.KVReader = &ColBatchScan{}
 var _ execinfra.Releasable = &ColBatchScan{}
 var _ colexecop.Closer = &ColBatchScan{}
 var _ colexecop.Operator = &ColBatchScan{}
@@ -151,17 +151,17 @@ func (s *ColBatchScan) DrainMeta(ctx context.Context) []execinfrapb.ProducerMeta
 	return trailingMeta
 }
 
-// GetBytesRead is part of the execinfra.KVReader interface.
+// GetBytesRead is part of the colexecop.KVReader interface.
 func (s *ColBatchScan) GetBytesRead() int64 {
 	return s.rf.fetcher.GetBytesRead()
 }
 
-// GetRowsRead is part of the execinfra.KVReader interface.
+// GetRowsRead is part of the colexecop.KVReader interface.
 func (s *ColBatchScan) GetRowsRead() int64 {
 	return s.rowsRead
 }
 
-// GetCumulativeContentionTime is part of the execinfra.KVReader interface.
+// GetCumulativeContentionTime is part of the colexecop.KVReader interface.
 func (s *ColBatchScan) GetCumulativeContentionTime() time.Duration {
 	if s.ctx == nil {
 		// Next was never called, so there was no contention events.

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 )
@@ -51,15 +52,18 @@ type ColBatchScan struct {
 	rf          *cFetcher
 	limitHint   int64
 	parallelize bool
-	ctx         context.Context
 	// tracingSpan is created when the stats should be collected for the query
 	// execution, and it will be finished when closing the operator.
 	tracingSpan *tracing.Span
-	// rowsRead contains the number of total rows this ColBatchScan has returned
-	// so far.
-	rowsRead int64
-	// init is true after Init() has been called.
-	init bool
+	mu          struct {
+		syncutil.Mutex
+		ctx context.Context
+		// init is true after Init() has been called.
+		init bool
+		// rowsRead contains the number of total rows this ColBatchScan has
+		// returned so far.
+		rowsRead int64
+	}
 	// ResultTypes is the slice of resulting column types from this operator.
 	// It should be used rather than the slice of column types from the scanned
 	// table because the scan might synthesize additional implicit system columns.
@@ -73,7 +77,11 @@ var _ colexecop.Operator = &ColBatchScan{}
 
 // Init initializes a ColBatchScan.
 func (s *ColBatchScan) Init() {
-	s.init = true
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Note that we're intentionally holding the lock until the cFetcher is
+	// properly initialized.
+	s.mu.init = true
 	limitBatches := !s.parallelize
 	if err := s.rf.StartScan(
 		s.flowCtx.Txn, s.spans, limitBatches, s.limitHint, s.flowCtx.TraceKV,
@@ -85,33 +93,44 @@ func (s *ColBatchScan) Init() {
 
 // Next is part of the Operator interface.
 func (s *ColBatchScan) Next(ctx context.Context) coldata.Batch {
-	if s.ctx == nil {
+	s.mu.Lock()
+	if s.mu.ctx == nil {
 		// This is the first call to Next(), so we will capture the context and
 		// possibly replace it with a child below.
-		s.ctx = ctx
-		if execinfra.ShouldCollectStats(s.ctx, s.flowCtx) {
+		s.mu.ctx = ctx
+		if execinfra.ShouldCollectStats(s.mu.ctx, s.flowCtx) {
 			// We need to start a child span so that the only contention events
 			// present in the recording would be because of this cFetcher.
-			s.ctx, s.tracingSpan = execinfra.ProcessorSpan(s.ctx, "colbatchscan")
+			s.mu.ctx, s.tracingSpan = execinfra.ProcessorSpan(s.mu.ctx, "colbatchscan")
 		}
 	}
-	bat, err := s.rf.NextBatch(s.ctx)
+	ctx = s.mu.ctx
+	s.mu.Unlock()
+	bat, err := s.rf.NextBatch(ctx)
 	if err != nil {
 		colexecerror.InternalError(err)
 	}
 	if bat.Selection() != nil {
 		colexecerror.InternalError(errors.AssertionFailedf("unexpectedly a selection vector is set on the batch coming from CFetcher"))
 	}
-	s.rowsRead += int64(bat.Length())
+	s.mu.Lock()
+	s.mu.rowsRead += int64(bat.Length())
+	s.mu.Unlock()
 	return bat
 }
 
 // DrainMeta is part of the MetadataSource interface.
 func (s *ColBatchScan) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
-	if !s.init {
+	s.mu.Lock()
+	initialized := s.mu.init
+	s.mu.Unlock()
+	if !initialized {
 		// In some pathological queries like `SELECT 1 FROM t HAVING true`, Init()
 		// and Next() may never get called. Return early to avoid using an
 		// uninitialized fetcher.
+		// TODO(yuzefovich): we probably don't need this anymore given that we
+		// call Init() on fixedNumTuplesNoInputOp and we have the invariants
+		// checker ensuring that Init() is called before DrainMeta().
 		return nil
 	}
 	var trailingMeta []execinfrapb.ProducerMetadata
@@ -144,7 +163,10 @@ func (s *ColBatchScan) DrainMeta(ctx context.Context) []execinfrapb.ProducerMeta
 		// TODO(yuzefovich): this is temporary hack that will be fixed by adding
 		// context.Context argument to Init() and removing it from Next() and
 		// DrainMeta().
-		if trace := execinfra.GetTraceData(s.ctx); trace != nil {
+		s.mu.Lock()
+		traceCtx := s.mu.ctx
+		s.mu.Unlock()
+		if trace := execinfra.GetTraceData(traceCtx); trace != nil {
 			trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{TraceData: trace})
 		}
 	}
@@ -153,21 +175,31 @@ func (s *ColBatchScan) DrainMeta(ctx context.Context) []execinfrapb.ProducerMeta
 
 // GetBytesRead is part of the colexecop.KVReader interface.
 func (s *ColBatchScan) GetBytesRead() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Note that if Init() was never called, s.rf.fetcher will remain nil, and
+	// GetBytesRead() will return 0. We are also holding the mutex, so a
+	// concurrent call to Init() will have to wait, and the fetcher will remain
+	// uninitialized until we return.
 	return s.rf.fetcher.GetBytesRead()
 }
 
 // GetRowsRead is part of the colexecop.KVReader interface.
 func (s *ColBatchScan) GetRowsRead() int64 {
-	return s.rowsRead
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.mu.rowsRead
 }
 
 // GetCumulativeContentionTime is part of the colexecop.KVReader interface.
 func (s *ColBatchScan) GetCumulativeContentionTime() time.Duration {
-	if s.ctx == nil {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.mu.ctx == nil {
 		// Next was never called, so there was no contention events.
 		return 0
 	}
-	return execinfra.GetCumulativeContentionTime(s.ctx)
+	return execinfra.GetCumulativeContentionTime(s.mu.ctx)
 }
 
 var colBatchScanPool = sync.Pool{

--- a/pkg/sql/colflow/colrpc/BUILD.bazel
+++ b/pkg/sql/colflow/colrpc/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/sql/types",
         "//pkg/util/log",
         "//pkg/util/log/logcrash",
+        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
         "@com_github_apache_arrow_go_arrow//array",

--- a/pkg/sql/colflow/colrpc/BUILD.bazel
+++ b/pkg/sql/colflow/colrpc/BUILD.bazel
@@ -21,7 +21,6 @@ go_library(
         "//pkg/sql/types",
         "//pkg/util/log",
         "//pkg/util/log/logcrash",
-        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
         "@com_github_apache_arrow_go_arrow//array",

--- a/pkg/sql/colflow/stats.go
+++ b/pkg/sql/colflow/stats.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colflow/colrpc"
-	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -116,7 +115,7 @@ func (bic *batchInfoCollector) getElapsedTime() time.Duration {
 // present in the chain of operators rooted at 'op'.
 func newVectorizedStatsCollector(
 	op colexecop.Operator,
-	kvReader execinfra.KVReader,
+	kvReader colexecop.KVReader,
 	id execinfrapb.ComponentID,
 	inputWatch *timeutil.StopWatch,
 	memMonitors []*mon.BytesMonitor,
@@ -138,7 +137,7 @@ func newVectorizedStatsCollector(
 type vectorizedStatsCollectorImpl struct {
 	batchInfoCollector
 
-	kvReader     execinfra.KVReader
+	kvReader     colexecop.KVReader
 	memMonitors  []*mon.BytesMonitor
 	diskMonitors []*mon.BytesMonitor
 }
@@ -156,27 +155,16 @@ func (vsc *vectorizedStatsCollectorImpl) getStats() *execinfrapb.ComponentStats 
 		s.Exec.MaxAllocatedDisk.Add(diskMon.MaximumBytes())
 	}
 
-	// Depending on kvReader, the accumulated time spent by the wrapped operator
-	// inside Next() is reported as either execution time or KV time.
-	kvTime := false
 	if vsc.kvReader != nil {
-		kvTime = true
-		if _, isProcessor := vsc.kvReader.(execinfra.Processor); isProcessor {
-			// We have a wrapped processor that performs KV reads. Most likely
-			// it is a rowexec.joinReader, so we want to display "execution
-			// time" and not "KV time". In the less likely case that it is a
-			// wrapped rowexec.tableReader showing "execution time" is also
-			// acceptable.
-			kvTime = false
-		}
-	}
-
-	if kvTime {
+		// Note that kvReader is non-nil only for ColBatchScans, and this is the
+		// only case when we want to add the number of rows read, bytes read,
+		// and the contention time (because the wrapped row-execution KV reading
+		// processors - joinReaders, tableReaders, zigzagJoiners, and
+		// invertedJoiners - will add these statistics themselves). Similarly,
+		// for those wrapped processors it is ok to show the time as "execution
+		// time" since "KV time" would only make sense for tableReaders, and
+		// they are less likely to be wrapped than others.
 		s.KV.KVTime.Set(time)
-		// Note that kvTime is true only for ColBatchScans, and this is the
-		// only case when we want to add the number of rows read (because the
-		// wrapped joinReaders and tableReaders will add that statistic
-		// themselves).
 		s.KV.TuplesRead.Set(uint64(vsc.kvReader.GetRowsRead()))
 		s.KV.BytesRead.Set(uint64(vsc.kvReader.GetBytesRead()))
 		s.KV.ContentionTime.Set(vsc.kvReader.GetCumulativeContentionTime())

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -315,7 +315,7 @@ func (f *vectorizedFlow) Cleanup(ctx context.Context) {
 // must have already been wrapped).
 func (s *vectorizedFlowCreator) wrapWithVectorizedStatsCollectorBase(
 	op colexecop.Operator,
-	kvReader execinfra.KVReader,
+	kvReader colexecop.KVReader,
 	inputs []colexecop.Operator,
 	component execinfrapb.ComponentID,
 	monitors []*mon.BytesMonitor,

--- a/pkg/sql/execinfra/operator.go
+++ b/pkg/sql/execinfra/operator.go
@@ -10,8 +10,6 @@
 
 package execinfra
 
-import "time"
-
 // OpNode is an interface to operator-like structures with children.
 type OpNode interface {
 	// ChildCount returns the number of children (inputs) of the operator.
@@ -19,15 +17,4 @@ type OpNode interface {
 
 	// Child returns the nth child (input) of the operator.
 	Child(nth int, verbose bool) OpNode
-}
-
-// KVReader is an operator that performs KV reads.
-type KVReader interface {
-	// GetBytesRead returns the number of bytes read from KV by this operator.
-	GetBytesRead() int64
-	// GetRowsRead returns the number of rows read from KV by this operator.
-	GetRowsRead() int64
-	// GetCumulativeContentionTime returns the amount of time KV reads spent
-	// contending.
-	GetCumulativeContentionTime() time.Duration
 }

--- a/pkg/sql/row/BUILD.bazel
+++ b/pkg/sql/row/BUILD.bazel
@@ -52,6 +52,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/mon",
         "//pkg/util/sequence",
+        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/unique",
         "//pkg/util/uuid",

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -1623,11 +1623,7 @@ func (rf *Fetcher) PartialKey(nCols int) (roachpb.Key, error) {
 
 // GetBytesRead returns total number of bytes read by the underlying KVFetcher.
 func (rf *Fetcher) GetBytesRead() int64 {
-	if f := rf.kvFetcher; f != nil {
-		return f.bytesRead
-	}
-	// Not yet initialized.
-	return 0
+	return rf.kvFetcher.GetBytesRead()
 }
 
 // Only unique secondary indexes have extra columns to decode (namely the

--- a/pkg/sql/rowexec/inverted_joiner_test.go
+++ b/pkg/sql/rowexec/inverted_joiner_test.go
@@ -695,7 +695,10 @@ func TestInvertedJoiner(t *testing.T) {
 
 				var result rowenc.EncDatumRows
 				for {
-					row := out.NextNoMeta(t)
+					row, meta := out.Next()
+					if meta != nil && meta.Metrics == nil {
+						t.Fatalf("unexpected metadata %+v", meta)
+					}
 					if row == nil {
 						break
 					}

--- a/pkg/sql/rowexec/zigzagjoiner_test.go
+++ b/pkg/sql/rowexec/zigzagjoiner_test.go
@@ -531,7 +531,10 @@ func TestZigzagJoiner(t *testing.T) {
 
 			var res rowenc.EncDatumRows
 			for {
-				row := out.NextNoMeta(t)
+				row, meta := out.Next()
+				if meta != nil && meta.Metrics == nil {
+					t.Fatalf("unexpected metadata %+v", meta)
+				}
 				if row == nil {
 					break
 				}


### PR DESCRIPTION
Backport 2/2 commits from #61937.

/cc @cockroachdb/release

---

**colflow: clean up vectorized stats for rowexec processors**

Previously, the wrapped row-execution KV reading processors were
implementing `execinfra.KVReader` interface, but they were never used as
such, only the ColBatchScans would get used to retrieve the KV stats.
This is the case because the row-execution processors report their
execution stats themselves, and we don't want to duplicate that info.
This commit moves `KVReader` interface into `colexecop` package and now
only the ColBatchScans implement it. This allowed for some cleanup
around the vectorized stats code, but the main reason for performing
this change is that the contract of the interface will be modified by
the follow-up commit to mention the safety under concurrent usage, and
I didn't want to change the row-execution processors for that since the
relevant methods never get called anyway.

Additionally, this commit begins emitting of rows-read and bytes-read by
the zigzagJoiners and invertedJoiners to complete the metrics picture.

Release note: None

**colexec: make vectorized stats concurrency safe**

Previously, the collection of vectorized stats was not synchronized with
the operators themselves. Namely, it was possible to call methods like
`GetBytesRead` on the ColBatchScans and Inboxes from a different
goroutine (the root materializer or the outbox) than from the main
goroutine of the operator. This is now fixed by putting mutexes in place
and updating `colexecop.KVReader` interface to require concurrency-safe
implementations.

Fixes: #61899.

Release note: None
