### PR TITLE
makefile: add vendor/modules.txt target for ordering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,6 +371,8 @@ pkg/ui/yarn.installed: pkg/ui/package.json pkg/ui/yarn.lock pkg/ui/yarn.protobuf
 	rm -rf pkg/ui/node_modules/@types/node
 	touch $@
 
+vendor/modules.txt: | bin/.submodules-initialized
+
 # Update the git hooks and install commands from dependencies whenever they
 # change.
 # These should be synced with `./pkg/cmd/import-tools/main.go`.
@@ -1842,4 +1844,3 @@ build/variables.mk: Makefile build/archive/contents/Makefile pkg/ui/Makefile bui
 include build/variables.mk
 $(foreach v,$(filter-out $(strip $(VALID_VARS)),$(.VARIABLES)),\
 	$(if $(findstring command line,$(origin $v)),$(error Variable '$v' is not recognized by this Makefile)))
-


### PR DESCRIPTION
Developers trying to run `make build` from a fresh checkout have
reported hitting:

```
make build
Running make with -j8
GOPATH set to /Users/someuser/go
make: *** No rule to make target 'vendor/modules.txt', needed by 'bin/.bootstrap'.  Stop.
```

Using `remake`'s tracing feature, we can see that the problem appears
to be that `bin/.bootstrap` depends on both `vendor/modules.txt` and
`bin/.submodules-initialized`. While `bin/.submodules-initialized`
would create `vendor/modules.txt`, make is choosing to run
`vendor/modules.txt` first:

```
> GOPATH=~/cleango/ remake -j1 --trace build
Reading makefiles...
GOPATH set to /Users/ssd/cleango
Updating makefiles...
Updating goal targets...
 File 'build' does not exist.
   File 'cockroach' does not exist.
     File 'pkg/ui/distccl/bindata.go' does not exist.
       File 'bin/.bootstrap' does not exist.
         File 'vendor/modules.txt' does not exist.
        Must remake target 'vendor/modules.txt'.
```

Adding a target for `vendor/modules.txt` with an empty recipe encodes
fixes up the dependnecy issue.

Release note: None