### PR TITLE
opt: remap interesting orderings of Projects

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/groupby
+++ b/pkg/sql/opt/memo/testdata/logprops/groupby
@@ -218,6 +218,7 @@ project
  │    │    ├── key: (11)
  │    │    ├── fd: (11)-->(2)
  │    │    ├── prune: (2,11)
+ │    │    ├── interesting orderings: (+11)
  │    │    ├── scan xyzs
  │    │    │    ├── columns: xyzs.x:1(int!null) xyzs.y:2(int) z:3(float!null) s:4(string) xyzs.crdb_internal_mvcc_timestamp:5(decimal)
  │    │    │    ├── key: (1)

--- a/pkg/sql/opt/memo/testdata/logprops/project
+++ b/pkg/sql/opt/memo/testdata/logprops/project
@@ -205,6 +205,7 @@ project
  ├── columns: case:6(int!null)
  ├── key: (6)
  ├── prune: (6)
+ ├── interesting orderings: (+6)
  ├── scan xysd
  │    ├── columns: x:1(int!null)
  │    ├── key: (1)

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -51,13 +51,13 @@ func (c *CustomFuncs) GenerateMergeJoins(
 	// left side. The CommuteJoin rule will ensure that we actually try both
 	// sides.
 	orders := DeriveInterestingOrderings(left).Copy()
-	orders.RestrictToCols(leftEq.ToSet())
+	orders.RestrictToCols(leftEq.ToSet(), nil /* equivCols */)
 
 	if !c.NoJoinHints(joinPrivate) || c.e.evalCtx.SessionData.ReorderJoinsLimit == 0 {
 		// If we are using a hint, or the join limit is set to zero, the join won't
 		// be commuted. Add the orderings from the right side.
 		rightOrders := DeriveInterestingOrderings(right).Copy()
-		rightOrders.RestrictToCols(leftEq.ToSet())
+		rightOrders.RestrictToCols(leftEq.ToSet(), nil /* equivCols */)
 		orders = append(orders, rightOrders...)
 
 		// If we don't allow hash join, we must do our best to generate a merge

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -6694,25 +6694,68 @@ project
  └── distinct-on
       ├── columns: k:1!null u:2!null v:3
       ├── grouping columns: k:1!null
+      ├── internal-ordering: +1 opt(2)
       ├── key: (1)
       ├── fd: ()-->(2), (1)-->(3)
       ├── project
       │    ├── columns: k:1!null u:2!null v:3
       │    ├── key: (1)
       │    ├── fd: ()-->(2), (1)-->(3)
+      │    ├── ordering: +1 opt(2) [actual: +1]
       │    ├── index-join d
       │    │    ├── columns: k:6!null u:7!null v:8
       │    │    ├── key: (6)
       │    │    ├── fd: ()-->(7), (6)-->(8)
+      │    │    ├── ordering: +6 opt(7) [actual: +6]
       │    │    └── scan d@u
       │    │         ├── columns: k:6!null u:7!null
       │    │         ├── constraint: /7/6: [/2 - /2]
       │    │         ├── key: (6)
-      │    │         └── fd: ()-->(7)
+      │    │         ├── fd: ()-->(7)
+      │    │         └── ordering: +6 opt(7) [actual: +6]
       │    └── projections
       │         ├── k:6 [as=k:1, outer=(6)]
       │         ├── u:7 [as=u:2, outer=(7)]
       │         └── v:8 [as=v:3, outer=(8)]
+      └── aggregations
+           ├── const-agg [as=u:2, outer=(2)]
+           │    └── u:2
+           └── const-agg [as=v:3, outer=(3)]
+                └── v:3
+
+# Columns are passed-through correctly when EliminateUnionAllRight is applied.
+opt expect=SplitDisjunction
+SELECT k FROM d WHERE (u = 2 AND u = 4) OR v = 1
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── distinct-on
+      ├── columns: k:1!null u:2 v:3!null
+      ├── grouping columns: k:1!null
+      ├── internal-ordering: +1 opt(3)
+      ├── key: (1)
+      ├── fd: ()-->(3), (1)-->(2)
+      ├── project
+      │    ├── columns: k:1!null u:2 v:3!null
+      │    ├── key: (1)
+      │    ├── fd: ()-->(3), (1)-->(2)
+      │    ├── ordering: +1 opt(3) [actual: +1]
+      │    ├── index-join d
+      │    │    ├── columns: k:11!null u:12 v:13!null
+      │    │    ├── key: (11)
+      │    │    ├── fd: ()-->(13), (11)-->(12)
+      │    │    ├── ordering: +11 opt(13) [actual: +11]
+      │    │    └── scan d@v
+      │    │         ├── columns: k:11!null v:13!null
+      │    │         ├── constraint: /13/11: [/1 - /1]
+      │    │         ├── key: (11)
+      │    │         ├── fd: ()-->(13)
+      │    │         └── ordering: +11 opt(13) [actual: +11]
+      │    └── projections
+      │         ├── k:11 [as=k:1, outer=(11)]
+      │         ├── u:12 [as=u:2, outer=(12)]
+      │         └── v:13 [as=v:3, outer=(13)]
       └── aggregations
            ├── const-agg [as=u:2, outer=(2)]
            │    └── u:2


### PR DESCRIPTION
Interesting ordering columns for Projects are now remapped when the
orderings contain a column that is projected with a new column ID. This
allows interesting orderings to propagate upward in more cases.
Specifically, this allows a streaming DistinctOn expression to be
planned when the SplitDisjunction rule splits a disjunction into a
UnionAll and the UnionAll is eliminated when one side of the disjunction
is found to be a contradiction.

Fixes #58435 

Release note: None