### PR TITLE
ui: add time delta to lease timing in range report

### DIFF
--- a/pkg/ui/src/views/reports/containers/range/print.ts
+++ b/pkg/ui/src/views/reports/containers/range/print.ts
@@ -98,10 +98,30 @@ export function PrintTimestampDelta(
   return PrintDuration(diff);
 }
 
+// PrintTimestampDeltaFromNow is like PrintTimestampDelta, except it works both
+// when `timestamp` is below or above `now`, and at appends "ago" or "in the
+// future" to the result.
+export function PrintTimestampDeltaFromNow(
+  timestamp: protos.cockroach.util.hlc.ITimestamp,
+  now: moment.Moment,
+): string {
+  if (_.isNil(timestamp)) {
+    return "";
+  }
+  const time: moment.Moment = LongToMoment(timestamp.wall_time);
+  if (now.isAfter(time)) {
+    const diff = moment.duration(moment().diff(time));
+    return `${PrintDuration(diff)} ago`;
+  }
+  const diff = moment.duration(time.diff(moment()));
+  return `${PrintDuration(diff)} in the future`;
+}
+
 export default {
   Duration: PrintDuration,
   ReplicaID: PrintReplicaID,
   Time: PrintTime,
   Timestamp: PrintTimestamp,
   TimestampDelta: PrintTimestampDelta,
+  TimestampDeltaFromNow: PrintTimestampDeltaFromNow,
 };


### PR DESCRIPTION
This patch changes the Lease Start and Lease Expiration in the range
report to also report the delta from now.
Looks like:
```
Lease Start:     2021-03-23 21:27:53
                 (2s 884ms ago)
LeaseExpiration: 2021-03-23 21:28:02
                 (6s 121ms in the future)
```

Release note: None