### PR TITLE
cdc: Handle changefeed over multiple tables with the same name.

### DIFF
--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -39,9 +39,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func makeTopic(name string) tableDescriptorTopic {
+func makeTopic(name string) *tableDescriptorTopic {
 	desc := tabledesc.NewBuilder(&descpb.TableDescriptor{Name: name}).BuildImmutableTable()
-	return tableDescriptorTopic{desc}
+	return &tableDescriptorTopic{TableDescriptor: desc, name: name}
 }
 
 func TestCloudStorageSink(t *testing.T) {

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -50,8 +50,11 @@ func (p asyncProducerMock) Close() error {
 	return nil
 }
 
-func topic(name string) tableDescriptorTopic {
-	return tableDescriptorTopic{tabledesc.NewBuilder(&descpb.TableDescriptor{Name: name}).BuildImmutableTable()}
+func topic(name string) *tableDescriptorTopic {
+	return &tableDescriptorTopic{
+		TableDescriptor: tabledesc.NewBuilder(&descpb.TableDescriptor{Name: name}).BuildImmutableTable(),
+		name:            name,
+	}
 }
 
 func TestKafkaSink(t *testing.T) {
@@ -183,10 +186,12 @@ func TestSQLSink(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	topic := func(name string) tableDescriptorTopic {
+	topic := func(name string) *tableDescriptorTopic {
 		id, _ := strconv.ParseUint(name, 36, 64)
-		return tableDescriptorTopic{
-			tabledesc.NewBuilder(&descpb.TableDescriptor{Name: name, ID: descpb.ID(id)}).BuildImmutableTable()}
+		return &tableDescriptorTopic{
+			TableDescriptor: tabledesc.NewBuilder(&descpb.TableDescriptor{Name: name, ID: descpb.ID(id)}).BuildImmutableTable(),
+			name:            name,
+		}
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
Require the user specify `full_table_name` option when
creating changefeed over multiple tables with the same name.

Fixes #32509

Release Notes: None