### PR TITLE
cli: better document the logging flags

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1098,7 +1098,12 @@ Available Commands:
 Flags:
   -h, --help                 help for cockroach
       --log <string>         
-                                     Logging configuration. See the documentation for details.
+                                     Logging configuration, expressed using YAML syntax. For example, you
+                                     can change the default logging directory with: --log='file-defaults:
+                                     {dir: ...}'. See the documentation for more options and details.  To
+                                     preview how the log configuration is applied, or preview the default
+                                     configuration, you can use the 'cockroach debug check-log-config'
+                                     sub-command.
                                     
       --version              version for cockroach
 

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1339,8 +1339,15 @@ This can be used to check schema and data correctness without running the entire
 	}
 
 	Log = FlagInfo{
-		Name:        "log",
-		Description: `Logging configuration. See the documentation for details.`,
+		Name: "log",
+		Description: `Logging configuration, expressed using YAML syntax.
+For example, you can change the default logging directory with:
+--log='file-defaults: {dir: ...}'.
+See the documentation for more options and details.
+
+To preview how the log configuration is applied, or preview the
+default configuration, you can use the 'cockroach debug check-log-config' sub-command.
+`,
 	}
 
 	DeprecatedStderrThreshold = FlagInfo{

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -299,37 +299,37 @@ func init() {
 		// TODO(knz): Remove this.
 		varFlag(pf, &cliCtx.deprecatedLogOverrides.stderrThreshold, cliflags.DeprecatedStderrThreshold)
 		_ = pf.MarkDeprecated(cliflags.DeprecatedStderrThreshold.Name,
-			"use --"+cliflags.Log.Name+" instead to specify sinks.stderr.filter.")
+			"use --"+cliflags.Log.Name+" instead to specify 'sinks: {stderr: {filter: ...}}'.")
 		// This flag can also be specified without an explicit argument.
 		pf.Lookup(cliflags.DeprecatedStderrThreshold.Name).NoOptDefVal = "DEFAULT"
 
 		varFlag(pf, &cliCtx.deprecatedLogOverrides.stderrNoColor, cliflags.DeprecatedStderrNoColor)
 		_ = pf.MarkDeprecated(cliflags.DeprecatedStderrNoColor.Name,
-			"use --"+cliflags.Log.Name+" instead to specify sinks.stderr.no-color.")
+			"use --"+cliflags.Log.Name+" instead to specify 'sinks: {stderr: {no-color: true}}'")
 
 		varFlag(pf, &cliCtx.deprecatedLogOverrides.logDir, cliflags.DeprecatedLogDir)
 		_ = pf.MarkDeprecated(cliflags.DeprecatedLogDir.Name,
-			"use --"+cliflags.Log.Name+" instead to specify file-defaults.dir.")
+			"use --"+cliflags.Log.Name+" instead to specify 'file-defaults: {dir: ...}'")
 
 		varFlag(pf, cliCtx.deprecatedLogOverrides.fileMaxSizeVal, cliflags.DeprecatedLogFileMaxSize)
 		_ = pf.MarkDeprecated(cliflags.DeprecatedLogFileMaxSize.Name,
-			"use --"+cliflags.Log.Name+" instead to specify file-defaults.max-file-size.")
+			"use --"+cliflags.Log.Name+" instead to specify 'file-defaults: {max-file-size: ...}'")
 
 		varFlag(pf, cliCtx.deprecatedLogOverrides.maxGroupSizeVal, cliflags.DeprecatedLogGroupMaxSize)
 		_ = pf.MarkDeprecated(cliflags.DeprecatedLogGroupMaxSize.Name,
-			"use --"+cliflags.Log.Name+" instead to specify file-defaults.max-group-size.")
+			"use --"+cliflags.Log.Name+" instead to specify 'file-defaults: {max-group-size: ...}'")
 
 		varFlag(pf, &cliCtx.deprecatedLogOverrides.fileThreshold, cliflags.DeprecatedFileThreshold)
 		_ = pf.MarkDeprecated(cliflags.DeprecatedFileThreshold.Name,
-			"use --"+cliflags.Log.Name+" instead to specify file-defaults.filter.")
+			"use --"+cliflags.Log.Name+" instead to specify 'file-defaults: {filter: ...}'")
 
 		varFlag(pf, &cliCtx.deprecatedLogOverrides.redactableLogs, cliflags.DeprecatedRedactableLogs)
 		_ = pf.MarkDeprecated(cliflags.DeprecatedRedactableLogs.Name,
-			"use --"+cliflags.Log.Name+" instead to specify file-defaults:redactable-logs.")
+			"use --"+cliflags.Log.Name+" instead to specify 'file-defaults: {redactable: ...}")
 
 		varFlag(pf, &cliCtx.deprecatedLogOverrides.sqlAuditLogDir, cliflags.DeprecatedSQLAuditLogDir)
 		_ = pf.MarkDeprecated(cliflags.DeprecatedSQLAuditLogDir.Name,
-			"use --"+cliflags.Log.Name+" instead to specify sinks:file-groups:sql-audit.")
+			"use --"+cliflags.Log.Name+" instead to specify 'sinks: {file-groups: {sql-audit: {channels: SENSITIVE_ACCESS, dir: ...}}}")
 	}
 
 	// Remember we are starting in the background as the `start` command will


### PR DESCRIPTION
Fixes  #59674. 

Release note (cli change): The `--help` text for `--log` now
references the fact that the flag accepts YAML syntax and
also points to the `cockroach debug check-log-config` command.

NB for the doc writer: it would be useful to explain via examples
how to read a logging configuration from a file, using
the shell redirection syntax when invoking `cockroach` from
a script or the command line. For example, `cockroach --log="$(cat myconfig.yaml)"`