### PR TITLE
importccl: log all ignored pgdump stmts in different log files

### DIFF
--- a/pkg/ccl/importccl/import_processor.go
+++ b/pkg/ccl/importccl/import_processor.go
@@ -233,7 +233,8 @@ func makeInputConverter(
 		return newPgCopyReader(spec.Format.PgCopy, kvCh, spec.WalltimeNanos,
 			int(spec.ReaderParallelism), singleTable, singleTableTargetCols, evalCtx)
 	case roachpb.IOFileFormat_PgDump:
-		return newPgDumpReader(ctx, kvCh, spec.Format.PgDump, spec.WalltimeNanos, spec.Tables, evalCtx)
+		return newPgDumpReader(ctx, int64(spec.Progress.JobID), kvCh, spec.Format.PgDump,
+			spec.WalltimeNanos, spec.Tables, evalCtx)
 	case roachpb.IOFileFormat_Avro:
 		return newAvroInputReader(
 			kvCh, singleTable, spec.Format.Avro, spec.WalltimeNanos,

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -5788,7 +5789,7 @@ func TestImportPgDumpIgnoredStmts(t *testing.T) {
 	t.Run("ignore-unsupported", func(t *testing.T) {
 		sqlDB.Exec(t, "CREATE DATABASE foo; USE foo;")
 		sqlDB.Exec(t, "IMPORT PGDUMP ($1) WITH ignore_unsupported_statements", srv.URL)
-		// Check that statements which are not expected to be ignored, are still
+		// Check that statements that are not expected to be ignored, are still
 		// processed.
 		sqlDB.CheckQueryResults(t, "SELECT * FROM foo", [][]string{{"1"}, {"2"}, {"3"}})
 	})
@@ -5800,16 +5801,20 @@ func TestImportPgDumpIgnoredStmts(t *testing.T) {
 
 	t.Run("require-both-unsupported-options", func(t *testing.T) {
 		sqlDB.Exec(t, "CREATE DATABASE foo2; USE foo2;")
-		ignoredLog := `userfile:///ignore.log`
+		ignoredLog := `userfile:///ignore`
 		sqlDB.ExpectErr(t, "cannot log unsupported PGDUMP stmts without `ignore_unsupported_statements` option",
 			"IMPORT PGDUMP ($1) WITH log_ignored_statements=$2", srv.URL, ignoredLog)
 	})
 
 	t.Run("log-unsupported-stmts", func(t *testing.T) {
 		sqlDB.Exec(t, "CREATE DATABASE foo3; USE foo3;")
-		ignoredLog := `userfile:///ignore.log`
-		sqlDB.Exec(t, "IMPORT PGDUMP ($1) WITH ignore_unsupported_statements, log_ignored_statements=$2",
-			srv.URL, ignoredLog)
+		ignoredLog := `userfile:///ignore`
+		defer testingSetMaxLogIgnoredImportStatements(10 /* maxLogSize */)()
+		var importJobID int
+		var unused interface{}
+		sqlDB.QueryRow(t, "IMPORT PGDUMP ($1) WITH ignore_unsupported_statements, "+
+			"log_ignored_statements=$2", srv.URL, ignoredLog).Scan(&importJobID, &unused, &unused,
+			&unused, &unused, &unused)
 		// Check that statements which are not expected to be ignored, are still
 		// processed.
 		sqlDB.CheckQueryResults(t, "SELECT * FROM foo", [][]string{{"1"}, {"2"}, {"3"}})
@@ -5823,13 +5828,24 @@ func TestImportPgDumpIgnoredStmts(t *testing.T) {
 			tc.Servers[0].InternalExecutor().(*sql.InternalExecutor), tc.Servers[0].DB())
 		require.NoError(t, err)
 		defer store.Close()
-		content, err := store.ReadFile(ctx, pgDumpUnsupportedSchemaStmtLog)
-		require.NoError(t, err)
-		descBytes, err := ioutil.ReadAll(content)
-		require.NoError(t, err)
-		expectedSchemaLog := `Unsupported statements during schema parse phase:
 
-create trigger: could not be parsed
+		// We expect there to be two log files since we have 13 unsupported statements.
+		dirName := fmt.Sprintf("import%d", importJobID)
+		checkFiles := func(expectedFileContent []string, logSubdir string) {
+			files, err := store.ListFiles(ctx, fmt.Sprintf("*/%s/*", logSubdir))
+			require.NoError(t, err)
+			for i, file := range files {
+				require.Equal(t, file, path.Join(dirName, logSubdir, fmt.Sprintf("%d.log", i)))
+				content, err := store.ReadFile(ctx, file)
+				require.NoError(t, err)
+				descBytes, err := ioutil.ReadAll(content)
+				require.NoError(t, err)
+				require.Equal(t, []byte(expectedFileContent[i]), descBytes)
+			}
+		}
+
+		schemaFileContents := []string{
+			`create trigger: could not be parsed
 revoke privileges on sequence: could not be parsed
 revoke privileges on sequence: could not be parsed
 grant privileges on sequence: could not be parsed
@@ -5839,24 +5855,20 @@ create extension if not exists with: could not be parsed
 create function: could not be parsed
 alter function: could not be parsed
 COMMENT ON TABLE t IS 'This should be skipped': unsupported by IMPORT
+`,
+			`COMMENT ON DATABASE t IS 'This should be skipped': unsupported by IMPORT
+COMMENT ON COLUMN t IS 'This should be skipped': unsupported by IMPORT
+unsupported function call: set_config in stmt: SELECT set_config('search_path', '', false): unsupported by IMPORT
+`,
+		}
+		checkFiles(schemaFileContents, pgDumpUnsupportedSchemaStmtLog)
 
-Logging 10 out of 13 ignored statements.
-`
-		require.Equal(t, []byte(expectedSchemaLog), descBytes)
-
-		expectedDataLog := `Unsupported statements during data ingestion phase:
-
-unsupported 3 fn args in select: ['search_path' '' false]: unsupported by IMPORT
+		ingestionFileContents := []string{
+			`unsupported 3 fn args in select: ['search_path' '' false]: unsupported by IMPORT
 unsupported *tree.Delete statement: DELETE FROM geometry_columns WHERE (f_table_name = 'nyc_census_blocks') AND (f_table_schema = 'public'): unsupported by IMPORT
-
-Logging 2 out of 2 ignored statements.
-`
-
-		content, err = store.ReadFile(ctx, pgDumpUnsupportedDataStmtLog)
-		require.NoError(t, err)
-		descBytes, err = ioutil.ReadAll(content)
-		require.NoError(t, err)
-		require.Equal(t, []byte(expectedDataLog), descBytes)
+`,
+		}
+		checkFiles(ingestionFileContents, pgDumpUnsupportedDataStmtLog)
 	})
 }
 


### PR DESCRIPTION
Previously, we would only log the first 10 ignored stmts, and skip over
logging the rest. This was done due to concerns about memory usage when
buffering, as ExternalStorage does not support streaming writes (yet).
This change writes a new file every time we have buffered 10 ignored
stmts. The files are written in the subdirectory
`import<jobID>/(unsupported_schema_stmts|unsupported_data_stmts)/<filenum>.log`

This allows for several imports to also log unsupported stmts to the
same user provided location without stepping on each others toes.

Release note (bug fix): log all unsupported pgdump statements across
smaller log files that can be found in the subdir
`import<jobID>/(unsupported_schema_stmts|unsupported_data_stmts)/<filenum>.log`