### PR TITLE
kvserver: de-flake TestReplicateRogueRemovedNode

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -285,7 +285,6 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":kvserver"],
     shard_count = 16,
-    tags = ["flaky"],
     deps = [
         "//pkg/base",
         "//pkg/cli/exit",


### PR DESCRIPTION
Fixes #60025.

Release note: None
