### PR TITLE
backupccl: run FK schema migration during RESTORE AOST

### DIFF
--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -552,6 +552,14 @@ func maybeUpgradeTableDescsInBackupManifests(
 				backupManifest.Descriptors[j] = *sqlbase.WrapDescriptor(table)
 			}
 		}
+		for j := range backupManifest.DescriptorChanges {
+			if table := backupManifest.DescriptorChanges[j].Desc.Table(hlc.Timestamp{}); table != nil {
+				if _, err := table.MaybeUpgradeForeignKeyRepresentation(ctx, protoGetter, skipFKsWithNoMatchingTable); err != nil {
+					return err
+				}
+				backupManifest.DescriptorChanges[j].Desc = sqlbase.WrapDescriptor(table)
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Part of the 19.x to 20.x upgrade included work on how schema metadata
encoded foreign keys to eventually remove the need for them to be attached
to indexes, and instead be stored on the table itself.

This work included migrating existing schemas to reflect this reorganization
and also included 'upgrading' schema metadata as it was RESTORE'd from a backup
that may have backed up the old representation.

However this on-the-fly upgrade was only applied to some of the copies of the
schema stored in the backup, namely the snapshot of 'latest' table descriptors
that is kept in backupManifest.Descriptors. A parallel optional structure called
DescriptorChanges exists in so-called 'revision_history' backups that has not
just the schema as it existed when backed up, but also prior version of it that
were revised during the backup window. The schema migraiton upgraded the schema
in 'Descriptors' but did not upgrade the prior copies of schema in 'DescriptorChanges'.

This meant that if a RESTORE was performed with an AS OF SYSTEM TIME clause, it
would search for the correct copy of the schema as of that time, then restore it,
and thus would use a copy from DescriptorChanges that had not been migrated, instead
of the copy from Descriptors, which the schema migration had processed.

Release note (bug fix): Fix a bug where 'RESTORE ... AS OF SYSTEM TIME' that used 'skip_missing_foreign_keys' when run on a backup from a 19.x or older version would incorrectly restore schema metadata relating to the foreign key leading to errors when using or inspecting that table after RESTORE.