### PR TITLE
sql: allow VIEW and SEQUENCEs for multi-region databases

### DIFF
--- a/pkg/ccl/importccl/read_import_mysql.go
+++ b/pkg/ccl/importccl/read_import_mysql.go
@@ -432,6 +432,8 @@ func mysqlTableToCockroach(
 				priv,
 				tree.PersistencePermanent,
 				nil, /* params */
+				// If this is multi-region, this will get added by WriteDescriptors.
+				false, /* isMultiRegion */
 			)
 		} else {
 			priv := descpb.NewDefaultPrivilegeDescriptor(owner)
@@ -446,6 +448,8 @@ func mysqlTableToCockroach(
 				priv,
 				tree.PersistencePermanent,
 				nil, /* params */
+				// If this is multi-region, this will get added by WriteDescriptors.
+				false, /* isMultiRegion */
 			)
 		}
 		if err != nil {

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -308,6 +308,8 @@ func createPostgresSequences(
 			descpb.NewDefaultPrivilegeDescriptor(owner),
 			tree.PersistencePermanent,
 			nil, /* params */
+			// If this is multi-region, this will get added by WriteDescriptors.
+			false, /* isMultiRegion */
 		)
 		if err != nil {
 			return nil, err
@@ -456,8 +458,15 @@ func readPostgresCreateTable(
 			}
 
 			// Construct sequence descriptors.
-			seqs, err := createPostgresSequences(ctx, parentID, schemaObjects.createSeq, fks,
-				walltime, owner, schemaNameToDesc)
+			seqs, err := createPostgresSequences(
+				ctx,
+				parentID,
+				schemaObjects.createSeq,
+				fks,
+				walltime,
+				owner,
+				schemaNameToDesc,
+			)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/pkg/ccl/importccl/testdata/mysqldump/views_and_sequences.sql
+++ b/pkg/ccl/importccl/testdata/mysqldump/views_and_sequences.sql
@@ -1,0 +1,81 @@
+-- MySQL dump 10.13  Distrib 8.0.23, for osx10.15 (x86_64)
+--
+-- Host: localhost    Database: bob
+-- ------------------------------------------------------
+-- Server version	8.0.23
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!50503 SET NAMES utf8mb4 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `tbl`
+--
+
+DROP TABLE IF EXISTS `tbl`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `tbl` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `a` int DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `tbl`
+--
+
+LOCK TABLES `tbl` WRITE;
+/*!40000 ALTER TABLE `tbl` DISABLE KEYS */;
+/*!40000 ALTER TABLE `tbl` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Temporary view structure for view `v`
+--
+
+DROP TABLE IF EXISTS `v`;
+/*!50001 DROP VIEW IF EXISTS `v`*/;
+SET @saved_cs_client     = @@character_set_client;
+/*!50503 SET character_set_client = utf8mb4 */;
+/*!50001 CREATE VIEW `v` AS SELECT 
+ 1 AS `id`,
+ 1 AS `a`*/;
+SET character_set_client = @saved_cs_client;
+
+--
+-- Final view structure for view `v`
+--
+
+/*!50001 DROP VIEW IF EXISTS `v`*/;
+/*!50001 SET @saved_cs_client          = @@character_set_client */;
+/*!50001 SET @saved_cs_results         = @@character_set_results */;
+/*!50001 SET @saved_col_connection     = @@collation_connection */;
+/*!50001 SET character_set_client      = utf8mb4 */;
+/*!50001 SET character_set_results     = utf8mb4 */;
+/*!50001 SET collation_connection      = utf8mb4_0900_ai_ci */;
+/*!50001 CREATE ALGORITHM=UNDEFINED */
+/*!50013 DEFINER=`root`@`localhost` SQL SECURITY DEFINER */
+/*!50001 VIEW `v` AS select `tbl`.`id` AS `id`,`tbl`.`a` AS `a` from `tbl` */;
+/*!50001 SET character_set_client      = @saved_cs_client */;
+/*!50001 SET character_set_results     = @saved_cs_results */;
+/*!50001 SET collation_connection      = @saved_col_connection */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2021-03-17  8:23:08

--- a/pkg/ccl/importccl/testdata/pgdump/views_and_sequences.sql
+++ b/pkg/ccl/importccl/testdata/pgdump/views_and_sequences.sql
@@ -1,0 +1,78 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 13.2
+-- Dumped by pg_dump version 13.2
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: s; Type: SEQUENCE; Schema: public; Owner: otan
+--
+
+CREATE SEQUENCE public.s
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.s OWNER TO otan;
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: tbl; Type: TABLE; Schema: public; Owner: otan
+--
+
+CREATE TABLE public.tbl (
+    a integer,
+    b integer
+);
+
+
+ALTER TABLE public.tbl OWNER TO otan;
+
+--
+-- Name: v; Type: VIEW; Schema: public; Owner: otan
+--
+
+CREATE VIEW public.v AS
+ SELECT tbl.a
+   FROM public.tbl;
+
+
+ALTER TABLE public.v OWNER TO otan;
+
+--
+-- Data for Name: tbl; Type: TABLE DATA; Schema: public; Owner: otan
+--
+
+COPY public.tbl (a, b) FROM stdin;
+\.
+
+
+--
+-- Name: s; Type: SEQUENCE SET; Schema: public; Owner: otan
+--
+
+SELECT pg_catalog.setval('public.s', 1, false);
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/pkg/ccl/importccl/testutils_test.go
+++ b/pkg/ccl/importccl/testutils_test.go
@@ -64,7 +64,8 @@ func descForTable(
 			ts,
 			priv,
 			tree.PersistencePermanent,
-			nil, /* params */
+			nil,   /* params */
+			false, /* isMultiRegion */
 		)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -1307,3 +1307,55 @@ DATABASE zone_config_drop_region  ALTER DATABASE zone_config_drop_region CONFIGU
                           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
                           voter_constraints = '[+region=ca-central-1]',
                           lease_preferences = '[[+region=ca-central-1]]'
+
+#
+# Tests with views and sequences.
+#
+
+statement ok
+CREATE DATABASE db_with_views_and_sequences;
+USE db_with_views_and_sequences
+
+statement ok
+CREATE TABLE t (id INT PRIMARY KEY, a INT, b INT);
+INSERT INTO t VALUES (1, 2, 3), (4, 5, 6);
+CREATE SEQUENCE s;
+CREATE VIEW v AS SELECT id, a, b FROM t
+
+statement ok
+ALTER DATABASE db_with_views_and_sequences SET PRIMARY REGION "ap-southeast-2"
+
+query TT colnames
+SELECT table_name, locality FROM [SHOW TABLES]
+----
+table_name  locality
+t           REGIONAL BY TABLE IN PRIMARY REGION
+s           REGIONAL BY TABLE IN PRIMARY REGION
+v           REGIONAL BY TABLE IN PRIMARY REGION
+
+statement ok
+CREATE SEQUENCE s2;
+CREATE VIEW v2 AS SELECT id, a, b FROM t
+
+query TT colnames
+SELECT table_name, locality FROM [SHOW TABLES]
+----
+table_name  locality
+t           REGIONAL BY TABLE IN PRIMARY REGION
+s           REGIONAL BY TABLE IN PRIMARY REGION
+v           REGIONAL BY TABLE IN PRIMARY REGION
+s2          REGIONAL BY TABLE IN PRIMARY REGION
+v2          REGIONAL BY TABLE IN PRIMARY REGION
+
+statement ok
+ALTER DATABASE db_with_views_and_sequences DROP REGION "ap-southeast-2"
+
+query TT colnames
+SELECT table_name, locality FROM [SHOW TABLES]
+----
+table_name  locality
+t           NULL
+s           NULL
+v           NULL
+s2          NULL
+v2          NULL

--- a/pkg/sql/add_column.go
+++ b/pkg/sql/add_column.go
@@ -55,7 +55,6 @@ func (p *planner) addColumnImpl(
 	if seqName != nil {
 		if err := doCreateSequence(
 			params,
-			n.n.String(),
 			seqDbDesc,
 			n.tableDesc.GetParentSchemaID(),
 			seqName,

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -2416,6 +2416,16 @@ func newTableDesc(
 		n.Defs = newDefs
 	}
 
+	_, dbDesc, err := params.p.Descriptors().GetImmutableDatabaseByID(
+		params.ctx, params.p.txn, parentID, tree.DatabaseLookupFlags{
+			Required:    true,
+			AvoidCached: true,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	for i, def := range n.Defs {
 		d, ok := def.(*tree.ColumnTableDef)
 		if !ok {
@@ -2429,7 +2439,6 @@ func newTableDesc(
 		if seqName != nil {
 			if err := doCreateSequence(
 				params,
-				n.String(),
 				seqDbDesc,
 				parentSchemaID,
 				seqName,
@@ -2444,13 +2453,6 @@ func newTableDesc(
 			ensureCopy()
 			n.Defs[i] = newDef
 		}
-	}
-
-	_, dbDesc, err := params.p.Descriptors().GetImmutableDatabaseByID(
-		params.ctx, params.p.txn, parentID, tree.DatabaseLookupFlags{},
-	)
-	if err != nil {
-		return nil, err
 	}
 
 	// We need to run NewTableDesc with caching disabled, because

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -184,6 +184,7 @@ func (n *createViewNode) startExec(params runParams) error {
 			&params.p.semaCtx,
 			params.p.EvalContext(),
 			n.persistence,
+			n.dbDesc.IsMultiRegion(),
 		)
 		if err != nil {
 			return err
@@ -299,6 +300,7 @@ func makeViewTableDesc(
 	semaCtx *tree.SemaContext,
 	evalCtx *tree.EvalContext,
 	persistence tree.Persistence,
+	isMultiRegion bool,
 ) (tabledesc.Mutable, error) {
 	desc := tabledesc.InitTableDescriptor(
 		id,
@@ -310,6 +312,9 @@ func makeViewTableDesc(
 		persistence,
 	)
 	desc.ViewQuery = viewQuery
+	if isMultiRegion {
+		desc.SetTableLocalityRegionalByTable(tree.PrimaryRegionNotSpecifiedName)
+	}
 	if err := addResultColumns(ctx, semaCtx, evalCtx, &desc, resultColumns); err != nil {
 		return tabledesc.Mutable{}, err
 	}

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -74,7 +74,8 @@ func CreateTestTableDescriptor(
 			hlc.Timestamp{}, /* creationTime */
 			privileges,
 			tree.PersistencePermanent,
-			nil, /* params */
+			nil,   /* params */
+			false, /* isMultiRegion */
 		)
 		return desc, err
 	default:

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -253,6 +253,7 @@ func (v virtualSchemaView) initVirtualTableDesc(
 		nil, /* semaCtx */
 		nil, /* evalCtx */
 		tree.PersistencePermanent,
+		false, /* isMultiRegion */
 	)
 	return mutDesc.TableDescriptor, err
 }


### PR DESCRIPTION
Refs #61382 -- missing materialized views.

Release note (bug fix): Allow VIEWs and SEQUENCEs in multi-region
databases. They will have REGIONAL BY TABLE set.

