### PR TITLE
cli: support addr 0 in multi-node demo

### DIFF
--- a/pkg/cli/demo_cluster.go
+++ b/pkg/cli/demo_cluster.go
@@ -340,7 +340,13 @@ func testServerArgsForTransientCluster(
 		// Unit tests can be run with multiple processes side-by-side with
 		// `make stress`. This is bound to not work with fixed ports.
 		sqlPort := sqlBasePort + int(nodeID) - 1
+		if sqlBasePort == 0 {
+			sqlPort = 0
+		}
 		httpPort := httpBasePort + int(nodeID) - 1
+		if httpBasePort == 0 {
+			httpPort = 0
+		}
 		args.SQLAddr = fmt.Sprintf(":%d", sqlPort)
 		args.HTTPAddr = fmt.Sprintf(":%d", httpPort)
 	}


### PR DESCRIPTION
Before this change, if you specified that the ports should be chosen by the
system with `--http-port 0 --sql-port 0` then it would not work for multi-node
demo. This fixes that.

Release note: None