### PR TITLE
opt: make opt tests work in bazel

### DIFF
--- a/pkg/sql/opt/memo/BUILD.bazel
+++ b/pkg/sql/opt/memo/BUILD.bazel
@@ -60,9 +60,9 @@ go_test(
     ],
     data = glob(["testdata/**"]) + [
         "@cockroach//c-deps:libgeos",
+        "//pkg/sql/opt/testutils/opttester:testfixtures",
     ],
     embed = [":memo"],
-    tags = ["broken_in_bazel"],
     deps = [
         "//pkg/settings/cluster",
         "//pkg/sql/inverted",

--- a/pkg/sql/opt/norm/BUILD.bazel
+++ b/pkg/sql/opt/norm/BUILD.bazel
@@ -66,9 +66,9 @@ go_test(
     ],
     data = glob(["testdata/**"]) + [
         "@cockroach//c-deps:libgeos",
+        "//pkg/sql/opt/testutils/opttester:testfixtures",
     ],
     embed = [":norm"],
-    tags = ["broken_in_bazel"],
     deps = [
         "//pkg/settings/cluster",
         "//pkg/sql/opt",

--- a/pkg/sql/opt/testutils/opttester/BUILD.bazel
+++ b/pkg/sql/opt/testutils/opttester/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/opttester",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/build/bazel",
         "//pkg/roachpb",
         "//pkg/security",
         "//pkg/settings/cluster",
@@ -54,4 +55,10 @@ go_test(
         "//pkg/sql/opt/testutils/testcat",
         "@com_github_cockroachdb_datadriven//:datadriven",
     ],
+)
+
+filegroup(
+    name = "testfixtures",
+    srcs = glob(["testfixtures/**"]),
+    visibility = ["//pkg/sql/opt:__subpackages__"],
 )

--- a/pkg/sql/opt/xform/BUILD.bazel
+++ b/pkg/sql/opt/xform/BUILD.bazel
@@ -62,9 +62,9 @@ go_test(
     ],
     data = glob(["testdata/**"]) + [
         "@cockroach//c-deps:libgeos",
+        "//pkg/sql/opt/testutils/opttester:testfixtures",
     ],
     embed = [":xform"],
-    tags = ["broken_in_bazel"],
     deps = [
         "//pkg/config/zonepb",
         "//pkg/roachpb",


### PR DESCRIPTION
Under bazel, we have to declare the dependency on test fixtures and we
have to ask bazel for the path of the file.

Fixes #61919

Release note: None