### PR TITLE
release-21.1: cdc: Improve error message.

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -190,7 +190,14 @@ func changefeedPlanHook(
 		targetDescs, _, err := backupbase.ResolveTargetsToDescriptors(
 			ctx, p, statementTime, &changefeedStmt.Targets)
 		if err != nil {
-			return errors.Wrap(err, "failed to resolve targets in the CHANGEFEED stmt")
+			err = errors.Wrap(err, "failed to resolve targets in the CHANGEFEED stmt")
+			if !initialHighWater.IsEmpty() {
+				// We specified cursor -- it is possible the targets do not exist at that time.
+				// Give a bit more context in the error message.
+				err = errors.WithHintf(err,
+					"do the targets exist at the specified cursor time %s?", initialHighWater)
+			}
+			return err
 		}
 
 		targets := make(jobspb.ChangefeedTargets, len(targetDescs))


### PR DESCRIPTION
Backport 1/1 commits from #61907.

/cc @cockroachdb/release

---

Improve error messages when the changefeed
targets do not exist at the requested cursor time.

Fixes #59363

Release Notes: None

Release Justification: Low impact, usability change.
