### PR TITLE
workload/schemachange: import workloadccl for testing

### DIFF
--- a/pkg/workload/schemachange/BUILD.bazel
+++ b/pkg/workload/schemachange/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/ccl",
+        "//pkg/ccl/workloadccl",
         "//pkg/security",
         "//pkg/security/securitytest",
         "//pkg/server",

--- a/pkg/workload/schemachange/schema_change_external_test.go
+++ b/pkg/workload/schemachange/schema_change_external_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl"
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/workloadccl"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"


### PR DESCRIPTION
I think this dependency needs to exist for bazel.

Release note: None