### PR TITLE
release-21.1: sql: Change to using a session variable instead of FORCE syntax for overriding zone configuration settings for MR databases and tables

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
@@ -32,7 +32,7 @@ DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USIN
                             voter_constraints = '[+region=ca-central-1]',
                             lease_preferences = '[[+region=ca-central-1]]'
 
-statement error attempting to modify protected field "num_voters" of a multi-region database zone configuration
+statement error attempting to modify protected field "num_voters" of a multi-region zone configuration
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING num_voters = 5
 
 query TT
@@ -65,22 +65,22 @@ DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USIN
                             lease_preferences = '[[+region=ca-central-1]]'
 
 # Ensure all fields are blocked
-statement error attempting to modify protected field "global_reads" of a multi-region database zone configuration
+statement error attempting to modify protected field "global_reads" of a multi-region zone configuration
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING global_reads = true
 
-statement error attempting to modify protected field "num_replicas" of a multi-region database zone configuration
+statement error attempting to modify protected field "num_replicas" of a multi-region zone configuration
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING num_replicas = 7
 
-statement error attempting to modify protected field "constraints" of a multi-region database zone configuration
+statement error attempting to modify protected field "constraints" of a multi-region zone configuration
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING constraints = '{+region=ap-southeast-2: 1}'
 
-statement error attempting to modify protected field "voter_constraints" of a multi-region database zone configuration
+statement error attempting to modify protected field "voter_constraints" of a multi-region zone configuration
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING voter_constraints = '[+region=ap-southeast-2]'
 
-statement error attempting to modify protected field "lease_preferences" of a multi-region database zone configuration
+statement error attempting to modify protected field "lease_preferences" of a multi-region zone configuration
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING lease_preferences = '[[+region=ap-southeast-2]]'
 
-# With above modified zone config, try and drop a region to get warning again
+# With above modified zone config, try and drop a region to get error again
 statement error attempting to update zone configuration for database "mr-zone-configs" which contains modified field "num_voters"
 ALTER DATABASE "mr-zone-configs" DROP REGION "ap-southeast-2"
 
@@ -126,7 +126,7 @@ DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USIN
                             lease_preferences = '[[+region=us-east-1]]'
 
 # Alter with one protected field and one unprotected field.
-statement error attempting to modify protected field "num_replicas" of a multi-region database zone configuration
+statement error attempting to modify protected field "num_replicas" of a multi-region zone configuration
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING num_replicas = 7, gc.ttlseconds = 100000
 
 statement ok
@@ -138,7 +138,7 @@ ALTER DATABASE "mr-zone-configs" SURVIVE REGION FAILURE
 statement ok
 ALTER DATABASE "mr-zone-configs" SURVIVE REGION FAILURE FORCE
 
-statement error attempting to modify protected field "constraints" of a multi-region database zone configuration
+statement error attempting to modify protected field "constraints" of a multi-region zone configuration
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING constraints = '{+region=us-east-1: 3}'
 
 statement ok
@@ -150,7 +150,7 @@ ALTER DATABASE "mr-zone-configs" DROP REGION "ap-southeast-2"
 statement ok
 ALTER DATABASE "mr-zone-configs" DROP REGION "ap-southeast-2" FORCE
 
-statement error attempting to modify protected field "voter_constraints" of a multi-region database zone configuration
+statement error attempting to modify protected field "voter_constraints" of a multi-region zone configuration
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING voter_constraints = '[+region=ap-southeast-2]'
 
 statement ok
@@ -188,7 +188,7 @@ DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USIN
                             voter_constraints = '{+region=us-east-1: 2}',
                             lease_preferences = '[[+region=us-east-1]]'
 
-statement error attempting to modify protected field "lease_preferences" of a multi-region database zone configuration
+statement error attempting to modify protected field "lease_preferences" of a multi-region zone configuration
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING lease_preferences = '[[+region=ap-southeast-2]]'
 
 statement ok
@@ -236,6 +236,255 @@ postgres         root   NULL            {}       NULL
 system           node   NULL            {}       NULL
 test             root   NULL            {}       NULL
 
-# FIXME: Write some more testcases here which test constraints which are longer to ensure
-# that slice checking is working (e.g. a constraints list which is much longer than what
-# the MR zone config would generate).
+statement ok
+ALTER DATABASE "mr-zone-configs" SET PRIMARY REGION "us-east-1"
+
+statement ok
+ALTER DATABASE "mr-zone-configs" ADD REGION "ca-central-1"
+
+statement ok
+ALTER DATABASE "mr-zone-configs" ADD REGION "ap-southeast-2"
+
+query TTTTT colnames
+SHOW DATABASES
+----
+database_name    owner  primary_region  regions                                  survival_goal
+defaultdb        root   NULL            {}                                       NULL
+mr-zone-configs  root   us-east-1       {ap-southeast-2,ca-central-1,us-east-1}  zone
+postgres         root   NULL            {}                                       NULL
+system           node   NULL            {}                                       NULL
+test             root   NULL            {}                                       NULL
+
+# Ensure that changes to the table-level zone config also require overriding.
+statement ok
+CREATE TABLE regional_by_row (
+  pk INT PRIMARY KEY,
+  i INT,
+  INDEX(i),
+  FAMILY (pk, i)
+) LOCALITY REGIONAL BY ROW
+
+statement ok
+CREATE TABLE regional_by_table (
+  pk INT PRIMARY KEY,
+  i INT,
+  INDEX(i),
+  FAMILY (pk, i)
+) LOCALITY REGIONAL BY TABLE
+
+statement ok
+ALTER table regional_by_row CONFIGURE ZONE USING gc.ttlseconds = 10
+
+statement error attempting to modify protected field "num_replicas" of a multi-region zone configuration
+ALTER table regional_by_row CONFIGURE ZONE USING num_replicas = 10
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER table regional_by_row CONFIGURE ZONE USING num_replicas = 10;
+SET override_multi_region_zone_config = false
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
+----
+TABLE regional_by_row  ALTER TABLE regional_by_row CONFIGURE ZONE USING
+                       range_min_bytes = 134217728,
+                       range_max_bytes = 536870912,
+                       gc.ttlseconds = 10,
+                       num_replicas = 10,
+                       num_voters = 3,
+                       constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                       voter_constraints = '[+region=us-east-1]',
+                       lease_preferences = '[[+region=us-east-1]]'
+
+statement error attempting to modify protected field "num_replicas" of a multi-region zone configuration
+ALTER partition "us-east-1" of index regional_by_row@primary CONFIGURE ZONE USING num_replicas = 10
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER partition "us-east-1" of index regional_by_row@primary CONFIGURE ZONE USING num_replicas = 10;
+SET override_multi_region_zone_config = false
+
+query TTT
+SELECT ZONE_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_replicas = 10,
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
+statement error attempting to update zone configuration for table "regional_by_row" which contains modified field "num_replicas"
+ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY TABLE
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY TABLE;
+SET override_multi_region_zone_config = false
+
+statement error attempting to modify protected field "num_replicas" of a multi-region zone configuration
+ALTER index regional_by_row@primary CONFIGURE ZONE USING num_replicas = 10
+
+query TTT
+SELECT ZONE_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+
+query TT
+SHOW ZONE CONFIGURATION FOR INDEX regional_by_row@primary
+----
+TABLE regional_by_row  ALTER TABLE regional_by_row CONFIGURE ZONE USING
+                       range_min_bytes = 134217728,
+                       range_max_bytes = 536870912,
+                       gc.ttlseconds = 10,
+                       num_replicas = 5,
+                       num_voters = 3,
+                       constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                       voter_constraints = '[+region=us-east-1]',
+                       lease_preferences = '[[+region=us-east-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR INDEX regional_by_row@regional_by_row_i_idx
+----
+TABLE regional_by_row  ALTER TABLE regional_by_row CONFIGURE ZONE USING
+                       range_min_bytes = 134217728,
+                       range_max_bytes = 536870912,
+                       gc.ttlseconds = 10,
+                       num_replicas = 5,
+                       num_voters = 3,
+                       constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                       voter_constraints = '[+region=us-east-1]',
+                       lease_preferences = '[[+region=us-east-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
+----
+TABLE regional_by_row  ALTER TABLE regional_by_row CONFIGURE ZONE USING
+                       range_min_bytes = 134217728,
+                       range_max_bytes = 536870912,
+                       gc.ttlseconds = 10,
+                       num_replicas = 5,
+                       num_voters = 3,
+                       constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                       voter_constraints = '[+region=us-east-1]',
+                       lease_preferences = '[[+region=us-east-1]]'
+
+statement ok
+ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY ROW
+
+statement ok
+ALTER TABLE regional_by_row SET LOCALITY GLOBAL
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER index regional_by_row@primary CONFIGURE ZONE USING num_replicas = 10;
+SET override_multi_region_zone_config = false
+
+statement ok
+ALTER TABLE regional_by_row SET LOCALITY GLOBAL
+
+statement error attempting to update zone configuration for table "regional_by_row" which contains a zone configuration on index "primary"
+ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY ROW
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY ROW;
+SET override_multi_region_zone_config = false
+
+statement ok
+CREATE TABLE regional_by_row_as (
+  pk INT PRIMARY KEY,
+  i INT,
+  cr crdb_internal_region NOT NULL DEFAULT 'ca-central-1',
+  INDEX(i),
+  FAMILY (cr, pk, i)
+) LOCALITY REGIONAL BY ROW AS "cr";
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER index regional_by_row_as@primary CONFIGURE ZONE USING num_replicas = 10;
+SET override_multi_region_zone_config = false
+
+query TT
+SHOW ZONE CONFIGURATION FOR INDEX regional_by_row_as@primary
+----
+INDEX regional_by_row_as@primary  ALTER INDEX regional_by_row_as@primary CONFIGURE ZONE USING
+                                  range_min_bytes = 134217728,
+                                  range_max_bytes = 536870912,
+                                  gc.ttlseconds = 90000,
+                                  num_replicas = 10,
+                                  num_voters = 3,
+                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                  voter_constraints = '[+region=us-east-1]',
+                                  lease_preferences = '[[+region=us-east-1]]'
+
+statement error attempting to update zone configuration for table "regional_by_row_as" which contains a zone configuration on index "primary" with multi-region field "num_replicas" set
+ALTER TABLE regional_by_row_as SET LOCALITY REGIONAL BY ROW
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER TABLE regional_by_row_as SET LOCALITY REGIONAL BY ROW;
+SET override_multi_region_zone_config = false
+
+query TT
+SHOW ZONE CONFIGURATION FOR INDEX regional_by_row_as@primary
+----
+DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
+                            range_min_bytes = 134217728,
+                            range_max_bytes = 536870912,
+                            gc.ttlseconds = 90000,
+                            num_replicas = 5,
+                            num_voters = 3,
+                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                            voter_constraints = '[+region=us-east-1]',
+                            lease_preferences = '[[+region=us-east-1]]'
+
+query TT
+SHOW CREATE TABLE regional_by_row_as
+----
+regional_by_row_as          CREATE TABLE public.regional_by_row_as (
+                            pk INT8 NOT NULL,
+                            i INT8 NULL,
+                            cr public.crdb_internal_region NOT NULL DEFAULT 'ca-central-1':::public.crdb_internal_region,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                            INDEX regional_by_row_as_i_idx (i ASC),
+                            FAMILY fam_0_cr_pk_i (cr, pk, i, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+query TTT
+SELECT ZONE_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row_as]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_as@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_as@regional_by_row_as_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row_as@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row_as@regional_by_row_as_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row_as@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row_as@regional_by_row_as_i_idx  us-east-1

--- a/pkg/ccl/multiregionccl/regional_by_row_test.go
+++ b/pkg/ccl/multiregionccl/regional_by_row_test.go
@@ -545,8 +545,10 @@ COMMIT;`)
 	// and we won't require the explicit force here.
 	testutils.SucceedsSoon(t, func() error {
 		_, err = sqlDB.Exec(`BEGIN;
+  SET override_multi_region_zone_config = true;
 	ALTER DATABASE db ADD REGION "us-east3";
-	ALTER DATABASE db DROP REGION "us-east2" FORCE;
+	ALTER DATABASE db DROP REGION "us-east2";
+  SET override_multi_region_zone_config = false;
 	COMMIT;`)
 		return err
 	})

--- a/pkg/config/zonepb/zone.go
+++ b/pkg/config/zonepb/zone.go
@@ -78,6 +78,30 @@ var MultiRegionZoneConfigFieldsSet = func() map[tree.Name]struct{} {
 	return ret
 }()
 
+// IsAnyMultiRegionFieldSet returns true if any of the multi-region fields are
+// set on the given zone config, and false if none of them are set.
+func (z *ZoneConfig) IsAnyMultiRegionFieldSet() (bool, string) {
+	if z.GlobalReads != nil {
+		return true, "global_reads"
+	}
+	if z.NumVoters != nil {
+		return true, "num_voters"
+	}
+	if z.NumReplicas != nil {
+		return true, "num_replicas"
+	}
+	if len(z.Constraints) != 0 {
+		return true, "constraints"
+	}
+	if len(z.LeasePreferences) != 0 {
+		return true, "lease_preferences"
+	}
+	if len(z.VoterConstraints) != 0 {
+		return true, "voter_constraints"
+	}
+	return false, ""
+}
+
 // ZoneSpecifierFromID creates a tree.ZoneSpecifier for the zone with the
 // given ID.
 func ZoneSpecifierFromID(
@@ -702,6 +726,24 @@ func (z *ZoneConfig) DiffWithZone(other ZoneConfig, fieldList []tree.Name) (bool
 			}
 		default:
 			return false, "", errors.AssertionFailedf("unknown zone configuration field %q", fieldName)
+		}
+	}
+
+	// Look into all subzones and ensure they're equal across both zone
+	// configs.
+	if len(z.Subzones) != len(other.Subzones) {
+		return false, "subzones", nil
+	}
+	for i, s := range z.Subzones {
+		o := other.Subzones[i]
+		if s.IndexID != o.IndexID {
+			return false, "subzone_index_id", nil
+		}
+		if s.PartitionName != o.PartitionName {
+			return false, "subzone_partition_name", nil
+		}
+		if b, str, err := s.Config.DiffWithZone(o.Config, fieldList); !b {
+			return b, str, err
 		}
 	}
 	return true, "", nil

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -236,6 +236,13 @@ var dropEnumValueEnabledClusterMode = settings.RegisterBoolSetting(
 	false,
 )
 
+var overrideMultiRegionZoneConfigClusterMode = settings.RegisterBoolSetting(
+	"sql.defaults.override_multi_region_zone_config.enabled",
+	"default value for override_multi_region_zone_config; "+
+		"allows for overriding the zone configs of a multi-region table or database",
+	false,
+)
+
 var hashShardedIndexesEnabledClusterMode = settings.RegisterBoolSetting(
 	"sql.defaults.experimental_hash_sharded_indexes.enabled",
 	"default value for experimental_enable_hash_sharded_indexes; allows for creation of hash sharded indexes by default",
@@ -2310,6 +2317,10 @@ func (m *sessionDataMutator) SetImplicitColumnPartitioningEnabled(val bool) {
 
 func (m *sessionDataMutator) SetDropEnumValueEnabled(val bool) {
 	m.data.DropEnumValueEnabled = val
+}
+
+func (m *sessionDataMutator) SetOverrideMultiRegionZoneConfigEnabled(val bool) {
+	m.data.OverrideMultiRegionZoneConfigEnabled = val
 }
 
 func (m *sessionDataMutator) SetHashShardedIndexesEnabled(val bool) {

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -3631,6 +3631,7 @@ node_id                                               1
 optimizer                                             on
 optimizer_use_histograms                              on
 optimizer_use_multicol_stats                          on
+override_multi_region_zone_config                     off
 prefer_lookup_joins_for_fks                           off
 reorder_joins_limit                                   8
 require_explicit_primary_keys                         off

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2131,6 +2131,7 @@ max_index_keys                                        32                  NULL  
 node_id                                               1                   NULL      NULL        NULL        string
 optimizer_use_histograms                              on                  NULL      NULL        NULL        string
 optimizer_use_multicol_stats                          on                  NULL      NULL        NULL        string
+override_multi_region_zone_config                     off                 NULL      NULL        NULL        string
 prefer_lookup_joins_for_fks                           off                 NULL      NULL        NULL        string
 reorder_joins_limit                                   8                   NULL      NULL        NULL        string
 require_explicit_primary_keys                         off                 NULL      NULL        NULL        string
@@ -2210,6 +2211,7 @@ max_index_keys                                        32                  NULL  
 node_id                                               1                   NULL  user     NULL      1                   1
 optimizer_use_histograms                              on                  NULL  user     NULL      on                  on
 optimizer_use_multicol_stats                          on                  NULL  user     NULL      on                  on
+override_multi_region_zone_config                     off                 NULL  user     NULL      off                 off
 prefer_lookup_joins_for_fks                           off                 NULL  user     NULL      off                 off
 reorder_joins_limit                                   8                   NULL  user     NULL      8                   8
 require_explicit_primary_keys                         off                 NULL  user     NULL      off                 off
@@ -2286,6 +2288,7 @@ node_id                                               NULL    NULL     NULL     
 optimizer                                             NULL    NULL     NULL     NULL        NULL
 optimizer_use_histograms                              NULL    NULL     NULL     NULL        NULL
 optimizer_use_multicol_stats                          NULL    NULL     NULL     NULL        NULL
+override_multi_region_zone_config                     NULL    NULL     NULL     NULL        NULL
 prefer_lookup_joins_for_fks                           NULL    NULL     NULL     NULL        NULL
 reorder_joins_limit                                   NULL    NULL     NULL     NULL        NULL
 require_explicit_primary_keys                         NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -70,6 +70,7 @@ max_index_keys                                        32
 node_id                                               1
 optimizer_use_histograms                              on
 optimizer_use_multicol_stats                          on
+override_multi_region_zone_config                     off
 prefer_lookup_joins_for_fks                           off
 reorder_joins_limit                                   8
 require_explicit_primary_keys                         off

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -12,7 +12,9 @@ package sql
 
 import (
 	"context"
+	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
@@ -822,46 +824,63 @@ func (p *planner) CurrentDatabaseRegionConfig() (tree.DatabaseRegionConfig, erro
 	return dbDesc.GetRegionConfig(), nil
 }
 
-// CheckZoneConfigChangePermittedForMultiRegionDatabase checks if a zone config
-// change is permitted for a multi-region database. The change is permitted iff
-// it is not modifying a protested multi-region field of the zone configs (as
-// defined by zonepb.MultiRegionZoneConfigFields).
-func (p *planner) CheckZoneConfigChangePermittedForMultiRegionDatabase(
-	ctx context.Context, dbName tree.Name, options tree.KVOptions, force bool,
+// CheckZoneConfigChangePermittedForMultiRegion checks if a zone config
+// change is permitted for a multi-region database, table, index or partition.
+// The change is permitted iff it is not modifying a protected multi-region
+// field of the zone configs (as defined by zonepb.MultiRegionZoneConfigFields).
+func (p *planner) CheckZoneConfigChangePermittedForMultiRegion(
+	ctx context.Context, zs tree.ZoneSpecifier, options tree.KVOptions, force bool,
 ) error {
 	// If the user has specified the FORCE option, the world is their oyster.
 	if force {
 		return nil
 	}
 
-	_, dbDesc, err := p.Descriptors().GetImmutableDatabaseByName(
-		ctx,
-		p.txn,
-		string(dbName),
-		tree.DatabaseLookupFlags{Required: true},
-	)
-	if err != nil {
-		return err
-	}
-
-	if dbDesc.RegionConfig != nil {
-		// This is clearly an n^2 operation, but since there are only a single
-		// digit number of zone config keys, it's likely faster to do it this way
-		// than incur the memory allocation of creating a map.
-		for _, opt := range options {
-			for _, cfg := range zonepb.MultiRegionZoneConfigFields {
-				if opt.Key == cfg {
-					// User is trying to update a zone config value that's protected for
-					// multi-region databases. Return the constructed error.
-					err := errors.Newf("attempting to modify protected field %q of a multi-region database zone configuration",
-						string(opt.Key),
-					)
-					return errors.WithHint(err, "to override this error, specify the FORCE option")
-				}
-			}
+	// Check if what we're altering is a multi-region entity.
+	if zs.Database != "" {
+		_, dbDesc, err := p.Descriptors().GetImmutableDatabaseByName(
+			ctx,
+			p.txn,
+			string(zs.Database),
+			tree.DatabaseLookupFlags{Required: true},
+		)
+		if err != nil {
+			return err
+		}
+		if dbDesc.RegionConfig == nil {
+			// Not a multi-region database, we're done here.
+			return nil
+		}
+	} else {
+		// We're dealing with a table, index, or partition zone configuration
+		// change.  Get the table descriptor so we can determine if this is a
+		// multi-region table/index/partition.
+		table, err := p.resolveTableForZone(ctx, &zs)
+		if err != nil {
+			return err
+		}
+		if table == nil || table.GetLocalityConfig() == nil {
+			// Not a multi-region table, we're done here.
+			return nil
 		}
 	}
 
+	// This is clearly an n^2 operation, but since there are only a single
+	// digit number of zone config keys, it's likely faster to do it this way
+	// than incur the memory allocation of creating a map.
+	for _, opt := range options {
+		for _, cfg := range zonepb.MultiRegionZoneConfigFields {
+			if opt.Key == cfg {
+				// User is trying to update a zone config value that's protected for
+				// multi-region databases. Return the constructed error.
+				err := errors.Newf("attempting to modify protected field %q of a multi-region zone configuration",
+					string(opt.Key),
+				)
+				return errors.WithHint(err, "to override this error, "+
+					"SET override_multi_region_zone_config = true and reissue the command")
+			}
+		}
+	}
 	return nil
 }
 
@@ -908,6 +927,121 @@ func validateZoneConfigForMultiRegionDatabaseWasNotModifiedByUser(
 			"a user modified field")
 		return errors.WithHint(err, "to override this error and proceed with "+
 			"the overwrite, specify \"FORCE\" at the end of the statement")
+	}
+
+	return nil
+}
+
+// validateZoneConfigForMultiRegionTableWasNotModifiedByUser validates that
+// the table's zone configuration was not modified by the user. The function is
+// intended to be called in cases where a multi-region operation will overwrite
+// the table's (or index's/partition's) zone configuration and we wish to warn
+// the user about that before it occurs (and require the
+// override_multi_region_zone_config session variable to be set).
+func validateZoneConfigForMultiRegionTableWasNotModifiedByUser(
+	ctx context.Context,
+	txn *kv.Txn,
+	execCfg *ExecutorConfig,
+	regionConfig descpb.DatabaseDescriptor_RegionConfig,
+	desc *tabledesc.Mutable,
+	toRegionalByRow bool,
+	override bool,
+	opts ...applyZoneConfigForMultiRegionTableOption,
+) error {
+	// If the user is forcing, or this is not a multi-region table our work here
+	// is done.
+	if override || desc.GetLocalityConfig() == nil {
+		return nil
+	}
+
+	hint := "to proceed with the override, SET override_multi_region_zone_config = true, and reissue the statement"
+
+	currentZoneConfig, err := getZoneConfigRaw(ctx, txn, execCfg.Codec, desc.GetID())
+	if err != nil {
+		return err
+	}
+	if currentZoneConfig == nil {
+		currentZoneConfig = zonepb.NewZoneConfig()
+	}
+
+	// The expected zone config starts from the same base config as the current
+	// zone config, so copy it over to be used down below.
+	expectedZoneConfig := currentZoneConfig
+
+	if toRegionalByRow {
+		// We're going to REGIONAL BY ROW. Check to see if the to be applied zone
+		// configurations will override any existing zone configurations on the
+		// table's indexes. We say "override" here, and not "overwrite" because
+		// REGIONAL BY ROW tables will not write zone configs at the index level,
+		// but instead, at the index partition level. That being said, application
+		// of a partition-level zone config will override any applied index-level
+		// zone config, so it's important that we warn the user of that.
+		for _, s := range currentZoneConfig.Subzones {
+			if s.PartitionName == "" {
+				// Found a zone config on an index. Check to see if any of its
+				// multi-region fields are set.
+				if isSet, str := s.Config.IsAnyMultiRegionFieldSet(); isSet {
+					// Find the name of the offending index to use in the message below.
+					// In the case where we can't find the name, do our best and return
+					// the ID.
+					indexName := fmt.Sprintf("unknown with ID = %s",
+						strconv.FormatUint(uint64(s.IndexID), 10))
+					for _, i := range desc.ActiveIndexes() {
+						if uint32(i.GetID()) == s.IndexID {
+							indexName = i.GetName()
+						}
+					}
+					err := errors.Newf(
+						"attempting to update zone configuration for table %q which "+
+							"contains a zone configuration on index %q with multi-region field %q set",
+						desc.GetName(),
+						indexName,
+						str,
+					)
+					err = errors.WithDetail(err, "the attempted operation will override "+
+						"the index zone configuration field")
+					return errors.WithHint(err, hint)
+				}
+			}
+		}
+	}
+
+	// Fill in the expectedZoneConfig using the specified option.
+	for _, opt := range opts {
+		_, newZoneConfig, err := opt(
+			*expectedZoneConfig,
+			regionConfig,
+			desc,
+		)
+		if err != nil {
+			return err
+		}
+		expectedZoneConfig = &newZoneConfig
+	}
+
+	// Mark the NumReplicas as 0 if we have subzones but no other features
+	// in the zone config. This signifies a placeholder.
+	if len(expectedZoneConfig.Subzones) > 0 && isPlaceholderZoneConfigForMultiRegion(*expectedZoneConfig) {
+		expectedZoneConfig.NumReplicas = proto.Int32(0)
+	}
+
+	// Compare the two zone configs to see if anything is amiss.
+	same, field, err := currentZoneConfig.DiffWithZone(
+		*expectedZoneConfig,
+		zonepb.MultiRegionZoneConfigFields,
+	)
+	if err != nil {
+		return err
+	}
+	if !same {
+		err := errors.Newf(
+			"attempting to update zone configuration for table %q which contains modified field %q ",
+			desc.GetName(),
+			field,
+		)
+		err = errors.WithDetail(err, "the attempted operation will overwrite "+
+			"a user modified field")
+		return errors.WithHint(err, hint)
 	}
 
 	return nil

--- a/pkg/sql/rowenc/testutils.go
+++ b/pkg/sql/rowenc/testutils.go
@@ -824,6 +824,12 @@ func RandTypeFromSlice(rng *rand.Rand, typs []*types.T) *types.T {
 func RandColumnType(rng *rand.Rand) *types.T {
 	for {
 		typ := RandType(rng)
+		switch typ.Oid() {
+		case oid.T_int2vector, oid.T_oidvector:
+			// OIDVECTOR and INT2VECTOR are not valid column types for
+			// user-created tables.
+			continue
+		}
 		if err := colinfo.ValidateColumnDefType(typ); err == nil {
 			return typ
 		}
@@ -1517,7 +1523,7 @@ func randColumnTableDef(rand *rand.Rand, tableIdx int, colIdx int) *tree.ColumnT
 		// We make a unique name for all columns by prefixing them with the table
 		// index to make it easier to reference columns from different tables.
 		Name: tree.Name(fmt.Sprintf("col%d_%d", tableIdx, colIdx)),
-		Type: RandSortingType(rand),
+		Type: RandColumnType(rand),
 	}
 	columnDef.Nullable.Nullability = tree.Nullability(rand.Intn(int(tree.SilentNull) + 1))
 	return columnDef

--- a/pkg/sql/rowenc/testutils.go
+++ b/pkg/sql/rowenc/testutils.go
@@ -1220,8 +1220,8 @@ func RandCreateTableWithInterleave(
 
 		// Make a random primary key with high likelihood.
 		if rng.Intn(8) != 0 {
-			indexDef := randIndexTableDefFromCols(rng, columnDefs)
-			if len(indexDef.Columns) > 0 {
+			indexDef, ok := randIndexTableDefFromCols(rng, columnDefs)
+			if ok && !indexDef.Inverted {
 				defs = append(defs, &tree.UniqueConstraintTableDef{
 					PrimaryKey:    true,
 					IndexTableDef: indexDef,
@@ -1252,11 +1252,13 @@ func RandCreateTableWithInterleave(
 	// Make indexes.
 	nIdxs := rng.Intn(10)
 	for i := 0; i < nIdxs; i++ {
-		indexDef := randIndexTableDefFromCols(rng, columnDefs)
-		if len(indexDef.Columns) == 0 {
+		indexDef, ok := randIndexTableDefFromCols(rng, columnDefs)
+		if !ok {
 			continue
 		}
-		unique := rng.Intn(2) == 0
+		// Make forward indexes unique 50% of the time. Inverted indexes cannot
+		// be unique.
+		unique := !indexDef.Inverted && rng.Intn(2) == 0
 		if unique {
 			defs = append(defs, &tree.UniqueConstraintTableDef{
 				IndexTableDef: indexDef,
@@ -1626,11 +1628,12 @@ func randComputedColumnTableDef(
 	return newDef
 }
 
-// randIndexTableDefFromCols creates an IndexTableDef with a random subset of
-// the given columns and a random direction.
+// randIndexTableDefFromCols attempts to create an IndexTableDef with a random
+// subset of the given columns and a random direction. If unsuccessful, ok=false
+// is returned.
 func randIndexTableDefFromCols(
 	rng *rand.Rand, columnTableDefs []*tree.ColumnTableDef,
-) tree.IndexTableDef {
+) (def tree.IndexTableDef, ok bool) {
 	cpy := make([]*tree.ColumnTableDef, len(columnTableDefs))
 	copy(cpy, columnTableDefs)
 	rng.Shuffle(len(cpy), func(i, j int) { cpy[i], cpy[j] = cpy[j], cpy[i] })
@@ -1638,18 +1641,28 @@ func randIndexTableDefFromCols(
 
 	cols := cpy[:nCols]
 
-	indexElemList := make(tree.IndexElemList, 0, len(cols))
+	def.Columns = make(tree.IndexElemList, 0, len(cols))
 	for i := range cols {
 		semType := tree.MustBeStaticallyKnownType(cols[i].Type)
-		if !colinfo.ColumnTypeIsIndexable(semType) {
-			continue
+
+		// The non-terminal index columns must be indexable.
+		if isLastCol := i == len(cols)-1; !isLastCol && !colinfo.ColumnTypeIsIndexable(semType) {
+			return tree.IndexTableDef{}, false
 		}
-		indexElemList = append(indexElemList, tree.IndexElem{
+
+		// The last index column can be inverted-indexable, which makes the
+		// index an inverted index.
+		if colinfo.ColumnTypeIsInvertedIndexable(semType) {
+			def.Inverted = true
+		}
+
+		def.Columns = append(def.Columns, tree.IndexElem{
 			Column:    cols[i].Name,
 			Direction: tree.Direction(rng.Intn(int(tree.Descending) + 1)),
 		})
 	}
-	return tree.IndexTableDef{Columns: indexElemList}
+
+	return def, true
 }
 
 // randPartialIndexPredicateFromCols creates a partial index expression with a

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -211,6 +211,9 @@ type LocalOnlySessionData struct {
 	ImplicitColumnPartitioningEnabled bool
 	// DropEnumValueEnabled indicates whether enum values can be dropped.
 	DropEnumValueEnabled bool
+	// OverrideMultiRegionZoneConfigEnabled indicates whether zone configurations can be
+	// modified for multi-region databases and tables/indexes/partitions.
+	OverrideMultiRegionZoneConfigEnabled bool
 	// HashShardedIndexesEnabled indicates whether hash sharded indexes can be created.
 	HashShardedIndexesEnabled bool
 	// DisallowFullTableScans indicates whether queries that plan full table scans

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -130,15 +130,22 @@ func (p *planner) SetZoneConfig(ctx context.Context, n *tree.SetZoneConfig) (pla
 		return nil, errorutil.UnsupportedWithMultiTenancy(multitenancyZoneCfgIssueNo)
 	}
 
+	var override bool
+	// TODO(ajstorm): This branching is temporary until we remove the FORCE option
+	// from database commands
 	if n.Database != "" {
-		if err := p.CheckZoneConfigChangePermittedForMultiRegionDatabase(
-			ctx,
-			n.Database,
-			n.Options,
-			n.Force,
-		); err != nil {
-			return nil, err
-		}
+		override = n.Force
+	} else {
+		override = p.SessionData().OverrideMultiRegionZoneConfigEnabled
+	}
+
+	if err := p.CheckZoneConfigChangePermittedForMultiRegion(
+		ctx,
+		n.ZoneSpecifier,
+		n.Options,
+		override,
+	); err != nil {
+		return nil, err
 	}
 
 	var yamlConfig tree.TypedExpr
@@ -950,8 +957,9 @@ func getZoneConfigRaw(
 }
 
 // RemoveIndexZoneConfigs removes the zone configurations for some
-// indexs being dropped. It is a no-op if there is no zone
-// configuration or run on behalf of a tenant.
+// indexes being dropped. It is a no-op if there is no zone
+// configuration, there's no index zone configs to be dropped,
+// or it is run on behalf of a tenant.
 //
 // It operates entirely on the current goroutine and is thus able to
 // reuse an existing client.Txn safely.

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -1161,6 +1161,25 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`override_multi_region_zone_config`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`override_multi_region_zone_config`),
+		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("override_multi_region_zone_config", s)
+			if err != nil {
+				return err
+			}
+			m.SetOverrideMultiRegionZoneConfigEnabled(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) string {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData.OverrideMultiRegionZoneConfigEnabled)
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return formatBoolAsPostgresSetting(overrideMultiRegionZoneConfigClusterMode.Get(sv))
+		},
+	},
+
+	// CockroachDB extension.
 	`experimental_enable_hash_sharded_indexes`: {
 		GetStringVal: makePostgresBoolGetStringValFn(`experimental_enable_hash_sharded_indexes`),
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {

--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -15,7 +15,7 @@
     "cypress:update-snapshots": "yarn cypress run --env updateSnapshots=true --spec 'cypress/integration/**/*.visual.spec.ts'"
   },
   "dependencies": {
-    "@cockroachlabs/cluster-ui": "^0.2.12",
+    "@cockroachlabs/cluster-ui": "^0.2.15",
     "analytics-node": "^3.5.0",
     "antd": "^3.25.2",
     "babel-polyfill": "^6.26.0",

--- a/pkg/ui/yarn.lock
+++ b/pkg/ui/yarn.lock
@@ -1813,10 +1813,10 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@cockroachlabs/cluster-ui@^0.2.12":
-  version "0.2.12"
-  resolved "https://registry.yarnpkg.com/@cockroachlabs/cluster-ui/-/cluster-ui-0.2.12.tgz#0dc482bbdc70923f3c52a9e1388f7539b8a4f536"
-  integrity sha512-fnlcLrQL2QJXyiv16EzPc6sDd/mjV53u7OKi7sCTMSMM/fBqF9pNuUaRYG0azMtVPrkpHmaDvRaiDcNJHdF9Ww==
+"@cockroachlabs/cluster-ui@^0.2.15":
+  version "0.2.15"
+  resolved "https://registry.yarnpkg.com/@cockroachlabs/cluster-ui/-/cluster-ui-0.2.15.tgz#4411c126c0d6c8e453e5841d10cebb5604606b2a"
+  integrity sha512-nGsYLA5m2WT5WHMTn5fWJJMuuy3idru6kxtyJ/BqyN97PHZbisQDjMcX1wuLHYhPaQbhXBmfEefyehcn93CpWg==
   dependencies:
     "@babel/runtime" "^7.12.13"
     "@cockroachlabs/crdb-protobuf-client" "^0.0.7"


### PR DESCRIPTION
Backport 3/3 commits from #62008.

/cc @cockroachdb/release

---

sql: Block zone config updates to multi-region tables

Block users from updating the zone configurations of multi-region
tables, without first having them set the session variable
`override_multi_region_zone_config` to true. We block updates to
multi-region table/partition/index zone configurations because we don't
want users to accidentally override the prescribed settings, leaving
them open to sub-optimal performance. Note that only the multi-region
fields of the zone configuration are blocked behind this variable. All
other fields (gc.ttlseconds, range_min/max_bytes, etc) can be updated
without overriding.

Release note (sql change): Block users from updating the zone
configurations of multi-region tables.

sql: Use session variable instead of FORCE to override zone configs

With #61499 we introduced new syntax (FORCE) to override setting the
zone configurations on multi-region databases. Upon further reflection,
it was decided that a session variable would be better suited to the
task. This commit pulls out the FORCE syntax and replaces it with the
use of override_multi_region_zone_config;

Release note (sql change): Revert the release notes on #61499.  We now
use a session variable (override_multi_region_zone_config) to override
the zone configuration on multi-region databases (and tables).

Resolves: #57668.

Note to reviewers: Please ignore the first commit, as it's being separately reviewed as part of #61889.  That commit was pulle out into a separate PR as it's a release blocker, and there was a need to get it in urgently.
