### PR TITLE
kvserver: unskip TestEagerReplication

### DIFF
--- a/pkg/kv/kvserver/replicate_test.go
+++ b/pkg/kv/kvserver/replicate_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -29,7 +28,6 @@ import (
 
 func TestEagerReplication(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 54646, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()


### PR DESCRIPTION
PR #61847 fixed the flake in TestEagerReplication but was not
rebased with master, so the skipped tag was not properly removed.
This PR actually unskips TestEagerReplication.

Release note: None