### PR TITLE
geo/geomfn: add point in polygon optimization to st_intersects

### DIFF
--- a/pkg/geo/geogen/geogen.go
+++ b/pkg/geo/geogen/geogen.go
@@ -191,7 +191,7 @@ func RandomPolygon(
 	// TODO(otan): generate random holes inside the Polygon.
 	// Ideas:
 	// * We can do something like use 4 arbitrary points in the LinearRing to generate a BoundingBox,
-	//   and re-use "PointInLinearRing" to generate N random points inside the 4 points to form
+	//   and re-use "PointIntersectsLinearRing" to generate N random points inside the 4 points to form
 	//   a "sub" linear ring inside.
 	// * Generate a random set of polygons, see which ones they fully cover and use that.
 	return geom.NewPolygon(layout).MustSetCoords([][]geom.Coord{

--- a/pkg/geo/geogfn/distance.go
+++ b/pkg/geo/geogfn/distance.go
@@ -358,8 +358,8 @@ func (c *geographyDistanceCalculator) NewEdgeCrosser(
 	}
 }
 
-// PointInLinearRing implements geodist.DistanceCalculator.
-func (c *geographyDistanceCalculator) PointInLinearRing(
+// PointIntersectsLinearRing implements geodist.DistanceCalculator.
+func (c *geographyDistanceCalculator) PointIntersectsLinearRing(
 	point geodist.Point, polygon geodist.LinearRing,
 ) bool {
 	return polygon.(*s2GeodistLinearRing).ContainsPoint(point.GeogPoint)

--- a/pkg/geo/geomfn/binary_predicates_test.go
+++ b/pkg/geo/geomfn/binary_predicates_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 var (
+	emptyPoint           = geo.MustParseGeometry("POINT EMPTY")
 	emptyRect            = geo.MustParseGeometry("POLYGON EMPTY")
 	emptyLine            = geo.MustParseGeometry("LINESTRING EMPTY")
 	leftRect             = geo.MustParseGeometry("POLYGON((-1.0 0.0, 0.0 0.0, 0.0 1.0, -1.0 1.0, -1.0 0.0))")
@@ -28,6 +29,19 @@ var (
 	rightRectPoint       = geo.MustParseGeometry("POINT(0.5 0.5)")
 	overlappingRightRect = geo.MustParseGeometry("POLYGON((-0.1 0.0, 1.0 0.0, 1.0 1.0, -0.1 1.0, -0.1 0.0))")
 	middleLine           = geo.MustParseGeometry("LINESTRING(-0.5 0.5, 0.5 0.5)")
+	leftRectWithHole     = geo.MustParseGeometry("POLYGON((-1.0 0.0, 0.0 0.0, 0.0 1.0, -1.0 1.0, -1.0 0.0), " +
+		"(-0.75 0.25, -0.75 0.75, -0.25 0.75, -0.25 0.25, -0.75 0.25))")
+	bothLeftRects = geo.MustParseGeometry("MULTIPOLYGON(((-1.0 0.0, 0.0 0.0, 0.0 1.0, -1.0 1.0, -1.0 0.0)), " +
+		"((-1.0 0.0, 0.0 0.0, 0.0 1.0, -1.0 1.0, -1.0 0.0), (-0.75 0.25, -0.75 0.75, -0.25 0.75, -0.25 0.25, -0.75 0.25)))")
+	bothLeftRectsHoleFirst = geo.MustParseGeometry("MULTIPOLYGON(" +
+		"((-1.0 0.0, 0.0 0.0, 0.0 1.0, -1.0 1.0, -1.0 0.0), " +
+		"(-0.75 0.25, -0.75 0.75, -0.25 0.75, -0.25 0.25, -0.75 0.25)), " +
+		"((-1.0 0.0, 0.0 0.0, 0.0 1.0, -1.0 1.0, -1.0 0.0)))")
+	leftRectCornerPoint     = geo.MustParseGeometry("POINT(-1.0 0.0)")
+	leftRectEdgePoint       = geo.MustParseGeometry("POINT(-1.0 0.2)")
+	leftRectHoleCornerPoint = geo.MustParseGeometry("POINT(-0.75 0.75)")
+	leftRectHoleEdgePoint   = geo.MustParseGeometry("POINT(-0.75 0.5)")
+	leftRectMultiPoint      = geo.MustParseGeometry("MULTIPOINT(-0.5 0.5, -0.9 0.1)")
 )
 
 func TestCovers(t *testing.T) {
@@ -91,6 +105,11 @@ func TestContains(t *testing.T) {
 		{rightRectPoint, rightRectPoint, true},
 		{rightRect, rightRect, true},
 		{leftRect, rightRect, false},
+		{emptyRect, emptyPoint, false},
+		{leftRectWithHole, leftRectPoint, false},
+		{leftRectWithHole, leftRectMultiPoint, false},
+		{leftRect, leftRectMultiPoint, true},
+		{bothLeftRectsHoleFirst, leftRectPoint, true},
 	}
 
 	for i, tc := range testCases {
@@ -224,6 +243,16 @@ func TestIntersects(t *testing.T) {
 		{leftRect, rightRect, true},
 		{leftRect, middleLine, true},
 		{rightRect, middleLine, true},
+		{leftRectPoint, leftRect, true},
+		{leftRectPoint, leftRectWithHole, false},
+		{leftRect, leftRectPoint, true},
+		{leftRectWithHole, leftRectPoint, false},
+		{leftRectPoint, bothLeftRects, true},
+		{leftRectWithHole, leftRectMultiPoint, true},
+		{leftRectCornerPoint, leftRect, true},
+		{leftRectEdgePoint, leftRect, true},
+		{leftRectHoleEdgePoint, leftRectWithHole, true},
+		{leftRectHoleCornerPoint, leftRectWithHole, true},
 	}
 
 	for i, tc := range testCases {
@@ -372,6 +401,10 @@ func TestWithin(t *testing.T) {
 		{rightRect, rightRectPoint, false},
 		{rightRectPoint, rightRect, true},
 		{leftRect, rightRect, false},
+		{emptyPoint, emptyRect, false},
+		{leftRectPoint, leftRect, true},
+		{leftRectMultiPoint, leftRect, true},
+		{leftRectMultiPoint, leftRectWithHole, false},
 	}
 
 	for i, tc := range testCases {

--- a/pkg/geo/iterator.go
+++ b/pkg/geo/iterator.go
@@ -115,3 +115,9 @@ func (it *GeomTIterator) next() (geom.T, bool, error) {
 		return nil, false, errors.Newf("unknown type: %T", t)
 	}
 }
+
+// Reset resets an iterator back to the first element.
+func (it *GeomTIterator) Reset() {
+	it.idx = 0
+	it.subIt = nil
+}


### PR DESCRIPTION
This patch improves the performance of st_intersects for the
common use case of testing whether a (multi)polygon and a
(multi)point intersect.

Release note: None