### PR TITLE
sql/sem/builtins: reword follower_read_timestamp notices

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/as_of
+++ b/pkg/sql/logictest/testdata/logic_test/as_of
@@ -47,12 +47,6 @@ SELECT * FROM t AS OF SYSTEM TIME follower_read_timestamp()
 NOTICE: follower_read_timestamp does not returns a value that is less likely to read from the closest replica in a non-CCL distribution, using -4.8s from statement time instead
 NOTICE: follower_read_timestamp does not returns a value that is less likely to read from the closest replica in a non-CCL distribution, using -4.8s from statement time instead
 
-query T noticetrace
-SELECT * FROM t AS OF SYSTEM TIME experimental_follower_read_timestamp()
-----
-NOTICE: follower_read_timestamp does not returns a value that is less likely to read from the closest replica in a non-CCL distribution, using -4.8s from statement time instead
-NOTICE: follower_read_timestamp does not returns a value that is less likely to read from the closest replica in a non-CCL distribution, using -4.8s from statement time instead
-
 statement error pq: unknown signature: follower_read_timestamp\(string\) \(desired <timestamptz>\)
 SELECT * FROM t AS OF SYSTEM TIME follower_read_timestamp('boom')
 

--- a/pkg/sql/logictest/testdata/logic_test/as_of
+++ b/pkg/sql/logictest/testdata/logic_test/as_of
@@ -44,8 +44,8 @@ SELECT pg_sleep(5) -- we need to sleep so that the 4.8s elapses and the SELECT *
 query T noticetrace
 SELECT * FROM t AS OF SYSTEM TIME follower_read_timestamp()
 ----
-NOTICE: follower_read_timestamp does not returns a value that is less likely to read from the closest replica in a non-CCL distribution, using -4.8s from statement time instead
-NOTICE: follower_read_timestamp does not returns a value that is less likely to read from the closest replica in a non-CCL distribution, using -4.8s from statement time instead
+NOTICE: follower reads disabled because you are running a non-CCL distribution
+NOTICE: follower reads disabled because you are running a non-CCL distribution
 
 statement error pq: unknown signature: follower_read_timestamp\(string\) \(desired <timestamptz>\)
 SELECT * FROM t AS OF SYSTEM TIME follower_read_timestamp('boom')

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -7260,12 +7260,7 @@ func recentTimestamp(ctx *tree.EvalContext) (time.Time, error) {
 		telemetry.Inc(sqltelemetry.FollowerReadDisabledCCLCounter)
 		ctx.ClientNoticeSender.BufferClientNotice(
 			ctx.Context,
-			pgnotice.Newf(
-				tree.FollowerReadTimestampFunctionName+
-					" does not returns a value that is less likely to read from the closest replica "+
-					"in a non-CCL distribution, using %s from statement time instead",
-				defaultFollowerReadDuration,
-			),
+			pgnotice.Newf("follower reads disabled because you are running a non-CCL distribution"),
 		)
 		return ctx.StmtTimestamp.Add(defaultFollowerReadDuration), nil
 	}
@@ -7274,12 +7269,7 @@ func recentTimestamp(ctx *tree.EvalContext) (time.Time, error) {
 		if code := pgerror.GetPGCode(err); code == pgcode.CCLValidLicenseRequired {
 			telemetry.Inc(sqltelemetry.FollowerReadDisabledNoEnterpriseLicense)
 			ctx.ClientNoticeSender.BufferClientNotice(
-				ctx.Context,
-				pgnotice.Newf(
-					"%s: using %s from current statement time instead",
-					defaultFollowerReadDuration,
-					err.Error(),
-				),
+				ctx.Context, pgnotice.Newf("follower reads disabled: %s", err.Error()),
 			)
 			return ctx.StmtTimestamp.Add(defaultFollowerReadDuration), nil
 		}


### PR DESCRIPTION
The use of follower_read_timestamp() uses notices when either the binary
is non-CCL or when it is CCL but there's no enterprise license
activated. The notices were confusing: the non-CCL one had bad grammar
and talked about the timestamp returned and how it's "less likely" to
result in a follower read. The no license one had the wrong order for
arguments resulting in a mangled message. Both of them were trying to
narrowly refer to what the function returns and  missing the bigger
point - which is that routing to followers is disabled when there's no
license.

Now they read:

NOTICE: follower reads disabled because you are running a non-CCL distribution

NOTICE: follower reads disabled: use of follower reads requires an enterprise license. see https://cockroachlabs.com/pricing?cluster=5a077685-de30-496e-9804-77fa9cd60eb9 for details on how to enable enterprise features

Release note: None