### PR TITLE
sql: Block discarding zone config for MR entities

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
@@ -521,3 +521,51 @@ lease_preferences = '[[+region=us-east-1]]'  regional_by_row_as@primary  us-east
 num_voters = 3,
 voter_constraints = '[+region=us-east-1]',
 lease_preferences = '[[+region=us-east-1]]'  regional_by_row_as@regional_by_row_as_i_idx  us-east-1
+
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
+----
+DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
+                            range_min_bytes = 1000,
+                            range_max_bytes = 100000,
+                            gc.ttlseconds = 100000,
+                            num_replicas = 5,
+                            num_voters = 3,
+                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                            voter_constraints = '[+region=us-east-1]',
+                            lease_preferences = '[[+region=us-east-1]]'
+
+statement error attempting to discard the zone configuration of a multi-region entity
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE DISCARD
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE DISCARD;
+SET override_multi_region_zone_config = false
+
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
+----
+RANGE default  ALTER RANGE default CONFIGURE ZONE USING
+               range_min_bytes = 134217728,
+               range_max_bytes = 536870912,
+               gc.ttlseconds = 90000,
+               num_replicas = 3,
+               constraints = '[]',
+               lease_preferences = '[]'
+
+statement error attempting to discard the zone configuration of a multi-region entity
+ALTER INDEX regional_by_row@primary CONFIGURE ZONE DISCARD
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER INDEX regional_by_row@primary CONFIGURE ZONE DISCARD;
+SET override_multi_region_zone_config = false
+
+statement error attempting to discard the zone configuration of a multi-region entity
+ALTER PARTITION "ca-central-1" OF INDEX regional_by_row@primary CONFIGURE ZONE DISCARD
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER PARTITION "ca-central-1" OF INDEX regional_by_row@primary CONFIGURE ZONE DISCARD;
+SET override_multi_region_zone_config = false


### PR DESCRIPTION
Block discards of multi-region zone configs behind the
override_multi_region_zone_config session variable.

Release note (sql change): Discarding a zone configuration from a
multi-region enabled entity is blocked behind the
override_multi_region_zone_config session variable.

Resolves: #61773 