### PR TITLE
sql: add interleaved_indexes/interleaved_tables into crdb_internal

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -4144,7 +4144,11 @@ CREATE TABLE crdb_internal.interleaved (
 		STRING NOT NULL,
 	index_name
 		STRING NOT NULL,
-	parent_index
+	parent_database_name
+		STRING NOT NULL,
+	parent_schema_name
+		STRING NOT NULL,
+	parent_table_name
 		STRING NOT NULL
 );`,
 	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
@@ -4158,13 +4162,8 @@ CREATE TABLE crdb_internal.interleaved (
 					if index.NumInterleaveAncestors() == 0 {
 						continue
 					}
-
 					ancestor := index.GetInterleaveAncestor(index.NumInterleaveAncestors() - 1)
 					parentTable, err := lookupFn.getTableByID(ancestor.TableID)
-					if err != nil {
-						return err
-					}
-					parentIndex, err := parentTable.FindIndexWithID(ancestor.IndexID)
 					if err != nil {
 						return err
 					}
@@ -4172,16 +4171,18 @@ CREATE TABLE crdb_internal.interleaved (
 					if err != nil {
 						return err
 					}
-					database, err := lookupFn.getDatabaseByID(parentTable.GetParentID())
+					parentDatabase, err := lookupFn.getDatabaseByID(parentTable.GetParentID())
 					if err != nil {
 						return err
 					}
 
-					if err := addRow(tree.NewDString(database.GetName()),
-						tree.NewDString(parentSchemaName),
+					if err := addRow(tree.NewDString(db.GetName()),
+						tree.NewDString(schemaName),
 						tree.NewDString(table.GetName()),
 						tree.NewDString(index.GetName()),
-						tree.NewDString(parentIndex.GetName())); err != nil {
+						tree.NewDString(parentDatabase.GetName()),
+						tree.NewDString(parentSchemaName),
+						tree.NewDString(parentTable.GetName())); err != nil {
 						return err
 					}
 				}

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -386,13 +386,17 @@ CREATE TABLE crdb_internal.interleaved (
    schema_name STRING NOT NULL,
    table_name STRING NOT NULL,
    index_name STRING NOT NULL,
-   parent_index STRING NOT NULL
+   parent_database_name STRING NOT NULL,
+   parent_schema_name STRING NOT NULL,
+   parent_table_name STRING NOT NULL
 )  CREATE TABLE crdb_internal.interleaved (
    database_name STRING NOT NULL,
    schema_name STRING NOT NULL,
    table_name STRING NOT NULL,
    index_name STRING NOT NULL,
-   parent_index STRING NOT NULL
+   parent_database_name STRING NOT NULL,
+   parent_schema_name STRING NOT NULL,
+   parent_table_name STRING NOT NULL
 )  {}  {}
 CREATE TABLE crdb_internal.invalid_objects (
    id INT8 NULL,

--- a/pkg/sql/logictest/testdata/logic_test/interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved
@@ -497,22 +497,34 @@ CREATE INDEX NIINDX3 ON CHILD(z);
 statement ok
 CREATE INDEX IINDX ON CHILD(rowid,x,y,z) INTERLEAVE IN PARENT PARENT(rowid);
 
+# Child in different schema then parent
+statement ok
+CREATE TABLE parentDS (k STRING PRIMARY KEY);
 
+statement ok
+CREATE SCHEMA child_schema;
 
-query TTTTT
+statement ok
+CREATE TABLE child_schema.child (ck INT8 PRIMARY KEY, k STRING NOT NULL UNIQUE);
+
+statement ok
+CREATE INDEX interl ON child_schema.child (k) INTERLEAVE IN PARENT parentDS (k);
+
+query TTTTTTT
 select * from "".crdb_internal.interleaved;
 ----
-test   public  p1_1                      p1_id                    primary
-test   public  all_interleaves           primary                  primary
-test   public  all_interleaves           all_interleaves_c_d_idx  primary
-test   public  all_interleaves           all_interleaves_d_c_key  primary
-test   public  orders                    primary                  primary
-other  public  interdb                   primary                  primary
-test   public  c20067                    primary                  primary
-test   public  documents                 primary                  primary
-test   public  big_interleave_parent     primary                  primary
-test   public  big_interleave_child      primary                  primary
-test   public  interleave_create_notice  primary                  primary
-test   public  interleave_create_notice  interleave_index         primary
-test   public  interleave_pk_notice      primary                  primary
-test   public  child                     iindx                    primary
+test  public        p1_1                      p1_id                    test   public  p1_1
+test  public        all_interleaves           primary                  test   public  p1_1
+test  public        all_interleaves           all_interleaves_c_d_idx  test   public  p1_1
+test  public        all_interleaves           all_interleaves_d_c_key  test   public  p1_1
+test  public        orders                    primary                  test   public  customers
+test  public        interdb                   primary                  other  public  foo
+test  public        c20067                    primary                  test   public  p20067
+test  public        documents                 primary                  test   public  users
+test  public        big_interleave_parent     primary                  test   public  big_interleave_grandparent
+test  public        big_interleave_child      primary                  test   public  big_interleave_parent
+test  public        interleave_create_notice  primary                  test   public  interleave_parent
+test  public        interleave_create_notice  interleave_index         test   public  interleave_parent
+test  public        interleave_pk_notice      primary                  test   public  interleave_parent
+test  public        child                     iindx                    test   public  parent
+test  child_schema  child                     interl                   test   public  parentds


### PR DESCRIPTION
Previous, when we added the crdb_internal.interleaved table that
showed all interleaved indexes, however it was impossible tell
which table the primary key of the parent table was interleaved.
This was inadequate because users could not tell what the parent
table was. To address this, this patch removes
crdb_internal.interleaved and converts it into two virtual tables
interlaved_indexes/interleaved_tables where the one is for
non-primary key indexes and the second is for tables interleaved
on the primary key.

Release note (sql change): Renamed crdb_internal.interleaved to
crdb_internal.interlaved_indexes and added crdb_internal.interlaved_table
for viewing interleaved tables on the primary key.