### PR TITLE
release-21.1: roachtest: use 2-minute ramp times for YCSB workloads

### DIFF
--- a/pkg/cmd/roachtest/ycsb.go
+++ b/pkg/cmd/roachtest/ycsb.go
@@ -49,7 +49,7 @@ func registerYCSB(r *testRegistry) {
 		m := newMonitor(ctx, c, c.Range(1, nodes))
 		m.Go(func(ctx context.Context) error {
 			sfu := fmt.Sprintf(" --select-for-update=%t", t.IsBuildVersion("v19.2.0"))
-			ramp := " --ramp=" + ifLocal("0s", "1m")
+			ramp := " --ramp=" + ifLocal("0s", "2m")
 			duration := " --duration=" + ifLocal("10s", "10m")
 			cmd := fmt.Sprintf(
 				"./workload run ycsb --init --insert-count=1000000 --workload=%s --concurrency=%d"+


### PR DESCRIPTION
Backport 1/1 commits from #62535.

/cc @cockroachdb/release

---

In #62534 it was shown that it takes up to two minutes before we have
good enough statistics to allocate appropriately sized batches. However,
the YCSB workloads only had a 1-minute ramp time, which would skew the
results as throughput would abruptly change when the statistics were
updated during the test.

This patch changes the ramp time for YCSB workloads to 2 minutes to make
sure we have appropriate statistics before starting the actual test.

Release note: None
