### PR TITLE
telemetry: add test for ALTER TYPE ... DROP VALUE

### DIFF
--- a/pkg/sql/testdata/telemetry/enums
+++ b/pkg/sql/testdata/telemetry/enums
@@ -14,6 +14,16 @@ ALTER TYPE t ADD VALUE 'howdy'
 sql.schema.alter_type.add_value
 sql.udts.alter_enum
 
+exec
+SET enable_drop_enum_value = true
+----
+
+feature-usage
+ALTER TYPE t DROP VALUE 'hello'
+----
+sql.schema.alter_type.drop_value
+sql.udts.alter_enum
+
 feature-usage
 CREATE TABLE tt (x t)
 ----


### PR DESCRIPTION
Turns out we already had telemetry for ALTER TYPE ... DROP VALUE under
`sql.schema.alter_type.drop_value`, so all that was needed here was a
test.

Closes #61765

Release note: None