### PR TITLE
release-20.1: vendor: upgrade cockroachdb/errors

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -406,7 +406,7 @@
 
 [[projects]]
   branch = "v1.2.4-cockroach20.1"
-  digest = "1:9d93287c86a1c5466b903c1c452e5cd395161ad78477b252fd953b53d1fc589c"
+  digest = "1:a1ea27ac5663ce464fe2d1558821f8c7caa100249d13c76a17180cee2a1d8bfe"
   name = "github.com/cockroachdb/errors"
   packages = [
     ".",
@@ -429,7 +429,7 @@
     "withstack",
   ]
   pruneopts = "UT"
-  revision = "32a264b562e5b80d53e2d08f017cde819321e4fb"
+  revision = "c0fc9576112100df3c37384a7768283971388874"
 
 [[projects]]
   digest = "1:a44e537b3e080ff297315d166956dba9607f070644a89be78b59af6c54876b64"


### PR DESCRIPTION
This fixes the "skippy peanut butter" vulnerability in error Protobufs.
There are no known unprivileged exploits for these.

/cc @cockroachdb/release

Release note: None