### PR TITLE
cliccl/load: fix flaky TestLoadShowBackups and TestLoadShowIncremental

### DIFF
--- a/pkg/ccl/cliccl/load.go
+++ b/pkg/ccl/cliccl/load.go
@@ -201,7 +201,7 @@ func runLoadShowIncremental(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 28, 1, 2, ' ', 0)
+	w := tabwriter.NewWriter(os.Stdout, 28 /*minwidth*/, 1 /*tabwidth*/, 2 /*padding*/, ' ' /*padchar*/, 0 /*flags*/)
 	basepath := uri.Path
 	manifestPaths := append([]string{""}, incPaths...)
 	stores := make([]cloud.ExternalStorage, len(manifestPaths))


### PR DESCRIPTION
Previously, TestLoadShowBackups and TestLoadShowIncremental use
timestamps as backup folder names without checking the
intervals between the timestamps. This is flaky when the interval is less
than 10 milliseconds because folder names generated in format of
DateBasedIncFolderName or DateBasedIntoFolderName will be the same.

This patch checks the intervals of generated timestamps to ensure that
the incremental backups are actually created in different folders.

Resolves: #62111

Release note: none.