### PR TITLE
release-20.2: bulkio: update help text for create/resume/drop schedule

### DIFF
--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2268,7 +2268,7 @@ backup_options:
 // %Category: CCL
 // %Text:
 // CREATE SCHEDULE [<description>]
-// FOR BACKUP [<targets>] TO <location...>
+// FOR BACKUP [<targets>] INTO <location...>
 // [WITH <backup_option>[=<value>] [, ...]]
 // RECURRING [crontab|NEVER] [FULL BACKUP <crontab|ALWAYS>]
 // [WITH EXPERIMENTAL SCHEDULE OPTIONS <schedule_option>[= <value>] [, ...] ]
@@ -7051,7 +7051,7 @@ resume_jobs_stmt:
 // RESUME SCHEDULES <selectclause>
 //  selectclause: select statement returning schedule IDs to resume.
 //
-// RESUME SCHEDULES <jobid>
+// RESUME SCHEDULE <scheduleID>
 //
 // %SeeAlso: PAUSE SCHEDULES, SHOW JOBS, RESUME JOBS
 resume_schedules_stmt:
@@ -7080,7 +7080,7 @@ resume_schedules_stmt:
 // DROP SCHEDULES <selectclause>
 //  selectclause: select statement returning schedule IDs to resume.
 //
-// DROP SCHEDULE <scheduleid>
+// DROP SCHEDULE <scheduleID>
 //
 // %SeeAlso: PAUSE SCHEDULES, SHOW JOBS, CANCEL JOBS
 drop_schedule_stmt:


### PR DESCRIPTION
Backport 1/1 commits from #61543.

/cc @cockroachdb/release

---

Resolves: #54402 #54211

Release justification: low risk, high benefit changes to existing functionality

Release note: None
Signed-off-by: Tharun <rajendrantharun@live.com>
