### PR TITLE
release-21.1: sql: disallow adding OIDVECTOR and INT2VECTOR columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1699,3 +1699,16 @@ ORDER BY feature_name DESC
 ----
 job.schema_change.successful
 job.schema_change.failed
+
+# Regression test for #61762. Do not allow adding OIDVECTOR or INT2VECTOR
+# columns.
+subtest regression_61762
+
+statement ok
+CREATE TABLE t61762 ()
+
+statement error VECTOR column types are unsupported
+ALTER TABLE t61762 ADD COLUMN v OIDVECTOR
+
+statement error VECTOR column types are unsupported
+ALTER TABLE t61762 ADD COLUMN v INT2VECTOR


### PR DESCRIPTION
Backport 1/1 commits from #61763.

/cc @cockroachdb/release

---

Creating columns of type `OIDVECTOR` or `INT2VECTOR` is not allowed in
`CREATE TABLE` statements. This commit disallows these types in
`ALTER TABLE ... ADD COLUMN` statements for consistency.

Fixes #61762

Release justification: This is a low-risk bug fix.

Release note (bug fix): Adding columns of type `OIDVECTOR` or
`INT2VECTOR` to a table in `ALTER TABLE ... ADD COLUMN` statements is no
longer allowed. These types are not allowed in user-created tables via
`CREATE TABLE ` and were erroneously allowed previously in
`ALTER TABLE ... ADD COLUMN`.
