### PR TITLE
scripts: update download buttons in generated release notes

### DIFF
--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -854,12 +854,16 @@ if not hidedownloads:
 
     print("""### Downloads
 
-<div id="os-tabs" class="clearfix">
-    <a href="https://binaries.cockroachdb.com/cockroach-""" + current_version + """.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-""" + current_version + """.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-""" + current_version + """.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-""" + current_version + """.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
+<div id="os-tabs" class="filters clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-""" + current_version + """.linux-amd64.tgz"><button id="linux" class="filter-button" data-scope="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-""" + current_version + """.darwin-10.9-amd64.tgz"><button id="mac" class="filter-button" data-scope="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-""" + current_version + """.windows-6.2-amd64.zip"><button id="windows" class="filter-button" data-scope="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-""" + current_version + """.src.tgz"><button id="source" class="filter-button" data-scope="source" data-eventcategory="source-release-notes"></a>
 </div>
+
+<section class="filter-content" data-scope="windows">
+{% include windows_warning.md %}
+</section>
 """)
 
     print("""### Docker image


### PR DESCRIPTION
This PR adds a data-scope attribute so that we can
expose a warning when the Windows executable is
downloaded. It is the same warning that appears
elsewhere in our docs, e.g.,
https://www.cockroachlabs.com/docs/v20.2/install-cockroachdb-windows#download-the-executable