### PR TITLE
cloudimpltests: test ExternalStorage providers return FileNotFound error

### DIFF
--- a/pkg/storage/cloud/external_storage.go
+++ b/pkg/storage/cloud/external_storage.go
@@ -51,6 +51,8 @@ type ExternalStorage interface {
 	Settings() *cluster.Settings
 
 	// ReadFile is shorthand for ReadFileAt with offset 0.
+	// ErrFileDoesNotExist is raised if `basename` cannot be located in storage.
+	// This can be leveraged for an existence check.
 	ReadFile(ctx context.Context, basename string) (io.ReadCloser, error)
 
 	// ReadFileAt returns a Reader for requested name reading at offset.


### PR DESCRIPTION
This commit adds a test to ensure that ExternalStorage providers return
the expected file does not exist error when attempting to read a file
that doesn't exist.

We previously asserted this in a couple of tests, but this change aims to
have a single test that runs against all external storage providers.

Cloud providers have yet to be added.

Release note: None