### PR TITLE
cli/demo: label the URLs consistently with 'start'

### DIFF
--- a/pkg/cli/demo_cluster.go
+++ b/pkg/cli/demo_cluster.go
@@ -882,7 +882,7 @@ func (c *transientCluster) listDemoNodes(w io.Writer, justOne bool) {
 		}
 		serverURL := s.Cfg.AdminURL()
 		if !demoCtx.insecure {
-			// Print node ID and console URL. Embed the autologin feature inside the URL.
+			// Print node ID and web UI URL. Embed the autologin feature inside the URL.
 			// We avoid printing those when insecure, as the autologin path is not available
 			// in that case.
 			pwauth := url.Values{
@@ -892,18 +892,18 @@ func (c *transientCluster) listDemoNodes(w io.Writer, justOne bool) {
 			serverURL.Path = server.DemoLoginPath
 			serverURL.RawQuery = pwauth.Encode()
 		}
-		fmt.Fprintf(w, "  (console) %s\n", serverURL)
-		// Print unix socket if defined.
-		if c.useSockets {
-			sock := c.sockForServer(nodeID)
-			fmt.Fprintln(w, "  (sql)    ", sock)
-		}
+		fmt.Fprintln(w, "  (webui)   ", serverURL)
 		// Print network URL if defined.
 		netURL, err := c.getNetworkURLForServer(i, nil, false /*includeAppName*/)
 		if err != nil {
 			fmt.Fprintln(stderr, errors.Wrap(err, "retrieving network URL"))
 		} else {
-			fmt.Fprintln(w, "  (sql/tcp)", netURL)
+			fmt.Fprintln(w, "  (sql)     ", netURL)
+		}
+		// Print unix socket if defined.
+		if c.useSockets {
+			sock := c.sockForServer(nodeID)
+			fmt.Fprintln(w, "  (sql/unix)", sock)
 		}
 		fmt.Fprintln(w)
 	}

--- a/pkg/cli/interactive_tests/test_demo.tcl
+++ b/pkg/cli/interactive_tests/test_demo.tcl
@@ -9,7 +9,7 @@ eexpect "Welcome"
 # Warn the user that they won't get persistence.
 eexpect "your changes to data stored in the demo session will not be saved!"
 # Inform the necessary URL.
-eexpect "(console)"
+eexpect "(webui)"
 eexpect "http:"
 # Ensure same messages as cockroach sql.
 eexpect "Server version"
@@ -34,16 +34,16 @@ eexpect "defaultdb>"
 # Show the URLs.
 # Also check that the default port is used.
 send "\\demo ls\r"
-eexpect "(console)"
+eexpect "(webui)"
 eexpect "http://"
 eexpect ":8080"
 eexpect "(sql)"
-eexpect "root:unused@"
-eexpect "=26257"
-eexpect "(sql/tcp)"
 eexpect "root@"
 eexpect ":26257"
 eexpect "sslmode=disable"
+eexpect "(sql/unix)"
+eexpect "root:unused@"
+eexpect "=26257"
 eexpect "defaultdb>"
 
 interrupt
@@ -57,13 +57,13 @@ eexpect "defaultdb>"
 
 # Show the URLs.
 send "\\demo ls\r"
-eexpect "(console)"
+eexpect "(webui)"
 eexpect "http://"
 eexpect "(sql)"
-eexpect "root:unused@"
-eexpect "(sql/tcp)"
 eexpect "root@"
 eexpect "sslmode=disable"
+eexpect "(sql/unix)"
+eexpect "root:unused@"
 eexpect "defaultdb>"
 
 interrupt
@@ -85,16 +85,16 @@ eexpect "defaultdb>"
 # Show the URLs.
 # Also check that the default port is used.
 send "\\demo ls\r"
-eexpect "(console)"
+eexpect "(webui)"
 eexpect "http://"
 eexpect ":8080"
 eexpect "(sql)"
 eexpect "demo:"
-eexpect "=26257"
-eexpect "(sql/tcp)"
-eexpect "demo:"
 eexpect ":26257"
 eexpect "sslmode=require"
+eexpect "(sql/unix)"
+eexpect "demo:"
+eexpect "=26257"
 eexpect "defaultdb>"
 
 interrupt
@@ -110,13 +110,13 @@ eexpect "defaultdb>"
 
 # Show the URLs.
 send "\\demo ls\r"
-eexpect "(console)"
+eexpect "(webui)"
 eexpect "http://"
 eexpect "(sql)"
 eexpect "demo:"
-eexpect "(sql/tcp)"
-eexpect "demo:"
 eexpect "sslmode=require"
+eexpect "(sql/unix)"
+eexpect "demo:"
 eexpect "defaultdb>"
 
 interrupt
@@ -130,7 +130,7 @@ spawn $argv demo --insecure --empty
 # Check that we see our message.
 eexpect "Connection parameters"
 eexpect "(sql)"
-eexpect "(sql/tcp)"
+eexpect "(sql/unix)"
 expect root@
 send_eof
 eexpect eof
@@ -141,19 +141,19 @@ spawn $argv demo --insecure --nodes 3 --empty
 # Check that we get a message for each node.
 eexpect "Connection parameters"
 eexpect "(sql)"
-eexpect "(sql/tcp)"
+eexpect "(sql/unix)"
 eexpect "defaultdb>"
 
 send "\\demo ls\r"
 eexpect "node 1"
 eexpect "(sql)"
-eexpect "(sql/tcp)"
+eexpect "(sql/unix)"
 eexpect "node 2"
 eexpect "(sql)"
-eexpect "(sql/tcp)"
+eexpect "(sql/unix)"
 eexpect "node 3"
 eexpect "(sql)"
-eexpect "(sql/tcp)"
+eexpect "(sql/unix)"
 eexpect "defaultdb>"
 
 send_eof
@@ -161,7 +161,7 @@ eexpect eof
 
 spawn $argv demo --insecure=false --empty
 # Expect that security related tags are part of the connection URL.
-eexpect "(sql/tcp)"
+eexpect "(sql)"
 eexpect "sslmode=require"
 eexpect "defaultdb>"
 
@@ -196,17 +196,17 @@ eexpect "defaultdb>"
 # Show the URLs.
 send "\\demo ls\r"
 eexpect "(sql)"
-eexpect "=23000"
-eexpect "(sql/tcp)"
 eexpect ":23000"
+eexpect "(sql/unix)"
+eexpect "=23000"
 eexpect "(sql)"
-eexpect "=23001"
-eexpect "(sql/tcp)"
 eexpect ":23001"
+eexpect "(sql/unix)"
+eexpect "=23001"
 eexpect "(sql)"
-eexpect "=23002"
-eexpect "(sql/tcp)"
 eexpect ":23002"
+eexpect "(sql/unix)"
+eexpect "=23002"
 eexpect "defaultdb>"
 
 interrupt


### PR DESCRIPTION
Fixes #47977. 

Before:

```
Connection parameters:
  (console) http://127.0.0.1:8080/demologin?password=demo63578&username=demo
  (sql)     postgres://demo:demo63578@?host=%2Ftmp%2Fdemo916006859&port=26257
  (sql/tcp) postgres://demo:demo63578@127.0.0.1:26257?sslmode=require
```

After:

```
Connection parameters:
  (webui)    http://127.0.0.1:8080/demologin?password=demo66299&username=demo
  (sql)      postgres://demo:demo66299@127.0.0.1:26257?sslmode=require
  (sql/unix) postgres://demo:demo66299@?host=%2Ftmp%2Fdemo869742428&port=26257
```

Release note (cli change): The prefixes displayed before connection
URLs when `cockroach demo` starts up have been updated to better align
with the output of `cockroach start`.