### PR TITLE
mutations: format SQL so it can be reparsed successfully

### DIFF
--- a/pkg/sql/mutations/mutations.go
+++ b/pkg/sql/mutations/mutations.go
@@ -155,7 +155,7 @@ func ApplyString(
 	if changed {
 		var sb strings.Builder
 		for _, s := range stmts {
-			sb.WriteString(s.String())
+			sb.WriteString(tree.Serialize(s))
 			sb.WriteString(";\n")
 		}
 		input = sb.String()


### PR DESCRIPTION
If the SQL has `'Inf'::float` it would previously be serialized as `Inf`
with no quotes, so could not be parsed.

Release note: None