### PR TITLE
sql: fix pg_type_is_visible and ::regtype cast to handle UDTs

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2944,6 +2944,8 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 <tr><td><a name="pg_sleep"></a><code>pg_sleep(seconds: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>pg_sleep makes the current session’s process sleep until seconds seconds have elapsed. seconds is a value of type double precision, so fractional-second delays can be specified.</p>
 </span></td></tr>
 <tr><td><a name="pg_table_is_visible"></a><code>pg_table_is_visible(oid: oid) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether the table with the given OID belongs to one of the schemas on the search path.</p>
+</span></td></tr>
+<tr><td><a name="pg_type_is_visible"></a><code>pg_type_is_visible(oid: oid) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether the type with the given OID belongs to one of the schemas on the search path.</p>
 </span></td></tr></tbody>
 </table>
 

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -249,7 +249,7 @@ func (so *importSequenceOperators) LookupSchema(
 
 // IsTableVisible is part of the tree.EvalDatabase interface.
 func (so *importSequenceOperators) IsTableVisible(
-	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, tableID int64,
+	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, tableID oid.Oid,
 ) (bool, bool, error) {
 	return false, false, errors.WithStack(errSequenceOperators)
 }

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -254,6 +254,13 @@ func (so *importSequenceOperators) IsTableVisible(
 	return false, false, errors.WithStack(errSequenceOperators)
 }
 
+// IsTypeVisible is part of the tree.EvalDatabase interface.
+func (so *importSequenceOperators) IsTypeVisible(
+	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, typeID oid.Oid,
+) (bool, bool, error) {
+	return false, false, errors.WithStack(errSequenceOperators)
+}
+
 // Implements the tree.SequenceOperators interface.
 func (so *importSequenceOperators) IncrementSequence(
 	ctx context.Context, seqName *tree.TableName,

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -72,7 +72,7 @@ func (so *DummySequenceOperators) LookupSchema(
 
 // IsTableVisible is part of the tree.EvalDatabase interface.
 func (so *DummySequenceOperators) IsTableVisible(
-	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, tableID int64,
+	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, tableID oid.Oid,
 ) (bool, bool, error) {
 	return false, false, errors.WithStack(errSequenceOperators)
 }
@@ -193,7 +193,7 @@ func (ep *DummyEvalPlanner) LookupSchema(
 
 // IsTableVisible is part of the tree.EvalDatabase interface.
 func (ep *DummyEvalPlanner) IsTableVisible(
-	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, tableID int64,
+	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, tableID oid.Oid,
 ) (bool, bool, error) {
 	return false, false, errors.WithStack(errEvalPlanner)
 }

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -77,6 +77,13 @@ func (so *DummySequenceOperators) IsTableVisible(
 	return false, false, errors.WithStack(errSequenceOperators)
 }
 
+// IsTypeVisible is part of the tree.EvalDatabase interface.
+func (so *DummySequenceOperators) IsTypeVisible(
+	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, typeID oid.Oid,
+) (bool, bool, error) {
+	return false, false, errors.WithStack(errEvalPlanner)
+}
+
 // IncrementSequence is part of the tree.SequenceOperators interface.
 func (so *DummySequenceOperators) IncrementSequence(
 	ctx context.Context, seqName *tree.TableName,
@@ -194,6 +201,13 @@ func (ep *DummyEvalPlanner) LookupSchema(
 // IsTableVisible is part of the tree.EvalDatabase interface.
 func (ep *DummyEvalPlanner) IsTableVisible(
 	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, tableID oid.Oid,
+) (bool, bool, error) {
+	return false, false, errors.WithStack(errEvalPlanner)
+}
+
+// IsTypeVisible is part of the tree.EvalDatabase interface.
+func (ep *DummyEvalPlanner) IsTypeVisible(
+	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, typeID oid.Oid,
 ) (bool, bool, error) {
 	return false, false, errors.WithStack(errEvalPlanner)
 }

--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -83,38 +83,31 @@ NULL
 
 statement ok
 CREATE TABLE is_visible(a int primary key);
+CREATE TYPE visible_type AS ENUM('a');
 CREATE SCHEMA other;
 CREATE TABLE other.not_visible(a int primary key);
+CREATE TYPE other.not_visible_type AS ENUM('b');
 CREATE DATABASE db2;
 SET DATABASE = db2;
 CREATE TABLE table_in_db2(a int primary key);
+CREATE TYPE type_in_db2 AS ENUM('c');
 
 let $table_in_db2_id
 SELECT c.oid FROM pg_class c WHERE c.relname = 'table_in_db2';
 
+let $type_in_db2_id
+SELECT t.oid FROM pg_type t WHERE t.typname = 'type_in_db2';
+
 statement ok
 SET DATABASE = test;
 
-query B
-SELECT pg_table_is_visible(c.oid)
+query TB rowsort
+SELECT c.relname, pg_table_is_visible(c.oid)
 FROM pg_class c
-WHERE c.relname = 'is_visible'
+WHERE c.relname IN ('is_visible', 'not_visible')
 ----
-true
-
-query B
-SELECT pg_table_is_visible(c.oid)
-FROM pg_class c
-WHERE c.relname = 'pg_type'
-----
-true
-
-query B
-SELECT pg_table_is_visible(c.oid)
-FROM pg_class c
-WHERE c.relname = 'not_visible'
-----
-false
+is_visible   true
+not_visible  false
 
 # Looking up a table in a different database should return NULL.
 query B
@@ -125,5 +118,37 @@ NULL
 # Looking up a non-existent OID should return NULL.
 query B
 SELECT pg_table_is_visible(1010101010)
+----
+NULL
+
+query B
+SELECT pg_table_is_visible(NULL)
+----
+NULL
+
+query TB rowsort
+SELECT t.typname, pg_type_is_visible(t.oid)
+FROM pg_type t
+WHERE t.typname IN ('int8', '_date', 'visible_type', 'not_visible_type')
+----
+int8              true
+_date             true
+visible_type      true
+not_visible_type  false
+
+# Looking up a table in a different database should return NULL.
+query B
+SELECT pg_type_is_visible($type_in_db2_id)
+----
+NULL
+
+# Looking up a non-existent OID should return NULL.
+query B
+SELECT pg_type_is_visible(1010101010)
+----
+NULL
+
+query B
+SELECT pg_type_is_visible(NULL)
 ----
 NULL

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -173,25 +173,56 @@ pg_constraint  0
 ## Test visibility of pg_* via oid casts.
 
 statement ok
-CREATE TABLE a (id INT PRIMARY KEY)
+CREATE TABLE a (id INT PRIMARY KEY);
+CREATE TYPE typ AS ENUM ('a')
+
+let $table_oid
+SELECT c.oid FROM pg_class c WHERE c.relname = 'a';
+
+query O
+SELECT $table_oid::oid::regclass
+----
+a
+
+let $type_oid
+SELECT t.oid FROM pg_type t WHERE t.typname = 'typ';
+
+query O
+SELECT $type_oid::oid::regtype
+----
+typ
 
 query T
 SELECT relname from pg_class where oid='a'::regclass
 ----
 a
 
+query T
+SELECT typname from pg_type where oid='typ'::regtype
+----
+typ
+
 ## Regression for #16767 - ensure regclass casts use normalized table names
 
 statement ok
-CREATE TABLE hasCase (id INT PRIMARY KEY)
+CREATE TABLE hasCase (id INT PRIMARY KEY);
+CREATE TYPE typHasCase AS ENUM ('a')
 
 query T
 SELECT relname from pg_class where oid='hasCase'::regclass
 ----
 hascase
 
+query T
+SELECT typname from pg_type where oid='typHasCase'::regtype
+----
+typhascase
+
 statement ok
 CREATE TABLE "quotedCase" (id INT PRIMARY KEY)
+
+statement ok
+CREATE TYPE "typQuotedCase" AS ENUM ('a')
 
 query error pgcode 42P01 relation "quotedcase" does not exist
 SELECT relname from pg_class where oid='quotedCase'::regclass
@@ -201,8 +232,16 @@ SELECT relname from pg_class where oid='"quotedCase"'::regclass
 ----
 quotedCase
 
-# a non-root user with sufficient permissions can get the OID of a table from
-# the current database
+query error pgcode 42704 type 'typquotedcase' does not exist
+SELECT typname from pg_type where oid='typQuotedCase'::regtype
+
+query T
+SELECT typname from pg_type where oid='"typQuotedCase"'::regtype
+----
+typQuotedCase
+
+# a non-root user with sufficient permissions can get the OID of a table or
+# type from the current database
 
 statement ok
 GRANT ALL ON DATABASE test TO testuser
@@ -217,12 +256,17 @@ SELECT relname from pg_class where oid='a'::regclass
 ----
 a
 
+query T
+SELECT typname from pg_type where oid='typ'::regtype
+----
+typ
+
 user root
 
 statement ok
 CREATE DATABASE otherdb
 
-## a non-root user can't get the OID of a table from a different database
+## a non-root user can't get the OID of a table or type from a different database
 
 user testuser
 
@@ -232,25 +276,38 @@ SET DATABASE = otherdb
 query error pgcode 42P01 relation "a" does not exist
 SELECT 'a'::regclass
 
+query error pgcode 42704 type 'typ' does not exist
+SELECT 'typ'::regtype
+
 user root
 
 statement ok
 SET DATABASE = otherdb
 
 statement ok
-CREATE TABLE a (id INT PRIMARY KEY, foo STRING)
+CREATE TABLE a (id INT PRIMARY KEY, foo STRING);
+CREATE TYPE typ AS ENUM ('a', 'b')
 
 ## There is now a table named 'a' in both the database 'otherdb' and the
 ## database 'test'. The following query shows that the root user can still
 ## determine the OID of the table 'a' by using a regclass cast, despite the
 ## fact that the root user has visibility into both of the tables. The 'a' that
 ## gets selected should be the 'a' that exists in the current database.
+## The same exact reasoning applies to the type named 'typ'.
 ## See https://github.com/cockroachdb/cockroach/issues/13695
 
 query OI
 SELECT relname, relnatts FROM pg_class WHERE oid='a'::regclass
 ----
 a  2
+
+query OI
+SELECT t.typname, count(*) FROM pg_type t
+LEFT JOIN pg_enum e ON t.oid = e.enumtypid
+WHERE t.oid = 'typ'::regtype
+GROUP BY t.typname;
+----
+typ  2
 
 statement ok
 SET DATABASE = test
@@ -259,6 +316,14 @@ query OI
 SELECT relname, relnatts FROM pg_class WHERE oid='a'::regclass
 ----
 a  1
+
+query OI
+SELECT t.typname, count(*) FROM pg_type t
+LEFT JOIN pg_enum e ON t.oid = e.enumtypid
+WHERE t.oid = 'typ'::regtype
+GROUP BY t.typname;
+----
+typ  1
 
 statement ok
 CREATE DATABASE thirddb
@@ -272,6 +337,12 @@ SET DATABASE = thirddb
 
 query error pgcode 42P01 relation "a" does not exist
 SELECT relname, relnatts FROM pg_class WHERE oid='a'::regclass
+
+query error pgcode 42704 type 'typ' does not exist
+SELECT t.typname, count(*) FROM pg_type t
+LEFT JOIN pg_enum e ON t.oid = e.enumtypid
+WHERE t.oid = 'typ'::regtype
+GROUP BY t.typname;
 
 statement ok
 CREATE TABLE o (a OID PRIMARY KEY)

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -209,7 +209,7 @@ func (p *planner) CommonLookupFlags(required bool) tree.CommonLookupFlags {
 
 // IsTableVisible is part of the tree.EvalDatabase interface.
 func (p *planner) IsTableVisible(
-	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, tableID int64,
+	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, tableID oid.Oid,
 ) (isVisible, exists bool, err error) {
 	// TODO(ajwerner): look at this error and only no-op if it is
 	// ErrDescriptorNotFound or something like it.

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -211,13 +211,17 @@ func (p *planner) CommonLookupFlags(required bool) tree.CommonLookupFlags {
 func (p *planner) IsTableVisible(
 	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, tableID oid.Oid,
 ) (isVisible, exists bool, err error) {
-	// TODO(ajwerner): look at this error and only no-op if it is
-	// ErrDescriptorNotFound or something like it.
 	tableDesc, err := p.LookupTableByID(ctx, descpb.ID(tableID))
 	if err != nil {
-		// If an error happened here, it means the table doesn't exist, so we
-		// return "not exists" rather than the error.
-		return false, false, nil //nolint:returnerrcheck
+		// If a "not found" error happened here, we return "not exists" rather than
+		// the error.
+		if errors.Is(err, catalog.ErrDescriptorNotFound) ||
+			errors.Is(err, catalog.ErrDescriptorDropped) ||
+			pgerror.GetPGCode(err) == pgcode.UndefinedTable ||
+			pgerror.GetPGCode(err) == pgcode.UndefinedObject {
+			return false, false, nil //nolint:returnerrcheck
+		}
+		return false, false, err
 	}
 	schemaID := tableDesc.GetParentSchemaID()
 	schemaDesc, err := p.Descriptors().GetImmutableSchemaByID(ctx, p.Txn(), schemaID,
@@ -245,6 +249,39 @@ func (p *planner) IsTableVisible(
 	iter := searchPath.Iter()
 	for scName, ok := iter.Next(); ok; scName, ok = iter.Next() {
 		if schemaDesc.Name == scName {
+			return true, true, nil
+		}
+	}
+	return false, true, nil
+}
+
+// IsTypeVisible is part of the tree.EvalDatabase interface.
+func (p *planner) IsTypeVisible(
+	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, typeID oid.Oid,
+) (isVisible bool, exists bool, err error) {
+	// Check builtin types first. They are always globally visible.
+	if _, ok := types.OidToType[typeID]; ok {
+		return true, true, nil
+	}
+	typName, _, err := p.GetTypeDescriptor(ctx, typedesc.UserDefinedTypeOIDToID(typeID))
+	if err != nil {
+		// If a "not found" error happened here, we return "not exists" rather than
+		// the error.
+		if errors.Is(err, catalog.ErrDescriptorNotFound) ||
+			errors.Is(err, catalog.ErrDescriptorDropped) ||
+			pgerror.GetPGCode(err) == pgcode.UndefinedObject {
+			return false, false, nil //nolint:returnerrcheck
+		}
+		return false, false, err
+	}
+	if typName.CatalogName.String() != curDB {
+		// If the type is in a different database, then it's considered to be
+		// "not existing" instead of just "not visible"; this matches PostgreSQL.
+		return false, false, nil
+	}
+	iter := searchPath.Iter()
+	for scName, ok := iter.Next(); ok; scName, ok = iter.Next() {
+		if typName.SchemaName.String() == scName {
 			return true, true, nil
 		}
 	}

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -1085,9 +1085,9 @@ SELECT description
 			Types:      tree.ArgTypes{{"oid", types.Oid}},
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				oid := tree.MustBeDOid(args[0])
+				oidArg := tree.MustBeDOid(args[0])
 				isVisible, exists, err := ctx.Planner.IsTableVisible(
-					ctx.Context, ctx.SessionData.Database, ctx.SessionData.SearchPath, int64(oid.DInt),
+					ctx.Context, ctx.SessionData.Database, ctx.SessionData.SearchPath, oid.Oid(oidArg.DInt),
 				)
 				if err != nil {
 					return nil, err

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -1113,16 +1113,19 @@ SELECT description
 			Types:      tree.ArgTypes{{"oid", types.Oid}},
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				oidArg := args[0]
-				if oidArg == tree.DNull {
+				oidArg := tree.MustBeDOid(args[0])
+				isVisible, exists, err := ctx.Planner.IsTypeVisible(
+					ctx.Context, ctx.SessionData.Database, ctx.SessionData.SearchPath, oid.Oid(oidArg.DInt),
+				)
+				if err != nil {
+					return nil, err
+				}
+				if !exists {
 					return tree.DNull, nil
 				}
-				if _, ok := types.OidToType[oid.Oid(int(oidArg.(*tree.DOid).DInt))]; ok {
-					return tree.DBoolTrue, nil
-				}
-				return tree.DNull, nil
+				return tree.MakeDBool(tree.DBool(isVisible)), nil
 			},
-			Info:       notUsableInfo,
+			Info:       "Returns whether the type with the given OID belongs to one of the schemas on the search path.",
 			Volatility: tree.VolatilityStable,
 		},
 	),

--- a/pkg/sql/sem/tree/casts.go
+++ b/pkg/sql/sem/tree/casts.go
@@ -1295,12 +1295,12 @@ func performIntToOidCast(ctx *EvalContext, t *types.T, v DInt) (Datum, error) {
 		return &DOid{semanticType: t, DInt: v}, nil
 	case oid.T_regtype:
 		// Mapping an oid to a regtype is easy: we have a hardcoded map.
-		typ, ok := types.OidToType[oid.Oid(v)]
 		ret := &DOid{semanticType: t, DInt: v}
-		if !ok {
-			return ret, nil
+		if typ, ok := types.OidToType[oid.Oid(v)]; ok {
+			ret.name = typ.PGName()
+		} else if typ, err := ctx.Planner.ResolveTypeByOID(ctx.Context, oid.Oid(v)); err == nil {
+			ret.name = typ.PGName()
 		}
-		ret.name = typ.PGName()
 		return ret, nil
 
 	case oid.T_regproc, oid.T_regprocedure:

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -4309,7 +4309,7 @@ func ParseDOid(ctx *EvalContext, s string, t *types.T) (*DOid, error) {
 		// Trim type modifiers, e.g. `numeric(10,3)` becomes `numeric`.
 		s = pgSignatureRegexp.ReplaceAllString(s, "$1")
 
-		dOid, missingTypeErr := queryOid(ctx, t, NewDString(s))
+		dOid, missingTypeErr := queryOid(ctx, t, NewDString(Name(s).Normalize()))
 		if missingTypeErr == nil {
 			return dOid, missingTypeErr
 		}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3038,6 +3038,12 @@ type EvalDatabase interface {
 	IsTableVisible(
 		ctx context.Context, curDB string, searchPath sessiondata.SearchPath, tableID oid.Oid,
 	) (isVisible bool, exists bool, err error)
+
+	// IsTypeVisible checks if the type with the given ID belongs to a schema
+	// on the given sessiondata.SearchPath.
+	IsTypeVisible(
+		ctx context.Context, curDB string, searchPath sessiondata.SearchPath, typeID oid.Oid,
+	) (isVisible bool, exists bool, err error)
 }
 
 // EvalPlanner is a limited planner that can be used from EvalContext.

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3036,10 +3036,7 @@ type EvalDatabase interface {
 	// IsTableVisible checks if the table with the given ID belongs to a schema
 	// on the given sessiondata.SearchPath.
 	IsTableVisible(
-		ctx context.Context,
-		curDB string,
-		searchPath sessiondata.SearchPath,
-		tableID int64,
+		ctx context.Context, curDB string, searchPath sessiondata.SearchPath, tableID oid.Oid,
 	) (isVisible bool, exists bool, err error)
 }
 


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/61216
fixes https://github.com/cockroachdb/cockroach/issues/60008

The 1st commit is a simple refactor.

Release note (bug fix): Previously, casting an OID to a regtype did not
work for user-defined types. This is now fixed.

Release note (bug fix): Previously, the pg_type_is_visible builtin
function did not correctly handle user-defined types. This is fixed now.

