### PR TITLE
release-20.2: filetable: fix race in userfile table creation

### DIFF
--- a/pkg/ccl/importccl/exportcsv_test.go
+++ b/pkg/ccl/importccl/exportcsv_test.go
@@ -75,7 +75,7 @@ func TestExportImportBank(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	db, dir, cleanup := setupExportableBank(t, 3, 100)
+	db, _, cleanup := setupExportableBank(t, 3, 100)
 	defer cleanup()
 
 	// Add some unicode to prove FmtExport works as advertised.
@@ -83,6 +83,7 @@ func TestExportImportBank(t *testing.T) {
 	db.Exec(t, "UPDATE bank SET payload = NULL WHERE id % 2 = 0")
 
 	chunkSize := 13
+	baseExportDir := "userfile:///t/"
 	for _, null := range []string{"", "NULL"} {
 		nullAs, nullIf := "", ", nullif = ''"
 		if null != "" {
@@ -90,27 +91,20 @@ func TestExportImportBank(t *testing.T) {
 			nullIf = fmt.Sprintf(", nullif = '%s'", null)
 		}
 		t.Run("null="+null, func(t *testing.T) {
-			var files []string
+			exportDir := filepath.Join(baseExportDir, t.Name())
 
 			var asOf string
 			db.QueryRow(t, "SELECT cluster_logical_timestamp()").Scan(&asOf)
 
-			for _, row := range db.QueryStr(t,
-				fmt.Sprintf(`EXPORT INTO CSV 'nodelocal://0/t'
-					WITH chunk_rows = $1, delimiter = '|' %s
-					FROM SELECT * FROM bank AS OF SYSTEM TIME %s`, nullAs, asOf), chunkSize,
-			) {
-				files = append(files, row[0])
-				f, err := ioutil.ReadFile(filepath.Join(dir, "t", row[0]))
-				if err != nil {
-					t.Fatal(err)
-				}
-				t.Log(string(f))
-			}
+			db.Exec(t,
+				fmt.Sprintf(`EXPORT INTO CSV $1
+				WITH chunk_rows = $2, delimiter = '|' %s
+				FROM SELECT * FROM bank AS OF SYSTEM TIME %s`, nullAs, asOf), exportDir, chunkSize,
+			)
 
 			schema := bank.FromRows(1).Tables()[0].Schema
-			fileList := "'nodelocal://0/t/" + strings.Join(files, "', 'nodelocal://0/t/") + "'"
-			db.Exec(t, fmt.Sprintf(`IMPORT TABLE bank2 %s CSV DATA (%s) WITH delimiter = '|'%s`, schema, fileList, nullIf))
+			exportedFiles := filepath.Join(exportDir, "*")
+			db.Exec(t, fmt.Sprintf(`IMPORT TABLE bank2 %s CSV DATA ($1) WITH delimiter = '|'%s`, schema, nullIf), exportedFiles)
 
 			db.CheckQueryResults(t,
 				fmt.Sprintf(`SELECT * FROM bank AS OF SYSTEM TIME %s ORDER BY id`, asOf), db.QueryStr(t, `SELECT * FROM bank2 ORDER BY id`),

--- a/pkg/storage/cloudimpl/filetable/file_table_read_writer.go
+++ b/pkg/storage/cloudimpl/filetable/file_table_read_writer.go
@@ -289,7 +289,7 @@ func NewFileToTableSystem(
 		// TODO(adityamaru): Handle scenario where the user has already created
 		// tables with the same names not via the FileToTableSystem
 		// object. Not sure if we want to error out or work around it.
-		tablesExist, err := f.checkIfFileAndPayloadTableExist(ctx, e.ie)
+		tablesExist, err := f.checkIfFileAndPayloadTableExist(ctx, txn, e.ie)
 		if err != nil {
 			return err
 		}
@@ -722,7 +722,7 @@ func (f *FileToTableSystem) ReadFile(ctx context.Context, filename string) (io.R
 }
 
 func (f *FileToTableSystem) checkIfFileAndPayloadTableExist(
-	ctx context.Context, ie *sql.InternalExecutor,
+	ctx context.Context, txn *kv.Txn, ie *sql.InternalExecutor,
 ) (bool, error) {
 	tablePrefix, err := f.GetTableName()
 	if err != nil {
@@ -751,7 +751,7 @@ func (f *FileToTableSystem) checkIfFileAndPayloadTableExist(
 	tableExistenceQuery := fmt.Sprintf(
 		`SELECT quote_ident(table_name) FROM [SHOW TABLES FROM %s] WHERE quote_ident(table_name)=$1 OR quote_ident(table_name)=$2`,
 		databaseSchema)
-	rows, err := ie.QueryEx(ctx, "tables-exist", nil,
+	rows, err := ie.QueryEx(ctx, "tables-exist", txn,
 		sessiondata.InternalExecutorOverride{User: security.RootUser},
 		tableExistenceQuery, fileTableName, payloadTableName)
 	if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #62461.

/cc @cockroachdb/release

---

Previously, userfile would create the userfile table in a separate
transaction from the one that checked to see if it existed. This lead to
a potential race between concurrent userfile uploads where one upload
would first see that the table does not yet exist, but by the time it
went to create the table another thread had already created it.

This lead to some file writes erroring with a relation already exists
error.

Fixes https://github.com/cockroachdb/cockroach/issues/61816.

Release note (bug fix): Writing files to userfile would sometimes
results in an error claiming that the userfile table already exists.
This is now fixed.
