### PR TITLE
backupccl: add more locality-aware backup tests

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -449,42 +449,49 @@ func TestBackupRestorePartitioned(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	const numAccounts = 1000
-	ctx, tc, sqlDB, dir, cleanupFn := BackupRestoreTestSetup(t, MultiNode, numAccounts, InitManualReplication)
+
+	args := base.TestClusterArgs{
+		ServerArgsPerNode: map[int]base.TestServerArgs{
+			0: {
+				Locality: roachpb.Locality{Tiers: []roachpb.Tier{
+					{Key: "region", Value: "west"},
+					// NB: This has the same value as an az in the east region
+					// on purpose.
+					{Key: "az", Value: "az1"},
+					{Key: "dc", Value: "dc1"},
+				}},
+			},
+			1: {
+				Locality: roachpb.Locality{Tiers: []roachpb.Tier{
+					{Key: "region", Value: "east"},
+					// NB: This has the same value as an az in the west region
+					// on purpose.
+					{Key: "az", Value: "az1"},
+					{Key: "dc", Value: "dc2"},
+				}},
+			},
+			2: {
+				Locality: roachpb.Locality{Tiers: []roachpb.Tier{
+					{Key: "region", Value: "east"},
+					{Key: "az", Value: "az2"},
+					{Key: "dc", Value: "dc3"},
+				}},
+			},
+		},
+	}
+
+	ctx, _, sqlDB, dir, cleanupFn := backupRestoreTestSetupWithParams(t, 3 /* nodes */, numAccounts, InitManualReplication, args)
 	defer cleanupFn()
 
-	// Ensure that each node has at least one leaseholder. (These splits were
-	// made in BackupRestoreTestSetup.) These are wrapped with SucceedsSoon()
-	// because EXPERIMENTAL_RELOCATE can fail if there are other replication
-	// changes happening.
-	for _, stmt := range []string{
-		`ALTER TABLE data.bank EXPERIMENTAL_RELOCATE VALUES (ARRAY[1], 0)`,
-		`ALTER TABLE data.bank EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 100)`,
-		`ALTER TABLE data.bank EXPERIMENTAL_RELOCATE VALUES (ARRAY[3], 200)`,
-	} {
-		testutils.SucceedsSoon(t, func() error {
-			_, err := sqlDB.DB.ExecContext(ctx, stmt)
-			return err
-		})
+	// locationToDir converts backup URIs based on LocalFoo to the temporary
+	// file it represents on disk.
+	locationToDir := func(location string) string {
+		return strings.Replace(location, LocalFoo, filepath.Join(dir, "foo"), 1)
 	}
-	const localFoo1 = LocalFoo + "/1"
-	const localFoo2 = LocalFoo + "/2"
-	const localFoo3 = LocalFoo + "/3"
-	backupURIs := []string{
-		fmt.Sprintf("%s?COCKROACH_LOCALITY=%s", localFoo1, url.QueryEscape("default")),
-		fmt.Sprintf("%s?COCKROACH_LOCALITY=%s", localFoo2, url.QueryEscape("dc=dc1")),
-		fmt.Sprintf("%s?COCKROACH_LOCALITY=%s", localFoo3, url.QueryEscape("dc=dc2")),
-	}
-	restoreURIs := []string{
-		localFoo1,
-		localFoo2,
-		localFoo3,
-	}
-	backupAndRestore(ctx, t, tc, backupURIs, restoreURIs, numAccounts)
 
-	// Verify that at least one SST exists in each backup destination.
-	sstMatcher := regexp.MustCompile(`\d+\.sst`)
-	for i := 1; i <= 3; i++ {
-		subDir := fmt.Sprintf("%s/foo/%d", dir, i)
+	hasSSTs := func(location string) bool {
+		sstMatcher := regexp.MustCompile(`\d+\.sst`)
+		subDir := locationToDir(location)
 		files, err := ioutil.ReadDir(subDir)
 		if err != nil {
 			t.Fatal(err)
@@ -496,16 +503,25 @@ func TestBackupRestorePartitioned(t *testing.T) {
 				break
 			}
 		}
-		if !found {
-			t.Fatalf("no SSTs found in %s", subDir)
+		return found
+	}
+
+	requireHasSSTs := func(t *testing.T, locations ...string) {
+		for _, location := range locations {
+			require.True(t, hasSSTs(location))
 		}
 	}
-	// The PartitionGZip subtest is to verify that partition descriptor files
-	// are in the GZip compressed format.
-	t.Run("PartitionGZip", func(t *testing.T) {
+
+	requireHasNoSSTs := func(t *testing.T, locations ...string) {
+		for _, location := range locations {
+			require.False(t, hasSSTs(location))
+		}
+	}
+
+	requireCompressedManifest := func(t *testing.T, locations ...string) {
 		partitionMatcher := regexp.MustCompile(`^BACKUP_PART_`)
-		for i := 1; i <= 3; i++ {
-			subDir := fmt.Sprintf("%s/foo/%d", dir, i)
+		for _, location := range locations {
+			subDir := locationToDir(location)
 			files, err := ioutil.ReadDir(subDir)
 			if err != nil {
 				t.Fatal(err)
@@ -522,6 +538,99 @@ func TestBackupRestorePartitioned(t *testing.T) {
 				}
 			}
 		}
+	}
+
+	runBackupRestore := func(t *testing.T, sqlDB *sqlutils.SQLRunner, backupURIs []string) {
+		locationFmtString, locationURIArgs := uriFmtStringAndArgs(backupURIs)
+		backupQuery := fmt.Sprintf("BACKUP DATABASE data TO %s", locationFmtString)
+		sqlDB.Exec(t, backupQuery, locationURIArgs...)
+
+		sqlDB.Exec(t, `DROP DATABASE data;`)
+		restoreQuery := fmt.Sprintf("RESTORE DATABASE data FROM %s", locationFmtString)
+		sqlDB.Exec(t, restoreQuery, locationURIArgs...)
+	}
+
+	// Ensure that each node has at least one leaseholder. (These splits were
+	// made in BackupRestoreTestSetup.) These are wrapped with SucceedsSoon()
+	// because EXPERIMENTAL_RELOCATE can fail if there are other replication
+	// changes happening.
+	for _, stmt := range []string{
+		`ALTER TABLE data.bank EXPERIMENTAL_RELOCATE VALUES (ARRAY[1], 0)`,
+		`ALTER TABLE data.bank EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 100)`,
+		`ALTER TABLE data.bank EXPERIMENTAL_RELOCATE VALUES (ARRAY[3], 200)`,
+	} {
+		testutils.SucceedsSoon(t, func() error {
+			_, err := sqlDB.DB.ExecContext(ctx, stmt)
+			return err
+		})
+	}
+
+	t.Run("partition-by-unique-key", func(t *testing.T) {
+		testSubDir := t.Name()
+		locations := []string{
+			LocalFoo + "/" + testSubDir + "/1",
+			LocalFoo + "/" + testSubDir + "/2",
+			LocalFoo + "/" + testSubDir + "/3",
+		}
+		backupURIs := []string{
+			// The first location will contain data from node 3 with config
+			// dc=dc3.
+			fmt.Sprintf("%s?COCKROACH_LOCALITY=%s", locations[0], url.QueryEscape("default")),
+			fmt.Sprintf("%s?COCKROACH_LOCALITY=%s", locations[1], url.QueryEscape("dc=dc1")),
+			fmt.Sprintf("%s?COCKROACH_LOCALITY=%s", locations[2], url.QueryEscape("dc=dc2")),
+		}
+		runBackupRestore(t, sqlDB, backupURIs)
+
+		// Verify that at least one SST exists in each backup destination.
+		requireHasSSTs(t, locations...)
+
+		// Verify that all of the partition manifests are compressed.
+		requireCompressedManifest(t, locations...)
+	})
+
+	// Test that we're selecting the most specific locality tier for a location.
+	t.Run("partition-by-different-tiers", func(t *testing.T) {
+		testSubDir := t.Name()
+		locations := []string{
+			LocalFoo + "/" + testSubDir + "/1",
+			LocalFoo + "/" + testSubDir + "/2",
+			LocalFoo + "/" + testSubDir + "/3",
+			LocalFoo + "/" + testSubDir + "/4",
+		}
+		backupURIs := []string{
+			fmt.Sprintf("%s?COCKROACH_LOCALITY=%s", locations[0], url.QueryEscape("default")),
+			fmt.Sprintf("%s?COCKROACH_LOCALITY=%s", locations[1], url.QueryEscape("region=east")),
+			fmt.Sprintf("%s?COCKROACH_LOCALITY=%s", locations[2], url.QueryEscape("az=az1")),
+			fmt.Sprintf("%s?COCKROACH_LOCALITY=%s", locations[3], url.QueryEscape("az=az2")),
+		}
+
+		runBackupRestore(t, sqlDB, backupURIs)
+
+		// All data should be covered by az=az1 or az=az2, so expect all the
+		// data on those locations.
+		requireHasNoSSTs(t, locations[0], locations[1])
+		requireHasSSTs(t, locations[2], locations[3])
+	})
+
+	t.Run("partition-by-several-keys", func(t *testing.T) {
+		testSubDir := t.Name()
+		locations := []string{
+			LocalFoo + "/" + testSubDir + "/1",
+			LocalFoo + "/" + testSubDir + "/2",
+			LocalFoo + "/" + testSubDir + "/3",
+			LocalFoo + "/" + testSubDir + "/4",
+		}
+		backupURIs := []string{
+			fmt.Sprintf("%s?COCKROACH_LOCALITY=%s", locations[0], url.QueryEscape("default")),
+			fmt.Sprintf("%s?COCKROACH_LOCALITY=%s", locations[1], url.QueryEscape("region=east,az=az1")),
+			fmt.Sprintf("%s?COCKROACH_LOCALITY=%s", locations[2], url.QueryEscape("region=east,az=az2")),
+			fmt.Sprintf("%s?COCKROACH_LOCALITY=%s", locations[3], url.QueryEscape("region=west,az=az1")),
+		}
+
+		// Specifying multiple tiers is not supported.
+		locationFmtString, locationURIArgs := uriFmtStringAndArgs(backupURIs)
+		backupQuery := fmt.Sprintf("BACKUP DATABASE data TO %s", locationFmtString)
+		sqlDB.ExpectErr(t, `tier must be in the form "key=value" not "region=east,az=az1"`, backupQuery, locationURIArgs...)
 	})
 }
 
@@ -904,27 +1013,6 @@ func backupAndRestore(
 	restoreURIs []string,
 	numAccounts int,
 ) {
-	// uriFmtStringAndArgs returns format strings like "$1" or "($1, $2, $3)" and
-	// an []interface{} of URIs for the BACKUP/RESTORE queries.
-	uriFmtStringAndArgs := func(uris []string) (string, []interface{}) {
-		urisForFormat := make([]interface{}, len(uris))
-		var fmtString strings.Builder
-		if len(uris) > 1 {
-			fmtString.WriteString("(")
-		}
-		for i, uri := range uris {
-			if i > 0 {
-				fmtString.WriteString(", ")
-			}
-			fmtString.WriteString(fmt.Sprintf("$%d", i+1))
-			urisForFormat[i] = uri
-		}
-		if len(uris) > 1 {
-			fmtString.WriteString(")")
-		}
-		return fmtString.String(), urisForFormat
-	}
-
 	conn := tc.Conns[0]
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 	{

--- a/pkg/ccl/backupccl/helpers_test.go
+++ b/pkg/ccl/backupccl/helpers_test.go
@@ -438,3 +438,24 @@ func getKVCount(ctx context.Context, kvDB *kv.DB, dbName, tableName string) (int
 	kvs, err := kvDB.Scan(ctx, tablePrefix, tableEnd, 0)
 	return len(kvs), err
 }
+
+// uriFmtStringAndArgs returns format strings like "$1" or "($1, $2, $3)" and
+// an []interface{} of URIs for the BACKUP/RESTORE queries.
+func uriFmtStringAndArgs(uris []string) (string, []interface{}) {
+	urisForFormat := make([]interface{}, len(uris))
+	var fmtString strings.Builder
+	if len(uris) > 1 {
+		fmtString.WriteString("(")
+	}
+	for i, uri := range uris {
+		if i > 0 {
+			fmtString.WriteString(", ")
+		}
+		fmtString.WriteString(fmt.Sprintf("$%d", i+1))
+		urisForFormat[i] = uri
+	}
+	if len(uris) > 1 {
+		fmtString.WriteString(")")
+	}
+	return fmtString.String(), urisForFormat
+}


### PR DESCRIPTION
This commit cleans up some of the locality-aware backup/restore testing,
adding test coverage exercsing the we select the more specific locality
available and that we return an error when attempting to specify more
than one KV in the COCKROACH_LOCALITY parameter.

Release note: None