### PR TITLE
importccl: commit planner transaction in planHook

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -953,6 +953,19 @@ func importPlanHook(
 			return nil
 		}
 
+		// We're about to have side-effects not tied to this tranaction
+		// (creating the job record below). This is okay as long as the
+		// transaction eventually commits. To ensure that the transaction
+		// commits, we commit it here. This is allowed since we know we're in an
+		// implicit transaction.
+		// We know we're in an implicit transaction because we would have
+		// already returned if it were a detached job, and we check at the start
+		// of the plan hooks that the transaction is implicit if the detached
+		// option was not specified.
+		if err := p.ExtendedEvalContext().Txn.Commit(ctx); err != nil {
+			return err
+		}
+
 		var sj *jobs.StartableJob
 		jobID := p.ExecCfg().JobRegistry.MakeJobID()
 		if err := p.ExecCfg().DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) (err error) {


### PR DESCRIPTION
This change commits the planner's transaction during import's plan hook.
It also uses the planner's transaction to create the job record. This
prevents transaction retries from re-running the plan hook and creating
duplicate job records.

Previously, the planner transaction when running the import job may have
retried when the conn executor would auto commit the transaction. Upon
auto commit, uncommited table descriptors would be validated. This
validation could raise a retryable txn error in the case of contention
and cause the entire plan hook to be run again.

Fixes https://github.com/cockroachdb/cockroach/issues/61065.



Release justification: bug fix

Release note (bug fix): Fix a bug where duplicate IMPORT job records
were created due to transaction restarts.