### PR TITLE
settings: add default value accessors for settings

### DIFF
--- a/pkg/settings/bool.go
+++ b/pkg/settings/bool.go
@@ -44,6 +44,11 @@ func (*BoolSetting) Typ() string {
 	return "b"
 }
 
+// Get default value for setting
+func (i *BoolSetting) Default() bool {
+	return i.defaultValue
+}
+
 // Override changes the setting without validation and also overrides the
 // default value.
 //

--- a/pkg/settings/duration.go
+++ b/pkg/settings/duration.go
@@ -64,6 +64,11 @@ func (*DurationSetting) Typ() string {
 	return "d"
 }
 
+// Get default value for setting
+func (d *DurationSetting) Default() time.Duration {
+	return d.defaultValue
+}
+
 // Validate that a value conforms with the validation function.
 func (d *DurationSetting) Validate(v time.Duration) error {
 	if d.validateFn != nil {

--- a/pkg/settings/float.go
+++ b/pkg/settings/float.go
@@ -51,6 +51,11 @@ func (*FloatSetting) Typ() string {
 	return "f"
 }
 
+// Get default value for setting
+func (f *FloatSetting) Default() float64 {
+	return f.defaultValue
+}
+
 // Override changes the setting panicking if validation fails and also overrides
 // the default value.
 //

--- a/pkg/settings/int.go
+++ b/pkg/settings/int.go
@@ -47,6 +47,11 @@ func (*IntSetting) Typ() string {
 	return "i"
 }
 
+// Get default value for setting
+func (i *IntSetting) Default() int64 {
+	return i.defaultValue
+}
+
 // Validate that a value conforms with the validation function.
 func (i *IntSetting) Validate(v int64) error {
 	if i.validateFn != nil {

--- a/pkg/settings/string.go
+++ b/pkg/settings/string.go
@@ -42,6 +42,11 @@ func (*StringSetting) Typ() string {
 	return "s"
 }
 
+// Get default value for setting
+func (s *StringSetting) Default() string {
+	return s.defaultValue
+}
+
 // Get retrieves the string value in the setting.
 func (s *StringSetting) Get(sv *Values) string {
 	loaded := sv.getGeneric(s.slotIdx)


### PR DESCRIPTION
External tools and tests need access to default values of settings to
avoid adding constants or duplicating values. This change exposes
default as:
  defaultBudget := queueGuaranteedProcessingTimeBudget.Default()

Release note: None