### PR TITLE
release-21.1: sql: fix pgerror code for ADD REGION when region already added

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -588,7 +588,7 @@ DATABASE alter_test_db  ALTER DATABASE alter_test_db CONFIGURE ZONE USING
 statement error region "test" does not exist
 ALTER DATABASE alter_test_db ADD REGION "test"
 
-statement error region "ap-southeast-2" already added to database
+statement error pgcode 42710 region "ap-southeast-2" already added to database
 ALTER DATABASE alter_test_db ADD REGION "ap-southeast-2"
 
 statement error cannot add region

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -219,7 +219,11 @@ func (n *alterDatabaseAddRegionNode) startExec(params runParams) error {
 		jobDesc,
 	); err != nil {
 		if pgerror.GetPGCode(err) == pgcode.DuplicateObject {
-			return errors.Newf("region %q already added to database", n.n.Region)
+			return pgerror.Newf(
+				pgcode.DuplicateObject,
+				"region %q already added to database",
+				n.n.Region,
+			)
 		}
 		return err
 	}


### PR DESCRIPTION
Backport 1/4 commits from #62238.

/cc @cockroachdb/release

---

see individual commits for details
