### PR TITLE
release-21.1: geo/geomfn: fix st_shortestline and st_longestline for ZM coords

### DIFF
--- a/pkg/geo/geomfn/distance.go
+++ b/pkg/geo/geomfn/distance.go
@@ -155,7 +155,8 @@ func distanceLineStringInternal(
 	default:
 		return geo.Geometry{}, errors.Newf("programmer error: unknown behavior")
 	}
-	lineString := geom.NewLineStringFlat(geom.XY, append(coordA, coordB...)).SetSRID(int(a.SRID()))
+	lineCoords := []float64{coordA.X(), coordA.Y(), coordB.X(), coordB.Y()}
+	lineString := geom.NewLineStringFlat(geom.XY, lineCoords).SetSRID(int(a.SRID()))
 	return geo.MakeGeometryFromGeomT(lineString)
 }
 

--- a/pkg/geo/geomfn/distance_test.go
+++ b/pkg/geo/geomfn/distance_test.go
@@ -39,6 +39,15 @@ var distanceTestCases = []struct {
 		"LINESTRING (1 1, 1 1)",
 	},
 	{
+		"Same 3D POINTs",
+		"POINT(1.0 2.0 3.0)",
+		"POINT(1.0 2.0 3.0)",
+		0,
+		0,
+		"LINESTRING (1 2, 1 2)",
+		"LINESTRING (1 2, 1 2)",
+	},
+	{
 		"Different POINTs",
 		"POINT(1.0 1.0)",
 		"POINT(2.0 1.0)",
@@ -46,6 +55,15 @@ var distanceTestCases = []struct {
 		1,
 		"LINESTRING(1.0 1.0, 2.0 1.0)",
 		"LINESTRING (1 1, 2 1)",
+	},
+	{
+		"Different 3D POINTs",
+		"POINT(0.0 1.0 2.0)",
+		"POINT(0.0 3.0 5.0)",
+		2,
+		2,
+		"LINESTRING (0 1, 0 3)",
+		"LINESTRING (0 1, 0 3)",
 	},
 	{
 		"POINT on LINESTRING",


### PR DESCRIPTION
Backport 1/1 commits from #62488.

/cc @cockroachdb/release

---

Previously, we were appending the coords slice for the two endpoints,
which would result in incorrect behaviour when the geometry had
more than two dimensions.

Fixes #62319.

Release note: None
