### PR TITLE
lint: don't use -unused.whole-program when PKG is specified

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1608,12 +1608,16 @@ func TestLint(t *testing.T) {
 	t.Run("TestStaticCheck", func(t *testing.T) {
 		// staticcheck uses 2.4GB of ram (as of 2019-05-10), so don't parallelize it.
 		skip.UnderShort(t)
+		var args []string
+		if pkgSpecified {
+			args = []string{pkgScope}
+		} else {
+			args = []string{"-unused.whole-program", pkgScope}
+		}
 		cmd, stderr, filter, err := dirCmd(
 			crdb.Dir,
 			"staticcheck",
-			"-unused.whole-program",
-			pkgScope,
-		)
+			args...)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
The unused linter's whole program mode will create false-positives
when PKG is specified. As a result, anyone trying to use

    make lint PKG=./pkg/SOMETHING

has to carefully read the failure output to see if it was actually a
success. By not passing that flag when PKG is specified, more cases of
the above command complete without erroneous findings.

Release note: None