### PR TITLE
release-21.1: sql: remove global zone configs on final DROP REGION

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -1012,7 +1012,8 @@ statement error pq: database has no regions to drop
 ALTER DATABASE non_multi_region_db DROP REGION "ca-central-1"
 
 statement ok
-CREATE DATABASE drop_region_db PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1"
+CREATE DATABASE drop_region_db PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1";
+USE drop_region_db
 
 statement error pq: cannot drop region "ca-central-1"\nHINT: You must designate another region as the primary region using ALTER DATABASE drop_region_db PRIMARY REGION <region name> or remove all other regions before attempting to drop region "ca-central-1"
 ALTER DATABASE drop_region_db DROP REGION "ca-central-1"
@@ -1045,7 +1046,17 @@ statement error pq: relation "t" \([0-9]+\): invalid locality config: region "us
 CREATE TABLE drop_region_db.public.t(a int) LOCALITY REGIONAL BY TABLE IN "us-east-1"
 
 statement ok
+CREATE TABLE regional_by_table () LOCALITY REGIONAL BY TABLE
+
+statement ok
 CREATE TABLE drop_region_db.public.t(a int) LOCALITY REGIONAL BY TABLE IN "ap-southeast-2"
+
+statement ok
+CREATE TABLE global_table () LOCALITY GLOBAL
+
+statement ok
+CREATE TABLE global_table_custom_gc_ttl () LOCALITY GLOBAL;
+ALTER TABLE global_table_custom_gc_ttl CONFIGURE ZONE USING gc.ttlseconds = 10
 
 statement error pq: could not remove enum value "ap-southeast-2" as it is the home region for table "t"
 ALTER DATABASE drop_region_db DROP REGION "ap-southeast-2"
@@ -1055,6 +1066,39 @@ DROP TABLE drop_region_db.public.t
 
 statement ok
 ALTER DATABASE drop_region_db DROP REGION "ap-southeast-2"
+
+statement ok
+ALTER DATABASE drop_region_db DROP REGION "ca-central-1"
+
+query TT colnames
+SELECT table_name, locality FROM [SHOW TABLES]
+----
+table_name                  locality
+regional_by_table           NULL
+global_table                NULL
+global_table_custom_gc_ttl  NULL
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE global_table
+----
+RANGE default  ALTER RANGE default CONFIGURE ZONE USING
+               range_min_bytes = 134217728,
+               range_max_bytes = 536870912,
+               gc.ttlseconds = 90000,
+               num_replicas = 3,
+               constraints = '[]',
+               lease_preferences = '[]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE global_table_custom_gc_ttl
+----
+TABLE global_table_custom_gc_ttl  ALTER TABLE global_table_custom_gc_ttl CONFIGURE ZONE USING
+                                  range_min_bytes = 134217728,
+                                  range_max_bytes = 536870912,
+                                  gc.ttlseconds = 10,
+                                  num_replicas = 3,
+                                  constraints = '[]',
+                                  lease_preferences = '[]'
 
 # Test a table that is implicitly homed in the primary region because it was
 # created before the first region was added to the multi-region DB.

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -514,6 +514,17 @@ var ApplyZoneConfigForMultiRegionTableOptionTableAndIndexes = func(
 	return hasNewSubzones, zc, nil
 }
 
+// applyZoneConfigForMultiRegionTableOptionRemoveGlobalZoneConfig signals
+// to remove the global zone configuration for a given table.
+var applyZoneConfigForMultiRegionTableOptionRemoveGlobalZoneConfig = func(
+	zc zonepb.ZoneConfig,
+	regionConfig multiregion.RegionConfig,
+	table catalog.TableDescriptor,
+) (bool, zonepb.ZoneConfig, error) {
+	zc.CopyFromZone(*zonepb.NewZoneConfig(), zonepb.MultiRegionZoneConfigFields)
+	return false, zc, nil
+}
+
 // ApplyZoneConfigForMultiRegionTable applies zone config settings based
 // on the options provided.
 func ApplyZoneConfigForMultiRegionTable(


### PR DESCRIPTION
Backport 1/1 commits from #62121.

/cc @cockroachdb/release

---

Release note (bug fix): Fix a bug where using DROP REGION on the last
region of the given multi-region database would not delete the global
zone configurations for LOCALITY GLOBAL tables.
