### PR TITLE
util/interval: fix BenchmarkBTreeDeleteInsertCloneEachTime

### DIFF
--- a/pkg/kv/kvserver/concurrency/lockstate_interval_btree_test.go
+++ b/pkg/kv/kvserver/concurrency/lockstate_interval_btree_test.go
@@ -556,6 +556,18 @@ func run(tb testing.TB, name string, f func(testing.TB)) {
 	}
 }
 
+func iters(tb testing.TB, count int) int {
+	switch v := tb.(type) {
+	case *testing.T:
+		return count
+	case *testing.B:
+		return v.N
+	default:
+		tb.Fatalf("unknown %T", tb)
+		return 0
+	}
+}
+
 func verify(tb testing.TB, tr *btree) {
 	if tt, ok := tb.(*testing.T); ok {
 		tr.Verify(tt)
@@ -580,7 +592,8 @@ func startTimer(tb testing.TB) {
 	}
 }
 
-func runBTreeInsert(tb testing.TB, count, iters int) {
+func runBTreeInsert(tb testing.TB, count int) {
+	iters := iters(tb, count)
 	insertP := perm(count)
 	resetTimer(tb)
 	for i := 0; i < iters; {
@@ -596,7 +609,8 @@ func runBTreeInsert(tb testing.TB, count, iters int) {
 	}
 }
 
-func runBTreeDelete(tb testing.TB, count, iters int) {
+func runBTreeDelete(tb testing.TB, count int) {
+	iters := iters(tb, count)
 	insertP, removeP := perm(count), perm(count)
 	resetTimer(tb)
 	for i := 0; i < iters; {
@@ -621,7 +635,8 @@ func runBTreeDelete(tb testing.TB, count, iters int) {
 	}
 }
 
-func runBTreeDeleteInsert(tb testing.TB, count, iters int) {
+func runBTreeDeleteInsert(tb testing.TB, count int) {
+	iters := iters(tb, count)
 	insertP := perm(count)
 	var tr btree
 	for _, item := range insertP {
@@ -638,7 +653,8 @@ func runBTreeDeleteInsert(tb testing.TB, count, iters int) {
 	}
 }
 
-func runBTreeDeleteInsertCloneOnce(tb testing.TB, count, iters int) {
+func runBTreeDeleteInsertCloneOnce(tb testing.TB, count int) {
+	iters := iters(tb, count)
 	insertP := perm(count)
 	var tr btree
 	for _, item := range insertP {
@@ -656,9 +672,10 @@ func runBTreeDeleteInsertCloneOnce(tb testing.TB, count, iters int) {
 	}
 }
 
-func runBTreeDeleteInsertCloneEachTime(tb testing.TB, count, iters int) {
+func runBTreeDeleteInsertCloneEachTime(tb testing.TB, count int) {
 	for _, reset := range []bool{false, true} {
 		run(tb, fmt.Sprintf("reset=%t", reset), func(tb testing.TB) {
+			iters := iters(tb, count)
 			insertP := perm(count)
 			var tr, trReset btree
 			for _, item := range insertP {
@@ -693,27 +710,27 @@ func randCount() int {
 
 func TestBTreeInsert(t *testing.T) {
 	count := randCount()
-	runBTreeInsert(t, count, count)
+	runBTreeInsert(t, count)
 }
 
 func TestBTreeDelete(t *testing.T) {
 	count := randCount()
-	runBTreeDelete(t, count, count)
+	runBTreeDelete(t, count)
 }
 
 func TestBTreeDeleteInsert(t *testing.T) {
 	count := randCount()
-	runBTreeDeleteInsert(t, count, count)
+	runBTreeDeleteInsert(t, count)
 }
 
 func TestBTreeDeleteInsertCloneOnce(t *testing.T) {
 	count := randCount()
-	runBTreeDeleteInsertCloneOnce(t, count, count)
+	runBTreeDeleteInsertCloneOnce(t, count)
 }
 
 func TestBTreeDeleteInsertCloneEachTime(t *testing.T) {
 	count := randCount()
-	runBTreeDeleteInsertCloneEachTime(t, count, count)
+	runBTreeDeleteInsertCloneEachTime(t, count)
 }
 
 // TestBTreeSeekOverlapRandom tests btree iterator overlap operations using
@@ -863,21 +880,21 @@ func forBenchmarkSizes(b *testing.B, f func(b *testing.B, count int)) {
 // BenchmarkBTreeInsert measures btree insertion performance.
 func BenchmarkBTreeInsert(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		runBTreeInsert(b, count, b.N)
+		runBTreeInsert(b, count)
 	})
 }
 
 // BenchmarkBTreeDelete measures btree deletion performance.
 func BenchmarkBTreeDelete(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		runBTreeDelete(b, count, b.N)
+		runBTreeDelete(b, count)
 	})
 }
 
 // BenchmarkBTreeDeleteInsert measures btree deletion and insertion performance.
 func BenchmarkBTreeDeleteInsert(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		runBTreeDeleteInsert(b, count, b.N)
+		runBTreeDeleteInsert(b, count)
 	})
 }
 
@@ -885,7 +902,7 @@ func BenchmarkBTreeDeleteInsert(b *testing.B) {
 // performance after the tree has been copy-on-write cloned once.
 func BenchmarkBTreeDeleteInsertCloneOnce(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		runBTreeDeleteInsertCloneOnce(b, count, b.N)
+		runBTreeDeleteInsertCloneOnce(b, count)
 	})
 }
 
@@ -893,7 +910,7 @@ func BenchmarkBTreeDeleteInsertCloneOnce(b *testing.B) {
 // performance while the tree is repeatedly copy-on-write cloned.
 func BenchmarkBTreeDeleteInsertCloneEachTime(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		runBTreeDeleteInsertCloneEachTime(b, count, b.N)
+		runBTreeDeleteInsertCloneEachTime(b, count)
 	})
 }
 

--- a/pkg/kv/kvserver/spanlatch/latch_interval_btree_test.go
+++ b/pkg/kv/kvserver/spanlatch/latch_interval_btree_test.go
@@ -556,6 +556,18 @@ func run(tb testing.TB, name string, f func(testing.TB)) {
 	}
 }
 
+func iters(tb testing.TB, count int) int {
+	switch v := tb.(type) {
+	case *testing.T:
+		return count
+	case *testing.B:
+		return v.N
+	default:
+		tb.Fatalf("unknown %T", tb)
+		return 0
+	}
+}
+
 func verify(tb testing.TB, tr *btree) {
 	if tt, ok := tb.(*testing.T); ok {
 		tr.Verify(tt)
@@ -580,7 +592,8 @@ func startTimer(tb testing.TB) {
 	}
 }
 
-func runBTreeInsert(tb testing.TB, count, iters int) {
+func runBTreeInsert(tb testing.TB, count int) {
+	iters := iters(tb, count)
 	insertP := perm(count)
 	resetTimer(tb)
 	for i := 0; i < iters; {
@@ -596,7 +609,8 @@ func runBTreeInsert(tb testing.TB, count, iters int) {
 	}
 }
 
-func runBTreeDelete(tb testing.TB, count, iters int) {
+func runBTreeDelete(tb testing.TB, count int) {
+	iters := iters(tb, count)
 	insertP, removeP := perm(count), perm(count)
 	resetTimer(tb)
 	for i := 0; i < iters; {
@@ -621,7 +635,8 @@ func runBTreeDelete(tb testing.TB, count, iters int) {
 	}
 }
 
-func runBTreeDeleteInsert(tb testing.TB, count, iters int) {
+func runBTreeDeleteInsert(tb testing.TB, count int) {
+	iters := iters(tb, count)
 	insertP := perm(count)
 	var tr btree
 	for _, item := range insertP {
@@ -638,7 +653,8 @@ func runBTreeDeleteInsert(tb testing.TB, count, iters int) {
 	}
 }
 
-func runBTreeDeleteInsertCloneOnce(tb testing.TB, count, iters int) {
+func runBTreeDeleteInsertCloneOnce(tb testing.TB, count int) {
+	iters := iters(tb, count)
 	insertP := perm(count)
 	var tr btree
 	for _, item := range insertP {
@@ -656,9 +672,10 @@ func runBTreeDeleteInsertCloneOnce(tb testing.TB, count, iters int) {
 	}
 }
 
-func runBTreeDeleteInsertCloneEachTime(tb testing.TB, count, iters int) {
+func runBTreeDeleteInsertCloneEachTime(tb testing.TB, count int) {
 	for _, reset := range []bool{false, true} {
 		run(tb, fmt.Sprintf("reset=%t", reset), func(tb testing.TB) {
+			iters := iters(tb, count)
 			insertP := perm(count)
 			var tr, trReset btree
 			for _, item := range insertP {
@@ -693,27 +710,27 @@ func randCount() int {
 
 func TestBTreeInsert(t *testing.T) {
 	count := randCount()
-	runBTreeInsert(t, count, count)
+	runBTreeInsert(t, count)
 }
 
 func TestBTreeDelete(t *testing.T) {
 	count := randCount()
-	runBTreeDelete(t, count, count)
+	runBTreeDelete(t, count)
 }
 
 func TestBTreeDeleteInsert(t *testing.T) {
 	count := randCount()
-	runBTreeDeleteInsert(t, count, count)
+	runBTreeDeleteInsert(t, count)
 }
 
 func TestBTreeDeleteInsertCloneOnce(t *testing.T) {
 	count := randCount()
-	runBTreeDeleteInsertCloneOnce(t, count, count)
+	runBTreeDeleteInsertCloneOnce(t, count)
 }
 
 func TestBTreeDeleteInsertCloneEachTime(t *testing.T) {
 	count := randCount()
-	runBTreeDeleteInsertCloneEachTime(t, count, count)
+	runBTreeDeleteInsertCloneEachTime(t, count)
 }
 
 // TestBTreeSeekOverlapRandom tests btree iterator overlap operations using
@@ -863,21 +880,21 @@ func forBenchmarkSizes(b *testing.B, f func(b *testing.B, count int)) {
 // BenchmarkBTreeInsert measures btree insertion performance.
 func BenchmarkBTreeInsert(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		runBTreeInsert(b, count, b.N)
+		runBTreeInsert(b, count)
 	})
 }
 
 // BenchmarkBTreeDelete measures btree deletion performance.
 func BenchmarkBTreeDelete(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		runBTreeDelete(b, count, b.N)
+		runBTreeDelete(b, count)
 	})
 }
 
 // BenchmarkBTreeDeleteInsert measures btree deletion and insertion performance.
 func BenchmarkBTreeDeleteInsert(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		runBTreeDeleteInsert(b, count, b.N)
+		runBTreeDeleteInsert(b, count)
 	})
 }
 
@@ -885,7 +902,7 @@ func BenchmarkBTreeDeleteInsert(b *testing.B) {
 // performance after the tree has been copy-on-write cloned once.
 func BenchmarkBTreeDeleteInsertCloneOnce(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		runBTreeDeleteInsertCloneOnce(b, count, b.N)
+		runBTreeDeleteInsertCloneOnce(b, count)
 	})
 }
 
@@ -893,7 +910,7 @@ func BenchmarkBTreeDeleteInsertCloneOnce(b *testing.B) {
 // performance while the tree is repeatedly copy-on-write cloned.
 func BenchmarkBTreeDeleteInsertCloneEachTime(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		runBTreeDeleteInsertCloneEachTime(b, count, b.N)
+		runBTreeDeleteInsertCloneEachTime(b, count)
 	})
 }
 

--- a/pkg/util/interval/generic/example_interval_btree_test.go
+++ b/pkg/util/interval/generic/example_interval_btree_test.go
@@ -556,6 +556,18 @@ func run(tb testing.TB, name string, f func(testing.TB)) {
 	}
 }
 
+func iters(tb testing.TB, count int) int {
+	switch v := tb.(type) {
+	case *testing.T:
+		return count
+	case *testing.B:
+		return v.N
+	default:
+		tb.Fatalf("unknown %T", tb)
+		return 0
+	}
+}
+
 func verify(tb testing.TB, tr *btree) {
 	if tt, ok := tb.(*testing.T); ok {
 		tr.Verify(tt)
@@ -580,7 +592,8 @@ func startTimer(tb testing.TB) {
 	}
 }
 
-func runBTreeInsert(tb testing.TB, count, iters int) {
+func runBTreeInsert(tb testing.TB, count int) {
+	iters := iters(tb, count)
 	insertP := perm(count)
 	resetTimer(tb)
 	for i := 0; i < iters; {
@@ -596,7 +609,8 @@ func runBTreeInsert(tb testing.TB, count, iters int) {
 	}
 }
 
-func runBTreeDelete(tb testing.TB, count, iters int) {
+func runBTreeDelete(tb testing.TB, count int) {
+	iters := iters(tb, count)
 	insertP, removeP := perm(count), perm(count)
 	resetTimer(tb)
 	for i := 0; i < iters; {
@@ -621,7 +635,8 @@ func runBTreeDelete(tb testing.TB, count, iters int) {
 	}
 }
 
-func runBTreeDeleteInsert(tb testing.TB, count, iters int) {
+func runBTreeDeleteInsert(tb testing.TB, count int) {
+	iters := iters(tb, count)
 	insertP := perm(count)
 	var tr btree
 	for _, item := range insertP {
@@ -638,7 +653,8 @@ func runBTreeDeleteInsert(tb testing.TB, count, iters int) {
 	}
 }
 
-func runBTreeDeleteInsertCloneOnce(tb testing.TB, count, iters int) {
+func runBTreeDeleteInsertCloneOnce(tb testing.TB, count int) {
+	iters := iters(tb, count)
 	insertP := perm(count)
 	var tr btree
 	for _, item := range insertP {
@@ -656,9 +672,10 @@ func runBTreeDeleteInsertCloneOnce(tb testing.TB, count, iters int) {
 	}
 }
 
-func runBTreeDeleteInsertCloneEachTime(tb testing.TB, count, iters int) {
+func runBTreeDeleteInsertCloneEachTime(tb testing.TB, count int) {
 	for _, reset := range []bool{false, true} {
 		run(tb, fmt.Sprintf("reset=%t", reset), func(tb testing.TB) {
+			iters := iters(tb, count)
 			insertP := perm(count)
 			var tr, trReset btree
 			for _, item := range insertP {
@@ -693,27 +710,27 @@ func randCount() int {
 
 func TestBTreeInsert(t *testing.T) {
 	count := randCount()
-	runBTreeInsert(t, count, count)
+	runBTreeInsert(t, count)
 }
 
 func TestBTreeDelete(t *testing.T) {
 	count := randCount()
-	runBTreeDelete(t, count, count)
+	runBTreeDelete(t, count)
 }
 
 func TestBTreeDeleteInsert(t *testing.T) {
 	count := randCount()
-	runBTreeDeleteInsert(t, count, count)
+	runBTreeDeleteInsert(t, count)
 }
 
 func TestBTreeDeleteInsertCloneOnce(t *testing.T) {
 	count := randCount()
-	runBTreeDeleteInsertCloneOnce(t, count, count)
+	runBTreeDeleteInsertCloneOnce(t, count)
 }
 
 func TestBTreeDeleteInsertCloneEachTime(t *testing.T) {
 	count := randCount()
-	runBTreeDeleteInsertCloneEachTime(t, count, count)
+	runBTreeDeleteInsertCloneEachTime(t, count)
 }
 
 // TestBTreeSeekOverlapRandom tests btree iterator overlap operations using
@@ -863,21 +880,21 @@ func forBenchmarkSizes(b *testing.B, f func(b *testing.B, count int)) {
 // BenchmarkBTreeInsert measures btree insertion performance.
 func BenchmarkBTreeInsert(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		runBTreeInsert(b, count, b.N)
+		runBTreeInsert(b, count)
 	})
 }
 
 // BenchmarkBTreeDelete measures btree deletion performance.
 func BenchmarkBTreeDelete(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		runBTreeDelete(b, count, b.N)
+		runBTreeDelete(b, count)
 	})
 }
 
 // BenchmarkBTreeDeleteInsert measures btree deletion and insertion performance.
 func BenchmarkBTreeDeleteInsert(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		runBTreeDeleteInsert(b, count, b.N)
+		runBTreeDeleteInsert(b, count)
 	})
 }
 
@@ -885,7 +902,7 @@ func BenchmarkBTreeDeleteInsert(b *testing.B) {
 // performance after the tree has been copy-on-write cloned once.
 func BenchmarkBTreeDeleteInsertCloneOnce(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		runBTreeDeleteInsertCloneOnce(b, count, b.N)
+		runBTreeDeleteInsertCloneOnce(b, count)
 	})
 }
 
@@ -893,7 +910,7 @@ func BenchmarkBTreeDeleteInsertCloneOnce(b *testing.B) {
 // performance while the tree is repeatedly copy-on-write cloned.
 func BenchmarkBTreeDeleteInsertCloneEachTime(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		runBTreeDeleteInsertCloneEachTime(b, count, b.N)
+		runBTreeDeleteInsertCloneEachTime(b, count)
 	})
 }
 

--- a/pkg/util/interval/generic/internal/interval_btree_tmpl_test.go
+++ b/pkg/util/interval/generic/internal/interval_btree_tmpl_test.go
@@ -556,6 +556,18 @@ func run(tb testing.TB, name string, f func(testing.TB)) {
 	}
 }
 
+func iters(tb testing.TB, count int) int {
+	switch v := tb.(type) {
+	case *testing.T:
+		return count
+	case *testing.B:
+		return v.N
+	default:
+		tb.Fatalf("unknown %T", tb)
+		return 0
+	}
+}
+
 func verify(tb testing.TB, tr *btree) {
 	if tt, ok := tb.(*testing.T); ok {
 		tr.Verify(tt)
@@ -580,7 +592,8 @@ func startTimer(tb testing.TB) {
 	}
 }
 
-func runBTreeInsert(tb testing.TB, count, iters int) {
+func runBTreeInsert(tb testing.TB, count int) {
+	iters := iters(tb, count)
 	insertP := perm(count)
 	resetTimer(tb)
 	for i := 0; i < iters; {
@@ -596,7 +609,8 @@ func runBTreeInsert(tb testing.TB, count, iters int) {
 	}
 }
 
-func runBTreeDelete(tb testing.TB, count, iters int) {
+func runBTreeDelete(tb testing.TB, count int) {
+	iters := iters(tb, count)
 	insertP, removeP := perm(count), perm(count)
 	resetTimer(tb)
 	for i := 0; i < iters; {
@@ -621,7 +635,8 @@ func runBTreeDelete(tb testing.TB, count, iters int) {
 	}
 }
 
-func runBTreeDeleteInsert(tb testing.TB, count, iters int) {
+func runBTreeDeleteInsert(tb testing.TB, count int) {
+	iters := iters(tb, count)
 	insertP := perm(count)
 	var tr btree
 	for _, item := range insertP {
@@ -638,7 +653,8 @@ func runBTreeDeleteInsert(tb testing.TB, count, iters int) {
 	}
 }
 
-func runBTreeDeleteInsertCloneOnce(tb testing.TB, count, iters int) {
+func runBTreeDeleteInsertCloneOnce(tb testing.TB, count int) {
+	iters := iters(tb, count)
 	insertP := perm(count)
 	var tr btree
 	for _, item := range insertP {
@@ -656,9 +672,10 @@ func runBTreeDeleteInsertCloneOnce(tb testing.TB, count, iters int) {
 	}
 }
 
-func runBTreeDeleteInsertCloneEachTime(tb testing.TB, count, iters int) {
+func runBTreeDeleteInsertCloneEachTime(tb testing.TB, count int) {
 	for _, reset := range []bool{false, true} {
 		run(tb, fmt.Sprintf("reset=%t", reset), func(tb testing.TB) {
+			iters := iters(tb, count)
 			insertP := perm(count)
 			var tr, trReset btree
 			for _, item := range insertP {
@@ -693,27 +710,27 @@ func randCount() int {
 
 func TestBTreeInsert(t *testing.T) {
 	count := randCount()
-	runBTreeInsert(t, count, count)
+	runBTreeInsert(t, count)
 }
 
 func TestBTreeDelete(t *testing.T) {
 	count := randCount()
-	runBTreeDelete(t, count, count)
+	runBTreeDelete(t, count)
 }
 
 func TestBTreeDeleteInsert(t *testing.T) {
 	count := randCount()
-	runBTreeDeleteInsert(t, count, count)
+	runBTreeDeleteInsert(t, count)
 }
 
 func TestBTreeDeleteInsertCloneOnce(t *testing.T) {
 	count := randCount()
-	runBTreeDeleteInsertCloneOnce(t, count, count)
+	runBTreeDeleteInsertCloneOnce(t, count)
 }
 
 func TestBTreeDeleteInsertCloneEachTime(t *testing.T) {
 	count := randCount()
-	runBTreeDeleteInsertCloneEachTime(t, count, count)
+	runBTreeDeleteInsertCloneEachTime(t, count)
 }
 
 // TestBTreeSeekOverlapRandom tests btree iterator overlap operations using
@@ -863,21 +880,21 @@ func forBenchmarkSizes(b *testing.B, f func(b *testing.B, count int)) {
 // BenchmarkBTreeInsert measures btree insertion performance.
 func BenchmarkBTreeInsert(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		runBTreeInsert(b, count, b.N)
+		runBTreeInsert(b, count)
 	})
 }
 
 // BenchmarkBTreeDelete measures btree deletion performance.
 func BenchmarkBTreeDelete(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		runBTreeDelete(b, count, b.N)
+		runBTreeDelete(b, count)
 	})
 }
 
 // BenchmarkBTreeDeleteInsert measures btree deletion and insertion performance.
 func BenchmarkBTreeDeleteInsert(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		runBTreeDeleteInsert(b, count, b.N)
+		runBTreeDeleteInsert(b, count)
 	})
 }
 
@@ -885,7 +902,7 @@ func BenchmarkBTreeDeleteInsert(b *testing.B) {
 // performance after the tree has been copy-on-write cloned once.
 func BenchmarkBTreeDeleteInsertCloneOnce(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		runBTreeDeleteInsertCloneOnce(b, count, b.N)
+		runBTreeDeleteInsertCloneOnce(b, count)
 	})
 }
 
@@ -893,7 +910,7 @@ func BenchmarkBTreeDeleteInsertCloneOnce(b *testing.B) {
 // performance while the tree is repeatedly copy-on-write cloned.
 func BenchmarkBTreeDeleteInsertCloneEachTime(b *testing.B) {
 	forBenchmarkSizes(b, func(b *testing.B, count int) {
-		runBTreeDeleteInsertCloneEachTime(b, count, b.N)
+		runBTreeDeleteInsertCloneEachTime(b, count)
 	})
 }
 


### PR DESCRIPTION
The benchmark was not using the subtest's `b.N`, so it was getting bogus
results. This confused #62212, which saw a regression from 0.000008611111111
nanoseconds to 0.0000101 nanoseconds.

With this fix, the benchmark no longer shows any movement over the past release
and produces much more realistic results:
```
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkBTreeDeleteInsertCloneEachTime/count=16/reset=false-16         	 2367748	       492.7 ns/op
BenchmarkBTreeDeleteInsertCloneEachTime/count=16/reset=true-16          	 6090852	       191.7 ns/op
BenchmarkBTreeDeleteInsertCloneEachTime/count=128/reset=false-16        	  991534	      1102 ns/op
BenchmarkBTreeDeleteInsertCloneEachTime/count=128/reset=true-16         	 2328866	       508.7 ns/op
BenchmarkBTreeDeleteInsertCloneEachTime/count=1024/reset=false-16       	  550702	      2088 ns/op
BenchmarkBTreeDeleteInsertCloneEachTime/count=1024/reset=true-16        	 1209684	      1054 ns/op
BenchmarkBTreeDeleteInsertCloneEachTime/count=8192/reset=false-16       	  463558	      2176 ns/op
BenchmarkBTreeDeleteInsertCloneEachTime/count=8192/reset=true-16        	  724923	      1542 ns/op
BenchmarkBTreeDeleteInsertCloneEachTime/count=65536/reset=false-16      	  264100	      4833 ns/op
BenchmarkBTreeDeleteInsertCloneEachTime/count=65536/reset=true-16       	  429841	      2467 ns/op
```