### PR TITLE
release-21.1: mutations: fix partial index and FK constraint bug

### DIFF
--- a/pkg/internal/sqlsmith/setup.go
+++ b/pkg/internal/sqlsmith/setup.go
@@ -70,12 +70,6 @@ func randTables(r *rand.Rand) string {
 	// Create the random tables.
 	stmts := rowenc.RandCreateTables(r, "table", r.Intn(5)+1,
 		mutations.StatisticsMutator,
-		// The PartialIndexMutator must be listed before the ForeignKeyMutator.
-		// A foreign key requires a unique index on the referenced column. These
-		// unique indexes are created by the ForeignKeyMutator. If the
-		// PartialIndexMutator is listed after the ForeignKeyMutator, it may
-		// mutate these unique indexes into partial unique indexes, which do not
-		// satisfy the requirements for creating the foreign key.
 		mutations.PartialIndexMutator,
 		mutations.ForeignKeyMutator,
 	)


### PR DESCRIPTION
Backport 1/1 commits from #62469.

/cc @cockroachdb/release

---

Do not mutate an index to become a partial index if that index is used
to satisfy a foreign key constraint.

This caused the failure in https://github.com/cockroachdb/cockroach/issues/56845#issuecomment-804621735 

Release note: None
