### PR TITLE
release-20.1: sql: dropping and creating tables in a transaction behaves wrong

### DIFF
--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -14,25 +14,41 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/docs"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
+	"github.com/cockroachdb/errors"
 )
 
 // createViewNode represents a CREATE VIEW statement.
 type createViewNode struct {
-	viewName tree.Name
+	// viewName is the fully qualified name of the new view.
+	viewName *tree.TableName
 	// viewQuery contains the view definition, with all table names fully
 	// qualified.
-	viewQuery   string
-	ifNotExists bool
-	temporary   bool
-	dbDesc      *sqlbase.DatabaseDescriptor
-	columns     sqlbase.ResultColumns
+	viewQuery    string
+	ifNotExists  bool
+	replace      bool
+	persistence  tree.Persistence
+	materialized bool
+	dbDesc       *dbdesc.Immutable
+	columns      colinfo.ResultColumns
 
 	// planDeps tracks which tables and views the view being created
 	// depends on. This is collected during the construction of
@@ -46,125 +62,215 @@ type createViewNode struct {
 func (n *createViewNode) ReadingOwnWrites() {}
 
 func (n *createViewNode) startExec(params runParams) error {
-	telemetry.Inc(sqltelemetry.SchemaChangeCreateCounter("view"))
+	tableType := tree.GetTableType(
+		false /* isSequence */, true /* isView */, n.materialized,
+	)
+	if n.replace {
+		telemetry.Inc(sqltelemetry.SchemaChangeCreateCounter(fmt.Sprintf("or_replace_%s", tableType)))
+	} else {
+		telemetry.Inc(sqltelemetry.SchemaChangeCreateCounter(tableType))
+	}
 
-	viewName := string(n.viewName)
-	isTemporary := n.temporary
+	viewName := n.viewName.Object()
+	persistence := n.persistence
 	log.VEventf(params.ctx, 2, "dependencies for view %s:\n%s", viewName, n.planDeps.String())
+
+	// Check that the view does not contain references to other databases.
+	if !allowCrossDatabaseViews.Get(&params.p.execCfg.Settings.SV) {
+		for _, dep := range n.planDeps {
+			if dbID := dep.desc.GetParentID(); dbID != n.dbDesc.ID && dbID != keys.SystemDatabaseID {
+				return errors.WithHintf(
+					pgerror.Newf(pgcode.FeatureNotSupported,
+						"the view cannot refer to other databases; (see the '%s' cluster setting)",
+						allowCrossDatabaseViewsSetting),
+					crossDBReferenceDeprecationHint(),
+				)
+			}
+		}
+	}
 
 	// First check the backrefs and see if any of them are temporary.
 	// If so, promote this view to temporary.
-	backRefMutables := make(map[sqlbase.ID]*sqlbase.MutableTableDescriptor, len(n.planDeps))
+	backRefMutables := make(map[descpb.ID]*tabledesc.Mutable, len(n.planDeps))
 	for id, updated := range n.planDeps {
-		backRefMutable := params.p.Tables().getUncommittedTableByID(id).MutableTableDescriptor
+		backRefMutable := params.p.Descriptors().GetUncommittedTableByID(id)
 		if backRefMutable == nil {
-			backRefMutable = sqlbase.NewMutableExistingTableDescriptor(*updated.desc.TableDesc())
+			backRefMutable = tabledesc.NewExistingMutable(*updated.desc.TableDesc())
 		}
-		if !isTemporary && backRefMutable.Temporary {
+		if !persistence.IsTemporary() && backRefMutable.Temporary {
 			// This notice is sent from pg, let's imitate.
-			params.p.SendClientNotice(params.ctx,
-				pgerror.Noticef(`view "%s" will be a temporary view`, viewName),
+			params.p.BufferClientNotice(
+				params.ctx,
+				pgnotice.Newf(`view "%s" will be a temporary view`, viewName),
 			)
-			isTemporary = true
+			persistence = tree.PersistenceTemporary
 		}
 		backRefMutables[id] = backRefMutable
 	}
 
-	tKey, schemaID, err := getTableCreateParams(params, n.dbDesc.ID, isTemporary, viewName)
+	var replacingDesc *tabledesc.Mutable
+	tKey, schemaID, err := getTableCreateParams(params, n.dbDesc.GetID(), persistence, n.viewName,
+		tree.ResolveRequireViewDesc, n.ifNotExists)
 	if err != nil {
-		if sqlbase.IsRelationAlreadyExistsError(err) && n.ifNotExists {
+		switch {
+		case !sqlerrors.IsRelationAlreadyExistsError(err):
+			return err
+		case n.ifNotExists:
 			return nil
+		case n.replace:
+			// If we are replacing an existing view see if what we are
+			// replacing is actually a view.
+			id, err := catalogkv.GetDescriptorID(params.ctx, params.p.txn, params.ExecCfg().Codec, tKey)
+			if err != nil {
+				return err
+			}
+			desc, err := params.p.Descriptors().GetMutableTableVersionByID(params.ctx, id, params.p.txn)
+			if err != nil {
+				return err
+			}
+			if err := params.p.CheckPrivilege(params.ctx, desc, privilege.DROP); err != nil {
+				return err
+			}
+			if !desc.IsView() {
+				return pgerror.Newf(pgcode.WrongObjectType, `%q is not a view`, viewName)
+			}
+			replacingDesc = desc
+		default:
+			return err
 		}
-		return err
 	}
 
-	schemaName := tree.PublicSchemaName
-	if isTemporary {
+	if n.persistence.IsTemporary() {
 		telemetry.Inc(sqltelemetry.CreateTempViewCounter)
-		schemaName = tree.Name(params.p.TemporarySchemaName())
 	}
 
-	id, err := GenerateUniqueDescID(params.ctx, params.extendedEvalCtx.ExecCfg.DB)
-	if err != nil {
-		return err
-	}
+	privs := CreateInheritedPrivilegesFromDBDesc(n.dbDesc, params.SessionData().User())
 
-	// Inherit permissions from the database descriptor.
-	privs := n.dbDesc.GetPrivileges()
+	var newDesc *tabledesc.Mutable
 
-	desc, err := makeViewTableDesc(
-		viewName,
-		n.viewQuery,
-		n.dbDesc.ID,
-		schemaID,
-		id,
-		n.columns,
-		params.creationTimeForNewTableDescriptor(),
-		privs,
-		&params.p.semaCtx,
-		isTemporary,
-	)
-	if err != nil {
-		return err
-	}
+	// If replacingDesc != nil, we found an existing view while resolving
+	// the name for our view. So instead of creating a new view, replace
+	// the existing one.
+	if replacingDesc != nil {
+		newDesc, err = params.p.replaceViewDesc(params.ctx, n, replacingDesc, backRefMutables)
+		if err != nil {
+			return err
+		}
+	} else {
+		// If we aren't replacing anything, make a new table descriptor.
+		id, err := catalogkv.GenerateUniqueDescID(params.ctx, params.p.ExecCfg().DB, params.p.ExecCfg().Codec)
+		if err != nil {
+			return err
+		}
+		// creationTime is initialized to a zero value and populated at read time.
+		// See the comment in desc.MaybeIncrementVersion.
+		//
+		// TODO(ajwerner): remove the timestamp from MakeViewTableDesc, it's
+		// currently relied on in import and restore code and tests.
+		var creationTime hlc.Timestamp
+		desc, err := makeViewTableDesc(
+			params.ctx,
+			viewName,
+			n.viewQuery,
+			n.dbDesc.GetID(),
+			schemaID,
+			id,
+			n.columns,
+			creationTime,
+			privs,
+			&params.p.semaCtx,
+			params.p.EvalContext(),
+			n.persistence,
+		)
+		if err != nil {
+			return err
+		}
 
-	// Collect all the tables/views this view depends on.
-	for backrefID := range n.planDeps {
-		desc.DependsOn = append(desc.DependsOn, backrefID)
-	}
+		if n.materialized {
+			// Ensure all nodes are the correct version.
+			if !params.ExecCfg().Settings.Version.IsActive(params.ctx, clusterversion.MaterializedViews) {
+				return pgerror.New(pgcode.FeatureNotSupported,
+					"all nodes are not the correct version to use materialized views")
+			}
+			// If the view is materialized, set up some more state on the view descriptor.
+			// In particular,
+			// * mark the descriptor as a materialized view
+			// * mark the state as adding and remember the AsOf time to perform
+			//   the view query
+			// * use AllocateIDs to give the view descriptor a primary key
+			desc.IsMaterializedView = true
+			desc.State = descpb.DescriptorState_ADD
+			desc.CreateAsOfTime = params.p.Txn().ReadTimestamp()
+			if err := desc.AllocateIDs(params.ctx); err != nil {
+				return err
+			}
+		}
 
-	// TODO (lucy): I think this needs a NodeFormatter implementation. For now,
-	// do some basic string formatting (not accurate in the general case).
-	if err = params.p.createDescriptorWithID(
-		params.ctx, tKey.Key(), id, &desc, params.EvalContext().Settings,
-		fmt.Sprintf("CREATE VIEW %q AS %q", n.viewName, n.viewQuery),
-	); err != nil {
-		return err
+		// Collect all the tables/views this view depends on.
+		for backrefID := range n.planDeps {
+			desc.DependsOn = append(desc.DependsOn, backrefID)
+		}
+
+		// TODO (lucy): I think this needs a NodeFormatter implementation. For now,
+		// do some basic string formatting (not accurate in the general case).
+		if err = params.p.createDescriptorWithID(
+			params.ctx, tKey.Key(params.ExecCfg().Codec), id, &desc, params.EvalContext().Settings,
+			fmt.Sprintf("CREATE VIEW %q AS %q", n.viewName, n.viewQuery),
+		); err != nil {
+			return err
+		}
+		newDesc = &desc
 	}
 
 	// Persist the back-references in all referenced table descriptors.
 	for id, updated := range n.planDeps {
 		backRefMutable := backRefMutables[id]
+		// In case that we are replacing a view that already depends on
+		// this table, remove all existing references so that we don't leave
+		// any out of date references. Then, add the new references.
+		backRefMutable.DependedOnBy = removeMatchingReferences(
+			backRefMutable.DependedOnBy,
+			newDesc.ID,
+		)
 		for _, dep := range updated.deps {
 			// The logical plan constructor merely registered the dependencies.
 			// It did not populate the "ID" field of TableDescriptor_Reference,
 			// because the ID of the newly created view descriptor was not
 			// yet known.
 			// We need to do it here.
-			dep.ID = desc.ID
+			dep.ID = newDesc.ID
 			backRefMutable.DependedOnBy = append(backRefMutable.DependedOnBy, dep)
 		}
-		// TODO (lucy): Have more consistent/informative names for dependent jobs.
 		if err := params.p.writeSchemaChange(
-			params.ctx, backRefMutable, sqlbase.InvalidMutationID, "updating view reference",
+			params.ctx,
+			backRefMutable,
+			descpb.InvalidMutationID,
+			fmt.Sprintf("updating view reference %q in table %s(%d)", n.viewName,
+				updated.desc.GetName(), updated.desc.GetID(),
+			),
 		); err != nil {
 			return err
 		}
 	}
 
-	if err := desc.Validate(params.ctx, params.p.txn); err != nil {
+	// Install back references to types used by this view.
+	if err := params.p.addBackRefsFromAllTypesInTable(params.ctx, newDesc); err != nil {
+		return err
+	}
+
+	dg := catalogkv.NewOneLevelUncachedDescGetter(params.p.txn, params.ExecCfg().Codec)
+	if err := newDesc.Validate(params.ctx, dg); err != nil {
 		return err
 	}
 
 	// Log Create View event. This is an auditable log event and is
 	// recorded in the same transaction as the table descriptor update.
-	tn := tree.MakeTableNameWithSchema(tree.Name(n.dbDesc.Name), schemaName, n.viewName)
-	return MakeEventLogger(params.extendedEvalCtx.ExecCfg).InsertEventRecord(
-		params.ctx,
-		params.p.txn,
-		EventLogCreateView,
-		int32(desc.ID),
-		int32(params.extendedEvalCtx.NodeID),
-		struct {
-			ViewName  string
-			ViewQuery string
-			User      string
-		}{
-			ViewName:  tn.FQString(),
+	return params.p.logEvent(params.ctx,
+		newDesc.ID,
+		&eventpb.CreateView{
+			ViewName:  n.viewName.FQString(),
 			ViewQuery: n.viewQuery,
-			User:      params.SessionData().User,
-		},
-	)
+		})
 }
 
 func (*createViewNode) Next(runParams) (bool, error) { return false, nil }
@@ -179,47 +285,192 @@ func (n *createViewNode) Close(ctx context.Context)  {}
 // doesn't matter if reads/writes use a cached descriptor that doesn't
 // include the back-references.
 func makeViewTableDesc(
+	ctx context.Context,
 	viewName string,
 	viewQuery string,
-	parentID sqlbase.ID,
-	schemaID sqlbase.ID,
-	id sqlbase.ID,
-	resultColumns []sqlbase.ResultColumn,
+	parentID descpb.ID,
+	schemaID descpb.ID,
+	id descpb.ID,
+	resultColumns []colinfo.ResultColumn,
 	creationTime hlc.Timestamp,
-	privileges *sqlbase.PrivilegeDescriptor,
+	privileges *descpb.PrivilegeDescriptor,
 	semaCtx *tree.SemaContext,
-	temporary bool,
-) (sqlbase.MutableTableDescriptor, error) {
-	desc := InitTableDescriptor(
+	evalCtx *tree.EvalContext,
+	persistence tree.Persistence,
+) (tabledesc.Mutable, error) {
+	desc := tabledesc.InitTableDescriptor(
 		id,
 		parentID,
 		schemaID,
 		viewName,
 		creationTime,
 		privileges,
-		temporary,
+		persistence,
 	)
 	desc.ViewQuery = viewQuery
-	for _, colRes := range resultColumns {
-		columnTableDef := tree.ColumnTableDef{Name: tree.Name(colRes.Name), Type: colRes.Typ}
-		// The new types in the CREATE VIEW column specs never use
-		// SERIAL so we need not process SERIAL types here.
-		col, _, _, err := sqlbase.MakeColumnDefDescs(&columnTableDef, semaCtx)
-		if err != nil {
-			return desc, err
-		}
-		desc.AddColumn(col)
+	if err := addResultColumns(ctx, semaCtx, evalCtx, &desc, resultColumns); err != nil {
+		return tabledesc.Mutable{}, err
 	}
-	if err := desc.AllocateIDs(); err != nil {
-		return sqlbase.MutableTableDescriptor{}, err
-	}
+
 	return desc, nil
 }
 
-func overrideColumnNames(cols sqlbase.ResultColumns, newNames tree.NameList) sqlbase.ResultColumns {
-	res := append(sqlbase.ResultColumns(nil), cols...)
+// replaceViewDesc modifies and returns the input view descriptor changed
+// to hold the new view represented by n. Note that back references from
+// tables that the new view depends on still need to be added. This function
+// will additionally drop backreferences from tables the old view depended
+// on that the new view no longer depends on.
+func (p *planner) replaceViewDesc(
+	ctx context.Context,
+	n *createViewNode,
+	toReplace *tabledesc.Mutable,
+	backRefMutables map[descpb.ID]*tabledesc.Mutable,
+) (*tabledesc.Mutable, error) {
+	// Set the query to the new query.
+	toReplace.ViewQuery = n.viewQuery
+	// Reset the columns to add the new result columns onto.
+	toReplace.Columns = make([]descpb.ColumnDescriptor, 0, len(n.columns))
+	toReplace.NextColumnID = 0
+	if err := addResultColumns(ctx, &p.semaCtx, p.EvalContext(), toReplace, n.columns); err != nil {
+		return nil, err
+	}
+
+	// Compare toReplace against its ClusterVersion to verify if
+	// its new set of columns is valid for a replacement view.
+	if err := verifyReplacingViewColumns(
+		toReplace.ClusterVersion.Columns,
+		toReplace.Columns,
+	); err != nil {
+		return nil, err
+	}
+
+	// Remove the back reference from all tables that the view depended on.
+	for _, id := range toReplace.DependsOn {
+		desc, ok := backRefMutables[id]
+		if !ok {
+			var err error
+			desc, err = p.Descriptors().GetMutableTableVersionByID(ctx, id, p.txn)
+			if err != nil {
+				return nil, err
+			}
+			backRefMutables[id] = desc
+		}
+
+		// If n.planDeps doesn't contain id, then the new view definition doesn't
+		// reference this table anymore, so we can remove all existing references.
+		if _, ok := n.planDeps[id]; !ok {
+			desc.DependedOnBy = removeMatchingReferences(desc.DependedOnBy, toReplace.ID)
+			if err := p.writeSchemaChange(
+				ctx,
+				desc,
+				descpb.InvalidMutationID,
+				fmt.Sprintf("removing view reference for %q from %s(%d)", n.viewName,
+					desc.Name, desc.ID,
+				),
+			); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// Since the view query has been replaced, the dependencies that this
+	// table descriptor had are gone.
+	toReplace.DependsOn = make([]descpb.ID, 0, len(n.planDeps))
+	for backrefID := range n.planDeps {
+		toReplace.DependsOn = append(toReplace.DependsOn, backrefID)
+	}
+
+	// Since we are replacing an existing view here, we need to write the new
+	// descriptor into place.
+	if err := p.writeSchemaChange(ctx, toReplace, descpb.InvalidMutationID,
+		fmt.Sprintf("CREATE OR REPLACE VIEW %q AS %q", n.viewName, n.viewQuery),
+	); err != nil {
+		return nil, err
+	}
+	return toReplace, nil
+}
+
+// addResultColumns adds the resultColumns as actual column
+// descriptors onto desc.
+func addResultColumns(
+	ctx context.Context,
+	semaCtx *tree.SemaContext,
+	evalCtx *tree.EvalContext,
+	desc *tabledesc.Mutable,
+	resultColumns colinfo.ResultColumns,
+) error {
+	for _, colRes := range resultColumns {
+		columnTableDef := tree.ColumnTableDef{Name: tree.Name(colRes.Name), Type: colRes.Typ}
+		// Nullability constraints do not need to exist on the view, since they are
+		// already enforced on the source data.
+		columnTableDef.Nullable.Nullability = tree.SilentNull
+		// The new types in the CREATE VIEW column specs never use
+		// SERIAL so we need not process SERIAL types here.
+		col, _, _, err := tabledesc.MakeColumnDefDescs(ctx, &columnTableDef, semaCtx, evalCtx)
+		if err != nil {
+			return err
+		}
+		desc.AddColumn(col)
+	}
+	if err := desc.AllocateIDs(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+// verifyReplacingViewColumns ensures that the new set of view columns must
+// have at least the same prefix of columns as the old view. We attempt to
+// match the postgres error message in each of the error cases below.
+func verifyReplacingViewColumns(oldColumns, newColumns []descpb.ColumnDescriptor) error {
+	if len(newColumns) < len(oldColumns) {
+		return pgerror.Newf(pgcode.InvalidTableDefinition, "cannot drop columns from view")
+	}
+	for i := range oldColumns {
+		oldCol, newCol := &oldColumns[i], &newColumns[i]
+		if oldCol.Name != newCol.Name {
+			return pgerror.Newf(
+				pgcode.InvalidTableDefinition,
+				`cannot change name of view column %q to %q`,
+				oldCol.Name,
+				newCol.Name,
+			)
+		}
+		if !newCol.Type.Identical(oldCol.Type) {
+			return pgerror.Newf(
+				pgcode.InvalidTableDefinition,
+				`cannot change type of view column %q from %s to %s`,
+				oldCol.Name,
+				oldCol.Type.String(),
+				newCol.Type.String(),
+			)
+		}
+		if newCol.Hidden != oldCol.Hidden {
+			return pgerror.Newf(
+				pgcode.InvalidTableDefinition,
+				`cannot change visibility of view column %q`,
+				oldCol.Name,
+			)
+		}
+		if newCol.Nullable != oldCol.Nullable {
+			return pgerror.Newf(
+				pgcode.InvalidTableDefinition,
+				`cannot change nullability of view column %q`,
+				oldCol.Name,
+			)
+		}
+	}
+	return nil
+}
+
+func overrideColumnNames(cols colinfo.ResultColumns, newNames tree.NameList) colinfo.ResultColumns {
+	res := append(colinfo.ResultColumns(nil), cols...)
 	for i := range res {
 		res[i].Name = string(newNames[i])
 	}
 	return res
+}
+
+func crossDBReferenceDeprecationHint() string {
+	return fmt.Sprintf("Note that cross-database references will be removed in future releases. See: %s",
+		docs.ReleaseNotesURL(`#deprecations`))
 }

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -1232,7 +1232,7 @@ CREATE TABLE test.t(a INT PRIMARY KEY);
 	}
 
 	// Check that CREATE TABLE with the same name returns a proper error.
-	if _, err := db.Exec(`CREATE TABLE test.t(a INT PRIMARY KEY)`); !testutils.IsError(err, `relation "t" already exists`) {
+	if _, err := db.Exec(`CREATE TABLE test.t(a INT PRIMARY KEY)`); !testutils.IsError(err, `table "t" is being dropped, try again later`) {
 		t.Fatal(err)
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -4,6 +4,9 @@
 # (at the top because it requires a session in which `lastval` has never been called)
 
 statement ok
+SET CLUSTER SETTING sql.cross_db_sequence_owners.enabled = TRUE
+
+statement ok
 SET DATABASE = test
 
 statement ok
@@ -55,6 +58,32 @@ SELECT lastval()
 ----
 11
 
+let $lastval_test_id
+SELECT 'lastval_test'::regclass::int
+
+query I
+SELECT nextval($lastval_test_id::regclass)
+----
+3
+
+query I
+SELECT lastval()
+----
+3
+
+let $lastval_test_2_id
+SELECT 'lastval_test_2'::regclass::int
+
+query I
+SELECT nextval($lastval_test_2_id::regclass)
+----
+12
+
+query I
+SELECT lastval()
+----
+12
+
 # SEQUENCE CREATION
 
 statement ok
@@ -93,37 +122,28 @@ CREATE SEQUENCE limit_test MAXVALUE 10 START WITH 11
 statement error pgcode 22023 START value \(5\) cannot be less than MINVALUE \(10\)
 CREATE SEQUENCE limit_test MINVALUE 10 START WITH 5
 
-statement error pgcode 22023 CACHE \(-1\) must be greater than zero
-CREATE SEQUENCE cache_test CACHE -1
-
-statement error pgcode 22023 CACHE \(0\) must be greater than zero
-CREATE SEQUENCE cache_test CACHE 0
-
-statement error pgcode 0A000 CACHE values larger than 1 are not supported, found 5
-CREATE SEQUENCE cache_test CACHE 5
-
 statement error pgcode 0A000 CYCLE option is not supported
 CREATE SEQUENCE cycle_test CYCLE
 
 statement ok
-CREATE SEQUENCE ignored_options_test CACHE 1 NO CYCLE
+CREATE SEQUENCE ignored_options_test NO CYCLE
 
 # Verify presence in crdb_internal.create_statements.
 
 statement ok
 CREATE SEQUENCE show_create_test
 
-query ITTITTTTTTTT colnames
+query ITTITTTTTTTBB colnames
 SELECT * FROM crdb_internal.create_statements WHERE descriptor_name = 'show_create_test'
 ----
-database_id  database_name  schema_name  descriptor_id  descriptor_type  descriptor_name   create_statement                                                                              state   create_nofks                                                                                  alter_statements  validate_statements zone_configuration_statements
-52           test           public       66             sequence         show_create_test  CREATE SEQUENCE show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1  PUBLIC  CREATE SEQUENCE show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1  {}                {}                  {}
+database_id  database_name  schema_name  descriptor_id  descriptor_type  descriptor_name   create_statement                                                                                     state   create_nofks                                                                                         alter_statements  validate_statements  has_partitions  is_multi_region
+52           test           public       63             sequence         show_create_test  CREATE SEQUENCE public.show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1  PUBLIC  CREATE SEQUENCE public.show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1  {}                {}                   false           false
 
 query TT colnames
 SHOW CREATE SEQUENCE show_create_test
 ----
 table_name        create_statement
-show_create_test  CREATE SEQUENCE show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1
+show_create_test  CREATE SEQUENCE public.show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1
 
 # DML ERRORS
 
@@ -143,25 +163,33 @@ TRUNCATE foo
 statement error pgcode 42809 "foo" is not a table
 DROP TABLE foo
 
+# Create a sequence on another schema
+statement ok
+CREATE SCHEMA other_schema
+
+statement ok
+CREATE SEQUENCE other_schema.seq
+
 # List sequences with SHOW
 
-query T
+query TT rowsort
 SHOW SEQUENCES
 ----
-foo
-high_minvalue_test
-ignored_options_test
-lastval_test
-lastval_test_2
-show_create_test
+public        foo
+public        high_minvalue_test
+public        ignored_options_test
+public        lastval_test
+public        lastval_test_2
+other_schema  seq
+public        show_create_test
 
 statement ok
 CREATE DATABASE seqdb; USE seqdb; CREATE SEQUENCE otherseq; USE test
 
-query T
+query TT rowsort
 SHOW SEQUENCES FROM seqdb
 ----
-otherseq
+public  otherseq
 
 # You can select from a sequence to get its value.
 
@@ -212,6 +240,19 @@ SELECT currval('foo')
 ----
 2
 
+let $foo_id
+SELECT 'foo'::regclass::int
+
+query I
+SELECT nextval($foo_id::regclass)
+----
+3
+
+query I
+SELECT currval($foo_id::regclass)
+----
+3
+
 query T
 SELECT pg_sequence_parameters('foo'::regclass::oid)
 ----
@@ -252,6 +293,14 @@ SELECT nextval('baz')
 ----
 7
 
+let $baz_id
+SELECT 'baz'::regclass::int
+
+query I
+SELECT nextval($baz_id::regclass)
+----
+12
+
 query T
 SELECT pg_sequence_parameters('baz'::regclass::oid)
 ----
@@ -271,6 +320,14 @@ query I
 SELECT nextval('down_test')
 ----
 -6
+
+let $down_test_id
+SELECT 'down_test'::regclass::int
+
+query I
+SELECT nextval($down_test_id::regclass)
+----
+-7
 
 query T
 SELECT pg_sequence_parameters('down_test'::regclass::oid)
@@ -387,6 +444,25 @@ SELECT lastval()
 ----
 11
 
+let $setval_test_id
+SELECT 'setval_test'::regclass::int
+
+query I
+SELECT setval($setval_test_id::regclass, 20)
+----
+20
+
+# Calling setval doesn't affect currval or lastval; they return the last value obtained with nextval.
+query I
+SELECT currval($setval_test_id::regclass)
+----
+11
+
+query I
+SELECT nextval($setval_test_id::regclass)
+----
+21
+
 # setval doesn't let you set values outside the bounds.
 
 statement ok
@@ -443,6 +519,39 @@ SELECT nextval('setval_is_called_test')
 ----
 22
 
+let $setval_is_called_test_id
+SELECT 'setval_is_called_test'::regclass::int
+
+query I
+SELECT setval($setval_is_called_test_id::regclass, 30, false)
+----
+30
+
+query I
+SELECT nextval($setval_is_called_test_id::regclass)
+----
+30
+
+query I
+SELECT nextval($setval_is_called_test_id::regclass)
+----
+31
+
+query I
+SELECT setval($setval_is_called_test_id::regclass, 30, true)
+----
+30
+
+query I
+SELECT nextval($setval_is_called_test_id::regclass)
+----
+31
+
+query I
+SELECT nextval($setval_is_called_test_id::regclass)
+----
+32
+
 # You can use setval to reset to minvalue.
 
 statement ok
@@ -495,6 +604,12 @@ SELECT nextval('limit_test')
 
 statement error pgcode 2200H pq: nextval\(\): reached maximum value of sequence "limit_test" \(10\)
 SELECT nextval('limit_test')
+
+let $limit_test_id
+SELECT 'limit_test'::regclass::int
+
+statement error pgcode 2200H pq: nextval\(\): reached maximum value of sequence "limit_test" \(10\)
+SELECT nextval($limit_test_id::regclass)
 
 query I
 SELECT currval('limit_test')
@@ -853,7 +968,7 @@ CREATE SEQUENCE sv VIRTUAL
 query T
 SELECT create_statement FROM [SHOW CREATE SEQUENCE sv]
 ----
-CREATE SEQUENCE sv MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1 VIRTUAL
+CREATE SEQUENCE public.sv MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1 VIRTUAL
 
 statement ok
 CREATE TABLE svals(x INT)
@@ -890,7 +1005,7 @@ DROP SEQUENCE sv
 subtest generator_timeout
 
 statement ok
-SET statement_timeout = 1
+SET statement_timeout = 10
 
 statement error pq: query execution canceled due to statement timeout
 select * from generate_series(1,10000000) where generate_series = 0;
@@ -1071,6 +1186,17 @@ DROP TABLE b;
 
 statement ok
 DROP TABLE a;
+
+# A dependency on a sequence should be added if the sequence is used in a
+# currval call. (Regression #50033)
+
+statement ok
+CREATE SEQUENCE currval_dep_test;
+CREATE TABLE c(a INT DEFAULT(currval('currval_dep_test')))
+
+statement error pq: cannot drop sequence currval_dep_test because other objects depend on it
+DROP SEQUENCE currval_dep_test
+
 subtest regression_50649
 
 statement ok
@@ -1218,3 +1344,452 @@ ALTER TABLE t_50711 DROP COLUMN a
 
 statement ok
 ALTER TABLE t_50711 DROP COLUMN b
+
+# Verify that we don't allow OWNED BY to refer to other databases (depending on
+# the cluster setting).
+statement ok
+SET CLUSTER SETTING sql.cross_db_sequence_owners.enabled = FALSE
+
+statement ok
+CREATE DATABASE db1
+
+statement ok
+CREATE DATABASE db2
+
+statement ok
+CREATE TABLE db1.t (a INT)
+
+statement ok
+CREATE SEQUENCE db1.seq OWNED BY db1.t.a
+
+statement error OWNED BY cannot refer to other databases
+CREATE SEQUENCE db2.seq OWNED BY db1.t.a
+
+statement ok
+CREATE TABLE db2.t (a INT)
+
+statement ok
+CREATE SEQUENCE db2.seq OWNED BY db2.t.a
+
+statement error OWNED BY cannot refer to other databases
+ALTER SEQUENCE db2.seq OWNED BY db1.t.a
+
+statement ok
+SET CLUSTER SETTING sql.cross_db_sequence_owners.enabled = TRUE
+
+statement ok
+ALTER SEQUENCE db2.seq OWNED BY db1.t.a
+
+statement ok
+CREATE SEQUENCE db2.seq2 OWNED BY db1.t.a
+
+statement error invalid OWNED BY option
+ALTER SEQUENCE db2.seq2 OWNED BY doesntexist
+
+# Test that passing a descriptor other than a sequence
+# returns an appropriate error.
+subtest invalid_ids
+
+statement ok
+CREATE TABLE t (i SERIAL PRIMARY KEY)
+
+let $t_id
+SELECT 't'::regclass::int
+
+statement error pgcode 42809 "test.public.t" is not a sequence
+SELECT nextval($t_id::regclass)
+
+statement error pgcode 42809 "test.public.t" is not a sequence
+SELECT setval($t_id::regclass, 30, false)
+
+statement error pgcode 42809 "test.public.t" is not a sequence
+SELECT currval($t_id::regclass)
+
+statement ok
+CREATE VIEW v AS (SELECT i FROM t)
+
+let $v_id
+SELECT 'v'::regclass::int
+
+statement error pgcode 42809 "test.public.v" is not a sequence
+SELECT nextval($v_id::regclass)
+
+statement error pgcode 42809 "test.public.v" is not a sequence
+SELECT setval($v_id::regclass, 30, false)
+
+statement error pgcode 42809 "test.public.v" is not a sequence
+SELECT currval($v_id::regclass)
+
+statement ok
+CREATE SCHEMA sc
+
+let $sc_id
+SELECT id FROM system.namespace WHERE name='sc'
+
+statement error does not exist
+SELECT nextval($sc_id::regclass)
+
+statement error does not exist
+SELECT setval($sc_id::regclass, 30, false)
+
+statement error does not exist
+SELECT currval($sc_id::regclass)
+
+statement ok
+CREATE DATABASE db
+
+let $db_id
+SELECT id FROM system.namespace WHERE name='db'
+
+statement error does not exist
+SELECT nextval($db_id::regclass)
+
+statement error does not exist
+SELECT setval($db_id::regclass, 30, false)
+
+statement error does not exist
+SELECT currval($db_id::regclass)
+
+statement ok
+CREATE TYPE e AS ENUM ('foo', 'bar')
+
+let $e_id
+SELECT id FROM system.namespace WHERE name='e'
+
+statement error does not exist
+SELECT nextval($e_id::regclass)
+
+statement error does not exist
+SELECT setval($e_id::regclass, 30, false)
+
+statement error does not exist
+SELECT currval($e_id::regclass)
+
+statement error does not exist
+SELECT nextval(12345::regclass) # Bogus ID
+
+statement error does not exist
+SELECT setval(12345::regclass, 30, false) # Bogus ID
+
+statement error does not exist
+SELECT currval(12345::regclass) # Bogus ID
+
+subtest cached_sequences
+
+statement error pgcode 22023 CACHE \(-1\) must be greater than zero
+CREATE SEQUENCE cache_test CACHE -1
+
+statement error pgcode 22023 CACHE \(0\) must be greater than zero
+CREATE SEQUENCE cache_test CACHE 0
+
+statement ok
+CREATE SEQUENCE cache_test CACHE 10 INCREMENT 1
+
+# Verify cache invalidation with schema changes.
+
+# 10 values (1,2,...,10) are cached, and the underlying sequence is incremented to 10.
+query I
+SELECT nextval('cache_test')
+----
+1
+
+# sanity checks
+query I
+SELECT lastval()
+----
+1
+
+query I
+SELECT currval('cache_test')
+----
+1
+
+query I
+SELECT last_value FROM cache_test
+----
+10
+
+statement ok
+BEGIN
+
+statement ok
+ALTER SEQUENCE cache_test INCREMENT 5
+
+# The cache is invalidated due to the above schema change, and 10 new values (15,20,...,60) are cached.
+query I
+SELECT nextval('cache_test')
+----
+15
+
+# Rollback the schema change to use the old INCREMENT amount.
+statement ok
+ABORT
+
+# The underlying sequence was still incremented despite the txn being aborted.
+query I
+SELECT last_value FROM cache_test
+----
+60
+
+# 10 new values (61,62,...,70) are cached.
+query I
+SELECT nextval('cache_test')
+----
+61
+
+query I
+SELECT last_value FROM cache_test
+----
+70
+
+statement ok
+DROP SEQUENCE cache_test
+
+subtest cached_sequences_with_bounds_increasing
+
+statement ok
+CREATE SEQUENCE cached_upper_bound_test MAXVALUE 4 START WITH 2 CACHE 5 INCREMENT BY 2;
+
+# Without this MAXVALUE CONSTRAINT, the values 2,4,6,8,10 would be cached
+# and the underlying sequence would be set to 10. Given the constraint, only
+# 2 and 4 are cached, but the underlying sequence is still set to 10.
+
+query I
+SELECT nextval('cached_upper_bound_test');
+----
+2
+
+query I
+SELECT nextval('cached_upper_bound_test');
+----
+4
+
+query I
+SELECT last_value FROM cached_upper_bound_test;
+----
+10
+
+# nextval() should return errors while still incrementing the underlying sequence
+# by 10 each time (cache size of 5 * increment of 2). Despite the underlying sequence changing,
+# currval() and lastval() should not change.
+
+statement error pgcode 2200H pq: nextval\(\): reached maximum value of sequence "cached_upper_bound_test" \(4\)
+SELECT nextval('cached_upper_bound_test');
+
+statement error pgcode 2200H pq: nextval\(\): reached maximum value of sequence "cached_upper_bound_test" \(4\)
+SELECT nextval('cached_upper_bound_test');
+
+query I
+SELECT lastval();
+----
+4
+
+query I
+SELECT currval('cached_upper_bound_test');
+----
+4
+
+query I
+SELECT last_value FROM cached_upper_bound_test;
+----
+30
+
+# Performing a schema change on the sequence to increase the bounds should reset the underlying
+# sequence to its original MAXVALUE.
+
+statement ok
+ALTER SEQUENCE cached_upper_bound_test MAXVALUE 100;
+
+query I
+SELECT last_value FROM cached_upper_bound_test;
+----
+4
+
+# Calling nextval() should cache the values 6,8,10,12,14 while incrementing
+# the underlying sequence to 14.
+
+query I
+SELECT nextval('cached_upper_bound_test');
+----
+6
+
+query I
+SELECT last_value FROM cached_upper_bound_test;
+----
+14
+
+query I
+SELECT lastval();
+----
+6
+
+query I
+SELECT currval('cached_upper_bound_test');
+----
+6
+
+statement ok
+drop sequence cached_upper_bound_test;
+
+# This test is the same as cached_sequences_with_bounds_increasing, except it uses negative values.
+subtest cached_sequences_with_bounds_decreasing
+
+statement ok
+CREATE SEQUENCE cached_lower_bound_test MINVALUE -4 START WITH -2 CACHE 5 INCREMENT BY -2;
+
+query I
+SELECT nextval('cached_lower_bound_test');
+----
+-2
+
+
+query I
+SELECT nextval('cached_lower_bound_test');
+----
+-4
+
+query I
+SELECT last_value FROM cached_lower_bound_test;
+----
+-10
+
+statement error pgcode 2200H pq: nextval\(\): reached minimum value of sequence "cached_lower_bound_test" \(-4\)
+SELECT nextval('cached_lower_bound_test');
+
+statement error pgcode 2200H pq: nextval\(\): reached minimum value of sequence "cached_lower_bound_test" \(-4\)
+SELECT nextval('cached_lower_bound_test');
+
+query I
+SELECT last_value FROM cached_lower_bound_test;
+----
+-30
+
+statement ok
+ALTER SEQUENCE cached_lower_bound_test MINVALUE -100;
+
+query I
+SELECT last_value FROM cached_lower_bound_test;
+----
+-4
+
+query I
+SELECT nextval('cached_lower_bound_test');
+----
+-6
+
+query I
+SELECT last_value FROM cached_lower_bound_test;
+----
+-14
+
+statement ok
+DROP SEQUENCE cached_lower_bound_test;
+
+# This test is the same as cached_sequences_with_bounds_decreasing, except it uses both positive and negative values.
+subtest cached_sequences_with_bounds_middle
+
+statement ok
+CREATE SEQUENCE cached_lower_bound_test_2 MINVALUE -2 MAXVALUE 2 START WITH 2 CACHE 5 INCREMENT BY -2;
+
+query I
+SELECT nextval('cached_lower_bound_test_2');
+----
+2
+
+
+query I
+SELECT nextval('cached_lower_bound_test_2');
+----
+0
+
+query I
+SELECT nextval('cached_lower_bound_test_2');
+----
+-2
+
+query I
+SELECT last_value FROM cached_lower_bound_test_2;
+----
+-6
+
+statement error pgcode 2200H pq: nextval\(\): reached minimum value of sequence "cached_lower_bound_test_2" \(-2\)
+SELECT nextval('cached_lower_bound_test_2');
+
+statement error pgcode 2200H pq: nextval\(\): reached minimum value of sequence "cached_lower_bound_test_2" \(-2\)
+SELECT nextval('cached_lower_bound_test_2');
+
+query I
+SELECT last_value FROM cached_lower_bound_test_2;
+----
+-26
+
+statement ok
+ALTER SEQUENCE cached_lower_bound_test_2 MINVALUE -100;
+
+query I
+SELECT last_value FROM cached_lower_bound_test_2;
+----
+-2
+
+query I
+SELECT nextval('cached_lower_bound_test_2');
+----
+-4
+
+query I
+SELECT last_value FROM cached_lower_bound_test_2;
+----
+-12
+
+statement ok
+DROP SEQUENCE cached_lower_bound_test_2;
+
+# Unit test for #60737
+
+statement ok
+CREATE SEQUENCE s1 MINVALUE -4 START WITH -2 CACHE 5 INCREMENT BY -2;
+
+statement ok
+CREATE TABLE s2 (A int)
+
+# Case 1: Both s1's are sequences and the old one is being dropped.
+statement ok
+BEGIN
+
+statement ok
+DROP SEQUENCE s1
+
+statement error pgcode 55000 sequence "s1" is being dropped, try again later
+CREATE SEQUENCE IF NOT EXISTS s1 MINVALUE -4 START WITH -2 CACHE 5 INCREMENT BY -2;
+
+statement ok
+END
+
+# Case 2: Both s2's are different types and the old one is being dropped.
+statement ok
+BEGIN
+
+statement ok
+DROP TABLE s2
+
+statement error pgcode 42809 "s2" is not a sequence
+CREATE SEQUENCE IF NOT EXISTS s2 MINVALUE -4 START WITH -2 CACHE 5 INCREMENT BY -2;
+
+statement ok
+END
+
+# Case 3: Both s2's are a different type
+statement ok
+BEGIN
+
+statement error pgcode 42809 "s2" is not a sequence
+CREATE SEQUENCE IF NOT EXISTS s2 MINVALUE -4 START WITH -2 CACHE 5 INCREMENT BY -2;
+
+statement ok
+END
+
+statement ok
+DROP SEQUENCE s1
+
+statement ok
+DROP TABLE s2

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -1,7 +1,7 @@
 statement ok
 SET DATABASE = ""
 
-statement error no database specified
+statement error no database or schema specified
 CREATE TABLE a (id INT PRIMARY KEY)
 
 statement error invalid table name: test.""
@@ -40,11 +40,11 @@ CREATE TABLE IF NOT EXISTS a (id INT PRIMARY KEY)
 statement ok
 COMMENT ON TABLE a IS 'a_comment'
 
-query T colnames
+query TTTTIT colnames
 SHOW TABLES FROM test
 ----
-table_name
-a
+schema_name  table_name  type   owner  estimated_row_count  locality
+public       a           table  root   0                    NULL
 
 statement ok
 CREATE TABLE b (id INT PRIMARY KEY)
@@ -67,31 +67,31 @@ query TTBITTBB colnames
 SHOW INDEXES FROM c
 ----
 table_name  index_name     non_unique  seq_in_index  column_name  direction  storing  implicit
-c           primary        false       1             id           ASC        false    false
+c           c_bar_key      false       1             bar          ASC        false    false
+c           c_bar_key      false       2             id           ASC        false    true
+c           c_foo_bar_idx  true        1             foo          ASC        false    false
+c           c_foo_bar_idx  true        2             bar          DESC       false    false
+c           c_foo_bar_idx  true        3             id           ASC        false    true
 c           c_foo_idx      true        1             foo          ASC        false    false
 c           c_foo_idx      true        2             id           ASC        false    true
 c           c_foo_idx1     true        1             foo          ASC        false    false
 c           c_foo_idx1     true        2             id           ASC        false    true
-c           c_foo_bar_idx  true        1             foo          ASC        false    false
-c           c_foo_bar_idx  true        2             bar          DESC       false    false
-c           c_foo_bar_idx  true        3             id           ASC        false    true
-c           c_bar_key      false       1             bar          ASC        false    false
-c           c_bar_key      false       2             id           ASC        false    true
+c           primary        false       1             id           ASC        false    false
 
 query TTBITTBBT colnames
 SHOW INDEXES FROM c WITH COMMENT
 ----
 table_name  index_name     non_unique  seq_in_index  column_name  direction  storing  implicit  comment
-c           primary        false       1             id           ASC        false    false     NULL
+c           c_bar_key      false       1             bar          ASC        false    false     NULL
+c           c_bar_key      false       2             id           ASC        false    true      NULL
+c           c_foo_bar_idx  true        1             foo          ASC        false    false     NULL
+c           c_foo_bar_idx  true        2             bar          DESC       false    false     NULL
+c           c_foo_bar_idx  true        3             id           ASC        false    true      NULL
 c           c_foo_idx      true        1             foo          ASC        false    false     index_comment
 c           c_foo_idx      true        2             id           ASC        false    true      index_comment
 c           c_foo_idx1     true        1             foo          ASC        false    false     NULL
 c           c_foo_idx1     true        2             id           ASC        false    true      NULL
-c           c_foo_bar_idx  true        1             foo          ASC        false    false     NULL
-c           c_foo_bar_idx  true        2             bar          DESC       false    false     NULL
-c           c_foo_bar_idx  true        3             id           ASC        false    true      NULL
-c           c_bar_key      false       1             bar          ASC        false    false     NULL
-c           c_bar_key      false       2             id           ASC        false    true      NULL
+c           primary        false       1             id           ASC        false    false     NULL
 
 # primary keys can never be null
 
@@ -133,15 +133,16 @@ a            INT8       false        NULL            ·                      {pr
 b            INT8       false        NULL            ·                      {primary}  false
 c            INT8       false        NULL            ·                      {primary}  false
 
-query TT
+query TTTTITT colnames
 SHOW TABLES FROM test WITH COMMENT
 ----
-a  a_comment
-b  ·
-c  ·
-d  ·
-e  ·
-f  ·
+schema_name  table_name  type   owner  estimated_row_count  locality  comment
+public       a           table  root   0                    NULL      a_comment
+public       b           table  root   0                    NULL      ·
+public       c           table  root   0                    NULL      ·
+public       d           table  root   0                    NULL      ·
+public       e           table  root   0                    NULL      ·
+public       f           table  root   0                    NULL      ·
 
 statement ok
 SET DATABASE = ""
@@ -179,8 +180,8 @@ query TTBTTTB colnames
 SHOW COLUMNS FROM test.users
 ----
 column_name  data_type     is_nullable  column_default  generation_expression  indices            is_hidden
-id           INT8          false        NULL            ·                      {primary,foo,bar}  false
-name         VARCHAR       false        NULL            ·                      {foo,bar}          false
+id           INT8          false        NULL            ·                      {bar,foo,primary}  false
+name         VARCHAR       false        NULL            ·                      {bar,foo}          false
 title        VARCHAR       true         NULL            ·                      {}                 false
 nickname     STRING        true         NULL            ·                      {}                 false
 username     STRING(10)    true         NULL            ·                      {}                 false
@@ -190,11 +191,11 @@ query TTBITTBB colnames
 SHOW INDEXES FROM test.users
 ----
 table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-users       primary     false       1             id           ASC        false    false
-users       foo         true        1             name         ASC        false    false
-users       foo         true        2             id           ASC        false    true
 users       bar         false       1             id           ASC        false    false
 users       bar         false       2             name         ASC        false    false
+users       foo         true        1             name         ASC        false    false
+users       foo         true        2             id           ASC        false    true
+users       primary     false       1             id           ASC        false    false
 
 statement error precision for type float must be at least 1 bit
 CREATE TABLE test.precision (x FLOAT(0))
@@ -208,7 +209,7 @@ CREATE TABLE test.precision (x DECIMAL(2, 4))
 query TT
 SHOW CREATE TABLE test.users
 ----
-test.public.users  CREATE TABLE users (
+test.public.users  CREATE TABLE public.users (
                    id INT8 NOT NULL,
                    name VARCHAR NOT NULL,
                    title VARCHAR NULL,
@@ -223,7 +224,7 @@ test.public.users  CREATE TABLE users (
                    FAMILY fam_2_nickname (nickname),
                    FAMILY fam_3_username_email (username, email),
                    CONSTRAINT check_nickname_name CHECK (length(nickname) < length(name)),
-                   CONSTRAINT check_nickname CHECK (length(nickname) < 10)
+                   CONSTRAINT check_nickname CHECK (length(nickname) < 10:::INT8)
 )
 
 statement ok
@@ -264,7 +265,7 @@ CREATE TABLE test.named_constraints (
 query TT
 SHOW CREATE TABLE test.named_constraints
 ----
-test.public.named_constraints  CREATE TABLE named_constraints (
+test.public.named_constraints  CREATE TABLE public.named_constraints (
                                id INT8 NOT NULL,
                                name VARCHAR NOT NULL,
                                title VARCHAR NULL DEFAULT 'VP of Something':::STRING,
@@ -281,7 +282,7 @@ test.public.named_constraints  CREATE TABLE named_constraints (
                                FAMILY fam_2_nickname (nickname),
                                FAMILY fam_3_username_email (username, email),
                                CONSTRAINT ck2 CHECK (length(nickname) < length(name)),
-                               CONSTRAINT ck1 CHECK (length(nickname) < 10)
+                               CONSTRAINT ck1 CHECK (length(nickname) < 10:::INT8)
 )
 
 query TTTTB colnames
@@ -478,8 +479,10 @@ CREATE TABLE test.null_default (
 query TT
 SHOW CREATE TABLE test.null_default
 ----
-test.public.null_default  CREATE TABLE null_default (
+test.public.null_default  CREATE TABLE public.null_default (
                           ts TIMESTAMP NULL,
+                          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                          CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
                           FAMILY "primary" (ts, rowid)
 )
 
@@ -497,3 +500,384 @@ query I
 SELECT a.public.c.d FROM a.public.c
 ----
 1
+
+statement ok
+CREATE TABLE t0 (a INT)
+
+statement ok
+GRANT ALL ON t0 to testuser
+
+statement ok
+CREATE DATABASE rowtest
+
+statement ok
+GRANT ALL ON DATABASE rowtest TO testuser
+
+user testuser
+
+statement ok
+SET DATABASE = rowtest
+
+statement ok
+CREATE TABLE t1 (a INT)
+
+statement ok
+INSERT INTO t1 SELECT a FROM generate_series(1, 1024) AS a(a)
+
+# only tables from current database
+query TTTTIT
+SHOW TABLES
+----
+public  t1  table  testuser  0  NULL
+
+# see only virtual tables (estimated_row_count is NULL)
+# and tables testuser has access to (estimated_row_count >= 0)
+query TI rowsort
+select table_name, estimated_row_count from crdb_internal.table_row_statistics;
+----
+backward_dependencies                      NULL
+builtin_functions                          NULL
+cluster_contention_events                  NULL
+cluster_database_privileges                NULL
+cluster_queries                            NULL
+cluster_sessions                           NULL
+cluster_settings                           NULL
+cluster_transactions                       NULL
+create_statements                          NULL
+create_type_statements                     NULL
+databases                                  NULL
+feature_usage                              NULL
+forward_dependencies                       NULL
+gossip_alerts                              NULL
+gossip_liveness                            NULL
+gossip_network                             NULL
+gossip_nodes                               NULL
+index_columns                              NULL
+invalid_objects                            NULL
+jobs                                       NULL
+kv_node_status                             NULL
+kv_store_status                            NULL
+leases                                     NULL
+node_build_info                            NULL
+node_contention_events                     NULL
+node_inflight_trace_spans                  NULL
+node_metrics                               NULL
+node_queries                               NULL
+node_runtime_info                          NULL
+node_sessions                              NULL
+node_statement_statistics                  NULL
+node_transaction_statistics                NULL
+node_transactions                          NULL
+node_txn_stats                             NULL
+partitions                                 NULL
+predefined_comments                        NULL
+ranges                                     NULL
+ranges_no_leases                           NULL
+schema_changes                             NULL
+session_trace                              NULL
+session_variables                          NULL
+table_columns                              NULL
+table_indexes                              NULL
+table_row_statistics                       NULL
+tables                                     NULL
+zones                                      NULL
+administrable_role_authorizations          NULL
+applicable_roles                           NULL
+character_sets                             NULL
+check_constraints                          NULL
+collation_character_set_applicability      NULL
+collations                                 NULL
+column_privileges                          NULL
+column_udt_usage                           NULL
+columns                                    NULL
+constraint_column_usage                    NULL
+enabled_roles                              NULL
+key_column_usage                           NULL
+parameters                                 NULL
+referential_constraints                    NULL
+role_table_grants                          NULL
+routines                                   NULL
+schema_privileges                          NULL
+schemata                                   NULL
+sequences                                  NULL
+session_variables                          NULL
+statistics                                 NULL
+table_constraints                          NULL
+table_privileges                           NULL
+tables                                     NULL
+type_privileges                            NULL
+user_privileges                            NULL
+views                                      NULL
+pg_aggregate                               NULL
+pg_aggregate_fnoid_index                   NULL
+pg_am                                      NULL
+pg_am_oid_index                            NULL
+pg_amop                                    NULL
+pg_amop_fam_strat_index                    NULL
+pg_amop_oid_index                          NULL
+pg_amop_opr_fam_index                      NULL
+pg_amproc                                  NULL
+pg_amproc_fam_proc_index                   NULL
+pg_amproc_oid_index                        NULL
+pg_attrdef                                 NULL
+pg_attrdef_adrelid_adnum_index             NULL
+pg_attrdef_oid_index                       NULL
+pg_attribute                               NULL
+pg_attribute_relid_attnum_index            NULL
+pg_auth_members                            NULL
+pg_auth_members_member_role_index          NULL
+pg_auth_members_role_member_index          NULL
+pg_authid                                  NULL
+pg_authid_oid_index                        NULL
+pg_available_extension_versions            NULL
+pg_available_extensions                    NULL
+pg_cast                                    NULL
+pg_cast_oid_index                          NULL
+pg_cast_source_target_index                NULL
+pg_class                                   NULL
+pg_class_oid_index                         NULL
+pg_class_tblspc_relfilenode_index          NULL
+pg_collation                               NULL
+pg_collation_oid_index                     NULL
+pg_config                                  NULL
+pg_constraint                              NULL
+pg_constraint_conparentid_index            NULL
+pg_constraint_contypid_index               NULL
+pg_constraint_oid_index                    NULL
+pg_conversion                              NULL
+pg_conversion_default_index                NULL
+pg_conversion_oid_index                    NULL
+pg_cursors                                 NULL
+pg_database                                NULL
+pg_database_oid_index                      NULL
+pg_db_role_setting                         NULL
+pg_db_role_setting_databaseid_rol_index    NULL
+pg_default_acl                             NULL
+pg_default_acl_oid_index                   NULL
+pg_default_acl_role_nsp_obj_index          NULL
+pg_depend                                  NULL
+pg_depend_depender_index                   NULL
+pg_depend_reference_index                  NULL
+pg_description                             NULL
+pg_description_o_c_o_index                 NULL
+pg_enum                                    NULL
+pg_enum_oid_index                          NULL
+pg_enum_typid_sortorder_index              NULL
+pg_event_trigger                           NULL
+pg_event_trigger_oid_index                 NULL
+pg_extension                               NULL
+pg_extension_oid_index                     NULL
+pg_file_settings                           NULL
+pg_foreign_data_wrapper                    NULL
+pg_foreign_data_wrapper_oid_index          NULL
+pg_foreign_server                          NULL
+pg_foreign_server_oid_index                NULL
+pg_foreign_table                           NULL
+pg_foreign_table_relid_index               NULL
+pg_group                                   NULL
+pg_hba_file_rules                          NULL
+pg_index                                   NULL
+pg_index_indexrelid_index                  NULL
+pg_index_indrelid_index                    NULL
+pg_indexes                                 NULL
+pg_inherits                                NULL
+pg_inherits_parent_index                   NULL
+pg_inherits_relid_seqno_index              NULL
+pg_init_privs_o_c_o_index                  NULL
+pg_language                                NULL
+pg_language_oid_index                      NULL
+pg_largeobject                             NULL
+pg_largeobject_loid_pn_index               NULL
+pg_largeobject_metadata_oid_index          NULL
+pg_locks                                   NULL
+pg_matviews                                NULL
+pg_namespace                               NULL
+pg_namespace_oid_index                     NULL
+pg_opclass                                 NULL
+pg_opclass_oid_index                       NULL
+pg_operator                                NULL
+pg_operator_oid_index                      NULL
+pg_opfamily                                NULL
+pg_opfamily_oid_index                      NULL
+pg_partitioned_table_partrelid_index       NULL
+pg_policies                                NULL
+pg_policy_oid_index                        NULL
+pg_prepared_statements                     NULL
+pg_prepared_xacts                          NULL
+pg_proc                                    NULL
+pg_proc_oid_index                          NULL
+pg_publication                             NULL
+pg_publication_oid_index                   NULL
+pg_publication_rel                         NULL
+pg_publication_rel_oid_index               NULL
+pg_publication_rel_prrelid_prpubid_index   NULL
+pg_publication_tables                      NULL
+pg_range                                   NULL
+pg_range_rngtypid_index                    NULL
+pg_replication_origin                      NULL
+pg_replication_origin_roiident_index       NULL
+pg_replication_origin_roname_index         NULL
+pg_rewrite                                 NULL
+pg_rewrite_oid_index                       NULL
+pg_roles                                   NULL
+pg_rules                                   NULL
+pg_seclabel                                NULL
+pg_seclabel_object_index                   NULL
+pg_seclabels                               NULL
+pg_sequence                                NULL
+pg_sequence_seqrelid_index                 NULL
+pg_settings                                NULL
+pg_shadow                                  NULL
+pg_shdepend                                NULL
+pg_shdepend_depender_index                 NULL
+pg_shdepend_reference_index                NULL
+pg_shdescription                           NULL
+pg_shdescription_o_c_index                 NULL
+pg_shmem_allocations                       NULL
+pg_shseclabel                              NULL
+pg_shseclabel_object_index                 NULL
+pg_stat_activity                           NULL
+pg_stat_all_indexes                        NULL
+pg_stat_all_tables                         NULL
+pg_stat_archiver                           NULL
+pg_stat_bgwriter                           NULL
+pg_stat_database                           NULL
+pg_stat_database_conflicts                 NULL
+pg_stat_gssapi                             NULL
+pg_stat_progress_analyze                   NULL
+pg_stat_progress_basebackup                NULL
+pg_stat_progress_cluster                   NULL
+pg_stat_progress_create_index              NULL
+pg_stat_progress_vacuum                    NULL
+pg_stat_slru                               NULL
+pg_stat_ssl                                NULL
+pg_stat_sys_indexes                        NULL
+pg_stat_sys_tables                         NULL
+pg_stat_user_functions                     NULL
+pg_stat_user_indexes                       NULL
+pg_stat_user_tables                        NULL
+pg_stat_xact_all_tables                    NULL
+pg_stat_xact_sys_tables                    NULL
+pg_stat_xact_user_functions                NULL
+pg_stat_xact_user_tables                   NULL
+pg_statio_all_indexes                      NULL
+pg_statio_all_sequences                    NULL
+pg_statio_all_tables                       NULL
+pg_statio_sys_indexes                      NULL
+pg_statio_sys_sequences                    NULL
+pg_statio_sys_tables                       NULL
+pg_statio_user_indexes                     NULL
+pg_statio_user_sequences                   NULL
+pg_statio_user_tables                      NULL
+pg_statistic_ext                           NULL
+pg_statistic_ext_data_stxoid_index         NULL
+pg_statistic_ext_oid_index                 NULL
+pg_statistic_ext_relid_index               NULL
+pg_statistic_relid_att_inh_index           NULL
+pg_subscription                            NULL
+pg_subscription_oid_index                  NULL
+pg_subscription_rel_srrelid_srsubid_index  NULL
+pg_tables                                  NULL
+pg_tablespace                              NULL
+pg_tablespace_oid_index                    NULL
+pg_timezone_abbrevs                        NULL
+pg_timezone_names                          NULL
+pg_transform                               NULL
+pg_transform_oid_index                     NULL
+pg_transform_type_lang_index               NULL
+pg_trigger                                 NULL
+pg_trigger_oid_index                       NULL
+pg_trigger_tgconstraint_index              NULL
+pg_ts_config                               NULL
+pg_ts_config_map                           NULL
+pg_ts_config_map_index                     NULL
+pg_ts_config_oid_index                     NULL
+pg_ts_dict                                 NULL
+pg_ts_dict_oid_index                       NULL
+pg_ts_parser                               NULL
+pg_ts_parser_oid_index                     NULL
+pg_ts_template                             NULL
+pg_ts_template_oid_index                   NULL
+pg_type                                    NULL
+pg_type_oid_index                          NULL
+pg_user                                    NULL
+pg_user_mapping                            NULL
+pg_user_mapping_oid_index                  NULL
+pg_user_mapping_user_server_index          NULL
+pg_user_mappings                           NULL
+pg_views                                   NULL
+geography_columns                          NULL
+geometry_columns                           NULL
+spatial_ref_sys                            NULL
+t1                                         0
+
+statement ok
+ANALYZE t1
+
+query I
+SELECT estimated_row_count FROM [SHOW TABLES] where table_name = 't1'
+----
+1024
+
+statement ok
+DELETE FROM rowtest.t1 WHERE a > 1000;
+
+statement ok
+ANALYZE rowtest.t1
+
+query I
+SELECT estimated_row_count FROM [SHOW TABLES from rowtest] where table_name = 't1'
+----
+1000
+
+user root
+
+# Unit test for #60737
+
+statement ok
+CREATE TABLE t1  (a INT PRIMARY KEY, b INT)
+
+statement ok
+CREATE TYPE t2 as enum('foo')
+
+# Case 1: Both t1's are tables and the old one is being dropped.
+statement ok
+BEGIN
+
+statement ok
+DROP TABLE t1
+
+statement error pgcode 55000 table "t1" is being dropped, try again later
+CREATE TABLE IF NOT EXISTS t1 (a INT PRIMARY KEY, b INT)
+
+statement ok
+END
+
+# Case 2: Both t2's are different types and the old one is being dropped.
+statement ok
+BEGIN
+
+statement ok
+DROP TYPE t2
+
+statement error pgcode 42809 "t2" is not a table
+CREATE TABLE IF NOT EXISTS t2 (a INT PRIMARY KEY, b INT)
+
+statement ok
+END
+
+# Case 3: Both s2's are a different type
+statement ok
+BEGIN
+
+statement error pgcode 42809 "t2" is not a table
+CREATE TABLE IF NOT EXISTS t2 (a INT PRIMARY KEY, b INT)
+
+statement ok
+END
+
+statement ok
+DROP table t1
+
+statement ok
+DROP TYPE t2

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -1,3 +1,6 @@
+statement ok
+SET CLUSTER SETTING sql.cross_db_views.enabled = TRUE
+
 # NOTE: Keep this table at the beginning of the file to ensure that its numeric
 #       reference is 53 (the numeric reference of the first table). If the
 #       numbering scheme in cockroach changes, this test will break.
@@ -183,27 +186,27 @@ x y
 query TT
 SHOW CREATE VIEW v1
 ----
-v1  CREATE VIEW v1 (a, b) AS SELECT a, b FROM test.public.t
+v1  CREATE VIEW public.v1 (a, b) AS SELECT a, b FROM test.public.t
 
 query TT
 SHOW CREATE VIEW v2
 ----
-v2  CREATE VIEW v2 (x, y) AS SELECT a, b FROM test.public.t
+v2  CREATE VIEW public.v2 (x, y) AS SELECT a, b FROM test.public.t
 
 query TT
 SHOW CREATE VIEW v6
 ----
-v6  CREATE VIEW v6 (x, y) AS SELECT a, b FROM test.public.v1
+v6  CREATE VIEW public.v6 (x, y) AS SELECT a, b FROM test.public.v1
 
 query TT
 SHOW CREATE VIEW v7
 ----
-v7  CREATE VIEW v7 (x, y) AS SELECT a, b FROM test.public.v1 ORDER BY a DESC LIMIT 2
+v7  CREATE VIEW public.v7 (x, y) AS SELECT a, b FROM test.public.v1 ORDER BY a DESC LIMIT 2
 
 query TT
 SHOW CREATE VIEW test2.v1
 ----
-test2.public.v1  CREATE VIEW v1 (x, y) AS SELECT x, y FROM test.public.v2
+test2.public.v1  CREATE VIEW public.v1 (x, y) AS SELECT x, y FROM test.public.v2
 
 statement ok
 GRANT SELECT ON t TO testuser
@@ -252,7 +255,7 @@ SELECT * FROM v6
 query TT
 SHOW CREATE VIEW v1
 ----
-v1  CREATE VIEW v1 (a, b) AS SELECT a, b FROM test.public.t
+v1  CREATE VIEW public.v1 (a, b) AS SELECT a, b FROM test.public.t
 
 user root
 
@@ -524,7 +527,7 @@ CREATE VIEW w AS WITH a AS (SELECT 1 AS x) SELECT x FROM a
 query T
 SELECT create_statement FROM [SHOW CREATE w]
 ----
-CREATE VIEW w (x) AS WITH a AS (SELECT 1 AS x) SELECT x FROM a
+CREATE VIEW public.w (x) AS WITH a AS (SELECT 1 AS x) SELECT x FROM a
 
 statement ok
 CREATE VIEW w2 AS WITH t AS (SELECT x FROM w) SELECT x FROM t
@@ -532,7 +535,7 @@ CREATE VIEW w2 AS WITH t AS (SELECT x FROM w) SELECT x FROM t
 query T
 SELECT create_statement FROM [SHOW CREATE w2]
 ----
-CREATE VIEW w2 (x) AS WITH t AS (SELECT x FROM test.public.w) SELECT x FROM t
+CREATE VIEW public.w2 (x) AS WITH t AS (SELECT x FROM test.public.w) SELECT x FROM t
 
 statement ok
 CREATE VIEW w3 AS (WITH t AS (SELECT x FROM w) SELECT x FROM t)
@@ -540,7 +543,7 @@ CREATE VIEW w3 AS (WITH t AS (SELECT x FROM w) SELECT x FROM t)
 query T
 SELECT create_statement FROM [SHOW CREATE w3]
 ----
-CREATE VIEW w3 (x) AS (WITH t AS (SELECT x FROM test.public.w) SELECT x FROM t)
+CREATE VIEW public.w3 (x) AS (WITH t AS (SELECT x FROM test.public.w) SELECT x FROM t)
 
 statement ok
 CREATE TABLE ab (a INT PRIMARY KEY, b INT)
@@ -584,7 +587,318 @@ CREATE VIEW v47704 AS
 query T
 SELECT create_statement FROM [ SHOW CREATE VIEW v47704 ]
 ----
-CREATE VIEW v47704 (first_value) AS SELECT first_value(a47704.foo) OVER (PARTITION BY a47704.foo ORDER BY a47704.foo) FROM test.public.a47704 JOIN test.public.b47704 ON a47704.foo = b47704.foo
+CREATE VIEW public.v47704 (first_value) AS SELECT first_value(a47704.foo) OVER (PARTITION BY a47704.foo ORDER BY a47704.foo) FROM test.public.a47704 JOIN test.public.b47704 ON a47704.foo = b47704.foo
 
 statement ok
 SELECT * FROM v47704
+
+subtest create_or_replace
+
+user root
+
+statement ok
+DROP TABLE IF EXISTS t, t2;
+CREATE TABLE t (x INT);
+INSERT INTO t VALUES (1), (2);
+CREATE TABLE t2 (x INT);
+INSERT INTO t2 VALUES (3), (4);
+
+# Test some error cases.
+
+statement error pq: \"t\" is not a view
+CREATE OR REPLACE VIEW t AS VALUES (1)
+
+statement ok
+CREATE OR REPLACE VIEW tview AS SELECT x AS x, x+1 AS x1, x+2 AS x2 FROM t
+
+# Test cases where new columns don't line up.
+
+statement error pq: cannot drop columns from view
+CREATE OR REPLACE VIEW tview AS SELECT x AS x, x+1 AS x1 FROM t
+
+statement error pq: cannot change name of view column \"x\" to \"xy\"
+CREATE OR REPLACE VIEW tview AS SELECT x AS xy, x+1 AS x1, x+2 AS x2 FROM t
+
+statement error pq: cannot change type of view column "x1" from int to string
+CREATE OR REPLACE VIEW tview AS SELECT x AS x, (x+1)::STRING AS x1, x+2 AS x2 FROM t
+
+statement ok
+CREATE OR REPLACE VIEW tview AS SELECT x AS x, x+1 AS x1, x+2 AS x2, x+3 AS x3 FROM t
+
+query IIII rowsort
+SELECT * FROM tview
+----
+1 2 3 4
+2 3 4 5
+
+# Test cases where back references get updated.
+statement ok
+CREATE OR REPLACE VIEW tview AS SELECT x AS x, x+1 AS x1, x+2 AS x2, x+3 AS x3 FROM t2
+
+query IIII rowsort
+SELECT * FROM tview
+----
+3 4 5 6
+4 5 6 7
+
+# After remaking tview, it no longer depends on t.
+statement ok
+DROP TABLE t
+
+# However, we now depend on t2.
+statement error cannot drop relation "t2" because view "tview" depends on it
+DROP TABLE t2
+
+# Test that if we add a reference to something in t2 and use it when replacing
+# the view that we now reference that object as well.
+statement ok
+CREATE INDEX i ON t2 (x);
+CREATE INDEX i2 ON t2 (x);
+CREATE OR REPLACE VIEW tview AS SELECT x AS x, x+1 AS x1, x+2 AS x2, x+3 AS x3 FROM t2@i
+
+statement error pq: cannot drop index \"i\" because view \"tview\" depends on it
+DROP INDEX t2@i
+
+# However, if we change the view, we should be able to drop i.
+statement ok
+CREATE OR REPLACE VIEW tview AS SELECT x AS x, x+1 AS x1, x+2 AS x2, x+3 AS x3 FROM t2@i2;
+DROP INDEX t2@i
+
+# ... and not i2.
+statement error pq: cannot drop index \"i2\" because view \"tview\" depends on it
+DROP INDEX t2@i2
+
+# Ensure that users can't replace views they don't have privilege to.
+statement ok
+GRANT CREATE ON DATABASE test TO testuser;
+GRANT CREATE, SELECT ON TABLE tview, t2 TO testuser
+
+user testuser
+
+statement error pq: user testuser does not have DROP privilege on relation tview
+CREATE OR REPLACE VIEW tview AS SELECT x AS x, x+1 AS x1, x+2 AS x2, x+3 AS x3 FROM t2
+
+# Give privilege now.
+user root
+
+statement ok
+GRANT DROP ON TABLE tview TO testuser
+
+user testuser
+
+statement ok
+CREATE OR REPLACE VIEW tview AS SELECT x AS x, x+1 AS x1, x+2 AS x2, x+3 AS x3 FROM t2
+
+user root
+
+# Ensure a view that contains a table that is referenced multiple times with
+# different column sets depends on the correct columns.
+# Depended on columns should not be droppable.
+
+# Only column a should be depended on in this case.
+statement ok
+DROP TABLE ab CASCADE;
+CREATE TABLE ab (a INT, b INT);
+CREATE VIEW vab (x) AS SELECT ab.a FROM ab, ab AS ab2
+
+statement ok
+ALTER TABLE ab DROP COLUMN b
+
+statement error pq: cannot drop column "a" because view "vab" depends on it
+ALTER TABLE ab DROP COLUMN a
+
+statement ok
+CREATE TABLE abc (a INT, b INT, c INT);
+CREATE VIEW vabc AS SELECT abc.a, abc2.b, abc3.c FROM abc, abc AS abc2, abc AS abc3
+
+# All three columns a,b,c should not be droppable.
+statement error pq: cannot drop column "a" because view "vabc" depends on it
+ALTER TABLE abc DROP COLUMN a
+
+statement error pq: cannot drop column "b" because view "vabc" depends on it
+ALTER TABLE abc DROP COLUMN b
+
+statement error pq: cannot drop column "c" because view "vabc" depends on it
+ALTER TABLE abc DROP COLUMN c
+
+# RegClass objects used in expressions should be added to view dependencies.
+statement ok
+CREATE TABLE toreg();
+CREATE VIEW vregclass AS SELECT 'toreg'::regclass
+
+statement error pq: cannot drop relation "toreg" because view "vregclass" depends on it
+DROP TABLE toreg;
+
+statement ok
+DROP VIEW vregclass;
+CREATE VIEW vregclass AS SELECT x FROM (SELECT CAST('toreg' AS regclass) AS x)
+
+statement error pq: cannot drop relation "toreg" because view "vregclass" depends on it
+DROP TABLE toreg;
+
+statement ok
+DROP VIEW vregclass;
+CREATE SEQUENCE s_reg;
+CREATE VIEW vregclass AS SELECT x FROM [SELECT 's_reg'::REGCLASS AS x]
+
+statement error pq: cannot drop sequence s_reg because other objects depend on it
+DROP SEQUENCE s_reg
+
+# RegClass dependencies should not be added if the RegClass expression contains
+# a variable.
+statement ok
+DROP VIEW vregclass;
+CREATE VIEW vregclass AS SELECT x::regclass FROM (SELECT 's_reg' AS x);
+DROP SEQUENCE s_reg;
+
+statement ok
+DROP VIEW vregclass;
+CREATE VIEW vregclass AS SELECT x::regclass FROM (SELECT 'does_not_exist' AS x);
+
+statement error pq: relation "does_not_exist" does not exist
+SELECT * FROM vregclass
+
+statement ok
+DROP VIEW vregclass;
+CREATE table tregclass();
+CREATE VIEW vregclass AS SELECT 1 FROM (SELECT 1) AS foo WHERE 'tregclass'::regclass = 'tregclass'::regclass;
+
+statement error pq: cannot drop relation "tregclass" because view "vregclass" depends on it
+DROP TABLE tregclass
+
+# Test that we disallow cross-database references from views, depending on the
+# cluster setting.
+subtest cross_db_views
+
+statement ok
+SET CLUSTER SETTING sql.cross_db_views.enabled = FALSE
+
+statement ok
+CREATE DATABASE db1
+
+statement ok
+CREATE DATABASE db2
+
+statement ok
+USE db1
+
+statement ok
+CREATE TABLE ab (a INT, b INT)
+
+statement ok
+CREATE VIEW v1 AS SELECT a+b FROM ab
+
+statement ok
+CREATE VIEW db1.public.v2 AS SELECT a+b FROM db1.public.ab
+
+statement error the view cannot refer to other databases
+CREATE VIEW db2.v AS SELECT a+b FROM db1.public.ab
+
+statement ok
+CREATE VIEW db2.replace AS SELECT 1
+
+statement error the view cannot refer to other databases
+CREATE OR REPLACE VIEW db2.replace AS SELECT a+b FROM db1.public.ab
+
+statement ok
+CREATE SEQUENCE db2.seq
+
+statement error the view cannot refer to other databases
+CREATE VIEW v2 AS SELECT last_value FROM db2.seq
+
+# Verify that cross-schema views are allowed.
+statement ok
+CREATE SCHEMA sc2
+
+statement ok
+CREATE VIEW db1.sc2.v AS SELECT a+b FROM db1.public.ab
+
+statement ok
+CREATE TABLE db1.sc2.cd (c INT, d INT)
+
+statement ok
+CREATE VIEW db1.public.v3 AS SELECT a+b+c+d FROM db1.public.ab, db1.sc2.cd
+
+# Verify that views involving system tables are allowed.
+
+statement ok
+CREATE VIEW sys AS SELECT id FROM system.descriptor
+
+statement ok
+CREATE VIEW sys2 AS SELECT id, a+b FROM system.descriptor, ab
+
+statement ok
+USE db2
+
+statement ok
+CREATE TABLE cd (c INT, d INT)
+
+statement error the view cannot refer to other databases
+CREATE VIEW v AS SELECT a+b+c+d FROM cd, db1.public.ab
+
+statement ok
+SET CLUSTER SETTING sql.cross_db_views.enabled = TRUE
+
+statement ok
+CREATE VIEW db2.v1 AS SELECT a+b FROM db1.public.ab
+
+statement ok
+CREATE VIEW db2.v2 AS SELECT a+b+c+d FROM cd, db1.public.ab
+
+# Unit test for #60737
+statement ok
+CREATE TABLE t (a INT PRIMARY KEY, b INT)
+
+statement ok
+INSERT INTO t VALUES (1, 99), (2, 98), (3, 97)
+
+statement ok
+CREATE VIEW v3 AS SELECT a, b FROM t
+
+statement ok
+CREATE TYPE v4 as enum('foo')
+
+# Case 1: Both v3's are views and the old one is being dropped.
+statement ok
+BEGIN
+
+statement ok
+DROP VIEW v3
+
+statement error pgcode 55000 view "v3" is being dropped, try again later
+CREATE VIEW IF NOT EXISTS v3 AS SELECT a, b FROM t
+
+statement ok
+END
+
+# Case 2: Both v4's are different types and the old one is being dropped.
+statement ok
+BEGIN
+
+statement ok
+DROP TYPE v4
+
+statement error pgcode 42809 "v4" is not a view
+CREATE VIEW IF NOT EXISTS v4 AS SELECT a, b FROM t
+
+statement ok
+END
+
+# Case 3: Both v4's are a different type
+statement ok
+BEGIN
+
+statement error pgcode 42809 "v4" is not a view
+CREATE VIEW IF NOT EXISTS v4 AS SELECT a, b FROM t
+
+statement ok
+END
+
+statement ok
+DROP VIEW v3
+
+statement ok
+DROP TYPE v4
+
+statement ok
+DROP TABLE t

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -3451,7 +3451,7 @@ INSERT INTO t.kv VALUES ('a', 'b');
 			name:        `drop-create`,
 			firstStmt:   `DROP TABLE t.kv`,
 			secondStmt:  `CREATE TABLE t.kv (k CHAR PRIMARY KEY, v CHAR)`,
-			expectedErr: `relation "kv" already exists`,
+			expectedErr: `table "kv" is being dropped, try again later`,
 		},
 		// schema change followed by another statement works.
 		{


### PR DESCRIPTION
Backport 1/1 commits from #61135.

/cc @cockroachdb/release

---

Fixes: #60737

Previously, when dropping and creating a view/table/sequence with if
exists clause in a single transaction would drop the view and not
create the view again, since we would see a descriptor in a dropping
state as created. Similarly if the dropped object was a different
type we would silently ignore the error for the IF NOT EXISTS case.
To address this incorrect behaviour, this patch will return a
ObjectNotInPrerequisiteState if a descriptor in a dropping state is
found. Secondly, if the IF NOT EXISTS flag is specified we will
validate that the types match otherwise return WrongObjectType.

Release note (bug fix): Dropping and recreating a view/table/sequence
in a transaction will now correctly error out if a conflicting object
exists or if the drop is incomplete.

Release justification: Low risk change to address a high severity
issue where users could have failures due to incorrect behaviour.