### PR TITLE
cli/demo: `--empty` -> `--no-example-database`; add env var

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -84,7 +84,7 @@ func Example_demo() {
 
 	testData := [][]string{
 		{`demo`, `-e`, `show database`},
-		{`demo`, `-e`, `show database`, `--empty`},
+		{`demo`, `-e`, `show database`, `--no-example-database`},
 		{`demo`, `-e`, `show application_name`},
 		{`demo`, `--format=table`, `-e`, `show database`},
 		{`demo`, `-e`, `select 1 as "1"`, `-e`, `select 3 as "3"`},
@@ -115,7 +115,7 @@ func Example_demo() {
 	// demo -e show database
 	// database
 	// movr
-	// demo -e show database --empty
+	// demo -e show database --no-example-database
 	// database
 	// defaultdb
 	// demo -e show application_name

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1194,10 +1194,16 @@ If set, disable cockroach demo from attempting to obtain a temporary license.`,
 	}
 
 	UseEmptyDatabase = FlagInfo{
-		Name: "empty",
+		Name:        "empty",
+		Description: `Deprecated in favor of --no-example-database`,
+	}
+
+	NoExampleDatabase = FlagInfo{
+		Name:   "no-example-database",
+		EnvVar: "COCKROACH_NO_EXAMPLE_DATABASE",
 		Description: `
-Start with an empty database: avoid pre-loading a default dataset in
-the demo shell.`,
+Disable the creation of a default dataset in the demo shell.
+This makes 'cockroach demo' faster to start.`,
 	}
 
 	GeoLibsDir = FlagInfo{

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -533,7 +533,7 @@ var demoCtx struct {
 	cacheSize                 int64
 	disableTelemetry          bool
 	disableLicenseAcquisition bool
-	useEmptyDatabase          bool
+	noExampleDatabase         bool
 	runWorkload               bool
 	localities                demoLocalityList
 	geoPartitionedReplicas    bool
@@ -551,7 +551,7 @@ func setDemoContextDefaults() {
 	demoCtx.nodes = 1
 	demoCtx.sqlPoolMemorySize = 128 << 20 // 128MB, chosen to fit 9 nodes on 2GB machine.
 	demoCtx.cacheSize = 64 << 20          // 64MB, chosen to fit 9 nodes on 2GB machine.
-	demoCtx.useEmptyDatabase = false
+	demoCtx.noExampleDatabase = false
 	demoCtx.simulateLatency = false
 	demoCtx.runWorkload = false
 	demoCtx.localities = nil

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -36,7 +36,7 @@ Start an in-memory, standalone, single-node CockroachDB instance, and open an
 interactive SQL prompt to it. Various datasets are available to be preloaded as
 subcommands: e.g. "cockroach demo startrek". See --help for a full list.
 
-By default, the 'movr' dataset is pre-loaded. You can also use --empty
+By default, the 'movr' dataset is pre-loaded. You can also use --no-example-database
 to avoid pre-loading a dataset.
 
 cockroach demo attempts to connect to a Cockroach Labs server to obtain a
@@ -175,14 +175,14 @@ func incrementTelemetryCounters(cmd *cobra.Command) {
 func checkDemoConfiguration(
 	cmd *cobra.Command, gen workload.Generator,
 ) (workload.Generator, error) {
-	if gen == nil && !demoCtx.useEmptyDatabase {
-		// Use a default dataset unless prevented by --empty.
+	if gen == nil && !demoCtx.noExampleDatabase {
+		// Use a default dataset unless prevented by --no-example-database.
 		gen = defaultGenerator
 	}
 
 	// Make sure that the user didn't request a workload and an empty database.
-	if demoCtx.runWorkload && demoCtx.useEmptyDatabase {
-		return nil, errors.New("cannot run a workload against an empty database")
+	if demoCtx.runWorkload && demoCtx.noExampleDatabase {
+		return nil, errors.New("cannot run a workload when generation of the example database is disabled")
 	}
 
 	// Make sure the number of nodes is valid.
@@ -208,9 +208,9 @@ func checkDemoConfiguration(
 			return nil, errors.Newf("enterprise features are needed for this demo (%s)", geoFlag)
 		}
 
-		// Make sure that the user didn't request to have a topology and an empty database.
-		if demoCtx.useEmptyDatabase {
-			return nil, errors.New("cannot setup geo-partitioned replicas topology on an empty database")
+		// Make sure that the user didn't request to have a topology and disable the example database.
+		if demoCtx.noExampleDatabase {
+			return nil, errors.New("cannot setup geo-partitioned replicas topology without generating an example database")
 		}
 
 		// Make sure that the Movr database is selected when automatically partitioning.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -745,7 +745,9 @@ func init() {
 		_ = f.MarkHidden(cliflags.Global.Name)
 		// The --empty flag is only valid for the top level demo command,
 		// so we use the regular flag set.
-		boolFlag(demoCmd.Flags(), &demoCtx.useEmptyDatabase, cliflags.UseEmptyDatabase)
+		boolFlag(demoCmd.Flags(), &demoCtx.noExampleDatabase, cliflags.UseEmptyDatabase)
+		_ = f.MarkDeprecated(cliflags.UseEmptyDatabase.Name, "use --no-workload-database")
+		boolFlag(demoCmd.Flags(), &demoCtx.noExampleDatabase, cliflags.NoExampleDatabase)
 		// We also support overriding the GEOS library path for 'demo'.
 		// Even though the demoCtx uses mostly different configuration
 		// variables from startCtx, this is one case where we afford

--- a/pkg/cli/interactive_tests/test_demo.tcl
+++ b/pkg/cli/interactive_tests/test_demo.tcl
@@ -27,7 +27,7 @@ start_test "Check that demo insecure says hello properly"
 
 # With env var.
 set ::env(COCKROACH_INSECURE) "true"
-spawn $argv demo --empty
+spawn $argv demo --no-example-database
 eexpect "Welcome"
 eexpect "defaultdb>"
 
@@ -51,7 +51,7 @@ eexpect eof
 
 # With command-line override.
 set ::env(COCKROACH_INSECURE) "false"
-spawn $argv demo --insecure=true --empty
+spawn $argv demo --insecure=true --no-example-database
 eexpect "Welcome"
 eexpect "defaultdb>"
 
@@ -76,7 +76,7 @@ start_test "Check that demo secure says hello properly"
 
 # With env var.
 set ::env(COCKROACH_INSECURE) "false"
-spawn $argv demo --empty
+spawn $argv demo --no-example-database
 eexpect "Welcome"
 eexpect "The user \"demo\" with password"
 eexpect "has been created."
@@ -102,7 +102,7 @@ eexpect eof
 
 # With command-line override.
 set ::env(COCKROACH_INSECURE) "true"
-spawn $argv demo --insecure=false --empty
+spawn $argv demo --insecure=false --no-example-database
 eexpect "Welcome"
 eexpect "The user \"demo\" with password"
 eexpect "has been created."
@@ -126,7 +126,7 @@ end_test
 
 # Test that demo displays connection URLs for nodes in the cluster.
 start_test "Check that node URLs are displayed"
-spawn $argv demo --insecure --empty
+spawn $argv demo --insecure --no-example-database
 # Check that we see our message.
 eexpect "Connection parameters"
 eexpect "(sql)"
@@ -136,7 +136,7 @@ send_eof
 eexpect eof
 
 # Start the test again with a multi node cluster.
-spawn $argv demo --insecure --nodes 3 --empty
+spawn $argv demo --insecure --nodes 3 --no-example-database
 
 # Check that we get a message for each node.
 eexpect "Connection parameters"
@@ -159,7 +159,7 @@ eexpect "defaultdb>"
 send_eof
 eexpect eof
 
-spawn $argv demo --insecure=false --empty
+spawn $argv demo --insecure=false --no-example-database
 # Expect that security related tags are part of the connection URL.
 eexpect "(sql/tcp)"
 eexpect "sslmode=require"
@@ -172,7 +172,7 @@ end_test
 
 start_test "Check that the port numbers can be overridden from the command line."
 
-spawn $argv demo --empty --nodes 3 --http-port 8000
+spawn $argv demo --no-example-database --nodes 3 --http-port 8000
 eexpect "Welcome"
 eexpect "defaultdb>"
 
@@ -189,7 +189,7 @@ eexpect "defaultdb>"
 interrupt
 eexpect eof
 
-spawn $argv demo --empty --nodes 3 --sql-port 23000
+spawn $argv demo --no-example-database --nodes 3 --sql-port 23000
 eexpect "Welcome"
 eexpect "defaultdb>"
 

--- a/pkg/cli/interactive_tests/test_demo_global.tcl
+++ b/pkg/cli/interactive_tests/test_demo_global.tcl
@@ -8,7 +8,7 @@ set timeout 90
 start_test "Check --global flag runs as expected"
 
 # Start a demo with --global set
-spawn $argv demo --empty --nodes 9 --global
+spawn $argv demo --no-example-database --nodes 9 --global
 
 # Ensure db is defaultdb.
 eexpect "defaultdb>"

--- a/pkg/cli/interactive_tests/test_dump_sig.tcl
+++ b/pkg/cli/interactive_tests/test_dump_sig.tcl
@@ -25,7 +25,7 @@ eexpect ":/# "
 end_test
 
 start_test "Check that the client also can generate goroutine dumps."
-send "$argv demo --empty\r"
+send "$argv demo --no-example-database\r"
 eexpect root@
 # Dump goroutines in server.
 system "killall -QUIT `basename \$(realpath $argv)`"

--- a/pkg/cli/interactive_tests/test_flags.tcl
+++ b/pkg/cli/interactive_tests/test_flags.tcl
@@ -80,13 +80,13 @@ eexpect {Failed running "start"}
 end_test
 
 start_test "Check that demo start-up flags are reported to telemetry"
-send "$argv demo --empty --echo-sql --logtostderr=WARNING\r"
+send "$argv demo --no-example-database --echo-sql --logtostderr=WARNING\r"
 eexpect "defaultdb>"
 send "SELECT * FROM crdb_internal.feature_usage WHERE feature_name LIKE 'cli.demo.%' ORDER BY 1;\r"
 eexpect feature_name
 eexpect "cli.demo.explicitflags.echo-sql"
-eexpect "cli.demo.explicitflags.empty"
 eexpect "cli.demo.explicitflags.logtostderr"
+eexpect "cli.demo.explicitflags.no-example-database"
 eexpect "cli.demo.runs"
 eexpect "defaultdb>"
 interrupt

--- a/pkg/cli/interactive_tests/test_local_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_local_cmds.tcl
@@ -290,7 +290,7 @@ stop_server $argv
 start_test "Check that client-side options can be overridden with set"
 
 # First establish a baseline with all the defaults.
-send "$argv demo --empty\r"
+send "$argv demo --no-example-database\r"
 eexpect root@
 send "\\set display_format csv\r"
 send "\\set\r"
@@ -305,7 +305,7 @@ interrupt
 eexpect ":/# "
 
 # Then verify that the defaults can be overridden.
-send "$argv demo --empty --set=auto_trace=on --set=check_syntax=false --set=echo=true --set=errexit=true --set=prompt1=%n@haa --set=show_times=false\r"
+send "$argv demo --no-example-database --set=auto_trace=on --set=check_syntax=false --set=echo=true --set=errexit=true --set=prompt1=%n@haa --set=show_times=false\r"
 eexpect root@
 send "\\set display_format csv\r"
 send "\\set\r"

--- a/pkg/cli/interactive_tests/test_notice.tcl
+++ b/pkg/cli/interactive_tests/test_notice.tcl
@@ -4,7 +4,7 @@ source [file join [file dirname $argv0] common.tcl]
 
 # This test ensures notices are being sent as expected.
 
-spawn $argv demo --empty
+spawn $argv demo --no-example-database
 eexpect root@
 
 start_test "Test that notices always appear at the end after all results."

--- a/pkg/cmd/smithtest/main.go
+++ b/pkg/cmd/smithtest/main.go
@@ -257,7 +257,7 @@ func (s WorkerSetup) run(ctx context.Context, rnd *rand.Rand) error {
 		// If we can't ping, check if the statement caused a panic.
 		if err := db.PingContext(ctx); err != nil {
 			input := fmt.Sprintf("%s; %s;", initSQL, stmt)
-			out, _ := exec.CommandContext(ctx, s.cockroach, "demo", "--empty", "-e", input).CombinedOutput()
+			out, _ := exec.CommandContext(ctx, s.cockroach, "demo", "--no-example-database", "-e", input).CombinedOutput()
 			var pqerr pq.Error
 			if match := stackRE.FindStringSubmatch(string(out)); match != nil {
 				pqerr.Detail = strings.TrimSpace(match[1])


### PR DESCRIPTION
Fixes #47757 

The flag `--empty` was not, in fact, creating an empty cluster; the
two base databases `defaultdb` and `postgres` are still
created. Therefore the name of the flag was misleading.

What the flag is really doing is disable the generation
of the example database powered by the selected workload.

Release note (cli change): The flag `--empty` for `cockroach demo` has
been renamed to `--no-example-database`. The previous form of the
flag is still recognized but is marked as deprecated. Additionally,
the user can now set the env var `COCKROACH_NO_EXAMPLE_DATABASE` to
obtain this behavior automatically in every new demo session.