### PR TITLE
mutations: disallow VIRTUAL columns for PostgreSQL

### DIFF
--- a/pkg/sql/mutations/mutations.go
+++ b/pkg/sql/mutations/mutations.go
@@ -585,6 +585,11 @@ var postgresStatementMutator MultiStatementMutation = func(rng *rand.Rand, stmts
 						def.Unique.WithoutIndex = false
 						changed = true
 					}
+					if def.IsVirtual() {
+						def.Computed.Virtual = false
+						def.Computed.Computed = true
+						changed = true
+					}
 				case *tree.UniqueConstraintTableDef:
 					if def.Interleave != nil {
 						def.Interleave = nil


### PR DESCRIPTION
PostgreSQL does not support this syntax.

Release note: None