### PR TITLE
bazel: delete pinned in-tree llvm toolchain

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -133,31 +133,6 @@ load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
 
-# Load up the pinned clang toolchain.
-
-http_archive(
-    name = "com_grail_bazel_toolchain",
-    sha256 = "b924b102adc0c3368d38a19bd971cb4fa75362a27bc363d0084b90ca6877d3f0",
-    strip_prefix = "bazel-toolchain-0.5.7",
-    urls = ["https://github.com/grailbio/bazel-toolchain/archive/0.5.7.tar.gz"],
-)
-
-load("@com_grail_bazel_toolchain//toolchain:deps.bzl", "bazel_toolchain_dependencies")
-
-bazel_toolchain_dependencies()
-
-load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
-
-llvm_toolchain(
-    name = "llvm_toolchain",
-    absolute_paths = True,
-    llvm_version = "10.0.0",
-)
-
-load("@llvm_toolchain//:toolchains.bzl", "llvm_register_toolchains")
-
-llvm_register_toolchains()
-
 # Load up cockroachdb's go dependencies (the ones listed under go.mod). The
 # `DEPS.bzl` file is kept up to date using the `update-repos` Gazelle command
 # (see `make bazel-generate`).

--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get update \
     libtinfo-dev \
     make \
     netbase \
-    python3 \
     unzip \
  && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100 \
     --slave /usr/bin/clang++ clang++ /usr/bin/clang++-10 \


### PR DESCRIPTION
We included this open-source library here as a stopgap solution targeted
for dev environments, but it seems to break in enough different
circumstances where we don't seem to be reaping the benefits
(ex: #61938, #62146).

I plan to replace this with something bespoke that is more likely to
work for Cockroach devs, especially on Macbooks.

Release note: None