### PR TITLE
mutations: do not generate histograms for JSON

### DIFF
--- a/pkg/sql/mutations/mutations.go
+++ b/pkg/sql/mutations/mutations.go
@@ -210,6 +210,10 @@ func statisticsMutator(
 			n := rng.Intn(10)
 			seen := map[string]bool{}
 			colType := tree.MustBeStaticallyKnownType(col.Type)
+			// The JSON family does not have a key encoding.
+			if colType.Family() == types.JsonFamily {
+				return
+			}
 			h := stats.HistogramData{
 				ColumnType: colType,
 			}


### PR DESCRIPTION
EncodeTableKey does not work for JSON, so avoid collecting histograms
for them.

Resolves #62057
Resolves #62058

Release note: None