### PR TITLE
release-21.1: kvserver: consider replica GC when leader loses quorum

### DIFF
--- a/pkg/kv/kvserver/replica_gc_queue.go
+++ b/pkg/kv/kvserver/replica_gc_queue.go
@@ -43,6 +43,10 @@ const (
 	// would require the replica to be removed from the range before it ever
 	// learned about its promotion but that state shouldn't last long so we
 	// also treat idle replicas in that state as suspect.
+	//
+	// A leader unable to make progress (e.g. because it's lost a quorum) is
+	// also considered suspect, since Node.ResetQuorum() may be used to restore
+	// the range elsewhere.
 	ReplicaGCQueueSuspectTimeout = 1 * time.Second
 )
 
@@ -152,12 +156,8 @@ func (rgcq *replicaGCQueue) shouldQueue(
 	// 10 days before removing the node. Finally we consider replicas which are
 	// VOTER_INCOMING as suspect because no replica should stay in that state for
 	// too long and being conservative here doesn't seem worthwhile.
-	isSuspect := replDesc.GetType() != roachpb.VOTER_FULL && replDesc.GetType() != roachpb.NON_VOTER
-	if raftStatus := repl.RaftStatus(); raftStatus != nil {
-		isSuspect = isSuspect ||
-			(raftStatus.SoftState.RaftState == raft.StateCandidate ||
-				raftStatus.SoftState.RaftState == raft.StatePreCandidate)
-	} else {
+	var isSuspect bool
+	if raftStatus := repl.RaftStatus(); raftStatus == nil {
 		// If a replica doesn't have an active raft group, we should check
 		// whether or not it is active. If not, we should process the replica
 		// because it has probably already been removed from its raft group but
@@ -167,6 +167,24 @@ func (rgcq *replicaGCQueue) shouldQueue(
 		if repl.store.cfg.NodeLiveness != nil {
 			if liveness, ok := repl.store.cfg.NodeLiveness.Self(); ok && !liveness.Membership.Active() {
 				return true, replicaGCPriorityDefault
+			}
+		}
+	} else if t := replDesc.GetType(); t != roachpb.VOTER_FULL && t != roachpb.NON_VOTER {
+		isSuspect = true
+	} else {
+		switch raftStatus.SoftState.RaftState {
+		case raft.StateCandidate, raft.StatePreCandidate:
+			isSuspect = true
+		case raft.StateLeader:
+			// If the replica is the leader, we check whether it has a quorum.
+			// Otherwise, it's possible that e.g. Node.ResetQuorum will be used
+			// to recover the range elsewhere, and we should relinquish our
+			// lease and GC the range.
+			if repl.store.cfg.NodeLiveness != nil {
+				livenessMap := repl.store.cfg.NodeLiveness.GetIsLiveMap()
+				isSuspect = !repl.Desc().Replicas().CanMakeProgress(func(d roachpb.ReplicaDescriptor) bool {
+					return livenessMap[d.NodeID].IsLive
+				})
 			}
 		}
 	}

--- a/pkg/kv/kvserver/replica_gc_queue.go
+++ b/pkg/kv/kvserver/replica_gc_queue.go
@@ -152,7 +152,7 @@ func (rgcq *replicaGCQueue) shouldQueue(
 	// 10 days before removing the node. Finally we consider replicas which are
 	// VOTER_INCOMING as suspect because no replica should stay in that state for
 	// too long and being conservative here doesn't seem worthwhile.
-	isSuspect := replDesc.GetType() != roachpb.VOTER_FULL
+	isSuspect := replDesc.GetType() != roachpb.VOTER_FULL && replDesc.GetType() != roachpb.NON_VOTER
 	if raftStatus := repl.RaftStatus(); raftStatus != nil {
 		isSuspect = isSuspect ||
 			(raftStatus.SoftState.RaftState == raft.StateCandidate ||

--- a/pkg/kv/kvserver/reset_quorum_test.go
+++ b/pkg/kv/kvserver/reset_quorum_test.go
@@ -31,11 +31,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestResetQuorum tests the ResetQuorum method in various scenarios.
-// We do this by starting a four-node cluster with a scratch range
-// replicated to all nodes but n1. We then shut down nodes as necessary,
-// to simulate partial or total data loss, check to see if the range is
-// unavailable, and finally attempt to use ResetQuorum against it.
+// TestResetQuorum tests the ResetQuorum method in various scenarios. We do this
+// by starting a five-node cluster with a scratch range replicated to all nodes
+// but n1, with n5 as a non-voting replica. We then shut down nodes as
+// necessary, to simulate partial or total data loss, check to see if the range
+// is unavailable, and finally attempt to use ResetQuorum against it.
 //
 // We cover resetting quorum for:
 // 1. A range with no remaining replicas.
@@ -44,9 +44,11 @@ import (
 // empty slate.
 // 3. A range with replicas on nodes other than the one being addressed.
 // We expect existing replicas to be nuked away and to end up with an
-// empty slate.
-// 4. A range that has not lost quorum (error expected).
-// 5. A meta range (error expected).
+// empty slate, except for the non-voting replica.
+// 4. A range with a leaseholder replica on a node other than the one being
+// addressed. We expect it to be nuked, except for the non-voting replica.
+// 5. A range that has not lost quorum (error expected).
+// 6. A meta range (error expected).
 func TestResetQuorum(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -56,8 +58,8 @@ func TestResetQuorum(t *testing.T) {
 	ctx := context.Background()
 	livenessDuration := 3000 * time.Millisecond
 
-	// This function sets up a test cluster with 4 nodes with a scratch
-	// range on n2, n3, and n4 only.
+	// This function sets up a test cluster with 5 nodes with a scratch
+	// range on n2, n3, and n4 with n5 as a non-voting replica.
 	setup := func(
 		t *testing.T,
 	) (tc *testcluster.TestCluster, k roachpb.Key, id roachpb.RangeID) {
@@ -72,11 +74,11 @@ func TestResetQuorum(t *testing.T) {
 				},
 			},
 		}
-		tc = testcluster.StartTestCluster(t, 4, clusterArgs)
+		tc = testcluster.StartTestCluster(t, 5, clusterArgs)
 
-		n1, n2, n3, n4 := 0, 1, 2, 3
+		n1, n2, n3, n4, n5 := 0, 1, 2, 3, 4
 
-		// Set up a scratch range isolated to n2, n3, and n4.
+		// Set up a scratch range isolated to n2, n3, and n4, with a non-voter on n5.
 		k = tc.ScratchRange(t)
 		_, err := tc.AddVoters(k, tc.Target(n2))
 		require.NoError(t, err)
@@ -84,14 +86,16 @@ func TestResetQuorum(t *testing.T) {
 		require.NoError(t, err)
 		desc, err := tc.AddVoters(k, tc.Target(n4))
 		require.NoError(t, err)
+		_, err = tc.AddNonVoters(k, tc.Target(n5))
+		require.NoError(t, err)
 		require.NoError(t, tc.TransferRangeLease(desc, tc.Target(n2)))
 		desc, err = tc.RemoveVoters(k, tc.Target(n1))
 		require.NoError(t, err)
-		require.Len(t, desc.Replicas().Descriptors(), 3)
+		require.Len(t, desc.Replicas().Descriptors(), 4)
 
 		srv := tc.Server(n1)
 
-		require.NoError(t, srv.DB().Put(ctx, k, "bar"))
+		require.NoError(t, srv.DB().Put(ctx, k, "original"))
 
 		metaKey := keys.RangeMetaKey(desc.EndKey).AsRawKey()
 		// Read the meta2 which ResetQuorum updates while the range
@@ -109,7 +113,7 @@ func TestResetQuorum(t *testing.T) {
 	checkUnavailable := func(srv serverutils.TestServerInterface, k roachpb.Key) {
 		cCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
 		defer cancel()
-		err := srv.DB().Put(cCtx, k, "baz")
+		err := srv.DB().Put(cCtx, k, "unavailable")
 		// NB: we don't assert on the exact error since our RPC layer
 		// tries to return a better error than DeadlineExceeded (at
 		// the time of writing, we get a connection failure to n2),
@@ -123,7 +127,7 @@ func TestResetQuorum(t *testing.T) {
 	// reset by getting the range descriptor from meta2 and
 	// verifying that the given node is the only replica.
 	verifyResult := func(
-		t *testing.T, srv serverutils.TestServerInterface, k roachpb.Key, store *kvserver.Store, rangeID roachpb.RangeID,
+		t *testing.T, srv serverutils.TestServerInterface, k roachpb.Key, rangeID roachpb.RangeID,
 	) {
 		val, err := srv.DB().Get(ctx, k)
 		require.NoError(t, err)
@@ -131,10 +135,10 @@ func TestResetQuorum(t *testing.T) {
 			t.Fatalf("key not empty, expected to be empty after resetting quorum")
 		}
 
-		require.NoError(t, srv.DB().Put(ctx, k, "baz"))
+		require.NoError(t, srv.DB().Put(ctx, k, "reset"))
 
 		var updatedDesc roachpb.RangeDescriptor
-		require.NoError(t, store.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		require.NoError(t, srv.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 			kvs, err := kvclient.ScanMetaKVs(ctx, txn, roachpb.Span{
 				Key:    roachpb.KeyMin,
 				EndKey: roachpb.KeyMax,
@@ -161,73 +165,135 @@ func TestResetQuorum(t *testing.T) {
 		}
 	}
 
+	checkReplicaGC := func(t *testing.T, srv serverutils.TestServerInterface, rangeID roachpb.RangeID) {
+		store, err := srv.GetStores().(*kvserver.Stores).GetStore(srv.GetFirstStoreID())
+		require.NoError(t, err)
+		require.Eventually(t, func() bool {
+			return store.GetReplicaIfExists(rangeID) == nil
+		}, 10*time.Second, 200*time.Millisecond, "old replica not GCed on node %v", srv.NodeID())
+	}
+
+	checkConsistency := func(t *testing.T, srvs ...serverutils.TestServerInterface) {
+		for _, srv := range srvs {
+			store, err := srv.GetStores().(*kvserver.Stores).GetStore(srv.GetFirstStoreID())
+			require.NoError(t, err)
+			err = store.ForceConsistencyQueueProcess()
+			require.NoError(t, err, "consistency check failed on node %v", srv.NodeID())
+		}
+	}
+
 	t.Run("with-full-quorum-loss", func(t *testing.T) {
 		tc, k, id := setup(t)
 		defer tc.Stopper().Stop(ctx)
-		n1, n2, n3, n4 := 0, 1, 2, 3
+		n1, n2, n3, n4, n5 := 0, 1, 2, 3, 4
 		srv := tc.Server(n1)
 		tc.StopServer(n2)
 		tc.StopServer(n3)
 		tc.StopServer(n4)
-		// Wait for n2, n3, and n4 liveness to expire.
-		time.Sleep(livenessDuration)
+		tc.StopServer(n5)
 
+		// Wait for n2, n3, n4, and n5 liveness to expire.
+		time.Sleep(livenessDuration)
 		checkUnavailable(srv, k)
 
-		// Get the store on the designated survivor n1.
-		var store *kvserver.Store
-		require.NoError(t, srv.GetStores().(*kvserver.Stores).VisitStores(func(inner *kvserver.Store) error {
-			store = inner
-			return nil
-		}))
-		if store == nil {
-			t.Fatal("no store found on n1")
-		}
-
 		// Call ResetQuorum to reset quorum on the unhealthy range.
-		_, err := srv.Node().(*server.Node).ResetQuorum(
-			ctx,
-			&roachpb.ResetQuorumRequest{
-				RangeID: int32(id),
-			},
-		)
+		_, err := srv.Node().(*server.Node).ResetQuorum(ctx, &roachpb.ResetQuorumRequest{
+			RangeID: int32(id),
+		})
 		require.NoError(t, err)
+		verifyResult(t, srv, k, id)
 
-		verifyResult(t, srv, k, store, id)
+		// Run consistency check on survivor.
+		checkConsistency(t, srv)
 	})
 
 	t.Run("with-replica-on-target", func(t *testing.T) {
 		tc, k, id := setup(t)
 		defer tc.Stopper().Stop(ctx)
-		n2, n3, n4 := 1, 2, 3
+		n2, n3, n4, n5 := 1, 2, 3, 4
 		srv := tc.Server(n4)
 		tc.StopServer(n2)
 		tc.StopServer(n3)
+		tc.StopServer(n5)
+
 		// Wait for n2, n3, and n4 liveness to expire.
 		time.Sleep(livenessDuration)
-
 		checkUnavailable(srv, k)
 
-		// Get the store on the designated survivor n4.
-		var store *kvserver.Store
-		require.NoError(t, srv.GetStores().(*kvserver.Stores).VisitStores(func(inner *kvserver.Store) error {
-			store = inner
-			return nil
-		}))
-		if store == nil {
-			t.Fatal("no store found on n4")
-		}
+		// Call ResetQuorum to reset quorum on the unhealthy range.
+		_, err := srv.Node().(*server.Node).ResetQuorum(ctx, &roachpb.ResetQuorumRequest{
+			RangeID: int32(id),
+		})
+		require.NoError(t, err)
+		verifyResult(t, srv, k, id)
+
+		// Run consistency check on survivor.
+		checkConsistency(t, srv)
+	})
+
+	t.Run("with-replicas-elsewhere", func(t *testing.T) {
+		tc, k, id := setup(t)
+		defer tc.Stopper().Stop(ctx)
+		n1, n2, n3, n4, n5 := 0, 1, 2, 3, 4
+		srv := tc.Server(n1)
+		tc.StopServer(n2)
+		tc.StopServer(n3)
+
+		// Wait for n2 and n3 liveness to expire.
+		time.Sleep(livenessDuration)
+		checkUnavailable(srv, k)
 
 		// Call ResetQuorum to reset quorum on the unhealthy range.
-		_, err := srv.Node().(*server.Node).ResetQuorum(
-			ctx,
-			&roachpb.ResetQuorumRequest{
-				RangeID: int32(id),
-			},
-		)
+		_, err := srv.Node().(*server.Node).ResetQuorum(ctx, &roachpb.ResetQuorumRequest{
+			RangeID: int32(id),
+		})
 		require.NoError(t, err)
+		verifyResult(t, srv, k, id)
 
-		verifyResult(t, srv, k, store, id)
+		// Check that voting replica on n4 was GCed, and check consistency
+		// both of reset (n1), GCed (n4), and possibly stale (n5) replicas.
+		checkReplicaGC(t, tc.Server(n4), id)
+		checkConsistency(t, srv, tc.Server(n4), tc.Server(n5))
+
+		// Non-voting replica (n5) may or may not have been GCed, so we don't
+		// assert anything about it. But in any case, requests via that node
+		// should go to the reset leaseholder and return the reset value.
+		kv, err := tc.Server(n5).DB().Get(ctx, k)
+		require.NoError(t, err)
+		require.Equal(t, []byte("reset"), kv.ValueBytes())
+	})
+
+	t.Run("with-leaseholder-elsewhere", func(t *testing.T) {
+		tc, k, id := setup(t)
+		defer tc.Stopper().Stop(ctx)
+		n1, n2, n3, n4, n5 := 0, 1, 2, 3, 4
+		srv := tc.Server(n1)
+		tc.StopServer(n3)
+		tc.StopServer(n4)
+
+		// Wait for n3 and n4 liveness to expire.
+		time.Sleep(livenessDuration)
+		checkUnavailable(srv, k)
+
+		// Call ResetQuorum to reset quorum on the unhealthy range.
+		_, err := srv.Node().(*server.Node).ResetQuorum(ctx, &roachpb.ResetQuorumRequest{
+			RangeID: int32(id),
+		})
+		require.NoError(t, err)
+		verifyResult(t, srv, k, id)
+
+		// Check that the old leaseholder replica on n2 is GCed, and check
+		// consistency both of reset (n1), GCed (n2), and possibly stale (n5)
+		// replicas.
+		checkReplicaGC(t, tc.Server(n2), id)
+		checkConsistency(t, srv, tc.Server(n2), tc.Server(n5))
+
+		// Non-voting replica (n5) may or may not have been GCed, so we don't
+		// assert anything about it. But in any case, requests via that node
+		// should go to the reset leaseholder and return the reset value.
+		kv, err := tc.Server(n5).DB().Get(ctx, k)
+		require.NoError(t, err)
+		require.Equal(t, []byte("reset"), kv.ValueBytes())
 	})
 
 	t.Run("without-quorum-loss", func(t *testing.T) {
@@ -236,12 +302,9 @@ func TestResetQuorum(t *testing.T) {
 		srv := tc.Server(0)
 
 		// Call ResetQuorum to attempt to reset quorum on a healthy range.
-		_, err := srv.Node().(*server.Node).ResetQuorum(
-			ctx,
-			&roachpb.ResetQuorumRequest{
-				RangeID: int32(id),
-			},
-		)
+		_, err := srv.Node().(*server.Node).ResetQuorum(ctx, &roachpb.ResetQuorumRequest{
+			RangeID: int32(id),
+		})
 		testutils.IsError(err, "targeted range to recover has not lost quorum.")
 	})
 
@@ -251,12 +314,9 @@ func TestResetQuorum(t *testing.T) {
 		srv := tc.Server(0)
 
 		// Call ResetQuorum to attempt to reset quorum on a meta range.
-		_, err := srv.Node().(*server.Node).ResetQuorum(
-			ctx,
-			&roachpb.ResetQuorumRequest{
-				RangeID: int32(keys.MetaRangesID),
-			},
-		)
+		_, err := srv.Node().(*server.Node).ResetQuorum(ctx, &roachpb.ResetQuorumRequest{
+			RangeID: int32(keys.MetaRangesID),
+		})
 		testutils.IsError(err, "targeted range to recover is a meta1 or meta2 range.")
 	})
 }


### PR DESCRIPTION
Backport 2/2 commits from #61977.

/cc @cockroachdb/release

---

The replica GC queue will normally wait 10 days before checking whether
a replica should be GCed (e.g. by looking up the range descriptor). If
the replica is considered suspect (e.g. when it is a Raft candidate),
the descriptor will be checked every second instead.

However, a leader was never considered suspect. This could cause a
situation where a leader who lost a quorum and was replaced via
`Node.ResetQuorum()` would cling onto the range until the 10 day GC
timeout expired and it finally checked the range descriptor.

This patch considers leaders who are not able to make progress suspect,
thereby checking the range descriptor every second and GCing the replica
if it has been removed from the descriptor. It also adds back a
`ResetQuorum` test case that was removed previously as it would fail in
this scenario.

Resolves #58376.

Release note (bug fix): A Raft leader who loses quorum will now
relinquish its range lease and remove the replica if the range is
recreated elsewhere, e.g. via `Node.ResetQuorum()`.
