### PR TITLE
sql: fix EXPLAIN ANALYZE (DEBUG) for queries with LocalPlanNode

### DIFF
--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -168,11 +168,11 @@ func NewVectorizedFlow(base *flowinfra.FlowBase) flowinfra.Flow {
 // Setup is part of the flowinfra.Flow interface.
 func (f *vectorizedFlow) Setup(
 	ctx context.Context, spec *execinfrapb.FlowSpec, opt flowinfra.FuseOpt,
-) (context.Context, error) {
+) (context.Context, []execinfra.OpNode, error) {
 	var err error
-	ctx, err = f.FlowBase.Setup(ctx, spec, opt)
+	ctx, _, err = f.FlowBase.Setup(ctx, spec, opt)
 	if err != nil {
-		return ctx, err
+		return ctx, nil, err
 	}
 	if log.V(1) {
 		log.Infof(ctx, "setting up vectorize flow %s", f.ID.Short())
@@ -189,7 +189,7 @@ func (f *vectorizedFlow) Setup(
 		GetPather:      f,
 	}
 	if err := diskQueueCfg.EnsureDefaults(); err != nil {
-		return ctx, err
+		return ctx, nil, err
 	}
 	f.countingSemaphore = newCountingSemaphore(f.Cfg.VecFDSemaphore, f.Cfg.Metrics.VecOpenFDs)
 	flowCtx := f.GetFlowCtx()
@@ -209,14 +209,19 @@ func (f *vectorizedFlow) Setup(
 	if f.testingKnobs.onSetupFlow != nil {
 		f.testingKnobs.onSetupFlow(f.creator)
 	}
-	_, err = f.creator.setupFlow(ctx, flowCtx, spec.Processors, f.GetLocalProcessors(), opt)
+	leaves, err := f.creator.setupFlow(ctx, flowCtx, spec.Processors, f.GetLocalProcessors(), opt)
 	if err == nil {
 		f.testingInfo.numClosers = f.creator.numClosers
 		f.testingInfo.numClosed = &f.creator.numClosed
 		if log.V(1) {
 			log.Info(ctx, "vectorized flow setup succeeded")
 		}
-		return ctx, nil
+		if !f.IsLocal() {
+			// For distributed flows set leaves to nil, per the contract of
+			// flowinfra.Flow.Setup.
+			leaves = nil
+		}
+		return ctx, leaves, nil
 	}
 	// It is (theoretically) possible that some of the memory monitoring
 	// infrastructure was created even in case of an error, and we need to clean
@@ -226,7 +231,7 @@ func (f *vectorizedFlow) Setup(
 	if log.V(1) {
 		log.Infof(ctx, "failed to vectorize: %s", err)
 	}
-	return ctx, err
+	return ctx, nil, err
 }
 
 var _ colcontainer.GetPather = &vectorizedFlow{}

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -168,7 +168,7 @@ func NewVectorizedFlow(base *flowinfra.FlowBase) flowinfra.Flow {
 // Setup is part of the flowinfra.Flow interface.
 func (f *vectorizedFlow) Setup(
 	ctx context.Context, spec *execinfrapb.FlowSpec, opt flowinfra.FuseOpt,
-) (context.Context, []execinfra.OpNode, error) {
+) (context.Context, execinfra.OpChains, error) {
 	var err error
 	ctx, _, err = f.FlowBase.Setup(ctx, spec, opt)
 	if err != nil {
@@ -209,29 +209,29 @@ func (f *vectorizedFlow) Setup(
 	if f.testingKnobs.onSetupFlow != nil {
 		f.testingKnobs.onSetupFlow(f.creator)
 	}
-	leaves, err := f.creator.setupFlow(ctx, flowCtx, spec.Processors, f.GetLocalProcessors(), opt)
-	if err == nil {
-		f.testingInfo.numClosers = f.creator.numClosers
-		f.testingInfo.numClosed = &f.creator.numClosed
+	opChains, err := f.creator.setupFlow(ctx, flowCtx, spec.Processors, f.GetLocalProcessors(), opt)
+	if err != nil {
+		// It is (theoretically) possible that some of the memory monitoring
+		// infrastructure was created even in case of an error, and we need to
+		// clean that up.
+		f.creator.cleanup(ctx)
+		f.creator.Release()
 		if log.V(1) {
-			log.Info(ctx, "vectorized flow setup succeeded")
+			log.Infof(ctx, "failed to vectorize: %s", err)
 		}
-		if !f.IsLocal() {
-			// For distributed flows set leaves to nil, per the contract of
-			// flowinfra.Flow.Setup.
-			leaves = nil
-		}
-		return ctx, leaves, nil
+		return ctx, nil, err
 	}
-	// It is (theoretically) possible that some of the memory monitoring
-	// infrastructure was created even in case of an error, and we need to clean
-	// that up.
-	f.creator.cleanup(ctx)
-	f.creator.Release()
+	f.testingInfo.numClosers = f.creator.numClosers
+	f.testingInfo.numClosed = &f.creator.numClosed
 	if log.V(1) {
-		log.Infof(ctx, "failed to vectorize: %s", err)
+		log.Info(ctx, "vectorized flow setup succeeded")
 	}
-	return ctx, nil, err
+	if !f.IsLocal() {
+		// For distributed flows set opChains to nil, per the contract of
+		// flowinfra.Flow.Setup.
+		opChains = nil
+	}
+	return ctx, opChains, nil
 }
 
 var _ colcontainer.GetPather = &vectorizedFlow{}
@@ -495,9 +495,9 @@ type vectorizedFlowCreator struct {
 	// procIdxQueue is a queue of indices into processorSpecs (the argument to
 	// setupFlow), for topologically ordered processing.
 	procIdxQueue []int
-	// leaves accumulates all operators that have no further outputs on the
+	// opChains accumulates all operators that have no further outputs on the
 	// current node, for the purposes of EXPLAIN output.
-	leaves []execinfra.OpNode
+	opChains execinfra.OpChains
 	// operatorConcurrency is set if any operators are executed in parallel.
 	operatorConcurrency bool
 	// monitors contains all monitors (for both memory and disk usage) of the
@@ -559,7 +559,7 @@ func newVectorizedFlowCreator(
 		exprHelper:             creator.exprHelper,
 		typeResolver:           typeResolver,
 		procIdxQueue:           creator.procIdxQueue,
-		leaves:                 creator.leaves,
+		opChains:               creator.opChains,
 		monitors:               creator.monitors,
 		accounts:               creator.accounts,
 		releasables:            creator.releasables,
@@ -595,7 +595,7 @@ func (s *vectorizedFlowCreator) Release() {
 		streamIDToSpecIdx: s.streamIDToSpecIdx,
 		exprHelper:        s.exprHelper,
 		procIdxQueue:      s.procIdxQueue[:0],
-		leaves:            s.leaves[:0],
+		opChains:          s.opChains[:0],
 		monitors:          s.monitors[:0],
 		accounts:          s.accounts[:0],
 		releasables:       s.releasables[:0],
@@ -785,8 +785,9 @@ func (s *vectorizedFlowCreator) setupRouter(
 		}
 	}
 	if !foundLocalOutput {
-		// No local output means that our router is a leaf node.
-		s.leaves = append(s.leaves, router)
+		// No local output means that our router is a root of its operator
+		// chain.
+		s.opChains = append(s.opChains, router)
 	}
 	return nil
 }
@@ -971,9 +972,9 @@ func (s *vectorizedFlowCreator) setupOutput(
 		if err != nil {
 			return err
 		}
-		// An outbox is a leaf: there's nothing that sees it as an input on this
-		// node.
-		s.leaves = append(s.leaves, outbox)
+		// An outbox is a root of its operator chain: there's nothing that sees
+		// it as an input on this node.
+		s.opChains = append(s.opChains, outbox)
 	case execinfrapb.StreamEndpointSpec_SYNC_RESPONSE:
 		// Make the materializer, which will write to the given receiver.
 		proc, err := colexec.NewMaterializer(
@@ -987,8 +988,8 @@ func (s *vectorizedFlowCreator) setupOutput(
 		if err != nil {
 			return err
 		}
-		// A materializer is a leaf.
-		s.leaves = append(s.leaves, proc)
+		// A materializer is a root of its operator chain.
+		s.opChains = append(s.opChains, proc)
 		s.addMaterializer(proc)
 	default:
 		return errors.Errorf("unsupported output stream type %s", outputStream.Type)
@@ -1015,7 +1016,7 @@ func (s *vectorizedFlowCreator) setupFlow(
 	processorSpecs []execinfrapb.ProcessorSpec,
 	localProcessors []execinfra.LocalProcessor,
 	opt flowinfra.FuseOpt,
-) (leaves []execinfra.OpNode, err error) {
+) (opChains execinfra.OpChains, err error) {
 	if vecErr := colexecerror.CatchVectorizedRuntimeError(func() {
 		// The column factory will not change the eval context, so we can use
 		// the one we have in the flow context, without making a copy.
@@ -1160,9 +1161,9 @@ func (s *vectorizedFlowCreator) setupFlow(
 			}
 		}
 	}); vecErr != nil {
-		return s.leaves, vecErr
+		return s.opChains, vecErr
 	}
-	return s.leaves, err
+	return s.opChains, err
 }
 
 type vectorizedInboundStreamHandler struct {

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -294,7 +294,7 @@ func TestVectorizedFlowTempDirectory(t *testing.T) {
 			creator = c
 		}
 
-		_, err := vf.Setup(ctx, &execinfrapb.FlowSpec{}, flowinfra.FuseNormally)
+		_, _, err := vf.Setup(ctx, &execinfrapb.FlowSpec{}, flowinfra.FuseNormally)
 		require.NoError(t, err)
 
 		// No directory should have been created.
@@ -328,7 +328,7 @@ func TestVectorizedFlowTempDirectory(t *testing.T) {
 			creator = c
 		}
 
-		_, err := vf.Setup(ctx, &execinfrapb.FlowSpec{}, flowinfra.FuseNormally)
+		_, _, err := vf.Setup(ctx, &execinfrapb.FlowSpec{}, flowinfra.FuseNormally)
 		require.NoError(t, err)
 
 		createTempDir := creator.diskQueueCfg.GetPather.GetPath

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -189,14 +189,14 @@ func (ds *ServerImpl) setupFlow(
 	req *execinfrapb.SetupFlowRequest,
 	syncFlowConsumer execinfra.RowReceiver,
 	localState LocalState,
-) (context.Context, flowinfra.Flow, error) {
+) (context.Context, flowinfra.Flow, []execinfra.OpNode, error) {
 	if !FlowVerIsCompatible(req.Version, execinfra.MinAcceptedVersion, execinfra.Version) {
 		err := errors.Errorf(
 			"version mismatch in flow request: %d; this node accepts %d through %d",
 			req.Version, execinfra.MinAcceptedVersion, execinfra.Version,
 		)
 		log.Warningf(ctx, "%v", err)
-		return ctx, nil, err
+		return ctx, nil, nil, err
 	}
 
 	const opName = "flow"
@@ -255,14 +255,14 @@ func (ds *ServerImpl) setupFlow(
 		evalCtx.Mon = monitor
 	} else {
 		if localState.IsLocal {
-			return nil, nil, errors.AssertionFailedf(
+			return nil, nil, nil, errors.AssertionFailedf(
 				"EvalContext expected to be populated when IsLocal is set")
 		}
 
 		sd, err := sessiondata.UnmarshalNonLocal(req.EvalContext.SessionData)
 		if err != nil {
 			sp.Finish()
-			return ctx, nil, err
+			return ctx, nil, nil, err
 		}
 		ie := &lazyInternalExecutor{
 			newInternalExecutor: func() sqlutil.InternalExecutor {
@@ -275,7 +275,7 @@ func (ds *ServerImpl) setupFlow(
 		// processors.
 		leafTxn, err = makeLeaf(req)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		evalCtx = &tree.EvalContext{
 			Settings:    ds.ServerConfig.Settings,
@@ -324,15 +324,17 @@ func (ds *ServerImpl) setupFlow(
 		opt = flowinfra.FuseAggressively
 	}
 
+	var leaves []execinfra.OpNode
 	var err error
-	if ctx, err = f.Setup(ctx, &req.Flow, opt); err != nil {
+	ctx, leaves, err = f.Setup(ctx, &req.Flow, opt)
+	if err != nil {
 		log.Errorf(ctx, "error setting up flow: %s", err)
 		// Flow.Cleanup will not be called, so we have to close the memory monitor
 		// and finish the span manually.
 		monitor.Stop(ctx)
 		sp.Finish()
 		ctx = tracing.ContextWithSpan(ctx, nil)
-		return ctx, nil, err
+		return ctx, nil, nil, err
 	}
 	if !f.IsLocal() {
 		flowCtx.AddLogTag("f", f.GetFlowCtx().ID.Short())
@@ -356,7 +358,7 @@ func (ds *ServerImpl) setupFlow(
 			var err error
 			leafTxn, err = makeLeaf(req)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
 		}
 		txn = leafTxn
@@ -370,7 +372,7 @@ func (ds *ServerImpl) setupFlow(
 	// then the processors have erroneously captured the Root. See #41992.
 	f.SetTxn(txn)
 
-	return ctx, f, nil
+	return ctx, f, leaves, nil
 }
 
 // newFlowContext creates a new FlowCtx that can be used during execution of
@@ -475,14 +477,14 @@ func (ds *ServerImpl) SetupLocalSyncFlow(
 	req *execinfrapb.SetupFlowRequest,
 	output execinfra.RowReceiver,
 	localState LocalState,
-) (context.Context, flowinfra.Flow, error) {
-	ctx, f, err := ds.setupFlow(
+) (context.Context, flowinfra.Flow, []execinfra.OpNode, error) {
+	ctx, f, leaves, err := ds.setupFlow(
 		ctx, tracing.SpanFromContext(ctx), parentMonitor, req, output, localState,
 	)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	return ctx, f, err
+	return ctx, f, leaves, err
 }
 
 // SetupFlow is part of the DistSQLServer interface.
@@ -495,7 +497,7 @@ func (ds *ServerImpl) SetupFlow(
 	// Note: the passed context will be canceled when this RPC completes, so we
 	// can't associate it with the flow.
 	ctx = ds.AnnotateCtx(context.Background())
-	ctx, f, err := ds.setupFlow(ctx, parentSpan, ds.memMonitor, req, nil /* syncFlowConsumer */, LocalState{})
+	ctx, f, _, err := ds.setupFlow(ctx, parentSpan, ds.memMonitor, req, nil /* syncFlowConsumer */, LocalState{})
 	if err == nil {
 		err = ds.flowScheduler.ScheduleFlow(ctx, f)
 	}

--- a/pkg/sql/distsql/vectorized_panic_propagation_test.go
+++ b/pkg/sql/distsql/vectorized_panic_propagation_test.go
@@ -67,7 +67,7 @@ func TestNonVectorizedPanicDoesntHangServer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx, err = base.Setup(ctx, nil, flowinfra.FuseAggressively)
+	ctx, _, err = base.Setup(ctx, nil, flowinfra.FuseAggressively)
 	require.NoError(t, err)
 
 	base.SetProcessors([]execinfra.Processor{mat})

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -634,7 +634,7 @@ type PlanningCtx struct {
 
 	// If set, the flows for the physical plan will be passed to this function.
 	// The flows are not safe for use past the lifetime of the saveFlows function.
-	saveFlows func(map[roachpb.NodeID]*execinfrapb.FlowSpec) error
+	saveFlows func(map[roachpb.NodeID]*execinfrapb.FlowSpec, []execinfra.OpNode) error
 
 	// If set, we will record the mapping from planNode to tracing metadata to
 	// later allow associating statistics with the planNode.
@@ -683,8 +683,8 @@ func (p *PlanningCtx) EvaluateSubqueries() bool {
 // plans and their diagrams.
 func (p *PlanningCtx) getDefaultSaveFlowsFunc(
 	ctx context.Context, planner *planner, typ planComponentType,
-) func(map[roachpb.NodeID]*execinfrapb.FlowSpec) error {
-	return func(flows map[roachpb.NodeID]*execinfrapb.FlowSpec) error {
+) func(map[roachpb.NodeID]*execinfrapb.FlowSpec, []execinfra.OpNode) error {
+	return func(flows map[roachpb.NodeID]*execinfrapb.FlowSpec, leaves []execinfra.OpNode) error {
 		var diagram execinfrapb.FlowDiagram
 		if planner.instrumentation.shouldSaveDiagrams() {
 			diagramFlags := execinfrapb.DiagramFlags{
@@ -702,7 +702,9 @@ func (p *PlanningCtx) getDefaultSaveFlowsFunc(
 			flowCtx := newFlowCtxForExplainPurposes(p, planner, &planner.extendedEvalCtx.DistSQLPlanner.rpcCtx.ClusterID)
 			getExplain := func(verbose bool) []string {
 				explain, err := colflow.ExplainVec(
-					ctx, flowCtx, flows, p.infra.LocalProcessors, verbose, planner.curPlan.flags.IsDistributed(),
+					ctx, flowCtx, flows, p.infra.LocalProcessors, leaves,
+					planner.extendedEvalCtx.DistSQLPlanner.gatewayNodeID,
+					verbose, planner.curPlan.flags.IsDistributed(),
 				)
 				if err != nil {
 					// In some edge cases (like when subqueries are present or

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -125,14 +125,14 @@ func (dsp *DistSQLPlanner) setupFlows(
 	recv *DistSQLReceiver,
 	localState distsql.LocalState,
 	collectStats bool,
-) (context.Context, flowinfra.Flow, error) {
+) (context.Context, flowinfra.Flow, []execinfra.OpNode, error) {
 	thisNodeID := dsp.gatewayNodeID
 	_, ok := flows[thisNodeID]
 	if !ok {
-		return nil, nil, errors.AssertionFailedf("missing gateway flow")
+		return nil, nil, nil, errors.AssertionFailedf("missing gateway flow")
 	}
 	if localState.IsLocal && len(flows) != 1 {
-		return nil, nil, errors.AssertionFailedf("IsLocal set but there's multiple flows")
+		return nil, nil, nil, errors.AssertionFailedf("IsLocal set but there's multiple flows")
 	}
 
 	evalCtxProto := execinfrapb.MakeEvalContext(&evalCtx.EvalContext)
@@ -158,7 +158,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 			if err := colflow.IsSupported(vectorizeMode, spec); err != nil {
 				log.VEventf(ctx, 2, "failed to vectorize: %s", err)
 				if vectorizeMode == sessiondatapb.VectorizeExperimentalAlways {
-					return nil, nil, err
+					return nil, nil, nil, err
 				}
 				// Vectorization is not supported for this flow, so we override the
 				// setting.
@@ -176,7 +176,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 			// A tenant server should never find itself distributing flows.
 			// NB: we wouldn't hit this in practice but if we did the actual
 			// error would be opaque.
-			return nil, nil, errorutil.UnsupportedWithMultiTenancy(47900)
+			return nil, nil, nil, errorutil.UnsupportedWithMultiTenancy(47900)
 		}
 		req := setupReq
 		req.Flow = *flowSpec
@@ -209,7 +209,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 		// into the local flow.
 	}
 	if firstErr != nil {
-		return nil, nil, firstErr
+		return nil, nil, nil, firstErr
 	}
 
 	// Set up the flow on this node.
@@ -320,7 +320,7 @@ func (dsp *DistSQLPlanner) Run(
 		localState.IsLocal = true
 	}
 
-	ctx, flow, err := dsp.setupFlows(
+	ctx, flow, leaves, err := dsp.setupFlows(
 		ctx, evalCtx, leafInputState, flows, recv, localState, planCtx.collectExecStats,
 	)
 	if err != nil {
@@ -337,7 +337,7 @@ func (dsp *DistSQLPlanner) Run(
 	}
 
 	if planCtx.saveFlows != nil {
-		if err := planCtx.saveFlows(flows); err != nil {
+		if err := planCtx.saveFlows(flows, leaves); err != nil {
 			recv.SetError(err)
 			return func() {}
 		}

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -125,7 +125,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 	recv *DistSQLReceiver,
 	localState distsql.LocalState,
 	collectStats bool,
-) (context.Context, flowinfra.Flow, []execinfra.OpNode, error) {
+) (context.Context, flowinfra.Flow, execinfra.OpChains, error) {
 	thisNodeID := dsp.gatewayNodeID
 	_, ok := flows[thisNodeID]
 	if !ok {
@@ -320,7 +320,7 @@ func (dsp *DistSQLPlanner) Run(
 		localState.IsLocal = true
 	}
 
-	ctx, flow, leaves, err := dsp.setupFlows(
+	ctx, flow, opChains, err := dsp.setupFlows(
 		ctx, evalCtx, leafInputState, flows, recv, localState, planCtx.collectExecStats,
 	)
 	if err != nil {
@@ -337,7 +337,7 @@ func (dsp *DistSQLPlanner) Run(
 	}
 
 	if planCtx.saveFlows != nil {
-		if err := planCtx.saveFlows(flows, leaves); err != nil {
+		if err := planCtx.saveFlows(flows, opChains); err != nil {
 			recv.SetError(err)
 			return func() {}
 		}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -965,7 +965,7 @@ type ExecutorTestingKnobs struct {
 	// query (i.e. no subqueries). The physical plan is only safe for use for the
 	// lifetime of this function. Note that returning a nil function is
 	// unsupported and will lead to a panic.
-	TestingSaveFlows func(stmt string) func(map[roachpb.NodeID]*execinfrapb.FlowSpec) error
+	TestingSaveFlows func(stmt string) func(map[roachpb.NodeID]*execinfrapb.FlowSpec, []execinfra.OpNode) error
 
 	// DeterministicExplain, if set, will result in overriding fields in EXPLAIN
 	// and EXPLAIN ANALYZE that can vary between runs (like elapsed times).

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -965,7 +965,7 @@ type ExecutorTestingKnobs struct {
 	// query (i.e. no subqueries). The physical plan is only safe for use for the
 	// lifetime of this function. Note that returning a nil function is
 	// unsupported and will lead to a panic.
-	TestingSaveFlows func(stmt string) func(map[roachpb.NodeID]*execinfrapb.FlowSpec, []execinfra.OpNode) error
+	TestingSaveFlows func(stmt string) func(map[roachpb.NodeID]*execinfrapb.FlowSpec, execinfra.OpChains) error
 
 	// DeterministicExplain, if set, will result in overriding fields in EXPLAIN
 	// and EXPLAIN ANALYZE that can vary between runs (like elapsed times).

--- a/pkg/sql/execinfra/operator.go
+++ b/pkg/sql/execinfra/operator.go
@@ -18,3 +18,7 @@ type OpNode interface {
 	// Child returns the nth child (input) of the operator.
 	Child(nth int, verbose bool) OpNode
 }
+
+// OpChains describes a forest of OpNodes that represent a single physical plan.
+// Each entry in the slice is a root of a separate OpNode tree.
+type OpChains []OpNode

--- a/pkg/sql/execstats/traceanalyzer_test.go
+++ b/pkg/sql/execstats/traceanalyzer_test.go
@@ -59,11 +59,11 @@ func TestTraceAnalyzer(t *testing.T) {
 			UseDatabase: "test",
 			Knobs: base.TestingKnobs{
 				SQLExecutor: &sql.ExecutorTestingKnobs{
-					TestingSaveFlows: func(stmt string) func(map[roachpb.NodeID]*execinfrapb.FlowSpec) error {
+					TestingSaveFlows: func(stmt string) func(map[roachpb.NodeID]*execinfrapb.FlowSpec, []execinfra.OpNode) error {
 						if stmt != testStmt {
-							return func(map[roachpb.NodeID]*execinfrapb.FlowSpec) error { return nil }
+							return func(map[roachpb.NodeID]*execinfrapb.FlowSpec, []execinfra.OpNode) error { return nil }
 						}
-						return func(flows map[roachpb.NodeID]*execinfrapb.FlowSpec) error {
+						return func(flows map[roachpb.NodeID]*execinfrapb.FlowSpec, _ []execinfra.OpNode) error {
 							flowsMetadata := execstats.NewFlowsMetadata(flows)
 							analyzer := execstats.NewTraceAnalyzer(flowsMetadata)
 							analyzerChan <- analyzer

--- a/pkg/sql/execstats/traceanalyzer_test.go
+++ b/pkg/sql/execstats/traceanalyzer_test.go
@@ -59,11 +59,11 @@ func TestTraceAnalyzer(t *testing.T) {
 			UseDatabase: "test",
 			Knobs: base.TestingKnobs{
 				SQLExecutor: &sql.ExecutorTestingKnobs{
-					TestingSaveFlows: func(stmt string) func(map[roachpb.NodeID]*execinfrapb.FlowSpec, []execinfra.OpNode) error {
+					TestingSaveFlows: func(stmt string) func(map[roachpb.NodeID]*execinfrapb.FlowSpec, execinfra.OpChains) error {
 						if stmt != testStmt {
-							return func(map[roachpb.NodeID]*execinfrapb.FlowSpec, []execinfra.OpNode) error { return nil }
+							return func(map[roachpb.NodeID]*execinfrapb.FlowSpec, execinfra.OpChains) error { return nil }
 						}
-						return func(flows map[roachpb.NodeID]*execinfrapb.FlowSpec, _ []execinfra.OpNode) error {
+						return func(flows map[roachpb.NodeID]*execinfrapb.FlowSpec, _ execinfra.OpChains) error {
 							flowsMetadata := execstats.NewFlowsMetadata(flows)
 							analyzer := execstats.NewTraceAnalyzer(flowsMetadata)
 							analyzerChan <- analyzer

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -76,7 +76,8 @@ func (n *explainVecNode) startExec(params runParams) error {
 	}
 	verbose := n.options.Flags[tree.ExplainFlagVerbose]
 	n.run.lines, err = colflow.ExplainVec(
-		params.ctx, flowCtx, flows, physPlan.LocalProcessors, verbose, willDistribute,
+		params.ctx, flowCtx, flows, physPlan.LocalProcessors, nil, /* opChains */
+		distSQLPlanner.gatewayNodeID, verbose, willDistribute,
 	)
 	if err != nil {
 		return err

--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -74,7 +74,7 @@ type Flow interface {
 	// The second return argument contains all operator chains planned on the
 	// gateway node if the flow is vectorized and the physical plan is fully
 	// local (in all other cases the second return argument is nil).
-	Setup(ctx context.Context, spec *execinfrapb.FlowSpec, opt FuseOpt) (_ context.Context, opChains []execinfra.OpNode, _ error)
+	Setup(ctx context.Context, spec *execinfrapb.FlowSpec, opt FuseOpt) (context.Context, execinfra.OpChains, error)
 
 	// SetTxn is used to provide the transaction in which the flow will run.
 	// It needs to be called after Setup() and before Start/Run.
@@ -181,7 +181,7 @@ type FlowBase struct {
 // Setup is part of the Flow interface.
 func (f *FlowBase) Setup(
 	ctx context.Context, spec *execinfrapb.FlowSpec, _ FuseOpt,
-) (context.Context, []execinfra.OpNode, error) {
+) (context.Context, execinfra.OpChains, error) {
 	ctx, f.ctxCancel = contextutil.WithCancel(ctx)
 	f.ctxDone = ctx.Done()
 	f.spec = spec

--- a/pkg/sql/flowinfra/flow_scheduler_test.go
+++ b/pkg/sql/flowinfra/flow_scheduler_test.go
@@ -48,7 +48,7 @@ func newMockFlow() *mockFlow {
 
 func (m *mockFlow) Setup(
 	_ context.Context, _ *execinfrapb.FlowSpec, _ FuseOpt,
-) (context.Context, error) {
+) (context.Context, []execinfra.OpNode, error) {
 	panic("not implemented")
 }
 

--- a/pkg/sql/flowinfra/flow_scheduler_test.go
+++ b/pkg/sql/flowinfra/flow_scheduler_test.go
@@ -48,7 +48,7 @@ func newMockFlow() *mockFlow {
 
 func (m *mockFlow) Setup(
 	_ context.Context, _ *execinfrapb.FlowSpec, _ FuseOpt,
-) (context.Context, []execinfra.OpNode, error) {
+) (context.Context, execinfra.OpChains, error) {
 	panic("not implemented")
 }
 

--- a/pkg/sql/flowinfra/server_test.go
+++ b/pkg/sql/flowinfra/server_test.go
@@ -168,7 +168,7 @@ func runLocalFlow(
 	evalCtx := tree.MakeTestingEvalContext(s.ClusterSettings())
 	defer evalCtx.Stop(ctx)
 	var rowBuf distsqlutils.RowBuffer
-	flowCtx, flow, err := s.DistSQLServer().(*distsql.ServerImpl).SetupLocalSyncFlow(ctx, evalCtx.Mon, req, &rowBuf, distsql.LocalState{})
+	flowCtx, flow, _, err := s.DistSQLServer().(*distsql.ServerImpl).SetupLocalSyncFlow(ctx, evalCtx.Mon, req, &rowBuf, distsql.LocalState{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/logictest/testdata/logic_test/explain_analyze
+++ b/pkg/sql/logictest/testdata/logic_test/explain_analyze
@@ -187,3 +187,8 @@ CREATE TABLE c (c INT8 PRIMARY KEY, p INT8 REFERENCES p (p))
 
 query error pgcode 23503 insert on table \"c\" violates foreign key constraint \"fk_p_ref_p\"
 EXPLAIN ANALYZE (DISTSQL) INSERT INTO c SELECT x, x + 1 FROM (VALUES (1), (2)) AS v (x)
+
+# Regression test for the vectorized engine not playing nicely with
+# LocalPlanNodes (#62261).
+query error pgcode 23503 insert on table \"c\" violates foreign key constraint \"fk_p_ref_p\"
+EXPLAIN ANALYZE (DEBUG) INSERT INTO c SELECT x, x + 1 FROM (VALUES (1), (2)) AS v (x)

--- a/pkg/sql/physicalplan/aggregator_funcs_test.go
+++ b/pkg/sql/physicalplan/aggregator_funcs_test.go
@@ -75,7 +75,7 @@ func runTestFlow(
 
 	var rowBuf distsqlutils.RowBuffer
 
-	ctx, flow, err := distSQLSrv.SetupLocalSyncFlow(context.Background(), distSQLSrv.ParentMemoryMonitor, &req, &rowBuf, distsql.LocalState{})
+	ctx, flow, _, err := distSQLSrv.SetupLocalSyncFlow(context.Background(), distSQLSrv.ParentMemoryMonitor, &req, &rowBuf, distsql.LocalState{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/rowflow/row_based_flow.go
+++ b/pkg/sql/rowflow/row_based_flow.go
@@ -56,7 +56,7 @@ func NewRowBasedFlow(base *flowinfra.FlowBase) flowinfra.Flow {
 // Setup if part of the flowinfra.Flow interface.
 func (f *rowBasedFlow) Setup(
 	ctx context.Context, spec *execinfrapb.FlowSpec, opt flowinfra.FuseOpt,
-) (context.Context, []execinfra.OpNode, error) {
+) (context.Context, execinfra.OpChains, error) {
 	var err error
 	ctx, _, err = f.FlowBase.Setup(ctx, spec, opt)
 	if err != nil {

--- a/pkg/sql/rowflow/row_based_flow.go
+++ b/pkg/sql/rowflow/row_based_flow.go
@@ -56,20 +56,20 @@ func NewRowBasedFlow(base *flowinfra.FlowBase) flowinfra.Flow {
 // Setup if part of the flowinfra.Flow interface.
 func (f *rowBasedFlow) Setup(
 	ctx context.Context, spec *execinfrapb.FlowSpec, opt flowinfra.FuseOpt,
-) (context.Context, error) {
+) (context.Context, []execinfra.OpNode, error) {
 	var err error
-	ctx, err = f.FlowBase.Setup(ctx, spec, opt)
+	ctx, _, err = f.FlowBase.Setup(ctx, spec, opt)
 	if err != nil {
-		return ctx, err
+		return ctx, nil, err
 	}
 	// First step: setup the input synchronizers for all processors.
 	inputSyncs, err := f.setupInputSyncs(ctx, spec, opt)
 	if err != nil {
-		return ctx, err
+		return ctx, nil, err
 	}
 
 	// Then, populate processors.
-	return ctx, f.setupProcessors(ctx, spec, inputSyncs)
+	return ctx, nil, f.setupProcessors(ctx, spec, inputSyncs)
 }
 
 // setupProcessors creates processors for each spec in f.spec, fusing processors


### PR DESCRIPTION
**sql: fix EXPLAIN ANALYZE (DEBUG) for queries with LocalPlanNode**

We recently added `EXPLAIN (VEC)` diagrams to the stmt bundle. However,
one edge case was overlooked (namely, a poor interaction between
planNode-to-processor and processor-to-operator adapters). Whenever we
encounter a `planNode` that isn't supported by DistSQL we break away
a part of the planNode tree and introduce two adapters:
1. `planNodeToRowSource` that is a DistSQL processor and is responsible
for draining the DistSQL input to the second adapter
2. `rowSourceToPlanNode` that is a planNode connecting the DistSQL input
to the unsupported planNode tree part.

The crucial observation is that the creation of these two adapters
happens during the physical planning stage whereas the addition of the
DistSQL input to be drained by `planNodeToRowSource` happens during the
flow setup (in `rowexec.NewProcessor`).

Now, `EXPLAIN (VEC)` works by taking in the physical plan, setting up
all of the flows and iterating over the resulting trees. When we added
`(VEC)` and `(VEC, VERBOSE)` flavors of EXPLAIN to the bundle, we added
two more code paths that would fully instantiate the flows, and we would
have 3 instantiations total (the first one is for the actual query
execution). Since `planNodeToRowSource` is created during the physical
planning, it would be modified every time to include the "new" DistSQL
input to be drained. This would lead to a nil pointer exception because
the second and the third "new" inputs are never started.

This commit fixes the issue by explicitly propagating the operator
chains from the flow setup to `saveFlows` function so that we could
avoid instantiation of the whole flow infrastructure for the second and
the third times. This is done only for LocalSyncFlows because all
physical plans containing `LocalPlanNode`s are fully local.

Fixes: #62261.

Release note: None (no stable release with this bug)

**sql: mechanical rename**

This commit renames `leaves` when talking about the vectorized operator
chains to `opChains` since the objects stored in the slice are actually
roots of the chains. It also introduces an alias for
`[]execinfrapb.OpNode`. Additionally, it switches the logic of handling
an error during the vectorized flow setup so that an error is checked
first (a common way to do so).

Release note: None