### PR TITLE
sql: prevent dropping regions when regions <= 3 on SURVIVE REGION FAILURE

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -28,6 +28,9 @@ CREATE DATABASE region_test_db PRIMARY REGION "ap-southeast-2" SURVIVE ZONE FAIL
 statement ok
 CREATE DATABASE multi_region_test_db PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1" SURVIVE REGION FAILURE
 
+statement error cannot DROP REGION on database multi_region_test_db as databases with SURVIVE REGION FAILURE must have at least 3 regions\nHINT: you must first add another region, or configure the database to SURVIVE ZONE FAILURE using ALTER DATABASE multi_region_test_db SURVIVE ZONE FAILURE
+ALTER DATABASE multi_region_test_db DROP REGION "ap-southeast-2"
+
 statement ok
 CREATE DATABASE multi_region_test_explicit_primary_region_db PRIMARY REGION "ap-southeast-2" REGIONS "ap-southeast-2", "ca-central-1", "us-east-1" SURVIVE REGION FAILURE
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
@@ -51,7 +51,7 @@ DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USIN
 statement ok
 SET override_multi_region_zone_config = true;
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING num_voters = 5;
-SET override_multi_region_zone_config = false;
+SET override_multi_region_zone_config = false
 
 query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
@@ -89,12 +89,12 @@ ALTER DATABASE "mr-zone-configs" DROP REGION "ap-southeast-2"
 statement ok
 SET override_multi_region_zone_config = true;
 ALTER DATABASE "mr-zone-configs" DROP REGION "ap-southeast-2";
-SET override_multi_region_zone_config = false;
+SET override_multi_region_zone_config = false
 
 statement ok
 SET override_multi_region_zone_config = true;
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING global_reads = true;
-SET override_multi_region_zone_config = false;
+SET override_multi_region_zone_config = false
 
 statement error attempting to update zone configuration for database "mr-zone-configs" which contains modified field "global_reads"
 ALTER DATABASE "mr-zone-configs" ADD REGION "ap-southeast-2"
@@ -102,7 +102,7 @@ ALTER DATABASE "mr-zone-configs" ADD REGION "ap-southeast-2"
 statement ok
 SET override_multi_region_zone_config = true;
 ALTER DATABASE "mr-zone-configs" ADD REGION "ap-southeast-2";
-SET override_multi_region_zone_config = false;
+SET override_multi_region_zone_config = false
 
 # Zone config is unmodified now. We don't need to override.
 statement ok
@@ -111,12 +111,12 @@ ALTER DATABASE "mr-zone-configs" DROP REGION "ap-southeast-2"
 statement ok
 SET override_multi_region_zone_config = true;
 ALTER DATABASE "mr-zone-configs" ADD REGION "ap-southeast-2";
-SET override_multi_region_zone_config = false;
+SET override_multi_region_zone_config = false
 
 statement ok
 SET override_multi_region_zone_config = true;
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING num_replicas = 7;
-SET override_multi_region_zone_config = false;
+SET override_multi_region_zone_config = false
 
 statement error attempting to update zone configuration for database "mr-zone-configs" which contains modified field "num_replicas"
 ALTER DATABASE "mr-zone-configs" SET PRIMARY REGION "us-east-1"
@@ -124,7 +124,7 @@ ALTER DATABASE "mr-zone-configs" SET PRIMARY REGION "us-east-1"
 statement ok
 SET override_multi_region_zone_config = true;
 ALTER DATABASE "mr-zone-configs" SET PRIMARY REGION "us-east-1";
-SET override_multi_region_zone_config = false;
+SET override_multi_region_zone_config = false
 
 query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
@@ -146,7 +146,7 @@ ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING num_replicas = 7, gc.ttlse
 statement ok
 SET override_multi_region_zone_config = true;
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING num_replicas = 7, gc.ttlseconds = 100000;
-SET override_multi_region_zone_config = false;
+SET override_multi_region_zone_config = false
 
 statement error attempting to update zone configuration for database "mr-zone-configs" which contains modified field "num_replicas"
 ALTER DATABASE "mr-zone-configs" SURVIVE REGION FAILURE
@@ -154,7 +154,12 @@ ALTER DATABASE "mr-zone-configs" SURVIVE REGION FAILURE
 statement ok
 SET override_multi_region_zone_config = true;
 ALTER DATABASE "mr-zone-configs" SURVIVE REGION FAILURE;
-SET override_multi_region_zone_config = false;
+SET override_multi_region_zone_config = false
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER DATABASE "mr-zone-configs" SURVIVE ZONE FAILURE;
+SET override_multi_region_zone_config = false
 
 statement error attempting to modify protected field "constraints" of a multi-region zone configuration
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING constraints = '{+region=us-east-1: 3}'
@@ -162,7 +167,7 @@ ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING constraints = '{+region=us
 statement ok
 SET override_multi_region_zone_config = true;
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING constraints = '{+region=us-east-1: 3}';
-SET override_multi_region_zone_config = false;
+SET override_multi_region_zone_config = false
 
 statement error attempting to update zone configuration for database "mr-zone-configs" which contains modified field "constraints"
 ALTER DATABASE "mr-zone-configs" DROP REGION "ap-southeast-2"
@@ -170,7 +175,7 @@ ALTER DATABASE "mr-zone-configs" DROP REGION "ap-southeast-2"
 statement ok
 SET override_multi_region_zone_config = true;
 ALTER DATABASE "mr-zone-configs" DROP REGION "ap-southeast-2";
-SET override_multi_region_zone_config = false;
+SET override_multi_region_zone_config = false
 
 statement error attempting to modify protected field "voter_constraints" of a multi-region zone configuration
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING voter_constraints = '[+region=ap-southeast-2]'
@@ -178,7 +183,7 @@ ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING voter_constraints = '[+reg
 statement ok
 SET override_multi_region_zone_config = true;
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING voter_constraints = '[+region=ap-southeast-2]';
-SET override_multi_region_zone_config = false;
+SET override_multi_region_zone_config = false
 
 query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
@@ -187,8 +192,8 @@ DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USIN
                             range_min_bytes = 134217728,
                             range_max_bytes = 536870912,
                             gc.ttlseconds = 90000,
-                            num_replicas = 5,
-                            num_voters = 5,
+                            num_replicas = 4,
+                            num_voters = 3,
                             constraints = '{+region=ca-central-1: 1, +region=us-east-1: 1}',
                             voter_constraints = '[+region=ap-southeast-2]',
                             lease_preferences = '[[+region=us-east-1]]'
@@ -199,7 +204,7 @@ ALTER DATABASE "mr-zone-configs" DROP REGION "ca-central-1"
 statement ok
 SET override_multi_region_zone_config = true;
 ALTER DATABASE "mr-zone-configs" DROP REGION "ca-central-1";
-SET override_multi_region_zone_config = false;
+SET override_multi_region_zone_config = false
 
 query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
@@ -208,10 +213,10 @@ DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USIN
                             range_min_bytes = 134217728,
                             range_max_bytes = 536870912,
                             gc.ttlseconds = 90000,
-                            num_replicas = 5,
-                            num_voters = 5,
+                            num_replicas = 3,
+                            num_voters = 3,
                             constraints = '{+region=us-east-1: 1}',
-                            voter_constraints = '{+region=us-east-1: 2}',
+                            voter_constraints = '[+region=us-east-1]',
                             lease_preferences = '[[+region=us-east-1]]'
 
 statement error attempting to modify protected field "lease_preferences" of a multi-region zone configuration
@@ -220,7 +225,7 @@ ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING lease_preferences = '[[+re
 statement ok
 SET override_multi_region_zone_config = true;
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING lease_preferences = '[[+region=ap-southeast-2]]';
-SET override_multi_region_zone_config = false;
+SET override_multi_region_zone_config = false
 
 query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
@@ -229,10 +234,10 @@ DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USIN
                             range_min_bytes = 134217728,
                             range_max_bytes = 536870912,
                             gc.ttlseconds = 90000,
-                            num_replicas = 5,
-                            num_voters = 5,
+                            num_replicas = 3,
+                            num_voters = 3,
                             constraints = '{+region=us-east-1: 1}',
-                            voter_constraints = '{+region=us-east-1: 2}',
+                            voter_constraints = '[+region=us-east-1]',
                             lease_preferences = '[[+region=ap-southeast-2]]'
 
 statement error attempting to update zone configuration for database "mr-zone-configs" which contains modified field "lease_preferences"
@@ -241,7 +246,7 @@ ALTER DATABASE "mr-zone-configs" DROP REGION "us-east-1"
 statement ok
 SET override_multi_region_zone_config = true;
 ALTER DATABASE "mr-zone-configs" DROP REGION "us-east-1";
-SET override_multi_region_zone_config = false;
+SET override_multi_region_zone_config = false
 
 query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
@@ -250,10 +255,10 @@ DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USIN
                             range_min_bytes = 134217728,
                             range_max_bytes = 536870912,
                             gc.ttlseconds = 90000,
-                            num_replicas = 5,
-                            num_voters = 5,
+                            num_replicas = 3,
+                            num_voters = 3,
                             constraints = '{+region=us-east-1: 1}',
-                            voter_constraints = '{+region=us-east-1: 2}',
+                            voter_constraints = '[+region=us-east-1]',
                             lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TTTTT colnames

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -277,6 +277,7 @@ go_library(
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/hydratedtables",
         "//pkg/sql/catalog/lease",
+        "//pkg/sql/catalog/multiregion",
         "//pkg/sql/catalog/resolver",
         "//pkg/sql/catalog/schemadesc",
         "//pkg/sql/catalog/schemaexpr",

--- a/pkg/sql/catalog/multiregion/BUILD.bazel
+++ b/pkg/sql/catalog/multiregion/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "multiregion",
+    srcs = ["multiregion.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/multiregion",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/sql/catalog/multiregion/multiregion.go
+++ b/pkg/sql/catalog/multiregion/multiregion.go
@@ -1,0 +1,17 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package multiregion provides functions and structs for interacting with the
+// static multi-region state configured by users on their databases.
+package multiregion
+
+// MinNumRegionsForSurviveRegionGoal is the minimum number of regions that a
+// a database must have to survive a REGION failure.
+const MinNumRegionsForSurviveRegionGoal = 3

--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -16,6 +16,7 @@ import (
 	"bytes"
 	"context"
 	"sort"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -619,6 +620,22 @@ func (desc *Immutable) validateMultiRegion(
 	if dbPrimaryRegion != primaryRegion {
 		vea.Report(errors.AssertionFailedf("unexpected primary region on db desc: %q expected %q",
 			dbPrimaryRegion, primaryRegion))
+	}
+
+	if dbDesc.GetRegionConfig().SurvivalGoal == descpb.SurvivalGoal_REGION_FAILURE {
+		regionNames, err := desc.RegionNames()
+		if err != nil {
+			vea.Report(err)
+		}
+		if len(regionNames) < 3 {
+			vea.Report(
+				errors.AssertionFailedf(
+					"expected >= 3 regions, got %d: %s",
+					len(regionNames),
+					strings.Join(regionNames.ToStrings(), ","),
+				),
+			)
+		}
 	}
 }
 

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/multiregion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
@@ -254,11 +255,11 @@ func validateDatabaseRegionConfig(regionConfig descpb.DatabaseDescriptor_RegionC
 		return errors.AssertionFailedf("expected > 0 number of regions in the region config")
 	}
 	if regionConfig.SurvivalGoal == descpb.SurvivalGoal_REGION_FAILURE &&
-		len(regionConfig.Regions) < minNumRegionsForSurviveRegionGoal {
+		len(regionConfig.Regions) < multiregion.MinNumRegionsForSurviveRegionGoal {
 		return pgerror.Newf(
 			pgcode.InvalidParameterValue,
 			"at least %d regions are required for surviving a region failure",
-			minNumRegionsForSurviveRegionGoal,
+			multiregion.MinNumRegionsForSurviveRegionGoal,
 		)
 	}
 	return nil

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -32,8 +32,6 @@ import (
 	"github.com/gogo/protobuf/proto"
 )
 
-const minNumRegionsForSurviveRegionGoal = 3
-
 // LiveClusterRegions is a set representing regions that are live in
 // a given cluster.
 type LiveClusterRegions map[descpb.RegionName]struct{}


### PR DESCRIPTION
Refs: #61774

Release note (bug fix): Prevent regions being dropped on multi-region
databases when there are <= 3 regions left on the database.