### PR TITLE
sql: add times series metrics for disk spilling

### DIFF
--- a/pkg/sql/execinfra/metrics.go
+++ b/pkg/sql/execinfra/metrics.go
@@ -31,6 +31,10 @@ type DistSQLMetrics struct {
 	VecOpenFDs            *metric.Gauge
 	CurDiskBytesCount     *metric.Gauge
 	MaxDiskBytesHist      *metric.Histogram
+	QueriesSpilled        *metric.Counter
+	QueryHasSpilled       *metric.Counter
+	SpilledBytesWritten   *metric.Counter
+	SpilledBytesRead      *metric.Counter
 }
 
 // MetricStruct implements the metrics.Struct interface.
@@ -111,6 +115,30 @@ var (
 		Measurement: "Disk",
 		Unit:        metric.Unit_BYTES,
 	}
+	metaQueriesSpilled = metric.Metadata{
+		Name:        "sql.distsql.queries.spilled",
+		Help:        "Number of times queries have spilled to disk",
+		Measurement: "Queries",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaQueryHasSpilled = metric.Metadata{
+		Name:        "sql.distsql.query.has.spilled",
+		Help:        "Number of queries that have spilled to disk",
+		Measurement: "Queries",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaSpilledBytesWritten = metric.Metadata{
+		Name:        "sql.disk.distsql.spilled.bytes.written",
+		Help:        "Number of bytes written to temporary disk storage as a result of spilling",
+		Measurement: "Disk",
+		Unit:        metric.Unit_BYTES,
+	}
+	metaSpilledBytesRead = metric.Metadata{
+		Name:        "sql.disk.distsql.spilled.bytes.read",
+		Help:        "Number of bytes read from temporary disk storage as a result of spilling",
+		Measurement: "Disk",
+		Unit:        metric.Unit_BYTES,
+	}
 )
 
 // See pkg/sql/mem_metrics.go
@@ -132,6 +160,10 @@ func MakeDistSQLMetrics(histogramWindow time.Duration) DistSQLMetrics {
 		VecOpenFDs:            metric.NewGauge(metaVecOpenFDs),
 		CurDiskBytesCount:     metric.NewGauge(metaDiskCurBytes),
 		MaxDiskBytesHist:      metric.NewHistogram(metaDiskMaxBytes, histogramWindow, log10int64times1000, 3),
+		QueriesSpilled:        metric.NewCounter(metaQueriesSpilled),
+		QueryHasSpilled:       metric.NewCounter(metaQueryHasSpilled),
+		SpilledBytesWritten:   metric.NewCounter(metaSpilledBytesWritten),
+		SpilledBytesRead:      metric.NewCounter(metaSpilledBytesRead),
 	}
 }
 

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1667,6 +1667,22 @@ var charts = []sectionDescription{
 				Title:   "Disk Usage per Statement",
 				Metrics: []string{"sql.disk.distsql.max"},
 			},
+			{
+				Title:   "Number of Times Queries Have Spilled To Disk",
+				Metrics: []string{"sql.distsql.queries.spilled"},
+			},
+			{
+				Title:   "Number of Queries Spilled to Disk",
+				Metrics: []string{"sql.distsql.query.has.spilled"},
+			},
+			{
+				Title:   "Number of Bytes Written Due to Disk Spilling",
+				Metrics: []string{"sql.disk.distsql.spilled.bytes.written"},
+			},
+			{
+				Title:   "Number of Bytes Read Due to Disk Spilling",
+				Metrics: []string{"sql.disk.distsql.spilled.bytes.read"},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
Add time series metrics for disk spilling to track
queries spilled to disk, bytes written, and bytes
read.

Fixes: #61363

Release note (ui change): User can see time series metrics
for disk spilling in advanced debug console