### PR TITLE
release-21.1: sql: allow `MDY, ISO` as a setting for DateStyle

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -150,6 +150,12 @@ SET escape_string_warning = 'off'
 statement ok
 SET datestyle = 'ISO'
 
+statement ok
+SET datestyle = 'ISO, MDY'
+
+statement ok
+SET datestyle = 'mdy, iso'
+
 statement error invalid value for parameter "DateStyle": "other"
 SET datestyle = 'other'
 

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -256,10 +256,11 @@ var varGen = map[string]sessionVar{
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
 			s = strings.ToLower(s)
 			parts := strings.Split(s, ",")
-			if strings.TrimSpace(parts[0]) != "iso" ||
-				(len(parts) == 2 && strings.TrimSpace(parts[1]) != "mdy") ||
-				len(parts) > 2 {
-				err := newVarValueError("DateStyle", s, "ISO", "ISO, MDY")
+			isOnlyISO := len(parts) == 1 && strings.TrimSpace(parts[0]) == "iso"
+			isISOMDY := len(parts) == 2 && strings.TrimSpace(parts[0]) == "iso" && strings.TrimSpace(parts[1]) == "mdy"
+			isMDYISO := len(parts) == 2 && strings.TrimSpace(parts[0]) == "mdy" && strings.TrimSpace(parts[1]) == "iso"
+			if !(isOnlyISO || isISOMDY || isMDYISO) {
+				err := newVarValueError("DateStyle", s, "ISO", "ISO, MDY", "MDY, ISO")
 				err = errors.WithDetail(err, compatErrMsg)
 				return err
 			}


### PR DESCRIPTION
Backport 1/1 commits from #62042.

/cc @cockroachdb/release

---

fixes #62026 

This is equivalent to the `ISO, MDY` setting. Allowing this value as
well improves compatibility with some tools.

Release note: None
