### PR TITLE
ui: Replace "Admin UI" with "DB Console" on login

### DIFF
--- a/pkg/ui/src/views/login/loginPage.tsx
+++ b/pkg/ui/src/views/login/loginPage.tsx
@@ -162,7 +162,7 @@ export class LoginPage extends React.Component<Props> {
             <section className="section login-page__form">
               <div className="form-container">
                 <Text textType={TextTypes.Heading2}>
-                  Log in to the Admin UI
+                  Log in to the DB Console
                 </Text>
                 {this.renderError()}
                 <PasswordLoginForm {...this.props} />
@@ -171,8 +171,8 @@ export class LoginPage extends React.Component<Props> {
             </section>
             <section className="section login-page__info">
               <Text textType={TextTypes.Heading3}>
-                A user with a password is required to log in to the Admin UI on
-                secure clusters.
+                A user with a password is required to log in to the DB Console
+                on secure clusters.
               </Text>
               <Text textType={TextTypes.Heading5}>
                 Create a user with this SQL command:


### PR DESCRIPTION
Changed a few remaining instances of "Admin UI" to "DB Console" that
were spotted on the login page.

Release note (ui change): Change copy that referred to the app as "Admin
UI" to "DB Console" instead