### PR TITLE
sql: fix internal error when comparing collation names

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/collatedstring
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring
@@ -483,3 +483,27 @@ SELECT s FROM nocase_strings WHERE s = ('bbb' COLLATE "en-us-u-ks-l"evel2")
 
 statement error DEFAULT collations are not supported
 SELECT 'default collate'::text collate "default"
+
+statement ok
+CREATE TABLE nocase_strings2 (
+  i INT,
+  s STRING COLLATE "en-US-u-ks-level2"
+);
+
+statement ok
+INSERT INTO nocase_strings2 VALUES (1, 'Aaa' COLLATE "en-US-u-ks-level2"), (2, 'Bbb' COLLATE "en-US-u-ks-level2");
+
+query T
+SELECT s FROM nocase_strings2 WHERE s = ('bbb' COLLATE "en-US-u-ks-level2")
+----
+Bbb
+
+query T
+SELECT s FROM nocase_strings2 WHERE s = ('bbb' COLLATE "en-us-u-ks-level2")
+----
+Bbb
+
+query T
+SELECT s FROM nocase_strings2 WHERE s = ('bbb' COLLATE "en_US_u_ks_level2")
+----
+Bbb

--- a/pkg/sql/rowenc/BUILD.bazel
+++ b/pkg/sql/rowenc/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/inverted",
+        "//pkg/sql/lex",
         "//pkg/sql/parser",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",

--- a/pkg/sql/rowenc/column_type_encoding.go
+++ b/pkg/sql/rowenc/column_type_encoding.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/geo"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/bitarray"
@@ -811,7 +812,7 @@ func MarshalColumnValue(col *descpb.ColumnDescriptor, val tree.Datum) (roachpb.V
 		}
 	case types.CollatedStringFamily:
 		if v, ok := val.(*tree.DCollatedString); ok {
-			if v.Locale == col.Type.Locale() {
+			if lex.LocaleNamesAreEqual(v.Locale, col.Type.Locale()) {
 				r.SetString(v.Contents)
 				return r, nil
 			}


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/56335
(that issue was previously closed and just got reopened)

Release note (bug fix): An internal error caused by comparing
collation names that had different upper/lower case is now fixed.