### PR TITLE
cli/sql: properly format different times and floats

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -286,16 +286,32 @@ func Example_sql_format() {
 
 	c.RunWithArgs([]string{"sql", "-e", "create database t; create table t.times (bare timestamp, withtz timestamptz)"})
 	c.RunWithArgs([]string{"sql", "-e", "insert into t.times values ('2016-01-25 10:10:10', '2016-01-25 10:10:10-05:00')"})
-	c.RunWithArgs([]string{"sql", "-e", "select * from t.times"})
+	c.RunWithArgs([]string{"sql", "-e", "select bare from t.times; select withtz from t.times"})
+	c.RunWithArgs([]string{"sql", "-e", "select '2021-03-20'::date; select '01:01'::time; select '01:01'::timetz"})
+	c.RunWithArgs([]string{"sql", "-e", "select (1/3.0)::real; select (1/3.0)::double precision"})
 
 	// Output:
 	// sql -e create database t; create table t.times (bare timestamp, withtz timestamptz)
 	// CREATE TABLE
 	// sql -e insert into t.times values ('2016-01-25 10:10:10', '2016-01-25 10:10:10-05:00')
 	// INSERT 1
-	// sql -e select * from t.times
-	// bare	withtz
-	// 2016-01-25 10:10:10+00:00:00	2016-01-25 15:10:10+00:00:00
+	// sql -e select bare from t.times; select withtz from t.times
+	// bare
+	// 2016-01-25 10:10:10
+	// withtz
+	// 2016-01-25 15:10:10+00:00:00
+	// sql -e select '2021-03-20'::date; select '01:01'::time; select '01:01'::timetz
+	// date
+	// 2021-03-20
+	// time
+	// 01:01:00
+	// timetz
+	// 01:01:00+00:00:00
+	// sql -e select (1/3.0)::real; select (1/3.0)::double precision
+	// float4
+	// 0.33333334
+	// float8
+	// 0.3333333333333333
 }
 
 func Example_sql_column_labels() {

--- a/pkg/cli/format_table.go
+++ b/pkg/cli/format_table.go
@@ -94,11 +94,12 @@ func newRowSliceIter(allRows [][]string, align string) *rowSliceIter {
 
 type rowIter struct {
 	rows          *sqlRows
+	colTypes      []string
 	showMoreChars bool
 }
 
 func (iter *rowIter) Next() (row []string, err error) {
-	nextRowString, err := getNextRowStrings(iter.rows, iter.showMoreChars)
+	nextRowString, err := getNextRowStrings(iter.rows, iter.colTypes, iter.showMoreChars)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +110,7 @@ func (iter *rowIter) Next() (row []string, err error) {
 }
 
 func (iter *rowIter) ToSlice() ([][]string, error) {
-	return getAllRowStrings(iter.rows, iter.showMoreChars)
+	return getAllRowStrings(iter.rows, iter.colTypes, iter.showMoreChars)
 }
 
 func (iter *rowIter) Align() []int {
@@ -137,6 +138,7 @@ func (iter *rowIter) Align() []int {
 func newRowIter(rows *sqlRows, showMoreChars bool) *rowIter {
 	return &rowIter{
 		rows:          rows,
+		colTypes:      rows.getColTypes(),
 		showMoreChars: showMoreChars,
 	}
 }

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -826,12 +826,12 @@ func (c *cliState) doRefreshPrompts(nextState cliStateEnum) cliStateEnum {
 func (c *cliState) refreshTransactionStatus() {
 	c.lastKnownTxnStatus = unknownTxnStatus
 
-	dbVal, hasVal := c.conn.getServerValue("transaction status", `SHOW TRANSACTION STATUS`)
+	dbVal, dbColType, hasVal := c.conn.getServerValue("transaction status", `SHOW TRANSACTION STATUS`)
 	if !hasVal {
 		return
 	}
 
-	txnString := formatVal(dbVal,
+	txnString := formatVal(dbVal, dbColType,
 		false /* showPrintableUnicode */, false /* shownewLinesAndTabs */)
 
 	// Change the prompt based on the response from the server.
@@ -859,7 +859,7 @@ func (c *cliState) refreshDatabaseName() string {
 		return unknownDbName
 	}
 
-	dbVal, hasVal := c.conn.getServerValue("database name", `SHOW DATABASE`)
+	dbVal, dbColType, hasVal := c.conn.getServerValue("database name", `SHOW DATABASE`)
 	if !hasVal {
 		return unknownDbName
 	}
@@ -870,7 +870,7 @@ func (c *cliState) refreshDatabaseName() string {
 			" Use SET database = <dbname> to change, CREATE DATABASE to make a new database.")
 	}
 
-	dbName := formatVal(dbVal.(string),
+	dbName := formatVal(dbVal, dbColType,
 		false /* showPrintableUnicode */, false /* shownewLinesAndTabs */)
 
 	// Preserve the current database name in case of reconnects.

--- a/pkg/util/timeutil/timeutil.go
+++ b/pkg/util/timeutil/timeutil.go
@@ -13,3 +13,18 @@ package timeutil
 // FullTimeFormat is the time format used to display any timestamp
 // with date, time and time zone data.
 const FullTimeFormat = "2006-01-02 15:04:05.999999-07:00:00"
+
+// TimestampWithoutTZFormat is the time format used to display
+// timestamps without a time zone offset.
+const TimestampWithoutTZFormat = "2006-01-02 15:04:05.999999"
+
+// TimeWithTZFormat is the time format used to display a time
+// with a time zone offset.
+const TimeWithTZFormat = "15:04:05.999999-07:00:00"
+
+// TimeWithoutTZFormat is the time format used to display a time
+// without a time zone offset.
+const TimeWithoutTZFormat = "15:04:05.999999"
+
+// DateFormat is the time format used to display a date.
+const DateFormat = "2006-01-02"


### PR DESCRIPTION
Fixes #29044. 

Prior to this patch, the SQL shell would improperly format
variants of timestamps (time, date) and mistakenly
use the same format for 32-bit and 64-bit float.
This patch corrects this.

Release note (cli change): The SQL shell (`cockroach demo`, `cockroach
sql`) now attempts to better format values that are akin to time/date,
as well as floating-point numbers.