### PR TITLE
changefeedccl: allow topic_name parameter for changefeed kafka sinks

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -2079,7 +2079,7 @@ func TestChangefeedErrors(t *testing.T) {
 	// Test that a well-formed URI gets as far as unavailable kafka error.
 	sqlDB.ExpectErr(
 		t, `client has run out of available brokers`,
-		`CREATE CHANGEFEED FOR foo INTO 'kafka://nope/?tls_enabled=true&insecure_tls_skip_verify=true'`,
+		`CREATE CHANGEFEED FOR foo INTO 'kafka://nope/?tls_enabled=true&insecure_tls_skip_verify=true&topic_name=foo'`,
 	)
 
 	// kafka_topic_prefix was referenced by an old version of the RFC, it's
@@ -2087,6 +2087,12 @@ func TestChangefeedErrors(t *testing.T) {
 	sqlDB.ExpectErr(
 		t, `unknown sink query parameter: kafka_topic_prefix`,
 		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?kafka_topic_prefix=foo`,
+	)
+
+	// topic_name is only honored for kafka sinks
+	sqlDB.ExpectErr(
+		t, `unknown sink query parameter: topic_name`,
+		`CREATE CHANGEFEED FOR foo INTO $1`, `experimental-sql://d/?topic_name=foo`,
 	)
 
 	// schema_topic will be implemented but isn't yet.

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -92,6 +92,7 @@ const (
 	SinkParamTLSEnabled       = `tls_enabled`
 	SinkParamSkipTLSVerify    = `insecure_tls_skip_verify`
 	SinkParamTopicPrefix      = `topic_prefix`
+	SinkParamTopicName        = `topic_name`
 	SinkSchemeBuffer          = ``
 	SinkSchemeExperimentalSQL = `experimental-sql`
 	SinkSchemeKafka           = `kafka`


### PR DESCRIPTION
Previously, changes for a table went to a Kafka topic
named for that table, with users only able to specify a prefix.
Some users, however, need changes to go to a specific topic,
including sometimes the same one for more than one table,
distinguishing messages using metadata.
This patch allows the `?topic_name=foo` parameter to be added
to Kafka sink URIs. This will override the per-table topic
generation, so that changes for every table will all go to
the specified topic. It may be used in conjunction with
`topic_prefix`, although the distinction is not meaningful.

Release note (enterprise change): Kafka sink URIs now accept
the "topic_name" parameter to override per-table topic names.

Closes #59300
Closes #58302
