### PR TITLE
sql: Fix multi-region restore

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1251,7 +1251,7 @@ func createImportingDescriptors(
 								return err
 							}
 
-							regionConfig, err := sql.SynthesizeRegionConfig(ctx, txn, desc.ID, descsCol)
+							regionConfig, err := sql.SynthesizeRegionConfigOffline(ctx, txn, desc.ID, descsCol)
 							if err != nil {
 								return err
 							}


### PR DESCRIPTION
Updating PR.  This will now just fix the underlying restore problem, and will keep the flaky test removed until we track down one underlying problem in KV.  See underlying commit record for more info.

Release note: None
