### PR TITLE
bazel: set `crdb_test`, `crdb_test_off` build tags appropriately

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,7 @@
 # TODO(irfansharif): We should fold this into `dev` instead (#56965).
 
-build --ui_event_filters=-DEBUG --define gotags=bazel
-test --define gotags=bazel
+build --ui_event_filters=-DEBUG --define gotags=bazel,crdb_test_off
+test --define gotags=bazel,crdb_test
 query --ui_event_filters=-DEBUG
 
 try-import %workspace%/.bazelrc.user

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,7 +12,7 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 #
 # gazelle:prefix github.com/cockroachdb/cockroach
 # gazelle:build_file_name BUILD.bazel
-# gazelle:build_tags bazel
+# gazelle:build_tags bazel,crdb_test,crdb_test_off
 
 # Enable protobuf generation.
 #

--- a/pkg/sql/opt/memo/BUILD.bazel
+++ b/pkg/sql/opt/memo/BUILD.bazel
@@ -3,14 +3,16 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "memo",
     srcs = [
-        "check_expr_skip.go",
+        "check_expr.go",
+        "check_expr_skip.go",  # keep
         "constraint_builder.go",
         "cost.go",
         "expr.go",
         "expr_format.go",
         "expr_name_gen.go",
         "extract.go",
-        "filters_expr_mutate_checker_skip.go",
+        "filters_expr_mutate_checker.go",
+        "filters_expr_mutate_checker_skip.go",  # keep
         "group.go",
         "interner.go",
         "logical_props_builder.go",

--- a/pkg/sql/opt/props/BUILD.bazel
+++ b/pkg/sql/opt/props/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "multiplicity.go",
         "selectivity.go",
         "statistics.go",
+        "verify.go",
         "volatility.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/props",

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     srcs = [
         "constants.go",
         "crdb_test_off.go",
+        "crdb_test_on.go",  # keep
         "every_n.go",
         "fast_int_map.go",
         "fast_int_set.go",


### PR DESCRIPTION
Fixes #61724

Release note: None