### PR TITLE
release-20.2: mutations: disallow spatial types for Postgres Tables

### DIFF
--- a/pkg/sql/mutations/mutations.go
+++ b/pkg/sql/mutations/mutations.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 )
 
@@ -633,7 +634,7 @@ func postgresCreateTableMutator(
 						}
 						if def.Name != "" {
 							// Unset Name here because
-							// constaint names cannot
+							// constraint names cannot
 							// be shared among tables,
 							// so multiple PK constraints
 							// named "primary" is an error.
@@ -652,6 +653,25 @@ func postgresCreateTableMutator(
 						Storing:  def.Storing,
 					})
 					changed = true
+				case *tree.ColumnTableDef:
+					colType := tree.MustBeStaticallyKnownType(def.Type)
+					switch colType.Family() {
+					case types.GeometryFamily, types.GeographyFamily, types.Box2DFamily:
+						// PostgreSQL does not have any spatial types. Turn them into
+						// String types.
+						def.Type = types.String
+						mutated = append(mutated, &tree.AlterTable{
+							Table: stmt.Table.ToUnresolvedObjectName(),
+							Cmds: tree.AlterTableCmds{
+								&tree.AlterTableAlterColumnType{
+									Column: def.Name,
+									ToType: types.String,
+								},
+							},
+						})
+						changed = true
+					}
+					newdefs = append(newdefs, def)
 				default:
 					newdefs = append(newdefs, def)
 				}


### PR DESCRIPTION
Backport 1/1 commits from #62086.

/cc @cockroachdb/release

---

This is affecting ComposeCompare tests.
see #61683 

Release note: None


