### PR TITLE
release-21.1: kvserver: fix removal of separated intents in ClearRange

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
@@ -29,13 +29,13 @@ import (
 
 type wrappedBatch struct {
 	storage.Batch
-	clearCount      int
+	clearIterCount  int
 	clearRangeCount int
 }
 
-func (wb *wrappedBatch) ClearEngineKey(key storage.EngineKey) error {
-	wb.clearCount++
-	return wb.Batch.ClearEngineKey(key)
+func (wb *wrappedBatch) ClearIterRange(iter storage.MVCCIterator, start, end roachpb.Key) error {
+	wb.clearIterCount++
+	return wb.Batch.ClearIterRange(iter, start, end)
 }
 
 func (wb *wrappedBatch) ClearMVCCRangeAndIntents(start, end roachpb.Key) error {
@@ -64,24 +64,24 @@ func TestCmdClearRangeBytesThreshold(t *testing.T) {
 	overFull := ClearRangeBytesThreshold/len(valueStr) + 1
 	tests := []struct {
 		keyCount           int
-		expClearCount      int
+		expClearIterCount  int
 		expClearRangeCount int
 	}{
 		{
 			keyCount:           1,
-			expClearCount:      1,
+			expClearIterCount:  1,
 			expClearRangeCount: 0,
 		},
 		// More than a single key, but not enough to use ClearRange.
 		{
 			keyCount:           halfFull,
-			expClearCount:      halfFull,
+			expClearIterCount:  1,
 			expClearRangeCount: 0,
 		},
 		// With key sizes requiring additional space, this will overshoot.
 		{
 			keyCount:           overFull,
-			expClearCount:      0,
+			expClearIterCount:  0,
 			expClearRangeCount: 1,
 		},
 	}
@@ -131,8 +131,8 @@ func TestCmdClearRangeBytesThreshold(t *testing.T) {
 			}
 
 			// Verify we see the correct counts for Clear and ClearRange.
-			if a, e := batch.clearCount, test.expClearCount; a != e {
-				t.Errorf("expected %d clears; got %d", e, a)
+			if a, e := batch.clearIterCount, test.expClearIterCount; a != e {
+				t.Errorf("expected %d iter range clears; got %d", e, a)
 			}
 			if a, e := batch.clearRangeCount, test.expClearRangeCount; a != e {
 				t.Errorf("expected %d clear ranges; got %d", e, a)


### PR DESCRIPTION
Backport 1/1 commits from #61649.

/cc @cockroachdb/release

---

`ClearRange` removes a key range and its intents. It normally does this
with `Writer.ClearMVCCRangeAndIntents`, but has an optimization for
small ranges where it directly removes the keys using an iterator.
However, this did not take separated intents into account, and could
leave behind stray intents in the lock table, as uncovered in
`TestTxnClearRangeIntents`.

This patch changes the small-range optimization to use
`Writer.ClearIterRange()` over an `MVCCIterator` instead, which will
correctly remove intents regardless of whether separated intents have
been enabled or not.

Resolves #61606.

Release note: None