### PR TITLE
colflow: fix premature vectorized stats collection

### DIFF
--- a/pkg/sql/colflow/BUILD.bazel
+++ b/pkg/sql/colflow/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//pkg/util/randutil",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+        "//pkg/util/tracing",
         "//pkg/util/treeprinter",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -203,6 +203,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					&colexecop.TestingSemaphore{},
 					diskAccounts,
 					toDrain,
+					nil, /* getStats */
 					nil, /* toClose */
 				)
 				for i := 0; i < numInboxes; i++ {

--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze
@@ -1,7 +1,7 @@
-# LogicTest: fakedist-vec-off
+# LogicTest: default-configs !local-spec-planning !fakedist-spec-planning
 #
-# TODO(radu): enable other configs when the vectorized stat collector issue
-# #56928 is fixed.
+# TODO(yuzefovich): for some reason spec-planning configs are not happy. Figure
+# it out.
 
 statement ok
 CREATE TABLE kv (k INT PRIMARY KEY, v INT, FAMILY (k, v))


### PR DESCRIPTION
Previously, we could call `finishVectorizedStatsCollectors` prematurely
in some edge cases (e.g. when the right side of the hash join is empty,
we could collect the stats from the left input tree too early). This was
caused by the fact that we accumulate the vectorized stats collectors
into a queue which is handled by the outboxes or the root materializer.
This commit begins sharing the responsibility of the collecting stats
with the hash router too. The reasoning for this change is that when the
hash router exits, all stats collectors in its input tree should have
the final info, and the hash router can collect correct stats. Those
stats are added as another metadata object to be returned by the last to
exit router output.

Fixes: #56928.

Release note (bug fix): Previously, CockroachDB when collecting
execution statistics (e.g. when running EXPLAIN ANALYZE) could collect
them prematurely which would result in incorrect stats. This is now
fixed.