### PR TITLE
release-21.1: contention: properly protect AddContentionEvent by mutex

### DIFF
--- a/pkg/sql/contention/registry.go
+++ b/pkg/sql/contention/registry.go
@@ -241,6 +241,8 @@ func NewRegistry() *Registry {
 
 // AddContentionEvent adds a new ContentionEvent to the Registry.
 func (r *Registry) AddContentionEvent(c roachpb.ContentionEvent) {
+	r.globalLock.Lock()
+	defer r.globalLock.Unlock()
 	_, rawTableID, rawIndexID, err := keys.DecodeTableIDIndexID(c.Key)
 	if err != nil {
 		// The key is not a valid SQL key, so we store it in a separate cache.
@@ -254,8 +256,6 @@ func (r *Registry) AddContentionEvent(c roachpb.ContentionEvent) {
 	}
 	tableID := descpb.ID(rawTableID)
 	indexID := descpb.IndexID(rawIndexID)
-	r.globalLock.Lock()
-	defer r.globalLock.Unlock()
 	if v, ok := r.indexMap.get(tableID, indexID); !ok {
 		// This is the first contention event seen for the given tableID/indexID
 		// pair.


### PR DESCRIPTION
Backport 1/1 commits from #62163.

/cc @cockroachdb/release

---

Whenever we're adding a contention event to the registry, we need to
acquire the lock. Previously, we correctly did so for SQL keys but
forgot to do so for non-SQL keys (the support for which has been
recently added). This commit fixes that issue.

Fixes: #62160.

Release note: None (no stable release with the bug)
