### PR TITLE
opt: add support for inverted joins using <@ with JSON and Array columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_join_json_array
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_join_json_array
@@ -326,6 +326,269 @@ ON inv_join.a1 = cross_join.a1 AND inv_join.a2 = cross_join.a2
 WHERE inv_join.a1 IS NULL OR cross_join.a1 IS NULL
 ----
 
+# This query performs an inverted join.
+query ITIT
+SELECT * FROM json_tab@foo_inv AS j1, json_tab AS j2 WHERE j1.b <@ j2.b ORDER BY j1.a, j2.a
+----
+1   {"a": "b"}                             1   {"a": "b"}
+1   {"a": "b"}                             7   {"a": "b", "c": "d"}
+2   [1, 2, 3, 4, "foo"]                    2   [1, 2, 3, 4, "foo"]
+3   {"a": {"b": "c"}}                      3   {"a": {"b": "c"}}
+3   {"a": {"b": "c"}}                      31  {"a": {"b": "c", "d": "e"}, "f": "g"}
+4   {"a": {"b": [1]}}                      4   {"a": {"b": [1]}}
+4   {"a": {"b": [1]}}                      5   {"a": {"b": [1, [2]]}}
+5   {"a": {"b": [1, [2]]}}                 5   {"a": {"b": [1, [2]]}}
+6   {"a": {"b": [[2]]}}                    5   {"a": {"b": [1, [2]]}}
+6   {"a": {"b": [[2]]}}                    6   {"a": {"b": [[2]]}}
+7   {"a": "b", "c": "d"}                   7   {"a": "b", "c": "d"}
+8   {"a": {"b": true}}                     8   {"a": {"b": true}}
+9   {"a": {"b": false}}                    9   {"a": {"b": false}}
+10  "a"                                    10  "a"
+10  "a"                                    19  ["a", "a"]
+10  "a"                                    27  [true, false, null, 1.23, "a"]
+10  "a"                                    39  ["a"]
+11  null                                   11  null
+11  null                                   27  [true, false, null, 1.23, "a"]
+12  true                                   12  true
+12  true                                   27  [true, false, null, 1.23, "a"]
+13  false                                  13  false
+13  false                                  27  [true, false, null, 1.23, "a"]
+14  1                                      2   [1, 2, 3, 4, "foo"]
+14  1                                      14  1
+14  1                                      22  [1, 2, 3, 1]
+14  1                                      33  [1, "bar"]
+14  1                                      35  [1]
+15  1.23                                   15  1.23
+15  1.23                                   27  [true, false, null, 1.23, "a"]
+16  [{"a": {"b": [1, [2]]}}, "d"]          16  [{"a": {"b": [1, [2]]}}, "d"]
+17  {}                                     1   {"a": "b"}
+17  {}                                     3   {"a": {"b": "c"}}
+17  {}                                     4   {"a": {"b": [1]}}
+17  {}                                     5   {"a": {"b": [1, [2]]}}
+17  {}                                     6   {"a": {"b": [[2]]}}
+17  {}                                     7   {"a": "b", "c": "d"}
+17  {}                                     8   {"a": {"b": true}}
+17  {}                                     9   {"a": {"b": false}}
+17  {}                                     17  {}
+17  {}                                     23  {"a": 123.123}
+17  {}                                     24  {"a": 123.123000}
+17  {}                                     25  {"a": [{}]}
+17  {}                                     28  {"a": {}}
+17  {}                                     30  {"a": []}
+17  {}                                     31  {"a": {"b": "c", "d": "e"}, "f": "g"}
+17  {}                                     32  {"a": [1]}
+17  {}                                     34  {"a": 1}
+17  {}                                     40  {"a": [[]]}
+18  []                                     2   [1, 2, 3, 4, "foo"]
+18  []                                     16  [{"a": {"b": [1, [2]]}}, "d"]
+18  []                                     18  []
+18  []                                     19  ["a", "a"]
+18  []                                     20  [{"a": "a"}, {"a": "a"}]
+18  []                                     21  [[[["a"]]], [[["a"]]]]
+18  []                                     22  [1, 2, 3, 1]
+18  []                                     26  [[], {}]
+18  []                                     27  [true, false, null, 1.23, "a"]
+18  []                                     33  [1, "bar"]
+18  []                                     35  [1]
+18  []                                     36  [2]
+18  []                                     37  [[1]]
+18  []                                     38  [[2]]
+18  []                                     39  ["a"]
+18  []                                     41  [[1, 2]]
+18  []                                     42  [[1], [2]]
+18  []                                     43  [{"a": "b", "c": "d"}]
+18  []                                     44  [{"a": "b"}, {"c": "d"}]
+19  ["a", "a"]                             19  ["a", "a"]
+19  ["a", "a"]                             27  [true, false, null, 1.23, "a"]
+19  ["a", "a"]                             39  ["a"]
+20  [{"a": "a"}, {"a": "a"}]               20  [{"a": "a"}, {"a": "a"}]
+21  [[[["a"]]], [[["a"]]]]                 21  [[[["a"]]], [[["a"]]]]
+22  [1, 2, 3, 1]                           2   [1, 2, 3, 4, "foo"]
+22  [1, 2, 3, 1]                           22  [1, 2, 3, 1]
+23  {"a": 123.123}                         23  {"a": 123.123}
+23  {"a": 123.123}                         24  {"a": 123.123000}
+24  {"a": 123.123000}                      23  {"a": 123.123}
+24  {"a": 123.123000}                      24  {"a": 123.123000}
+25  {"a": [{}]}                            25  {"a": [{}]}
+26  [[], {}]                               26  [[], {}]
+27  [true, false, null, 1.23, "a"]         27  [true, false, null, 1.23, "a"]
+28  {"a": {}}                              3   {"a": {"b": "c"}}
+28  {"a": {}}                              4   {"a": {"b": [1]}}
+28  {"a": {}}                              5   {"a": {"b": [1, [2]]}}
+28  {"a": {}}                              6   {"a": {"b": [[2]]}}
+28  {"a": {}}                              8   {"a": {"b": true}}
+28  {"a": {}}                              9   {"a": {"b": false}}
+28  {"a": {}}                              28  {"a": {}}
+28  {"a": {}}                              31  {"a": {"b": "c", "d": "e"}, "f": "g"}
+30  {"a": []}                              25  {"a": [{}]}
+30  {"a": []}                              30  {"a": []}
+30  {"a": []}                              32  {"a": [1]}
+30  {"a": []}                              40  {"a": [[]]}
+31  {"a": {"b": "c", "d": "e"}, "f": "g"}  31  {"a": {"b": "c", "d": "e"}, "f": "g"}
+32  {"a": [1]}                             32  {"a": [1]}
+33  [1, "bar"]                             33  [1, "bar"]
+34  {"a": 1}                               34  {"a": 1}
+35  [1]                                    2   [1, 2, 3, 4, "foo"]
+35  [1]                                    22  [1, 2, 3, 1]
+35  [1]                                    33  [1, "bar"]
+35  [1]                                    35  [1]
+36  [2]                                    2   [1, 2, 3, 4, "foo"]
+36  [2]                                    22  [1, 2, 3, 1]
+36  [2]                                    36  [2]
+37  [[1]]                                  37  [[1]]
+37  [[1]]                                  41  [[1, 2]]
+37  [[1]]                                  42  [[1], [2]]
+38  [[2]]                                  38  [[2]]
+38  [[2]]                                  41  [[1, 2]]
+38  [[2]]                                  42  [[1], [2]]
+39  ["a"]                                  19  ["a", "a"]
+39  ["a"]                                  27  [true, false, null, 1.23, "a"]
+39  ["a"]                                  39  ["a"]
+40  {"a": [[]]}                            40  {"a": [[]]}
+41  [[1, 2]]                               41  [[1, 2]]
+42  [[1], [2]]                             41  [[1, 2]]
+42  [[1], [2]]                             42  [[1], [2]]
+43  [{"a": "b", "c": "d"}]                 43  [{"a": "b", "c": "d"}]
+44  [{"a": "b"}, {"c": "d"}]               43  [{"a": "b", "c": "d"}]
+44  [{"a": "b"}, {"c": "d"}]               44  [{"a": "b"}, {"c": "d"}]
+
+# This query performs a cross join followed by a filter.
+query ITIT
+SELECT * FROM json_tab@primary AS j1, json_tab AS j2 WHERE j1.b <@ j2.b ORDER BY j1.a, j2.a
+----
+1   {"a": "b"}                             1   {"a": "b"}
+1   {"a": "b"}                             7   {"a": "b", "c": "d"}
+2   [1, 2, 3, 4, "foo"]                    2   [1, 2, 3, 4, "foo"]
+3   {"a": {"b": "c"}}                      3   {"a": {"b": "c"}}
+3   {"a": {"b": "c"}}                      31  {"a": {"b": "c", "d": "e"}, "f": "g"}
+4   {"a": {"b": [1]}}                      4   {"a": {"b": [1]}}
+4   {"a": {"b": [1]}}                      5   {"a": {"b": [1, [2]]}}
+5   {"a": {"b": [1, [2]]}}                 5   {"a": {"b": [1, [2]]}}
+6   {"a": {"b": [[2]]}}                    5   {"a": {"b": [1, [2]]}}
+6   {"a": {"b": [[2]]}}                    6   {"a": {"b": [[2]]}}
+7   {"a": "b", "c": "d"}                   7   {"a": "b", "c": "d"}
+8   {"a": {"b": true}}                     8   {"a": {"b": true}}
+9   {"a": {"b": false}}                    9   {"a": {"b": false}}
+10  "a"                                    10  "a"
+10  "a"                                    19  ["a", "a"]
+10  "a"                                    27  [true, false, null, 1.23, "a"]
+10  "a"                                    39  ["a"]
+11  null                                   11  null
+11  null                                   27  [true, false, null, 1.23, "a"]
+12  true                                   12  true
+12  true                                   27  [true, false, null, 1.23, "a"]
+13  false                                  13  false
+13  false                                  27  [true, false, null, 1.23, "a"]
+14  1                                      2   [1, 2, 3, 4, "foo"]
+14  1                                      14  1
+14  1                                      22  [1, 2, 3, 1]
+14  1                                      33  [1, "bar"]
+14  1                                      35  [1]
+15  1.23                                   15  1.23
+15  1.23                                   27  [true, false, null, 1.23, "a"]
+16  [{"a": {"b": [1, [2]]}}, "d"]          16  [{"a": {"b": [1, [2]]}}, "d"]
+17  {}                                     1   {"a": "b"}
+17  {}                                     3   {"a": {"b": "c"}}
+17  {}                                     4   {"a": {"b": [1]}}
+17  {}                                     5   {"a": {"b": [1, [2]]}}
+17  {}                                     6   {"a": {"b": [[2]]}}
+17  {}                                     7   {"a": "b", "c": "d"}
+17  {}                                     8   {"a": {"b": true}}
+17  {}                                     9   {"a": {"b": false}}
+17  {}                                     17  {}
+17  {}                                     23  {"a": 123.123}
+17  {}                                     24  {"a": 123.123000}
+17  {}                                     25  {"a": [{}]}
+17  {}                                     28  {"a": {}}
+17  {}                                     30  {"a": []}
+17  {}                                     31  {"a": {"b": "c", "d": "e"}, "f": "g"}
+17  {}                                     32  {"a": [1]}
+17  {}                                     34  {"a": 1}
+17  {}                                     40  {"a": [[]]}
+18  []                                     2   [1, 2, 3, 4, "foo"]
+18  []                                     16  [{"a": {"b": [1, [2]]}}, "d"]
+18  []                                     18  []
+18  []                                     19  ["a", "a"]
+18  []                                     20  [{"a": "a"}, {"a": "a"}]
+18  []                                     21  [[[["a"]]], [[["a"]]]]
+18  []                                     22  [1, 2, 3, 1]
+18  []                                     26  [[], {}]
+18  []                                     27  [true, false, null, 1.23, "a"]
+18  []                                     33  [1, "bar"]
+18  []                                     35  [1]
+18  []                                     36  [2]
+18  []                                     37  [[1]]
+18  []                                     38  [[2]]
+18  []                                     39  ["a"]
+18  []                                     41  [[1, 2]]
+18  []                                     42  [[1], [2]]
+18  []                                     43  [{"a": "b", "c": "d"}]
+18  []                                     44  [{"a": "b"}, {"c": "d"}]
+19  ["a", "a"]                             19  ["a", "a"]
+19  ["a", "a"]                             27  [true, false, null, 1.23, "a"]
+19  ["a", "a"]                             39  ["a"]
+20  [{"a": "a"}, {"a": "a"}]               20  [{"a": "a"}, {"a": "a"}]
+21  [[[["a"]]], [[["a"]]]]                 21  [[[["a"]]], [[["a"]]]]
+22  [1, 2, 3, 1]                           2   [1, 2, 3, 4, "foo"]
+22  [1, 2, 3, 1]                           22  [1, 2, 3, 1]
+23  {"a": 123.123}                         23  {"a": 123.123}
+23  {"a": 123.123}                         24  {"a": 123.123000}
+24  {"a": 123.123000}                      23  {"a": 123.123}
+24  {"a": 123.123000}                      24  {"a": 123.123000}
+25  {"a": [{}]}                            25  {"a": [{}]}
+26  [[], {}]                               26  [[], {}]
+27  [true, false, null, 1.23, "a"]         27  [true, false, null, 1.23, "a"]
+28  {"a": {}}                              3   {"a": {"b": "c"}}
+28  {"a": {}}                              4   {"a": {"b": [1]}}
+28  {"a": {}}                              5   {"a": {"b": [1, [2]]}}
+28  {"a": {}}                              6   {"a": {"b": [[2]]}}
+28  {"a": {}}                              8   {"a": {"b": true}}
+28  {"a": {}}                              9   {"a": {"b": false}}
+28  {"a": {}}                              28  {"a": {}}
+28  {"a": {}}                              31  {"a": {"b": "c", "d": "e"}, "f": "g"}
+30  {"a": []}                              25  {"a": [{}]}
+30  {"a": []}                              30  {"a": []}
+30  {"a": []}                              32  {"a": [1]}
+30  {"a": []}                              40  {"a": [[]]}
+31  {"a": {"b": "c", "d": "e"}, "f": "g"}  31  {"a": {"b": "c", "d": "e"}, "f": "g"}
+32  {"a": [1]}                             32  {"a": [1]}
+33  [1, "bar"]                             33  [1, "bar"]
+34  {"a": 1}                               34  {"a": 1}
+35  [1]                                    2   [1, 2, 3, 4, "foo"]
+35  [1]                                    22  [1, 2, 3, 1]
+35  [1]                                    33  [1, "bar"]
+35  [1]                                    35  [1]
+36  [2]                                    2   [1, 2, 3, 4, "foo"]
+36  [2]                                    22  [1, 2, 3, 1]
+36  [2]                                    36  [2]
+37  [[1]]                                  37  [[1]]
+37  [[1]]                                  41  [[1, 2]]
+37  [[1]]                                  42  [[1], [2]]
+38  [[2]]                                  38  [[2]]
+38  [[2]]                                  41  [[1, 2]]
+38  [[2]]                                  42  [[1], [2]]
+39  ["a"]                                  19  ["a", "a"]
+39  ["a"]                                  27  [true, false, null, 1.23, "a"]
+39  ["a"]                                  39  ["a"]
+40  {"a": [[]]}                            40  {"a": [[]]}
+41  [[1, 2]]                               41  [[1, 2]]
+42  [[1], [2]]                             41  [[1, 2]]
+42  [[1], [2]]                             42  [[1], [2]]
+43  [{"a": "b", "c": "d"}]                 43  [{"a": "b", "c": "d"}]
+44  [{"a": "b"}, {"c": "d"}]               43  [{"a": "b", "c": "d"}]
+44  [{"a": "b"}, {"c": "d"}]               44  [{"a": "b"}, {"c": "d"}]
+
+# This query is checking that the results of the previous two queries are identical.
+# There should be no rows output.
+query IIII
+SELECT * FROM
+(SELECT j1.a, j2.a FROM json_tab@foo_inv AS j1, json_tab AS j2 WHERE j1.b <@ j2.b) AS inv_join(a1, a2)
+FULL OUTER JOIN
+(SELECT j1.a, j2.a FROM json_tab@primary AS j1, json_tab AS j2 WHERE j1.b <@ j2.b) AS cross_join(a1, a2)
+ON inv_join.a1 = cross_join.a1 AND inv_join.a2 = cross_join.a2
+WHERE inv_join.a1 IS NULL OR cross_join.a1 IS NULL
+----
+
 # This query performs an inverted join with an additional filter.
 query ITIT
 SELECT j1.*, j2.* FROM json_tab AS j2 INNER INVERTED JOIN json_tab AS j1
@@ -386,6 +649,67 @@ FULL OUTER JOIN
 (
   SELECT j1.a, j2.a FROM json_tab@primary AS j1, json_tab AS j2
   WHERE j1.b @> j2.b AND j1.b @> '{"a": {}}' AND j2.a < 20
+) AS cross_join(a1, a2)
+ON inv_join.a1 = cross_join.a1 AND inv_join.a2 = cross_join.a2
+WHERE inv_join.a1 IS NULL OR cross_join.a1 IS NULL
+----
+
+# This query performs an inverted join with an additional filter.
+query ITIT
+SELECT j1.*, j2.* FROM json_tab AS j2 INNER INVERTED JOIN json_tab AS j1
+ON j1.b <@ j2.b AND j1.b <@ '{"a": {}}' AND j2.a < 20
+ORDER BY j1.a, j2.a
+----
+17  {}         1   {"a": "b"}
+17  {}         3   {"a": {"b": "c"}}
+17  {}         4   {"a": {"b": [1]}}
+17  {}         5   {"a": {"b": [1, [2]]}}
+17  {}         6   {"a": {"b": [[2]]}}
+17  {}         7   {"a": "b", "c": "d"}
+17  {}         8   {"a": {"b": true}}
+17  {}         9   {"a": {"b": false}}
+17  {}         17  {}
+28  {"a": {}}  3   {"a": {"b": "c"}}
+28  {"a": {}}  4   {"a": {"b": [1]}}
+28  {"a": {}}  5   {"a": {"b": [1, [2]]}}
+28  {"a": {}}  6   {"a": {"b": [[2]]}}
+28  {"a": {}}  8   {"a": {"b": true}}
+28  {"a": {}}  9   {"a": {"b": false}}
+
+# This query performs a cross join followed by a filter.
+query ITIT
+SELECT * FROM json_tab@primary AS j1, json_tab AS j2
+WHERE j1.b <@ j2.b AND j1.b <@ '{"a": {}}' AND j2.a < 20
+ORDER BY j1.a, j2.a
+----
+17  {}         1   {"a": "b"}
+17  {}         3   {"a": {"b": "c"}}
+17  {}         4   {"a": {"b": [1]}}
+17  {}         5   {"a": {"b": [1, [2]]}}
+17  {}         6   {"a": {"b": [[2]]}}
+17  {}         7   {"a": "b", "c": "d"}
+17  {}         8   {"a": {"b": true}}
+17  {}         9   {"a": {"b": false}}
+17  {}         17  {}
+28  {"a": {}}  3   {"a": {"b": "c"}}
+28  {"a": {}}  4   {"a": {"b": [1]}}
+28  {"a": {}}  5   {"a": {"b": [1, [2]]}}
+28  {"a": {}}  6   {"a": {"b": [[2]]}}
+28  {"a": {}}  8   {"a": {"b": true}}
+28  {"a": {}}  9   {"a": {"b": false}}
+
+# This query is checking that the results of the previous two queries are identical.
+# There should be no rows output.
+query IIII
+SELECT * FROM
+(
+  SELECT j1.a, j2.a FROM json_tab AS j2 INNER INVERTED JOIN json_tab AS j1
+  ON j1.b <@ j2.b AND j1.b <@ '{"a": {}}' AND j2.a < 20
+) AS inv_join(a1, a2)
+FULL OUTER JOIN
+(
+  SELECT j1.a, j2.a FROM json_tab@primary AS j1, json_tab AS j2
+  WHERE j1.b <@ j2.b AND j1.b <@ '{"a": {}}' AND j2.a < 20
 ) AS cross_join(a1, a2)
 ON inv_join.a1 = cross_join.a1 AND inv_join.a2 = cross_join.a2
 WHERE inv_join.a1 IS NULL OR cross_join.a1 IS NULL
@@ -452,6 +776,63 @@ NULL  NULL                                   44  [{"a": "b"}, {"c": "d"}]
 31    {"a": {"b": "c", "d": "e"}, "f": "g"}  3   {"a": {"b": "c"}}
 31    {"a": {"b": "c", "d": "e"}, "f": "g"}  17  {}
 
+# This query performs a left inverted join with an additional filter.
+query ITIT
+SELECT j1.*, j2.* FROM json_tab AS j2 LEFT INVERTED JOIN json_tab AS j1
+ON j1.b <@ j2.b AND j1.b <@ '{"a": {}}' AND j2.a < 20
+ORDER BY j1.a, j2.a
+----
+NULL  NULL       2   [1, 2, 3, 4, "foo"]
+NULL  NULL       10  "a"
+NULL  NULL       11  null
+NULL  NULL       12  true
+NULL  NULL       13  false
+NULL  NULL       14  1
+NULL  NULL       15  1.23
+NULL  NULL       16  [{"a": {"b": [1, [2]]}}, "d"]
+NULL  NULL       18  []
+NULL  NULL       19  ["a", "a"]
+NULL  NULL       20  [{"a": "a"}, {"a": "a"}]
+NULL  NULL       21  [[[["a"]]], [[["a"]]]]
+NULL  NULL       22  [1, 2, 3, 1]
+NULL  NULL       23  {"a": 123.123}
+NULL  NULL       24  {"a": 123.123000}
+NULL  NULL       25  {"a": [{}]}
+NULL  NULL       26  [[], {}]
+NULL  NULL       27  [true, false, null, 1.23, "a"]
+NULL  NULL       28  {"a": {}}
+NULL  NULL       29  NULL
+NULL  NULL       30  {"a": []}
+NULL  NULL       31  {"a": {"b": "c", "d": "e"}, "f": "g"}
+NULL  NULL       32  {"a": [1]}
+NULL  NULL       33  [1, "bar"]
+NULL  NULL       34  {"a": 1}
+NULL  NULL       35  [1]
+NULL  NULL       36  [2]
+NULL  NULL       37  [[1]]
+NULL  NULL       38  [[2]]
+NULL  NULL       39  ["a"]
+NULL  NULL       40  {"a": [[]]}
+NULL  NULL       41  [[1, 2]]
+NULL  NULL       42  [[1], [2]]
+NULL  NULL       43  [{"a": "b", "c": "d"}]
+NULL  NULL       44  [{"a": "b"}, {"c": "d"}]
+17    {}         1   {"a": "b"}
+17    {}         3   {"a": {"b": "c"}}
+17    {}         4   {"a": {"b": [1]}}
+17    {}         5   {"a": {"b": [1, [2]]}}
+17    {}         6   {"a": {"b": [[2]]}}
+17    {}         7   {"a": "b", "c": "d"}
+17    {}         8   {"a": {"b": true}}
+17    {}         9   {"a": {"b": false}}
+17    {}         17  {}
+28    {"a": {}}  3   {"a": {"b": "c"}}
+28    {"a": {}}  4   {"a": {"b": [1]}}
+28    {"a": {}}  5   {"a": {"b": [1, [2]]}}
+28    {"a": {}}  6   {"a": {"b": [[2]]}}
+28    {"a": {}}  8   {"a": {"b": true}}
+28    {"a": {}}  9   {"a": {"b": false}}
+
 # This query performs a semi inverted join with an additional filter.
 query IT
 SELECT * FROM json_tab AS j2 WHERE EXISTS (
@@ -480,11 +861,73 @@ ORDER BY j2.a
 18  []
 19  ["a", "a"]
 
+# This query performs a semi inverted join with an additional filter.
+query IT
+SELECT * FROM json_tab AS j2 WHERE EXISTS (
+  SELECT * FROM json_tab@foo_inv AS j1
+  WHERE j1.b <@ j2.b AND j2.a < 20
+)
+ORDER BY j2.a
+----
+1   {"a": "b"}
+2   [1, 2, 3, 4, "foo"]
+3   {"a": {"b": "c"}}
+4   {"a": {"b": [1]}}
+5   {"a": {"b": [1, [2]]}}
+6   {"a": {"b": [[2]]}}
+7   {"a": "b", "c": "d"}
+8   {"a": {"b": true}}
+9   {"a": {"b": false}}
+10  "a"
+11  null
+12  true
+13  false
+14  1
+15  1.23
+16  [{"a": {"b": [1, [2]]}}, "d"]
+17  {}
+18  []
+19  ["a", "a"]
+
 # This query performs an anti inverted join with an additional filter.
 query IT
 SELECT * FROM json_tab AS j2 WHERE NOT EXISTS (
   SELECT * FROM json_tab@foo_inv AS j1
   WHERE j1.b @> j2.b AND j2.a < 20
+)
+ORDER BY j2.a
+----
+20  [{"a": "a"}, {"a": "a"}]
+21  [[[["a"]]], [[["a"]]]]
+22  [1, 2, 3, 1]
+23  {"a": 123.123}
+24  {"a": 123.123000}
+25  {"a": [{}]}
+26  [[], {}]
+27  [true, false, null, 1.23, "a"]
+28  {"a": {}}
+29  NULL
+30  {"a": []}
+31  {"a": {"b": "c", "d": "e"}, "f": "g"}
+32  {"a": [1]}
+33  [1, "bar"]
+34  {"a": 1}
+35  [1]
+36  [2]
+37  [[1]]
+38  [[2]]
+39  ["a"]
+40  {"a": [[]]}
+41  [[1, 2]]
+42  [[1], [2]]
+43  [{"a": "b", "c": "d"}]
+44  [{"a": "b"}, {"c": "d"}]
+
+# This query performs an anti inverted join with an additional filter.
+query IT
+SELECT * FROM json_tab AS j2 WHERE NOT EXISTS (
+  SELECT * FROM json_tab@foo_inv AS j1
+  WHERE j1.b <@ j2.b AND j2.a < 20
 )
 ORDER BY j2.a
 ----
@@ -584,6 +1027,65 @@ ON inv_join.a1 = cross_join.a1 AND inv_join.a2 = cross_join.a2
 WHERE inv_join.a1 IS NULL OR cross_join.a1 IS NULL
 ----
 
+# This query performs an inverted join.
+query ITIT
+SELECT * FROM array_tab@foo_inv AS a1, array_tab AS a2 WHERE a1.b <@ a2.b ORDER BY a1.a, a2.a
+----
+1  {}         1  {}
+1  {}         2  {1}
+1  {}         3  {2}
+1  {}         4  {1,2}
+1  {}         5  {1,3}
+1  {}         6  {1,2,3,4}
+1  {}         7  {NULL}
+2  {1}        2  {1}
+2  {1}        4  {1,2}
+2  {1}        5  {1,3}
+2  {1}        6  {1,2,3,4}
+3  {2}        3  {2}
+3  {2}        4  {1,2}
+3  {2}        6  {1,2,3,4}
+4  {1,2}      4  {1,2}
+4  {1,2}      6  {1,2,3,4}
+5  {1,3}      5  {1,3}
+5  {1,3}      6  {1,2,3,4}
+6  {1,2,3,4}  6  {1,2,3,4}
+
+# This query performs a cross join followed by a filter.
+query ITIT
+SELECT * FROM array_tab@primary AS a1, array_tab AS a2 WHERE a1.b <@ a2.b ORDER BY a1.a, a2.a
+----
+1  {}         1  {}
+1  {}         2  {1}
+1  {}         3  {2}
+1  {}         4  {1,2}
+1  {}         5  {1,3}
+1  {}         6  {1,2,3,4}
+1  {}         7  {NULL}
+2  {1}        2  {1}
+2  {1}        4  {1,2}
+2  {1}        5  {1,3}
+2  {1}        6  {1,2,3,4}
+3  {2}        3  {2}
+3  {2}        4  {1,2}
+3  {2}        6  {1,2,3,4}
+4  {1,2}      4  {1,2}
+4  {1,2}      6  {1,2,3,4}
+5  {1,3}      5  {1,3}
+5  {1,3}      6  {1,2,3,4}
+6  {1,2,3,4}  6  {1,2,3,4}
+
+# This query is checking that the results of the previous two queries are identical.
+# There should be no rows output.
+query IIII
+SELECT * FROM
+(SELECT a1.a, a2.a FROM array_tab@foo_inv AS a1, array_tab AS a2 WHERE a1.b <@ a2.b) AS inv_join(a1, a2)
+FULL OUTER JOIN
+(SELECT a1.a, a2.a FROM array_tab@primary AS a1, array_tab AS a2 WHERE a1.b <@ a2.b) AS cross_join(a1, a2)
+ON inv_join.a1 = cross_join.a1 AND inv_join.a2 = cross_join.a2
+WHERE inv_join.a1 IS NULL OR cross_join.a1 IS NULL
+----
+
 # This query performs an inverted join with an additional filter.
 query ITIT
 SELECT a1.*, a2.* FROM array_tab@primary AS a2
@@ -641,6 +1143,51 @@ ON inv_join.a1 = cross_join.a1 AND inv_join.a2 = cross_join.a2
 WHERE inv_join.a1 IS NULL OR cross_join.a1 IS NULL
 ----
 
+# This query performs an inverted join with an additional filter.
+query ITIT
+SELECT a1.*, a2.* FROM array_tab@primary AS a2
+INNER INVERTED JOIN array_tab@foo_inv AS a1
+ON a1.b <@ a2.b AND a1.b <@ '{1}' AND a2.a < 5
+ORDER BY a1.a, a2.a
+----
+1  {}   1  {}
+1  {}   2  {1}
+1  {}   3  {2}
+1  {}   4  {1,2}
+2  {1}  2  {1}
+2  {1}  4  {1,2}
+
+# This query performs a cross join followed by a filter.
+query ITIT
+SELECT * FROM array_tab@primary AS a1, array_tab AS a2
+WHERE a1.b <@ a2.b AND a1.b <@ '{1}' AND a2.a < 5
+ORDER BY a1.a, a2.a
+----
+1  {}   1  {}
+1  {}   2  {1}
+1  {}   3  {2}
+1  {}   4  {1,2}
+2  {1}  2  {1}
+2  {1}  4  {1,2}
+
+# This query is checking that the results of the previous two queries are identical.
+# There should be no rows output.
+query IIII
+SELECT * FROM
+(
+  SELECT a1.a, a2.a FROM array_tab@primary AS a2
+  INNER INVERTED JOIN array_tab@foo_inv AS a1
+  ON a1.b <@ a2.b AND a1.b <@ '{1}' AND a2.a < 5
+) AS inv_join(a1, a2)
+FULL OUTER JOIN
+(
+  SELECT a1.a, a2.a FROM array_tab@primary AS a1, array_tab AS a2
+  WHERE a1.b <@ a2.b AND a1.b <@ '{1}' AND a2.a < 5
+) AS cross_join(a1, a2)
+ON inv_join.a1 = cross_join.a1 AND inv_join.a2 = cross_join.a2
+WHERE inv_join.a1 IS NULL OR cross_join.a1 IS NULL
+----
+
 # This query performs a left inverted join with an additional filter.
 query ITIT
 SELECT a1.*, a2.* FROM array_tab@primary AS a2
@@ -665,6 +1212,24 @@ NULL  NULL       8  NULL
 6     {1,2,3,4}  3  {2}
 6     {1,2,3,4}  4  {1,2}
 
+# This query performs a left inverted join with an additional filter.
+query ITIT
+SELECT a1.*, a2.* FROM array_tab@primary AS a2
+LEFT INVERTED JOIN array_tab@foo_inv AS a1
+ON a1.b <@ a2.b AND a1.b <@ '{1}' AND a2.a < 5
+ORDER BY a1.a, a2.a
+----
+NULL  NULL  5  {1,3}
+NULL  NULL  6  {1,2,3,4}
+NULL  NULL  7  {NULL}
+NULL  NULL  8  NULL
+1     {}    1  {}
+1     {}    2  {1}
+1     {}    3  {2}
+1     {}    4  {1,2}
+2     {1}   2  {1}
+2     {1}   4  {1,2}
+
 # This query performs a semi inverted join.
 query IT
 SELECT a2.* FROM array_tab@primary AS a2 WHERE EXISTS (
@@ -680,6 +1245,22 @@ ORDER BY a2.a
 5  {1,3}
 6  {1,2,3,4}
 
+# This query performs a semi inverted join.
+query IT
+SELECT a2.* FROM array_tab@primary AS a2 WHERE EXISTS (
+  SELECT * FROM array_tab@foo_inv AS a1
+  WHERE a1.b <@ a2.b
+)
+ORDER BY a2.a
+----
+1  {}
+2  {1}
+3  {2}
+4  {1,2}
+5  {1,3}
+6  {1,2,3,4}
+7  {NULL}
+
 # This query performs an anti inverted join.
 query IT
 SELECT a2.* FROM array_tab@primary AS a2 WHERE NOT EXISTS (
@@ -689,6 +1270,16 @@ SELECT a2.* FROM array_tab@primary AS a2 WHERE NOT EXISTS (
 ORDER BY a2.a
 ----
 7  {NULL}
+8  NULL
+
+# This query performs an anti inverted join.
+query IT
+SELECT a2.* FROM array_tab@primary AS a2 WHERE NOT EXISTS (
+  SELECT * FROM array_tab@foo_inv AS a1
+  WHERE a1.b <@ a2.b
+)
+ORDER BY a2.a
+----
 8  NULL
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -876,7 +876,7 @@ vectorized: true
 • filter
 │ columns: (a, b)
 │ estimated row count: 333 (missing stats)
-│ filter: ARRAY[] @> b
+│ filter: b <@ ARRAY[]
 │
 └── • index join
     │ columns: (a, b)
@@ -899,7 +899,7 @@ vectorized: true
 • filter
 │ columns: (a, b)
 │ estimated row count: 333 (missing stats)
-│ filter: ARRAY[0,1,2] @> b
+│ filter: b <@ ARRAY[0,1,2]
 │
 └── • index join
     │ columns: (a, b)
@@ -931,7 +931,7 @@ vectorized: true
 • filter
 │ columns: (a, b)
 │ estimated row count: 333 (missing stats)
-│ filter: ARRAY[NULL] @> b
+│ filter: b <@ ARRAY[NULL]
 │
 └── • index join
     │ columns: (a, b)
@@ -954,7 +954,7 @@ vectorized: true
 • filter
 │ columns: (a, b)
 │ estimated row count: 333 (missing stats)
-│ filter: ARRAY[0,1,NULL] @> b
+│ filter: b <@ ARRAY[0,1,NULL]
 │
 └── • index join
     │ columns: (a, b)
@@ -986,7 +986,7 @@ vectorized: true
 • filter
 │ columns: (a, b)
 │ estimated row count: 333 (missing stats)
-│ filter: '[]' @> b
+│ filter: b <@ '[]'
 │
 └── • index join
     │ columns: (a, b)
@@ -1010,7 +1010,7 @@ vectorized: true
 • filter
 │ columns: (a, b)
 │ estimated row count: 333 (missing stats)
-│ filter: '[1, 2]' @> b
+│ filter: b <@ '[1, 2]'
 │
 └── • index join
     │ columns: (a, b)
@@ -1042,7 +1042,7 @@ vectorized: true
 • filter
 │ columns: (a, b)
 │ estimated row count: 333 (missing stats)
-│ filter: '{}' @> b
+│ filter: b <@ '{}'
 │
 └── • index join
     │ columns: (a, b)
@@ -1065,7 +1065,7 @@ vectorized: true
 • filter
 │ columns: (a, b)
 │ estimated row count: 333 (missing stats)
-│ filter: '{"a": "b"}' @> b
+│ filter: b <@ '{"a": "b"}'
 │
 └── • index join
     │ columns: (a, b)
@@ -1097,7 +1097,7 @@ vectorized: true
 • filter
 │ columns: (a, b)
 │ estimated row count: 333 (missing stats)
-│ filter: '[{"a": "b"}, {"c": {"d": ["e"]}}, "f"]' @> b
+│ filter: b <@ '[{"a": "b"}, {"c": {"d": ["e"]}}, "f"]'
 │
 └── • index join
     │ columns: (a, b)

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_json_array
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_json_array
@@ -65,6 +65,53 @@ vectorized: true
           table: json_tab@primary
           spans: FULL SCAN
 
+# This query performs an inverted join.
+query T
+EXPLAIN SELECT * FROM json_tab@foo_inv AS j1, json_tab AS j2 WHERE j1.b <@ j2.b ORDER BY j1.a, j2.a
+----
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +a,+a
+│
+└── • lookup join
+    │ table: json_tab@primary
+    │ equality: (a) = (a)
+    │ equality cols are key
+    │ pred: b <@ b
+    │
+    └── • inverted join
+        │ table: json_tab@foo_inv
+        │
+        └── • scan
+              missing stats
+              table: json_tab@primary
+              spans: FULL SCAN
+
+# This query performs a cross join followed by a filter.
+query T
+EXPLAIN SELECT * FROM json_tab@primary AS j1, json_tab AS j2 WHERE j1.b <@ j2.b ORDER BY j1.a, j2.a
+----
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +a,+a
+│
+└── • cross join
+    │ pred: b <@ b
+    │
+    ├── • scan
+    │     missing stats
+    │     table: json_tab@primary
+    │     spans: FULL SCAN
+    │
+    └── • scan
+          missing stats
+          table: json_tab@primary
+          spans: FULL SCAN
+
 # This query performs an inverted join with an additional filter.
 query T
 EXPLAIN SELECT * FROM json_tab AS j2 INNER INVERTED JOIN json_tab AS j1
@@ -119,6 +166,60 @@ vectorized: true
               table: json_tab@primary
               spans: FULL SCAN
 
+# This query performs an inverted join with an additional filter.
+query T
+EXPLAIN SELECT * FROM json_tab AS j2 INNER INVERTED JOIN json_tab AS j1
+ON j1.b <@ j2.b AND j1.b <@ '{"a": {}}' AND j2.a < 20
+ORDER BY j1.a, j2.a
+----
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +a,+a
+│
+└── • lookup join
+    │ table: json_tab@primary
+    │ equality: (a) = (a)
+    │ equality cols are key
+    │ pred: (b <@ b) AND (b <@ '{"a": {}}')
+    │
+    └── • inverted join
+        │ table: json_tab@foo_inv
+        │
+        └── • scan
+              missing stats
+              table: json_tab@primary
+              spans: [ - /19]
+
+# This query performs a cross join followed by a filter.
+query T
+EXPLAIN SELECT * FROM json_tab@primary AS j1, json_tab AS j2
+WHERE j1.b <@ j2.b AND j1.b <@ '{"a": {}}' AND j2.a < 20
+ORDER BY j1.a, j2.a
+----
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +a,+a
+│
+└── • cross join
+    │ pred: b <@ b
+    │
+    ├── • filter
+    │   │ filter: b <@ '{"a": {}}'
+    │   │
+    │   └── • scan
+    │         missing stats
+    │         table: json_tab@primary
+    │         spans: FULL SCAN
+    │
+    └── • scan
+          missing stats
+          table: json_tab@primary
+          spans: [ - /19]
+
 # This query performs a left inverted join with an additional filter.
 query T
 EXPLAIN SELECT * FROM json_tab AS j2 LEFT INVERTED JOIN json_tab AS j1
@@ -136,6 +237,33 @@ vectorized: true
     │ equality: (a) = (a)
     │ equality cols are key
     │ pred: (b @> b) AND (b @> '{"a": {}}')
+    │
+    └── • inverted join (left outer)
+        │ table: json_tab@foo_inv
+        │ on: a < 20
+        │
+        └── • scan
+              missing stats
+              table: json_tab@primary
+              spans: FULL SCAN
+
+# This query performs a left inverted join with an additional filter.
+query T
+EXPLAIN SELECT * FROM json_tab AS j2 LEFT INVERTED JOIN json_tab AS j1
+ON j1.b <@ j2.b AND j1.b <@ '{"a": {}}' AND j2.a < 20
+ORDER BY j1.a, j2.a
+----
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +a,+a
+│
+└── • lookup join (left outer)
+    │ table: json_tab@primary
+    │ equality: (a) = (a)
+    │ equality cols are key
+    │ pred: (b <@ b) AND (b <@ '{"a": {}}')
     │
     └── • inverted join (left outer)
         │ table: json_tab@foo_inv
@@ -171,6 +299,31 @@ vectorized: true
           table: json_tab@primary
           spans: [ - /19]
 
+# This query performs a semi inverted join with an additional filter.
+query T
+EXPLAIN SELECT * FROM json_tab AS j2 WHERE EXISTS (
+  SELECT * FROM json_tab@foo_inv AS j1
+  WHERE j1.b <@ j2.b AND j2.a < 20
+)
+ORDER BY j2.a
+----
+distribution: local
+vectorized: true
+·
+• lookup join (semi)
+│ table: json_tab@primary
+│ equality: (a) = (a)
+│ equality cols are key
+│ pred: b <@ b
+│
+└── • inverted join
+    │ table: json_tab@foo_inv
+    │
+    └── • scan
+          missing stats
+          table: json_tab@primary
+          spans: [ - /19]
+
 # This query performs an anti inverted join with an additional filter.
 query T
 EXPLAIN SELECT * FROM json_tab AS j2 WHERE NOT EXISTS (
@@ -187,6 +340,32 @@ vectorized: true
 │ equality: (a) = (a)
 │ equality cols are key
 │ pred: b @> b
+│
+└── • inverted join (left outer)
+    │ table: json_tab@foo_inv
+    │ on: a < 20
+    │
+    └── • scan
+          missing stats
+          table: json_tab@primary
+          spans: FULL SCAN
+
+# This query performs an anti inverted join with an additional filter.
+query T
+EXPLAIN SELECT * FROM json_tab AS j2 WHERE NOT EXISTS (
+  SELECT * FROM json_tab@foo_inv AS j1
+  WHERE j1.b <@ j2.b AND j2.a < 20
+)
+ORDER BY j2.a
+----
+distribution: local
+vectorized: true
+·
+• lookup join (anti)
+│ table: json_tab@primary
+│ equality: (a) = (a)
+│ equality cols are key
+│ pred: b <@ b
 │
 └── • inverted join (left outer)
     │ table: json_tab@foo_inv
@@ -233,6 +412,53 @@ vectorized: true
 │
 └── • cross join
     │ pred: b @> b
+    │
+    ├── • scan
+    │     missing stats
+    │     table: array_tab@primary
+    │     spans: FULL SCAN
+    │
+    └── • scan
+          missing stats
+          table: array_tab@primary
+          spans: FULL SCAN
+
+# This query performs an inverted join.
+query T
+EXPLAIN SELECT * FROM array_tab@foo_inv AS a1, array_tab AS a2 WHERE a1.b <@ a2.b ORDER BY a1.a, a2.a
+----
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +a,+a
+│
+└── • lookup join
+    │ table: array_tab@primary
+    │ equality: (a) = (a)
+    │ equality cols are key
+    │ pred: b <@ b
+    │
+    └── • inverted join
+        │ table: array_tab@foo_inv
+        │
+        └── • scan
+              missing stats
+              table: array_tab@primary
+              spans: FULL SCAN
+
+# This query performs a cross join followed by a filter.
+query T
+EXPLAIN SELECT * FROM array_tab@primary AS a1, array_tab AS a2 WHERE a1.b <@ a2.b ORDER BY a1.a, a2.a
+----
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +a,+a
+│
+└── • cross join
+    │ pred: b <@ b
     │
     ├── • scan
     │     missing stats
@@ -299,6 +525,61 @@ vectorized: true
               table: array_tab@primary
               spans: FULL SCAN
 
+# This query performs an inverted join with an additional filter.
+query T
+EXPLAIN SELECT * FROM array_tab@primary AS a2
+INNER INVERTED JOIN array_tab@foo_inv AS a1
+ON a1.b <@ a2.b AND a1.b <@ '{1}' AND a2.a < 5
+ORDER BY a1.a, a2.a
+----
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +a,+a
+│
+└── • lookup join
+    │ table: array_tab@primary
+    │ equality: (a) = (a)
+    │ equality cols are key
+    │ pred: (b <@ b) AND (b <@ ARRAY[1])
+    │
+    └── • inverted join
+        │ table: array_tab@foo_inv
+        │
+        └── • scan
+              missing stats
+              table: array_tab@primary
+              spans: [ - /4]
+
+# This query performs a cross join followed by a filter.
+query T
+EXPLAIN SELECT * FROM array_tab@primary AS a1, array_tab AS a2
+WHERE a1.b <@ a2.b AND a1.b <@ '{1}' AND a2.a < 5
+ORDER BY a1.a, a2.a
+----
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +a,+a
+│
+└── • cross join
+    │ pred: b <@ b
+    │
+    ├── • filter
+    │   │ filter: b <@ ARRAY[1]
+    │   │
+    │   └── • scan
+    │         missing stats
+    │         table: array_tab@primary
+    │         spans: FULL SCAN
+    │
+    └── • scan
+          missing stats
+          table: array_tab@primary
+          spans: [ - /4]
+
 # This query performs a left inverted join with an additional filter.
 query T
 EXPLAIN SELECT a1.*, a2.* FROM array_tab@primary AS a2
@@ -317,6 +598,34 @@ vectorized: true
     │ equality: (a) = (a)
     │ equality cols are key
     │ pred: (b @> b) AND (b @> ARRAY[1])
+    │
+    └── • inverted join (left outer)
+        │ table: array_tab@foo_inv
+        │ on: a < 5
+        │
+        └── • scan
+              missing stats
+              table: array_tab@primary
+              spans: FULL SCAN
+
+# This query performs a left inverted join with an additional filter.
+query T
+EXPLAIN SELECT a1.*, a2.* FROM array_tab@primary AS a2
+LEFT INVERTED JOIN array_tab@foo_inv AS a1
+ON a1.b <@ a2.b AND a1.b <@ '{1}' AND a2.a < 5
+ORDER BY a1.a, a2.a
+----
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +a,+a
+│
+└── • lookup join (left outer)
+    │ table: array_tab@primary
+    │ equality: (a) = (a)
+    │ equality cols are key
+    │ pred: (b <@ b) AND (b <@ ARRAY[1])
     │
     └── • inverted join (left outer)
         │ table: array_tab@foo_inv
@@ -352,6 +661,31 @@ vectorized: true
           table: array_tab@primary
           spans: FULL SCAN
 
+# This query performs a semi inverted join.
+query T
+EXPLAIN SELECT a2.* FROM array_tab@primary AS a2 WHERE EXISTS (
+  SELECT * FROM array_tab@foo_inv AS a1
+  WHERE a1.b <@ a2.b
+)
+ORDER BY a2.a
+----
+distribution: local
+vectorized: true
+·
+• lookup join (semi)
+│ table: array_tab@primary
+│ equality: (a) = (a)
+│ equality cols are key
+│ pred: b <@ b
+│
+└── • inverted join
+    │ table: array_tab@foo_inv
+    │
+    └── • scan
+          missing stats
+          table: array_tab@primary
+          spans: FULL SCAN
+
 # This query performs an anti inverted join.
 query T
 EXPLAIN SELECT a2.* FROM array_tab@primary AS a2 WHERE NOT EXISTS (
@@ -368,6 +702,31 @@ vectorized: true
 │ equality: (a) = (a)
 │ equality cols are key
 │ pred: b @> b
+│
+└── • inverted join (left outer)
+    │ table: array_tab@foo_inv
+    │
+    └── • scan
+          missing stats
+          table: array_tab@primary
+          spans: FULL SCAN
+
+# This query performs an anti inverted join.
+query T
+EXPLAIN SELECT a2.* FROM array_tab@primary AS a2 WHERE NOT EXISTS (
+  SELECT * FROM array_tab@foo_inv AS a1
+  WHERE a1.b <@ a2.b
+)
+ORDER BY a2.a
+----
+distribution: local
+vectorized: true
+·
+• lookup join (anti)
+│ table: array_tab@primary
+│ equality: (a) = (a)
+│ equality cols are key
+│ pred: b <@ b
 │
 └── • inverted join (left outer)
     │ table: array_tab@foo_inv

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_multi_column
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_multi_column
@@ -79,3 +79,59 @@ vectorized: true
         │
         └── • values
               size: 1 column, 2 rows
+
+query T
+EXPLAIN SELECT j1.k
+FROM j1 INNER INVERTED JOIN j2
+ON i IN (10, 20) AND j2.j <@ j1.j
+----
+distribution: local
+vectorized: true
+·
+• lookup join
+│ table: j2@primary
+│ equality: (k) = (k)
+│ equality cols are key
+│ pred: j <@ j
+│
+└── • inverted join
+    │ table: j2@ij_idx
+    │
+    └── • cross join
+        │
+        ├── • scan
+        │     missing stats
+        │     table: j1@primary
+        │     spans: FULL SCAN
+        │
+        └── • values
+              size: 1 column, 2 rows
+
+query T
+EXPLAIN SELECT j1.k
+FROM j1 INNER INVERTED JOIN j2@isj_idx
+ON i = 10 AND s IN ('foo', 'bar') AND j2.j <@ j1.j
+----
+distribution: local
+vectorized: true
+·
+• lookup join
+│ table: j2@primary
+│ equality: (k) = (k)
+│ equality cols are key
+│ pred: j <@ j
+│
+└── • inverted join
+    │ table: j2@isj_idx
+    │
+    └── • cross join
+        │
+        ├── • render
+        │   │
+        │   └── • scan
+        │         missing stats
+        │         table: j1@primary
+        │         spans: FULL SCAN
+        │
+        └── • values
+              size: 1 column, 2 rows

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -626,7 +626,7 @@ vectorized: true
 • render
 │ columns: (r)
 │ estimated row count: 1,000 (missing stats)
-│ render r: j @> '{"a": 1}'
+│ render r: '{"a": 1}' <@ j
 │
 └── • scan
       columns: (j)

--- a/pkg/sql/opt/invertedidx/inverted_index_expr.go
+++ b/pkg/sql/opt/invertedidx/inverted_index_expr.go
@@ -192,6 +192,7 @@ func TryJoinInvertedIndex(
 		}
 	} else {
 		joinPlanner = &jsonOrArrayJoinPlanner{
+			factory:   factory,
 			tabID:     tabID,
 			index:     index,
 			inputCols: inputCols,

--- a/pkg/sql/opt/invertedidx/json_array.go
+++ b/pkg/sql/opt/invertedidx/json_array.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/invertedexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -29,6 +30,7 @@ import (
 )
 
 type jsonOrArrayJoinPlanner struct {
+	factory   *norm.Factory
 	tabID     opt.TableID
 	index     cat.Index
 	inputCols opt.ColSet
@@ -41,50 +43,79 @@ func (j *jsonOrArrayJoinPlanner) extractInvertedJoinConditionFromLeaf(
 	ctx context.Context, expr opt.ScalarExpr,
 ) opt.ScalarExpr {
 	switch t := expr.(type) {
-	case *memo.ContainsExpr:
-		if j.canExtractJSONOrArrayJoinCondition(t.Left, t.Right) {
-			return t
-		}
-		return nil
-
+	case *memo.ContainsExpr, *memo.ContainedByExpr:
+		return j.extractJSONOrArrayJoinCondition(t)
 	default:
 		return nil
 	}
 }
 
-// canExtractJSONOrArrayJoinCondition returns true if it is possible to extract
-// an inverted join condition from the given left and right expression
-// arguments. Returns false otherwise.
-func (j *jsonOrArrayJoinPlanner) canExtractJSONOrArrayJoinCondition(
-	left, right opt.ScalarExpr,
-) bool {
-	// The first argument should be a variable or expression corresponding to
-	// the index column.
-	// TODO(mgartner): The first argument could be an expression that matches a
-	// computed column expression if the computed column is indexed. Pass
-	// computedColumns to enable this.
-	if !isIndexColumn(j.tabID, j.index, left, nil /* computedColumns */) {
-		return false
+// extractJSONOrArrayJoinCondition returns a scalar expression if it is
+// possible to extract an inverted join condition from the left and right
+// arguments of the given expression. If the arguments need to be commuted,
+// it will construct a new expression. Returns nil otherwise.
+func (j *jsonOrArrayJoinPlanner) extractJSONOrArrayJoinCondition(
+	expr opt.ScalarExpr,
+) opt.ScalarExpr {
+	var left, right, indexCol, val opt.ScalarExpr
+	commuteArgs, containedBy := false, false
+	switch t := expr.(type) {
+	case *memo.ContainsExpr:
+		left = t.Left
+		right = t.Right
+	case *memo.ContainedByExpr:
+		left = t.Left
+		right = t.Right
+		containedBy = true
+	default:
+		return nil
 	}
-	if left.DataType().Family() == types.ArrayFamily &&
+	if isIndexColumn(j.tabID, j.index, left, nil /* computedColumns */) {
+		// When the first argument is a variable or expression corresponding to the
+		// index column, we keep the order of arguments as is and get the
+		// InvertedExpression for either left @> right or left <@ right.
+		// TODO(mgartner): The first argument could be an expression that matches a
+		// computed column expression if the computed column is indexed. Pass
+		// computedColumns to enable this.
+		indexCol, val = left, right
+	} else if isIndexColumn(j.tabID, j.index, right, nil /* computedColumns */) {
+		// When the second argument is a variable or expression corresponding to
+		// the index column, we must commute the right and left arguments and
+		// construct a new expression. We get the equivalent InvertedExpression for
+		// right <@ left or right @> left.
+		commuteArgs = true
+		indexCol, val = right, left
+	} else {
+		// If neither condition is met, we cannot create an InvertedExpression.
+		return nil
+	}
+	if indexCol.DataType().Family() == types.ArrayFamily &&
 		j.index.Version() < descpb.EmptyArraysInInvertedIndexesVersion {
 		// We cannot plan inverted joins on array indexes that do not include
 		// keys for empty arrays.
-		return false
+		return nil
 	}
-
-	// The second argument should either come from the input or be a constant.
+	// The non-indexed argument should either come from the input or be a
+	// constant.
 	var p props.Shared
-	memo.BuildSharedProps(right, &p)
+	memo.BuildSharedProps(val, &p)
 	if !p.OuterCols.Empty() {
 		if !p.OuterCols.SubsetOf(j.inputCols) {
-			return false
+			return nil
 		}
-	} else if !memo.CanExtractConstDatum(right) {
-		return false
+	} else if !memo.CanExtractConstDatum(val) {
+		return nil
 	}
 
-	return true
+	// If commuteArgs is true, we construct a new equivalent expression so that
+	// the left argument is the indexed column.
+	if commuteArgs {
+		if containedBy {
+			return j.factory.ConstructContains(right, left)
+		}
+		return j.factory.ConstructContainedBy(right, left)
+	}
+	return expr
 }
 
 // getInvertedExprForJSONOrArrayIndexForContaining gets an inverted.Expression that
@@ -185,10 +216,6 @@ func NewJSONOrArrayDatumsToInvertedExpr(
 	getInvertedExprLeaf := func(expr tree.TypedExpr) (tree.TypedExpr, error) {
 		switch t := expr.(type) {
 		case *tree.ComparisonExpr:
-			if t.Operator != tree.Contains {
-				return nil, fmt.Errorf("%s cannot be index-accelerated", t)
-			}
-
 			// We know that the non-index param is the second param.
 			nonIndexParam := t.Right.(tree.TypedExpr)
 
@@ -196,7 +223,15 @@ func NewJSONOrArrayDatumsToInvertedExpr(
 			// it for every row.
 			var spanExpr *inverted.SpanExpression
 			if d, ok := nonIndexParam.(tree.Datum); ok {
-				invertedExpr := getInvertedExprForJSONOrArrayIndexForContaining(evalCtx, d)
+				var invertedExpr inverted.Expression
+				switch t.Operator {
+				case tree.ContainedBy:
+					invertedExpr = getInvertedExprForJSONOrArrayIndexForContainedBy(evalCtx, d)
+				case tree.Contains:
+					invertedExpr = getInvertedExprForJSONOrArrayIndexForContaining(evalCtx, d)
+				default:
+					return nil, fmt.Errorf("%s cannot be index-accelerated", t)
+				}
 				spanExpr, _ = invertedExpr.(*inverted.SpanExpression)
 			}
 
@@ -241,7 +276,16 @@ func (g *jsonOrArrayDatumsToInvertedExpr) Convert(
 			if d == tree.DNull {
 				return nil, nil
 			}
-			return getInvertedExprForJSONOrArrayIndexForContaining(g.evalCtx, d), nil
+			switch t.Operator {
+			case tree.Contains:
+				return getInvertedExprForJSONOrArrayIndexForContaining(g.evalCtx, d), nil
+
+			case tree.ContainedBy:
+				return getInvertedExprForJSONOrArrayIndexForContainedBy(g.evalCtx, d), nil
+
+			default:
+				return nil, fmt.Errorf("unsupported expression %v", t)
+			}
 
 		default:
 			return nil, fmt.Errorf("unsupported expression %v", t)
@@ -294,7 +338,9 @@ func (j *jsonOrArrayFilterPlanner) extractInvertedFilterConditionFromLeaf(
 ) {
 	switch t := expr.(type) {
 	case *memo.ContainsExpr:
-		invertedExpr = j.extractJSONOrArrayContainsCondition(evalCtx, t.Left, t.Right)
+		invertedExpr = j.extractJSONOrArrayContainsCondition(evalCtx, t.Left, t.Right, false /* containedBy */)
+	case *memo.ContainedByExpr:
+		invertedExpr = j.extractJSONOrArrayContainsCondition(evalCtx, t.Left, t.Right, true /* containedBy */)
 	case *memo.EqExpr:
 		if fetch, ok := t.Left.(*memo.FetchValExpr); ok {
 			invertedExpr = j.extractJSONFetchValEqCondition(evalCtx, fetch, t.Right)
@@ -322,21 +368,20 @@ func (j *jsonOrArrayFilterPlanner) extractInvertedFilterConditionFromLeaf(
 // on the given left and right expression arguments. Returns an empty
 // InvertedExpression if no inverted filter could be extracted.
 func (j *jsonOrArrayFilterPlanner) extractJSONOrArrayContainsCondition(
-	evalCtx *tree.EvalContext, left, right opt.ScalarExpr,
+	evalCtx *tree.EvalContext, left, right opt.ScalarExpr, containedBy bool,
 ) inverted.Expression {
 	var indexColumn, constantVal opt.ScalarExpr
-	containedBy := false
 	if isIndexColumn(j.tabID, j.index, left, j.computedColumns) && memo.CanExtractConstDatum(right) {
 		// When the first argument is a variable or expression corresponding to the
 		// index column and the second argument is a constant, we get the
-		// InvertedExpression for left @> right.
+		// InvertedExpression for left @> right or left <@ right.
 		indexColumn, constantVal = left, right
 	} else if isIndexColumn(j.tabID, j.index, right, j.computedColumns) && memo.CanExtractConstDatum(left) {
 		// When the second argument is a variable or expression corresponding to
 		// the index column and the first argument is a constant, we get the
-		// equivalent InvertedExpression for right <@ left.
+		// equivalent InvertedExpression for right <@ left or right @> left.
 		indexColumn, constantVal = right, left
-		containedBy = true
+		containedBy = !containedBy
 	} else {
 		// If neither condition is met, we cannot create an InvertedExpression.
 		return inverted.NonInvertedColExpression{}

--- a/pkg/sql/opt/invertedidx/json_array_test.go
+++ b/pkg/sql/opt/invertedidx/json_array_test.go
@@ -58,12 +58,13 @@ func TestTryJoinJsonOrArrayIndex(t *testing.T) {
 		invertedExpr string
 	}{
 		{
-			// Indexed column must be first with @>.
+			// Indexed column can be on either side of @>.
 			filters:      "json1 @> json2",
 			indexOrd:     jsonOrd,
-			invertedExpr: "",
+			invertedExpr: "json2 <@ json1",
 		},
 		{
+			// Indexed column can be on either side of <@.
 			filters:      "json1 <@ json2",
 			indexOrd:     jsonOrd,
 			invertedExpr: "json2 @> json1",
@@ -74,16 +75,16 @@ func TestTryJoinJsonOrArrayIndex(t *testing.T) {
 			invertedExpr: "json2 @> json1",
 		},
 		{
-			// Indexed column must be first with @>.
+			// Indexed column can be on either side of @>.
 			filters:      "array1 @> array2",
 			indexOrd:     arrayOrd,
-			invertedExpr: "",
+			invertedExpr: "array2 <@ array1",
 		},
 		{
-			// Indexed column must be second with <@.
+			// Indexed column can be on either side of <@.
 			filters:      "array2 <@ array1",
 			indexOrd:     arrayOrd,
-			invertedExpr: "",
+			invertedExpr: "array2 <@ array1",
 		},
 		{
 			filters:      "array2 @> array1",

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -849,7 +849,7 @@ func ExprIsNeverNull(e opt.ScalarExpr, notNullCols opt.ColSet) bool {
 
 	case *AndExpr, *OrExpr, *GeExpr, *GtExpr, *NeExpr, *EqExpr, *LeExpr, *LtExpr, *LikeExpr,
 		*NotLikeExpr, *ILikeExpr, *NotILikeExpr, *SimilarToExpr, *NotSimilarToExpr, *RegMatchExpr,
-		*NotRegMatchExpr, *RegIMatchExpr, *NotRegIMatchExpr, *ContainsExpr, *JsonExistsExpr,
+		*NotRegMatchExpr, *RegIMatchExpr, *NotRegIMatchExpr, *ContainsExpr, *ContainedByExpr, *JsonExistsExpr,
 		*JsonAllExistsExpr, *JsonSomeExistsExpr, *AnyScalarExpr, *BitandExpr, *BitorExpr, *BitxorExpr,
 		*PlusExpr, *MinusExpr, *MultExpr, *DivExpr, *FloorDivExpr, *ModExpr, *PowExpr, *ConcatExpr,
 		*LShiftExpr, *RShiftExpr, *WhenExpr:

--- a/pkg/sql/opt/memo/testdata/stats/inverted-array
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-array
@@ -155,7 +155,7 @@ select
  │         │                <--- '\x43' --- '\x44'
  │         └── key: (1)
  └── filters
-      └── ARRAY[] @> a:2 [type=bool, outer=(2), immutable]
+      └── a:2 <@ ARRAY[] [type=bool, outer=(2), immutable]
 
 # The inverted index is used when checking if an array column is contained by a
 # constant. An additional filter is required.
@@ -194,7 +194,7 @@ select
  │              ├── key: (1)
  │              └── fd: (1)-->(4)
  └── filters
-      └── ARRAY[2] @> a:2 [type=bool, outer=(2), immutable]
+      └── a:2 <@ ARRAY[2] [type=bool, outer=(2), immutable]
 
 # A disjunction requires scanning all entries that match either the left or the
 # right. An additional filter is required.
@@ -233,7 +233,7 @@ select
  │              ├── key: (1)
  │              └── fd: (1)-->(4)
  └── filters
-      └── (ARRAY[2] @> a:2) OR (ARRAY[3] @> a:2) [type=bool, outer=(2), immutable]
+      └── (a:2 <@ ARRAY[2]) OR (a:2 <@ ARRAY[3]) [type=bool, outer=(2), immutable]
 
 
 # A conjunction requires scanning all entries that match both the left and
@@ -278,5 +278,5 @@ select
  │              ├── key: (1)
  │              └── fd: (1)-->(4)
  └── filters
-      ├── ARRAY[2] @> a:2 [type=bool, outer=(2), immutable]
-      └── ARRAY[3] @> a:2 [type=bool, outer=(2), immutable]
+      ├── a:2 <@ ARRAY[2] [type=bool, outer=(2), immutable]
+      └── a:2 <@ ARRAY[3] [type=bool, outer=(2), immutable]

--- a/pkg/sql/opt/memo/testdata/stats/inverted-join
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-join
@@ -216,6 +216,102 @@ project
            ├── t1.a:3 @> t2.a:9 [type=bool, outer=(3,9), immutable]
            └── t1.j:2 @> t2.j:8 [type=bool, outer=(2,8), immutable]
 
+opt
+SELECT t1.k
+FROM json_arr1 AS t1
+JOIN json_arr2 AS t2
+ON t1.j <@ t2.j
+----
+project
+ ├── columns: k:1(int!null)
+ ├── immutable
+ ├── stats: [rows=3333.33333]
+ └── inner-join (lookup json_arr1 [as=t1])
+      ├── columns: t1.k:1(int!null) t1.j:2(jsonb) t2.j:8(jsonb)
+      ├── key columns: [11] = [1]
+      ├── lookup columns are key
+      ├── immutable
+      ├── stats: [rows=3333.33333]
+      ├── fd: (1)-->(2)
+      ├── inner-join (inverted json_arr1@j_idx [as=t1])
+      │    ├── columns: t2.j:8(jsonb) t1.k:11(int!null)
+      │    ├── inverted-expr
+      │    │    └── t1.j:12 <@ t2.j:8 [type=bool]
+      │    ├── stats: [rows=100, distinct(11)=95.617925, null(11)=0]
+      │    ├── scan json_arr2 [as=t2]
+      │    │    ├── columns: t2.j:8(jsonb)
+      │    │    └── stats: [rows=10]
+      │    └── filters (true)
+      └── filters
+           └── t1.j:2 <@ t2.j:8 [type=bool, outer=(2,8), immutable]
+
+opt
+SELECT *
+FROM json_arr1 AS t1
+JOIN json_arr2 AS t2
+ON t1.a <@ t2.a AND t1.a <@ '{"foo"}'::string[] AND t2.k > 5
+----
+inner-join (lookup json_arr1 [as=t1])
+ ├── columns: k:1(int!null) j:2(jsonb) a:3(string[]) k:7(int!null) j:8(jsonb) a:9(string[])
+ ├── key columns: [11] = [1]
+ ├── lookup columns are key
+ ├── immutable
+ ├── stats: [rows=370.37037]
+ ├── key: (1,7)
+ ├── fd: (1)-->(2,3), (7)-->(8,9)
+ ├── inner-join (inverted json_arr1@a_idx [as=t1])
+ │    ├── columns: t2.k:7(int!null) t2.j:8(jsonb) t2.a:9(string[]) t1.k:11(int!null)
+ │    ├── inverted-expr
+ │    │    └── (t1.a:13 <@ t2.a:9) AND (t1.a:13 <@ ARRAY['foo']) [type=bool]
+ │    ├── stats: [rows=33.3333333, distinct(7)=3.33318943, null(7)=0, distinct(11)=32.9461714, null(11)=0]
+ │    ├── key: (7,11)
+ │    ├── fd: (7)-->(8,9)
+ │    ├── scan json_arr2 [as=t2]
+ │    │    ├── columns: t2.k:7(int!null) t2.j:8(jsonb) t2.a:9(string[])
+ │    │    ├── constraint: /7: [/6 - ]
+ │    │    ├── stats: [rows=3.33333333, distinct(7)=3.33333333, null(7)=0]
+ │    │    ├── key: (7)
+ │    │    └── fd: (7)-->(8,9)
+ │    └── filters (true)
+ └── filters
+      ├── t1.a:3 <@ t2.a:9 [type=bool, outer=(3,9), immutable]
+      └── t1.a:3 <@ ARRAY['foo'] [type=bool, outer=(3), immutable]
+
+opt
+SELECT t2.k
+FROM json_arr1 AS t1
+JOIN json_arr2 AS t2
+ON t1.a <@ t2.a AND t1.j <@ t2.j AND t2.k > 5
+----
+project
+ ├── columns: k:7(int!null)
+ ├── immutable
+ ├── stats: [rows=370.37037]
+ └── inner-join (lookup json_arr1 [as=t1])
+      ├── columns: t1.j:2(jsonb) t1.a:3(string[]) t2.k:7(int!null) t2.j:8(jsonb) t2.a:9(string[])
+      ├── key columns: [11] = [1]
+      ├── lookup columns are key
+      ├── immutable
+      ├── stats: [rows=370.37037]
+      ├── fd: (7)-->(8,9)
+      ├── inner-join (inverted json_arr1@j_idx [as=t1])
+      │    ├── columns: t2.k:7(int!null) t2.j:8(jsonb) t2.a:9(string[]) t1.k:11(int!null)
+      │    ├── inverted-expr
+      │    │    └── t1.j:12 <@ t2.j:8 [type=bool]
+      │    ├── stats: [rows=33.3333333, distinct(7)=3.33318943, null(7)=0, distinct(11)=32.9461714, null(11)=0]
+      │    ├── key: (7,11)
+      │    ├── fd: (7)-->(8,9)
+      │    ├── scan json_arr2 [as=t2]
+      │    │    ├── columns: t2.k:7(int!null) t2.j:8(jsonb) t2.a:9(string[])
+      │    │    ├── constraint: /7: [/6 - ]
+      │    │    ├── stats: [rows=3.33333333, distinct(7)=3.33333333, null(7)=0]
+      │    │    ├── key: (7)
+      │    │    └── fd: (7)-->(8,9)
+      │    └── filters (true)
+      └── filters
+           ├── t1.a:3 <@ t2.a:9 [type=bool, outer=(3,9), immutable]
+           └── t1.j:2 <@ t2.j:8 [type=bool, outer=(2,8), immutable]
+
 exec-ddl
 CREATE TABLE json_multi_col (
   k INT PRIMARY KEY,

--- a/pkg/sql/opt/memo/testdata/stats/inverted-json
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-json
@@ -291,7 +291,7 @@ select
  │         │                <--- '\x37000138' --- '\x37000139'
  │         └── key: (1)
  └── filters
-      └── '[]' @> j:2 [type=bool, outer=(2), immutable]
+      └── j:2 <@ '[]' [type=bool, outer=(2), immutable]
 
 # An inverted index scan is preferred for containment of an indexed column
 # by an empty object. An additional filter is required.
@@ -318,7 +318,7 @@ select
  │         │                <--- '\x37000139' --- '\x3700013a'
  │         └── key: (1)
  └── filters
-      └── '{}' @> j:2 [type=bool, outer=(2), immutable]
+      └── j:2 <@ '{}' [type=bool, outer=(2), immutable]
 
 # An inverted index scan is preferred for a more selective filter. An
 # additional filter is required.
@@ -357,7 +357,7 @@ select
  │              ├── key: (1)
  │              └── fd: (1)-->(4)
  └── filters
-      └── '{"c": "d"}' @> j:2 [type=bool, outer=(2), immutable]
+      └── j:2 <@ '{"c": "d"}' [type=bool, outer=(2), immutable]
 
 # A disjunction requires scanning all entries that match either the left or the
 # right. An additional filter is required.
@@ -398,7 +398,7 @@ select
  │              ├── key: (1)
  │              └── fd: (1)-->(4)
  └── filters
-      └── ('{"c": "d"}' @> j:2) OR ('{"e": "f"}' @> j:2) [type=bool, outer=(2), immutable]
+      └── (j:2 <@ '{"c": "d"}') OR (j:2 <@ '{"e": "f"}') [type=bool, outer=(2), immutable]
 
 # A conjunction requires scanning all entries that match both the left and the
 # right. An additional filter is required.
@@ -443,8 +443,8 @@ select
  │              ├── key: (1)
  │              └── fd: (1)-->(4)
  └── filters
-      ├── '{"c": "d"}' @> j:2 [type=bool, outer=(2), immutable]
-      └── '{"e": "f"}' @> j:2 [type=bool, outer=(2), immutable]
+      ├── j:2 <@ '{"c": "d"}' [type=bool, outer=(2), immutable]
+      └── j:2 <@ '{"e": "f"}' [type=bool, outer=(2), immutable]
 
 # An inverted index scan is preferred for a more selective filter. An
 # additional filter is required.
@@ -485,7 +485,7 @@ select
  │              ├── key: (1)
  │              └── fd: (1)-->(4)
  └── filters
-      └── '[2]' @> j:2 [type=bool, outer=(2), immutable]
+      └── j:2 <@ '[2]' [type=bool, outer=(2), immutable]
 
 # A disjunction requires scanning all entries that match either the left or the
 # right. An additional filter is required.
@@ -530,7 +530,7 @@ select
  │              ├── key: (1)
  │              └── fd: (1)-->(4)
  └── filters
-      └── ('[2]' @> j:2) OR ('[3]' @> j:2) [type=bool, outer=(2), immutable]
+      └── (j:2 <@ '[2]') OR (j:2 <@ '[3]') [type=bool, outer=(2), immutable]
 
 # A conjunction requires scanning all entries that match both the left and the
 # right. An additional filter is required.
@@ -581,8 +581,8 @@ select
  │              ├── key: (1)
  │              └── fd: (1)-->(4)
  └── filters
-      ├── '[2]' @> j:2 [type=bool, outer=(2), immutable]
-      └── '[3]' @> j:2 [type=bool, outer=(2), immutable]
+      ├── j:2 <@ '[2]' [type=bool, outer=(2), immutable]
+      └── j:2 <@ '[3]' [type=bool, outer=(2), immutable]
 
 # Histogram boundaries are for JSON values `true`, `"foo"`, `22`, `[]`, and
 # `{}`.

--- a/pkg/sql/opt/norm/rules/bool.opt
+++ b/pkg/sql/opt/norm/rules/bool.opt
@@ -114,8 +114,8 @@ $input
 [NegateComparison, Normalize]
 (Not
     $input:(Comparison $left:* $right:*) &
-        ^(Contains | JsonExists | JsonSomeExists | JsonAllExists
-                | Overlaps
+        ^(Contains | ContainedBy | JsonExists | JsonSomeExists
+                | JsonAllExists | Overlaps
         )
 )
 =>

--- a/pkg/sql/opt/norm/rules/comp.opt
+++ b/pkg/sql/opt/norm/rules/comp.opt
@@ -111,8 +111,8 @@
 [FoldNullComparisonRight, Normalize]
 (Eq | Ne | Ge | Gt | Le | Lt | Like | NotLike | ILike | NotILike
         | SimilarTo | NotSimilarTo | RegMatch | NotRegMatch
-        | RegIMatch | NotRegIMatch | Contains | Overlaps
-        | JsonExists | JsonSomeExists | JsonAllExists
+        | RegIMatch | NotRegIMatch | Contains | ContainedBy
+        | Overlaps | JsonExists | JsonSomeExists | JsonAllExists
     *
     $right:(Null)
 )

--- a/pkg/sql/opt/norm/testdata/rules/bool
+++ b/pkg/sql/opt/norm/testdata/rules/bool
@@ -418,7 +418,7 @@ select
  │    └── fd: (1)-->(2-5)
  └── filters
       ├── NOT ('[1, 2]' @> j:5) [outer=(5), immutable]
-      ├── NOT ('[3, 4]' @> j:5) [outer=(5), immutable]
+      ├── NOT (j:5 <@ '[3, 4]') [outer=(5), immutable]
       ├── NOT (j:5 ? 'foo') [outer=(5), immutable]
       ├── NOT (j:5 ?| ARRAY['foo']) [outer=(5), immutable]
       ├── NOT (j:5 ?& ARRAY['foo']) [outer=(5), immutable]

--- a/pkg/sql/opt/operator.go
+++ b/pkg/sql/opt/operator.go
@@ -136,6 +136,7 @@ var ComparisonOpReverseMap = map[Operator]tree.ComparisonOperator{
 	IsOp:             tree.IsNotDistinctFrom,
 	IsNotOp:          tree.IsDistinctFrom,
 	ContainsOp:       tree.Contains,
+	ContainedByOp:    tree.ContainedBy,
 	JsonExistsOp:     tree.JSONExists,
 	JsonSomeExistsOp: tree.JSONSomeExists,
 	JsonAllExistsOp:  tree.JSONAllExists,

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -447,6 +447,12 @@ define Contains {
     Right ScalarExpr
 }
 
+[Scalar, Bool, Comparison, CompositeInsensitive]
+define ContainedBy {
+    Left ScalarExpr
+    Right ScalarExpr
+}
+
 [Scalar, Bool, Comparison]
 define JsonExists {
     Left ScalarExpr

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -699,8 +699,7 @@ func (b *Builder) constructComparison(
 	case tree.Contains:
 		return b.factory.ConstructContains(left, right)
 	case tree.ContainedBy:
-		// This is just syntactic sugar that reverses the operands.
-		return b.factory.ConstructContains(right, left)
+		return b.factory.ConstructContainedBy(left, right)
 	case tree.JSONExists:
 		return b.factory.ConstructJsonExists(left, right)
 	case tree.JSONAllExists:

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -2179,9 +2179,9 @@ project
  │         │    │    └── columns: b.bar:5 b.baz:6 b.rowid:7!null b.crdb_internal_mvcc_timestamp:8
  │         │    └── filters (true)
  │         └── projections
- │              └── a.bar:1 @> b.baz:6 [as=column9:9]
+ │              └── b.baz:6 <@ a.bar:1 [as=column9:9]
  └── projections
-      └── column9:9 AND (b.baz:6 @> b.baz:6) [as=r:10]
+      └── column9:9 AND (b.baz:6 <@ b.baz:6) [as=r:10]
 
 exec-ddl
 CREATE TABLE times (t time PRIMARY KEY)

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -310,9 +310,9 @@ contains [type=bool]
 build-scalar vars=(a jsonb)
 '{"a":1}' <@ a
 ----
-contains [type=bool]
- ├── variable: a:1 [type=jsonb]
- └── const: '{"a": 1}' [type=jsonb]
+contained-by [type=bool]
+ ├── const: '{"a": 1}' [type=jsonb]
+ └── variable: a:1 [type=jsonb]
 
 build-scalar vars=(a jsonb)
 a ? 'a'

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -5399,6 +5399,32 @@ opt expect=GenerateInvertedJoins
 SELECT t1.k
 FROM json_arr1 AS t1
 JOIN json_arr2 AS t2
+ON t1.j <@ t2.j
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ └── inner-join (lookup json_arr1 [as=t1])
+      ├── columns: t1.k:1!null t1.j:3 t2.j:10
+      ├── key columns: [13] = [1]
+      ├── lookup columns are key
+      ├── immutable
+      ├── fd: (1)-->(3)
+      ├── inner-join (inverted json_arr1@j_idx [as=t1])
+      │    ├── columns: t2.j:10 t1.k:13!null
+      │    ├── inverted-expr
+      │    │    └── t1.j:15 <@ t2.j:10
+      │    ├── scan json_arr2 [as=t2]
+      │    │    └── columns: t2.j:10
+      │    └── filters (true)
+      └── filters
+           └── t1.j:3 <@ t2.j:10 [outer=(3,10), immutable]
+
+# Inner join with no additional filters.
+opt expect=GenerateInvertedJoins
+SELECT t1.k
+FROM json_arr1 AS t1
+JOIN json_arr2 AS t2
 ON t1.a @> t2.a
 ----
 project
@@ -5419,6 +5445,32 @@ project
       │    └── filters (true)
       └── filters
            └── t1.a:4 @> t2.a:11 [outer=(4,11), immutable]
+
+# Inner join with no additional filters.
+opt expect=GenerateInvertedJoins
+SELECT t1.k
+FROM json_arr1 AS t1
+JOIN json_arr2 AS t2
+ON t1.a <@ t2.a
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ └── inner-join (lookup json_arr1 [as=t1])
+      ├── columns: t1.k:1!null t1.a:4 t2.a:11
+      ├── key columns: [13] = [1]
+      ├── lookup columns are key
+      ├── immutable
+      ├── fd: (1)-->(4)
+      ├── inner-join (inverted json_arr1@a_idx [as=t1])
+      │    ├── columns: t2.a:11 t1.k:13!null
+      │    ├── inverted-expr
+      │    │    └── t1.a:16 <@ t2.a:11
+      │    ├── scan json_arr2 [as=t2]
+      │    │    └── columns: t2.a:11
+      │    └── filters (true)
+      └── filters
+           └── t1.a:4 <@ t2.a:11 [outer=(4,11), immutable]
 
 # Left join with no additional filters.
 opt expect=GenerateInvertedJoins
@@ -5448,6 +5500,35 @@ project
       │    └── filters (true)
       └── filters
            └── t1.j:8 @> t2.j:3 [outer=(3,8), immutable]
+
+# Left join with no additional filters.
+opt expect=GenerateInvertedJoins
+SELECT t1.k
+FROM json_arr2 AS t2
+LEFT JOIN json_arr1 AS t1
+ON t1.j <@ t2.j
+----
+project
+ ├── columns: k:6
+ ├── immutable
+ └── left-join (lookup json_arr1 [as=t1])
+      ├── columns: t2.j:3 t1.k:6 t1.j:8
+      ├── key columns: [13] = [6]
+      ├── lookup columns are key
+      ├── second join in paired joiner
+      ├── immutable
+      ├── fd: (6)-->(8)
+      ├── left-join (inverted json_arr1@j_idx [as=t1])
+      │    ├── columns: t2.j:3 t1.k:13 continuation:20
+      │    ├── first join in paired joiner; continuation column: continuation:20
+      │    ├── inverted-expr
+      │    │    └── t1.j:15 <@ t2.j:3
+      │    ├── fd: (13)-->(20)
+      │    ├── scan json_arr2 [as=t2]
+      │    │    └── columns: t2.j:3
+      │    └── filters (true)
+      └── filters
+           └── t1.j:8 <@ t2.j:3 [outer=(3,8), immutable]
 
 # Left join not possible when the order of tables is switched.
 opt expect-not=GenerateInvertedJoins
@@ -5507,6 +5588,36 @@ opt expect=GenerateInvertedJoinsFromSelect
 SELECT *
 FROM json_arr1 AS t1
 JOIN json_arr2 AS t2
+ON t1.j <@ t2.j AND t1.j <@ '{"foo": "bar"}'::jsonb AND t2.k > 5
+----
+inner-join (lookup json_arr1 [as=t1])
+ ├── columns: k:1!null i:2 j:3 a:4 k:8!null l:9 j:10 a:11
+ ├── key columns: [13] = [1]
+ ├── lookup columns are key
+ ├── immutable
+ ├── key: (1,8)
+ ├── fd: (1)-->(2-4), (8)-->(9-11)
+ ├── inner-join (inverted json_arr1@j_idx [as=t1])
+ │    ├── columns: t2.k:8!null l:9 t2.j:10 t2.a:11 t1.k:13!null
+ │    ├── inverted-expr
+ │    │    └── (t1.j:15 <@ t2.j:10) AND (t1.j:15 <@ '{"foo": "bar"}')
+ │    ├── key: (8,13)
+ │    ├── fd: (8)-->(9-11)
+ │    ├── scan json_arr2 [as=t2]
+ │    │    ├── columns: t2.k:8!null l:9 t2.j:10 t2.a:11
+ │    │    ├── constraint: /8: [/6 - ]
+ │    │    ├── key: (8)
+ │    │    └── fd: (8)-->(9-11)
+ │    └── filters (true)
+ └── filters
+      ├── t1.j:3 <@ t2.j:10 [outer=(3,10), immutable]
+      └── t1.j:3 <@ '{"foo": "bar"}' [outer=(3), immutable]
+
+# Inner join with additional filter.
+opt expect=GenerateInvertedJoinsFromSelect
+SELECT *
+FROM json_arr1 AS t1
+JOIN json_arr2 AS t2
 ON t1.a @> t2.a AND t1.a @> '{"foo"}'::string[] AND t2.k > 5
 ----
 inner-join (lookup json_arr1 [as=t1])
@@ -5531,6 +5642,36 @@ inner-join (lookup json_arr1 [as=t1])
  └── filters
       ├── t1.a:4 @> t2.a:11 [outer=(4,11), immutable]
       └── t1.a:4 @> ARRAY['foo'] [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+
+# Inner join with additional filter.
+opt expect=GenerateInvertedJoinsFromSelect
+SELECT *
+FROM json_arr1 AS t1
+JOIN json_arr2 AS t2
+ON t1.a <@ t2.a AND t1.a <@ '{"foo"}'::string[] AND t2.k > 5
+----
+inner-join (lookup json_arr1 [as=t1])
+ ├── columns: k:1!null i:2 j:3 a:4 k:8!null l:9 j:10 a:11
+ ├── key columns: [13] = [1]
+ ├── lookup columns are key
+ ├── immutable
+ ├── key: (1,8)
+ ├── fd: (1)-->(2-4), (8)-->(9-11)
+ ├── inner-join (inverted json_arr1@a_idx [as=t1])
+ │    ├── columns: t2.k:8!null l:9 t2.j:10 t2.a:11 t1.k:13!null
+ │    ├── inverted-expr
+ │    │    └── (t1.a:16 <@ t2.a:11) AND (t1.a:16 <@ ARRAY['foo'])
+ │    ├── key: (8,13)
+ │    ├── fd: (8)-->(9-11)
+ │    ├── scan json_arr2 [as=t2]
+ │    │    ├── columns: t2.k:8!null l:9 t2.j:10 t2.a:11
+ │    │    ├── constraint: /8: [/6 - ]
+ │    │    ├── key: (8)
+ │    │    └── fd: (8)-->(9-11)
+ │    └── filters (true)
+ └── filters
+      ├── t1.a:4 <@ t2.a:11 [outer=(4,11), immutable]
+      └── t1.a:4 <@ ARRAY['foo'] [outer=(4), immutable]
 
 # Left join with additional filter.
 opt expect=GenerateInvertedJoinsFromSelect
@@ -5564,6 +5705,38 @@ left-join (lookup json_arr1 [as=t1])
       ├── t1.a:9 @> t2.a:4 [outer=(4,9), immutable]
       └── t1.a:9 @> ARRAY['foo'] [outer=(9), immutable, constraints=(/9: (/NULL - ])]
 
+# Left join with additional filter.
+opt expect=GenerateInvertedJoinsFromSelect
+SELECT *
+FROM json_arr2 AS t2
+LEFT JOIN json_arr1 AS t1
+ON t1.a <@ t2.a AND t1.a <@ '{"foo"}'::string[] AND t2.k > 5
+----
+left-join (lookup json_arr1 [as=t1])
+ ├── columns: k:1!null l:2 j:3 a:4 k:6 i:7 j:8 a:9
+ ├── key columns: [13] = [6]
+ ├── lookup columns are key
+ ├── second join in paired joiner
+ ├── immutable
+ ├── key: (1,6)
+ ├── fd: (1)-->(2-4), (6)-->(7-9)
+ ├── left-join (inverted json_arr1@a_idx [as=t1])
+ │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:13 continuation:20
+ │    ├── first join in paired joiner; continuation column: continuation:20
+ │    ├── inverted-expr
+ │    │    └── (t1.a:16 <@ t2.a:4) AND (t1.a:16 <@ ARRAY['foo'])
+ │    ├── key: (1,13)
+ │    ├── fd: (1)-->(2-4), (13)-->(20)
+ │    ├── scan json_arr2 [as=t2]
+ │    │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-4)
+ │    └── filters
+ │         └── t2.k:1 > 5 [outer=(1), constraints=(/1: [/6 - ]; tight)]
+ └── filters
+      ├── t1.a:9 <@ t2.a:4 [outer=(4,9), immutable]
+      └── t1.a:9 <@ ARRAY['foo'] [outer=(9), immutable]
+
 # Semi-join.
 opt expect=(GenerateInvertedJoins)
 SELECT * FROM json_arr2 AS t2
@@ -5594,6 +5767,36 @@ semi-join (lookup json_arr1 [as=t1])
  └── filters
       └── t1.j:8 @> t2.j:3 [outer=(3,8), immutable]
 
+# Semi-join.
+opt expect=(GenerateInvertedJoins)
+SELECT * FROM json_arr2 AS t2
+WHERE EXISTS (
+  SELECT * FROM json_arr1 AS t1 WHERE t1.j <@ t2.j
+)
+----
+semi-join (lookup json_arr1 [as=t1])
+ ├── columns: k:1!null l:2 j:3 a:4
+ ├── key columns: [13] = [6]
+ ├── lookup columns are key
+ ├── second join in paired joiner
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── inner-join (inverted json_arr1@j_idx [as=t1])
+ │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:13!null continuation:20
+ │    ├── first join in paired joiner; continuation column: continuation:20
+ │    ├── inverted-expr
+ │    │    └── t1.j:15 <@ t2.j:3
+ │    ├── key: (1,13)
+ │    ├── fd: (1)-->(2-4), (13)-->(20)
+ │    ├── scan json_arr2 [as=t2]
+ │    │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-4)
+ │    └── filters (true)
+ └── filters
+      └── t1.j:8 <@ t2.j:3 [outer=(3,8), immutable]
+
 # Anti-join.
 opt expect=GenerateInvertedJoins
 SELECT * FROM json_arr2 AS t2
@@ -5623,6 +5826,36 @@ anti-join (lookup json_arr1 [as=t1])
  │    └── filters (true)
  └── filters
       └── t1.j:8 @> t2.j:3 [outer=(3,8), immutable]
+
+# Anti-join.
+opt expect=GenerateInvertedJoins
+SELECT * FROM json_arr2 AS t2
+WHERE NOT EXISTS (
+  SELECT * FROM json_arr1 AS t1 WHERE t1.j <@ t2.j
+)
+----
+anti-join (lookup json_arr1 [as=t1])
+ ├── columns: k:1!null l:2 j:3 a:4
+ ├── key columns: [13] = [6]
+ ├── lookup columns are key
+ ├── second join in paired joiner
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ ├── left-join (inverted json_arr1@j_idx [as=t1])
+ │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:13 continuation:20
+ │    ├── first join in paired joiner; continuation column: continuation:20
+ │    ├── inverted-expr
+ │    │    └── t1.j:15 <@ t2.j:3
+ │    ├── key: (1,13)
+ │    ├── fd: (1)-->(2-4), (13)-->(20)
+ │    ├── scan json_arr2 [as=t2]
+ │    │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-4)
+ │    └── filters (true)
+ └── filters
+      └── t1.j:8 <@ t2.j:3 [outer=(3,8), immutable]
 
 # Tests for indexes with older descriptor versions.
 

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -2167,7 +2167,7 @@ select
  │         │    └── spans: ["7\x00\x01*\x02\x00", "7\x00\x01*\x02\x00"]
  │         └── key: (1)
  └── filters
-      └── '1' @> j:4 [outer=(4), immutable]
+      └── j:4 <@ '1' [outer=(4), immutable]
 
 opt expect=GenerateInvertedIndexScans
 SELECT * FROM b WHERE j <@ '{}'
@@ -2187,7 +2187,7 @@ select
  │         │    └── spans: ["7\x00\x019", "7\x00\x019"]
  │         └── key: (1)
  └── filters
-      └── '{}' @> j:4 [outer=(4), immutable]
+      └── j:4 <@ '{}' [outer=(4), immutable]
 
 opt expect=GenerateInvertedIndexScans
 SELECT * FROM b WHERE j <@ '[]'
@@ -2207,7 +2207,7 @@ select
  │         │    └── spans: ["7\x00\x018", "7\x00\x018"]
  │         └── key: (1)
  └── filters
-      └── '[]' @> j:4 [outer=(4), immutable]
+      └── j:4 <@ '[]' [outer=(4), immutable]
 
 opt expect=GenerateInvertedIndexScans
 SELECT * FROM b WHERE j <@ '{"a": []}'
@@ -2238,7 +2238,7 @@ select
  │              ├── key: (1)
  │              └── fd: (1)-->(6)
  └── filters
-      └── '{"a": []}' @> j:4 [outer=(4), immutable]
+      └── j:4 <@ '{"a": []}' [outer=(4), immutable]
 
 opt expect=GenerateInvertedIndexScans
 SELECT * FROM b WHERE j <@ '[{"a": {"d": true}}, 1, "b"]'
@@ -2283,7 +2283,7 @@ select
  │              ├── key: (1)
  │              └── fd: (1)-->(6)
  └── filters
-      └── '[{"a": {"d": true}}, 1, "b"]' @> j:4 [outer=(4), immutable]
+      └── j:4 <@ '[{"a": {"d": true}}, 1, "b"]' [outer=(4), immutable]
 
 # Disjunction using the contained by operator.
 opt expect=GenerateInvertedIndexScans
@@ -2331,7 +2331,7 @@ select
  │              ├── key: (1)
  │              └── fd: (1)-->(6)
  └── filters
-      └── ('{"a": [3]}' @> j:4) OR ('[1, 2, 3]' @> j:4) [outer=(4), immutable]
+      └── (j:4 <@ '{"a": [3]}') OR (j:4 <@ '[1, 2, 3]') [outer=(4), immutable]
 
 # Conjunction using the contained by operator.
 opt expect=GenerateInvertedIndexScans
@@ -2387,8 +2387,8 @@ select
  │              ├── key: (1)
  │              └── fd: (1)-->(6)
  └── filters
-      ├── '{"a": [3]}' @> j:4 [outer=(4), immutable]
-      └── '[1, 2, 3]' @> j:4 [outer=(4), immutable]
+      ├── j:4 <@ '{"a": [3]}' [outer=(4), immutable]
+      └── j:4 <@ '[1, 2, 3]' [outer=(4), immutable]
 
 # Query using the fetch val and equality operators.
 opt expect=GenerateInvertedIndexScans
@@ -2711,7 +2711,7 @@ select
  │              ├── key: (1)
  │              └── fd: (1)-->(5)
  └── filters
-      └── ARRAY[1] @> a:2 [outer=(2), immutable]
+      └── a:2 <@ ARRAY[1] [outer=(2), immutable]
 
 opt expect=GenerateInvertedIndexScans
 SELECT * FROM c WHERE a <@ ARRAY[]::INT[]
@@ -2731,7 +2731,7 @@ select
  │         │    └── spans: ["C", "C"]
  │         └── key: (1)
  └── filters
-      └── ARRAY[] @> a:2 [outer=(2), immutable]
+      └── a:2 <@ ARRAY[] [outer=(2), immutable]
 
 opt expect=GenerateInvertedIndexScans
 SELECT * FROM c WHERE a <@ ARRAY[NULL]::INT[]
@@ -2751,7 +2751,7 @@ select
  │         │    └── spans: ["C", "C"]
  │         └── key: (1)
  └── filters
-      └── ARRAY[NULL] @> a:2 [outer=(2), immutable]
+      └── a:2 <@ ARRAY[NULL] [outer=(2), immutable]
 
 opt expect=GenerateInvertedIndexScans
 SELECT * FROM c WHERE a <@ ARRAY[1] OR a <@ ARRAY[2]
@@ -2782,7 +2782,7 @@ select
  │              ├── key: (1)
  │              └── fd: (1)-->(5)
  └── filters
-      └── (ARRAY[1] @> a:2) OR (ARRAY[2] @> a:2) [outer=(2), immutable]
+      └── (a:2 <@ ARRAY[1]) OR (a:2 <@ ARRAY[2]) [outer=(2), immutable]
 
 opt expect=GenerateInvertedIndexScans
 SELECT * FROM c WHERE a <@ ARRAY[1] AND a <@ ARRAY[2]
@@ -2818,8 +2818,8 @@ select
  │              ├── key: (1)
  │              └── fd: (1)-->(5)
  └── filters
-      ├── ARRAY[1] @> a:2 [outer=(2), immutable]
-      └── ARRAY[2] @> a:2 [outer=(2), immutable]
+      ├── a:2 <@ ARRAY[1] [outer=(2), immutable]
+      └── a:2 <@ ARRAY[2] [outer=(2), immutable]
 
 # Tests for indexes with older descriptor versions.
 
@@ -2915,7 +2915,7 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2,3)
  └── filters
-      └── ARRAY[2] @> a:2 [outer=(2), immutable]
+      └── a:2 <@ ARRAY[2] [outer=(2), immutable]
 
 exec-ddl
 DROP INDEX j_inv_idx


### PR DESCRIPTION
Previously, we did not support inverted joins for expressions when an indexed
JSON or Array column is on the left side of a <@ (contained by) expression, or
equivalently, if the indexed column is on the right side of a @> (contains)
expression. We already support inverted joins for expressions with an
indexed JSON or Array column on the left side of @>, or right side of <@.

This change adds support for inverted joins for all @> and <@ expressions with
JSON and Array columns, regardless of the order of arguments, provided that an
inverted index is available. An additional filter must be applied, as the span
expression will never be tight. The optimizer now constructs both Contains and
ContainedBy expressions, and commutes the arguments when necessary so that the
indexed column is always the first value in the generated inverted expression.

Fixes: #59763

Release note (performance improvement): Inverted joins using <@ (contained by)
and @> (contains) operators are now supported with the indexed column on either
side of the expression.