### PR TITLE
release-21.1: tracing: keep noopSpan immutable

### DIFF
--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -76,7 +76,7 @@ func (sp *Span) SetOperationName(operationName string) {
 // Finish idempotently marks the Span as completed (at which point it will
 // silently drop any new data added to it). Finishing a nil *Span is a noop.
 func (sp *Span) Finish() {
-	if sp == nil || atomic.AddInt32(&sp.numFinishCalled, 1) != 1 {
+	if sp == nil || sp.i.isNoop() || atomic.AddInt32(&sp.numFinishCalled, 1) != 1 {
 		return
 	}
 	sp.i.Finish()

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -615,3 +615,12 @@ func TestTracer_TracingVerbosityIndependentSemanticsIsActive(t *testing.T) {
 	tr.TracingVerbosityIndependentSemanticsIsActive = func() bool { return true }
 	require.NotNil(t, sp.GetRecording())
 }
+
+func TestNoopSpanFinish(t *testing.T) {
+	tr := NewTracer()
+	sp := tr.StartSpan("noop")
+	require.Equal(t, tr.noopSpan, sp)
+	require.EqualValues(t, 1, tr.noopSpan.numFinishCalled)
+	sp.Finish()
+	require.EqualValues(t, 1, tr.noopSpan.numFinishCalled)
+}


### PR DESCRIPTION
Backport 1/1 commits from #62352.

/cc @cockroachdb/release

---

We were incrementing `sp.NumFinishCalled` on `noopSpan.Finish` so it
would eventually have wrapped around and made the noop span unfinished,
which can't be good.

Release note: None

