### PR TITLE
bazel: Expose bazel build info (tag, rev, utcTime, typ)

### DIFF
--- a/.bazelrc.ci
+++ b/.bazelrc.ci
@@ -4,3 +4,6 @@
 # Set `-test.v` in Go tests.
 # Ref: https://github.com/bazelbuild/rules_go/pull/2456
 test --test_env=GO_TEST_WRAP_TESTV=1
+
+# Adding building info
+build --stamp --workspace_status_command=$(pwd)/build-rev.sh

--- a/build-rev.sh
+++ b/build-rev.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# This command is used by bazel as the workspace_status_command
+# to implement build stamping with git information.
+
+set -euo pipefail
+
+# Do not use plumbing commands, like git diff-index, in this target. Our build
+# process modifies files quickly enough that plumbing commands report false
+# positives on filesystems with only one second of resolution as a performance
+# optimization. Porcelain commands, like git diff, exist to detect and remove
+# these false positives.
+#
+# For details, see the "Possible timestamp problems with diff-files?" thread on
+# the Git mailing list (http://marc.info/?l=git&m=131687596307197).
+
+GIT_BUILD_TYPE="development"
+GIT_COMMIT=$(git rev-parse HEAD)
+GIT_TAG=$(git describe --tags --dirty --match=v[0-9]* 2> /dev/null || git rev-parse --short HEAD;)
+GIT_UTCTIME=$(date -u '+%Y/%m/%d %H:%M:%S')
+
+# Prefix with STABLE_ so that these values are saved to stable-status.txt
+# instead of volatile-status.txt.
+# Stamped rules will be retriggered by changes to stable-status.txt, but not by
+# changes to volatile-status.txt.
+cat <<EOF
+STABLE_BUILD_GIT_COMMIT ${GIT_COMMIT-}
+STABLE_BUILD_GIT_TAG ${GIT_TAG-}
+STABLE_BUILD_GIT_UTCTIME ${GIT_UTCTIME-}
+STABLE_BUILD_GIT_BUILD_TYPE ${GIT_BUILD_TYPE-}
+EOF

--- a/pkg/build/BUILD.bazel
+++ b/pkg/build/BUILD.bazel
@@ -13,6 +13,12 @@ go_library(
     embed = [":build_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/build",
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/cockroachdb/cockroach/pkg/build.rev": "{STABLE_BUILD_GIT_COMMIT}",
+        "github.com/cockroachdb/cockroach/pkg/build.tag": "{STABLE_BUILD_GIT_TAG}",
+        "github.com/cockroachdb/cockroach/pkg/build.utcTime": "{STABLE_BUILD_GIT_UTCTIME}",
+        "github.com/cockroachdb/cockroach/pkg/build.typ": "{STABLE_BUILD_GIT_BUILD_TYPE}",
+    },
     deps = [
         "//pkg/util/envutil",
         "//pkg/util/version",


### PR DESCRIPTION
As the first work related to #60963 We'd like the cockroach-short binary that CI makes to expose some of the Build Info stuff that we've been missing up to now.
We are adding the info that includes:

- github.com/cockroachdb/cockroach/pkg/build.utcTime
- github.com/cockroachdb/cockroach/pkg/build.tag
- github.com/cockroachdb/cockroach/pkg/build.rev
- github.com/cockroachdb/cockroach/pkg/build.typ

Release note: None

Release justification: non-production code changes