### PR TITLE
release-21.1: catalog: add namespace validation

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1981,17 +1981,30 @@ func (r *restoreResumer) dropDescriptors(
 	// Delete the database descriptors.
 	deletedDBs := make(map[descpb.ID]struct{})
 	for _, dbDesc := range details.DatabaseDescs {
-		db := dbdesc.NewBuilder(dbDesc).BuildExistingMutable()
-		// We need to ignore descriptors we just added since we haven't committed the txn that deletes these.
-		isDBEmpty, err := isDatabaseEmpty(ctx, txn, db.GetID(), allDescs, ignoredChildDescIDs)
-		if err != nil {
-			return errors.Wrapf(err, "checking if database %s is empty during restore cleanup", db.GetName())
-		}
 
+		// We need to ignore descriptors we just added since we haven't committed the txn that deletes these.
+		isDBEmpty, err := isDatabaseEmpty(ctx, txn, dbDesc.GetID(), allDescs, ignoredChildDescIDs)
+		if err != nil {
+			return errors.Wrapf(err, "checking if database %s is empty during restore cleanup", dbDesc.GetName())
+		}
 		if !isDBEmpty {
-			log.Warningf(ctx, "preserving database %s on restore failure because it contains new child objects or schemas", db.GetName())
+			log.Warningf(ctx, "preserving database %s on restore failure because it contains new child objects or schemas", dbDesc.GetName())
 			continue
 		}
+
+		db, err := descsCol.GetMutableDescriptorByID(ctx, dbDesc.GetID(), txn)
+		if err != nil {
+			return err
+		}
+
+		// Mark db as dropped and add uncommitted version to pass pre-txn
+		// descriptor validation.
+		db.SetDropped()
+		db.MaybeIncrementVersion()
+		if err := descsCol.AddUncommittedDescriptor(db); err != nil {
+			return err
+		}
+
 		descKey := catalogkeys.MakeDescMetadataKey(codec, db.GetID())
 		b.Del(descKey)
 		b.Del(catalogkeys.NewDatabaseKey(db.GetName()).Key(codec))

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -872,14 +872,14 @@ func resolveTargetDB(
 func maybeUpgradeTableDescsInBackupManifests(
 	ctx context.Context, backupManifests []BackupManifest, skipFKsWithNoMatchingTable bool,
 ) error {
-	descGetter := catalog.MapDescGetter{}
+	descGetter := catalog.MakeMapDescGetter()
 
 	// Populate the descGetter with all table descriptors in all backup
 	// descriptors so that they can be looked up.
 	for _, backupManifest := range backupManifests {
 		for _, desc := range backupManifest.Descriptors {
 			if table, _, _, _ := descpb.FromDescriptor(&desc); table != nil {
-				descGetter[table.ID] = tabledesc.NewBuilder(table).BuildImmutable()
+				descGetter.Descriptors[table.ID] = tabledesc.NewBuilder(table).BuildImmutable()
 			}
 		}
 	}

--- a/pkg/cli/testdata/doctor/testcluster
+++ b/pkg/cli/testdata/doctor/testcluster
@@ -2,6 +2,6 @@ doctor cluster
 ----
 debug doctor cluster
 Examining 35 descriptors and 36 namespace entries...
-  ParentID  50, ParentSchemaID 29: relation "foo" (53): not being dropped but no namespace entry found
+  ParentID  50, ParentSchemaID 29: relation "foo" (53): expected matching namespace entry, found none
 Examining 1 running jobs...
 ERROR: validation failed

--- a/pkg/cli/testdata/doctor/testzipdir
+++ b/pkg/cli/testdata/doctor/testzipdir
@@ -8,7 +8,7 @@ Examining 38 descriptors and 43 namespace entries...
   ParentID  52, ParentSchemaID 29: relation "vehicle_location_histories" (56): referenced database ID 52: descriptor not found
   ParentID  52, ParentSchemaID 29: relation "promo_codes" (57): referenced database ID 52: descriptor not found
   ParentID  52, ParentSchemaID 29: relation "user_promo_codes" (58): referenced database ID 52: descriptor not found
-Descriptor 52: has namespace row(s) [{ParentID:0 ParentSchemaID:0 Name:movr}] but no descriptor
+  ParentID   0, ParentSchemaID  0: namespace entry "movr" (52): descriptor not found
 Examining 1 running jobs...
 job 587337426984566785: schema change GC refers to missing table descriptor(s) [59]
 	existing descriptors that still need to be dropped []

--- a/pkg/sql/catalog/catalogkv/catalogkv.go
+++ b/pkg/sql/catalog/catalogkv/catalogkv.go
@@ -291,9 +291,11 @@ func GetAllDescriptors(
 	if err != nil {
 		return nil, err
 	}
-	dg := make(catalog.MapDescGetter, len(descs))
+	dg := catalog.MapDescGetter{
+		Descriptors: make(map[descpb.ID]catalog.Descriptor, len(descs)),
+	}
 	for _, desc := range descs {
-		dg[desc.GetID()] = desc
+		dg.Descriptors[desc.GetID()] = desc
 	}
 	if err := catalog.ValidateSelfAndCrossReferences(ctx, dg, descs...); err != nil {
 		return nil, err
@@ -414,7 +416,7 @@ func getDescriptorByID(
 		return nil, err
 	}
 	dg := NewOneLevelUncachedDescGetter(txn, codec)
-	const level = catalog.ValidationLevelSelfAndCrossReferences
+	const level = catalog.ValidationLevelCrossReferences
 	return descriptorFromKeyValue(ctx, codec, r, mutable, expectedType, required, dg, level)
 }
 
@@ -570,7 +572,7 @@ func getDescriptorsFromIDs(
 			catalog.Any,
 			bestEffort,
 			dg,
-			catalog.ValidationLevelSelfAndCrossReferences,
+			catalog.ValidationLevelCrossReferences,
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/sql/catalog/catalogkv/unwrap_validation_test.go
+++ b/pkg/sql/catalog/catalogkv/unwrap_validation_test.go
@@ -102,6 +102,12 @@ func (o oneLevelMapDescGetter) GetDesc(
 	)
 }
 
+func (o oneLevelMapDescGetter) GetNamespaceEntry(
+	_ context.Context, _, _ descpb.ID, _ string,
+) (descpb.ID, error) {
+	panic("not implemented")
+}
+
 func decodeDescriptorDSV(t *testing.T, descriptorCSVPath string) oneLevelMapDescGetter {
 	f, err := os.Open(descriptorCSVPath)
 	require.NoError(t, err)

--- a/pkg/sql/catalog/dbdesc/database_test.go
+++ b/pkg/sql/catalog/dbdesc/database_test.go
@@ -265,18 +265,18 @@ func TestValidateCrossDatabaseReferences(t *testing.T) {
 
 	for i, test := range tests {
 		privilege := descpb.NewDefaultPrivilegeDescriptor(security.AdminRoleName())
-		descs := catalog.MapDescGetter{}
+		descs := catalog.MakeMapDescGetter()
 		test.desc.Privileges = privilege
 		desc := NewBuilder(&test.desc).BuildImmutable()
-		descs[test.desc.ID] = desc
+		descs.Descriptors[test.desc.ID] = desc
 		test.multiRegionEnum.Privileges = privilege
-		descs[test.multiRegionEnum.ID] = typedesc.NewBuilder(&test.multiRegionEnum).BuildImmutable()
+		descs.Descriptors[test.multiRegionEnum.ID] = typedesc.NewBuilder(&test.multiRegionEnum).BuildImmutable()
 		for _, schemaDesc := range test.schemaDescs {
 			schemaDesc.Privileges = privilege
-			descs[schemaDesc.ID] = schemadesc.NewBuilder(&schemaDesc).BuildImmutable()
+			descs.Descriptors[schemaDesc.ID] = schemadesc.NewBuilder(&schemaDesc).BuildImmutable()
 		}
 		expectedErr := fmt.Sprintf("%s %q (%d): %s", desc.DescriptorType(), desc.GetName(), desc.GetID(), test.err)
-		const validateCrossReferencesOnly = catalog.ValidationLevelSelfAndCrossReferences &^ (catalog.ValidationLevelSelfAndCrossReferences >> 1)
+		const validateCrossReferencesOnly = catalog.ValidationLevelCrossReferences &^ (catalog.ValidationLevelCrossReferences >> 1)
 		if err := catalog.Validate(ctx, descs, validateCrossReferencesOnly, desc).CombinedError(); err == nil {
 			if test.err != "" {
 				t.Errorf("%d: expected \"%s\", but found success: %+v", i, expectedErr, test.desc)

--- a/pkg/sql/catalog/descs/BUILD.bazel
+++ b/pkg/sql/catalog/descs/BUILD.bazel
@@ -61,6 +61,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/sql/catalog",
+        "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/lease",
         "//pkg/sql/catalog/tabledesc",

--- a/pkg/sql/catalog/schemadesc/schema_desc_test.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc_test.go
@@ -164,14 +164,14 @@ func TestValidateCrossSchemaReferences(t *testing.T) {
 
 	for i, test := range tests {
 		privilege := descpb.NewDefaultPrivilegeDescriptor(security.AdminRoleName())
-		descs := catalog.MapDescGetter{}
+		descs := catalog.MakeMapDescGetter()
 		test.desc.Privileges = privilege
 		desc := schemadesc.NewBuilder(&test.desc).BuildImmutable()
-		descs[test.desc.ID] = desc
+		descs.Descriptors[test.desc.ID] = desc
 		test.dbDesc.Privileges = privilege
-		descs[test.dbDesc.ID] = dbdesc.NewBuilder(&test.dbDesc).BuildImmutable()
+		descs.Descriptors[test.dbDesc.ID] = dbdesc.NewBuilder(&test.dbDesc).BuildImmutable()
 		expectedErr := fmt.Sprintf("%s %q (%d): %s", desc.DescriptorType(), desc.GetName(), desc.GetID(), test.err)
-		const validateCrossReferencesOnly = catalog.ValidationLevelSelfAndCrossReferences &^ (catalog.ValidationLevelSelfAndCrossReferences >> 1)
+		const validateCrossReferencesOnly = catalog.ValidationLevelCrossReferences &^ (catalog.ValidationLevelCrossReferences >> 1)
 		if err := catalog.Validate(ctx, descs, validateCrossReferencesOnly, desc).CombinedError(); err == nil {
 			if test.err != "" {
 				t.Errorf("%d: expected \"%s\", but found success: %+v", i, expectedErr, test.desc)

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -1475,15 +1475,15 @@ func TestValidateCrossTableReferences(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		descs := catalog.MapDescGetter{}
-		descs[1] = dbdesc.NewBuilder(&descpb.DatabaseDescriptor{ID: 1}).BuildImmutable()
+		descs := catalog.MakeMapDescGetter()
+		descs.Descriptors[1] = dbdesc.NewBuilder(&descpb.DatabaseDescriptor{ID: 1}).BuildImmutable()
 		for _, otherDesc := range test.otherDescs {
 			otherDesc.Privileges = descpb.NewDefaultPrivilegeDescriptor(security.AdminRoleName())
-			descs[otherDesc.ID] = NewBuilder(&otherDesc).BuildImmutable()
+			descs.Descriptors[otherDesc.ID] = NewBuilder(&otherDesc).BuildImmutable()
 		}
 		desc := NewBuilder(&test.desc).BuildImmutable()
 		expectedErr := fmt.Sprintf("%s %q (%d): %s", desc.DescriptorType(), desc.GetName(), desc.GetID(), test.err)
-		const validateCrossReferencesOnly = catalog.ValidationLevelSelfAndCrossReferences &^ (catalog.ValidationLevelSelfAndCrossReferences >> 1)
+		const validateCrossReferencesOnly = catalog.ValidationLevelCrossReferences &^ (catalog.ValidationLevelCrossReferences >> 1)
 		if err := catalog.Validate(ctx, descs, validateCrossReferencesOnly, desc).CombinedError(); err == nil {
 			if test.err != "" {
 				t.Errorf("%d: expected \"%s\", but found success: %+v", i, expectedErr, test.desc)

--- a/pkg/sql/catalog/typedesc/type_desc_test.go
+++ b/pkg/sql/catalog/typedesc/type_desc_test.go
@@ -348,21 +348,21 @@ func TestValidateTypeDesc(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
-	descs := catalog.MapDescGetter{}
-	descs[100] = dbdesc.NewBuilder(&descpb.DatabaseDescriptor{
+	descs := catalog.MakeMapDescGetter()
+	descs.Descriptors[100] = dbdesc.NewBuilder(&descpb.DatabaseDescriptor{
 		Name: "db",
 		ID:   100,
 	}).BuildImmutable()
-	descs[101] = schemadesc.NewBuilder(&descpb.SchemaDescriptor{
+	descs.Descriptors[101] = schemadesc.NewBuilder(&descpb.SchemaDescriptor{
 		ID:       101,
 		ParentID: 100,
 		Name:     "schema",
 	}).BuildImmutable()
-	descs[102] = typedesc.NewBuilder(&descpb.TypeDescriptor{
+	descs.Descriptors[102] = typedesc.NewBuilder(&descpb.TypeDescriptor{
 		ID:   102,
 		Name: "type",
 	}).BuildImmutable()
-	descs[200] = dbdesc.NewBuilder(&descpb.DatabaseDescriptor{
+	descs.Descriptors[200] = dbdesc.NewBuilder(&descpb.DatabaseDescriptor{
 		Name: "multi-region-db",
 		ID:   200,
 		RegionConfig: &descpb.DatabaseDescriptor_RegionConfig{

--- a/pkg/sql/doctor/doctor_test.go
+++ b/pkg/sql/doctor/doctor_test.go
@@ -102,16 +102,16 @@ func TestExamineDescriptors(t *testing.T) {
 		errStr         string
 		expected       string
 	}{
-		{
+		{ // 1
 			valid:    true,
 			expected: "Examining 0 descriptors and 0 namespace entries...\n",
 		},
-		{
+		{ // 2
 			descTable: doctor.DescriptorTable{{ID: 1, DescBytes: []byte("#$@#@#$#@#")}},
 			errStr:    "failed to unmarshal descriptor",
 			expected:  "Examining 1 descriptors and 0 namespace entries...\n",
 		},
-		{
+		{ // 3
 			descTable: doctor.DescriptorTable{
 				{
 					ID: 1,
@@ -124,7 +124,7 @@ func TestExamineDescriptors(t *testing.T) {
   ParentID   0, ParentSchemaID 29: relation "" (2): different id in descriptor table: 1
 `,
 		},
-		{
+		{ // 4
 			descTable: doctor.DescriptorTable{
 				{
 					ID: 1,
@@ -138,7 +138,7 @@ func TestExamineDescriptors(t *testing.T) {
   ParentID   0, ParentSchemaID 29: relation "foo" (1): table must contain at least 1 column
 `,
 		},
-		{
+		{ // 5
 			descTable: doctor.DescriptorTable{
 				{
 					ID: 1,
@@ -155,7 +155,7 @@ func TestExamineDescriptors(t *testing.T) {
   ParentID   0, ParentSchemaID 29: relation "foo" (1): table must contain at least 1 column
 `,
 		},
-		{
+		{ // 6
 			descTable: doctor.DescriptorTable{
 				{
 					ID: 1,
@@ -165,10 +165,10 @@ func TestExamineDescriptors(t *testing.T) {
 				},
 			},
 			expected: `Examining 1 descriptors and 0 namespace entries...
-  ParentID   0, ParentSchemaID  0: database "db" (1): not being dropped but no namespace entry found
+  ParentID   0, ParentSchemaID  0: database "db" (1): expected matching namespace entry, found none
 `,
 		},
-		{
+		{ // 7
 			descTable: doctor.DescriptorTable{
 				{ID: 1, DescBytes: toBytes(t, validTableDesc)},
 				{
@@ -183,11 +183,11 @@ func TestExamineDescriptors(t *testing.T) {
 				{NameInfo: descpb.NameInfo{Name: "db"}, ID: 2},
 			},
 			expected: `Examining 2 descriptors and 2 namespace entries...
-  ParentID   2, ParentSchemaID 29: relation "t" (1): namespace entry {ParentID:0 ParentSchemaID:29 Name:t} not found in draining names
-  ParentID   2, ParentSchemaID 29: relation "t" (1): could not find name in namespace table
+  ParentID   2, ParentSchemaID 29: relation "t" (1): expected matching namespace entry, found none
+  ParentID   0, ParentSchemaID 29: namespace entry "t" (1): no matching name info found in non-dropped relation "t"
 `,
 		},
-		{
+		{ // 8
 			descTable: doctor.DescriptorTable{
 				{
 					ID: 1,
@@ -203,7 +203,7 @@ func TestExamineDescriptors(t *testing.T) {
   ParentID   2, ParentSchemaID  0: schema "schema" (1): referenced database ID 2: descriptor not found
 `,
 		},
-		{
+		{ // 9
 			descTable: doctor.DescriptorTable{
 				{
 					ID: 1,
@@ -220,7 +220,7 @@ func TestExamineDescriptors(t *testing.T) {
   ParentID   0, ParentSchemaID  0: type "type" (1): invalid parent schema ID 0
 `,
 		},
-		{
+		{ // 10
 			descTable: doctor.DescriptorTable{
 				{
 					ID: 1,
@@ -244,7 +244,7 @@ func TestExamineDescriptors(t *testing.T) {
   ParentID   3, ParentSchemaID  2: type "type" (1): arrayTypeID 0 does not exist for "ENUM": referenced type ID 0: descriptor not found
 `,
 		},
-		{
+		{ // 11
 			descTable: doctor.DescriptorTable{
 				{
 					ID: 51,
@@ -284,7 +284,7 @@ func TestExamineDescriptors(t *testing.T) {
   ParentID  51, ParentSchemaID 29: type "type" (52): validation: runtime error: invalid memory address or nil pointer dereference
 `,
 		},
-		{
+		{ // 12
 			descTable: doctor.DescriptorTable{
 				{ID: 1, DescBytes: toBytes(t, inSchemaValidTableDesc)},
 				{
@@ -317,26 +317,26 @@ func TestExamineDescriptors(t *testing.T) {
   ParentID   4, ParentSchemaID  0: schema "schema" (3): not present in parent database [4] schemas mapping
 `,
 		},
-		{
+		{ // 13
 			namespaceTable: doctor.NamespaceTable{
 				{NameInfo: descpb.NameInfo{Name: "foo"}, ID: keys.PublicSchemaID},
 				{NameInfo: descpb.NameInfo{Name: "bar"}, ID: keys.PublicSchemaID},
-				{NameInfo: descpb.NameInfo{Name: "pg_temp_foo"}, ID: 1},
+				{NameInfo: descpb.NameInfo{Name: "pg_temp_foo", ParentID: 123}, ID: 1},
 				{NameInfo: descpb.NameInfo{Name: "causes_error"}, ID: 2},
 			},
 			expected: `Examining 0 descriptors and 4 namespace entries...
-Descriptor 2: has namespace row(s) [{ParentID:0 ParentSchemaID:0 Name:causes_error}] but no descriptor
+  ParentID   0, ParentSchemaID  0: namespace entry "causes_error" (2): descriptor not found
 `,
 		},
-		{
+		{ // 14
 			namespaceTable: doctor.NamespaceTable{
 				{NameInfo: descpb.NameInfo{Name: "null"}, ID: int64(descpb.InvalidID)},
 			},
 			expected: `Examining 0 descriptors and 1 namespace entries...
-Row(s) [{ParentID:0 ParentSchemaID:0 Name:null}]: NULL value found
+  ParentID   0, ParentSchemaID  0: namespace entry "null" (0): invalid descriptor ID
 `,
 		},
-		{
+		{ // 15
 			valid: true,
 			descTable: doctor.DescriptorTable{
 				{ID: 1, DescBytes: toBytes(t, validTableDesc)},
@@ -353,7 +353,7 @@ Row(s) [{ParentID:0 ParentSchemaID:0 Name:null}]: NULL value found
 			},
 			expected: "Examining 2 descriptors and 2 namespace entries...\n",
 		},
-		{
+		{ // 16
 			valid: true,
 			descTable: doctor.DescriptorTable{
 				{
@@ -374,7 +374,7 @@ Row(s) [{ParentID:0 ParentSchemaID:0 Name:null}]: NULL value found
 			},
 			expected: "Examining 1 descriptors and 3 namespace entries...\n",
 		},
-		{
+		{ // 17
 			valid: false,
 			descTable: doctor.DescriptorTable{
 				{
@@ -394,10 +394,10 @@ Row(s) [{ParentID:0 ParentSchemaID:0 Name:null}]: NULL value found
 				{NameInfo: descpb.NameInfo{Name: "db2"}, ID: 1},
 			},
 			expected: `Examining 1 descriptors and 3 namespace entries...
-  ParentID   0, ParentSchemaID  0: database "db" (1): extra draining names found [{ParentID:0 ParentSchemaID:0 Name:db3}]
+  ParentID   0, ParentSchemaID  0: database "db" (1): expected matching namespace entry for draining name (0, 0, db3), found none
 `,
 		},
-		{
+		{ // 18
 			descTable: doctor.DescriptorTable{
 				{ID: 1, DescBytes: toBytes(t, droppedValidTableDesc)},
 				{
@@ -412,7 +412,7 @@ Row(s) [{ParentID:0 ParentSchemaID:0 Name:null}]: NULL value found
 				{NameInfo: descpb.NameInfo{Name: "db"}, ID: 2},
 			},
 			expected: `Examining 2 descriptors and 2 namespace entries...
-  ParentID   2, ParentSchemaID 29: relation "t" (1): dropped but namespace entry(s) found: [{2 29 t}]
+  ParentID   2, ParentSchemaID 29: namespace entry "t" (1): no matching name info in draining names of dropped relation
 `,
 		},
 	}

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -794,10 +794,11 @@ type internalLookupCtx struct {
 	typDescs    map[descpb.ID]*typedesc.Immutable
 	typIDs      []descpb.ID
 
-	// fallback is utilized in GetDesc
+	// fallback is utilized in GetDesc and GetNamespaceEntry.
 	fallback catalog.DescGetter
 }
 
+// GetDesc implements the catalog.DescGetter interface.
 func (l *internalLookupCtx) GetDesc(ctx context.Context, id descpb.ID) (catalog.Descriptor, error) {
 	if desc, ok := l.dbDescs[id]; ok {
 		return desc, nil
@@ -815,6 +816,16 @@ func (l *internalLookupCtx) GetDesc(ctx context.Context, id descpb.ID) (catalog.
 		return l.fallback.GetDesc(ctx, id)
 	}
 	return nil, nil
+}
+
+// GetNamespaceEntry implements the catalog.DescGetter interface.
+func (l *internalLookupCtx) GetNamespaceEntry(
+	ctx context.Context, parentID, parentSchemaID descpb.ID, name string,
+) (descpb.ID, error) {
+	if l.fallback != nil {
+		return l.fallback.GetNamespaceEntry(ctx, parentID, parentSchemaID, name)
+	}
+	return descpb.InvalidID, nil
 }
 
 // tableLookupFn can be used to retrieve a table descriptor and its corresponding


### PR DESCRIPTION
Backport 1/1 commits from #61961.

/cc @cockroachdb/release

---

Previously, the contents of the namespace table were only ever validated
by the doctor tool. This commit adds namespace validation checks into the
existing descriptor validation framework in the catalog package. These
checks are now run as part of the pre-txn-commit descriptor validation
suite.

Fixes #61010.

Release note (cli change): changed formatting of namespace validation
failures in doctor.
