### PR TITLE
teamcity: copy roachtest weekly script to build/

### DIFF
--- a/build/teamcity-weekly-roachtest.sh
+++ b/build/teamcity-weekly-roachtest.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# Note that when this script is called, the cockroach binary to be tested
+# already exists in the current directory.
+
+set -euo pipefail
+
+if [[ "$GOOGLE_EPHEMERAL_CREDENTIALS" ]]; then
+  echo "$GOOGLE_EPHEMERAL_CREDENTIALS" > creds.json
+  gcloud auth activate-service-account --key-file=creds.json
+  export ROACHPROD_USER=teamcity
+else
+  echo 'warning: GOOGLE_EPHEMERAL_CREDENTIALS not set' >&2
+  echo "Assuming that you've run \`gcloud auth login\` from inside the builder." >&2
+fi
+
+set -x
+
+if [[ ! -f ~/.ssh/id_rsa.pub ]]; then
+  ssh-keygen -q -N "" -f ~/.ssh/id_rsa
+fi
+
+export PATH=$PATH:$(go env GOPATH)/bin
+
+build_tag=$(git describe --abbrev=0 --tags --match=v[0-9]*)
+git checkout master
+git pull origin master
+
+git rev-parse HEAD
+build/builder/mkrelease.sh amd64-linux-gnu bin/workload bin/roachtest bin/roachprod
+
+# release-2.0 names the cockroach binary differently.
+if [[ -f cockroach-linux-2.6.32-gnu-amd64 ]]; then
+  mv cockroach-linux-2.6.32-gnu-amd64 cockroach.linux-2.6.32-gnu-amd64
+fi
+
+chmod +x cockroach.linux-2.6.32-gnu-amd64
+
+artifacts=$PWD/artifacts/$(date +"%%Y%%m%%d")-${TC_BUILD_ID}
+mkdir -p "$artifacts"
+# See https://github.com/cockroachdb/cockroach/issues/54570#issuecomment-706324593
+chmod o+rwx "${artifacts}"
+
+# NB: Teamcity has a 7920 minute timeout that, when reached,
+# kills the process without a stack trace (probably SIGKILL).
+# We'd love to see a stack trace though, so after 7800 minutes,
+# kill with SIGINT which will allow roachtest to fail tests and
+# cleanup.
+#
+# NB(2): We specify --zones below so that nodes are created in us-central1-b 
+# by default. This reserves us-east1-b (the roachprod default zone) for use
+# by manually created clusters.
+exit_status=0
+if ! timeout -s INT $((7800*60)) bin/roachtest run \
+  tag:weekly \
+  --build-tag "${build_tag}" \
+  --cluster-id "${TC_BUILD_ID}" \
+  --zones "us-central1-b,us-west1-b,europe-west2-b" \
+  --cockroach "$PWD/cockroach.linux-2.6.32-gnu-amd64" \
+  --roachprod "$PWD/bin/roachprod" \
+  --workload "$PWD/bin/workload" \
+  --artifacts "$artifacts" \
+  --parallelism 5 \
+  --encrypt=random \
+  --teamcity; then
+  exit_status=$?
+fi
+
+# Upload any stats.json files to the cockroach-nightly bucket.
+for file in $(find ${artifacts#${PWD}/} -name stats.json); do
+    gsutil cp ${file} gs://cockroach-nightly/${file}
+done
+
+exit "$exit_status"


### PR DESCRIPTION
This new script is just the content of the "custom script" of the
Cockroach > Nightlies > Roachtest Weekly build configuration; but with
a reference to `make` replaced by `mkrelease`. (See
https://github.com/cockroachdb/dev-inf/issues/347.)

Release note: None