### PR TITLE
sql: add tabledesc.NewUnsafeImmutable constructor

### DIFF
--- a/pkg/sql/catalog/tabledesc/table_desc_builder.go
+++ b/pkg/sql/catalog/tabledesc/table_desc_builder.go
@@ -67,6 +67,20 @@ func NewBuilderForFKUpgrade(
 	return b
 }
 
+// NewUnsafeImmutable should be used as sparingly as possible only in cases
+// where deep-copying the descpb.TableDescriptor struct is bad for performance
+// and is known to not be necessary for safety. This is typically the case when
+// the descpb struct is embedded in another proto message and is never used in
+// any way other than to build a catalog.TableDescriptor interface. Currently
+// this is the case for the execinfrapb package.
+// Deprecated: this should be replaced with a NewBuilder call which is
+// implemented in such a way that it can deep-copy the descpb.TableDescriptor
+// struct without reflection (which is what protoutil.Clone uses, sadly).
+func NewUnsafeImmutable(desc *descpb.TableDescriptor) catalog.TableDescriptor {
+	b := tableDescriptorBuilder{original: desc}
+	return b.BuildImmutableTable()
+}
+
 func newBuilder(desc *descpb.TableDescriptor) *tableDescriptorBuilder {
 	return &tableDescriptorBuilder{
 		original: protoutil.Clone(desc).(*descpb.TableDescriptor),

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -227,12 +227,11 @@ func NewColBatchScan(
 	}
 
 	limitHint := execinfra.LimitHint(spec.LimitHint, post)
-
 	// TODO(ajwerner): The need to construct an immutable here
 	// indicates that we're probably doing this wrong. Instead we should be
 	// just setting the ID and Version in the spec or something like that and
 	// retrieving the hydrated immutable from cache.
-	table := tabledesc.NewBuilder(&spec.Table).BuildImmutableTable()
+	table := spec.BuildTableDescriptor()
 	virtualColumn := tabledesc.FindVirtualColumn(table, spec.VirtualColumn)
 	cols := table.PublicColumns()
 	if spec.Visibility == execinfra.ScanVisibilityPublicAndNotPublic {

--- a/pkg/sql/execinfrapb/BUILD.bazel
+++ b/pkg/sql/execinfrapb/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/rpc",
         "//pkg/security",
         "//pkg/settings/cluster",
+        "//pkg/sql/catalog",
         "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/execinfrapb/flow_diagram.go
+++ b/pkg/sql/execinfrapb/flow_diagram.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/errors"
 	"github.com/dustin/go-humanize"
@@ -147,7 +146,7 @@ func (tr *TableReaderSpec) summary() (string, []string) {
 	details := []string{indexDetail(&tr.Table, tr.IndexIdx)}
 
 	if len(tr.Spans) > 0 {
-		tbl := tabledesc.NewBuilder(&tr.Table).BuildImmutableTable()
+		tbl := tr.BuildTableDescriptor()
 		// only show the first span
 		idx := tbl.ActiveIndexes()[int(tr.IndexIdx)]
 		valDirs := catalogkeys.IndexKeyValDirs(idx.IndexDesc())

--- a/pkg/sql/execinfrapb/processors.go
+++ b/pkg/sql/execinfrapb/processors.go
@@ -13,7 +13,9 @@ package execinfrapb
 import (
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
@@ -496,4 +498,44 @@ func (spec *WindowerSpec_Frame) ConvertToAST() (*tree.WindowFrame, error) {
 		Bounds:    bounds,
 		Exclusion: exclusion,
 	}, nil
+}
+
+// BuildTableDescriptor returns a catalog.TableDescriptor wrapping the
+// underlying Table field.
+func (spec *TableReaderSpec) BuildTableDescriptor() catalog.TableDescriptor {
+	return tabledesc.NewUnsafeImmutable(&spec.Table)
+}
+
+// BuildTableDescriptor returns a catalog.TableDescriptor wrapping the
+// underlying Table field.
+func (spec *JoinReaderSpec) BuildTableDescriptor() catalog.TableDescriptor {
+	return tabledesc.NewUnsafeImmutable(&spec.Table)
+}
+
+// BuildTableDescriptors returns a catalog.TableDescriptor slice wrapping the
+// underlying Tables field.
+func (spec *ZigzagJoinerSpec) BuildTableDescriptors() []catalog.TableDescriptor {
+	ret := make([]catalog.TableDescriptor, len(spec.Tables))
+	for i := range spec.Tables {
+		ret[i] = tabledesc.NewUnsafeImmutable(&spec.Tables[i])
+	}
+	return ret
+}
+
+// BuildTableDescriptor returns a catalog.TableDescriptor wrapping the
+// underlying Table field.
+func (spec *InvertedJoinerSpec) BuildTableDescriptor() catalog.TableDescriptor {
+	return tabledesc.NewUnsafeImmutable(&spec.Table)
+}
+
+// BuildTableDescriptor returns a catalog.TableDescriptor wrapping the
+// underlying Table field.
+func (spec *BackfillerSpec) BuildTableDescriptor() catalog.TableDescriptor {
+	return tabledesc.NewUnsafeImmutable(&spec.Table)
+}
+
+// BuildTableDescriptor returns a catalog.TableDescriptor wrapping the
+// underlying Table field.
+func (spec *BulkRowWriterSpec) BuildTableDescriptor() catalog.TableDescriptor {
+	return tabledesc.NewUnsafeImmutable(&spec.Table)
 }

--- a/pkg/sql/rowexec/bulk_row_writer.go
+++ b/pkg/sql/rowexec/bulk_row_writer.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
@@ -60,7 +59,7 @@ func newBulkRowWriterProcessor(
 		flowCtx:        flowCtx,
 		processorID:    processorID,
 		batchIdxAtomic: 0,
-		tableDesc:      tabledesc.NewBuilder(&spec.Table).BuildImmutableTable(),
+		tableDesc:      spec.BuildTableDescriptor(),
 		spec:           spec,
 		input:          input,
 		output:         output,

--- a/pkg/sql/rowexec/columnbackfiller.go
+++ b/pkg/sql/rowexec/columnbackfiller.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/backfill"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -46,7 +45,7 @@ func newColumnBackfiller(
 	columnBackfillerMon := execinfra.NewMonitor(ctx, flowCtx.Cfg.BackfillerMonitor,
 		"column-backfill-mon")
 	cb := &columnBackfiller{
-		desc: tabledesc.NewBuilder(&spec.Table).BuildImmutableTable(),
+		desc: spec.BuildTableDescriptor(),
 		backfiller: backfiller{
 			name:        "Column",
 			filter:      backfill.ColumnMutationFilter,

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -85,7 +85,7 @@ func newIndexBackfiller(
 	indexBackfillerMon := execinfra.NewMonitor(ctx, flowCtx.Cfg.BackfillerMonitor,
 		"index-backfill-mon")
 	ib := &indexBackfiller{
-		desc:    tabledesc.NewBuilder(&spec.Table).BuildImmutableTable(),
+		desc:    spec.BuildTableDescriptor(),
 		spec:    spec,
 		flowCtx: flowCtx,
 		output:  output,

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/invertedexpr"
@@ -187,7 +186,7 @@ func newInvertedJoiner(
 		return nil, errors.AssertionFailedf("unexpected inverted join type %s", spec.Type)
 	}
 	ij := &invertedJoiner{
-		desc:                 tabledesc.NewBuilder(&spec.Table).BuildImmutableTable(),
+		desc:                 spec.BuildTableDescriptor(),
 		input:                input,
 		inputTypes:           input.OutputTypes(),
 		prefixEqualityCols:   spec.PrefixEqualityColumns,

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
@@ -189,11 +188,11 @@ func newJoinReader(
 	}
 
 	var lookupCols []uint32
+	tableDesc := spec.BuildTableDescriptor()
 	switch readerType {
 	case indexJoinReaderType:
-		pkIDs := spec.Table.PrimaryIndex.ColumnIDs
-		lookupCols = make([]uint32, len(pkIDs))
-		for i := range pkIDs {
+		lookupCols = make([]uint32, tableDesc.GetPrimaryIndex().NumColumns())
+		for i := range lookupCols {
 			lookupCols[i] = uint32(i)
 		}
 	case lookupJoinReaderType:
@@ -202,7 +201,7 @@ func newJoinReader(
 		return nil, errors.Errorf("unsupported joinReaderType")
 	}
 	jr := &joinReader{
-		desc:                              tabledesc.NewBuilder(&spec.Table).BuildImmutableTable(),
+		desc:                              tableDesc,
 		maintainOrdering:                  spec.MaintainOrdering,
 		input:                             input,
 		lookupCols:                        lookupCols,

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -87,7 +87,7 @@ func newTableReader(
 	tr.parallelize = spec.Parallelize && tr.limitHint == 0
 	tr.maxTimestampAge = time.Duration(spec.MaxTimestampAgeNanos)
 
-	tableDesc := tabledesc.NewBuilder(&spec.Table).BuildImmutableTable()
+	tableDesc := spec.BuildTableDescriptor()
 	virtualColumn := tabledesc.FindVirtualColumn(tableDesc, spec.VirtualColumn)
 	cols := tableDesc.PublicColumns()
 	if spec.Visibility == execinfra.ScanVisibilityPublicAndNotPublic {


### PR DESCRIPTION
    sql: add tabledesc.NewUnsafeImmutable constructor
    
    Recent benchmark results revealed a performance regression in
    TableReader caused by the recent introduction of the descriptor builder
    pattern which deep-copies descpb messages using protoutil.Clone.
    See issue #62212 and commit 15ee387.
    
    This commit adds an unsafe table descriptor constructor which is used
    with table descriptors in execinfrapb messages. This unsafe constructor
    does not perform a deep copy. In this particular context this isn't a
    problem, because the table descriptor proto only exists as a means to
    serialize table descriptors across nodes in a read-only fashion and is
    known to not be used in any other capacity.
    
    Release note: None
