### PR TITLE
release-20.2: roachtest: improve sqlsmith

### DIFF
--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -176,7 +176,9 @@ func registerSQLSmith(r *testRegistry) {
 			}()
 			if err != nil {
 				es := err.Error()
-				if strings.Contains(es, "internal error") {
+				// TODO(yuzefovich): we temporarily ignore internal errors that
+				// are because of #39433.
+				if strings.Contains(es, "internal error") && !strings.Contains(es, "internal error: invalid index") {
 					logStmt(stmt)
 					t.Fatalf("error: %s\nstmt:\n%s;", err, stmt)
 				} else if strings.Contains(es, "communication error") {

--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -176,11 +176,20 @@ func registerSQLSmith(r *testRegistry) {
 			}()
 			if err != nil {
 				es := err.Error()
-				// TODO(yuzefovich): we temporarily ignore internal errors that
-				// are because of #39433.
-				if strings.Contains(es, "internal error") && !strings.Contains(es, "internal error: invalid index") {
-					logStmt(stmt)
-					t.Fatalf("error: %s\nstmt:\n%s;", err, stmt)
+				if strings.Contains(es, "internal error") {
+					// TODO(yuzefovich): we temporarily ignore internal errors
+					// that are because of #39433 and #40929.
+					var expectedError bool
+					for _, exp := range []string{
+						"internal error: invalid index",
+						"could not parse \"0E-2019\" as type decimal",
+					} {
+						expectedError = expectedError || strings.Contains(es, exp)
+					}
+					if !expectedError {
+						logStmt(stmt)
+						t.Fatalf("error: %s\nstmt:\n%s;", err, stmt)
+					}
 				} else if strings.Contains(es, "communication error") {
 					// A communication error can be because
 					// a non-gateway node has crashed.


### PR DESCRIPTION
Backport 1/2 commits from #58249.
Backport 1/1 commits from #62403.

/cc @cockroachdb/release

---

**roachtest: ignore a known issue in sqlsmith**

This commit temporarily skips failing `sqlsmith` roachtest on `internal
error: invalid index` errors which are due to issues with subqueries
(#39433) in order to reduce the noise.

Release note: None

**roachtest: not fail sqlsmith on known issue**

This commit makes `sqlsmith` roachtest not fail on one known issue (#40929)
in order to avoid unnecessary noise.

Release note: None