### PR TITLE
kvclient: don't route to followers if closed_timestmap.target_duration == 0

### DIFF
--- a/pkg/ccl/kvccl/kvfollowerreadsccl/BUILD.bazel
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "//pkg/kv",
         "//pkg/kv/kvclient/kvcoord",
         "//pkg/kv/kvserver",
+        "//pkg/kv/kvserver/closedts",
         "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/roachpb",
         "//pkg/rpc",

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads.go
@@ -13,6 +13,7 @@ package kvfollowerreadsccl
 import (
 	"context"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -57,6 +58,12 @@ func getFollowerReadLag(st *cluster.Settings) time.Duration {
 	targetMultiple := followerReadMultiple.Get(&st.SV)
 	targetDuration := closedts.TargetDuration.Get(&st.SV)
 	closeFraction := closedts.CloseFraction.Get(&st.SV)
+	// Zero targetDuration means follower reads are disabled.
+	if targetDuration == 0 {
+		// Returning an infinitely large negative value would push safe
+		// request timestamp into the distant past thus disabling follower reads.
+		return math.MinInt64
+	}
 	return -1 * time.Duration(float64(targetDuration)*
 		(1+closeFraction*targetMultiple))
 }


### PR DESCRIPTION
Fixes #60711
Follower read lag determines when to attempt routing to follower. When it is disabled by setting target_duration to 0, it should not attempt followers while the old behaviour was forcing the opposite behaviour. Setting lag to negative infinity in this case ensures only requests from distant future could be routed.