### PR TITLE
cdc: Improve avro encoder performance. 

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -176,6 +176,7 @@ go_test(
         "//pkg/util/span",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+        "//pkg/util/timeutil/pgdate",
         "//pkg/util/uuid",
         "//pkg/workload",
         "//pkg/workload/bank",

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -710,23 +710,23 @@ func randEncDatumRow(typ *types.T) rowenc.EncDatumRow {
 	}
 }
 
-// BenchmarkEncodeInt-16                     895807              1128 ns/op            1082 B/op         11 allocs/op
-// BenchmarkEncodeBool-16                   1000000              1065 ns/op            1042 B/op          9 allocs/op
-// BenchmarkEncodeFloat-16                  1000000              1137 ns/op            1082 B/op         11 allocs/op
-// BenchmarkEncodeBox2D-16                   524196              2241 ns/op            1588 B/op         24 allocs/op
-// BenchmarkEncodeGeography-16               785518              1371 ns/op            2082 B/op         11 allocs/op
-// BenchmarkEncodeGeometry-16               1000000              1333 ns/op            1954 B/op         11 allocs/op
-// BenchmarkEncodeBytes-16                  1073588              1185 ns/op            1113 B/op         12 allocs/op
-// BenchmarkEncodeString-16                 1000000              1078 ns/op            1042 B/op          9 allocs/op
-// BenchmarkEncodeDate-16                    986196              1106 ns/op            1050 B/op          9 allocs/op
-// BenchmarkEncodeTime-16                   1101405              1133 ns/op            1089 B/op         12 allocs/op
-// BenchmarkEncodeTimeTZ-16                  616290              1864 ns/op            1411 B/op         20 allocs/op
-// BenchmarkEncodeTimestamp-16               970492              1176 ns/op            1106 B/op         12 allocs/op
-// BenchmarkEncodeTimestampTZ-16             919526              1178 ns/op            1106 B/op         12 allocs/op
-// BenchmarkEncodeDecimal-16                 572534              2488 ns/op            1731 B/op         40 allocs/op
-// BenchmarkEncodeUUID-16                    794467              1417 ns/op            1186 B/op         12 allocs/op
-// BenchmarkEncodeINet-16                    776548              1324 ns/op            1162 B/op         14 allocs/op
-// BenchmarkEncodeJSON-16                    545298              3529 ns/op            2371 B/op         49 allocs/op
+// BenchmarkEncodeInt-16                    2006964               666.0 ns/op            73 B/op          5 allocs/op
+// BenchmarkEncodeBool-16                   1955925               589.0 ns/op            33 B/op          3 allocs/op
+// BenchmarkEncodeFloat-16                  2165485               674.5 ns/op            72 B/op          5 allocs/op
+// BenchmarkEncodeBox2D-16                   618493              1807 ns/op             771 B/op         19 allocs/op
+// BenchmarkEncodeGeography-16              2114208               689.1 ns/op           153 B/op          4 allocs/op
+// BenchmarkEncodeGeometry-16               2180958               723.0 ns/op           136 B/op          5 allocs/op
+// BenchmarkEncodeBytes-16                  2197863               700.5 ns/op            64 B/op          5 allocs/op
+// BenchmarkEncodeString-16                 1710142               685.9 ns/op            81 B/op          5 allocs/op
+// BenchmarkEncodeDate-16                   2448033               554.0 ns/op            32 B/op          3 allocs/op
+// BenchmarkEncodeTime-16                   1737711               644.7 ns/op            49 B/op          5 allocs/op
+// BenchmarkEncodeTimeTZ-16                  829166              1446 ns/op             402 B/op         14 allocs/op
+// BenchmarkEncodeTimestamp-16              1599121               744.3 ns/op            97 B/op          6 allocs/op
+// BenchmarkEncodeTimestampTZ-16            1610475               751.5 ns/op            97 B/op          6 allocs/op
+// BenchmarkEncodeDecimal-16                 728798              1593 ns/op             522 B/op         24 allocs/op
+// BenchmarkEncodeUUID-16                   1519089               784.1 ns/op           177 B/op          6 allocs/op
+// BenchmarkEncodeINet-16                   1420908               830.0 ns/op           153 B/op          8 allocs/op
+// BenchmarkEncodeJSON-16                   1000000              3090 ns/op            1490 B/op         45 allocs/op
 func BenchmarkEncodeInt(b *testing.B) {
 	benchmarkEncodeType(b, types.Int, randEncDatumRow(types.Int))
 }

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -676,4 +677,135 @@ func TestDecimalRatRoundtrip(t *testing.T) {
 			t.Errorf(`%s != %s`, dec, &roundtrip)
 		}
 	})
+}
+
+func benchmarkEncodeType(b *testing.B, typ *types.T, encRow rowenc.EncDatumRow) {
+	defer leaktest.AfterTest(b)()
+	defer log.Scope(b).Close(b)
+
+	tableDesc, err := parseTableDesc(
+		fmt.Sprintf(`CREATE TABLE bench_table (bench_field %s)`, typ.SQLString()))
+	require.NoError(b, err)
+	schema, err := tableToAvroSchema(tableDesc, "suffix", "namespace")
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := schema.BinaryFromRow(nil, encRow)
+		require.NoError(b, err)
+	}
+}
+
+// returns random EncDatum row where the first column is of specified
+// type and the second one an types.Int, corresponding to a row id.
+func randEncDatumRow(typ *types.T) rowenc.EncDatumRow {
+	const allowNull = true
+	const notNull = false
+	rnd, _ := randutil.NewTestPseudoRand()
+	return rowenc.EncDatumRow{
+		rowenc.DatumToEncDatum(typ, rowenc.RandDatum(rnd, typ, allowNull)),
+		rowenc.DatumToEncDatum(types.Int, rowenc.RandDatum(rnd, types.Int, notNull)),
+	}
+}
+
+// BenchmarkEncodeInt-16                     895807              1128 ns/op            1082 B/op         11 allocs/op
+// BenchmarkEncodeBool-16                   1000000              1065 ns/op            1042 B/op          9 allocs/op
+// BenchmarkEncodeFloat-16                  1000000              1137 ns/op            1082 B/op         11 allocs/op
+// BenchmarkEncodeBox2D-16                   524196              2241 ns/op            1588 B/op         24 allocs/op
+// BenchmarkEncodeGeography-16               785518              1371 ns/op            2082 B/op         11 allocs/op
+// BenchmarkEncodeGeometry-16               1000000              1333 ns/op            1954 B/op         11 allocs/op
+// BenchmarkEncodeBytes-16                  1073588              1185 ns/op            1113 B/op         12 allocs/op
+// BenchmarkEncodeString-16                 1000000              1078 ns/op            1042 B/op          9 allocs/op
+// BenchmarkEncodeDate-16                    986196              1106 ns/op            1050 B/op          9 allocs/op
+// BenchmarkEncodeTime-16                   1101405              1133 ns/op            1089 B/op         12 allocs/op
+// BenchmarkEncodeTimeTZ-16                  616290              1864 ns/op            1411 B/op         20 allocs/op
+// BenchmarkEncodeTimestamp-16               970492              1176 ns/op            1106 B/op         12 allocs/op
+// BenchmarkEncodeTimestampTZ-16             919526              1178 ns/op            1106 B/op         12 allocs/op
+// BenchmarkEncodeDecimal-16                 572534              2488 ns/op            1731 B/op         40 allocs/op
+// BenchmarkEncodeUUID-16                    794467              1417 ns/op            1186 B/op         12 allocs/op
+// BenchmarkEncodeINet-16                    776548              1324 ns/op            1162 B/op         14 allocs/op
+// BenchmarkEncodeJSON-16                    545298              3529 ns/op            2371 B/op         49 allocs/op
+func BenchmarkEncodeInt(b *testing.B) {
+	benchmarkEncodeType(b, types.Int, randEncDatumRow(types.Int))
+}
+
+func BenchmarkEncodeBool(b *testing.B) {
+	benchmarkEncodeType(b, types.Bool, randEncDatumRow(types.Bool))
+}
+
+func BenchmarkEncodeFloat(b *testing.B) {
+	benchmarkEncodeType(b, types.Float, randEncDatumRow(types.Float))
+}
+
+func BenchmarkEncodeBox2D(b *testing.B) {
+	benchmarkEncodeType(b, types.Box2D, randEncDatumRow(types.Box2D))
+}
+
+func BenchmarkEncodeGeography(b *testing.B) {
+	benchmarkEncodeType(b, types.Geography, randEncDatumRow(types.Geography))
+}
+
+func BenchmarkEncodeGeometry(b *testing.B) {
+	benchmarkEncodeType(b, types.Geometry, randEncDatumRow(types.Geometry))
+}
+
+func BenchmarkEncodeBytes(b *testing.B) {
+	benchmarkEncodeType(b, types.Bytes, randEncDatumRow(types.Bytes))
+}
+
+func BenchmarkEncodeString(b *testing.B) {
+	benchmarkEncodeType(b, types.String, randEncDatumRow(types.String))
+}
+
+func BenchmarkEncodeDate(b *testing.B) {
+	// RandDatum could return "interesting" dates (infinite past, etc).  Alas, avro
+	// doesn't support those yet, so override it to something we do support.
+	encRow := randEncDatumRow(types.Date)
+	if d, ok := encRow[0].Datum.(*tree.DDate); ok && !d.IsFinite() {
+		d.Date = pgdate.LowDate
+	}
+	benchmarkEncodeType(b, types.Date, encRow)
+}
+
+func BenchmarkEncodeTime(b *testing.B) {
+	benchmarkEncodeType(b, types.Time, randEncDatumRow(types.Time))
+}
+
+func BenchmarkEncodeTimeTZ(b *testing.B) {
+	benchmarkEncodeType(b, types.TimeTZ, randEncDatumRow(types.TimeTZ))
+}
+
+func BenchmarkEncodeTimestamp(b *testing.B) {
+	benchmarkEncodeType(b, types.Timestamp, randEncDatumRow(types.Timestamp))
+}
+
+func BenchmarkEncodeTimestampTZ(b *testing.B) {
+	benchmarkEncodeType(b, types.TimestampTZ, randEncDatumRow(types.TimestampTZ))
+}
+
+func BenchmarkEncodeDecimal(b *testing.B) {
+	typ := types.MakeDecimal(10, 4)
+	encRow := randEncDatumRow(typ)
+
+	// rowenc.RandDatum generates all possible datums. We just want small subset
+	// to fit in our specified precision/scale.
+	d := &tree.DDecimal{}
+	coeff := int64(rand.Uint64()) % 10000
+	d.Decimal.SetFinite(coeff, 2)
+	encRow[0] = rowenc.DatumToEncDatum(typ, d)
+	benchmarkEncodeType(b, typ, encRow)
+}
+
+func BenchmarkEncodeUUID(b *testing.B) {
+	benchmarkEncodeType(b, types.Uuid, randEncDatumRow(types.Uuid))
+}
+
+func BenchmarkEncodeINet(b *testing.B) {
+	benchmarkEncodeType(b, types.INet, randEncDatumRow(types.INet))
+}
+
+func BenchmarkEncodeJSON(b *testing.B) {
+	benchmarkEncodeType(b, types.Jsonb, randEncDatumRow(types.Jsonb))
 }


### PR DESCRIPTION
Add avro encoder benchmarks.

Avoid expensive allocations (maps) when encoding datums.
Improve encoder performance by ~40%, and significantly reduce
memory allocations per op.

Release Notes: None