### PR TITLE
kvserver: remove mentions of multiTestContext since it was deleted

### DIFF
--- a/pkg/kv/kvserver/client_raft_helpers_test.go
+++ b/pkg/kv/kvserver/client_raft_helpers_test.go
@@ -176,7 +176,7 @@ func (h *testClusterStoreRaftMessageHandler) HandleSnapshot(
 }
 
 // testClusterPartitionedRange is a convenient abstraction to create a range on a node
-// in a multiTestContext which can be partitioned and unpartitioned.
+// in a TestCluster which can be partitioned and unpartitioned.
 type testClusterPartitionedRange struct {
 	rangeID roachpb.RangeID
 	mu      struct {

--- a/pkg/kv/kvserver/replica_follower_read.go
+++ b/pkg/kv/kvserver/replica_follower_read.go
@@ -217,9 +217,7 @@ func (r *Replica) maxClosedRLocked(
 	var update replicaUpdate
 	// In some tests the lease can be empty, or the ClosedTimestampReceiver might
 	// not be set.
-	// TODO(andrei): Remove the ClosedTimestampReceiver == nil protection once the
-	// multiTestContext goes away.
-	if !replicationBehind && !lease.Empty() && r.store.cfg.ClosedTimestampReceiver != nil {
+	if !replicationBehind && !lease.Empty() {
 		otherSideTransportClosed, otherSideTransportLAI :=
 			r.store.cfg.ClosedTimestampReceiver.GetClosedTimestamp(ctx, r.RangeID, lease.Replica.NodeID)
 		if appliedLAI < otherSideTransportLAI {

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -218,7 +218,7 @@ func createTestStoreWithoutStart(
 	cfg.Gossip = gossip.NewTest(1, rpcContext, server, stopper, metric.NewRegistry(), cfg.DefaultZoneConfig)
 	cfg.StorePool = NewTestStorePool(*cfg)
 	// Many tests using this test harness (as opposed to higher-level
-	// ones like multiTestContext or TestServer) want to micro-manage
+	// ones like TestCluster and TestServer) want to micro-manage
 	// replicas and the background queues just get in the way. The
 	// scanner doesn't run frequently enough to expose races reliably,
 	// so just disable the scanner for all tests that use this function

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -307,9 +307,6 @@ type Context struct {
 	// For unittesting.
 	BreakerFactory  func() *circuit.Breaker
 	testingDialOpts []grpc.DialOption
-
-	// For testing. See the comment on the same field in HeartbeatService.
-	TestingAllowNamedRPCToAnonymousServer bool
 }
 
 // connKey is used as key in the Context.conns map.
@@ -1006,7 +1003,7 @@ func (ctx *Context) GRPCUnvalidatedDial(target string) *Connection {
 func (ctx *Context) GRPCDialNode(
 	target string, remoteNodeID roachpb.NodeID, class ConnectionClass,
 ) *Connection {
-	if remoteNodeID == 0 && !ctx.TestingAllowNamedRPCToAnonymousServer {
+	if remoteNodeID == 0 {
 		log.Fatalf(context.TODO(), "%v", errors.AssertionFailedf("invalid node ID 0 in GRPCDialNode()"))
 	}
 	return ctx.grpcDialNodeInternal(target, remoteNodeID, class)
@@ -1257,6 +1254,5 @@ func (ctx *Context) NewHeartbeatService() *HeartbeatService {
 		nodeID:                                &ctx.NodeID,
 		settings:                              ctx.Settings,
 		onHandlePing:                          ctx.OnIncomingPing,
-		testingAllowNamedRPCToAnonymousServer: ctx.TestingAllowNamedRPCToAnonymousServer,
 	}
 }

--- a/pkg/rpc/heartbeat.go
+++ b/pkg/rpc/heartbeat.go
@@ -55,13 +55,6 @@ type HeartbeatService struct {
 	disableClusterNameVerification bool
 
 	onHandlePing func(*PingRequest) error // see ContextOptions.OnIncomingPing
-
-	// TestingAllowNamedRPCToAnonymousServer, when defined (in tests),
-	// disables errors in case a heartbeat requests a specific node ID but
-	// the remote node doesn't have a node ID yet. This testing knob is
-	// currently used by the multiTestContext which does not suitably
-	// populate separate node IDs for each heartbeat service.
-	testingAllowNamedRPCToAnonymousServer bool
 }
 
 func checkClusterName(clusterName string, peerName string) error {
@@ -126,7 +119,7 @@ func (hs *HeartbeatService) Ping(ctx context.Context, args *PingRequest) (*PingR
 	if hs.nodeID != nil {
 		nodeID = hs.nodeID.Get()
 	}
-	if args.TargetNodeID != 0 && (!hs.testingAllowNamedRPCToAnonymousServer || nodeID != 0) && args.TargetNodeID != nodeID {
+	if args.TargetNodeID != 0 && args.TargetNodeID != nodeID {
 		// If nodeID != 0, the situation is clear (we are checking that
 		// the other side is talking to the right node).
 		//


### PR DESCRIPTION
PR #61561 removed multiTestContext. This PR cleans up comments
and code references that still referred to it.

Release note: None