### PR TITLE
sql: fix insert fast path when columns are not in order

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -51,16 +51,20 @@ go_test(
     srcs = [
         "builder_test.go",
         "main_test.go",
+        "mutation_test.go",
     ],
     data = glob(["testdata/**"]) + [
         "@cockroach//c-deps:libgeos",
     ],
+    embed = [":execbuilder"],
     deps = [
         "//pkg/security",
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/sql",
         "//pkg/sql/logictest",
+        "//pkg/sql/opt",
+        "//pkg/sql/sem/tree",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -243,18 +243,12 @@ func (b *Builder) tryBuildFastPathInsert(ins *memo.InsertExpr) (_ execPlan, ok b
 	colList = appendColsWhenPresent(colList, ins.InsertCols)
 	colList = appendColsWhenPresent(colList, ins.CheckCols)
 	colList = appendColsWhenPresent(colList, ins.PartialIndexPutCols)
-	if !colList.Equals(values.Cols) {
-		// We have a Values input, but the columns are not in the right order. For
-		// example:
-		//   INSERT INTO ab (SELECT y, x FROM (VALUES (1, 10)) AS v (x, y))
-		//
-		// TODO(radu): we could rearrange the columns of the rows below, or add
-		// a normalization rule that adds a Project to rearrange the Values node
-		// columns.
-		return execPlan{}, false, nil
-	}
-
 	rows, err := b.buildValuesRows(values)
+	if err != nil {
+		return execPlan{}, false, err
+	}
+	// We may need to rearrange the columns.
+	rows, err = rearrangeColumns(values.Cols, rows, colList)
 	if err != nil {
 		return execPlan{}, false, err
 	}
@@ -281,6 +275,36 @@ func (b *Builder) tryBuildFastPathInsert(ins *memo.InsertExpr) (_ execPlan, ok b
 		ep.outputCols = mutationOutputColMap(ins)
 	}
 	return ep, true, nil
+}
+
+// rearrangeColumns rearranges the columns in a matrix of TypedExpr values.
+//
+// Each column in inRows corresponds to a column in inCols. The values in the
+// columns are rearranged so that they correspond to wantedCols. Note that
+// wantedCols can contain the same column multiple times, in which case the
+// values will be duplicated.
+//
+// Returns an error if wantedCols contains a column that isn't part of inCols.
+func rearrangeColumns(
+	inCols opt.ColList, inRows [][]tree.TypedExpr, wantedCols opt.ColList,
+) (outRows [][]tree.TypedExpr, _ error) {
+	if inCols.Equals(wantedCols) {
+		// Nothing to do.
+		return inRows, nil
+	}
+
+	outRows = makeTypedExprMatrix(len(inRows), len(wantedCols))
+	for i, wanted := range wantedCols {
+		j, ok := inCols.Find(wanted)
+		if !ok {
+			return nil, errors.AssertionFailedf("no column %d in input", wanted)
+		}
+		for rowIdx := range inRows {
+			outRows[rowIdx][i] = inRows[rowIdx][j]
+		}
+	}
+
+	return outRows, nil
 }
 
 func (b *Builder) buildUpdate(upd *memo.UpdateExpr) (execPlan, error) {

--- a/pkg/sql/opt/exec/execbuilder/mutation_test.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation_test.go
@@ -1,0 +1,147 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package execbuilder
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestRearrangeColumns(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		cols     opt.ColList
+		wanted   opt.ColList
+		rows     []string
+		expected []string
+	}{
+		{ // 0
+			cols:   opt.ColList{1, 2, 3},
+			wanted: opt.ColList{1, 2, 3},
+			rows: []string{
+				"a1 a2 a3",
+				"b1 b2 b3",
+			},
+			expected: []string{
+				"a1 a2 a3",
+				"b1 b2 b3",
+			},
+		},
+		{ // 1
+			cols:   opt.ColList{1, 2, 3},
+			wanted: opt.ColList{1, 2, 2, 3},
+			rows: []string{
+				"a1 a2 a3",
+				"b1 b2 b3",
+			},
+			expected: []string{
+				"a1 a2 a2 a3",
+				"b1 b2 b2 b3",
+			},
+		},
+		{ // 2
+			cols:   opt.ColList{1, 2, 3},
+			wanted: opt.ColList{1, 3, 2},
+			rows: []string{
+				"a1 a2 a3",
+				"b1 b2 b3",
+			},
+			expected: []string{
+				"a1 a3 a2",
+				"b1 b3 b2",
+			},
+		},
+		{ // 3
+			cols:   opt.ColList{1, 2, 3},
+			wanted: opt.ColList{2, 1},
+			rows: []string{
+				"a1 a2 a3",
+				"b1 b2 b3",
+			},
+			expected: []string{
+				"a2 a1",
+				"b2 b1",
+			},
+		},
+		{ // 4
+			cols:   opt.ColList{1, 2, 3},
+			wanted: opt.ColList{3, 1, 1},
+			rows: []string{
+				"a1 a2 a3",
+			},
+			expected: []string{
+				"a3 a1 a1",
+			},
+		},
+		{ // 5
+			cols:     opt.ColList{1, 2, 3},
+			wanted:   opt.ColList{1, 3, 2},
+			rows:     nil,
+			expected: nil,
+		},
+		{ // 6
+			cols:   opt.ColList{1, 2},
+			wanted: opt.ColList{2, 1},
+			rows: []string{
+				"a1 a2",
+				"b1 b2",
+				"c1 c2",
+			},
+			expected: []string{
+				"a2 a1",
+				"b2 b1",
+				"c2 c1",
+			},
+		},
+		{ // 7
+			cols:   opt.ColList{1, 2},
+			wanted: opt.ColList{2, 1, 3},
+			rows: []string{
+				"a1 a2",
+				"b1 b2",
+			},
+			expected: []string{"error"},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			inRows := make([][]tree.TypedExpr, len(tc.rows))
+			for i := range tc.rows {
+				for _, str := range strings.Split(tc.rows[i], " ") {
+					inRows[i] = append(inRows[i], tree.NewDString(str))
+				}
+			}
+			var result []string
+			if outRows, err := rearrangeColumns(tc.cols, inRows, tc.wanted); err == nil {
+				for i, row := range outRows {
+					strs := make([]string, len(outRows[i]))
+					for j := range row {
+						strs[j] = string(*row[j].(*tree.DString))
+					}
+					result = append(result, strings.Join(strs, " "))
+				}
+			} else {
+				result = []string{"error"}
+			}
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("expected %#v, got %#v", tc.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/sql/opt/exec/execbuilder/testdata/insert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/insert
@@ -640,3 +640,26 @@ query TTT
 INSERT INTO t35364 (x) VALUES (1.5) RETURNING *
 ----
 2  2  7
+
+# Regression test for #62270: make sure the fast path is used when not
+# providing values for some columns.
+statement ok
+CREATE TABLE t62270_parent (id INT PRIMARY KEY);
+CREATE TABLE t62270_child (c UUID DEFAULT (gen_random_uuid()), p INT REFERENCES t62270_parent (id));
+
+query T
+EXPLAIN (VERBOSE) INSERT INTO t62270_child (p) VALUES (1)
+----
+distribution: local
+vectorized: true
+·
+• insert fast path
+  columns: ()
+  estimated row count: 0 (missing stats)
+  into: t62270_child(c, p, rowid)
+  auto commit
+  FK check: t62270_parent@primary
+  size: 3 columns, 1 row
+  row 0, expr 0: gen_random_uuid()
+  row 0, expr 1: 1
+  row 0, expr 2: unique_rowid()


### PR DESCRIPTION
The insert fast path assumes that the input columns are in the right
order. This is the case in practice in the common case when we provide
values for all columns; but it is not the case when we provide a
subset of columns. This results in the fast path not being used when
it should.

The fix is to permute the columns after we build the values matrix.

Fixes #62270.

Release note: None