### PR TITLE
sql: ensure user has correct privileges when adding/removing regions

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_privileges
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_privileges
@@ -1,0 +1,61 @@
+# LogicTest: multiregion-9node-3region-3azs
+
+user root
+
+statement ok
+CREATE DATABASE db;
+CREATE TABLE db.t();
+GRANT CREATE ON DATABASE db TO testuser;
+CREATE TABLE db.t2();
+ALTER USER testuser CREATEDB;
+
+user testuser
+
+statement error user testuser must be owner of t or have CREATE privilege on t
+ALTER DATABASE db SET PRIMARY REGION "us-east-1"
+
+user root
+
+statement ok
+GRANT CREATE ON TABLE db.t TO testuser
+
+user testuser
+
+statement ok
+ALTER DATABASE db SET PRIMARY REGION "us-east-1"
+
+user root
+
+statement ok
+REVOKE CREATE ON TABLE db.t FROM testuser
+
+user testuser
+
+statement error user testuser must be owner of t or have CREATE privilege on t
+ALTER DATABASE db DROP REGION "us-east-1"
+
+user root
+
+statement ok
+GRANT CREATE ON TABLE db.t TO testuser
+
+user testuser
+
+statement ok
+ALTER DATABASE db DROP REGION "us-east-1"
+
+# Same thing, but this time testuser is the owner of the table (and doesn't have
+# CREATE privileges on it).
+user root
+
+statement ok
+REVOKE CREATE ON TABLE db.t FROM testuser;
+ALTER TABLE db.t OWNER TO testuser
+
+user testuser
+
+statement ok
+ALTER DATABASE db SET PRIMARY REGION "us-east-1"
+
+statement ok
+ALTER DATABASE db DROP REGION "us-east-1"

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_privileges
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_privileges
@@ -59,3 +59,44 @@ ALTER DATABASE db SET PRIMARY REGION "us-east-1"
 
 statement ok
 ALTER DATABASE db DROP REGION "us-east-1"
+
+subtest alter_table_locality_privs
+
+user root
+
+statement ok
+CREATE DATABASE alter_db PRIMARY REGION "us-east-1";
+CREATE TABLE alter_db.t();
+
+user testuser
+
+statement error pq: user testuser must be owner of t or have CREATE privilege on t
+ALTER TABLE alter_db.t SET LOCALITY GLOBAL
+
+user root
+
+statement ok
+GRANT CREATE ON TABLE alter_db.t TO testuser
+
+user testuser
+
+statement ok
+ALTER TABLE alter_db.t SET LOCALITY GLOBAL
+
+# Same thing, this time make testuser the owner.
+
+user root
+
+statement ok
+REVOKE CREATE ON TABLE alter_db.t FROM testuser
+
+# To be able to gain ownership of the table, testuser needs to have CREATE
+# privilege on the database.
+statement ok
+GRANT CREATE ON DATABASE alter_db to testuser;
+ALTER TABLE alter_db.t OWNER TO testuser
+
+user testuser
+
+statement ok
+ALTER TABLE alter_db.t SET LOCALITY REGIONAL

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -135,6 +135,9 @@ func (p *planner) CheckPrivilegeForUser(
 
 // CheckPrivilege implements the AuthorizationAccessor interface.
 // Requires a valid transaction to be open.
+// TODO(arul): This CheckPrivileges method name is rather deceptive,
+// it should be probably be called CheckPrivilegesOrOwnership and return
+// a better error.
 func (p *planner) CheckPrivilege(
 	ctx context.Context, descriptor catalog.Descriptor, privilege privilege.Kind,
 ) error {


### PR DESCRIPTION
Previously we did not account for privileges on database objects when
adding the default locality config on first region add or removing the
locality config on last region drop properly. In particular, we weren't
adding/removing the locality config on any descriptor that wasn't
visible to the user. This is bad because our validation logic expects
only and all objects in multi-region databases to have a valid locality
config. This means future accesses to such descriptors would fail
validation.

The root of this problem was the API choice here, `ForEachTableDesc`,
which filters out invisible descriptors. This patch instead switches
to using `forEachTableInMultiRegionDatabase`. While here, instead of
issuing separate requests for every table, I refactored this thing to
issue a single batch request instead.

Now that we view all the descriptors inside the database, unfiltered,
we perform privilege checks on them before proceeding with the add/drop
operation. In particular, the semantics are:
- admin users are allowed to add/drop regions as they wish.
- non admin-users require the CREATE privilege or must have ownership
on all the objects inside the database.

Closes #61003

Release note (sql change): `ALTER DATABASE .. SET PRIMARY REGION` now
requires both CREATE and ZONECONFIG privilege on all  objects inside
the database when adding the first region to the database. Same for
dropping the last region using `ALTER DATABASE ... DROP REGION`.