### PR TITLE
release-20.1: kvclient: don't route to followers if closed_timestmap.target_duration == 0

### DIFF
--- a/pkg/ccl/followerreadsccl/followerreads.go
+++ b/pkg/ccl/followerreadsccl/followerreads.go
@@ -12,6 +12,7 @@ package followerreadsccl
 
 import (
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -57,6 +58,12 @@ func getFollowerReadDuration(st *cluster.Settings) time.Duration {
 	targetMultiple := followerReadMultiple.Get(&st.SV)
 	targetDuration := closedts.TargetDuration.Get(&st.SV)
 	closeFraction := closedts.CloseFraction.Get(&st.SV)
+	// Zero targetDuration means follower reads are disabled.
+	if targetDuration == 0 {
+		// Returning an infinitely large negative value would push safe
+		// request timestamp into the distant past thus disabling follower reads.
+		return math.MinInt64
+	}
 	return -1 * time.Duration(float64(targetDuration)*
 		(1+closeFraction*targetMultiple))
 }

--- a/pkg/ccl/followerreadsccl/followerreads_test.go
+++ b/pkg/ccl/followerreadsccl/followerreads_test.go
@@ -10,6 +10,7 @@ package followerreadsccl
 
 import (
 	"context"
+	"math"
 	"reflect"
 	"testing"
 	"time"
@@ -17,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -55,6 +57,19 @@ func TestEvalFollowerReadOffset(t *testing.T) {
 	if !testutils.IsError(err, "requires an enterprise license") {
 		t.Fatalf("failed to get error when evaluating follower read offset without " +
 			"an enterprise license")
+	}
+}
+
+func TestZeroDurationDisablesFollowerReadOffset(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	disableEnterprise := utilccl.TestingEnableEnterprise()
+	defer disableEnterprise()
+	st := cluster.MakeTestingClusterSettings()
+	closedts.TargetDuration.Override(&st.SV, 0)
+	if offset, err := evalFollowerReadOffset(uuid.MakeV4(), st); err != nil {
+		t.Fatal(err)
+	} else if offset != math.MinInt64 {
+		t.Fatalf("expected %v, got %v", math.MinInt64, offset)
 	}
 }
 
@@ -123,6 +138,12 @@ func TestCanSendToFollower(t *testing.T) {
 	if canSendToFollower(uuid.MakeV4(), st, roNew) {
 		t.Fatalf("should not be able to send a ro batch with new MaxTimestamp to a follower")
 	}
+	oldTD := closedts.TargetDuration.Get(&st.SV)
+	closedts.TargetDuration.Override(&st.SV, 0)
+	if canSendToFollower(uuid.MakeV4(), st, roOld) {
+		t.Fatalf("should not be able to send a ro batch to a follower when target_duration is zero")
+	}
+	closedts.TargetDuration.Override(&st.SV, oldTD)
 	disableEnterprise()
 	if canSendToFollower(uuid.MakeV4(), st, roOld) {
 		t.Fatalf("should not be able to send an old ro batch to a follower without enterprise enabled")


### PR DESCRIPTION
Backport 1/1 commits from #62149.

/cc @cockroachdb/release

---

Fixes #60711
Follower read lag determines when to attempt routing to follower. When it is disabled by setting target_duration to 0, it should not attempt followers while the old behaviour was forcing the opposite behaviour. Setting lag to negative infinity in this case ensures only requests from distant future could be routed.
