### PR TITLE
mutations: disallow spatial types for Postgres Tables

### DIFF
--- a/pkg/sql/mutations/BUILD.bazel
+++ b/pkg/sql/mutations/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/sql/rowenc",
         "//pkg/sql/sem/tree",
         "//pkg/sql/stats",
+        "//pkg/sql/types",
         "//pkg/util",
         "//pkg/util/encoding",
     ],

--- a/pkg/sql/mutations/mutations.go
+++ b/pkg/sql/mutations/mutations.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 )
 
@@ -658,7 +659,7 @@ func postgresCreateTableMutator(
 						}
 						if def.Name != "" {
 							// Unset Name here because
-							// constaint names cannot
+							// constraint names cannot
 							// be shared among tables,
 							// so multiple PK constraints
 							// named "primary" is an error.
@@ -677,6 +678,25 @@ func postgresCreateTableMutator(
 						Storing:  def.Storing,
 					})
 					changed = true
+				case *tree.ColumnTableDef:
+					colType := tree.MustBeStaticallyKnownType(def.Type)
+					switch colType.Family() {
+					case types.GeometryFamily, types.GeographyFamily, types.Box2DFamily:
+						// PostgreSQL does not have any spatial types. Turn them into
+						// String types.
+						def.Type = types.String
+						mutated = append(mutated, &tree.AlterTable{
+							Table: stmt.Table.ToUnresolvedObjectName(),
+							Cmds: tree.AlterTableCmds{
+								&tree.AlterTableAlterColumnType{
+									Column: def.Name,
+									ToType: types.String,
+								},
+							},
+						})
+						changed = true
+					}
+					newdefs = append(newdefs, def)
 				default:
 					newdefs = append(newdefs, def)
 				}


### PR DESCRIPTION
This is affecting ComposeCompare tests.
see #61683 

Release note: None

