### PR TITLE
colflow: fix premature stats collection and improve tracking

### DIFF
--- a/pkg/sql/colexec/BUILD.bazel
+++ b/pkg/sql/colexec/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "sort_chunks.go",
         "sort_utils.go",
         "sorttopk.go",
+        "stats.go",
         "tuple_proj_op.go",
         "unordered_distinct.go",
         "utils.go",

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -102,9 +102,9 @@ func wrapRowSources(
 				input,
 				inputTypes[i],
 				nil, /* output */
+				nil, /* getStats */
 				metadataSources,
 				nil, /* toClose */
-				nil, /* getStats */
 				nil, /* cancelFlow */
 			)
 			if err != nil {

--- a/pkg/sql/colexec/colbuilder/execplan_test.go
+++ b/pkg/sql/colexec/colbuilder/execplan_test.go
@@ -126,9 +126,9 @@ func TestNewColOperatorExpectedTypeSchema(t *testing.T) {
 		r.Op,
 		[]*types.T{types.Int},
 		nil, /* output */
-		nil, /* metadataSourcesQueue */
-		nil, /* toClose */
 		nil, /* getStats */
+		nil, /* metadataSources */
+		nil, /* toClose */
 		nil, /* cancelFlow */
 	)
 	require.NoError(t, err)

--- a/pkg/sql/colexec/materializer_test.go
+++ b/pkg/sql/colexec/materializer_test.go
@@ -68,9 +68,9 @@ func TestColumnarizeMaterialize(t *testing.T) {
 		c,
 		typs,
 		nil, /* output */
-		nil, /* metadataSourcesQueue */
-		nil, /* toClose */
 		nil, /* getStats */
+		nil, /* metadataSources */
+		nil, /* toClose */
 		nil, /* cancelFlow */
 	)
 	if err != nil {
@@ -152,9 +152,9 @@ func BenchmarkMaterializer(b *testing.B) {
 							input,
 							typs,
 							nil, /* output */
-							nil, /* metadataSourcesQueue */
-							nil, /* toClose */
 							nil, /* getStats */
+							nil, /* metadataSources */
+							nil, /* toClose */
 							nil, /* cancelFlow */
 						)
 						if err != nil {
@@ -207,9 +207,9 @@ func TestMaterializerNextErrorAfterConsumerDone(t *testing.T) {
 		&colexecop.CallbackOperator{},
 		nil, /* typ */
 		nil, /* output */
+		nil, /* getStats */
 		[]execinfrapb.MetadataSource{metadataSource},
 		nil, /* toClose */
-		nil, /* getStats */
 		nil, /* cancelFlow */
 	)
 	require.NoError(t, err)
@@ -256,9 +256,9 @@ func BenchmarkColumnarizeMaterialize(b *testing.B) {
 			c,
 			types,
 			nil, /* output */
-			nil, /* metadataSourcesQueue */
-			nil, /* toClose */
 			nil, /* getStats */
+			nil, /* metadataSources */
+			nil, /* toClose */
 			nil, /* cancelFlow */
 		)
 		if err != nil {

--- a/pkg/sql/colexec/parallel_unordered_synchronizer.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer.go
@@ -114,6 +114,13 @@ func (s *ParallelUnorderedSynchronizer) Child(nth int, verbose bool) execinfra.O
 type SynchronizerInput struct {
 	// Op is the input Operator.
 	Op colexecop.Operator
+	// StatsCollectors are all vectorized stats collectors in the input tree.
+	// The field is currently being used *only* to track all of the stats
+	// collectors in the input tree, and the synchronizers should *not* access
+	// it themselves.
+	// TODO(yuzefovich): actually move the logic of getting stats into the
+	// synchronizers.
+	StatsCollectors []VectorizedStatsCollector
 	// MetadataSources are metadata sources in the input tree that should be
 	// drained in the same goroutine as Op.
 	MetadataSources execinfrapb.MetadataSources

--- a/pkg/sql/colexec/stats.go
+++ b/pkg/sql/colexec/stats.go
@@ -1,0 +1,22 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colexec
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+)
+
+// VectorizedStatsCollector is the common interface implemented by collectors.
+type VectorizedStatsCollector interface {
+	colexecop.Operator
+	GetStats() *execinfrapb.ComponentStats
+}

--- a/pkg/sql/colexec/types_integration_test.go
+++ b/pkg/sql/colexec/types_integration_test.go
@@ -92,9 +92,9 @@ func TestSQLTypesIntegration(t *testing.T) {
 				arrowOp,
 				typs,
 				output,
-				nil, /* metadataSourcesQueue */
-				nil, /* toClose */
 				nil, /* getStats */
+				nil, /* metadataSources */
+				nil, /* toClose */
 				nil, /* cancelFlow */
 			)
 			require.NoError(t, err)

--- a/pkg/sql/colflow/BUILD.bazel
+++ b/pkg/sql/colflow/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//pkg/util/randutil",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+        "//pkg/util/tracing",
         "//pkg/util/treeprinter",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",

--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -226,7 +226,7 @@ func TestOutboxInbox(t *testing.T) {
 		defer outboxMemAcc.Close(ctx)
 		outbox, err := NewOutbox(
 			colmem.NewAllocator(ctx, &outboxMemAcc, coldata.StandardColumnFactory),
-			input, typs, nil /* metadataSource */, nil /* toClose */, nil, /* getStats */
+			input, typs, nil /* getStats */, nil /* metadataSources */, nil, /* toClose */
 		)
 		require.NoError(t, err)
 
@@ -503,13 +503,13 @@ func TestOutboxInboxMetadataPropagation(t *testing.T) {
 			}
 			outbox, err := NewOutbox(
 				colmem.NewAllocator(ctx, &outboxMemAcc, coldata.StandardColumnFactory),
-				input, typs, []execinfrapb.MetadataSource{
+				input, typs, nil /* getStats */, []execinfrapb.MetadataSource{
 					execinfrapb.CallbackMetadataSource{
 						DrainMetaCb: func(context.Context) []execinfrapb.ProducerMetadata {
 							return expectedMetadata
 						},
 					},
-				}, nil /* toClose */, nil /* getStats */)
+				}, nil /* toClose */)
 			require.NoError(t, err)
 
 			inboxMemAcc := testMemMonitor.MakeBoundAccount()
@@ -583,7 +583,7 @@ func BenchmarkOutboxInbox(b *testing.B) {
 	defer outboxMemAcc.Close(ctx)
 	outbox, err := NewOutbox(
 		colmem.NewAllocator(ctx, &outboxMemAcc, coldata.StandardColumnFactory),
-		input, typs, nil /* metadataSources */, nil /* toClose */, nil, /* getStats */
+		input, typs, nil /* getStats */, nil /* metadataSources */, nil, /* toClose */
 	)
 	require.NoError(b, err)
 
@@ -647,7 +647,7 @@ func TestOutboxStreamIDPropagation(t *testing.T) {
 	defer outboxMemAcc.Close(ctx)
 	outbox, err := NewOutbox(
 		colmem.NewAllocator(ctx, &outboxMemAcc, coldata.StandardColumnFactory),
-		input, typs, nil /* metadataSources */, nil /* toClose */, nil, /* getStats */
+		input, typs, nil /* getStats */, nil /* metadataSources */, nil, /* toClose */
 	)
 	require.NoError(t, err)
 

--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -80,9 +80,9 @@ func NewOutbox(
 	allocator *colmem.Allocator,
 	input colexecop.Operator,
 	typs []*types.T,
+	getStats func() []*execinfrapb.ComponentStats,
 	metadataSources []execinfrapb.MetadataSource,
 	toClose []colexecop.Closer,
-	getStats func() []*execinfrapb.ComponentStats,
 ) (*Outbox, error) {
 	c, err := colserde.NewArrowBatchConverter(typs)
 	if err != nil {
@@ -99,9 +99,9 @@ func NewOutbox(
 		typs:            typs,
 		converter:       c,
 		serializer:      s,
+		getStats:        getStats,
 		metadataSources: metadataSources,
 		closers:         toClose,
-		getStats:        getStats,
 	}
 	o.scratch.buf = &bytes.Buffer{}
 	o.scratch.msg = &execinfrapb.ProducerMessage{}

--- a/pkg/sql/colflow/colrpc/outbox_test.go
+++ b/pkg/sql/colflow/colrpc/outbox_test.go
@@ -37,7 +37,7 @@ func TestOutboxCatchesPanics(t *testing.T) {
 		typs     = []*types.T{types.Int}
 		rpcLayer = makeMockFlowStreamRPCLayer()
 	)
-	outbox, err := NewOutbox(testAllocator, input, typs, nil /* metadataSources */, nil /* toClose */, nil /* getStats */)
+	outbox, err := NewOutbox(testAllocator, input, typs, nil /* getStats */, nil /* metadataSources */, nil /* toClose */)
 	require.NoError(t, err)
 
 	// This test relies on the fact that BatchBuffer panics when there are no
@@ -91,14 +91,14 @@ func TestOutboxDrainsMetadataSources(t *testing.T) {
 	// uint32 that is set atomically when the outbox drains a metadata source.
 	newOutboxWithMetaSources := func(allocator *colmem.Allocator) (*Outbox, *uint32, error) {
 		var sourceDrained uint32
-		outbox, err := NewOutbox(allocator, input, typs, []execinfrapb.MetadataSource{
+		outbox, err := NewOutbox(allocator, input, typs, nil /* getStats */, []execinfrapb.MetadataSource{
 			execinfrapb.CallbackMetadataSource{
 				DrainMetaCb: func(context.Context) []execinfrapb.ProducerMetadata {
 					atomic.StoreUint32(&sourceDrained, 1)
 					return nil
 				},
 			},
-		}, nil /* toClose */, nil /* getStats */)
+		}, nil /* toClose */)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/sql/colflow/routers_test.go
+++ b/pkg/sql/colflow/routers_test.go
@@ -737,7 +737,7 @@ func TestHashRouterComputesDestination(t *testing.T) {
 		}
 	}
 
-	r := newHashRouterWithOutputs(in, []uint32{0}, nil /* ch */, outputs, nil /* toDrain */, nil /* toClose */)
+	r := newHashRouterWithOutputs(in, []uint32{0}, nil /* ch */, outputs, nil /* getStats */, nil /* toDrain */, nil /* toClose */)
 	for r.processNextBatch(ctx) {
 	}
 
@@ -780,7 +780,7 @@ func TestHashRouterCancellation(t *testing.T) {
 	in := colexecop.NewRepeatableBatchSource(tu.testAllocator, batch, typs)
 
 	unbufferedCh := make(chan struct{})
-	r := newHashRouterWithOutputs(in, []uint32{0}, unbufferedCh, routerOutputs, nil /* toDrain */, nil /* toClose */)
+	r := newHashRouterWithOutputs(in, []uint32{0}, unbufferedCh, routerOutputs, nil /* getStats */, nil /* toDrain */, nil /* toClose */)
 
 	t.Run("BeforeRun", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -881,7 +881,19 @@ func TestHashRouterOneOutput(t *testing.T) {
 			tu.testAllocator.ReleaseMemory(tu.testAllocator.Used())
 			diskAcc := tu.testDiskMonitor.MakeBoundAccount()
 			defer diskAcc.Close(ctx)
-			r, routerOutputs := NewHashRouter([]*colmem.Allocator{tu.testAllocator}, colexectestutils.NewOpFixedSelTestInput(tu.testAllocator, sel, len(sel), data, typs), typs, []uint32{0}, mtc.bytes, queueCfg, colexecop.NewTestingSemaphore(2), []*mon.BoundAccount{&diskAcc}, nil /* toDrain */, nil /* toClose */)
+			r, routerOutputs := NewHashRouter(
+				[]*colmem.Allocator{tu.testAllocator},
+				colexectestutils.NewOpFixedSelTestInput(tu.testAllocator, sel, len(sel), data, typs),
+				typs,
+				[]uint32{0}, /* hashCols */
+				mtc.bytes,
+				queueCfg,
+				colexecop.NewTestingSemaphore(2),
+				[]*mon.BoundAccount{&diskAcc},
+				nil, /* getStats */
+				nil, /* toDrain */
+				nil, /* toClose */
+			)
 
 			if len(routerOutputs) != 1 {
 				t.Fatalf("expected 1 router output but got %d", len(routerOutputs))
@@ -1072,6 +1084,7 @@ func TestHashRouterRandom(t *testing.T) {
 					hashCols,
 					unblockEventsChan,
 					outputs,
+					nil, /* getStats */
 					[]execinfrapb.MetadataSource{
 						execinfrapb.CallbackMetadataSource{
 							DrainMetaCb: func(_ context.Context) []execinfrapb.ProducerMetadata {
@@ -1295,7 +1308,19 @@ func BenchmarkHashRouter(b *testing.B) {
 					diskAccounts[i] = &diskAcc
 					defer diskAcc.Close(ctx)
 				}
-				r, outputs := NewHashRouter(allocators, input, typs, []uint32{0}, 64<<20, queueCfg, &colexecop.TestingSemaphore{}, diskAccounts, nil /* toDrain */, nil /* toClose */)
+				r, outputs := NewHashRouter(
+					allocators,
+					input,
+					typs,
+					[]uint32{0}, /* hashCols */
+					64<<20,      /* memoryLimit */
+					queueCfg,
+					&colexecop.TestingSemaphore{},
+					diskAccounts,
+					nil, /* getStats */
+					nil, /* toDrain */
+					nil, /* toClose */
+				)
 				b.SetBytes(8 * int64(coldata.BatchSize()) * int64(numInputBatches))
 				// We expect distribution to not change. This is a sanity check that
 				// we're resetting properly.

--- a/pkg/sql/colflow/stats_test.go
+++ b/pkg/sql/colflow/stats_test.go
@@ -51,7 +51,7 @@ func TestNumBatches(t *testing.T) {
 			break
 		}
 	}
-	s := vsc.(*vectorizedStatsCollectorImpl).getStats()
+	s := vsc.(*vectorizedStatsCollectorImpl).GetStats()
 	require.Equal(t, nBatches, int(s.Output.NumBatches.Value()))
 }
 
@@ -77,13 +77,13 @@ func TestNumTuples(t *testing.T) {
 				break
 			}
 		}
-		s := vsc.(*vectorizedStatsCollectorImpl).getStats()
+		s := vsc.(*vectorizedStatsCollectorImpl).GetStats()
 		require.Equal(t, nBatches*batchSize, int(s.Output.NumTuples.Value()))
 	}
 }
 
 // TestVectorizedStatsCollector is an integration test for the
-// vectorizedStatsCollector. It creates two inputs and feeds them into the
+// VectorizedStatsCollector. It creates two inputs and feeds them into the
 // merge joiner and makes sure that all the stats measured on the latter are as
 // expected.
 func TestVectorizedStatsCollector(t *testing.T) {
@@ -149,7 +149,7 @@ func TestVectorizedStatsCollector(t *testing.T) {
 			batchCount++
 			tupleCount += b.Length()
 		}
-		s := mjStatsCollector.(*vectorizedStatsCollectorImpl).getStats()
+		s := mjStatsCollector.(*vectorizedStatsCollectorImpl).GetStats()
 
 		require.Equal(t, nBatches*coldata.BatchSize(), int(s.Output.NumTuples.Value()))
 		// Two inputs are advancing the time source for a total of 2 * nBatches

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -44,9 +44,9 @@ func (c callbackRemoteComponentCreator) newOutbox(
 	allocator *colmem.Allocator,
 	input colexecop.Operator,
 	typs []*types.T,
+	_ func() []*execinfrapb.ComponentStats,
 	metadataSources []execinfrapb.MetadataSource,
 	_ []colexecop.Closer,
-	_ func() []*execinfrapb.ComponentStats,
 ) (*colrpc.Outbox, error) {
 	return c.newOutboxFn(allocator, input, typs, metadataSources)
 }
@@ -204,7 +204,7 @@ func TestDrainOnlyInputDAG(t *testing.T) {
 			// expect from the input DAG.
 			require.Len(t, sources, 1)
 			require.Len(t, inboxToNumInputTypes[sources[0].(*colexec.InvariantsChecker).Input.(*colrpc.Inbox)], numInputTypesToOutbox)
-			return colrpc.NewOutbox(allocator, op, typs, sources, nil /* toClose */, nil /* getStats */)
+			return colrpc.NewOutbox(allocator, op, typs, nil /* getStats */, sources, nil /* toClose */)
 		},
 		newInboxFn: func(allocator *colmem.Allocator, typs []*types.T, streamID execinfrapb.StreamID) (*colrpc.Inbox, error) {
 			inbox, err := colrpc.NewInbox(context.Background(), allocator, typs, streamID)

--- a/pkg/sql/colflow/vectorized_meta_propagation_test.go
+++ b/pkg/sql/colflow/vectorized_meta_propagation_test.go
@@ -78,9 +78,9 @@ func TestVectorizedMetaPropagation(t *testing.T) {
 		noop,
 		types,
 		nil, /* output */
+		nil, /* getStats */
 		[]execinfrapb.MetadataSource{col},
 		nil, /* toClose */
-		nil, /* getStats */
 		nil, /* cancelFlow */
 	)
 	if err != nil {

--- a/pkg/sql/colflow/vectorized_panic_propagation_test.go
+++ b/pkg/sql/colflow/vectorized_panic_propagation_test.go
@@ -60,9 +60,9 @@ func TestVectorizedInternalPanic(t *testing.T) {
 		vee,
 		types,
 		nil, /* output */
+		nil, /* getStats */
 		nil, /* metadataSourceQueue */
 		nil, /* toClose */
-		nil, /* getStats */
 		nil, /* cancelFlow */
 	)
 	if err != nil {
@@ -107,9 +107,9 @@ func TestNonVectorizedPanicPropagation(t *testing.T) {
 		nvee,
 		types,
 		nil, /* output */
+		nil, /* getStats */
 		nil, /* metadataSourceQueue */
 		nil, /* toClose */
-		nil, /* getStats */
 		nil, /* cancelFlow */
 	)
 	if err != nil {

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -175,9 +175,9 @@ func verifyColOperator(t *testing.T, args verifyColOperatorArgs) error {
 		result.Op,
 		args.pspec.ResultTypes,
 		nil, /* output */
+		nil, /* getStats */
 		result.MetadataSources,
 		result.ToClose,
-		nil, /* getStats */
 		nil, /* cancelFlow */
 	)
 	if err != nil {

--- a/pkg/sql/distsql/vectorized_panic_propagation_test.go
+++ b/pkg/sql/distsql/vectorized_panic_propagation_test.go
@@ -60,9 +60,9 @@ func TestNonVectorizedPanicDoesntHangServer(t *testing.T) {
 		},
 		nil, /* typs */
 		&distsqlutils.RowBuffer{},
+		nil, /* getStats */
 		nil, /* metadataSourceQueue */
 		nil, /* toClose */
-		nil, /* getStats */
 		nil, /* cancelFlow */
 	)
 	if err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze
@@ -1,7 +1,7 @@
-# LogicTest: fakedist-vec-off
+# LogicTest: default-configs !local-spec-planning !fakedist-spec-planning
 #
-# TODO(radu): enable other configs when the vectorized stat collector issue
-# #56928 is fixed.
+# TODO(yuzefovich): for some reason spec-planning configs are not happy. Figure
+# it out.
 
 statement ok
 CREATE TABLE kv (k INT PRIMARY KEY, v INT, FAMILY (k, v))

--- a/pkg/sql/sem/tree/eval_test/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test/eval_test.go
@@ -203,9 +203,9 @@ func TestEval(t *testing.T) {
 				result.Op,
 				[]*types.T{typedExpr.ResolvedType()},
 				nil, /* output */
+				nil, /* getStats */
 				result.MetadataSources,
 				nil, /* toClose */
-				nil, /* getStats */
 				nil, /* cancelFlow */
 			)
 			require.NoError(t, err)


### PR DESCRIPTION
This commit achieves two goals:

1. previously, we could call `finishVectorizedStatsCollectors` prematurely
in some edge cases (e.g. when the right side of the hash join is empty,
we could collect the stats from the left input tree too early). This was
caused by the fact that we accumulate the vectorized stats collectors
into a queue which is handled by the outboxes or the root materializer.
This commit begins sharing the responsibility of the collecting stats
with the hash router too. Only the hash router needs updating to achieve
the fix because it is currently the only component that splits an input
stream. The change is also sound because when the hash router exits, all
stats collectors in its input tree should have the final info, and the
hash router can collect correct stats. Those stats are added as another
metadata object to be returned by the last to exit router output.

2. `vectorizedStatsCollectorsQueue` on the flow creator is removed in
favor of more precise tracking of which stats collectors belong to which
tree. The motivation behind this changes is that the follow-up commits
will unify the retrieval of stats and draining of the metadata sources so
that the former always occurred right before the latter.

Also this commits renames `metadataSourcesQueue` to `metadataSources` and
changes the order of arguments in a few functions.

Fixes: #56928.

Release note (bug fix): Previously, CockroachDB when collecting
execution statistics (e.g. when running EXPLAIN ANALYZE) could collect
them prematurely which would result in incorrect stats. This is now
fixed.