### PR TITLE
backupccl: only backup public indexes

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -183,29 +183,41 @@ func getLogicallyMergedTableSpans(
 	endTime hlc.Timestamp,
 	checkForKVInBounds func(start, end roachpb.Key, endTime hlc.Timestamp) (bool, error),
 ) ([]roachpb.Span, error) {
-	var nonDropIndexIDs []descpb.IndexID
-	if err := catalog.ForEachNonDropIndex(table, func(idx catalog.Index) error {
+	// Spans with adding indexes are not safe to include in the backup since
+	// they may see non-transactional AddSST traffic. Future incremental backups
+	// will not have a way of incrementally backing up the data until #62585 is
+	// resolved.
+	addingIndexIDs := make(map[descpb.IndexID]struct{})
+	var publicIndexIDs []descpb.IndexID
+
+	allPhysicalIndexOpts := catalog.IndexOpts{DropMutations: true, AddMutations: true}
+	if err := catalog.ForEachIndex(table, allPhysicalIndexOpts, func(idx catalog.Index) error {
 		key := tableAndIndex{tableID: table.GetID(), indexID: idx.GetID()}
 		if added[key] {
 			return nil
 		}
 		added[key] = true
-		nonDropIndexIDs = append(nonDropIndexIDs, idx.GetID())
+		if idx.Public() {
+			publicIndexIDs = append(publicIndexIDs, idx.GetID())
+		}
+		if idx.Adding() {
+			addingIndexIDs[idx.GetID()] = struct{}{}
+		}
 		return nil
 	}); err != nil {
 		return nil, err
 	}
 
-	if len(nonDropIndexIDs) == 0 {
+	if len(publicIndexIDs) == 0 {
 		return nil, nil
 	}
 
 	// There is no merging possible with only a single index, short circuit.
-	if len(nonDropIndexIDs) == 1 {
-		return []roachpb.Span{table.IndexSpan(codec, nonDropIndexIDs[0])}, nil
+	if len(publicIndexIDs) == 1 {
+		return []roachpb.Span{table.IndexSpan(codec, publicIndexIDs[0])}, nil
 	}
 
-	sort.Sort(sortedIndexIDs(nonDropIndexIDs))
+	sort.Sort(sortedIndexIDs(publicIndexIDs))
 
 	var mergedIndexSpans []roachpb.Span
 
@@ -219,10 +231,10 @@ func getLogicallyMergedTableSpans(
 	// mergedSpan to encompass the lhsSpan as that is the furthest we can go.
 	// After recording the new "merged" span, we update mergedSpan to be the
 	// rhsSpan, and start processing the next logically mergeable span set.
-	mergedSpan := table.IndexSpan(codec, nonDropIndexIDs[0])
-	for curIndex := 0; curIndex < len(nonDropIndexIDs)-1; curIndex++ {
-		lhsIndexID := nonDropIndexIDs[curIndex]
-		rhsIndexID := nonDropIndexIDs[curIndex+1]
+	mergedSpan := table.IndexSpan(codec, publicIndexIDs[0])
+	for curIndex := 0; curIndex < len(publicIndexIDs)-1; curIndex++ {
+		lhsIndexID := publicIndexIDs[curIndex]
+		rhsIndexID := publicIndexIDs[curIndex+1]
 
 		lhsSpan := table.IndexSpan(codec, lhsIndexID)
 		rhsSpan := table.IndexSpan(codec, rhsIndexID)
@@ -245,17 +257,27 @@ func getLogicallyMergedTableSpans(
 			mergedSpan = rhsSpan
 		} else {
 			var foundDroppedKV bool
-			// Iterate over all index IDs between the two candidates (lhs and rhs)
-			// which may be logically merged. These index IDs represent dropped
-			// indexes between the two non-drop index spans.
+			// Iterate over all index IDs between the two candidates (lhs and
+			// rhs) which may be logically merged. These index IDs represent
+			// non-public (and perhaps dropped) indexes between the two public
+			// index spans.
 			for i := lhsIndexID + 1; i < rhsIndexID; i++ {
-				// If we find an index which has been dropped but not gc'ed, we cannot
-				// merge the lhs and rhs spans.
+				// If we find an index which has been dropped but not gc'ed, we
+				// cannot merge the lhs and rhs spans.
 				foundDroppedKV, err = checkForKVInBounds(lhsSpan.EndKey, rhsSpan.Key, endTime)
 				if err != nil {
 					return nil, err
 				}
-				if foundDroppedKV {
+				// If we find an index that is being added, don't merge the
+				// spans. We don't want to backup data that is being backfilled
+				// until the backfill is complete. Even if the backfill has not
+				// started yet and there is not data we should not include this
+				// span in the spans to back up since we want these spans to
+				// appear as introduced when the index becomes PUBLIC.
+				// The indexes will appear in introduced spans because indexes
+				// will never go from PUBLIC to ADDING.
+				_, foundAddingIndex := addingIndexIDs[i]
+				if foundDroppedKV || foundAddingIndex {
 					mergedSpan.EndKey = lhsSpan.EndKey
 					mergedIndexSpans = append(mergedIndexSpans, mergedSpan)
 					mergedSpan = rhsSpan
@@ -265,9 +287,9 @@ func getLogicallyMergedTableSpans(
 		}
 
 		// The loop will terminate after this iteration and so we must update the
-		// current mergedSpan to encompass the last element in the nonDropIndexIDs
+		// current mergedSpan to encompass the last element in the indexIDs
 		// slice as well.
-		if curIndex == len(nonDropIndexIDs)-2 {
+		if curIndex == len(publicIndexIDs)-2 {
 			mergedSpan.EndKey = rhsSpan.EndKey
 			mergedIndexSpans = append(mergedIndexSpans, mergedSpan)
 		}
@@ -331,10 +353,8 @@ func spansForAllTableIndexes(
 		// at least 2 revisions, and the first one should have the table in a PUBLIC
 		// state. We want (and do) ignore tables that have been dropped for the
 		// entire interval. DROPPED tables should never later become PUBLIC.
-		// TODO(pbardea): Consider and test the interaction between revision_history
-		// backups and OFFLINE tables.
 		rawTbl, _, _, _ := descpb.FromDescriptor(rev.Desc)
-		if rawTbl != nil && rawTbl.State != descpb.DescriptorState_DROP {
+		if rawTbl != nil && rawTbl.State == descpb.DescriptorState_PUBLIC {
 			tbl := tabledesc.NewBuilder(rawTbl).BuildImmutableTable()
 			revSpans, err := getLogicallyMergedTableSpans(tbl, added, execCfg.Codec, rev.Time,
 				checkForKVInBounds)

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -6162,17 +6162,41 @@ func getMockIndexDesc(indexID descpb.IndexID) descpb.IndexDescriptor {
 }
 
 func getMockTableDesc(
-	tableID descpb.ID, pkIndex descpb.IndexDescriptor, indexes []descpb.IndexDescriptor,
+	tableID descpb.ID,
+	pkIndex descpb.IndexDescriptor,
+	indexes []descpb.IndexDescriptor,
+	addingIndexes []descpb.IndexDescriptor,
+	droppingIndexes []descpb.IndexDescriptor,
 ) catalog.TableDescriptor {
 	mockTableDescriptor := descpb.TableDescriptor{
 		ID:           tableID,
 		PrimaryIndex: pkIndex,
 		Indexes:      indexes,
 	}
+	mutationID := descpb.MutationID(0)
+	for _, addingIndex := range addingIndexes {
+		mutationID++
+		mockTableDescriptor.Mutations = append(mockTableDescriptor.Mutations, descpb.DescriptorMutation{
+			State:       descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY,
+			Direction:   descpb.DescriptorMutation_ADD,
+			Descriptor_: &descpb.DescriptorMutation_Index{Index: &addingIndex},
+			MutationID:  mutationID,
+		})
+	}
+	for _, droppingIndex := range droppingIndexes {
+		mutationID++
+		mockTableDescriptor.Mutations = append(mockTableDescriptor.Mutations, descpb.DescriptorMutation{
+			State:       descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY,
+			Direction:   descpb.DescriptorMutation_DROP,
+			Descriptor_: &descpb.DescriptorMutation_Index{Index: &droppingIndex},
+			MutationID:  mutationID,
+		})
+	}
 	return tabledesc.NewBuilder(&mockTableDescriptor).BuildImmutableTable()
 }
 
 // Unit tests for the getLogicallyMergedTableSpans() method.
+// TODO(pbardea): Add ADDING and DROPPING indexes to these tests.
 func TestLogicallyMergedTableSpans(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	codec := keys.TODOSQLCodec
@@ -6183,6 +6207,8 @@ func TestLogicallyMergedTableSpans(t *testing.T) {
 		tableID                    descpb.ID
 		pkIndex                    descpb.IndexDescriptor
 		indexes                    []descpb.IndexDescriptor
+		addingIndexes              []descpb.IndexDescriptor
+		droppingIndexes            []descpb.IndexDescriptor
 		expectedSpans              []string
 	}{
 		{
@@ -6203,10 +6229,11 @@ func TestLogicallyMergedTableSpans(t *testing.T) {
 				}
 				return false, nil
 			},
-			tableID:       56,
-			pkIndex:       getMockIndexDesc(1),
-			indexes:       []descpb.IndexDescriptor{getMockIndexDesc(1), getMockIndexDesc(3)},
-			expectedSpans: []string{"/Table/56/{1-2}", "/Table/56/{3-4}"},
+			tableID:         56,
+			pkIndex:         getMockIndexDesc(1),
+			indexes:         []descpb.IndexDescriptor{getMockIndexDesc(1), getMockIndexDesc(3)},
+			droppingIndexes: []descpb.IndexDescriptor{getMockIndexDesc(2)},
+			expectedSpans:   []string{"/Table/56/{1-2}", "/Table/56/{3-4}"},
 		},
 		{
 			name: "gced-span-between-two-spans",
@@ -6231,7 +6258,8 @@ func TestLogicallyMergedTableSpans(t *testing.T) {
 			pkIndex: getMockIndexDesc(1),
 			indexes: []descpb.IndexDescriptor{getMockIndexDesc(1), getMockIndexDesc(3),
 				getMockIndexDesc(5)},
-			expectedSpans: []string{"/Table/58/{1-2}", "/Table/58/{3-4}", "/Table/58/{5-6}"},
+			droppingIndexes: []descpb.IndexDescriptor{getMockIndexDesc(2), getMockIndexDesc(4)},
+			expectedSpans:   []string{"/Table/58/{1-2}", "/Table/58/{3-4}", "/Table/58/{5-6}"},
 		},
 		{
 			name: "alternate-spans-gced",
@@ -6256,13 +6284,42 @@ func TestLogicallyMergedTableSpans(t *testing.T) {
 			pkIndex: getMockIndexDesc(1),
 			indexes: []descpb.IndexDescriptor{getMockIndexDesc(1), getMockIndexDesc(3),
 				getMockIndexDesc(5)},
-			expectedSpans: []string{"/Table/60/{1-2}", "/Table/60/{3-6}"},
+			droppingIndexes: []descpb.IndexDescriptor{getMockIndexDesc(2)},
+			expectedSpans:   []string{"/Table/60/{1-2}", "/Table/60/{3-6}"},
+		},
+		{
+			// Although there are no keys on index 2, we should not include its
+			// span since it holds an adding index.
+			name: "empty-adding-index",
+			checkForKVInBoundsOverride: func(start, end roachpb.Key, endTime hlc.Timestamp) (bool, error) {
+				return false, nil
+			},
+			tableID: 61,
+			pkIndex: getMockIndexDesc(1),
+			indexes: []descpb.IndexDescriptor{getMockIndexDesc(1), getMockIndexDesc(3),
+				getMockIndexDesc(4)},
+			addingIndexes: []descpb.IndexDescriptor{getMockIndexDesc(2)},
+			expectedSpans: []string{"/Table/61/{1-2}", "/Table/61/{3-5}"},
+		},
+		{
+			// It is safe to include empty dropped indexes.
+			name: "empty-dropping-index",
+			checkForKVInBoundsOverride: func(start, end roachpb.Key, endTime hlc.Timestamp) (bool, error) {
+				return false, nil
+			},
+			tableID: 62,
+			pkIndex: getMockIndexDesc(1),
+			indexes: []descpb.IndexDescriptor{getMockIndexDesc(1), getMockIndexDesc(3),
+				getMockIndexDesc(4)},
+			droppingIndexes: []descpb.IndexDescriptor{getMockIndexDesc(2)},
+			expectedSpans:   []string{"/Table/62/{1-5}"},
 		},
 	}
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			tableDesc := getMockTableDesc(test.tableID, test.pkIndex, test.indexes)
+			tableDesc := getMockTableDesc(test.tableID, test.pkIndex,
+				test.indexes, test.addingIndexes, test.droppingIndexes)
 			spans, err := getLogicallyMergedTableSpans(tableDesc, unusedMap, codec,
 				hlc.Timestamp{}, test.checkForKVInBoundsOverride)
 			var mergedSpans []string
@@ -7769,4 +7826,214 @@ func TestRestoreJobEventLogging(t *testing.T) {
 		string(jobs.StatusRunning)}
 	CheckEmittedEvents(t, expectedStatus, beforeSecondRestore.UnixNano(), jobID,
 		"restore", "RESTORE")
+}
+
+func TestBackupOnlyPublicIndexes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	skip.UnderRace(t, "likely slow under race")
+
+	numAccounts := 1000
+	chunkSize := int64(100)
+
+	// Create 2 blockers that block the backfill after 3 and 6 chunks have been
+	// processed respectively.
+	// Expect there to be 10 chunks in an index backfill:
+	//  numAccounts / chunkSize = 1000 / 100 = 10 chunks.
+	backfillBlockers := []thresholdBlocker{
+		makeThresholdBlocker(3),
+		makeThresholdBlocker(6),
+	}
+
+	// Separately, make a coule of blockers that block all schema change jobs.
+	blockBackfills := make(chan struct{})
+	// By default allow backfills to proceed.
+	close(blockBackfills)
+
+	var chunkCount int32
+	serverArgs := base.TestServerArgs{}
+	serverArgs.Knobs = base.TestingKnobs{
+		// Configure knobs to block the index backfills.
+		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+			BackfillChunkSize: chunkSize,
+		},
+		DistSQL: &execinfra.TestingKnobs{
+			RunBeforeBackfillChunk: func(sp roachpb.Span) error {
+				curChunk := int(atomic.LoadInt32(&chunkCount))
+				for _, blocker := range backfillBlockers {
+					blocker.maybeBlock(curChunk)
+				}
+				atomic.AddInt32(&chunkCount, 1)
+
+				// Separately, block backfills.
+				<-blockBackfills
+
+				return nil
+			},
+			// Flush every chunk during the backfills.
+			BulkAdderFlushesEveryBatch: true,
+		},
+	}
+	params := base.TestClusterArgs{ServerArgs: serverArgs}
+
+	ctx, tc, sqlDB, rawDir, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, numAccounts, InitManualReplication, params)
+	defer cleanupFn()
+	kvDB := tc.Server(0).DB()
+
+	locationToDir := func(location string) string {
+		return strings.Replace(location, LocalFoo, filepath.Join(rawDir, "foo"), 1)
+	}
+
+	// Test timeline:
+	//  1. Full backup
+	//  2. Backfill started
+	//  3. Inc 1
+	//  4. Inc 2
+	//  5. Backfill completeed
+	//  6. Inc 3
+	//  7. Drop index
+	//  8. Inc 4
+
+	// First take a full backup.
+	fullBackup := LocalFoo + "/full"
+	sqlDB.Exec(t, `BACKUP DATABASE data TO $1 WITH revision_history`, fullBackup)
+
+	fullBackupSpans := getSpansFromManifest(t, locationToDir(fullBackup))
+	require.Equal(t, 1, len(fullBackupSpans))
+	require.Equal(t, "/Table/53/{1-2}", fullBackupSpans[0].String())
+
+	// Now we're going to add an index. We should only see the index
+	// appear in the backup once it is PUBLIC.
+	var g errgroup.Group
+	g.Go(func() error {
+		// We use the underlying DB since the goroutine should not call t.Fatal.
+		_, err := sqlDB.DB.ExecContext(ctx,
+			`CREATE INDEX new_balance_idx ON data.bank(balance)`)
+		return errors.Wrap(err, "creating index")
+	})
+
+	inc1Loc := LocalFoo + "/inc1"
+	inc2Loc := LocalFoo + "/inc2"
+
+	g.Go(func() error {
+		defer backfillBlockers[0].allowToProceed()
+		backfillBlockers[0].waitUntilBlocked()
+
+		// Take an incremental backup and assert that it doesn't contain any
+		// data. The only added data was from the backfill, which should not
+		// be included because they are historical writes.
+		_, err := sqlDB.DB.ExecContext(ctx, `BACKUP DATABASE data TO $1 INCREMENTAL FROM $2 WITH revision_history`,
+			inc1Loc, fullBackup)
+		return errors.Wrap(err, "running inc 1 backup")
+	})
+
+	g.Go(func() error {
+		defer backfillBlockers[1].allowToProceed()
+		backfillBlockers[1].waitUntilBlocked()
+
+		// Take an incremental backup and assert that it doesn't contain any
+		// data. The only added data was from the backfill, which should not be
+		// included because they are historical writes.
+		_, err := sqlDB.DB.ExecContext(ctx, `BACKUP DATABASE data TO $1 INCREMENTAL FROM $2, $3 WITH revision_history`,
+			inc2Loc, fullBackup, inc1Loc)
+		return errors.Wrap(err, "running inc 2 backup")
+	})
+
+	// Wait for the backfill and incremental backup to complete.
+	require.NoError(t, g.Wait())
+
+	inc1Spans := getSpansFromManifest(t, locationToDir(inc1Loc))
+	require.Equalf(t, 0, len(inc1Spans), "expected inc1 to not have any data, found %v", inc1Spans)
+
+	inc2Spans := getSpansFromManifest(t, locationToDir(inc2Loc))
+	require.Equalf(t, 0, len(inc2Spans), "expected inc2 to not have any data, found %v", inc2Spans)
+
+	// Take another incremental backup that should only contain the newly added
+	// index.
+	inc3Loc := LocalFoo + "/inc3"
+	sqlDB.Exec(t, `BACKUP DATABASE data TO $1 INCREMENTAL FROM $2, $3, $4 WITH revision_history`,
+		inc3Loc, fullBackup, inc1Loc, inc2Loc)
+	inc3Spans := getSpansFromManifest(t, locationToDir(inc3Loc))
+	require.Equal(t, 1, len(inc3Spans))
+	require.Equal(t, "/Table/53/{2-3}", inc3Spans[0].String())
+
+	// Drop the index.
+	sqlDB.Exec(t, `DROP INDEX new_balance_idx`)
+
+	// Take another incremental backup.
+	inc4Loc := LocalFoo + "/inc4"
+	sqlDB.Exec(t, `BACKUP DATABASE data TO $1 INCREMENTAL FROM $2, $3, $4, $5 WITH revision_history`,
+		inc4Loc, fullBackup, inc1Loc, inc2Loc, inc3Loc)
+
+	numAccountsStr := strconv.Itoa(numAccounts)
+
+	// Restore the entire chain and check that we got the full indexes.
+	{
+		sqlDB.Exec(t, `CREATE DATABASE restoredb;`)
+		sqlDB.Exec(t, `RESTORE data.bank FROM $1, $2, $3, $4 WITH into_db='restoredb'`,
+			fullBackup, inc1Loc, inc2Loc, inc3Loc)
+		sqlDB.CheckQueryResults(t, `SELECT count(*) FROM restoredb.bank@[1]`, [][]string{{numAccountsStr}})
+		sqlDB.CheckQueryResults(t, `SELECT count(*) FROM restoredb.bank@[2]`, [][]string{{numAccountsStr}})
+		kvCount, err := getKVCount(ctx, kvDB, "restoredb", "bank")
+		require.NoError(t, err)
+		require.Equal(t, 2*numAccounts, kvCount)
+
+		// Cleanup.
+		sqlDB.Exec(t, `DROP DATABASE restoredb CASCADE;`)
+	}
+
+	// Restore to a time where the index was being added and check that the
+	// second index was regenerated entirely.
+	{
+		blockBackfills = make(chan struct{}) // block the synthesized schema change job
+		sqlDB.Exec(t, `CREATE DATABASE restoredb;`)
+		sqlDB.Exec(t, `RESTORE data.bank FROM $1, $2, $3 WITH into_db='restoredb';`,
+			fullBackup, inc1Loc, inc2Loc)
+		sqlDB.CheckQueryResults(t, `SELECT count(*) FROM restoredb.bank@[1]`, [][]string{{numAccountsStr}})
+		sqlDB.ExpectErr(t, "index .* not found", `SELECT count(*) FROM restoredb.bank@[2]`)
+
+		// Allow backfills to proceed.
+		close(blockBackfills)
+
+		// Wait for the synthesized schema change to finish, and assert that it
+		// finishes correctly.
+		scQueryRes := sqlDB.QueryStr(t, `SELECT job_id FROM [SHOW JOBS]
+		WHERE job_type = 'SCHEMA CHANGE' AND description LIKE 'RESTORING:%'`)
+		require.Equal(t, 1, len(scQueryRes),
+			`expected only 1 schema change to be generated by the restore`)
+		require.Equal(t, 1, len(scQueryRes[0]),
+			`expected only 1 column to be returned from query`)
+		scJobID, err := strconv.Atoi(scQueryRes[0][0])
+		require.NoError(t, err)
+		waitForSuccessfulJob(t, tc, jobspb.JobID(scJobID))
+
+		// The synthesized index addition has completed.
+		sqlDB.CheckQueryResults(t, `SELECT count(*) FROM restoredb.bank@[2]`, [][]string{{numAccountsStr}})
+		kvCount, err := getKVCount(ctx, kvDB, "restoredb", "bank")
+		require.NoError(t, err)
+		require.Equal(t, 2*numAccounts, kvCount)
+
+		// Cleanup.
+		sqlDB.Exec(t, `DROP DATABASE restoredb CASCADE;`)
+	}
+
+	// Restore to a time aftere the index was dropped and double check that we
+	// didn't bring back any keys from the dropped index.
+	{
+		blockBackfills = make(chan struct{}) // block the synthesized schema change job
+		sqlDB.Exec(t, `CREATE DATABASE restoredb;`)
+		sqlDB.Exec(t, `RESTORE data.bank FROM $1, $2, $3, $4, $5 WITH into_db='restoredb';`,
+			fullBackup, inc1Loc, inc2Loc, inc3Loc, inc4Loc)
+		sqlDB.CheckQueryResults(t, `SELECT count(*) FROM restoredb.bank@[1]`, [][]string{{numAccountsStr}})
+		sqlDB.ExpectErr(t, "index .* not found", `SELECT count(*) FROM restoredb.bank@[2]`)
+
+		// Allow backfills to proceed.
+		close(blockBackfills)
+		kvCount, err := getKVCount(ctx, kvDB, "restoredb", "bank")
+		require.NoError(t, err)
+		require.Equal(t, numAccounts, kvCount)
+
+		// Cleanup.
+		sqlDB.Exec(t, `DROP DATABASE restoredb CASCADE;`)
+	}
 }

--- a/pkg/ccl/backupccl/helpers_test.go
+++ b/pkg/ccl/backupccl/helpers_test.go
@@ -13,6 +13,7 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -23,13 +24,19 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	roachpb "github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/workload/bank"
 	"github.com/cockroachdb/cockroach/pkg/workload/workloadsql"
 	"github.com/cockroachdb/errors"
 	"github.com/kr/pretty"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -353,4 +360,63 @@ func makeInsecureHTTPServer(t *testing.T) (*url.URL, func()) {
 	}
 	uri.Path = filepath.Join(uri.Path, "testing")
 	return uri, cleanup
+}
+
+// thresholdBlocker is a small wrapper around channels that are commonly used to
+// block operations during testing.
+// For example, it can be used in conjection with the RunBeforeBackfillChunk and
+// BulkAdderFlushesEveryBatch cluster settings. The SQLSchemaChanger knob can be
+// used to control the chunk size.
+type thresholdBlocker struct {
+	threshold        int
+	reachedThreshold chan struct{}
+	canProceed       chan struct{}
+}
+
+func (t thresholdBlocker) maybeBlock(count int) {
+	if count == t.threshold {
+		close(t.reachedThreshold)
+		<-t.canProceed
+	}
+}
+
+func (t thresholdBlocker) waitUntilBlocked() {
+	<-t.reachedThreshold
+}
+
+func (t thresholdBlocker) allowToProceed() {
+	close(t.canProceed)
+}
+
+func makeThresholdBlocker(threshold int) thresholdBlocker {
+	return thresholdBlocker{
+		threshold:        threshold,
+		reachedThreshold: make(chan struct{}),
+		canProceed:       make(chan struct{}),
+	}
+}
+
+// getSpansFromManifest returns the spans that describe the data included in a
+// given backup.
+func getSpansFromManifest(t *testing.T, backupPath string) roachpb.Spans {
+	backupManifestBytes, err := ioutil.ReadFile(backupPath + "/" + backupManifestName)
+	require.NoError(t, err)
+	var backupManifest BackupManifest
+	decompressedBytes, err := decompressData(backupManifestBytes)
+	require.NoError(t, err)
+	require.NoError(t, protoutil.Unmarshal(decompressedBytes, &backupManifest))
+	spans := make(roachpb.Spans, 0, len(backupManifest.Files))
+	for _, file := range backupManifest.Files {
+		spans = append(spans, file.Span)
+	}
+	mergedSpans, _ := roachpb.MergeSpans(spans)
+	return mergedSpans
+}
+
+func getKVCount(ctx context.Context, kvDB *kv.DB, dbName, tableName string) (int, error) {
+	tableDesc := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, dbName, tableName)
+	tablePrefix := keys.SystemSQLCodec.TablePrefix(uint32(tableDesc.GetID()))
+	tableEnd := tablePrefix.PrefixEnd()
+	kvs, err := kvDB.Scan(ctx, tablePrefix, tableEnd, 0)
+	return len(kvs), err
 }

--- a/pkg/ccl/backupccl/restore_mid_schema_change_test.go
+++ b/pkg/ccl/backupccl/restore_mid_schema_change_test.go
@@ -19,6 +19,9 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -103,73 +106,91 @@ func TestRestoreMidSchemaChange(t *testing.T) {
 	}
 }
 
-func verifyMidSchemaChange(
-	t *testing.T, scName string, sqlDB *sqlutils.SQLRunner, isClusterRestore bool,
-) {
-	var expectedData [][]string
-	tableName := fmt.Sprintf("defaultdb.%s", scName)
-	// numJobsInCluster is the number of completed jobs that will be restored
-	// during a cluster restore.
-	var numJobsInCluster int
-	expNumSchemaChangeJobs := 1
-	// This enumerates the tests cases and specifies how each case should be
-	// handled.
+// expectedSCJobCount returns the expected number of schema change jobs
+// we expect to fin.d
+func expectedSCJobCount(scName string, isClusterRestore bool) int {
+	// The number of schema change under test. These will be the ones that are
+	// synthesized in database restore.
+	var expNumSCJobs int
+	var numBackgroundSCJobs int
+
+	// Some test cases may have more than 1 background schema change job.
 	switch scName {
-	case "midaddcol":
-		numJobsInCluster = 1 // the CREATE TABLE job
-		expectedData = [][]string{{"1", "1.3"}, {"2", "1.3"}, {"3", "1.3"}}
-	case "midaddconst":
-		numJobsInCluster = 1 // the CREATE TABLE job
-		expectedData = [][]string{{"1"}, {"2"}, {"3"}}
-		sqlDB.CheckQueryResults(t, "SELECT count(*) FROM [SHOW CONSTRAINTS FROM defaultdb.midaddconst] WHERE constraint_name = 'my_const'", [][]string{{"1"}})
-	case "midaddindex":
-		numJobsInCluster = 1 // the CREATE TABLE job
-		expectedData = [][]string{{"1"}, {"2"}, {"3"}}
-		sqlDB.CheckQueryResults(t, "SELECT count(*) FROM [SHOW INDEXES FROM defaultdb.midaddindex] WHERE column_name = 'a'", [][]string{{"1"}})
-	case "middropcol":
-		numJobsInCluster = 1 // the CREATE TABLE job
-		expectedData = [][]string{{"1"}, {"1"}, {"1"}, {"2"}, {"2"}, {"2"}, {"3"}, {"3"}, {"3"}}
 	case "midmany":
-		numJobsInCluster = 1 // the CREATE TABLE job
-		expNumSchemaChangeJobs = 3
-		expectedData = [][]string{{"1", "1.3"}, {"2", "1.3"}, {"3", "1.3"}}
-		sqlDB.CheckQueryResults(t, "SELECT count(*) FROM [SHOW CONSTRAINTS FROM defaultdb.midmany] WHERE constraint_name = 'my_const'", [][]string{{"1"}})
-		sqlDB.CheckQueryResults(t, "SELECT count(*) FROM [SHOW INDEXES FROM defaultdb.midmany] WHERE column_name = 'a'", [][]string{{"1"}})
-	case "midmultitxn":
-		numJobsInCluster = 1 // the CREATE TABLE job
-		expectedData = [][]string{{"1", "1.3"}, {"2", "1.3"}, {"3", "1.3"}}
-		sqlDB.CheckQueryResults(t, "SELECT count(*) FROM [SHOW CONSTRAINTS FROM defaultdb.midmultitxn] WHERE constraint_name = 'my_const'", [][]string{{"1"}})
-		sqlDB.CheckQueryResults(t, "SELECT count(*) FROM [SHOW INDEXES FROM defaultdb.midmultitxn] WHERE column_name = 'a'", [][]string{{"1"}})
+		numBackgroundSCJobs = 1 // the create table
+		// This test runs 3 schema changes on a single table.
+		expNumSCJobs = 3
 	case "midmultitable":
-		numJobsInCluster = 2 // the 2 CREATE TABLE jobs
-		expNumSchemaChangeJobs = 2
-		expectedData = [][]string{{"1", "1.3"}, {"2", "1.3"}, {"3", "1.3"}}
-		sqlDB.CheckQueryResults(t, fmt.Sprintf("SELECT * FROM %s1", tableName), expectedData)
-		expectedData = [][]string{{"1"}, {"2"}, {"3"}}
-		sqlDB.CheckQueryResults(t, fmt.Sprintf("SELECT * FROM %s2", tableName), expectedData)
-		tableName += "1"
+		numBackgroundSCJobs = 2 // this test creates 2 tables
+		expNumSCJobs = 2        // this test perform a schema change for each table
 	case "midprimarykeyswap":
-		numJobsInCluster = 2 // the CREATE TABLE job and the ALTER COLUMN
-		// The primary key swap will also create a cleanup job.
-		expNumSchemaChangeJobs = 2
-		expectedData = [][]string{{"1"}, {"2"}, {"3"}}
+		// Create table + alter column is done in the prep stage of this test.
+		numBackgroundSCJobs = 2
+		// PK change + PK cleanup
+		expNumSCJobs = 2
 	case "midprimarykeyswapcleanup":
-		// The CREATE TABLE job, the ALTER COLUMN, and the original ALTER PRIMARY
+		// This test performs an ALTER COLUMN, and the original ALTER PRIMARY
 		// KEY that is being cleaned up.
-		numJobsInCluster = 3
-		// This backup only contains the cleanup job mentioned above.
-		expectedData = [][]string{{"1"}, {"2"}, {"3"}}
+		numBackgroundSCJobs = 3
+		expNumSCJobs = 1
+	default:
+		// Most test cases only have 1 schema change under test.
+		expNumSCJobs = 1
+		// Most test cases have just a CREATE TABLE job that created the table
+		// under test.
+		numBackgroundSCJobs = 1
 	}
-	if scName != "midmultitable" {
-		sqlDB.CheckQueryResults(t, fmt.Sprintf("SELECT * FROM %s", tableName), expectedData)
-	}
+
+	// Since we're doing a cluster restore, we need to account for all of
+	// the schema change jobs that existed in the backup.
 	if isClusterRestore {
+		expNumSCJobs += numBackgroundSCJobs
+
 		// If we're performing a cluster restore, we also need to include the drop
 		// crdb_temp_system job.
-		expNumSchemaChangeJobs++
-		// And the create table jobs included from the backups.
-		expNumSchemaChangeJobs += numJobsInCluster
+		expNumSCJobs++
 	}
+
+	return expNumSCJobs
+}
+
+func validateTable(
+	t *testing.T, kvDB *kv.DB, sqlDB *sqlutils.SQLRunner, dbName string, tableName string,
+) {
+	desc := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, dbName, tableName)
+	// There should be no mutations on these table descriptors at this point.
+	require.Equal(t, 0, len(desc.TableDesc().Mutations))
+
+	var rowCount int
+	sqlDB.QueryRow(t, fmt.Sprintf(`SELECT count(*) FROM %s.%s`, dbName, tableName)).Scan(&rowCount)
+	// The number of entries in all indexes should be the same.
+	for _, index := range desc.AllIndexes() {
+		var indexCount int
+		sqlDB.QueryRow(t, fmt.Sprintf(`SELECT count(*) FROM %s.%s@[%d]`, dbName, tableName, index.GetID())).Scan(&indexCount)
+		require.Equal(t, rowCount, indexCount, `index should have the same number of rows as PK`)
+	}
+}
+
+func getTablesInTest(scName string) (tableNames []string) {
+	// Most of the backups name their table the test name.
+	tableNames = []string{scName}
+
+	// Some create multiple tables thouhg.
+	switch scName {
+	case "midmultitable":
+		tableNames = []string{"midmultitable1", "midmultitable2"}
+	}
+
+	return
+}
+
+func verifyMidSchemaChange(
+	t *testing.T, scName string, kvDB *kv.DB, sqlDB *sqlutils.SQLRunner, isClusterRestore bool,
+) {
+	tables := getTablesInTest(scName)
+
+	// Check that we are left with the expected number of schema change jobs.
+	expNumSchemaChangeJobs := expectedSCJobCount(scName, isClusterRestore)
 	schemaChangeJobs := sqlDB.QueryStr(t, "SELECT description FROM crdb_internal.jobs WHERE job_type = 'SCHEMA CHANGE'")
 	require.Equal(t, expNumSchemaChangeJobs, len(schemaChangeJobs),
 		"Expected %d schema change jobs but found %v", expNumSchemaChangeJobs, schemaChangeJobs)
@@ -189,9 +210,14 @@ func verifyMidSchemaChange(
 		require.Equal(t, expNumSchemaChangeJobs, len(schemaChangeJobs),
 			"Expected %d schema change jobs but found %v", expNumSchemaChangeJobs, schemaChangeJobs)
 	}
-	// Ensure that a schema change can complete on the restored table.
-	schemaChangeQuery := fmt.Sprintf("ALTER TABLE %s ADD CONSTRAINT post_restore_const CHECK (a > 0)", tableName)
-	sqlDB.Exec(t, schemaChangeQuery)
+
+	for _, tableName := range tables {
+		validateTable(t, kvDB, sqlDB, "defaultdb", tableName)
+		// Ensure that a schema change can complete on the restored table.
+		schemaChangeQuery := fmt.Sprintf("ALTER TABLE defaultdb.%s ADD CONSTRAINT post_restore_const CHECK (a > 0)", tableName)
+		sqlDB.Exec(t, schemaChangeQuery)
+	}
+
 }
 
 func restoreMidSchemaChange(
@@ -211,6 +237,7 @@ func restoreMidSchemaChange(
 			dirCleanupFn()
 		}()
 		sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+		kvDB := tc.Server(0).DB()
 
 		symlink := filepath.Join(dir, "foo")
 		err := os.Symlink(backupDir, symlink)
@@ -223,7 +250,9 @@ func restoreMidSchemaChange(
 		}
 		log.Infof(context.Background(), "%+v", sqlDB.QueryStr(t, "SHOW BACKUP $1", LocalFoo))
 		sqlDB.Exec(t, restoreQuery, LocalFoo)
-		sqlDB.CheckQueryResultsRetry(t, "SELECT * FROM crdb_internal.jobs WHERE job_type = 'SCHEMA CHANGE' AND status <> 'succeeded'", [][]string{})
-		verifyMidSchemaChange(t, schemaChangeName, sqlDB, isClusterRestore)
+		// Wait for all jobs to terminate. Some may fail since we don't restore
+		// adding spans.
+		sqlDB.CheckQueryResultsRetry(t, "SELECT * FROM crdb_internal.jobs WHERE job_type = 'SCHEMA CHANGE' AND NOT (status = 'succeeded' OR status = 'failed')", [][]string{})
+		verifyMidSchemaChange(t, schemaChangeName, kvDB, sqlDB, isClusterRestore)
 	}
 }


### PR DESCRIPTION
This commit ensures that backup only backs up PUBLIC indexes. This means
that it will not back up ADDING indexes.

This is because AddSSTable requests may write in the past, so
incremental backups may miss writes when performing a time-based scan
from the previous incremental backup.

Imforms https://github.com/cockroachdb/cockroach/issues/62564.

Test test previously failed with:
```
--- FAIL: TestBackupOnlyPublicSpans (1.92s)
    backup_test.go:7802: 
                Error Trace:    backup_test.go:7802
                Error:          Received unexpected error:
                                expected incremental backup to not contain any data, found spans [/Table/53/{2-3}]
```

Release note (bug fix): Fixes a bug where index backfill data may have
been missed by BACKUP in incremental backups.