### PR TITLE
release-21.1: geo: fix st_segmentize to work with ZM coords

### DIFF
--- a/pkg/geo/geogfn/segmentize.go
+++ b/pkg/geo/geogfn/segmentize.go
@@ -57,6 +57,13 @@ func Segmentize(geography geo.Geography, segmentMaxLength float64) (geo.Geograph
 // segments is the power of 2, and all the segments are of the same length.
 // Note: List of points does not consist of end point.
 func segmentizeCoords(a geom.Coord, b geom.Coord, segmentMaxAngle float64) ([]float64, error) {
+	if len(a) != len(b) {
+		return nil, errors.Newf("cannot segmentize two coordinates of different dimensions")
+	}
+	if segmentMaxAngle <= 0 {
+		return nil, errors.Newf("maximum segment angle must be positive")
+	}
+
 	// Converted geom.Coord into s2.Point so we can segmentize the coordinates.
 	pointA := s2.PointFromLatLng(s2.LatLngFromDegrees(a.Y(), a.X()))
 	pointB := s2.PointFromLatLng(s2.LatLngFromDegrees(b.Y(), b.X()))
@@ -65,19 +72,17 @@ func segmentizeCoords(a geom.Coord, b geom.Coord, segmentMaxAngle float64) ([]fl
 	// PostGIS' behavior appears to involve cutting this down into segments divisible
 	// by a power of two. As such, we do not use ceil(chordAngleBetweenPoints/segmentMaxAngle).
 	//
-	// This calculation is to determine the total number of segment between given
-	// 2 coordinates, ensuring that the segments are divided into parts divisible by
-	// a power of 2.
+	// This calculation determines the smallest power of 2 that is greater
+	// than ceil(chordAngleBetweenPoints/segmentMaxAngle).
 	//
-	// For that fraction by segment must be less than or equal to
-	// the fraction of max segment length to distance between point, since the
-	// total number of segment must be power of 2 therefore we can write as
-	// 1 / (2^n)[numberOfSegmentsToCreate] <= segmentMaxLength / distanceBetweenPoints < 1 / (2^(n-1))
-	// (2^n)[numberOfSegmentsToCreate] >= distanceBetweenPoints / segmentMaxLength > 2^(n-1)
-	// therefore n = ceil(log2(segmentMaxLength/distanceBetweenPoints)). Hence
-	// numberOfSegmentsToCreate = 2^(ceil(log2(segmentMaxLength/distanceBetweenPoints))).
+	// We can write that power as 2^n in the following inequality
+	// 2^n >= ceil(chordAngleBetweenPoints/segmentMaxLength) > 2^(n-1).
+	// We can drop the ceil since 2^n must be an int
+	// 2^n >= chordAngleBetweenPoints/segmentMaxLength > 2^(n-1).
+	// Then n = ceil(log2(chordAngleBetweenPoints/segmentMaxLength)).
+	// Hence numberOfSegmentsToCreate = 2^(ceil(log2(chordAngleBetweenPoints/segmentMaxLength))).
 	numberOfSegmentsToCreate := int(math.Pow(2, math.Ceil(math.Log2(chordAngleBetweenPoints/segmentMaxAngle))))
-	numPoints := 2 * (1 + numberOfSegmentsToCreate)
+	numPoints := len(a) * (1 + numberOfSegmentsToCreate)
 	if numPoints > geo.MaxAllowedSplitPoints {
 		return nil, errors.Newf(
 			"attempting to segmentize into too many coordinates; need %d points between %v and %v, max %d",
@@ -88,11 +93,19 @@ func segmentizeCoords(a geom.Coord, b geom.Coord, segmentMaxAngle float64) ([]fl
 		)
 	}
 	allSegmentizedCoordinates := make([]float64, 0, numPoints)
-	allSegmentizedCoordinates = append(allSegmentizedCoordinates, a.X(), a.Y())
+	allSegmentizedCoordinates = append(allSegmentizedCoordinates, a.Clone()...)
+	segmentFraction := 1.0 / float64(numberOfSegmentsToCreate)
 	for pointInserted := 1; pointInserted < numberOfSegmentsToCreate; pointInserted++ {
 		newPoint := s2.Interpolate(float64(pointInserted)/float64(numberOfSegmentsToCreate), pointA, pointB)
 		latLng := s2.LatLngFromPoint(newPoint)
 		allSegmentizedCoordinates = append(allSegmentizedCoordinates, latLng.Lng.Degrees(), latLng.Lat.Degrees())
+		// Linearly interpolate Z and/or M coordinates.
+		for i := 2; i < len(a); i++ {
+			allSegmentizedCoordinates = append(
+				allSegmentizedCoordinates,
+				a[i]*(1-float64(pointInserted)*segmentFraction)+b[i]*(float64(pointInserted)*segmentFraction),
+			)
+		}
 	}
 	return allSegmentizedCoordinates, nil
 }

--- a/pkg/geo/geomfn/segmentize.go
+++ b/pkg/geo/geomfn/segmentize.go
@@ -51,12 +51,20 @@ func Segmentize(g geo.Geometry, segmentMaxLength float64) (geo.Geometry, error) 
 // segment has a length less than or equal to given maximum segment length.
 // Note: List of points does not consist of end point.
 func segmentizeCoords(a geom.Coord, b geom.Coord, maxSegmentLength float64) ([]float64, error) {
+	if len(a) != len(b) {
+		return nil, errors.Newf("cannot segmentize two coordinates of different dimensions")
+	}
+	if maxSegmentLength <= 0 {
+		return nil, errors.Newf("maximum segment length must be positive")
+	}
+
+	// Only 2D distance is considered for determining number of segments.
 	distanceBetweenPoints := math.Sqrt(math.Pow(a.X()-b.X(), 2) + math.Pow(b.Y()-a.Y(), 2))
 
 	// numberOfSegmentsToCreate represent the total number of segments
 	// in which given two coordinates will be divided.
 	numberOfSegmentsToCreate := int(math.Ceil(distanceBetweenPoints / maxSegmentLength))
-	numPoints := 2 * (1 + numberOfSegmentsToCreate)
+	numPoints := len(a) * (1 + numberOfSegmentsToCreate)
 	if numPoints > geo.MaxAllowedSplitPoints {
 		return nil, errors.Newf(
 			"attempting to segmentize into too many coordinates; need %d points between %v and %v, max %d",
@@ -67,14 +75,20 @@ func segmentizeCoords(a geom.Coord, b geom.Coord, maxSegmentLength float64) ([]f
 		)
 	} // segmentFraction represent the fraction of length each segment
 	// has with respect to total length between two coordinates.
-	allSegmentizedCoordinates := make([]float64, 0, 2*(1+numberOfSegmentsToCreate))
+	allSegmentizedCoordinates := make([]float64, 0, numPoints)
 	allSegmentizedCoordinates = append(allSegmentizedCoordinates, a.Clone()...)
 	segmentFraction := 1.0 / float64(numberOfSegmentsToCreate)
 	for pointInserted := 1; pointInserted < numberOfSegmentsToCreate; pointInserted++ {
+		segmentPoint := make([]float64, 0, len(a))
+		for i := 0; i < len(a); i++ {
+			segmentPoint = append(
+				segmentPoint,
+				a[i]*(1-float64(pointInserted)*segmentFraction)+b[i]*(float64(pointInserted)*segmentFraction),
+			)
+		}
 		allSegmentizedCoordinates = append(
 			allSegmentizedCoordinates,
-			b.X()*float64(pointInserted)*segmentFraction+a.X()*(1-float64(pointInserted)*segmentFraction),
-			b.Y()*float64(pointInserted)*segmentFraction+a.Y()*(1-float64(pointInserted)*segmentFraction),
+			segmentPoint...,
 		)
 	}
 

--- a/pkg/geo/geosegmentize/geosegmentize.go
+++ b/pkg/geo/geosegmentize/geosegmentize.go
@@ -33,6 +33,7 @@ func Segmentize(
 	if geometry.Empty() {
 		return geometry, nil
 	}
+	layout := geometry.Layout()
 	switch geometry := geometry.(type) {
 	case *geom.Point, *geom.MultiPoint:
 		return geometry, nil
@@ -50,9 +51,9 @@ func Segmentize(
 		}
 		// Appending end point as it wasn't included in the iteration of coordinates.
 		allFlatCoordinates = append(allFlatCoordinates, geometry.Coord(geometry.NumCoords()-1)...)
-		return geom.NewLineStringFlat(geom.XY, allFlatCoordinates).SetSRID(geometry.SRID()), nil
+		return geom.NewLineStringFlat(layout, allFlatCoordinates).SetSRID(geometry.SRID()), nil
 	case *geom.MultiLineString:
-		segMultiLine := geom.NewMultiLineString(geom.XY).SetSRID(geometry.SRID())
+		segMultiLine := geom.NewMultiLineString(layout).SetSRID(geometry.SRID())
 		for lineIdx := 0; lineIdx < geometry.NumLineStrings(); lineIdx++ {
 			l, err := Segmentize(geometry.LineString(lineIdx), segmentMaxAngleOrLength, segmentizeCoords)
 			if err != nil {
@@ -78,9 +79,9 @@ func Segmentize(
 		}
 		// Appending end point as it wasn't included in the iteration of coordinates.
 		allFlatCoordinates = append(allFlatCoordinates, geometry.Coord(geometry.NumCoords()-1)...)
-		return geom.NewLinearRingFlat(geom.XY, allFlatCoordinates).SetSRID(geometry.SRID()), nil
+		return geom.NewLinearRingFlat(layout, allFlatCoordinates).SetSRID(geometry.SRID()), nil
 	case *geom.Polygon:
-		segPolygon := geom.NewPolygon(geom.XY).SetSRID(geometry.SRID())
+		segPolygon := geom.NewPolygon(layout).SetSRID(geometry.SRID())
 		for loopIdx := 0; loopIdx < geometry.NumLinearRings(); loopIdx++ {
 			l, err := Segmentize(geometry.LinearRing(loopIdx), segmentMaxAngleOrLength, segmentizeCoords)
 			if err != nil {
@@ -93,7 +94,7 @@ func Segmentize(
 		}
 		return segPolygon, nil
 	case *geom.MultiPolygon:
-		segMultiPolygon := geom.NewMultiPolygon(geom.XY).SetSRID(geometry.SRID())
+		segMultiPolygon := geom.NewMultiPolygon(layout).SetSRID(geometry.SRID())
 		for polygonIdx := 0; polygonIdx < geometry.NumPolygons(); polygonIdx++ {
 			p, err := Segmentize(geometry.Polygon(polygonIdx), segmentMaxAngleOrLength, segmentizeCoords)
 			if err != nil {
@@ -107,6 +108,10 @@ func Segmentize(
 		return segMultiPolygon, nil
 	case *geom.GeometryCollection:
 		segGeomCollection := geom.NewGeometryCollection().SetSRID(geometry.SRID())
+		err := segGeomCollection.SetLayout(layout)
+		if err != nil {
+			return nil, err
+		}
 		for geoIdx := 0; geoIdx < geometry.NumGeoms(); geoIdx++ {
 			g, err := Segmentize(geometry.Geom(geoIdx), segmentMaxAngleOrLength, segmentizeCoords)
 			if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #62508.

/cc @cockroachdb/release

---

Previously, st_segmentize did not handle the Z and M
coordinate properly.

Fixes #62290.

Release note: None
