### PR TITLE
release-21.1: sql: Change to using a session variable instead of FORCE syntax for overriding zone configuration settings for MR databases and tables

### DIFF
--- a/docs/generated/sql/bnf/alter_zone_database_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_zone_database_stmt.bnf
@@ -1,4 +1,4 @@
 alter_zone_database_stmt ::=
-	'ALTER' 'DATABASE' database_name 'CONFIGURE' 'ZONE' 'USING' variable '=' 'COPY' 'FROM' 'PARENT' ( ( ',' variable '=' value | ',' variable '=' 'COPY' 'FROM' 'PARENT' ) )* opt_force
-	| 'ALTER' 'DATABASE' database_name 'CONFIGURE' 'ZONE' 'USING' variable '=' value ( ( ',' variable '=' value | ',' variable '=' 'COPY' 'FROM' 'PARENT' ) )* opt_force
-	| 'ALTER' 'DATABASE' database_name 'CONFIGURE' 'ZONE' 'DISCARD' opt_force
+	'ALTER' 'DATABASE' database_name 'CONFIGURE' 'ZONE' 'USING' variable '=' 'COPY' 'FROM' 'PARENT' ( ( ',' variable '=' value | ',' variable '=' 'COPY' 'FROM' 'PARENT' ) )*
+	| 'ALTER' 'DATABASE' database_name 'CONFIGURE' 'ZONE' 'USING' variable '=' value ( ( ',' variable '=' value | ',' variable '=' 'COPY' 'FROM' 'PARENT' ) )*
+	| 'ALTER' 'DATABASE' database_name 'CONFIGURE' 'ZONE' 'DISCARD'

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1729,7 +1729,7 @@ alter_rename_database_stmt ::=
 	'ALTER' 'DATABASE' database_name 'RENAME' 'TO' database_name
 
 alter_zone_database_stmt ::=
-	'ALTER' 'DATABASE' database_name set_zone_config opt_force
+	'ALTER' 'DATABASE' database_name set_zone_config
 
 alter_database_owner ::=
 	'ALTER' 'DATABASE' database_name 'OWNER' 'TO' role_spec
@@ -1738,16 +1738,16 @@ alter_database_to_schema_stmt ::=
 	'ALTER' 'DATABASE' database_name 'CONVERT' 'TO' 'SCHEMA' 'WITH' 'PARENT' database_name
 
 alter_database_add_region_stmt ::=
-	'ALTER' 'DATABASE' database_name 'ADD' 'REGION' region_name opt_force
+	'ALTER' 'DATABASE' database_name 'ADD' 'REGION' region_name
 
 alter_database_drop_region_stmt ::=
-	'ALTER' 'DATABASE' database_name 'DROP' 'REGION' region_name opt_force
+	'ALTER' 'DATABASE' database_name 'DROP' 'REGION' region_name
 
 alter_database_survival_goal_stmt ::=
-	'ALTER' 'DATABASE' database_name survival_goal_clause opt_force
+	'ALTER' 'DATABASE' database_name survival_goal_clause
 
 alter_database_primary_region_stmt ::=
-	'ALTER' 'DATABASE' database_name primary_region_clause opt_force
+	'ALTER' 'DATABASE' database_name primary_region_clause
 
 alter_zone_range_stmt ::=
 	'ALTER' 'RANGE' zone_name set_zone_config
@@ -2237,10 +2237,6 @@ alter_index_cmds ::=
 
 sequence_option_list ::=
 	( sequence_option_elem ) ( ( sequence_option_elem ) )*
-
-opt_force ::=
-	'FORCE'
-	| 
 
 region_name ::=
 	name

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -1084,14 +1084,16 @@ txn_database_drop_regions  ca-central-1    true     {ca-az1,ca-az2,ca-az3}
 txn_database_drop_regions  ap-southeast-2  false    {ap-az1,ap-az2,ap-az3}
 txn_database_drop_regions  us-east-1       false    {us-az1,us-az2,us-az3}
 
-# Adding a FORCE to this second statement until we get a fix for #60620. When
-# that fix is ready, we can construct the view of the zone config as it was at
-# the beginning of the transaction, and the checks for FORCE should work again,
-# and we won't require the explicit force here.
+# Overriding this operation until we get a fix for #60620. When that fix is
+# ready, we can construct the view of the zone config as it was at the
+# beginning of the transaction, and the checks for override should work
+# again, and we won't require an explicit override here.
 statement ok
 BEGIN;
+SET override_multi_region_zone_config = true;
 ALTER DATABASE txn_database_drop_regions DROP REGION "us-east-1";
-ALTER DATABASE txn_database_drop_regions DROP REGION "ap-southeast-2" FORCE;
+ALTER DATABASE txn_database_drop_regions DROP REGION "ap-southeast-2";
+SET override_multi_region_zone_config = false;
 COMMIT;
 
 query TTBT colnames

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
@@ -49,7 +49,9 @@ DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USIN
                             lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
-ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING num_voters = 5 FORCE
+SET override_multi_region_zone_config = true;
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING num_voters = 5;
+SET override_multi_region_zone_config = false;
 
 query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
@@ -85,32 +87,44 @@ statement error attempting to update zone configuration for database "mr-zone-co
 ALTER DATABASE "mr-zone-configs" DROP REGION "ap-southeast-2"
 
 statement ok
-ALTER DATABASE "mr-zone-configs" DROP REGION "ap-southeast-2" FORCE
+SET override_multi_region_zone_config = true;
+ALTER DATABASE "mr-zone-configs" DROP REGION "ap-southeast-2";
+SET override_multi_region_zone_config = false;
 
 statement ok
-ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING global_reads = true force
+SET override_multi_region_zone_config = true;
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING global_reads = true;
+SET override_multi_region_zone_config = false;
 
 statement error attempting to update zone configuration for database "mr-zone-configs" which contains modified field "global_reads"
 ALTER DATABASE "mr-zone-configs" ADD REGION "ap-southeast-2"
 
 statement ok
-ALTER DATABASE "mr-zone-configs" ADD REGION "ap-southeast-2" force
+SET override_multi_region_zone_config = true;
+ALTER DATABASE "mr-zone-configs" ADD REGION "ap-southeast-2";
+SET override_multi_region_zone_config = false;
 
-# Zone config is unmodified now. We don't need force.
+# Zone config is unmodified now. We don't need to override.
 statement ok
 ALTER DATABASE "mr-zone-configs" DROP REGION "ap-southeast-2"
 
 statement ok
-ALTER DATABASE "mr-zone-configs" ADD REGION "ap-southeast-2" force
+SET override_multi_region_zone_config = true;
+ALTER DATABASE "mr-zone-configs" ADD REGION "ap-southeast-2";
+SET override_multi_region_zone_config = false;
 
 statement ok
-ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING num_replicas = 7 force
+SET override_multi_region_zone_config = true;
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING num_replicas = 7;
+SET override_multi_region_zone_config = false;
 
 statement error attempting to update zone configuration for database "mr-zone-configs" which contains modified field "num_replicas"
 ALTER DATABASE "mr-zone-configs" SET PRIMARY REGION "us-east-1"
 
 statement ok
-ALTER DATABASE "mr-zone-configs" SET PRIMARY REGION "us-east-1" FORCE
+SET override_multi_region_zone_config = true;
+ALTER DATABASE "mr-zone-configs" SET PRIMARY REGION "us-east-1";
+SET override_multi_region_zone_config = false;
 
 query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
@@ -130,31 +144,41 @@ statement error attempting to modify protected field "num_replicas" of a multi-r
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING num_replicas = 7, gc.ttlseconds = 100000
 
 statement ok
-ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING num_replicas = 7, gc.ttlseconds = 100000 force
+SET override_multi_region_zone_config = true;
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING num_replicas = 7, gc.ttlseconds = 100000;
+SET override_multi_region_zone_config = false;
 
 statement error attempting to update zone configuration for database "mr-zone-configs" which contains modified field "num_replicas"
 ALTER DATABASE "mr-zone-configs" SURVIVE REGION FAILURE
 
 statement ok
-ALTER DATABASE "mr-zone-configs" SURVIVE REGION FAILURE FORCE
+SET override_multi_region_zone_config = true;
+ALTER DATABASE "mr-zone-configs" SURVIVE REGION FAILURE;
+SET override_multi_region_zone_config = false;
 
 statement error attempting to modify protected field "constraints" of a multi-region zone configuration
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING constraints = '{+region=us-east-1: 3}'
 
 statement ok
-ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING constraints = '{+region=us-east-1: 3}' FORCE
+SET override_multi_region_zone_config = true;
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING constraints = '{+region=us-east-1: 3}';
+SET override_multi_region_zone_config = false;
 
 statement error attempting to update zone configuration for database "mr-zone-configs" which contains modified field "constraints"
 ALTER DATABASE "mr-zone-configs" DROP REGION "ap-southeast-2"
 
 statement ok
-ALTER DATABASE "mr-zone-configs" DROP REGION "ap-southeast-2" FORCE
+SET override_multi_region_zone_config = true;
+ALTER DATABASE "mr-zone-configs" DROP REGION "ap-southeast-2";
+SET override_multi_region_zone_config = false;
 
 statement error attempting to modify protected field "voter_constraints" of a multi-region zone configuration
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING voter_constraints = '[+region=ap-southeast-2]'
 
 statement ok
-ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING voter_constraints = '[+region=ap-southeast-2]' FORCE
+SET override_multi_region_zone_config = true;
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING voter_constraints = '[+region=ap-southeast-2]';
+SET override_multi_region_zone_config = false;
 
 query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
@@ -173,7 +197,9 @@ statement error attempting to update zone configuration for database "mr-zone-co
 ALTER DATABASE "mr-zone-configs" DROP REGION "ca-central-1"
 
 statement ok
-ALTER DATABASE "mr-zone-configs" DROP REGION "ca-central-1" FORCE
+SET override_multi_region_zone_config = true;
+ALTER DATABASE "mr-zone-configs" DROP REGION "ca-central-1";
+SET override_multi_region_zone_config = false;
 
 query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
@@ -192,7 +218,9 @@ statement error attempting to modify protected field "lease_preferences" of a mu
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING lease_preferences = '[[+region=ap-southeast-2]]'
 
 statement ok
-ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING lease_preferences = '[[+region=ap-southeast-2]]' FORCE
+SET override_multi_region_zone_config = true;
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING lease_preferences = '[[+region=ap-southeast-2]]';
+SET override_multi_region_zone_config = false;
 
 query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
@@ -211,7 +239,9 @@ statement error attempting to update zone configuration for database "mr-zone-co
 ALTER DATABASE "mr-zone-configs" DROP REGION "us-east-1"
 
 statement ok
-ALTER DATABASE "mr-zone-configs" DROP REGION "us-east-1" FORCE
+SET override_multi_region_zone_config = true;
+ALTER DATABASE "mr-zone-configs" DROP REGION "us-east-1";
+SET override_multi_region_zone_config = false;
 
 query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
@@ -32,7 +32,7 @@ DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USIN
                             voter_constraints = '[+region=ca-central-1]',
                             lease_preferences = '[[+region=ca-central-1]]'
 
-statement error attempting to modify protected field "num_voters" of a multi-region database zone configuration
+statement error attempting to modify protected field "num_voters" of a multi-region zone configuration
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING num_voters = 5
 
 query TT
@@ -65,22 +65,22 @@ DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USIN
                             lease_preferences = '[[+region=ca-central-1]]'
 
 # Ensure all fields are blocked
-statement error attempting to modify protected field "global_reads" of a multi-region database zone configuration
+statement error attempting to modify protected field "global_reads" of a multi-region zone configuration
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING global_reads = true
 
-statement error attempting to modify protected field "num_replicas" of a multi-region database zone configuration
+statement error attempting to modify protected field "num_replicas" of a multi-region zone configuration
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING num_replicas = 7
 
-statement error attempting to modify protected field "constraints" of a multi-region database zone configuration
+statement error attempting to modify protected field "constraints" of a multi-region zone configuration
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING constraints = '{+region=ap-southeast-2: 1}'
 
-statement error attempting to modify protected field "voter_constraints" of a multi-region database zone configuration
+statement error attempting to modify protected field "voter_constraints" of a multi-region zone configuration
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING voter_constraints = '[+region=ap-southeast-2]'
 
-statement error attempting to modify protected field "lease_preferences" of a multi-region database zone configuration
+statement error attempting to modify protected field "lease_preferences" of a multi-region zone configuration
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING lease_preferences = '[[+region=ap-southeast-2]]'
 
-# With above modified zone config, try and drop a region to get warning again
+# With above modified zone config, try and drop a region to get error again
 statement error attempting to update zone configuration for database "mr-zone-configs" which contains modified field "num_voters"
 ALTER DATABASE "mr-zone-configs" DROP REGION "ap-southeast-2"
 
@@ -126,7 +126,7 @@ DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USIN
                             lease_preferences = '[[+region=us-east-1]]'
 
 # Alter with one protected field and one unprotected field.
-statement error attempting to modify protected field "num_replicas" of a multi-region database zone configuration
+statement error attempting to modify protected field "num_replicas" of a multi-region zone configuration
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING num_replicas = 7, gc.ttlseconds = 100000
 
 statement ok
@@ -138,7 +138,7 @@ ALTER DATABASE "mr-zone-configs" SURVIVE REGION FAILURE
 statement ok
 ALTER DATABASE "mr-zone-configs" SURVIVE REGION FAILURE FORCE
 
-statement error attempting to modify protected field "constraints" of a multi-region database zone configuration
+statement error attempting to modify protected field "constraints" of a multi-region zone configuration
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING constraints = '{+region=us-east-1: 3}'
 
 statement ok
@@ -150,7 +150,7 @@ ALTER DATABASE "mr-zone-configs" DROP REGION "ap-southeast-2"
 statement ok
 ALTER DATABASE "mr-zone-configs" DROP REGION "ap-southeast-2" FORCE
 
-statement error attempting to modify protected field "voter_constraints" of a multi-region database zone configuration
+statement error attempting to modify protected field "voter_constraints" of a multi-region zone configuration
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING voter_constraints = '[+region=ap-southeast-2]'
 
 statement ok
@@ -188,7 +188,7 @@ DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USIN
                             voter_constraints = '{+region=us-east-1: 2}',
                             lease_preferences = '[[+region=us-east-1]]'
 
-statement error attempting to modify protected field "lease_preferences" of a multi-region database zone configuration
+statement error attempting to modify protected field "lease_preferences" of a multi-region zone configuration
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING lease_preferences = '[[+region=ap-southeast-2]]'
 
 statement ok
@@ -236,6 +236,255 @@ postgres         root   NULL            {}       NULL
 system           node   NULL            {}       NULL
 test             root   NULL            {}       NULL
 
-# FIXME: Write some more testcases here which test constraints which are longer to ensure
-# that slice checking is working (e.g. a constraints list which is much longer than what
-# the MR zone config would generate).
+statement ok
+ALTER DATABASE "mr-zone-configs" SET PRIMARY REGION "us-east-1"
+
+statement ok
+ALTER DATABASE "mr-zone-configs" ADD REGION "ca-central-1"
+
+statement ok
+ALTER DATABASE "mr-zone-configs" ADD REGION "ap-southeast-2"
+
+query TTTTT colnames
+SHOW DATABASES
+----
+database_name    owner  primary_region  regions                                  survival_goal
+defaultdb        root   NULL            {}                                       NULL
+mr-zone-configs  root   us-east-1       {ap-southeast-2,ca-central-1,us-east-1}  zone
+postgres         root   NULL            {}                                       NULL
+system           node   NULL            {}                                       NULL
+test             root   NULL            {}                                       NULL
+
+# Ensure that changes to the table-level zone config also require overriding.
+statement ok
+CREATE TABLE regional_by_row (
+  pk INT PRIMARY KEY,
+  i INT,
+  INDEX(i),
+  FAMILY (pk, i)
+) LOCALITY REGIONAL BY ROW
+
+statement ok
+CREATE TABLE regional_by_table (
+  pk INT PRIMARY KEY,
+  i INT,
+  INDEX(i),
+  FAMILY (pk, i)
+) LOCALITY REGIONAL BY TABLE
+
+statement ok
+ALTER table regional_by_row CONFIGURE ZONE USING gc.ttlseconds = 10
+
+statement error attempting to modify protected field "num_replicas" of a multi-region zone configuration
+ALTER table regional_by_row CONFIGURE ZONE USING num_replicas = 10
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER table regional_by_row CONFIGURE ZONE USING num_replicas = 10;
+SET override_multi_region_zone_config = false
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
+----
+TABLE regional_by_row  ALTER TABLE regional_by_row CONFIGURE ZONE USING
+                       range_min_bytes = 134217728,
+                       range_max_bytes = 536870912,
+                       gc.ttlseconds = 10,
+                       num_replicas = 10,
+                       num_voters = 3,
+                       constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                       voter_constraints = '[+region=us-east-1]',
+                       lease_preferences = '[[+region=us-east-1]]'
+
+statement error attempting to modify protected field "num_replicas" of a multi-region zone configuration
+ALTER partition "us-east-1" of index regional_by_row@primary CONFIGURE ZONE USING num_replicas = 10
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER partition "us-east-1" of index regional_by_row@primary CONFIGURE ZONE USING num_replicas = 10;
+SET override_multi_region_zone_config = false
+
+query TTT
+SELECT ZONE_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row@regional_by_row_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row@regional_by_row_i_idx  ca-central-1
+num_replicas = 10,
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
+
+statement error attempting to update zone configuration for table "regional_by_row" which contains modified field "num_replicas"
+ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY TABLE
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY TABLE;
+SET override_multi_region_zone_config = false
+
+statement error attempting to modify protected field "num_replicas" of a multi-region zone configuration
+ALTER index regional_by_row@primary CONFIGURE ZONE USING num_replicas = 10
+
+query TTT
+SELECT ZONE_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]
+ORDER BY partition_name, index_name
+----
+
+query TT
+SHOW ZONE CONFIGURATION FOR INDEX regional_by_row@primary
+----
+TABLE regional_by_row  ALTER TABLE regional_by_row CONFIGURE ZONE USING
+                       range_min_bytes = 134217728,
+                       range_max_bytes = 536870912,
+                       gc.ttlseconds = 10,
+                       num_replicas = 5,
+                       num_voters = 3,
+                       constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                       voter_constraints = '[+region=us-east-1]',
+                       lease_preferences = '[[+region=us-east-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR INDEX regional_by_row@regional_by_row_i_idx
+----
+TABLE regional_by_row  ALTER TABLE regional_by_row CONFIGURE ZONE USING
+                       range_min_bytes = 134217728,
+                       range_max_bytes = 536870912,
+                       gc.ttlseconds = 10,
+                       num_replicas = 5,
+                       num_voters = 3,
+                       constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                       voter_constraints = '[+region=us-east-1]',
+                       lease_preferences = '[[+region=us-east-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
+----
+TABLE regional_by_row  ALTER TABLE regional_by_row CONFIGURE ZONE USING
+                       range_min_bytes = 134217728,
+                       range_max_bytes = 536870912,
+                       gc.ttlseconds = 10,
+                       num_replicas = 5,
+                       num_voters = 3,
+                       constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                       voter_constraints = '[+region=us-east-1]',
+                       lease_preferences = '[[+region=us-east-1]]'
+
+statement ok
+ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY ROW
+
+statement ok
+ALTER TABLE regional_by_row SET LOCALITY GLOBAL
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER index regional_by_row@primary CONFIGURE ZONE USING num_replicas = 10;
+SET override_multi_region_zone_config = false
+
+statement ok
+ALTER TABLE regional_by_row SET LOCALITY GLOBAL
+
+statement error attempting to update zone configuration for table "regional_by_row" which contains a zone configuration on index "primary"
+ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY ROW
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY ROW;
+SET override_multi_region_zone_config = false
+
+statement ok
+CREATE TABLE regional_by_row_as (
+  pk INT PRIMARY KEY,
+  i INT,
+  cr crdb_internal_region NOT NULL DEFAULT 'ca-central-1',
+  INDEX(i),
+  FAMILY (cr, pk, i)
+) LOCALITY REGIONAL BY ROW AS "cr";
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER index regional_by_row_as@primary CONFIGURE ZONE USING num_replicas = 10;
+SET override_multi_region_zone_config = false
+
+query TT
+SHOW ZONE CONFIGURATION FOR INDEX regional_by_row_as@primary
+----
+INDEX regional_by_row_as@primary  ALTER INDEX regional_by_row_as@primary CONFIGURE ZONE USING
+                                  range_min_bytes = 134217728,
+                                  range_max_bytes = 536870912,
+                                  gc.ttlseconds = 90000,
+                                  num_replicas = 10,
+                                  num_voters = 3,
+                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                  voter_constraints = '[+region=us-east-1]',
+                                  lease_preferences = '[[+region=us-east-1]]'
+
+statement error attempting to update zone configuration for table "regional_by_row_as" which contains a zone configuration on index "primary" with multi-region field "num_replicas" set
+ALTER TABLE regional_by_row_as SET LOCALITY REGIONAL BY ROW
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER TABLE regional_by_row_as SET LOCALITY REGIONAL BY ROW;
+SET override_multi_region_zone_config = false
+
+query TT
+SHOW ZONE CONFIGURATION FOR INDEX regional_by_row_as@primary
+----
+DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
+                            range_min_bytes = 134217728,
+                            range_max_bytes = 536870912,
+                            gc.ttlseconds = 90000,
+                            num_replicas = 5,
+                            num_voters = 3,
+                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                            voter_constraints = '[+region=us-east-1]',
+                            lease_preferences = '[[+region=us-east-1]]'
+
+query TT
+SHOW CREATE TABLE regional_by_row_as
+----
+regional_by_row_as          CREATE TABLE public.regional_by_row_as (
+                            pk INT8 NOT NULL,
+                            i INT8 NULL,
+                            cr public.crdb_internal_region NOT NULL DEFAULT 'ca-central-1':::public.crdb_internal_region,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+                            INDEX regional_by_row_as_i_idx (i ASC),
+                            FAMILY fam_0_cr_pk_i (cr, pk, i, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+query TTT
+SELECT ZONE_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row_as]
+ORDER BY partition_name, index_name
+----
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_as@primary  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ap-southeast-2]',
+lease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_as@regional_by_row_as_i_idx  ap-southeast-2
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row_as@primary  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=ca-central-1]',
+lease_preferences = '[[+region=ca-central-1]]'  regional_by_row_as@regional_by_row_as_i_idx  ca-central-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row_as@primary  us-east-1
+num_voters = 3,
+voter_constraints = '[+region=us-east-1]',
+lease_preferences = '[[+region=us-east-1]]'  regional_by_row_as@regional_by_row_as_i_idx  us-east-1

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -1808,14 +1808,16 @@ CREATE TABLE regional_by_row_as (
   FAMILY (cr, pk, i)
 ) LOCALITY REGIONAL BY ROW AS "cr";
 
-# Adding a FORCE to this second statement until we get a fix for #60620. When
-# that fix is ready, we can construct the view of the zone config as it was at
-# the beginning of the transaction, and the checks for FORCE should work again,
-# and we won't require the explicit force here.
+# Overriding this operation until we get a fix for #60620. When that fix is
+# ready, we can construct the view of the zone config as it was at the
+# beginning of the transaction, and the checks for override should work
+# again, and we won't require an explicit override here.
 statement ok
 BEGIN;
+SET override_multi_region_zone_config = true;
 ALTER DATABASE add_regions_in_txn ADD REGION "us-east-1";
-ALTER DATABASE add_regions_in_txn ADD REGION "ap-southeast-2" FORCE;
+ALTER DATABASE add_regions_in_txn ADD REGION "ap-southeast-2";
+SET override_multi_region_zone_config = false;
 COMMIT;
 
 
@@ -2065,15 +2067,16 @@ regional_by_row_as                CREATE TABLE public.regional_by_row_as (
 ) LOCALITY REGIONAL BY ROW AS cr
 
 
-# Adding a FORCE to this second statement until we get a fix for #60620. When
-# that fix is ready, we can construct the view of the zone config as it was at
-# the beginning of the transaction, and the checks for FORCE should work again,
-# and we won't require the explicit force here.
-# Add and remove a region in the same txn.
+# Overriding this operation until we get a fix for #60620. When that fix is
+# ready, we can construct the view of the zone config as it was at the
+# beginning of the transaction, and the checks for override should work
+# again, and we won't require an explicit override here.
 statement ok
 BEGIN;
+SET override_multi_region_zone_config = true;
 ALTER DATABASE drop_regions ADD REGION "us-east-1";
-ALTER DATABASE drop_regions DROP REGION "ap-southeast-2" FORCE;
+ALTER DATABASE drop_regions DROP REGION "ap-southeast-2";
+SET override_multi_region_zone_config = false;
 COMMIT;
 
 query TTT

--- a/pkg/ccl/multiregionccl/regional_by_row_test.go
+++ b/pkg/ccl/multiregionccl/regional_by_row_test.go
@@ -545,8 +545,11 @@ COMMIT;`)
 	// and we won't require the explicit force here.
 	testutils.SucceedsSoon(t, func() error {
 		_, err = sqlDB.Exec(`BEGIN;
+  SET override_multi_region_zone_config = true;
 	ALTER DATABASE db ADD REGION "us-east3";
 	ALTER DATABASE db DROP REGION "us-east2" FORCE;
+	ALTER DATABASE db DROP REGION "us-east2";
+  SET override_multi_region_zone_config = false;
 	COMMIT;`)
 		return err
 	})

--- a/pkg/ccl/multiregionccl/regional_by_row_test.go
+++ b/pkg/ccl/multiregionccl/regional_by_row_test.go
@@ -526,30 +526,31 @@ CREATE TABLE db.t(k INT PRIMARY KEY) LOCALITY REGIONAL BY ROW`)
 		t.Error(err)
 	}
 
-	// Adding a FORCE to this second statement until we get a fix for #60620. When
-	// that fix is ready, we can construct the view of the zone config as it was at
-	// the beginning of the transaction, and the checks for FORCE should work again,
-	// and we won't require the explicit force here.
+	// Overriding this operation until we get a fix for #60620. When that fix is
+	// ready, we can construct the view of the zone config as it was at the
+	// beginning of the transaction, and the checks for override should work
+	// again, and we won't require an explicit override here.
 	_, err = sqlDB.Exec(`BEGIN;
+SET override_multi_region_zone_config = true;
 ALTER DATABASE db ADD REGION "us-east3";
-ALTER DATABASE db DROP REGION "us-east2" FORCE;
+ALTER DATABASE db DROP REGION "us-east2";
+SET override_multi_region_zone_config = false;
 COMMIT;`)
 	require.Error(t, err, "boom")
 
 	// The cleanup job should kick in and revert the changes that happened to the
 	// type descriptor in the user txn. We should eventually be able to add
 	// "us-east3" and remove "us-east2".
-	// Adding a FORCE to this second statement until we get a fix for #60620. When
-	// that fix is ready, we can construct the view of the zone config as it was at
-	// the beginning of the transaction, and the checks for FORCE should work again,
-	// and we won't require the explicit force here.
+	// Overriding this operation until we get a fix for #60620. When that fix is
+	// ready, we can construct the view of the zone config as it was at the
+	// beginning of the transaction, and the checks for override should work
+	// again, and we won't require an explicit override here.
 	testutils.SucceedsSoon(t, func() error {
 		_, err = sqlDB.Exec(`BEGIN;
-  SET override_multi_region_zone_config = true;
+	SET override_multi_region_zone_config = true;
 	ALTER DATABASE db ADD REGION "us-east3";
-	ALTER DATABASE db DROP REGION "us-east2" FORCE;
 	ALTER DATABASE db DROP REGION "us-east2";
-  SET override_multi_region_zone_config = false;
+	SET override_multi_region_zone_config = false;
 	COMMIT;`)
 		return err
 	})

--- a/pkg/ccl/multiregionccl/regional_by_row_test.go
+++ b/pkg/ccl/multiregionccl/regional_by_row_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -561,9 +560,6 @@ COMMIT;`)
 func TestIndexCleanupAfterAlterFromRegionalByRow(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
-	// TODO(ajstorm): Enable once #61944 goes in.
-	skip.UnderRace(t, `This test is too heavyweight to be stressed under race`)
 
 	// Decrease the adopt loop interval so that retries happen quickly.
 	defer sqltestutils.SetTestJobsAdoptInterval()()

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -177,7 +177,7 @@ func (n *alterDatabaseAddRegionNode) startExec(params runParams) error {
 		n.desc.Name,
 		params.p.txn,
 		params.ExecCfg().Codec,
-		n.n.Force,
+		params.p.SessionData().OverrideMultiRegionZoneConfigEnabled,
 		*n.desc.RegionConfig,
 	); err != nil {
 		return err
@@ -294,7 +294,7 @@ func (p *planner) AlterDatabaseDropRegion(
 		dbDesc.Name,
 		p.txn,
 		p.ExecCfg().Codec,
-		n.Force,
+		p.SessionData().OverrideMultiRegionZoneConfigEnabled,
 		*dbDesc.RegionConfig,
 	); err != nil {
 		return nil, err
@@ -722,7 +722,7 @@ func (n *alterDatabasePrimaryRegionNode) startExec(params runParams) error {
 			n.desc.Name,
 			params.p.txn,
 			params.ExecCfg().Codec,
-			n.n.Force,
+			params.p.SessionData().OverrideMultiRegionZoneConfigEnabled,
 			*n.desc.RegionConfig,
 		); err != nil {
 			return err
@@ -801,7 +801,7 @@ func (n *alterDatabaseSurvivalGoalNode) startExec(params runParams) error {
 		n.desc.Name,
 		params.p.txn,
 		params.ExecCfg().Codec,
-		n.n.Force,
+		params.p.SessionData().OverrideMultiRegionZoneConfigEnabled,
 		*n.desc.RegionConfig,
 	); err != nil {
 		return err

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -236,6 +236,13 @@ var dropEnumValueEnabledClusterMode = settings.RegisterBoolSetting(
 	false,
 )
 
+var overrideMultiRegionZoneConfigClusterMode = settings.RegisterBoolSetting(
+	"sql.defaults.override_multi_region_zone_config.enabled",
+	"default value for override_multi_region_zone_config; "+
+		"allows for overriding the zone configs of a multi-region table or database",
+	false,
+)
+
 var hashShardedIndexesEnabledClusterMode = settings.RegisterBoolSetting(
 	"sql.defaults.experimental_hash_sharded_indexes.enabled",
 	"default value for experimental_enable_hash_sharded_indexes; allows for creation of hash sharded indexes by default",
@@ -2310,6 +2317,10 @@ func (m *sessionDataMutator) SetImplicitColumnPartitioningEnabled(val bool) {
 
 func (m *sessionDataMutator) SetDropEnumValueEnabled(val bool) {
 	m.data.DropEnumValueEnabled = val
+}
+
+func (m *sessionDataMutator) SetOverrideMultiRegionZoneConfigEnabled(val bool) {
+	m.data.OverrideMultiRegionZoneConfigEnabled = val
 }
 
 func (m *sessionDataMutator) SetHashShardedIndexesEnabled(val bool) {

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -3631,6 +3631,7 @@ node_id                                               1
 optimizer                                             on
 optimizer_use_histograms                              on
 optimizer_use_multicol_stats                          on
+override_multi_region_zone_config                     off
 prefer_lookup_joins_for_fks                           off
 reorder_joins_limit                                   8
 require_explicit_primary_keys                         off

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2131,6 +2131,7 @@ max_index_keys                                        32                  NULL  
 node_id                                               1                   NULL      NULL        NULL        string
 optimizer_use_histograms                              on                  NULL      NULL        NULL        string
 optimizer_use_multicol_stats                          on                  NULL      NULL        NULL        string
+override_multi_region_zone_config                     off                 NULL      NULL        NULL        string
 prefer_lookup_joins_for_fks                           off                 NULL      NULL        NULL        string
 reorder_joins_limit                                   8                   NULL      NULL        NULL        string
 require_explicit_primary_keys                         off                 NULL      NULL        NULL        string
@@ -2210,6 +2211,7 @@ max_index_keys                                        32                  NULL  
 node_id                                               1                   NULL  user     NULL      1                   1
 optimizer_use_histograms                              on                  NULL  user     NULL      on                  on
 optimizer_use_multicol_stats                          on                  NULL  user     NULL      on                  on
+override_multi_region_zone_config                     off                 NULL  user     NULL      off                 off
 prefer_lookup_joins_for_fks                           off                 NULL  user     NULL      off                 off
 reorder_joins_limit                                   8                   NULL  user     NULL      8                   8
 require_explicit_primary_keys                         off                 NULL  user     NULL      off                 off
@@ -2286,6 +2288,7 @@ node_id                                               NULL    NULL     NULL     
 optimizer                                             NULL    NULL     NULL     NULL        NULL
 optimizer_use_histograms                              NULL    NULL     NULL     NULL        NULL
 optimizer_use_multicol_stats                          NULL    NULL     NULL     NULL        NULL
+override_multi_region_zone_config                     NULL    NULL     NULL     NULL        NULL
 prefer_lookup_joins_for_fks                           NULL    NULL     NULL     NULL        NULL
 reorder_joins_limit                                   NULL    NULL     NULL     NULL        NULL
 require_explicit_primary_keys                         NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -70,6 +70,7 @@ max_index_keys                                        32
 node_id                                               1
 optimizer_use_histograms                              on
 optimizer_use_multicol_stats                          on
+override_multi_region_zone_config                     off
 prefer_lookup_joins_for_fks                           off
 reorder_joins_limit                                   8
 require_explicit_primary_keys                         off

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1385,13 +1385,9 @@ func TestParse(t *testing.T) {
 
 		{`ALTER DATABASE a RENAME TO b`},
 		{`ALTER DATABASE a ADD REGION "us-west-1"`},
-		{`ALTER DATABASE a ADD REGION "us-west-1 FORCE"`},
 		{`ALTER DATABASE a DROP REGION "us-west-1"`},
-		{`ALTER DATABASE a DROP REGION "us-west-1 FORCE"`},
 		{`ALTER DATABASE a SURVIVE REGION FAILURE`},
-		{`ALTER DATABASE a SURVIVE REGION FAILURE FORCE`},
 		{`ALTER DATABASE a PRIMARY REGION "us-west-3"`},
-		{`ALTER DATABASE a PRIMARY REGION "us-west-3 FORCE"`},
 		{`EXPLAIN ALTER DATABASE a RENAME TO b`},
 
 		{`ALTER DATABASE a OWNER TO foo`},
@@ -1544,7 +1540,6 @@ func TestParse(t *testing.T) {
 		{`ALTER RANGE meta CONFIGURE ZONE = 'foo'`},
 
 		{`ALTER DATABASE db CONFIGURE ZONE = 'foo'`},
-		{`ALTER DATABASE db CONFIGURE ZONE = 'foo' FORCE`},
 		{`EXPLAIN ALTER DATABASE db CONFIGURE ZONE = 'foo'`},
 
 		{`ALTER TABLE db.t CONFIGURE ZONE = 'foo'`},
@@ -1570,7 +1565,6 @@ func TestParse(t *testing.T) {
 		{`ALTER RANGE default CONFIGURE ZONE USING foo = bar, baz = yay`},
 		{`ALTER RANGE meta CONFIGURE ZONE USING foo = bar, baz = yay`},
 		{`ALTER DATABASE db CONFIGURE ZONE USING foo = bar, baz = yay`},
-		{`ALTER DATABASE db CONFIGURE ZONE USING foo = bar, baz = yay FORCE`},
 		{`ALTER TABLE db.t CONFIGURE ZONE USING foo = bar, baz = yay`},
 		{`ALTER PARTITION p OF TABLE db.t CONFIGURE ZONE USING foo = bar, baz = yay`},
 		{`ALTER TABLE t CONFIGURE ZONE USING foo = bar, baz = yay`},
@@ -2466,8 +2460,6 @@ $function$`,
 			`ALTER RANGE meta CONFIGURE ZONE USING "foo.bar" = yay`},
 		{`ALTER DATABASE db CONFIGURE ZONE USING foo.bar = yay`,
 			`ALTER DATABASE db CONFIGURE ZONE USING "foo.bar" = yay`},
-		{`ALTER DATABASE db CONFIGURE ZONE USING foo.bar = yay FORCE`,
-			`ALTER DATABASE db CONFIGURE ZONE USING "foo.bar" = yay FORCE`},
 		{`ALTER TABLE db.t CONFIGURE ZONE USING foo.bar = yay`,
 			`ALTER TABLE db.t CONFIGURE ZONE USING "foo.bar" = yay`},
 		{`ALTER PARTITION p OF TABLE db.t CONFIGURE ZONE USING foo.bar = yay`,

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1079,8 +1079,6 @@ func (u *sqlSymUnion) objectNamePrefixList() tree.ObjectNamePrefixList {
 %type <bool> opt_unique opt_concurrently opt_cluster opt_without_index
 %type <bool> opt_index_access_method
 
-%type <bool> opt_force
-
 %type <*tree.Limit> limit_clause offset_clause opt_limit_clause
 %type <tree.Expr> select_fetch_first_value
 %type <empty> row_or_rows
@@ -1510,51 +1508,46 @@ alter_database_owner:
   }
 
 alter_database_add_region_stmt:
-  ALTER DATABASE database_name ADD REGION region_name opt_force
+  ALTER DATABASE database_name ADD REGION region_name
   {
     $$.val = &tree.AlterDatabaseAddRegion{
       Name: tree.Name($3),
       Region: tree.Name($6),
-      Force: $7.bool(),
     }
   }
 
 alter_database_drop_region_stmt:
-  ALTER DATABASE database_name DROP REGION region_name opt_force
+  ALTER DATABASE database_name DROP REGION region_name
   {
     $$.val = &tree.AlterDatabaseDropRegion{
       Name: tree.Name($3),
       Region: tree.Name($6),
-      Force: $7.bool(),
     }
   }
 
 alter_database_survival_goal_stmt:
-  ALTER DATABASE database_name survival_goal_clause opt_force
+  ALTER DATABASE database_name survival_goal_clause
   {
     $$.val = &tree.AlterDatabaseSurvivalGoal{
       Name: tree.Name($3),
       SurvivalGoal: $4.survivalGoal(),
-      Force: $5.bool(),
     }
   }
 
 alter_database_primary_region_stmt:
-  ALTER DATABASE database_name primary_region_clause opt_force
+  ALTER DATABASE database_name primary_region_clause
   {
     $$.val = &tree.AlterDatabasePrimaryRegion{
       Name: tree.Name($3),
       PrimaryRegion: tree.Name($4),
-      Force: $5.bool(),
     }
   }
-| ALTER DATABASE database_name SET primary_region_clause opt_force
+| ALTER DATABASE database_name SET primary_region_clause
   {
     /* SKIP DOC */
     $$.val = &tree.AlterDatabasePrimaryRegion{
       Name: tree.Name($3),
       PrimaryRegion: tree.Name($5),
-      Force: $6.bool(),
     }
   }
 
@@ -1757,11 +1750,10 @@ set_zone_config:
   }
 
 alter_zone_database_stmt:
-  ALTER DATABASE database_name set_zone_config opt_force
+  ALTER DATABASE database_name set_zone_config
   {
      s := $4.setZoneConfig()
      s.ZoneSpecifier = tree.ZoneSpecifier{Database: tree.Name($3)}
-     s.Force = $5.bool()
      $$.val = s
   }
 
@@ -1829,17 +1821,6 @@ alter_zone_partition_stmt:
     err = errors.WithHint(err, "try ALTER PARTITION <partition> OF INDEX <tablename>@*")
     return setErr(sqllex, err)
   }
-
-opt_force:
-  FORCE
-  {
-    $$.val = true
-  }
-| /* EMPTY */
-  {
-    $$.val = false
-  }
-
 
 var_set_list:
   var_name '=' COPY FROM PARENT

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -876,16 +876,8 @@ func (p *planner) CheckZoneConfigChangePermittedForMultiRegion(
 				err := errors.Newf("attempting to modify protected field %q of a multi-region zone configuration",
 					string(opt.Key),
 				)
-				// TODO(ajstorm): This branching is temporary until we convert database
-				//  operations over to the override_multi_region_zone_config session
-				//  variable.
-				if zs.Database != "" {
-					return errors.WithHint(err, "to override this error, specify the FORCE option")
-				} else {
-					return errors.WithHint(err, "to override this error, "+
-						"SET override_multi_region_zone_config = true and reissue the command")
-
-				}
+				return errors.WithHint(err, "to override this error, "+
+					"SET override_multi_region_zone_config = true and reissue the command")
 			}
 		}
 	}
@@ -904,11 +896,11 @@ func validateZoneConfigForMultiRegionDatabaseWasNotModifiedByUser(
 	dbName string,
 	txn *kv.Txn,
 	codec keys.SQLCodec,
-	force bool,
+	override bool,
 	regionConfig descpb.DatabaseDescriptor_RegionConfig,
 ) error {
-	// If the user is forcing, our work here is done.
-	if force {
+	// If the user is overriding, our work here is done.
+	if override {
 		return nil
 	}
 
@@ -957,7 +949,7 @@ func validateZoneConfigForMultiRegionTableWasNotModifiedByUser(
 	override bool,
 	opts ...applyZoneConfigForMultiRegionTableOption,
 ) error {
-	// If the user is forcing, or this is not a multi-region table our work here
+	// If the user is overriding, or this is not a multi-region table our work here
 	// is done.
 	if override || desc.GetLocalityConfig() == nil {
 		return nil

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -12,7 +12,9 @@ package sql
 
 import (
 	"context"
+	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
@@ -822,41 +824,67 @@ func (p *planner) CurrentDatabaseRegionConfig() (tree.DatabaseRegionConfig, erro
 	return dbDesc.GetRegionConfig(), nil
 }
 
-// CheckZoneConfigChangePermittedForMultiRegionDatabase checks if a zone config
-// change is permitted for a multi-region database. The change is permitted iff
-// it is not modifying a protested multi-region field of the zone configs (as
-// defined by zonepb.MultiRegionZoneConfigFields).
-func (p *planner) CheckZoneConfigChangePermittedForMultiRegionDatabase(
-	ctx context.Context, dbName tree.Name, options tree.KVOptions, force bool,
+// CheckZoneConfigChangePermittedForMultiRegion checks if a zone config
+// change is permitted for a multi-region database, table, index or partition.
+// The change is permitted iff it is not modifying a protected multi-region
+// field of the zone configs (as defined by zonepb.MultiRegionZoneConfigFields).
+func (p *planner) CheckZoneConfigChangePermittedForMultiRegion(
+	ctx context.Context, zs tree.ZoneSpecifier, options tree.KVOptions, force bool,
 ) error {
 	// If the user has specified the FORCE option, the world is their oyster.
 	if force {
 		return nil
 	}
 
-	_, dbDesc, err := p.Descriptors().GetImmutableDatabaseByName(
-		ctx,
-		p.txn,
-		string(dbName),
-		tree.DatabaseLookupFlags{Required: true},
-	)
-	if err != nil {
-		return err
+	// Check if what we're altering is a multi-region entity.
+	if zs.Database != "" {
+		_, dbDesc, err := p.Descriptors().GetImmutableDatabaseByName(
+			ctx,
+			p.txn,
+			string(zs.Database),
+			tree.DatabaseLookupFlags{Required: true},
+		)
+		if err != nil {
+			return err
+		}
+		if dbDesc.RegionConfig == nil {
+			// Not a multi-region database, we're done here.
+			return nil
+		}
+	} else {
+		// We're dealing with a table, index, or partition zone configuration
+		// change.  Get the table descriptor so we can determine if this is a
+		// multi-region table/index/partition.
+		table, err := p.resolveTableForZone(ctx, &zs)
+		if err != nil {
+			return err
+		}
+		if table == nil || table.GetLocalityConfig() == nil {
+			// Not a multi-region table, we're done here.
+			return nil
+		}
 	}
 
-	if dbDesc.RegionConfig != nil {
-		// This is clearly an n^2 operation, but since there are only a single
-		// digit number of zone config keys, it's likely faster to do it this way
-		// than incur the memory allocation of creating a map.
-		for _, opt := range options {
-			for _, cfg := range zonepb.MultiRegionZoneConfigFields {
-				if opt.Key == cfg {
-					// User is trying to update a zone config value that's protected for
-					// multi-region databases. Return the constructed error.
-					err := errors.Newf("attempting to modify protected field %q of a multi-region database zone configuration",
-						string(opt.Key),
-					)
+	// This is clearly an n^2 operation, but since there are only a single
+	// digit number of zone config keys, it's likely faster to do it this way
+	// than incur the memory allocation of creating a map.
+	for _, opt := range options {
+		for _, cfg := range zonepb.MultiRegionZoneConfigFields {
+			if opt.Key == cfg {
+				// User is trying to update a zone config value that's protected for
+				// multi-region databases. Return the constructed error.
+				err := errors.Newf("attempting to modify protected field %q of a multi-region zone configuration",
+					string(opt.Key),
+				)
+				// TODO(ajstorm): This branching is temporary until we convert database
+				//  operations over to the override_multi_region_zone_config session
+				//  variable.
+				if zs.Database != "" {
 					return errors.WithHint(err, "to override this error, specify the FORCE option")
+				} else {
+					return errors.WithHint(err, "to override this error, "+
+						"SET override_multi_region_zone_config = true and reissue the command")
+
 				}
 			}
 		}
@@ -908,6 +936,121 @@ func validateZoneConfigForMultiRegionDatabaseWasNotModifiedByUser(
 			"a user modified field")
 		return errors.WithHint(err, "to override this error and proceed with "+
 			"the overwrite, specify \"FORCE\" at the end of the statement")
+	}
+
+	return nil
+}
+
+// validateZoneConfigForMultiRegionTableWasNotModifiedByUser validates that
+// the table's zone configuration was not modified by the user. The function is
+// intended to be called in cases where a multi-region operation will overwrite
+// the table's (or index's/partition's) zone configuration and we wish to warn
+// the user about that before it occurs (and require the
+// override_multi_region_zone_config session variable to be set).
+func validateZoneConfigForMultiRegionTableWasNotModifiedByUser(
+	ctx context.Context,
+	txn *kv.Txn,
+	execCfg *ExecutorConfig,
+	regionConfig descpb.DatabaseDescriptor_RegionConfig,
+	desc *tabledesc.Mutable,
+	toRegionalByRow bool,
+	override bool,
+	opts ...applyZoneConfigForMultiRegionTableOption,
+) error {
+	// If the user is forcing, or this is not a multi-region table our work here
+	// is done.
+	if override || desc.GetLocalityConfig() == nil {
+		return nil
+	}
+
+	hint := "to proceed with the override, SET override_multi_region_zone_config = true, and reissue the statement"
+
+	currentZoneConfig, err := getZoneConfigRaw(ctx, txn, execCfg.Codec, desc.GetID())
+	if err != nil {
+		return err
+	}
+	if currentZoneConfig == nil {
+		currentZoneConfig = zonepb.NewZoneConfig()
+	}
+
+	// The expected zone config starts from the same base config as the current
+	// zone config, so copy it over to be used down below.
+	expectedZoneConfig := currentZoneConfig
+
+	if toRegionalByRow {
+		// We're going to REGIONAL BY ROW. Check to see if the to be applied zone
+		// configurations will override any existing zone configurations on the
+		// table's indexes. We say "override" here, and not "overwrite" because
+		// REGIONAL BY ROW tables will not write zone configs at the index level,
+		// but instead, at the index partition level. That being said, application
+		// of a partition-level zone config will override any applied index-level
+		// zone config, so it's important that we warn the user of that.
+		for _, s := range currentZoneConfig.Subzones {
+			if s.PartitionName == "" {
+				// Found a zone config on an index. Check to see if any of its
+				// multi-region fields are set.
+				if isSet, str := s.Config.IsAnyMultiRegionFieldSet(); isSet {
+					// Find the name of the offending index to use in the message below.
+					// In the case where we can't find the name, do our best and return
+					// the ID.
+					indexName := fmt.Sprintf("unknown with ID = %s",
+						strconv.FormatUint(uint64(s.IndexID), 10))
+					for _, i := range desc.ActiveIndexes() {
+						if uint32(i.GetID()) == s.IndexID {
+							indexName = i.GetName()
+						}
+					}
+					err := errors.Newf(
+						"attempting to update zone configuration for table %q which "+
+							"contains a zone configuration on index %q with multi-region field %q set",
+						desc.GetName(),
+						indexName,
+						str,
+					)
+					err = errors.WithDetail(err, "the attempted operation will override "+
+						"the index zone configuration field")
+					return errors.WithHint(err, hint)
+				}
+			}
+		}
+	}
+
+	// Fill in the expectedZoneConfig using the specified option.
+	for _, opt := range opts {
+		_, newZoneConfig, err := opt(
+			*expectedZoneConfig,
+			regionConfig,
+			desc,
+		)
+		if err != nil {
+			return err
+		}
+		expectedZoneConfig = &newZoneConfig
+	}
+
+	// Mark the NumReplicas as 0 if we have subzones but no other features
+	// in the zone config. This signifies a placeholder.
+	if len(expectedZoneConfig.Subzones) > 0 && isPlaceholderZoneConfigForMultiRegion(*expectedZoneConfig) {
+		expectedZoneConfig.NumReplicas = proto.Int32(0)
+	}
+
+	// Compare the two zone configs to see if anything is amiss.
+	same, field, err := currentZoneConfig.DiffWithZone(
+		*expectedZoneConfig,
+		zonepb.MultiRegionZoneConfigFields,
+	)
+	if err != nil {
+		return err
+	}
+	if !same {
+		err := errors.Newf(
+			"attempting to update zone configuration for table %q which contains modified field %q ",
+			desc.GetName(),
+			field,
+		)
+		err = errors.WithDetail(err, "the attempted operation will overwrite "+
+			"a user modified field")
+		return errors.WithHint(err, hint)
 	}
 
 	return nil

--- a/pkg/sql/sem/tree/alter_database.go
+++ b/pkg/sql/sem/tree/alter_database.go
@@ -32,7 +32,6 @@ func (node *AlterDatabaseOwner) Format(ctx *FmtCtx) {
 type AlterDatabaseAddRegion struct {
 	Name   Name
 	Region Name
-	Force  bool
 }
 
 var _ Statement = &AlterDatabaseAddRegion{}
@@ -43,16 +42,12 @@ func (node *AlterDatabaseAddRegion) Format(ctx *FmtCtx) {
 	ctx.FormatNode(&node.Name)
 	ctx.WriteString(" ADD REGION ")
 	ctx.FormatNode(&node.Region)
-	if node.Force {
-		ctx.WriteString(" FORCE")
-	}
 }
 
 // AlterDatabaseDropRegion represents a ALTER DATABASE DROP REGION statement.
 type AlterDatabaseDropRegion struct {
 	Name   Name
 	Region Name
-	Force  bool
 }
 
 var _ Statement = &AlterDatabaseDropRegion{}
@@ -63,16 +58,12 @@ func (node *AlterDatabaseDropRegion) Format(ctx *FmtCtx) {
 	ctx.FormatNode(&node.Name)
 	ctx.WriteString(" DROP REGION ")
 	ctx.FormatNode(&node.Region)
-	if node.Force {
-		ctx.WriteString(" FORCE")
-	}
 }
 
 // AlterDatabasePrimaryRegion represents a ALTER DATABASE PRIMARY REGION ... statement.
 type AlterDatabasePrimaryRegion struct {
 	Name          Name
 	PrimaryRegion Name
-	Force         bool
 }
 
 var _ Statement = &AlterDatabasePrimaryRegion{}
@@ -83,16 +74,12 @@ func (node *AlterDatabasePrimaryRegion) Format(ctx *FmtCtx) {
 	ctx.FormatNode(&node.Name)
 	ctx.WriteString(" PRIMARY REGION ")
 	node.PrimaryRegion.Format(ctx)
-	if node.Force {
-		ctx.WriteString(" FORCE")
-	}
 }
 
 // AlterDatabaseSurvivalGoal represents a ALTER DATABASE SURVIVE ... statement.
 type AlterDatabaseSurvivalGoal struct {
 	Name         Name
 	SurvivalGoal SurvivalGoal
-	Force        bool
 }
 
 var _ Statement = &AlterDatabaseSurvivalGoal{}
@@ -103,7 +90,4 @@ func (node *AlterDatabaseSurvivalGoal) Format(ctx *FmtCtx) {
 	ctx.FormatNode(&node.Name)
 	ctx.WriteString(" ")
 	node.SurvivalGoal.Format(ctx)
-	if node.Force {
-		ctx.WriteString(" FORCE")
-	}
 }

--- a/pkg/sql/sem/tree/zone.go
+++ b/pkg/sql/sem/tree/zone.go
@@ -21,8 +21,6 @@ type ZoneSpecifier struct {
 
 	// Partition is only respected when Table is set.
 	Partition Name
-
-	Force bool
 }
 
 // TelemetryName returns a name fitting for telemetry purposes.
@@ -143,8 +141,5 @@ func (node *SetZoneConfig) Format(ctx *FmtCtx) {
 				ctx.WriteString(` = COPY FROM PARENT`)
 			}
 		}
-	}
-	if node.Force {
-		ctx.WriteString(" FORCE")
 	}
 }

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -211,6 +211,9 @@ type LocalOnlySessionData struct {
 	ImplicitColumnPartitioningEnabled bool
 	// DropEnumValueEnabled indicates whether enum values can be dropped.
 	DropEnumValueEnabled bool
+	// OverrideMultiRegionZoneConfigEnabled indicates whether zone configurations can be
+	// modified for multi-region databases and tables/indexes/partitions.
+	OverrideMultiRegionZoneConfigEnabled bool
 	// HashShardedIndexesEnabled indicates whether hash sharded indexes can be created.
 	HashShardedIndexesEnabled bool
 	// DisallowFullTableScans indicates whether queries that plan full table scans

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -130,15 +130,22 @@ func (p *planner) SetZoneConfig(ctx context.Context, n *tree.SetZoneConfig) (pla
 		return nil, errorutil.UnsupportedWithMultiTenancy(multitenancyZoneCfgIssueNo)
 	}
 
+	var override bool
+	// TODO(ajstorm): This branching is temporary until we remove the FORCE option
+	// from database commands
 	if n.Database != "" {
-		if err := p.CheckZoneConfigChangePermittedForMultiRegionDatabase(
-			ctx,
-			n.Database,
-			n.Options,
-			n.Force,
-		); err != nil {
-			return nil, err
-		}
+		override = n.Force
+	} else {
+		override = p.SessionData().OverrideMultiRegionZoneConfigEnabled
+	}
+
+	if err := p.CheckZoneConfigChangePermittedForMultiRegion(
+		ctx,
+		n.ZoneSpecifier,
+		n.Options,
+		override,
+	); err != nil {
+		return nil, err
 	}
 
 	var yamlConfig tree.TypedExpr
@@ -950,8 +957,9 @@ func getZoneConfigRaw(
 }
 
 // RemoveIndexZoneConfigs removes the zone configurations for some
-// indexs being dropped. It is a no-op if there is no zone
-// configuration or run on behalf of a tenant.
+// indexes being dropped. It is a no-op if there is no zone
+// configuration, there's no index zone configs to be dropped,
+// or it is run on behalf of a tenant.
 //
 // It operates entirely on the current goroutine and is thus able to
 // reuse an existing client.Txn safely.

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -130,20 +130,11 @@ func (p *planner) SetZoneConfig(ctx context.Context, n *tree.SetZoneConfig) (pla
 		return nil, errorutil.UnsupportedWithMultiTenancy(multitenancyZoneCfgIssueNo)
 	}
 
-	var override bool
-	// TODO(ajstorm): This branching is temporary until we remove the FORCE option
-	// from database commands
-	if n.Database != "" {
-		override = n.Force
-	} else {
-		override = p.SessionData().OverrideMultiRegionZoneConfigEnabled
-	}
-
 	if err := p.CheckZoneConfigChangePermittedForMultiRegion(
 		ctx,
 		n.ZoneSpecifier,
 		n.Options,
-		override,
+		p.SessionData().OverrideMultiRegionZoneConfigEnabled,
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -1162,6 +1162,25 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`override_multi_region_zone_config`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`override_multi_region_zone_config`),
+		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("override_multi_region_zone_config", s)
+			if err != nil {
+				return err
+			}
+			m.SetOverrideMultiRegionZoneConfigEnabled(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) string {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData.OverrideMultiRegionZoneConfigEnabled)
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return formatBoolAsPostgresSetting(overrideMultiRegionZoneConfigClusterMode.Get(sv))
+		},
+	},
+
+	// CockroachDB extension.
 	`experimental_enable_hash_sharded_indexes`: {
 		GetStringVal: makePostgresBoolGetStringValFn(`experimental_enable_hash_sharded_indexes`),
 		Set: func(_ context.Context, m *sessionDataMutator, s string) error {


### PR DESCRIPTION
Backport 3/3 commits from #62008.

/cc @cockroachdb/release

---

sql: Block zone config updates to multi-region tables

Block users from updating the zone configurations of multi-region
tables, without first having them set the session variable
`override_multi_region_zone_config` to true. We block updates to
multi-region table/partition/index zone configurations because we don't
want users to accidentally override the prescribed settings, leaving
them open to sub-optimal performance. Note that only the multi-region
fields of the zone configuration are blocked behind this variable. All
other fields (gc.ttlseconds, range_min/max_bytes, etc) can be updated
without overriding.

Release note (sql change): Block users from updating the zone
configurations of multi-region tables.

sql: Use session variable instead of FORCE to override zone configs

With #61499 we introduced new syntax (FORCE) to override setting the
zone configurations on multi-region databases. Upon further reflection,
it was decided that a session variable would be better suited to the
task. This commit pulls out the FORCE syntax and replaces it with the
use of override_multi_region_zone_config;

Release note (sql change): Revert the release notes on #61499.  We now
use a session variable (override_multi_region_zone_config) to override
the zone configuration on multi-region databases (and tables).

Resolves: #57668.

Note to reviewers: Please ignore the first commit, as it's being separately reviewed as part of #61889.  That commit was pulle out into a separate PR as it's a release blocker, and there was a need to get it in urgently.
