### PR TITLE
sql: remove some remnants of the heuristics planner

### DIFF
--- a/pkg/sql/index_join.go
+++ b/pkg/sql/index_join.go
@@ -30,9 +30,7 @@ type indexJoinNode struct {
 
 	table *scanNode
 
-	// The columns returned by this node. While these are not ever different from
-	// the table scanNode in the heuristic planner, the optimizer plans them to
-	// be different in some cases.
+	// The columns returned by this node.
 	cols []descpb.ColumnDescriptor
 	// There is a 1-1 correspondence between cols and resultColumns.
 	resultColumns colinfo.ResultColumns

--- a/pkg/sql/logictest/logic_test.go
+++ b/pkg/sql/logictest/logic_test.go
@@ -20,8 +20,8 @@ import (
 // CockroachDB features. The tests use a similar methodology to the SQLLite
 // Sqllogictests. All of these tests should only verify correctness of output,
 // and not how that output was derived. Therefore, these tests can be run
-// using the heuristic planner, the cost-based optimizer, or even run against
-// Postgres to verify it returns the same logical results.
+// with multiple configs, or even run against Postgres to verify it returns the
+// same logical results.
 //
 // See the comments in logic.go for more details.
 func TestLogic(t *testing.T) {

--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -390,3 +390,11 @@ FROM
 ----
 NULL
 NULL
+
+statement ok
+CREATE TABLE t34524 (a INT PRIMARY KEY)
+
+# Regression test for #34524.
+query I
+(SELECT NULL FROM t34524) EXCEPT (VALUES((SELECT 1 FROM t34524 LIMIT 1)), (1))
+----

--- a/pkg/sql/opt/exec/execbuilder/testdata/union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/union
@@ -194,12 +194,3 @@ vectorized: true
           estimated row count: 1,000 (missing stats)
           table: uniontest@primary
           spans: FULL SCAN
-
-statement ok
-CREATE TABLE a (a INT PRIMARY KEY)
-
-# Regression test for #34524. This test is here because the issue still exists
-# in the heuristic planner.
-query I
-(SELECT NULL FROM a) EXCEPT (VALUES((SELECT 1 FROM a LIMIT 1)), (1))
-----

--- a/pkg/sql/opt/optbuilder/testdata/distinct
+++ b/pkg/sql/opt/optbuilder/testdata/distinct
@@ -130,9 +130,7 @@ SELECT DISTINCT y + z FROM xyz ORDER BY y + z
 error (22023): unsupported binary operator: <int> + <float>
 
 # This query causes an error in Postgres, and the optimizer has followed
-# that lead. However, it is supported by the heuristic planner in CockroachDB
-# with the semantics:
-#   SELECT y AS w FROM t GROUP BY y ORDER BY min(z);
+# that lead.
 build
 SELECT DISTINCT y AS w FROM xyz ORDER by z
 ----

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -80,9 +80,7 @@ project
       └── ordering: -1
 
 # This query causes an error in Postgres, and the optimizer has followed
-# that lead. However, it is supported by the heuristic planner in CockroachDB
-# with the semantics:
-#   SELECT c FROM t GROUP BY c ORDER BY max(b) DESC;
+# that lead.
 build
 SELECT DISTINCT c FROM t ORDER BY b DESC
 ----


### PR DESCRIPTION
The heuristic planner has been long gone, but some remnants still
remain. The most notable change is to `createTableNode` where we needed
to synthesize a row ID column in the HP. I also searched for "heuristic
pl" in the code base and found a few other mentions which are also
removed.

Two more are still present since they didn't seem as trivial.

Release note: None