### PR TITLE
sql: a drop column would cause check constraints to activate

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1054,7 +1054,7 @@ ALTER TABLE check_table ADD g INT
 statement ok
 ALTER TABLE check_table ADD CONSTRAINT g_0 CHECK (g > 0)
 
-statement error referencing constraint "g_0" in the middle of being added
+statement error unimplemented: constraint "g_0" in the middle of being added, try again later
 ALTER TABLE check_table DROP COLUMN g
 
 statement ok

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -2581,6 +2581,11 @@ func isCurrentMutationDiscarded(
 	if nextMutationIdx+1 > len(tableDesc.Mutations) {
 		return false, descpb.InvalidMutationID
 	}
+	// Drops will never get canceled out, since we need
+	// clean up.
+	if currentMutation.Direction == descpb.DescriptorMutation_DROP {
+		return false, descpb.InvalidMutationID
+	}
 
 	colToCheck := make([]descpb.ColumnID, 0, 1)
 	// Both NOT NULL related updates and check constraint updates


### PR DESCRIPTION
Fixes: #61749

Previously, when dropping a column the check constraints array
was incorrectly manipulated, so that mutations would instantly
become live for unrelated columns. This was inadequate because
a check constraints would become activated before validation
was completed. To address this, this patch is going to use
mutations to drop constraints instead of trying to directly
manipulate the check array.

Release note (bug fix): A drop column would cause check
constraints hat are currently validating to become active
on a table.