### PR TITLE
colbuilder: don't plan some redundant invariants checkers

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -1354,7 +1354,10 @@ func NewColOperator(
 	}
 	r.Op, r.ColumnTypes = addProjection(r.Op, r.ColumnTypes, projection)
 	if args.TestingKnobs.PlanInvariantsCheckers {
-		r.Op = colexec.NewInvariantsChecker(r.Op)
+		// Plan an invariants checker if it isn't already the root of the tree.
+		if _, isInvariantsChecker := r.Op.(*colexec.InvariantsChecker); !isInvariantsChecker {
+			r.Op = colexec.NewInvariantsChecker(r.Op)
+		}
 	}
 	// Handle the metadata sources from the input trees. Note that it is
 	// possible that we have created a materializer which took over draining


### PR DESCRIPTION
Previously, it was possible for us to plan two invariants checkers in
a row, namely, when we have a wrapped processor, we plan the checker on
top of the columnarizer (so that we can have access to the metadata
source) but we also add another checker at the end of `NewColOperator`
which would be redundant. This commit cleans up the logic a bit.

Release note: None