### PR TITLE
roachprod: Install and configure chrony on GCE clusters

### DIFF
--- a/pkg/cmd/roachprod/vm/gce/utils.go
+++ b/pkg/cmd/roachprod/vm/gce/utils.go
@@ -117,6 +117,13 @@ echo "kernel.core_pattern=$CORE_PATTERN" >> /etc/sysctl.conf
 
 sysctl --system  # reload sysctl settings
 
+sudo apt-get update -q
+sudo apt-get install -qy chrony
+echo -e "\nserver metadata.google.internal prefer iburst" | sudo tee -a /etc/chrony/chrony.conf
+echo -e "\nmakestep 0.1 3" | sudo tee -a /etc/chrony/chrony.conf
+sudo /etc/init.d/chrony restart
+sudo chronyc -a waitsync 30 0.01 | sudo tee -a /root/chrony.log
+
 sudo touch /mnt/data1/.roachprod-initialized
 `
 


### PR DESCRIPTION
Fixes #62063

In #31577 we switched to `chrony` for AWS, but not for CGE. By default
they GCE clusters based on Ubuntu 16.04 use `ntp`.

This patch installs `chrony` (and automatically removes `ntp`) on GCE
and configures `chrony` to use Google's time server.

Release note: None