### PR TITLE
release-21.1: delegate: order AZs in SHOW REGIONS commands

### DIFF
--- a/pkg/cli/interactive_tests/test_demo_global.tcl
+++ b/pkg/cli/interactive_tests/test_demo_global.tcl
@@ -13,6 +13,13 @@ spawn $argv demo --empty --nodes 9 --global
 # Ensure db is defaultdb.
 eexpect "defaultdb>"
 
+# Ensure regions display correctly.
+send "SELECT region, zones FROM \[SHOW REGIONS FROM CLUSTER\] ORDER BY region;\r"
+eexpect "  europe-west1 | {b,c,d}"
+eexpect "  us-east1     | {b,c,d}"
+eexpect "  us-west1     | {a,b,c}"
+eexpect "defaultdb>"
+
 interrupt
 eexpect eof
 end_test

--- a/pkg/sql/delegate/show_regions.go
+++ b/pkg/sql/delegate/show_regions.go
@@ -36,6 +36,7 @@ func (d *delegator) delegateShowRegions(n *tree.ShowRegions) (tree.Statement, er
 							'zone=([^,]*)'
 						)
 					)
+					ORDER BY locality
 				),
 				NULL
 			)


### PR DESCRIPTION
Backport 1/1 commits from #62490.

/cc @cockroachdb/release

---

Release note (sql change): Availability zones were not ordered when
using the SHOW REGIONS set of commands. This has now been changed to be
ordered.
