### PR TITLE
mutations: postgres fixes for computed columns and inverted indexes

### DIFF
--- a/pkg/sql/mutations/mutations.go
+++ b/pkg/sql/mutations/mutations.go
@@ -550,6 +550,7 @@ func postgresMutator(rng *rand.Rand, q string) string {
 		"INT2":    "INT8",
 		"INT4":    "INT8",
 		"STORING": "INCLUDE",
+		" AS (":   " GENERATED ALWAYS AS (",
 	} {
 		q = strings.Replace(q, from, to, -1)
 	}


### PR DESCRIPTION
mutations: don't use inverted indexes for postgres 

mutations: handle computed columns for postgres

Postgres uses the syntax `col GENERATED ALWAYS AS (func)` and not
`col AS (func)`.

