### PR TITLE
geo/geomfn: fix st_linelocatepoint to work with ZM coords

### DIFF
--- a/pkg/geo/geomfn/linestring.go
+++ b/pkg/geo/geomfn/linestring.go
@@ -91,8 +91,9 @@ func LineLocatePoint(line geo.Geometry, point geo.Geometry) (float64, error) {
 	}
 
 	p := closestT.(*geom.Point)
+	lineStart := geom.Coord{lineString.Coord(0).X(), lineString.Coord(0).Y()}
 	// build new line segment to the closest point we found
-	lineSegment := geom.NewLineString(geom.XY).MustSetCoords([]geom.Coord{lineString.Coord(0), p.Coords()})
+	lineSegment := geom.NewLineString(geom.XY).MustSetCoords([]geom.Coord{lineStart, p.Coords()})
 
 	// compute fraction of new line segment compared to total line length
 	return lineSegment.Length() / lineString.Length(), nil

--- a/pkg/geo/geomfn/linestring_test.go
+++ b/pkg/geo/geomfn/linestring_test.go
@@ -168,6 +168,11 @@ func TestLineLocatePoint(t *testing.T) {
 			point:      geom.NewPointFlat(geom.XY, []float64{3, 1}),
 			expected:   0.87,
 		},
+		{
+			lineString: geom.NewLineStringFlat(geom.XYZ, []float64{0, 0, 5, 1, 1, 26}),
+			point:      geom.NewPointFlat(geom.XYZ, []float64{0, 1, -1}),
+			expected:   0.5,
+		},
 	}
 
 	for index, tc := range testCases {


### PR DESCRIPTION
Previously, st_linelocatepoint would panic when the
line had Z and/or M coordinates.

Release note: None