### PR TITLE
importccl: add a few more ignore rules and wrap error with hint

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -5753,6 +5753,9 @@ func TestImportPgDumpIgnoredStmts(t *testing.T) {
 				COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
 				CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 
+				ALTER AGGREGATE myavg(integer) RENAME TO my_average;
+				ALTER DOMAIN zipcode SET NOT NULL;
+
 				-- Valid statement.
 				CREATE TABLE foo (id INT);
 
@@ -5865,7 +5868,11 @@ grant privileges on sequence: could not be parsed
 grant privileges on sequence: could not be parsed
 comment on extension: could not be parsed
 create extension if not exists with: could not be parsed
+alter aggregate: could not be parsed
+alter domain: could not be parsed
 create function: could not be parsed
+`,
+			`alter function: could not be parsed
 alter function: could not be parsed
 alter default privileges: could not be parsed
 `,

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -5873,10 +5873,8 @@ alter domain: could not be parsed
 create function: could not be parsed
 `,
 			`alter function: could not be parsed
-alter function: could not be parsed
 alter default privileges: could not be parsed
-`,
-			`alter table alter column add: could not be parsed
+alter table alter column add: could not be parsed
 copy from unsupported format: could not be parsed
 grant privileges on schema with: could not be parsed
 COMMENT ON TABLE t IS 'This should be skipped': unsupported by IMPORT

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2747,6 +2747,14 @@ alter_unsupported_stmt:
   {
     return unimplemented(sqllex, "alter function")
   }
+| ALTER DOMAIN error
+  {
+    return unimplemented(sqllex, "alter domain")
+  }
+| ALTER AGGREGATE error
+  {
+    return unimplemented(sqllex, "alter aggregate")
+  }
 | ALTER DEFAULT error
   {
     return unimplemented(sqllex, "alter default privileges")


### PR DESCRIPTION
Commit 1 - added two more ignore rules.

Commit 2 - wrap unsupported error with a hint pointing to the ignore options that can be supplied to get around this error.

Fixes: #62462
Fixes: #62092