### PR TITLE
release-21.1: opt: add telemetry for locality optimized search

### DIFF
--- a/pkg/ccl/telemetryccl/testdata/telemetry/multiregion
+++ b/pkg/ccl/telemetryccl/testdata/telemetry/multiregion
@@ -338,3 +338,18 @@ sql.multiregion.alter_table.locality.from.regional_by_row_as.to.regional_by_tabl
 exec
 ALTER TABLE t6 SET LOCALITY REGIONAL BY ROW AS "cr"
 ----
+
+# Test for locality optimized search counter.
+feature-allowlist
+sql.plan.opt.locality-optimized-search
+----
+
+exec
+USE survive_region;
+CREATE TABLE t7 (a INT PRIMARY KEY) LOCALITY REGIONAL BY ROW
+----
+
+feature-usage
+SELECT * FROM t7 WHERE a = 1
+----
+sql.plan.opt.locality-optimized-search

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1333,6 +1333,10 @@ func (b *Builder) buildSetOp(set memo.RelExpr) (execPlan, error) {
 
 	hardLimit := uint64(0)
 	if set.Op() == opt.LocalityOptimizedSearchOp {
+		if !b.disableTelemetry {
+			telemetry.Inc(sqltelemetry.LocalityOptimizedSearchUseCounter)
+		}
+
 		// If we are performing locality optimized search, set a limit equal to
 		// the maximum possible number of rows. This will tell the execution engine
 		// not to execute the right child if the limit is reached by the left

--- a/pkg/sql/sqltelemetry/planning.go
+++ b/pkg/sql/sqltelemetry/planning.go
@@ -176,6 +176,10 @@ var PartialIndexScanUseCounter = telemetry.GetCounterOnce("sql.plan.opt.partial-
 // on a partial index is planned.
 var PartialIndexLookupJoinUseCounter = telemetry.GetCounterOnce("sql.plan.opt.partial-index.lookup-join")
 
+// LocalityOptimizedSearchUseCounter is to be incremented whenever a locality
+// optimized search node is planned.
+var LocalityOptimizedSearchUseCounter = telemetry.GetCounterOnce("sql.plan.opt.locality-optimized-search")
+
 // CancelQueriesUseCounter is to be incremented whenever CANCEL QUERY or
 // CANCEL QUERIES is run.
 var CancelQueriesUseCounter = telemetry.GetCounterOnce("sql.session.cancel-queries")


### PR DESCRIPTION
Backport 1/1 commits from #62400.

/cc @cockroachdb/release

---

This commit adds a counter to be incremented whenever the optimizer
plans a locality optimized search operator.

Informs #61384

Release note: None
