### PR TITLE
release-21.1: sql: added setting for enable/disable queries against unimplemented virtual tables

### DIFF
--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -222,6 +222,9 @@ func constructVirtualScan(
 	if err != nil {
 		return nil, err
 	}
+	if !canQueryVirtualTable(p.EvalContext(), virtual) {
+		return nil, newUnimplementedVirtualTableError(tn.Schema(), tn.Table())
+	}
 	indexDesc := index.(*optVirtualIndex).desc
 	columns, constructor := virtual.getPlanInfo(
 		table.(*optVirtualTable).desc,

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -389,6 +389,12 @@ var experimentalStreamReplicationEnabled = settings.RegisterBoolSetting(
 	false,
 )
 
+var stubCatalogTablesEnabledClusterValue = settings.RegisterBoolSetting(
+	`sql.defaults.stub_catalog_tables.enabled`,
+	`default value for stub_catalog_tables session setting`,
+	true,
+)
+
 // ExperimentalDistSQLPlanningClusterSettingName is the name for the cluster
 // setting that controls experimentalDistSQLPlanningClusterMode below.
 const ExperimentalDistSQLPlanningClusterSettingName = "sql.defaults.experimental_distsql_planning"
@@ -2390,6 +2396,11 @@ func (m *sessionDataMutator) SetNoticeDisplaySeverity(severity pgnotice.DisplayS
 // initSequenceCache creates an empty sequence cache instance for the session.
 func (m *sessionDataMutator) initSequenceCache() {
 	m.data.SequenceCache = sessiondata.SequenceCache{}
+}
+
+// SetStubCatalogTableEnabled sets default value for stub_catalog_tables.
+func (m *sessionDataMutator) SetStubCatalogTablesEnabled(enabled bool) {
+	m.data.StubCatalogTablesEnabled = enabled
 }
 
 type sqlStatsCollector struct {

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -869,6 +869,7 @@ CREATE TABLE information_schema.parameters (
 	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var (
@@ -1081,6 +1082,7 @@ CREATE TABLE information_schema.routines (
 	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 // MySQL:    https://dev.mysql.com/doc/refman/5.7/en/schemata-table.html

--- a/pkg/sql/logictest/testdata/logic_test/cluster_settings
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_settings
@@ -115,3 +115,8 @@ WHERE variable IN ('cloudstorage.gs.default.key', 'sql.defaults.default_int_size
 ----
 cloudstorage.gs.default.key    foo
 sql.defaults.default_int_size  4
+
+query B
+SHOW CLUSTER SETTING sql.defaults.stub_catalog_tables.enabled
+----
+true

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -3649,6 +3649,7 @@ sql_safe_updates                                      off
 ssl_renegotiation_limit                               0
 standard_conforming_strings                           on
 statement_timeout                                     0
+stub_catalog_tables                                   on
 synchronize_seqscans                                  on
 synchronous_commit                                    on
 testing_vectorize_inject_panics                       off

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2146,6 +2146,7 @@ session_user                                          root                NULL  
 sql_safe_updates                                      off                 NULL      NULL        NULL        string
 standard_conforming_strings                           on                  NULL      NULL        NULL        string
 statement_timeout                                     0                   NULL      NULL        NULL        string
+stub_catalog_tables                           on                  NULL      NULL        NULL        string
 synchronize_seqscans                                  on                  NULL      NULL        NULL        string
 synchronous_commit                                    on                  NULL      NULL        NULL        string
 testing_vectorize_inject_panics                       off                 NULL      NULL        NULL        string
@@ -2226,6 +2227,7 @@ session_user                                          root                NULL  
 sql_safe_updates                                      off                 NULL  user     NULL      off                 off
 standard_conforming_strings                           on                  NULL  user     NULL      on                  on
 statement_timeout                                     0                   NULL  user     NULL      0s                  0s
+stub_catalog_tables                           on                  NULL  user     NULL      on                  on
 synchronize_seqscans                                  on                  NULL  user     NULL      on                  on
 synchronous_commit                                    on                  NULL  user     NULL      on                  on
 testing_vectorize_inject_panics                       off                 NULL  user     NULL      off                 off
@@ -2304,6 +2306,7 @@ session_user                                          NULL    NULL     NULL     
 sql_safe_updates                                      NULL    NULL     NULL     NULL        NULL
 standard_conforming_strings                           NULL    NULL     NULL     NULL        NULL
 statement_timeout                                     NULL    NULL     NULL     NULL        NULL
+stub_catalog_tables                                   NULL    NULL     NULL     NULL        NULL
 synchronize_seqscans                                  NULL    NULL     NULL     NULL        NULL
 synchronous_commit                                    NULL    NULL     NULL     NULL        NULL
 testing_vectorize_inject_panics                       NULL    NULL     NULL     NULL        NULL
@@ -3258,3 +3261,18 @@ GROUP BY indexname, indisunique, indisprimary, amname, exprdef, attoptions
 indexname            array_agg  indisunique  indisprimary  array_agg      amname  exprdef  attoptions
 indexes_include_idx  {a,c,d}    false        false         {ASC,ASC,ASC}  prefix  NULL     NULL
 primary              {id}       true         true          {ASC}          prefix  NULL     NULL
+
+statement ok
+SET stub_catalog_tables=false
+
+statement error pq: unimplemented: virtual schema table not implemented: pg_catalog.pg_seclabel
+SELECT * FROM pg_seclabel
+
+statement ok
+SELECT count(*) FROM pg_depend
+
+statement ok
+SET stub_catalog_tables=true
+
+statement ok
+SELECT * FROM pg_seclabel

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -85,6 +85,7 @@ session_user                                          root
 sql_safe_updates                                      off
 standard_conforming_strings                           on
 statement_timeout                                     0
+stub_catalog_tables                                   on
 synchronize_seqscans                                  on
 synchronous_commit                                    on
 testing_vectorize_inject_panics                       off

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -646,6 +646,9 @@ func (ef *execFactory) constructVirtualTableLookupJoin(
 	if err != nil {
 		return nil, err
 	}
+	if !canQueryVirtualTable(ef.planner.EvalContext(), virtual) {
+		return nil, newUnimplementedVirtualTableError(tn.Schema(), tn.Table())
+	}
 	if len(eqCols) > 1 {
 		return nil, errors.AssertionFailedf("vtable indexes with more than one column aren't supported yet")
 	}

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -505,6 +505,7 @@ https://www.postgresql.org/docs/9.6/catalog-pg-cast.html`,
 		// maintainability anyway.
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogAuthIDTable = virtualSchemaTable{
@@ -571,6 +572,7 @@ https://www.postgresql.org/docs/9.6/view-pg-available-extensions.html`,
 		// We support no extensions.
 		return nil
 	},
+	unimplemented: true,
 }
 
 func getOwnerOID(desc catalog.Descriptor) tree.Datum {
@@ -1137,6 +1139,7 @@ https://www.postgresql.org/docs/9.6/catalog-pg-conversion.html`,
 	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogDatabaseTable = virtualSchemaTable{
@@ -1175,6 +1178,7 @@ https://www.postgresql.org/docs/9.6/catalog-pg-default-acl.html`,
 	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var (
@@ -1454,6 +1458,7 @@ https://www.postgresql.org/docs/9.6/catalog-pg-event-trigger.html`,
 		// Event triggers are not currently supported.
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogExtensionTable = virtualSchemaTable{
@@ -1464,6 +1469,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-extension.html`,
 		// Extensions are not supported.
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogForeignDataWrapperTable = virtualSchemaTable{
@@ -1474,6 +1480,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-foreign-data-wrapper.html`,
 		// Foreign data wrappers are not supported.
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogForeignServerTable = virtualSchemaTable{
@@ -1484,6 +1491,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-foreign-server.html`,
 		// Foreign servers are not supported.
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogForeignTableTable = virtualSchemaTable{
@@ -1494,6 +1502,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-foreign-table.html`,
 		// Foreign tables are not supported.
 		return nil
 	},
+	unimplemented: true,
 }
 
 func makeZeroedOidVector(size int) (tree.Datum, error) {
@@ -1714,6 +1723,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-inherits.html`,
 		// Table inheritance is not supported.
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogLanguageTable = virtualSchemaTable{
@@ -1724,6 +1734,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-language.html`,
 		// Languages to write functions and stored procedures are not supported.
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogLocksTable = virtualSchemaTable{
@@ -1733,6 +1744,7 @@ https://www.postgresql.org/docs/9.6/view-pg-locks.html`,
 	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogMatViewsTable = virtualSchemaTable{
@@ -1809,6 +1821,7 @@ https://www.postgresql.org/docs/12/catalog-pg-opclass.html`,
 	populate: func(ctx context.Context, p *planner, db *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogOperatorTable = virtualSchemaTable{
@@ -1916,6 +1929,7 @@ https://www.postgresql.org/docs/9.6/view-pg-prepared-xacts.html`,
 	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 // pgCatalogPreparedStatementsTable implements the pg_prepared_statements table.
@@ -2114,6 +2128,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-range.html`,
 		// oidToDatum (and therefore pg_type).
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogRewriteTable = virtualSchemaTable{
@@ -2124,6 +2139,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-rewrite.html`,
 		// Rewrite rules are not supported.
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogRolesTable = virtualSchemaTable{
@@ -2177,6 +2193,7 @@ https://www.postgresql.org/docs/9.6/view-pg-seclabels.html`,
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogSequencesTable = virtualSchemaTable{
@@ -2270,6 +2287,7 @@ https://www.postgresql.org/docs/9.6/catalog-pg-shdepend.html`,
 	populate: func(ctx context.Context, p *planner, dbContext *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogTablesTable = virtualSchemaTable{
@@ -2323,6 +2341,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-trigger.html`,
 		// Triggers are unsupported.
 		return nil
 	},
+	unimplemented: true,
 }
 
 var (
@@ -2574,6 +2593,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-user-mapping.html`,
 		// Foreign servers are not supported.
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogStatActivityTable = virtualSchemaTable{
@@ -2583,6 +2603,7 @@ https://www.postgresql.org/docs/9.6/monitoring-stats.html#PG-STAT-ACTIVITY-VIEW`
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogSecurityLabelTable = virtualSchemaTable{
@@ -2592,6 +2613,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-seclabel.html`,
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogSharedSecurityLabelTable = virtualSchemaTable{
@@ -2601,6 +2623,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-shseclabel.html`,
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogPublicationRelTable = virtualSchemaTable{
@@ -2609,6 +2632,7 @@ var pgCatalogPublicationRelTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogConfigTable = virtualSchemaTable{
@@ -2617,6 +2641,7 @@ var pgCatalogConfigTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogAvailableExtensionVersionsTable = virtualSchemaTable{
@@ -2625,6 +2650,7 @@ var pgCatalogAvailableExtensionVersionsTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogOpfamilyTable = virtualSchemaTable{
@@ -2633,6 +2659,7 @@ var pgCatalogOpfamilyTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogShmemAllocationsTable = virtualSchemaTable{
@@ -2641,6 +2668,7 @@ var pgCatalogShmemAllocationsTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogDbRoleSettingTable = virtualSchemaTable{
@@ -2649,6 +2677,7 @@ var pgCatalogDbRoleSettingTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogTimezoneNamesTable = virtualSchemaTable{
@@ -2657,6 +2686,7 @@ var pgCatalogTimezoneNamesTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogPublicationTablesTable = virtualSchemaTable{
@@ -2665,6 +2695,7 @@ var pgCatalogPublicationTablesTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogUserMappingsTable = virtualSchemaTable{
@@ -2673,6 +2704,7 @@ var pgCatalogUserMappingsTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogTsTemplateTable = virtualSchemaTable{
@@ -2681,6 +2713,7 @@ var pgCatalogTsTemplateTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogRulesTable = virtualSchemaTable{
@@ -2689,6 +2722,7 @@ var pgCatalogRulesTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogShadowTable = virtualSchemaTable{
@@ -2697,6 +2731,7 @@ var pgCatalogShadowTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogPublicationTable = virtualSchemaTable{
@@ -2705,6 +2740,7 @@ var pgCatalogPublicationTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogGroupTable = virtualSchemaTable{
@@ -2713,6 +2749,7 @@ var pgCatalogGroupTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogCursorsTable = virtualSchemaTable{
@@ -2721,6 +2758,7 @@ var pgCatalogCursorsTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogTsParserTable = virtualSchemaTable{
@@ -2729,6 +2767,7 @@ var pgCatalogTsParserTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogSubscriptionTable = virtualSchemaTable{
@@ -2737,6 +2776,7 @@ var pgCatalogSubscriptionTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogAmprocTable = virtualSchemaTable{
@@ -2745,6 +2785,7 @@ var pgCatalogAmprocTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogTsDictTable = virtualSchemaTable{
@@ -2753,6 +2794,7 @@ var pgCatalogTsDictTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogTimezoneAbbrevsTable = virtualSchemaTable{
@@ -2761,6 +2803,7 @@ var pgCatalogTimezoneAbbrevsTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogTransformTable = virtualSchemaTable{
@@ -2769,6 +2812,7 @@ var pgCatalogTransformTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogTsConfigMapTable = virtualSchemaTable{
@@ -2777,6 +2821,7 @@ var pgCatalogTsConfigMapTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogFileSettingsTable = virtualSchemaTable{
@@ -2785,6 +2830,7 @@ var pgCatalogFileSettingsTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogPoliciesTable = virtualSchemaTable{
@@ -2793,6 +2839,7 @@ var pgCatalogPoliciesTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogTsConfigTable = virtualSchemaTable{
@@ -2801,6 +2848,7 @@ var pgCatalogTsConfigTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogHbaFileRulesTable = virtualSchemaTable{
@@ -2809,6 +2857,7 @@ var pgCatalogHbaFileRulesTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogStatisticExtTable = virtualSchemaTable{
@@ -2817,6 +2866,7 @@ var pgCatalogStatisticExtTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogReplicationOriginTable = virtualSchemaTable{
@@ -2825,6 +2875,7 @@ var pgCatalogReplicationOriginTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogAmopTable = virtualSchemaTable{
@@ -2833,6 +2884,7 @@ var pgCatalogAmopTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 var pgCatalogLargeobjectTable = virtualSchemaTable{
@@ -2841,6 +2893,7 @@ var pgCatalogLargeobjectTable = virtualSchemaTable{
 	populate: func(ctx context.Context, p *planner, _ *dbdesc.Immutable, addRow func(...tree.Datum) error) error {
 		return nil
 	},
+	unimplemented: true,
 }
 
 // typOid is the only OID generation approach that does not use oidHasher, because

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -249,6 +249,11 @@ type LocalOnlySessionData struct {
 	// SequenceCache stores sequence values which have been cached using the
 	// CACHE sequence option.
 	SequenceCache SequenceCache
+
+	// StubCatalogTablesEnabled allows queries against virtual
+	// tables that are not yet implemented.
+	StubCatalogTablesEnabled bool
+
 	///////////////////////////////////////////////////////////////////////////
 	// WARNING: consider whether a session parameter you're adding needs to  //
 	// be propagated to the remote nodes. If so, that parameter should live  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -729,6 +729,25 @@ var varGen = map[string]sessionVar{
 		},
 	},
 
+	// CockroachDB extension.
+	`stub_catalog_tables`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`stub_catalog_tables`),
+		Set: func(_ context.Context, m *sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("stub_catalog_tables", s)
+			if err != nil {
+				return err
+			}
+			m.SetStubCatalogTablesEnabled(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) string {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData.StubCatalogTablesEnabled)
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return formatBoolAsPostgresSetting(stubCatalogTablesEnabledClusterValue.Get(sv))
+		},
+	},
+
 	// See https://www.postgresql.org/docs/10/static/runtime-config-client.html
 	`extra_float_digits`: {
 		GetStringVal: makeIntGetStringValFn(`extra_float_digits`),


### PR DESCRIPTION
Backport 1/1 commits from #62052 .

/cc @cockroachdb/release

Previously, Unimplemented virtual tables where tables
listed in the virtual schema which do not have a definition
This was inadequate because:
- A lot of tables where added for compatibility reasons
which are not longer considered umimplemented
- A tool hung because was expecting an unimplemented table
return rows
To address this, this patch:
- Adds a new field to the virtualSchemaTable to set a virtual
table as unimplemented
- Added a setting for enable / disable queries against
virtual tables

Release note (sql change): Added the stub_catalog_tables session
variable, which is enabled by default. If disabled, querying an
unimplemented pg_catalog table will result in an error, as is the case
in v20.2 and earlier. Otherwise, the query will simply return no rows.

Fixes #61866