### PR TITLE
release-21.1: sql: Fix multi-region restore

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1252,7 +1252,7 @@ func createImportingDescriptors(
 								return err
 							}
 
-							regionConfig, err := sql.SynthesizeRegionConfig(ctx, txn, desc.ID, descsCol)
+							regionConfig, err := sql.SynthesizeRegionConfigOffline(ctx, txn, desc.ID, descsCol)
 							if err != nil {
 								return err
 							}

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -898,16 +898,36 @@ func (p *planner) CurrentDatabaseRegionConfig(
 	), nil
 }
 
-// SynthesizeRegionConfig returns a RegionConfig representing the user
-// configured state of a multi-region database by coalescing state from both
-// the database descriptor and multi-region type descriptor. It avoids the cache
-// and is intended for use by DDL statements.
+// SynthesizeRegionConfigOffline is the public function for the synthesizing
+// region configs in cases where the searched for descriptor may be in
+// the offline state. See synthesizeRegionConfig for more details on what it
+// does under the covers.
+func SynthesizeRegionConfigOffline(
+	ctx context.Context, txn *kv.Txn, dbID descpb.ID, descsCol *descs.Collection,
+) (multiregion.RegionConfig, error) {
+	return synthesizeRegionConfigImpl(ctx, txn, dbID, descsCol, true /* includeOffline */)
+}
+
+// SynthesizeRegionConfig is the public function for the synthesizing region
+// configs in the common case (i.e. not the offline case). See
+// synthesizeRegionConfig for more details on what it does under the covers.
 func SynthesizeRegionConfig(
 	ctx context.Context, txn *kv.Txn, dbID descpb.ID, descsCol *descs.Collection,
 ) (multiregion.RegionConfig, error) {
+	return synthesizeRegionConfigImpl(ctx, txn, dbID, descsCol, false /* includeOffline */)
+}
+
+// synthesizeRegionConfigImpl returns a RegionConfig representing the user
+// configured state of a multi-region database by coalescing state from both
+// the database descriptor and multi-region type descriptor. It avoids the cache
+// and is intended for use by DDL statements.
+func synthesizeRegionConfigImpl(
+	ctx context.Context, txn *kv.Txn, dbID descpb.ID, descsCol *descs.Collection, includeOffline bool,
+) (multiregion.RegionConfig, error) {
 	_, dbDesc, err := descsCol.GetImmutableDatabaseByID(ctx, txn, dbID, tree.DatabaseLookupFlags{
-		AvoidCached: true,
-		Required:    true,
+		AvoidCached:    true,
+		Required:       true,
+		IncludeOffline: includeOffline,
 	})
 	if err != nil {
 		return multiregion.RegionConfig{}, err
@@ -924,7 +944,8 @@ func SynthesizeRegionConfig(
 		regionEnumID,
 		tree.ObjectLookupFlags{
 			CommonLookupFlags: tree.CommonLookupFlags{
-				AvoidCached: true,
+				AvoidCached:    true,
+				IncludeOffline: includeOffline,
 			},
 		},
 	)


### PR DESCRIPTION
Backport 1/1 commits from #62215.

/cc @cockroachdb/release

---

Updating PR.  This will now just fix the underlying restore problem, and will keep the flaky test removed until we track down one underlying problem in KV.  See underlying commit record for more info.

Release note: None

