### PR TITLE
sql: add roach test / workload for testing connection latencies

### DIFF
--- a/pkg/ccl/workloadccl/allccl/BUILD.bazel
+++ b/pkg/ccl/workloadccl/allccl/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/ccl/workloadccl/roachmartccl",
         "//pkg/workload/bank",
         "//pkg/workload/bulkingest",
+        "//pkg/workload/connectionlatency",
         "//pkg/workload/debug",
         "//pkg/workload/examples",
         "//pkg/workload/geospatial",

--- a/pkg/ccl/workloadccl/allccl/all.go
+++ b/pkg/ccl/workloadccl/allccl/all.go
@@ -16,6 +16,7 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/workloadccl/roachmartccl"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/bank"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/bulkingest"
+	_ "github.com/cockroachdb/cockroach/pkg/workload/connectionlatency"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/debug"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/examples"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/geospatial"

--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "clock_util.go",
         "cluster.go",
         "cluster_init.go",
+        "connection_latency.go",
         "copy.go",
         "decommission.go",
         "decommission_self.go",

--- a/pkg/cmd/roachtest/connection_latency.go
+++ b/pkg/cmd/roachtest/connection_latency.go
@@ -1,0 +1,116 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	regionUsEast = "us-east1-b"
+	regionUsWest = "us-west1-b"
+	regionEuWest = "europe-west2-b"
+)
+
+func runConnectionLatencyTest(
+	ctx context.Context, t *test, c *cluster, numNodes int, numZones int,
+) {
+	err := c.PutE(ctx, t.l, cockroach, "./cockroach")
+	require.NoError(t, err)
+
+	err = c.PutE(ctx, t.l, workload, "./workload")
+	require.NoError(t, err)
+
+	err = c.StartE(ctx, startArgs("--secure"))
+	require.NoError(t, err)
+
+	certsDir := "certs"
+	urlTemplate := "postgres://%s@%s:%s?sslcert=%s/client.%s.crt&sslkey=%s/client.%s.key&sslrootcert=%s/ca.crt&sslmode=require"
+	var urls []string
+	externalIps := c.ExternalIP(ctx, c.All())
+	for _, u := range externalIps {
+		url := fmt.Sprintf(urlTemplate, "testuser", u, "26257", certsDir, "testuser", certsDir, "testuser", certsDir)
+		urls = append(urls, fmt.Sprintf("'%s'", url))
+	}
+
+	urlString := strings.Join(urls, " ")
+
+	// Only create the user once.
+	err = c.RunE(ctx, c.Node(1), `./cockroach sql --certs-dir certs -e "CREATE USER testuser CREATEDB"`)
+	require.NoError(t, err)
+
+	err = c.RunE(ctx, c.All(),
+		fmt.Sprintf(`./cockroach cert create-client testuser --certs-dir %s --ca-key=%s/ca.key`,
+			certsDir, certsDir))
+	require.NoError(t, err)
+
+	err = c.RunE(ctx, c.Node(1), "./workload init connectionlatency --user testuser --secure")
+	require.NoError(t, err)
+
+	runWorkload := func(loadNode nodeListOption, locality string) {
+		workloadCmd := fmt.Sprintf(
+			`./workload run connectionlatency %s --user testuser --secure --duration 30s --histograms=%s/stats.json --locality %s`,
+			urlString,
+			perfArtifactsDir,
+			locality,
+		)
+		err = c.RunE(ctx, loadNode, workloadCmd)
+		require.NoError(t, err)
+	}
+
+	if numZones > 1 {
+		numLoadNodes := numZones
+		loadGroups := makeLoadGroups(c, numZones, numNodes, numLoadNodes)
+		cockroachUsEast := loadGroups[0].loadNodes
+		cockroachUsWest := loadGroups[1].loadNodes
+		cockroachEuWest := loadGroups[2].loadNodes
+
+		runWorkload(cockroachUsEast, regionUsEast)
+		runWorkload(cockroachUsWest, regionUsWest)
+		runWorkload(cockroachEuWest, regionEuWest)
+	} else {
+		// Run only on the load node.
+		runWorkload(c.Node(numNodes+1), regionUsEast)
+	}
+}
+
+func registerConnectionLatencyTest(r *testRegistry) {
+	// Single region test.
+	numNodes := 3
+	r.Add(testSpec{
+		MinVersion: "v20.1.0",
+		Name:       fmt.Sprintf("connection_latency/nodes=%d", numNodes),
+		Owner:      OwnerSQLExperience,
+		Cluster:    makeClusterSpec(numNodes + 1), // Add one for load node.
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			runConnectionLatencyTest(ctx, t, c, numNodes, 1)
+		},
+	})
+
+	geoZones := []string{regionUsEast, regionUsWest, regionEuWest}
+	geoZonesStr := strings.Join(geoZones, ",")
+	numMultiRegionNodes := 9
+	numZones := len(geoZones)
+	loadNodes := numZones
+	r.Add(testSpec{
+		MinVersion: "v20.1.0",
+		Name:       fmt.Sprintf("connection_latency/nodes=%d/multiregion", numMultiRegionNodes),
+		Owner:      OwnerSQLExperience,
+		Cluster:    makeClusterSpec(numMultiRegionNodes+loadNodes, geo(), zones(geoZonesStr)),
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			runConnectionLatencyTest(ctx, t, c, numMultiRegionNodes, numZones)
+		},
+	})
+}

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -26,6 +26,7 @@ func registerTests(r *testRegistry) {
 	registerClearRange(r)
 	registerClockJumpTests(r)
 	registerClockMonotonicTests(r)
+	registerConnectionLatencyTest(r)
 	registerCopy(r)
 	registerDecommission(r)
 	registerDiskFull(r)

--- a/pkg/workload/connectionlatency/BUILD.bazel
+++ b/pkg/workload/connectionlatency/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "connectionlatency",
+    srcs = ["connectionlatency.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/workload/connectionlatency",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/util/log",
+        "//pkg/util/timeutil",
+        "//pkg/workload",
+        "//pkg/workload/histogram",
+        "@com_github_jackc_pgx_v4//:pgx",
+        "@com_github_spf13_pflag//:pflag",
+    ],
+)

--- a/pkg/workload/connectionlatency/connectionlatency.go
+++ b/pkg/workload/connectionlatency/connectionlatency.go
@@ -1,0 +1,122 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package connectionlatency
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
+	"github.com/jackc/pgx/v4"
+	"github.com/spf13/pflag"
+)
+
+type connectionLatency struct {
+	flags     workload.Flags
+	connFlags *workload.ConnFlags
+
+	locality string
+}
+
+func init() {
+	workload.Register(connectionLatencyMeta)
+}
+
+var connectionLatencyMeta = workload.Meta{
+	Name:        `connectionlatency`,
+	Description: `Testing Connection Latencies`,
+	Version:     `1.0.0`,
+	New: func() workload.Generator {
+		c := &connectionLatency{}
+		c.flags.FlagSet = pflag.NewFlagSet(`connectionlatency`, pflag.ContinueOnError)
+		c.flags.StringVar(&c.locality, `locality`, ``, `Which locality is the workload running in? (east,west,central)`)
+		c.connFlags = workload.NewConnFlags(&c.flags)
+		return c
+	},
+}
+
+// Meta implements the Generator interface.
+func (connectionLatency) Meta() workload.Meta { return connectionLatencyMeta }
+
+// Flags implements the Flagser interface.
+func (c *connectionLatency) Flags() workload.Flags { return c.flags }
+
+// Tables implements the Generator interface.
+func (connectionLatency) Tables() []workload.Table {
+	return nil
+}
+
+// Ops implements the Opser interface.
+func (c *connectionLatency) Ops(
+	ctx context.Context, urls []string, reg *histogram.Registry,
+) (workload.QueryLoad, error) {
+	ql := workload.QueryLoad{}
+	_, err := workload.SanitizeUrls(c, c.connFlags.DBOverride, urls)
+	if err != nil {
+		return workload.QueryLoad{}, err
+	}
+
+	for _, url := range urls {
+		op := &connectionOp{
+			url:   url,
+			hists: reg.GetHandle(),
+		}
+
+		conn, err := pgx.Connect(ctx, url)
+		if err != nil {
+			return workload.QueryLoad{}, err
+		}
+
+		var locality string
+		err = conn.QueryRow(ctx, "SHOW LOCALITY").Scan(&locality)
+		if err != nil {
+			return workload.QueryLoad{}, err
+		}
+
+		op.connectFrom = c.locality
+		op.connectTo = locality
+		ql.WorkerFns = append(ql.WorkerFns, op.run)
+	}
+	return ql, nil
+}
+
+type connectionOp struct {
+	url         string
+	hists       *histogram.Histograms
+	connectFrom string
+	connectTo   string
+}
+
+func (o *connectionOp) run(ctx context.Context) error {
+	start := timeutil.Now()
+	conn, err := pgx.Connect(ctx, o.url)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := conn.Close(ctx); err != nil {
+			log.Warningf(ctx, "%v", err)
+		}
+	}()
+	elapsed := timeutil.Since(start)
+	o.hists.Get(fmt.Sprintf(`connect-from-%s-to-%s`, o.connectFrom, o.connectTo)).Record(elapsed)
+
+	if _, err = conn.Exec(ctx, "SELECT 1"); err != nil {
+		return err
+	}
+	// Record the time it takes to do a select after connecting for reference.
+	elapsed = timeutil.Since(start)
+	o.hists.Get(`select`).Record(elapsed)
+	return nil
+}


### PR DESCRIPTION
Add roach test and workload test for testing connection latencies.

Release note: None

Making it a private test right now (not available through `cockroach workload`)

Need to also add it to teamcity and make sure the results are reported in roachperf, will open PR there.

Resolves https://github.com/cockroachdb/cockroach/issues/59394
