### PR TITLE
release-20.2: sql: dropping and creating view in a single transaction behaves wrong.

### DIFF
--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -59,7 +59,8 @@ func (n *createSequenceNode) ReadingOwnWrites() {}
 func (n *createSequenceNode) startExec(params runParams) error {
 	telemetry.Inc(sqltelemetry.SchemaChangeCreateCounter("sequence"))
 
-	_, schemaID, err := getTableCreateParams(params, n.dbDesc.GetID(), n.n.Persistence, &n.n.Name)
+	_, schemaID, err := getTableCreateParams(params, n.dbDesc.GetID(), n.n.Persistence, &n.n.Name,
+		tree.ResolveRequireSequenceDesc, n.n.IfNotExists)
 	if err != nil {
 		if sqlerrors.IsRelationAlreadyExistsError(err) && n.n.IfNotExists {
 			return nil

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -146,7 +146,12 @@ func (p *planner) getSchemaIDForCreate(
 // as well as the schema id. It returns valid data in the case that
 // the desired object exists.
 func getTableCreateParams(
-	params runParams, dbID descpb.ID, persistence tree.Persistence, tableName *tree.TableName,
+	params runParams,
+	dbID descpb.ID,
+	persistence tree.Persistence,
+	tableName *tree.TableName,
+	kind tree.RequiredTableKind,
+	ifNotExists bool,
 ) (tKey catalogkeys.DescriptorKey, schemaID descpb.ID, err error) {
 	// Check we are not creating a table which conflicts with an alias available
 	// as a built-in type in CockroachDB but an extension type on the public
@@ -216,18 +221,55 @@ func getTableCreateParams(
 		if err != nil {
 			return nil, 0, sqlerrors.WrapErrorWhileConstructingObjectAlreadyExistsErr(err)
 		}
+
+		// Ensure that the descriptor that does exist has the appropriate type.
+		{
+			mismatchedType := true
+			if tableDescriptor, ok := desc.(catalog.TableDescriptor); ok {
+				mismatchedType = false
+				switch kind {
+				case tree.ResolveRequireTableDesc:
+					mismatchedType = !tableDescriptor.IsTable()
+				case tree.ResolveRequireViewDesc:
+					mismatchedType = !tableDescriptor.IsView()
+				case tree.ResolveRequireSequenceDesc:
+					mismatchedType = !tableDescriptor.IsSequence()
+				}
+				// If kind any is passed then there will never be a mismatch
+				// and we can return an exists error.
+			}
+			// Only complain about mismatched types for
+			// if not exists clauses.
+			if mismatchedType && ifNotExists {
+				return nil, 0, pgerror.Newf(pgcode.WrongObjectType,
+					"%q is not a %s",
+					tableName.Table(),
+					kind)
+			}
+		}
+
+		// Check if the object already exists in a dropped state
+		if desc.Dropped() {
+			return nil, 0, pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+				"%s %q is being dropped, try again later",
+				kind,
+				tableName.Table())
+		}
+
 		// Still return data in this case.
 		return tKey, schemaID, sqlerrors.MakeObjectAlreadyExistsError(desc.DescriptorProto(), tableName.Table())
 	} else if err != nil {
 		return nil, 0, err
 	}
+
 	return tKey, schemaID, nil
 }
 
 func (n *createTableNode) startExec(params runParams) error {
 	telemetry.Inc(sqltelemetry.SchemaChangeCreateCounter("table"))
 
-	tKey, schemaID, err := getTableCreateParams(params, n.dbDesc.GetID(), n.n.Persistence, &n.n.Table)
+	tKey, schemaID, err := getTableCreateParams(params, n.dbDesc.GetID(), n.n.Persistence, &n.n.Table,
+		tree.ResolveRequireTableDesc, n.n.IfNotExists)
 	if err != nil {
 		if sqlerrors.IsRelationAlreadyExistsError(err) && n.n.IfNotExists {
 			return nil

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -105,8 +105,8 @@ func (n *createViewNode) startExec(params runParams) error {
 	}
 
 	var replacingDesc *tabledesc.Mutable
-
-	tKey, schemaID, err := getTableCreateParams(params, n.dbDesc.GetID(), persistence, n.viewName)
+	tKey, schemaID, err := getTableCreateParams(params, n.dbDesc.GetID(), persistence, n.viewName,
+		tree.ResolveRequireViewDesc, n.ifNotExists)
 	if err != nil {
 		switch {
 		case !sqlerrors.IsRelationAlreadyExistsError(err):

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -1130,7 +1130,7 @@ CREATE TABLE test.t(a INT PRIMARY KEY);
 	}
 
 	// Check that CREATE TABLE with the same name returns a proper error.
-	if _, err := db.Exec(`CREATE TABLE test.t(a INT PRIMARY KEY)`); !testutils.IsError(err, `relation "t" already exists`) {
+	if _, err := db.Exec(`CREATE TABLE test.t(a INT PRIMARY KEY)`); !testutils.IsError(err, `table "t" is being dropped, try again later`) {
 		t.Fatal(err)
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -1278,3 +1278,54 @@ ALTER SEQUENCE db2.seq OWNED BY db1.t.a
 
 statement ok
 CREATE SEQUENCE db2.seq2 OWNED BY db1.t.a
+
+# Unit test for #60737
+
+statement ok
+CREATE SEQUENCE s1 MINVALUE -4 START WITH -2 CACHE 1 INCREMENT BY -2;
+
+statement ok
+CREATE TABLE s2 (A int)
+
+# Case 1: Both s1's are sequences and the old one is being dropped.
+statement ok
+BEGIN
+
+statement ok
+DROP SEQUENCE s1
+
+statement error pgcode 55000 sequence "s1" is being dropped, try again later
+CREATE SEQUENCE IF NOT EXISTS s1 MINVALUE -4 START WITH -2 CACHE 1 INCREMENT BY -2;
+
+statement ok
+END
+
+# Case 2: Both s2's are different types and the old one is being dropped.
+statement ok
+BEGIN
+
+statement ok
+DROP TABLE s2
+
+statement error pgcode 42809 "s2" is not a sequence
+CREATE SEQUENCE IF NOT EXISTS s2 MINVALUE -4 START WITH -2 CACHE 1 INCREMENT BY -2;
+
+statement ok
+END
+
+# Case 3: Both s2's are a different type
+statement ok
+BEGIN
+
+statement error pgcode 42809 "s2" is not a sequence
+CREATE SEQUENCE IF NOT EXISTS s2 MINVALUE -4 START WITH -2 CACHE 1 INCREMENT BY -2;
+
+statement ok
+END
+
+statement ok
+DROP SEQUENCE s1
+
+statement ok
+DROP TABLE s2
+

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -673,3 +673,53 @@ SELECT estimated_row_count FROM [SHOW TABLES from rowtest] where table_name = 't
 1000
 
 user root
+
+# Unit test for #60737
+
+statement ok
+CREATE TABLE t1  (a INT PRIMARY KEY, b INT)
+
+statement ok
+CREATE TYPE t2 as enum('foo')
+
+# Case 1: Both t1's are tables and the old one is being dropped.
+statement ok
+BEGIN
+
+statement ok
+DROP TABLE t1
+
+statement error pgcode 55000 table "t1" is being dropped, try again later
+CREATE TABLE IF NOT EXISTS t1 (a INT PRIMARY KEY, b INT)
+
+statement ok
+END
+
+# Case 2: Both t2's are different types and the old one is being dropped.
+statement ok
+BEGIN
+
+statement ok
+DROP TYPE t2
+
+statement error pgcode 42809 "t2" is not a table
+CREATE TABLE IF NOT EXISTS t2 (a INT PRIMARY KEY, b INT)
+
+statement ok
+END
+
+# Case 3: Both s2's are a different type
+statement ok
+BEGIN
+
+statement error pgcode 42809 "t2" is not a table
+CREATE TABLE IF NOT EXISTS t2 (a INT PRIMARY KEY, b INT)
+
+statement ok
+END
+
+statement ok
+DROP table t1
+
+statement ok
+DROP TYPE t2

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -844,3 +844,61 @@ CREATE VIEW db2.v1 AS SELECT a+b FROM db1.public.ab
 
 statement ok
 CREATE VIEW db2.v2 AS SELECT a+b+c+d FROM cd, db1.public.ab
+
+# Unit test for #60737
+statement ok
+CREATE TABLE t (a INT PRIMARY KEY, b INT)
+
+statement ok
+INSERT INTO t VALUES (1, 99), (2, 98), (3, 97)
+
+statement ok
+CREATE VIEW v3 AS SELECT a, b FROM t
+
+statement ok
+CREATE TYPE v4 as enum('foo')
+
+# Case 1: Both v3's are views and the old one is being dropped.
+statement ok
+BEGIN
+
+statement ok
+DROP VIEW v3
+
+statement error pgcode 55000 view "v3" is being dropped, try again later
+CREATE VIEW IF NOT EXISTS v3 AS SELECT a, b FROM t
+
+statement ok
+END
+
+# Case 2: Both v4's are different types and the old one is being dropped.
+statement ok
+BEGIN
+
+statement ok
+DROP TYPE v4
+
+statement error pgcode 42809 "v4" is not a view
+CREATE VIEW IF NOT EXISTS v4 AS SELECT a, b FROM t
+
+statement ok
+END
+
+# Case 3: Both v4's are a different type
+statement ok
+BEGIN
+
+statement error pgcode 42809 "v4" is not a view
+CREATE VIEW IF NOT EXISTS v4 AS SELECT a, b FROM t
+
+statement ok
+END
+
+statement ok
+DROP VIEW v3
+
+statement ok
+DROP TYPE v4
+
+statement ok
+DROP TABLE t

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -3537,7 +3537,7 @@ INSERT INTO t.kv VALUES ('a', 'b');
 			name:        `drop-create`,
 			firstStmt:   `DROP TABLE t.kv`,
 			secondStmt:  `CREATE TABLE t.kv (k CHAR PRIMARY KEY, v CHAR)`,
-			expectedErr: `relation "kv" already exists`,
+			expectedErr: `table "kv" is being dropped, try again later`,
 		},
 		// schema change followed by another statement works.
 		{


### PR DESCRIPTION
Backport 1/1 commits from #61135.

/cc @cockroachdb/release

---

Fixes: #60737

Previously, when dropping and creating a view/table/sequence with if
exists clause in a single transaction would drop the view and not
create the view again, since we would see a descriptor in a dropping
state as created. Similarly, if the dropped object was a different
type we would silently ignore the error for the IF NOT EXISTS case.
To address this incorrect behaviour, this patch will return a
ObjectNotInPrerequisiteState if a descriptor in a dropping state is
found. Secondly, if the IF NOT EXISTS flag is specified we will
validate that the types match otherwise return WrongObjectType.

  Release note (bug fix): Dropping and recreating a view/table/sequence
  in a transaction will now correctly error out if a conflicting object
  exists or if the drop is incomplete.

  Release justification: Low risk change to address a high severity
  issue where users could have failures due to incorrect behaviour.

