### PR TITLE
tracing: lock around testing knobs

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -100,7 +100,7 @@ func TestDBAddSSTable(t *testing.T) {
 func runTestDBAddSSTable(
 	ctx context.Context, t *testing.T, db *kv.DB, tr *tracing.Tracer, store *kvserver.Store,
 ) {
-	tr.TestingIncludeAsyncSpansInRecordings() // we assert on async span traces in this test
+	tr.TestingRecordAsyncSpans() // we assert on async span traces in this test
 	{
 		key := storage.MVCCKey{Key: []byte("bb"), Timestamp: hlc.Timestamp{WallTime: 2}}
 		data, err := singleKVSSTable(key, roachpb.MakeValueFromString("1").RawBytes)

--- a/pkg/kv/kvserver/replica_sideload_test.go
+++ b/pkg/kv/kvserver/replica_sideload_test.go
@@ -584,7 +584,7 @@ func testRaftSSTableSideloadingProposal(t *testing.T, eng storage.Engine) {
 	tc.Start(t, stopper)
 
 	tr := tc.store.ClusterSettings().Tracer
-	tr.TestingIncludeAsyncSpansInRecordings() // we assert on async span traces in this test
+	tr.TestingRecordAsyncSpans() // we assert on async span traces in this test
 	ctx, collect, cancel := tracing.ContextWithRecordingSpan(context.Background(), tr, "test-recording")
 	defer cancel()
 

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -8487,7 +8487,7 @@ func TestFailureToProcessCommandClearsLocalResult(t *testing.T) {
 	r.mu.Unlock()
 
 	tr := tc.store.ClusterSettings().Tracer
-	tr.TestingIncludeAsyncSpansInRecordings() // we assert on async span traces in this test
+	tr.TestingRecordAsyncSpans() // we assert on async span traces in this test
 	opCtx, collect, cancel := tracing.ContextWithRecordingSpan(ctx, tr, "test-recording")
 	defer cancel()
 

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -160,7 +160,8 @@ type Tracer struct {
 	// to a function that returns `true`.
 	TracingVerbosityIndependentSemanticsIsActive func() bool
 
-	includeAsyncSpansInRecordings bool // see TestingIncludeAsyncSpansInRecordings
+	testingMu               syncutil.Mutex // protects testingRecordAsyncSpans
+	testingRecordAsyncSpans bool           // see TestingRecordAsyncSpans
 
 	testing *testingKnob
 }
@@ -713,11 +714,24 @@ func (t *Tracer) VisitSpans(visitor func(*Span) error) error {
 	return nil
 }
 
-// TestingIncludeAsyncSpansInRecordings is a test-only helper that configures
+// TestingRecordAsyncSpans is a test-only helper that configures
 // the tracer to include recordings from forked/async child spans, when
 // retrieving the recording for a parent span.
-func (t *Tracer) TestingIncludeAsyncSpansInRecordings() {
-	t.includeAsyncSpansInRecordings = true
+func (t *Tracer) TestingRecordAsyncSpans() {
+	t.testingMu.Lock()
+	defer t.testingMu.Unlock()
+
+	t.testingRecordAsyncSpans = true
+}
+
+// ShouldRecordAsyncSpans returns whether or not we should include recordings
+// from async child spans in the parent span. See TestingRecordAsyncSpans, this
+// mode is only used in tests.
+func (t *Tracer) ShouldRecordAsyncSpans() bool {
+	t.testingMu.Lock()
+	defer t.testingMu.Unlock()
+
+	return t.testingRecordAsyncSpans
 }
 
 // ForkSpan forks the current span, if any[1]. Forked spans "follow from" the
@@ -734,14 +748,14 @@ func (t *Tracer) TestingIncludeAsyncSpansInRecordings() {
 //
 // [1]: Looking towards the provided context to see if one exists.
 // [2]: Unless configured differently by tests, see
-//      TestingIncludeAsyncSpansInRecordings.
+//      TestingRecordAsyncSpans.
 func ForkSpan(ctx context.Context, opName string) (context.Context, *Span) {
 	sp := SpanFromContext(ctx)
 	if sp == nil {
 		return ctx, nil
 	}
 	collectionOpt := WithParentAndManualCollection(sp.Meta())
-	if sp.Tracer().includeAsyncSpansInRecordings {
+	if sp.Tracer().ShouldRecordAsyncSpans() {
 		// Using auto collection here ensures that recordings from async spans
 		// also show up at the parent.
 		collectionOpt = WithParentAndAutoCollection(sp)


### PR DESCRIPTION
Fixes #61393. There was a race condition in our tests by not doing so.

Release note: None