### PR TITLE
catalog: add telemetry for descriptor validation errors

### DIFF
--- a/pkg/server/telemetry/BUILD.bazel
+++ b/pkg/server/telemetry/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/server/telemetry",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/sql/catalog/catconstants",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/util/metric",

--- a/pkg/server/telemetry/features.go
+++ b/pkg/server/telemetry/features.go
@@ -13,8 +13,10 @@ package telemetry
 import (
 	"fmt"
 	"math"
+	"strings"
 	"sync/atomic"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -247,9 +249,13 @@ func RecordError(err error) {
 		default:
 			prefix = "othererror." + code.String() + "."
 		}
-
 		for _, tk := range tkeys {
-			Count(prefix + tk)
+			prefixedTelemetryKey := prefix + tk
+			if strings.HasPrefix(tk, catconstants.ValidationTelemetryKeyPrefix) {
+				// Descriptor validation errors already have their own prefixing scheme.
+				prefixedTelemetryKey = tk
+			}
+			Count(prefixedTelemetryKey)
 		}
 	}
 }

--- a/pkg/sql/catalog/BUILD.bazel
+++ b/pkg/sql/catalog/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/kv",
         "//pkg/roachpb",
         "//pkg/settings/cluster",
+        "//pkg/sql/catalog/catconstants",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",

--- a/pkg/sql/catalog/catalogkv/catalogkv.go
+++ b/pkg/sql/catalog/catalogkv/catalogkv.go
@@ -165,7 +165,7 @@ func descriptorFromKeyValue(
 	} else {
 		desc = b.BuildImmutable()
 	}
-	err = catalog.Validate(ctx, dg, validationLevel, desc).CombinedError()
+	err = catalog.Validate(ctx, dg, catalog.ValidationReadTelemetry, validationLevel, desc).CombinedError()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/catalog/catconstants/constants.go
+++ b/pkg/sql/catalog/catconstants/constants.go
@@ -198,3 +198,7 @@ const (
 	PgExtensionSpatialRefSysTableID
 	MinVirtualID = PgExtensionSpatialRefSysTableID
 )
+
+// ValidationTelemetryKeyPrefix is the prefix of telemetry keys pertaining to
+// descriptor validation failures.
+const ValidationTelemetryKeyPrefix = "sql.schema.validation_errors."

--- a/pkg/sql/catalog/dbdesc/database_test.go
+++ b/pkg/sql/catalog/dbdesc/database_test.go
@@ -287,7 +287,8 @@ func TestValidateCrossDatabaseReferences(t *testing.T) {
 			descs.Namespace[namespaceKey] = desc.GetID()
 		}
 		expectedErr := fmt.Sprintf("%s %q (%d): %s", desc.DescriptorType(), desc.GetName(), desc.GetID(), test.err)
-		if err := catalog.Validate(ctx, descs, catalog.ValidationLevelAllPreTxnCommit, desc).CombinedError(); err == nil {
+		results := catalog.Validate(ctx, descs, catalog.NoValidationTelemetry, catalog.ValidationLevelAllPreTxnCommit, desc)
+		if err := results.CombinedError(); err == nil {
 			if test.err != "" {
 				t.Errorf("%d: expected \"%s\", but found success: %+v", i, expectedErr, test.desc)
 			}

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -1528,7 +1528,13 @@ func (tc *Collection) ValidateUncommittedDescriptors(ctx context.Context, txn *k
 		return nil
 	}
 	bdg := catalogkv.NewOneLevelUncachedDescGetter(txn, tc.codec())
-	return catalog.Validate(ctx, bdg, catalog.ValidationLevelAllPreTxnCommit, descs...).CombinedError()
+	return catalog.Validate(
+		ctx,
+		bdg,
+		catalog.ValidationWriteTelemetry,
+		catalog.ValidationLevelAllPreTxnCommit,
+		descs...,
+	).CombinedError()
 }
 
 // User defined type accessors.

--- a/pkg/sql/catalog/schemadesc/schema_desc_test.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc_test.go
@@ -172,7 +172,8 @@ func TestValidateCrossSchemaReferences(t *testing.T) {
 		descs.Descriptors[test.dbDesc.ID] = dbdesc.NewBuilder(&test.dbDesc).BuildImmutable()
 		expectedErr := fmt.Sprintf("%s %q (%d): %s", desc.DescriptorType(), desc.GetName(), desc.GetID(), test.err)
 		const validateCrossReferencesOnly = catalog.ValidationLevelCrossReferences &^ (catalog.ValidationLevelCrossReferences >> 1)
-		if err := catalog.Validate(ctx, descs, validateCrossReferencesOnly, desc).CombinedError(); err == nil {
+		results := catalog.Validate(ctx, descs, catalog.NoValidationTelemetry, validateCrossReferencesOnly, desc)
+		if err := results.CombinedError(); err == nil {
 			if test.err != "" {
 				t.Errorf("%d: expected \"%s\", but found success: %+v", i, expectedErr, test.desc)
 			}

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -1485,7 +1485,8 @@ func TestValidateCrossTableReferences(t *testing.T) {
 		desc := NewBuilder(&test.desc).BuildImmutable()
 		expectedErr := fmt.Sprintf("%s %q (%d): %s", desc.DescriptorType(), desc.GetName(), desc.GetID(), test.err)
 		const validateCrossReferencesOnly = catalog.ValidationLevelCrossReferences &^ (catalog.ValidationLevelCrossReferences >> 1)
-		if err := catalog.Validate(ctx, descs, validateCrossReferencesOnly, desc).CombinedError(); err == nil {
+		results := catalog.Validate(ctx, descs, catalog.NoValidationTelemetry, validateCrossReferencesOnly, desc)
+		if err := results.CombinedError(); err == nil {
 			if test.err != "" {
 				t.Errorf("%d: expected \"%s\", but found success: %+v", i, expectedErr, test.desc)
 			}

--- a/pkg/sql/doctor/doctor.go
+++ b/pkg/sql/doctor/doctor.go
@@ -161,7 +161,8 @@ func validateSafely(
 			errs = append(errs, err)
 		}
 	}()
-	errs = append(errs, catalog.Validate(ctx, descGetter, catalog.ValidationLevelNamespace, desc).Errors()...)
+	results := catalog.Validate(ctx, descGetter, catalog.NoValidationTelemetry, catalog.ValidationLevelAllPreTxnCommit, desc)
+	errs = append(errs, results.Errors()...)
 	return errs
 }
 

--- a/pkg/sql/testdata/telemetry/error
+++ b/pkg/sql/testdata/telemetry/error
@@ -4,7 +4,54 @@ feature-allowlist
 othererror.*
 errorcodes.*
 unimplemented.*
+sql.schema.validation_errors.*
 ----
+
+# Table descriptor validation failure on read.
+feature-usage
+CREATE DATABASE t;
+CREATE TABLE t.test (k INT);
+CREATE TABLE fktbl (id INT PRIMARY KEY);
+CREATE TABLE tbl (customer INT NOT NULL REFERENCES fktbl (id));
+INSERT INTO system.users VALUES ('node', NULL, true);
+GRANT node TO root;
+DELETE FROM system.descriptor WHERE id=52;
+DELETE FROM system.descriptor WHERE id=54;
+REVOKE node FROM root;
+DELETE FROM system.users WHERE username = 'node';
+SELECT * FROM tbl;
+----
+error: pq: relation "tbl" (55): invalid foreign key: missing table=54: referenced table ID 54: descriptor not found
+errorcodes.XXUUU
+othererror.XXUUU
+sql.schema.validation_errors.read.cross_references.relation
+
+# Type descriptor validation failure on read.
+feature-usage
+CREATE TYPE greeting AS ENUM('hello', 'hi');
+INSERT INTO system.users VALUES ('node', NULL, true);
+GRANT node TO root;
+DELETE FROM system.descriptor WHERE id=57;
+REVOKE node FROM root;
+DELETE FROM system.users WHERE username = 'node';
+SELECT 'hello'::greeting;
+----
+error: pq: type "greeting" (56): arrayTypeID 57 does not exist for "ENUM": referenced type ID 57: descriptor not found
+errorcodes.XXUUU
+othererror.XXUUU
+sql.schema.validation_errors.read.cross_references.type
+
+# Table descriptor validation failure on transaction commit.
+feature-usage
+CREATE TABLE t (x INT PRIMARY KEY);
+BEGIN;
+ALTER TABLE t DROP CONSTRAINT "primary";
+COMMIT;
+----
+error: pq: relation "t" (58): unimplemented: primary key dropped without subsequent addition of new primary key in same transaction
+errorcodes.0A000
+sql.schema.validation_errors.write.pre_txn_commit.relation
+unimplemented.#48026
 
 # 42601 is pgcode.Syntax.
 feature-usage


### PR DESCRIPTION
This commit adds `sql.schema.validation_errors.*` telemetry keys to
descriptor validation errors.

Fixes #61786.

Release note: None