### PR TITLE
catalog: change descriptor deep copy implementation

### DIFF
--- a/pkg/sql/catalog/hydratedtables/hydratedcache_test.go
+++ b/pkg/sql/catalog/hydratedtables/hydratedcache_test.go
@@ -50,7 +50,8 @@ func TestHydratedCache(t *testing.T) {
 		// Show that the cache returned a new pointer and hydrated the UDT
 		// (user-defined type).
 		require.NotEqual(t, tableDescUDT, hydrated)
-		require.EqualValues(t, hydrated.PublicColumns()[0].GetType(), typ1T)
+		require.EqualValues(t, hydrated.PublicColumns()[0].GetType().TypeMeta.Name, typ1T.TypeMeta.Name)
+		require.EqualValues(t, hydrated.PublicColumns()[0].GetType().TypeMeta.Version, typ1T.TypeMeta.Version)
 
 		// Try again and ensure we get pointer-for-pointer the same descriptor.
 		res.calls = 0


### PR DESCRIPTION
    catalog: change descriptor deep copy implementation
    
    Previously, we used protoutil.Clone to deep-copy table (and other)
    descriptors in the catalog.DescriptorBuilder implementation. This patch
    replaces that with protoutil.Marshal/Unmarshal calls, which don't use
    reflection. Care is also taken to properly carry over type metadata,
    which protobuf doesn't know about.
    
    Release note: None