### PR TITLE
sql: properly synchronize the internal executor iterator

### DIFF
--- a/pkg/ccl/changefeedccl/changefeeddist/distflow.go
+++ b/pkg/ccl/changefeedccl/changefeeddist/distflow.go
@@ -158,7 +158,7 @@ func (w *changefeedResultWriter) AddRow(ctx context.Context, row tree.Datums) er
 		return nil
 	}
 }
-func (w *changefeedResultWriter) IncrementRowsAffected(n int) {
+func (w *changefeedResultWriter) IncrementRowsAffected(ctx context.Context, n int) {
 	w.rowsAffected += n
 }
 func (w *changefeedResultWriter) SetError(err error) {

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
@@ -183,7 +183,7 @@ func (s *streamIngestionResultWriter) AddRow(ctx context.Context, row tree.Datum
 }
 
 // IncrementRowsAffected implements the sql.rowResultWriter interface.
-func (s *streamIngestionResultWriter) IncrementRowsAffected(n int) {
+func (s *streamIngestionResultWriter) IncrementRowsAffected(ctx context.Context, n int) {
 	s.rowsAffected += n
 }
 

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -107,6 +107,7 @@ go_library(
         "insert_fast_path.go",
         "instrumentation.go",
         "internal.go",
+        "internal_result_channel.go",
         "inverted_filter.go",
         "inverted_join.go",
         "job_exec_context.go",

--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -717,7 +717,7 @@ type RestrictedCommandResult interface {
 
 	// IncrementRowsAffected increments a counter by n. This is used for all
 	// result types other than tree.Rows.
-	IncrementRowsAffected(n int)
+	IncrementRowsAffected(ctx context.Context, n int)
 
 	// RowsAffected returns either the number of times AddRow was called, or the
 	// sum of all n passed into IncrementRowsAffected.
@@ -928,7 +928,7 @@ func (r *streamingCommandResult) Err() error {
 }
 
 // IncrementRowsAffected is part of the RestrictedCommandResult interface.
-func (r *streamingCommandResult) IncrementRowsAffected(n int) {
+func (r *streamingCommandResult) IncrementRowsAffected(ctx context.Context, n int) {
 	r.rowsAffected += n
 	if r.ch != nil {
 		// streamingCommandResult might be used outside of the internal executor

--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -874,6 +874,11 @@ var _ CommandResultClose = &streamingCommandResult{}
 
 // SetColumns is part of the RestrictedCommandResult interface.
 func (r *streamingCommandResult) SetColumns(ctx context.Context, cols colinfo.ResultColumns) {
+	// The interface allows for cols to be nil, yet the iterator result expects
+	// non-nil value to indicate that it was the column metadata.
+	if cols == nil {
+		cols = colinfo.ResultColumns{}
+	}
 	r.ch <- ieIteratorResult{cols: cols}
 }
 

--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -50,7 +50,7 @@ func NewRowResultWriter(rowContainer *rowcontainer.RowContainer) *RowResultWrite
 }
 
 // IncrementRowsAffected implements the rowResultWriter interface.
-func (b *RowResultWriter) IncrementRowsAffected(n int) {
+func (b *RowResultWriter) IncrementRowsAffected(ctx context.Context, n int) {
 	b.rowsAffected += n
 }
 
@@ -87,7 +87,7 @@ func newCallbackResultWriter(
 	return &callbackResultWriter{fn: fn}
 }
 
-func (c *callbackResultWriter) IncrementRowsAffected(n int) {
+func (c *callbackResultWriter) IncrementRowsAffected(ctx context.Context, n int) {
 	c.rowsAffected += n
 }
 

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -459,7 +459,7 @@ type rowResultWriter interface {
 	// AddRow writes a result row.
 	// Note that the caller owns the row slice and might reuse it.
 	AddRow(ctx context.Context, row tree.Datums) error
-	IncrementRowsAffected(n int)
+	IncrementRowsAffected(ctx context.Context, n int)
 	SetError(error)
 	Err() error
 }
@@ -510,7 +510,7 @@ func (w *errOnlyResultWriter) Err() error {
 func (w *errOnlyResultWriter) AddRow(ctx context.Context, row tree.Datums) error {
 	panic("AddRow not supported by errOnlyResultWriter")
 }
-func (w *errOnlyResultWriter) IncrementRowsAffected(n int) {
+func (w *errOnlyResultWriter) IncrementRowsAffected(ctx context.Context, n int) {
 	panic("IncrementRowsAffected not supported by errOnlyResultWriter")
 }
 
@@ -692,7 +692,7 @@ func (r *DistSQLReceiver) Push(
 		// We only need the row count. planNodeToRowSource is set up to handle
 		// ensuring that the last stage in the pipeline will return a single-column
 		// row with the row count in it, so just grab that and exit.
-		r.resultWriter.IncrementRowsAffected(int(tree.MustBeDInt(row[0].Datum)))
+		r.resultWriter.IncrementRowsAffected(r.ctx, int(tree.MustBeDInt(row[0].Datum)))
 		return r.status
 	}
 

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -130,14 +129,15 @@ func (ie *InternalExecutor) SetSessionData(sessionData *sessiondata.SessionData)
 //
 // If txn is not nil, the statement will be executed in the respective txn.
 //
-// ch is used by the connExecutor goroutine to send the rows and will be closed
-// once the goroutine exits its run() loop.
+// The ieResultWriter coordinates communicating results to the client. It may
+// block execution when rows are being sent in order to prevent hazardous
+// concurrency.
 //
 // sd will constitute the executor's session state.
 func (ie *InternalExecutor) initConnEx(
 	ctx context.Context,
 	txn *kv.Txn,
-	ch chan ieIteratorResult,
+	w ieResultWriter,
 	sd *sessiondata.SessionData,
 	stmtBuf *StmtBuf,
 	wg *sync.WaitGroup,
@@ -145,7 +145,7 @@ func (ie *InternalExecutor) initConnEx(
 	errCallback func(error),
 ) {
 	clientComm := &internalClientComm{
-		ch: ch,
+		w: w,
 		// init lastDelivered below the position of the first result (0).
 		lastDelivered: -1,
 		sync:          syncCallback,
@@ -203,7 +203,7 @@ func (ie *InternalExecutor) initConnEx(
 			sqltelemetry.RecordError(ctx, err, &ex.server.cfg.Settings.SV)
 			errCallback(err)
 		}
-		close(ch)
+		w.finish()
 		closeMode := normalClose
 		if txn != nil {
 			closeMode = externalTxnClose
@@ -222,14 +222,17 @@ type ieIteratorResult struct {
 }
 
 type rowsIterator struct {
-	// ch is the channel on which the connExecutor goroutine sends the rows (in
-	// streamingCommandResult.AddRow). The iterator goroutine receives rows (or
-	// other metadata) and will block on this channel if it is empty. The
-	// channel will be closed when the connExecutor goroutine exits its run()
-	// loop.
-	ch           chan ieIteratorResult
+	r ieResultReader
+
 	rowsAffected int
 	resultCols   colinfo.ResultColumns
+
+	// first, if non-nil, is the first object read from r. We block the return
+	// of the created rowsIterator in execInternal() until the producer writes
+	// something into the corresponding ieResultWriter because this indicates
+	// that the query planning has been fully performed (we want to prohibit the
+	// concurrent usage of the transactions).
+	first *ieIteratorResult
 
 	lastRow tree.Datums
 	lastErr error
@@ -254,10 +257,6 @@ type rowsIterator struct {
 var _ sqlutil.InternalRows = &rowsIterator{}
 
 func (r *rowsIterator) Next(ctx context.Context) (_ bool, retErr error) {
-	if r.done {
-		return false, r.lastErr
-	}
-
 	// Due to recursive calls to Next() below, this deferred function might get
 	// executed multiple times, yet it is not a problem because Close() is
 	// idempotent and we're unsetting the error callback.
@@ -276,47 +275,60 @@ func (r *rowsIterator) Next(ctx context.Context) (_ bool, retErr error) {
 		retErr = r.lastErr
 	}()
 
-	select {
-	case next, ok := <-r.ch:
-		if !ok {
-			r.done = true
-			return false, nil
-		}
-		if next.row != nil {
+	if r.done {
+		return false, r.lastErr
+	}
+
+	// handleDataObject processes a single object read from ieResultReader and
+	// returns the result to be returned by Next. It also might call Next
+	// recursively if the object is a piece of metadata.
+	handleDataObject := func(data ieIteratorResult) (bool, error) {
+		if data.row != nil {
 			r.rowsAffected++
 			// No need to make a copy because streamingCommandResult does that
 			// for us.
-			r.lastRow = next.row
+			r.lastRow = data.row
 			return true, nil
 		}
-		if next.rowsAffectedIncrement != nil {
-			r.rowsAffected += *next.rowsAffectedIncrement
+		if data.rowsAffectedIncrement != nil {
+			r.rowsAffected += *data.rowsAffectedIncrement
 			return r.Next(ctx)
 		}
-		if next.cols != nil {
+		if data.cols != nil {
 			// Ignore the result columns if they are already set on the
 			// iterator: it is possible for ROWS statement type to be executed
 			// in a 'rows affected' mode, in such case the correct columns are
-			// set manually when instantiating an iterator, but the result
+			// set manually when instantiating the iterator, but the result
 			// columns of the statement are also sent by SetColumns() (we need
 			// to keep the former).
 			if r.resultCols == nil {
-				r.resultCols = next.cols
+				r.resultCols = data.cols
 			}
 			return r.Next(ctx)
 		}
-		if next.err == nil {
-			next.err = errors.AssertionFailedf("unexpectedly empty ieIteratorResult object")
+		if data.err == nil {
+			data.err = errors.AssertionFailedf("unexpectedly empty ieIteratorResult object")
 		}
-		r.lastErr = next.err
-		r.done = true
-		return false, r.lastErr
-
-	case <-ctx.Done():
-		r.lastErr = ctx.Err()
+		r.lastErr = data.err
 		r.done = true
 		return false, r.lastErr
 	}
+
+	if r.first != nil {
+		// This is the very first call to Next() and we have already buffered
+		// up the first piece of data before returning rowsIterator to the
+		// caller.
+		first := r.first
+		r.first = nil
+		return handleDataObject(*first)
+	}
+
+	var next ieIteratorResult
+	next, r.done, r.lastErr = r.r.nextResult(ctx)
+	if r.done || r.lastErr != nil {
+		return false, r.lastErr
+	}
+	return handleDataObject(next)
 }
 
 func (r *rowsIterator) Cur() tree.Datums {
@@ -336,23 +348,9 @@ func (r *rowsIterator) Close() error {
 			r.sp = nil
 		}
 	}()
-
-	// We also need to exhaust the channel since the connExecutor goroutine
-	// might be blocked on sending the row in AddRow().
-	// TODO(yuzefovich): at the moment, the connExecutor goroutine will not stop
-	// execution of the current command right away when the stmtBuf is closed
-	// (e.g. if it is currently executing ExecStmt command, all rows will still
-	// be pushed into the channel). Improve this.
-	for res := range r.ch {
-		// We are only interested in possible errors if we haven't already seen
-		// one. All other things are simply ignored.
-		if res.err != nil && r.lastErr == nil {
-			r.lastErr = res.err
-			if r.errCallback != nil {
-				r.lastErr = r.errCallback(r.lastErr)
-				r.errCallback = nil
-			}
-		}
+	// Close the ieResultReader to tell the writer that we're done.
+	if err := r.r.close(); err != nil && r.lastErr == nil {
+		r.lastErr = err
 	}
 	return r.lastErr
 }
@@ -405,7 +403,10 @@ func (ie *InternalExecutor) queryInternalBuffered(
 	limit int,
 	qargs ...interface{},
 ) ([]tree.Datums, colinfo.ResultColumns, error) {
-	it, err := ie.execInternal(ctx, opName, txn, sessionDataOverride, stmt, qargs...)
+	// We will run the query to completion, so we can use an async result
+	// channel.
+	rw := newAsyncIEResultChannel()
+	it, err := ie.execInternal(ctx, opName, rw, txn, sessionDataOverride, stmt, qargs...)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -504,7 +505,10 @@ func (ie *InternalExecutor) ExecEx(
 	stmt string,
 	qargs ...interface{},
 ) (int, error) {
-	it, err := ie.execInternal(ctx, opName, txn, session, stmt, qargs...)
+	// We will run the query to completion, so we can use an async result
+	// channel.
+	rw := newAsyncIEResultChannel()
+	it, err := ie.execInternal(ctx, opName, rw, txn, session, stmt, qargs...)
 	if err != nil {
 		return 0, err
 	}
@@ -542,7 +546,9 @@ func (ie *InternalExecutor) QueryIteratorEx(
 	stmt string,
 	qargs ...interface{},
 ) (sqlutil.InternalRows, error) {
-	return ie.execInternal(ctx, opName, txn, session, stmt, qargs...)
+	return ie.execInternal(
+		ctx, opName, newSyncIEResultChannel(), txn, session, stmt, qargs...,
+	)
 }
 
 // applyOverrides overrides the respective fields from sd for all the fields set on o.
@@ -590,13 +596,6 @@ var rowsAffectedResultColumns = colinfo.ResultColumns{
 	},
 }
 
-var ieIteratorChannelBufferSize = util.ConstantWithMetamorphicTestRange(
-	"iterator-channel-buffer-size",
-	32, /* defaultValue */
-	1,  /* min */
-	32, /* max */
-)
-
 // execInternal executes a statement.
 //
 // sessionDataOverride can be used to control select fields in the executor's
@@ -605,6 +604,7 @@ var ieIteratorChannelBufferSize = util.ConstantWithMetamorphicTestRange(
 func (ie *InternalExecutor) execInternal(
 	ctx context.Context,
 	opName string,
+	rw ieResultChannel,
 	txn *kv.Txn,
 	sessionDataOverride sessiondata.InternalExecutorOverride,
 	stmt string,
@@ -633,7 +633,6 @@ func (ie *InternalExecutor) execInternal(
 	// the span to the iterator. This is necessary so that the connExecutor
 	// exits before the span is finished.
 	ctx, sp := tracing.EnsureChildSpan(ctx, ie.s.cfg.AmbientCtx.Tracer, opName)
-
 	stmtBuf := NewStmtBuf()
 	var wg sync.WaitGroup
 
@@ -682,7 +681,6 @@ func (ie *InternalExecutor) execInternal(
 	// statement we care about before that command is sent for execution.
 	var resPos CmdPos
 
-	ch := make(chan ieIteratorResult, ieIteratorChannelBufferSize)
 	syncCallback := func(results []resWithPos) {
 		// Close the stmtBuf so that the connExecutor exits its run() loop.
 		stmtBuf.Close()
@@ -691,14 +689,18 @@ func (ie *InternalExecutor) execInternal(
 				// If we encounter an error, there's no point in looking
 				// further; the rest of the commands in the batch have been
 				// skipped.
-				ch <- ieIteratorResult{err: res.Err()}
+				_ = rw.addResult(ctx, ieIteratorResult{err: res.Err()})
 				return
 			}
 			if res.pos == resPos {
 				return
 			}
 		}
-		ch <- ieIteratorResult{err: errors.AssertionFailedf("missing result for pos: %d and no previous error", resPos)}
+		_ = rw.addResult(ctx, ieIteratorResult{
+			err: errors.AssertionFailedf(
+				"missing result for pos: %d and no previous error", resPos,
+			),
+		})
 	}
 	// errCallback is called if an error is returned from the connExecutor's
 	// run() loop.
@@ -706,9 +708,9 @@ func (ie *InternalExecutor) execInternal(
 		// The connExecutor exited its run() loop, so the stmtBuf must have been
 		// closed. Still, since Close() is idempotent, we'll call it here too.
 		stmtBuf.Close()
-		ch <- ieIteratorResult{err: err}
+		_ = rw.addResult(ctx, ieIteratorResult{err: err})
 	}
-	ie.initConnEx(ctx, txn, ch, sd, stmtBuf, &wg, syncCallback, errCallback)
+	ie.initConnEx(ctx, txn, rw, sd, stmtBuf, &wg, syncCallback, errCallback)
 
 	typeHints := make(tree.PlaceholderTypes, len(datums))
 	for i, d := range datums {
@@ -752,17 +754,47 @@ func (ie *InternalExecutor) execInternal(
 	if err := stmtBuf.Push(ctx, Sync{}); err != nil {
 		return nil, err
 	}
-
-	var resultColumns colinfo.ResultColumns
-	if parsed.AST.StatementType() != tree.Rows {
-		resultColumns = rowsAffectedResultColumns
+	r = &rowsIterator{
+		r:       rw,
+		stmtBuf: stmtBuf,
+		wg:      &wg,
 	}
-	return &rowsIterator{
-		ch:         ch,
-		resultCols: resultColumns,
-		stmtBuf:    stmtBuf,
-		wg:         &wg,
-	}, nil
+
+	if parsed.AST.StatementType() != tree.Rows {
+		r.resultCols = rowsAffectedResultColumns
+	}
+
+	// Now we need to block the reader goroutine until the query planning has
+	// been performed by the connExecutor goroutine. We do so by waiting until
+	// the first object is sent on the data channel.
+	{
+		var first ieIteratorResult
+		if first, r.done, r.lastErr = rw.firstResult(ctx); !r.done {
+			r.first = &first
+		}
+	}
+	if !r.done && r.first.cols != nil {
+		// If the query is of ROWS statement type, the very first thing sent on
+		// the channel will be the column schema. This will occur before the
+		// query is given to the execution engine, so we actually need to get
+		// the next piece from the data channel.
+		//
+		// Note that only statements of ROWS type should send the cols, but we
+		// choose to be defensive and don't assert that.
+		if r.resultCols == nil {
+			r.resultCols = r.first.cols
+		}
+		var first ieIteratorResult
+		first, r.done, r.lastErr = rw.nextResult(ctx)
+		if !r.done {
+			r.first = &first
+		}
+	}
+
+	// Note that if a context cancellation error has occurred, we still return
+	// the iterator and nil retErr so that the iterator is properly closed by
+	// the caller which will cleanup the connExecutor goroutine.
+	return r, nil
 }
 
 // internalClientComm is an implementation of ClientComm used by the
@@ -772,9 +804,8 @@ type internalClientComm struct {
 	// InternalExecutor.
 	results []resWithPos
 
-	// ch is the channel on which the results of the query execution (ExecStmt
-	// or ExecPortal commands) are propagated to the consumer (the iterator).
-	ch chan ieIteratorResult
+	// The results of the query execution will be written into w.
+	w ieResultWriter
 
 	lastDelivered CmdPos
 
@@ -808,7 +839,7 @@ func (icc *internalClientComm) CreateStatementResult(
 // closed.
 func (icc *internalClientComm) createRes(pos CmdPos, onClose func()) *streamingCommandResult {
 	res := &streamingCommandResult{
-		ch: icc.ch,
+		w: icc.w,
 		closeCallback: func(res *streamingCommandResult, typ resCloseType) {
 			if typ == discarded {
 				return

--- a/pkg/sql/internal_result_channel.go
+++ b/pkg/sql/internal_result_channel.go
@@ -1,0 +1,236 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+	"sync"
+
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/errors"
+)
+
+// ieResultChannel is used to coordinate passing results from an
+// internalExecutor to its corresponding iterator.
+type ieResultChannel interface {
+	ieResultReader
+	ieResultWriter
+}
+
+// ieResultReader is used to read internalExecutor results.
+// It is managed by the rowsIterator.
+type ieResultReader interface {
+
+	// firstResult returns the first result. The return values carry the same
+	// semantics as of nextResult. This method assumes that the writer is not
+	// currently blocked and waits for the initial result to be written.
+	firstResult(ctx context.Context) (_ ieIteratorResult, done bool, err error)
+
+	// nextResult returns the nextResult. Done will always be true if err
+	// is non-nil. Err will be non-nil if either close has been called or
+	// the passed context is finished.
+	nextResult(ctx context.Context) (_ ieIteratorResult, done bool, err error)
+
+	// close ensures that the either writer has finished writing. In the case
+	// of an asynchronous channel, close will drain the writer's channel. In the
+	// case of the synchronous channel, it will ensure that the writer receives
+	// an error when it wakes.
+	close() error
+}
+
+// ieResultWriter is used by the internalExecutor to write results to an
+// iterator.
+type ieResultWriter interface {
+
+	// addResult adds a result. It may block until the next result is requested
+	// by the reader, depending on the synchronization strategy.
+	addResult(ctx context.Context, result ieIteratorResult) error
+
+	// finish is used to indicate that the writer is done writing rows.
+	finish()
+}
+
+var asyncIEResultChannelBufferSize = util.ConstantWithMetamorphicTestRange(
+	"async-IE-result-channel-buffer-size",
+	32, /* defaultValue */
+	1,  /* min */
+	32, /* max */
+)
+
+// newAsyncIEResultChannel returns an ieResultChannel which does not attempt to
+// synchronize the writer with the reader.
+func newAsyncIEResultChannel() ieResultChannel {
+	return &asyncIEResultChannel{
+		dataCh: make(chan ieIteratorResult, asyncIEResultChannelBufferSize),
+	}
+}
+
+type asyncIEResultChannel struct {
+	dataCh chan ieIteratorResult
+}
+
+var _ ieResultChannel = &asyncIEResultChannel{}
+
+func (c *asyncIEResultChannel) firstResult(
+	ctx context.Context,
+) (_ ieIteratorResult, done bool, err error) {
+	select {
+	case <-ctx.Done():
+		return ieIteratorResult{}, true, ctx.Err()
+	case res, ok := <-c.dataCh:
+		if !ok {
+			return ieIteratorResult{}, true, nil
+		}
+		return res, false, nil
+	}
+}
+
+func (c *asyncIEResultChannel) nextResult(
+	ctx context.Context,
+) (_ ieIteratorResult, done bool, err error) {
+	return c.firstResult(ctx)
+}
+
+func (c *asyncIEResultChannel) close() error {
+	var firstErr error
+	for {
+		res, done, err := c.nextResult(context.TODO())
+		if firstErr == nil {
+			if res.err != nil {
+				firstErr = res.err
+			} else if err != nil {
+				firstErr = err
+			}
+		}
+		if done {
+			return firstErr
+		}
+	}
+}
+
+func (c *asyncIEResultChannel) addResult(ctx context.Context, result ieIteratorResult) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case c.dataCh <- result:
+		return nil
+	}
+}
+
+func (c *asyncIEResultChannel) finish() {
+	close(c.dataCh)
+}
+
+// syncIEResultChannel is used to ensure that in execution scenarios which
+// do not permit concurrency that there is none. It works by blocking the
+// writing goroutine immediately upon sending on the data channel and only
+// unblocking it after the reader signals.
+type syncIEResultChannel struct {
+
+	// dataCh is the channel on which the connExecutor goroutine sends the rows
+	// (in addResult) and will block on waitCh after each send. The iterator
+	// goroutine blocks on dataCh until there is something to receive (rows or
+	// other metadata) and will return the data to the caller. On the next call
+	// to Next(), the iterator goroutine unblocks the producer and will block
+	// itself again. dataCh will be closed (in finish()) when the connExecutor
+	// goroutine exits its run() loop whereas waitCh is closed when closing the
+	// iterator.
+	dataCh chan ieIteratorResult
+	waitCh chan struct{}
+
+	// doneCh is used to indicate that the ReadWriter has been closed.
+	// doneCh is closed under the doneOnce. The doneCh is only used for the
+	// syncIEResultChannel. This is crucial to ensure that a synchronous writer
+	// does not attempt to continue to operate after the reader has called close.
+	doneCh   chan struct{}
+	doneOnce sync.Once
+}
+
+var _ ieResultChannel = &syncIEResultChannel{}
+
+// newSyncIEResultChannel returns an ieResultChannel which synchronizes the
+// writer with the reader.
+func newSyncIEResultChannel() ieResultChannel {
+	return &syncIEResultChannel{
+		dataCh: make(chan ieIteratorResult),
+		waitCh: make(chan struct{}),
+		doneCh: make(chan struct{}),
+	}
+}
+
+func (i *syncIEResultChannel) firstResult(
+	ctx context.Context,
+) (_ ieIteratorResult, done bool, err error) {
+	select {
+	case <-ctx.Done():
+		return ieIteratorResult{}, true, ctx.Err()
+	case <-i.doneCh:
+		return ieIteratorResult{}, true, nil
+	case res, ok := <-i.dataCh:
+		if !ok {
+			return ieIteratorResult{}, true, nil
+		}
+		return res, false, nil
+	}
+}
+
+func (i *syncIEResultChannel) unblockWriter(ctx context.Context) (done bool, err error) {
+	select {
+	case <-ctx.Done():
+		return true, ctx.Err()
+	case <-i.doneCh:
+		return true, nil
+	case i.waitCh <- struct{}{}:
+		return false, nil
+	}
+}
+
+func (i *syncIEResultChannel) finish() {
+	close(i.dataCh)
+	close(i.waitCh)
+}
+
+func (i *syncIEResultChannel) nextResult(
+	ctx context.Context,
+) (_ ieIteratorResult, done bool, err error) {
+	if done, err = i.unblockWriter(ctx); done {
+		return ieIteratorResult{}, done, err
+	}
+	return i.firstResult(ctx)
+}
+
+func (i *syncIEResultChannel) close() error {
+	i.doneOnce.Do(func() { close(i.doneCh) })
+	return nil
+}
+
+// errSyncIEResultReaderCanceled is returned by the writer when the reader has
+// closed syncIEResultChannel. The error indicates to the writer to shut down
+// the query execution, but the reader won't propagate it further.
+var errSyncIEResultReaderCanceled = errors.New("synchronous ieResultReader closed")
+
+func (i *syncIEResultChannel) addResult(ctx context.Context, result ieIteratorResult) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-i.doneCh:
+		return errSyncIEResultReaderCanceled
+	case i.dataCh <- result:
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-i.doneCh:
+		return errSyncIEResultReaderCanceled
+	case <-i.waitCh:
+		return nil
+	}
+}

--- a/pkg/sql/logictest/testdata/logic_test/internal_executor
+++ b/pkg/sql/logictest/testdata/logic_test/internal_executor
@@ -1,0 +1,7 @@
+# Regression tests for incorrect concurrent usage of the txn in the internal
+# executor (#62415).
+statement ok
+SHOW JOBS WHEN COMPLETE SELECT job_id FROM [SHOW JOBS] WHERE job_type = 'SCHEMA CHANGE GC' AND  description like '%idx1%';
+
+statement ok
+SELECT a.job_id, b.job_id FROM [SHOW JOBS] a, [SHOW JOBS] b;

--- a/pkg/sql/pgwire/command_result.go
+++ b/pkg/sql/pgwire/command_result.go
@@ -276,7 +276,7 @@ func (r *commandResult) SetPortalOutput(
 }
 
 // IncrementRowsAffected is part of the CommandResult interface.
-func (r *commandResult) IncrementRowsAffected(n int) {
+func (r *commandResult) IncrementRowsAffected(ctx context.Context, n int) {
 	r.assertNotReleased()
 	r.rowsAffected += n
 }


### PR DESCRIPTION
**sql: fix an edge case in the internal executor**

`SetColumns` contract allows for the argument to be nil, yet the
iterator of the streaming internal executor expects that column schema,
if set, is non-nil. I don't think this could happen in practice, but
theoretically previously we could encounter an assertion error due to
none of the four fields in `ieIteratorResult` object being non-nil, and
now this is fixed.

Release note: None

**sql: add context to IncrementRowsAffected interface**

Release note: None

**sql: properly synchronize the internal executor iterator**

We recently merged an update to the internal executor to make it
streaming. Currently it is implemented by having two goroutines (the
iterator, "the consumer"; and the connExecutor, "the producer"). The
communication between them is done on the buffered channel. As a result,
both goroutines can run concurrently.

However, a crucial point was overlooked - our `kv.Txn`s cannot be used
concurrently. Imagine a plan that reads from two tables each of which is
populated via the internal executor: if we read from the first, and then
from the second concurrently, we will have the concurrent usage of the
txn for that plan.

This commit the problem by carving out a new abstraction to optionally
synchronize the execution of the internal executor with its corresponding
iterator. The abstraction comes in sync and async flavors. In the sync
form, the ieResultChannel ensures that the reader and writer do not
concurrently operate, and, additionally provides a mechanism whereby the
reader may ensure that the writer observes an error when its attempts to
publish the previous row returns. This last point is critical to ensure
that transactions are not erroneously used after it has become unsafe.

The async flavor is still used by the internal executor when it doesn't
return an iterator directly and executes the query to completion itself.

Fixes: #62415.

Release note: None (no stable release with this bug).