### PR TITLE
docs, server: update auto-generated logging docs

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -1,35 +1,37 @@
-# Documentation for notable events
-
 Certain notable events are reported using a structured format.
 Commonly, these notable events are also copied to the table
 `system.eventlog`, unless the cluster setting
 `server.eventlog.enabled` is unset.
 
 Additionally, notable events are copied to specific external logging
-channels, where they can be collected for further processing.
+channels in log messages, where they can be collected for further processing.
 
 The sections below document the possible notable event types
 in this version of CockroachDB. For each event type, a table
 documents the possible fields. A field may be omitted from
 an event if its value is empty or zero.
 
-A field is also marked as “Sensitive” if it may contain
-application-specific information or PII. In that case,
+A field is also considered "Sensitive" if it may contain
+application-specific information or personally identifiable information (PII). In that case,
 the copy of the event sent to the external logging channel
-may contain redaction markers, in a way compatible
-with the redaction facilities in `debug zip` or `debug merge-log`.
+will contain redaction markers in a format that is compatible
+with the redaction facilities in [`cockroach debug zip`](cockroach-debug-zip.html)
+and [`cockroach debug merge-logs`](cockroach-debug-merge-logs.html),
+provided the `redactable` functionality is enabled on the logging sink.
+
+Events not documented on this page will have an unstructured format in log messages.
 
 ## Cluster-level events
 
 Events in this category pertain to an entire cluster and are
 not relative to any particular tenant.
 
-In a multi-tenant setup, the system.eventlog table for individual
+In a multi-tenant setup, the `system.eventlog` table for individual
 tenants cannot contain a copy of cluster-level events; conversely,
-the system.eventlog table in the system tenant cannot contain the
+the `system.eventlog` table in the system tenant cannot contain the
 SQL-level events for individual tenants.
 
-Events in this category are logged to channel OPS.
+Events in this category are logged to the `OPS` channel.
 
 
 ### `certs_reload`
@@ -70,7 +72,7 @@ decommissioned.
 
 ### `node_decommissioning`
 
-NodeDecommissioned is recorded when a node is marked as
+An event of type `node_decommissioning` is recorded when a node is marked as
 decommissioning.
 
 
@@ -149,7 +151,7 @@ Egs: IMPORT/RESTORE will emit events on job creation and successful
 completion. If the job fails, events will be emitted on job creation,
 failure, and successful revert.
 
-Events in this category are logged to channel OPS.
+Events in this category are logged to the `OPS` channel.
 
 
 ### `import`
@@ -204,7 +206,7 @@ They are relative to a particular SQL tenant.
 In a multi-tenant setup, copies of these miscellaneous events are
 preserved in each tenant's own system.eventlog table.
 
-Events in this category are logged to channel DEV.
+Events in this category are logged to the `DEV` channel.
 
 
 ### `set_cluster_setting`
@@ -233,15 +235,15 @@ An event of type `set_cluster_setting` is recorded when a cluster setting is cha
 ## SQL Access Audit Events
 
 Events in this category are generated when a table has been
-marked as audited via `ALTER ... EXPERIMENTAL_AUDIT SET`.
+marked as audited via `ALTER TABLE ... EXPERIMENTAL_AUDIT SET`.
 
-This feature is experimental.
+{% include {{ page.version.version }}/misc/experimental-warning.md %}
 
-Note: these events are not written to `system.eventlog`, even
+Note: These events are not written to `system.eventlog`, even
 when the cluster setting `system.eventlog.enabled` is set. They
 are only emitted via external logging.
 
-Events in this category are logged to channel SENSITIVE_ACCESS.
+Events in this category are logged to the `SENSITIVE_ACCESS` channel.
 
 
 ### `admin_query`
@@ -310,11 +312,11 @@ a table marked as audited.
 
 Events in this category report executed queries.
 
-Note: these events are not written to `system.eventlog`, even
+Note: These events are not written to `system.eventlog`, even
 when the cluster setting `system.eventlog.enabled` is set. They
 are only emitted via external logging.
 
-Events in this category are logged to channel SQL_EXEC.
+Events in this category are logged to the `SQL_EXEC` channel.
 
 
 ### `query_execute`
@@ -354,9 +356,9 @@ schema.
 
 They are relative to a particular SQL tenant.
 In a multi-tenant setup, copies of DDL-related events are preserved
-in each tenant's own system.eventlog table.
+in each tenant's own `system.eventlog` table.
 
-Events in this category are logged to channel SQL_SCHEMA.
+Events in this category are logged to the `SQL_SCHEMA` channel.
 
 
 ### `alter_database_add_region`
@@ -1355,9 +1357,9 @@ grants for stored objects.
 
 They are relative to a particular SQL tenant.
 In a multi-tenant setup, copies of DDL-related events are preserved
-in each tenant's own system.eventlog table.
+in each tenant's own `system.eventlog` table.
 
-Events in this category are logged to channel PRIVILEGES.
+Events in this category are logged to the `PRIVILEGES` channel.
 
 
 ### `alter_database_owner`
@@ -1563,9 +1565,9 @@ and sessions.
 
 They are relative to a particular SQL tenant.
 In a multi-tenant setup, copies of these miscellaneous events are
-preserved in each tenant's own system.eventlog table.
+preserved in each tenant's own `system.eventlog` table.
 
-Events in this category are logged to channel SESSIONS.
+Events in this category are logged to the `SESSIONS` channel.
 
 
 ### `client_authentication_failed`
@@ -1730,7 +1732,7 @@ Note: these events are not written to `system.eventlog`, even
 when the cluster setting `system.eventlog.enabled` is set. They
 are only emitted via external logging.
 
-Events in this category are logged to channel SQL_PERF.
+Events in this category are logged to the `SQL_PERF` channel.
 
 
 ### `slow_query`
@@ -1771,14 +1773,14 @@ set to a non-zero value, AND
 ## SQL Slow Query Log (Internal)
 
 Events in this category report slow query execution by
-internal executors, i.e. when CockroachDB internally issues
+internal executors, i.e., when CockroachDB internally issues
 SQL statements.
 
 Note: these events are not written to `system.eventlog`, even
 when the cluster setting `system.eventlog.enabled` is set. They
 are only emitted via external logging.
 
-Events in this category are logged to channel SQL_INTERNAL_PERF.
+Events in this category are logged to the `SQL_INTERNAL_PERF` channel.
 
 
 ### `slow_query_internal`
@@ -1820,9 +1822,9 @@ properties of users and roles.
 
 They are relative to a particular SQL tenant.
 In a multi-tenant setup, copies of DDL-related events are preserved
-in each tenant's own system.eventlog table.
+in each tenant's own `system.eventlog` table.
 
-Events in this category are logged to channel USER_ADMIN.
+Events in this category are logged to the `USER_ADMIN` channel.
 
 
 ### `alter_role`
@@ -1894,18 +1896,18 @@ An event of type `drop_role` is recorded when a role is dropped.
 
 ## Zone config events
 
-Events in this category pertain to zone config changes on
+Events in this category pertain to zone configuration changes on
 the SQL schema or system ranges.
 
 When zone configs apply to individual tables or other objects in a
 SQL logical schema, they are relative to a particular SQL tenant.
 In a multi-tenant setup, copies of these zone config events are preserved
-in each tenant's own system.eventlog table.
+in each tenant's own `system.eventlog` table.
 
-When they apply to cluster-level ranges (e.g.  the system zone config),
-they are stored in the system tenant's own system.eventlog table.
+When they apply to cluster-level ranges (e.g., the system zone config),
+they are stored in the system tenant's own `system.eventlog` table.
 
-Events in this category are logged to channel OPS.
+Events in this category are logged to the `OPS` channel.
 
 
 ### `remove_zone_config`

--- a/docs/generated/logformats.md
+++ b/docs/generated/logformats.md
@@ -32,21 +32,20 @@ This is the legacy file format used from CockroachDB v1.0.
 Each log entry is emitted using a common prefix, described below,
 followed by:
 
-- The logging context tags enclosed between "[" and "]", if any. It is possible
+- The logging context tags enclosed between `[` and `]`, if any. It is possible
   for this to be omitted if there were no context tags.
 - the text of the log entry.
 
-Beware that the text of the log entry can span multiple lines. In particular,
-the following caveats apply:
+Beware that the text of the log entry can span multiple lines. The following caveats apply:
 
 
-- the text of the log entry can start with text enclosed between "[" and "]".
-  It is not possible to distinguish between logging context tag information
-  and a "[...]" string in the main text of the log entry, if there were
-  no logging tags to start with. This means that this format is ambiguous.
-  Consider `crdb-v1-count` for an unambiguous alternative.
+- The text of the log entry can start with text enclosed between `[` and `]`.
+  If there were no logging tags to start with, it is not possible to distinguish between
+  logging context tag information and a `[...]` string in the main text of the
+  log entry. This means that this format is ambiguous. For an unambiguous alternative,
+  consider `crdb-v1-count`.
 
-- the text of the log entry can embed arbitrary application-level strings,
+- The text of the log entry can embed arbitrary application-level strings,
   including strings that represent log entries. In particular, an accident
   of implementation can cause the common entry prefix (described below)
   to also appear on a line of its own, as part of the payload of a previous
@@ -68,10 +67,10 @@ regular log entries. This header reports when the file was created,
 which parameters were used to start the server, the server identifiers
 if known, and other metadata about the running process.
 
-This header appears to be logged at severity INFO (with an I prefix at the
-start of the line) even though it does not really have a severity. The
-header is printed unconditionally even when a filter is configured to
-omit entries at the INFO level.
+- This header appears to be logged at severity `INFO` (with an `I` prefix
+  at the start of the line) even though it does not really have a severity.
+- The header is printed unconditionally even when a filter is configured to
+  omit entries at the `INFO` level.
 
 ### Common log entry prefix
 
@@ -79,28 +78,26 @@ Each line of output starts with the following prefix:
 
      Lyymmdd hh:mm:ss.uuuuuu goid [chan@]file:line marker
 
-where the fields are defined as follows:
-
-| Field           | Description                                                       |
-|-----------------|------------------------------------------------------------------ |
-| L               | A single character, representing the log level (eg 'I' for INFO). |
-| yy              | The year (zero padded; ie 2016 is '16').                          |
-| mm              | The month (zero padded; ie May is '05').                          |
-| dd              | The day (zero padded).                                            |
-| hh:mm:ss.uuuuuu | Time in hours, minutes and fractional seconds. Timezone is UTC.   |
-| goid            | The goroutine id (omitted if zero for use by tests).              |
-| chan            | The channel number (omitted if zero for backward-compatibility).  |
-| file            | The file name where the entry originated.                         |
-| line            | The line number where the entry originated.                       |
-| marker          | Redactability marker (see below for details).                     |
+| Field           | Description                                                                                                               |
+|-----------------|---------------------------------------------------------------------------------------------------------------------------|
+| L               | A single character, representing the [log level](logging.html#logging-levels) (e.g., `I` for `INFO`). |
+| yy              | The year (zero padded; i.e., 2016 is `16`).                                                                     |
+| mm              | The month (zero padded; i.e., May is `05`).                                                                     |
+| dd              | The day (zero padded).                                                                                                    |
+| hh:mm:ss.uuuuuu | Time in hours, minutes and fractional seconds. Timezone is UTC.                                                           |
+| goid            | The goroutine id (omitted if zero for use by tests).                                                                      |
+| chan            | The channel number (omitted if zero for backward compatibility).                                                          |
+| file            | The file name where the entry originated.                                                                                 |
+| line            | The line number where the entry originated.                                                                               |
+| marker          | Redactability marker ` + redactableIndicator + ` (see below for details).                                       |
 
 The redactability marker can be empty; in this case, its position in the common prefix is
 a double ASCII space character which can be used to reliably identify this situation.
 
-If the marker "⋮" is present, the remainder of the log entry
+If the marker ` + redactableIndicator + ` is present, the remainder of the log entry
 contains delimiters (‹...›) around
 fields that are considered sensitive. These markers are automatically recognized
-by `debug zip` and `debug merge-logs` when log redaction is requested.
+by [`cockroach debug zip`](cockroach-debug-zip.html) and [`cockroach debug merge-logs`](cockroach-debug-merge-logs.html) when log redaction is requested.
 
 
 ## Format `crdb-v1-count`
@@ -110,11 +107,10 @@ This is an alternative, backward-compatible legacy file format used from Cockroa
 Each log entry is emitted using a common prefix, described below,
 followed by the text of the log entry.
 
-Beware that the text of the log entry can span multiple lines. In particular,
-the following caveats apply:
+Beware that the text of the log entry can span multiple lines. The following caveats apply:
 
 
-- the text of the log entry can embed arbitrary application-level strings,
+- The text of the log entry can embed arbitrary application-level strings,
   including strings that represent log entries. In particular, an accident
   of implementation can cause the common entry prefix (described below)
   to also appear on a line of its own, as part of the payload of a previous
@@ -136,41 +132,39 @@ regular log entries. This header reports when the file was created,
 which parameters were used to start the server, the server identifiers
 if known, and other metadata about the running process.
 
-This header appears to be logged at severity INFO (with an I prefix at the
-start of the line) even though it does not really have a severity. The
-header is printed unconditionally even when a filter is configured to
-omit entries at the INFO level.
+- This header appears to be logged at severity `INFO` (with an `I` prefix
+  at the start of the line) even though it does not really have a severity.
+- The header is printed unconditionally even when a filter is configured to
+  omit entries at the `INFO` level.
 
 ### Common log entry prefix
 
 Each line of output starts with the following prefix:
 
-     Lyymmdd hh:mm:ss.uuuuuu goid [chan@]file:line markertags counter
+     Lyymmdd hh:mm:ss.uuuuuu goid [chan@]file:line marker tags counter
 
-where the fields are defined as follows:
-
-| Field           | Description                                                       |
-|-----------------|------------------------------------------------------------------ |
-| L               | A single character, representing the log level (eg 'I' for INFO). |
-| yy              | The year (zero padded; ie 2016 is '16').                          |
-| mm              | The month (zero padded; ie May is '05').                          |
-| dd              | The day (zero padded).                                            |
-| hh:mm:ss.uuuuuu | Time in hours, minutes and fractional seconds. Timezone is UTC.   |
-| goid            | The goroutine id (omitted if zero for use by tests).              |
-| chan            | The channel number (omitted if zero for backward-compatibility).  |
-| file            | The file name where the entry originated.                         |
-| line            | The line number where the entry originated.                       |
-| marker          | Redactability marker (see below for details).                     |
-| tags            | The logging tags, enclosed between "[" and "]". May be absent.    |
-| counter         | The entry counter. Always present.                                |
+| Field           | Description                                                                                                               |
+|-----------------|---------------------------------------------------------------------------------------------------------------------------|
+| L               | A single character, representing the [log level](logging.html#logging-levels) (e.g., `I` for `INFO`). |
+| yy              | The year (zero padded; i.e., 2016 is `16`).                                                                     |
+| mm              | The month (zero padded; i.e., May is `05`).                                                                     |
+| dd              | The day (zero padded).                                                                                                    |
+| hh:mm:ss.uuuuuu | Time in hours, minutes and fractional seconds. Timezone is UTC.                                                           |
+| goid            | The goroutine id (omitted if zero for use by tests).                                                                      |
+| chan            | The channel number (omitted if zero for backward compatibility).                                                          |
+| file            | The file name where the entry originated.                                                                                 |
+| line            | The line number where the entry originated.                                                                               |
+| marker          | Redactability marker ` + redactableIndicator + ` (see below for details).                                       |
+| tags    | The logging tags, enclosed between `[` and `]`. May be absent. |
+| counter | The entry counter. Always present.                                                 |
 
 The redactability marker can be empty; in this case, its position in the common prefix is
 a double ASCII space character which can be used to reliably identify this situation.
 
-If the marker "⋮" is present, the remainder of the log entry
+If the marker ` + redactableIndicator + ` is present, the remainder of the log entry
 contains delimiters (‹...›) around
 fields that are considered sensitive. These markers are automatically recognized
-by `debug zip` and `debug merge-logs` when log redaction is requested.
+by [`cockroach debug zip`](cockroach-debug-zip.html) and [`cockroach debug merge-logs`](cockroach-debug-merge-logs.html) when log redaction is requested.
 
 
 ## Format `crdb-v1-tty`
@@ -202,52 +196,52 @@ Each line of output starts with the following prefix:
 
      Lyymmdd hh:mm:ss.uuuuuu goid [chan@]file:line marker [tags...] counter cont
 
-| Field           | Description                                                         |
-|-----------------|---------------------------------------------------------------------|
-| L               | A single character, representing the log level (eg 'I' for INFO).   |
-| yy              | The year (zero padded; ie 2016 is '16').                            |
-| mm              | The month (zero padded; ie May is '05').                            |
-| dd              | The day (zero padded).                                              |
-| hh:mm:ss.uuuuuu | Time in hours, minutes and fractional seconds. Timezone is UTC.     |
-| goid            | The goroutine id (zero when cannot be determined).                  |
-| chan            | The channel number (omitted if zero for backward-compatibility).    |
-| file            | The file name where the entry originated. Also see below.           |
-| line            | The line number where the entry originated.                         |
-| marker          | Redactability marker (see below for details).                       |
-| tags            | The logging tags, enclosed between "[" and "]". See below.          |
-| counter         | The optional entry counter (see below for details).                 |
-| cont            | Continuation mark for structured and multi-line entries. See below. |
+| Field           | Description                                                                                                               |
+|-----------------|---------------------------------------------------------------------------------------------------------------------------|
+| L               | A single character, representing the [log level](logging.html#logging-levels) (e.g., `I` for `INFO`). |
+| yy              | The year (zero padded; i.e., 2016 is `16`).                                                                     |
+| mm              | The month (zero padded; i.e., May is `05`).                                                                     |
+| dd              | The day (zero padded).                                                                                                    |
+| hh:mm:ss.uuuuuu | Time in hours, minutes and fractional seconds. Timezone is UTC.                                                           |
+| goid            | The goroutine id (zero when cannot be determined).                                                                        |
+| chan            | The channel number (omitted if zero for backward compatibility).                                                          |
+| file            | The file name where the entry originated. Also see below.                                                                 |
+| line            | The line number where the entry originated.                                                                               |
+| marker          | Redactability marker "⋮" (see below for details).                                               |
+| tags            | The logging tags, enclosed between `[` and `]`. See below.                                            |
+| counter         | The optional entry counter (see below for details).                                                                       |
+| cont            | Continuation mark for structured and multi-line entries. See below.                                                       |
 
 The `chan@` prefix before the file name indicates the logging channel,
-and is omitted if the channel is DEV.
+and is omitted if the channel is `DEV`.
 
-The file name may be prefixed by the string "`(gostd) `" to indicate
+The file name may be prefixed by the string `(gostd) ` to indicate
 that the log entry was produced inside the Go standard library, instead
 of a CockroachDB component. Entry parsers must be configured to ignore this prefix
 when present.
 
-The `marker` part is the redactability marker.
-The redactability marker can be empty; in this case, its position in the common prefix is
+`marker` can be empty; in this case, its position in the common prefix is
 a double ASCII space character which can be used to reliably identify this situation.
-If the marker is "⋮", the remainder of the log entry
-contains delimiters (‹...›) around
-fields that are considered sensitive. These markers are automatically recognized
-by `debug zip` and `debug merge-logs` when log redaction is requested.
+If the marker "⋮" is present, the remainder of the log entry
+contains delimiters (‹...›)
+around fields that are considered sensitive. These markers are automatically recognized
+by [`cockroach debug zip`](cockroach-debug-zip.html) and [`cockroach debug merge-logs`](cockroach-debug-merge-logs.html)
+when log redaction is requested.
 
-The logging `tags` part is enclosed between square brackets `[...]`,
+The logging `tags` are enclosed between square brackets `[...]`,
 and the syntax `[-]` is used when there are no logging tags
 associated with the log entry.
 
-The `counter` part is numeric, and is incremented for every
+`counter` is numeric, and is incremented for every
 log entry emitted to this sink. (There is thus one counter sequence per
 sink.) For entries that do not have a counter value
-associated, for example header entries in file sinks, the counter position
-in the common prefix is empty: the tags part that precedes is then
-followed by two ASCII space characters, instead of one space, the counter
+associated (e.g., header entries in file sinks), the counter position
+in the common prefix is empty: `tags` is then
+followed by two ASCII space characters, instead of one space; the `counter`,
 and another space. The presence of the two ASCII spaces indicates
 reliably that no counter was present.
 
-The `cont` part is a format/continuation indicator:
+`cont` is a format/continuation indicator:
 
 | Continuation indicator | ASCII | Description |
 |------------------------|-------|--|
@@ -282,23 +276,24 @@ Example long entries broken up into multiple lines:
 
 ### Backward-compatibility notes
 
-Entries in this format can be read by most crdb-v1 log parsers,
+Entries in this format can be read by most `crdb-v1` log parsers,
 in particular the one included in the DB console and
-also the `debug merge-logs` facility.
+also the [`cockroach debug merge-logs`](cockroach-debug-merge-logs.html)
+facility.
 
 However, implementers of previous version parsers must
 understand that the logging tags field is now always
 included, and the lack of logging tags is included
-by a tag string set to "`[-]`".
+by a tag string set to `[-]`.
 
 Likewise, the entry counter is now also always included,
-and there is a special character after the entry counter
+and there is a special character after `counter`
 to indicate whether the remainder of the line is a
 structured entry, or a continuation of a previous entry.
 
 Finally, in the previous format, structured entries
-were prefixed with the string "Structured entry:". In
-the new format, they are prefixed by the '=' continuation
+were prefixed with the string `Structured entry:`. In
+the new format, they are prefixed by the `=` continuation
 indicator.
 
 
@@ -356,13 +351,13 @@ Additionally, the following fields are conditionally present:
 | `stacks`  | Goroutine stacks, for fatal events. |
 
 When an entry is structured, the `event` field maps to a dictionary
-whose structure is one of the documented structured events. See the reference
-documentation for structured events for a list of possible payloads.
+whose structure is one of the documented structured events. See the [reference documentation](eventlog.html)
+for structured events for a list of possible payloads.
 
-Then the entry is marked as "redactable", the `tags`, `message` and/or `event` payloads
+When the entry is marked as `redactable`, the `tags`, `message`, and/or `event` payloads
 contain delimiters (‹...›) around
 fields that are considered sensitive. These markers are automatically recognized
-by `debug zip` and `debug merge-logs` when log redaction is requested.
+by [`cockroach debug zip`](cockroach-debug-zip.html) and [`cockroach debug merge-logs`](cockroach-debug-merge-logs.html) when log redaction is requested.
 
 
 
@@ -413,13 +408,13 @@ Additionally, the following fields are conditionally present:
 | `stacks`  | Goroutine stacks, for fatal events. |
 
 When an entry is structured, the `event` field maps to a dictionary
-whose structure is one of the documented structured events. See the reference
-documentation for structured events for a list of possible payloads.
+whose structure is one of the documented structured events. See the [reference documentation](eventlog.html)
+for structured events for a list of possible payloads.
 
-Then the entry is marked as "redactable", the `tags`, `message` and/or `event` payloads
+When the entry is marked as `redactable`, the `tags`, `message`, and/or `event` payloads
 contain delimiters (‹...›) around
 fields that are considered sensitive. These markers are automatically recognized
-by `debug zip` and `debug merge-logs` when log redaction is requested.
+by [`cockroach debug zip`](cockroach-debug-zip.html) and [`cockroach debug merge-logs`](cockroach-debug-merge-logs.html) when log redaction is requested.
 
 
 
@@ -471,13 +466,13 @@ Additionally, the following fields are conditionally present:
 | `stacks`  | Goroutine stacks, for fatal events. |
 
 When an entry is structured, the `event` field maps to a dictionary
-whose structure is one of the documented structured events. See the reference
-documentation for structured events for a list of possible payloads.
+whose structure is one of the documented structured events. See the [reference documentation](eventlog.html)
+for structured events for a list of possible payloads.
 
-Then the entry is marked as "redactable", the `tags`, `message` and/or `event` payloads
+When the entry is marked as `redactable`, the `tags`, `message`, and/or `event` payloads
 contain delimiters (‹...›) around
 fields that are considered sensitive. These markers are automatically recognized
-by `debug zip` and `debug merge-logs` when log redaction is requested.
+by [`cockroach debug zip`](cockroach-debug-zip.html) and [`cockroach debug merge-logs`](cockroach-debug-merge-logs.html) when log redaction is requested.
 
 
 
@@ -529,13 +524,13 @@ Additionally, the following fields are conditionally present:
 | `stacks`  | Goroutine stacks, for fatal events. |
 
 When an entry is structured, the `event` field maps to a dictionary
-whose structure is one of the documented structured events. See the reference
-documentation for structured events for a list of possible payloads.
+whose structure is one of the documented structured events. See the [reference documentation](eventlog.html)
+for structured events for a list of possible payloads.
 
-Then the entry is marked as "redactable", the `tags`, `message` and/or `event` payloads
+When the entry is marked as `redactable`, the `tags`, `message`, and/or `event` payloads
 contain delimiters (‹...›) around
 fields that are considered sensitive. These markers are automatically recognized
-by `debug zip` and `debug merge-logs` when log redaction is requested.
+by [`cockroach debug zip`](cockroach-debug-zip.html) and [`cockroach debug merge-logs`](cockroach-debug-merge-logs.html) when log redaction is requested.
 
 
 

--- a/docs/generated/logging.md
+++ b/docs/generated/logging.md
@@ -2,159 +2,165 @@
 
 ## INFO
 
-The INFO severity is used for informational messages, when no action
-is required as a result.
+The `INFO` severity is used for informational messages that do not
+require action.
 
 ## WARNING
 
-The WARNING severity is used for situations which may require special handling,
-while normal operation is expected to resume automatically.
+The `WARNING` severity is used for situations which may require special handling,
+where normal operation is expected to resume automatically.
 
 ## ERROR
 
-The ERROR severity is used for situations that require special handling,
-when normal operation could not proceed as expected.
+The `ERROR` severity is used for situations that require special handling,
+where normal operation could not proceed as expected.
 Other operations can continue mostly unaffected.
 
 ## FATAL
 
-The FATAL severity is used for situations that require an immedate, hard
+The `FATAL` severity is used for situations that require an immedate, hard
 server shutdown. A report is also sent to telemetry if telemetry
 is enabled.
 
 
 # Logging channels
 
-## DEV
+## `DEV`
 
-The DEV channel is the channel used during development, to collect log
-details useful for troubleshooting when it is unclear which other
-channel to use. It is also the default logging channel in
-CockroachDB, when the caller does not indicate a channel.
+The `DEV` channel is used during development to collect log
+details useful for troubleshooting that fall outside the
+scope of other channels. It is also the default logging
+channel for events not associated with a channel.
 
 This channel is special in that there are no constraints as to
 what may or may not be logged on it. Conversely, users in
-production deployments are invited to not collect DEV logs in
+production deployments are invited to not collect `DEV` logs in
 centralized logging facilities, because they likely contain
 sensitive operational data.
+See [Configure logs](configure-logs.html#dev-channel).
 
-## OPS
+## `OPS`
 
-The OPS channel is the channel used to report "point" operational events,
+The `OPS` channel is used to report "point" operational events,
 initiated by user operators or automation:
 
-- operator or system actions on server processes: process starts,
+- Operator or system actions on server processes: process starts,
   stops, shutdowns, crashes (if they can be logged),
-  including each time: command-line parameters, current version being run.
-- actions that impact the topology of a cluster: node additions,
+  including each time: command-line parameters, current version being run
+- Actions that impact the topology of a cluster: node additions,
   removals, decommissions, etc.
-- job-related initiation or termination.
-- cluster setting changes.
-- zone configuration changes.
+- Job-related initiation or termination
+- [Cluster setting](cluster-settings.html) changes
+- [Zone configuration](configure-replication-zones.html) changes
 
-## HEALTH
+## `HEALTH`
 
-The HEALTH channel is the channel used to report "background" operational
+The `HEALTH` channel is used to report "background" operational
 events, initiated by CockroachDB or reporting on automatic processes:
 
-- current resource usage, including critical resource usage.
-- node-node connection events, including connection errors and
-  gossip details.
-- range and table leasing events.
-- up-, down-replication; range unavailability.
+- Current resource usage, including critical resource usage
+- Node-node connection events, including connection errors and
+  gossip details
+- Range and table leasing events
+- Up- and down-replication, range unavailability
 
-## STORAGE
+## `STORAGE`
 
-The STORAGE channel is the channel used to report low-level storage
+The `STORAGE` channel is used to report low-level storage
 layer events (RocksDB/Pebble).
 
-## SESSIONS
+## `SESSIONS`
 
-The SESSIONS channel is the channel used to report client network activity:
+The `SESSIONS` channel is used to report client network activity when enabled via
+the `server.auth_log.sql_connections.enabled` and/or
+`server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
+[cluster settings](cluster-settings.html):
 
-- connections opened/closed.
-- authentication events: logins, failed attempts.
-- session and query cancellation.
+- Connections opened/closed
+- Authentication events: logins, failed attempts
+- Session and query cancellation
 
 This is typically configured in "audit" mode, with event
 numbering and synchronous writes.
 
-## SQL_SCHEMA
+## `SQL_SCHEMA`
 
-The SQL_SCHEMA channel is the channel used to report changes to the
+The `SQL_SCHEMA` channel is used to report changes to the
 SQL logical schema, excluding privilege and ownership changes
-(which are reported on the separate channel PRIVILEGES) and
-zone config changes (which go to OPS).
+(which are reported separately on the `PRIVILEGES` channel) and
+zone configuration changes (which go to the `OPS` channel).
 
 This includes:
 
-- database/schema/table/sequence/view/type creation
-- adding/removing/changing table columns
-- changing sequence parameters
+- Database/schema/table/sequence/view/type creation
+- Adding/removing/changing table columns
+- Changing sequence parameters
 
-etc., more generally changes to the schema that affect the
+`SQL_SCHEMA` events generally comprise changes to the schema that affect the
 functional behavior of client apps using stored objects.
 
-## USER_ADMIN
+## `USER_ADMIN`
 
-The USER_ADMIN channel is the channel used to report changes
+The `USER_ADMIN` channel is used to report changes
 in users and roles, including:
 
-- users added/dropped.
-- changes to authentication credentials, incl passwords, validity etc.
-- role grants/revocations.
-- role option grants/revocations.
+- Users added/dropped
+- Changes to authentication credentials (e.g., passwords, validity, etc.)
+- Role grants/revocations
+- Role option grants/revocations
 
 This is typically configured in "audit" mode, with event
 numbering and synchronous writes.
 
-## PRIVILEGES
+## `PRIVILEGES`
 
-The PRIVILEGES channel is the channel used to report data
+The `PRIVILEGES` channel is used to report data
 authorization changes, including:
 
-- privilege grants/revocations on database, objects etc.
-- object ownership changes.
+- Privilege grants/revocations on database, objects, etc.
+- Object ownership changes
 
 This is typically configured in "audit" mode, with event
 numbering and synchronous writes.
 
-## SENSITIVE_ACCESS
+## `SENSITIVE_ACCESS`
 
-The SENSITIVE_ACCESS channel is the channel used to report SQL
-data access to sensitive data (when enabled):
+The `SENSITIVE_ACCESS` channel is used to report SQL
+data access to sensitive data:
 
-- data access audit events (when table audit is enabled).
-- SQL statements executed by users with the ADMIN bit.
-- operations that write to `system` tables.
+- Data access audit events (when table audit is enabled via
+  [EXPERIMENTAL_AUDIT](experimental-audit.html))
+- SQL statements executed by users with the admin role
+- Operations that write to system tables
 
 This is typically configured in "audit" mode, with event
 numbering and synchronous writes.
 
-## SQL_EXEC
+## `SQL_EXEC`
 
-The SQL_EXEC channel is the channel used to report SQL execution on
+The `SQL_EXEC` channel is used to report SQL execution on
 behalf of client connections:
 
-- logical SQL statement executions (if enabled)
-- pgwire events (if enabled)
+- Logical SQL statement executions (when enabled via the
+  `sql.trace.log_statement_execute` [cluster setting](cluster-settings.html))
+- pgwire events (when enabled)
 
-## SQL_PERF
+## `SQL_PERF`
 
-The SQL_PERF channel is the channel used to report SQL executions
-that are marked to be highlighted as "out of the ordinary"
+The `SQL_PERF` channel is used to report SQL executions
+that are marked as "out of the ordinary"
 to facilitate performance investigations.
-This includes the "SQL slow query log".
+This includes the SQL "slow query log".
 
-Arguably, this channel overlaps with SQL_EXEC defined above.
-However, we keep them separate for backward-compatibility
-with previous versions, where the corresponding events
+Arguably, this channel overlaps with `SQL_EXEC`.
+However, we keep both channels separate for backward compatibility
+with versions prior to v21.1, where the corresponding events
 were redirected to separate files.
 
-## SQL_INTERNAL_PERF
+## `SQL_INTERNAL_PERF`
 
-The SQL_INTERNAL_PERF channel is like the SQL perf channel above but aimed at
+The `SQL_INTERNAL_PERF` channel is like the `SQL_PERF` channel, but is aimed at
 helping developers of CockroachDB itself. It exists as a separate
-channel so as to not pollute the SQL perf logging output with
+channel so as to not pollute the `SQL_PERF` logging output with
 internal troubleshooting details.
 

--- a/docs/generated/logsinks.md
+++ b/docs/generated/logsinks.md
@@ -4,23 +4,21 @@
 The supported log output sink types are documented below.
 
 
-- [output to files](#sink-output-to-files)
+- [Output to files](#sink-output-to-files)
 
-- [output to Fluentd-compatible log collectors](#sink-output-to-fluentd-compatible-log-collectors)
+- [Output to Fluentd-compatible log collectors](#sink-output-to-fluentd-compatible-log-collectors)
 
-- [standard error stream](#sink-standard-error-stream)
+- [Standard error stream](#sink-standard-error-stream)
 
 
 
 <a name="output-to-files">
 
-## Sink type: output to files
+## Sink type: Output to files
 
 
-Files under a configurable logging directory.
-
-This sink type causes logging data to be captured into *file groups*,
-one group per configured sink.
+This sink type causes logging data to be captured into log files in a
+configurable logging directory.
 
 The configuration key under the `sinks` key in the YAML
 configuration is `file-groups`. Example configuration:
@@ -31,22 +29,18 @@ configuration is `file-groups`. Example configuration:
              channels: HEALTH
 
 Each generated log file is prefixed by the name of the process,
-followed by the name of the group, separated by a hyphen.  For
-example, the group `health` will generate files named
-`cockroach-health.XXX.log`, assuming the process is named
-`cockroach`. (A user can influence the prefix by renaming the
-program executable.)
+followed by the name of the group, separated by a hyphen. For example,
+the group `health` will generate files named `cockroach-health.XXX.log`,
+assuming the process is named `cockroach`. (A user can influence the
+prefix by renaming the program executable.)
 
 The files are named so that a lexicographical sort of the
 directory contents presents the file in creation order.
 
-Additionally, every time a new log file is generated,
-a shorthand symbolic link (e.g. `cockroach-health.log`)
-is maintain to point to the latest file.
+A symlink (e.g. `cockroach-health.log`) for each group points to the latest generated log file.
 
-Regarding configuration, a cascading defaults mechanism is
-available: every new file group sink configured automatically
-inherits the configurations set in the `file-defaults` section.
+Every new file group sink configured automatically inherits
+the configurations set in the `file-defaults` section.
 
 For example:
 
@@ -64,8 +58,9 @@ For example:
             # Example override:
             dir: health-logs # override the default 'logs'
 
-Users are invited to peruse the `check-log-config` tool to
-verify the effect of defaults inheritance.
+{{site.data.alerts.callout_success}}
+Run `cockroach debug check-log-config` to verify the effect of defaults inheritance.
+{{site.data.alerts.end}}
 
 
 
@@ -95,19 +90,20 @@ Configuration options shared across all sink types:
 
 <a name="output-to-fluentd-compatible-log-collectors">
 
-## Sink type: output to Fluentd-compatible log collectors
+## Sink type: Output to Fluentd-compatible log collectors
 
 
 This sink type causes logging data to be sent over the network, to
 a log collector that can ingest log data in a
 [Fluentd](https://www.fluentd.org)-compatible protocol.
 
-Note that TLS is not supported yet: the connection to the log
-collector is neither authenticated nor encrypted. Given that
-logging events may contain sensitive information, care should be
-taken to keep the log collector and the CockroachDB node close
-together on a private network, or connect them using a secure
-VPN. TLS support may be added at a later date.
+{{site.data.alerts.callout_danger}}
+TLS is not supported yet: the connection to the log collector is neither
+authenticated nor encrypted. Given that logging events may contain sensitive
+information, care should be taken to keep the log collector and the CockroachDB
+node close together on a private network, or connect them using a secure VPN.
+TLS support may be added at a later date.
+{{site.data.alerts.end}}
 
 At the time of this writing, a Fluent sink buffers at most one log
 entry and retries sending the event at most one time if a network
@@ -115,7 +111,7 @@ error is encountered. This is just sufficient to tolerate a restart
 of the Fluentd collector after a configuration change under light
 logging activity. If the server is unavailable for too long, or if
 more than one error is encountered, an error is reported to the
-process' standard error output with a copy of the logging event and
+process's standard error output with a copy of the logging event and
 the logging event is dropped.
 
 The configuration key under the `sinks` key in the YAML
@@ -127,9 +123,7 @@ configuration is `fluent-servers`. Example configuration:
              channels: HEALTH
              address: 127.0.0.1:5170
 
-A cascading defaults mechanism is available for configurations:
-every new server sink configured automatically inherits the
-configurations set in the `fluent-defaults` section.
+Every new server sink configured automatically inherits the configurations set in the `fluent-defaults` section.
 
 For example:
 
@@ -146,10 +140,11 @@ For example:
 The default output format for Fluent sinks is
 `json-fluent-compact`. The `fluent` variants of the JSON formats
 include a `tag` field as required by the Fluentd protocol, which
-the non-`fluent` JSON format variants do not include.
+the non-`fluent` JSON [format variants](logformats.html) do not include.
 
-Users are invited to peruse the `check-log-config` tool to
-verify the effect of defaults inheritance.
+{{site.data.alerts.callout_info}}
+Run `cockroach debug check-log-config` to verify the effect of defaults inheritance.
+{{site.data.alerts.end}}
 
 
 
@@ -177,7 +172,7 @@ Configuration options shared across all sink types:
 
 <a name="standard-error-stream">
 
-## Sink type: standard error stream
+## Sink type: Standard error stream
 
 
 The standard error output stream of the running `cockroach`
@@ -190,28 +185,25 @@ is `stderr`. Example configuration:
        stderr:           # standard error sink configuration starts here
           channels: DEV
 
-Note: the server start-up messages are still emitted at the start
-of the standard error stream even when logging to stderr is
-enabled.  This makes it generally difficult to automate integration
-with log analyzers. Generally, we recommend operators to either use
-file logging or native network logging instead of using standard
-error when integrating with automated monitoring software.
+{{site.data.alerts.callout_info}}
+The server start-up messages are still emitted at the start of the standard error
+stream even when logging to `stderr` is enabled. This makes it generally difficult
+to automate integration of `stderr` with log analyzers. Generally, we recommend using
+[file logging](#output-to-files) or [network logging](#output-to-fluentd-compatible-log-collectors)
+instead of `stderr` when integrating with automated monitoring software.
+{{site.data.alerts.end}}
 
-Note: it is not possible to enable the "redactable" parameter on
-the stderr sink if the "capture-stray-errors" functionality
-(i.e. capturing stray error information to files) is disabled.
+It is not possible to enable the `redactable` parameter on the `stderr` sink if
+`capture-stray-errors` (i.e., capturing stray error information to files) is disabled.
+This is because when `capture-stray-errors` is disabled, the process's standard error stream
+can contain an arbitrary interleaving of [logging events](eventlog.html) and stray
+errors. It is possible for stray error output to interfere with redaction markers
+and remove the guarantees that information outside of redaction markers does not
+contain sensitive information.
 
-This is because when "capture-stray-errors" is disabled, the
-process' standard error stream can contain an arbitrary
-interleaving of logging events and stray errors; in particular, it
-is possible for stray error output to interfere with redaction
-markers and remove the guarantees that information outside of
-redaction markers does not contain sensitive information.
-
-Note: for a similar reason, no guarantees of parsability of the output
-format is available when the "capture-stray-errors" functionality
-is disabled, since the standard error stream can then contain an
-arbitrary interleaving of non-formatted error data.
+For a similar reason, no guarantee of parsability of the output format is available
+when `capture-stray-errors` is disabled, since the standard error stream can then
+contain an arbitrary interleaving of non-formatted error data.
 
 
 
@@ -238,6 +230,7 @@ Configuration options shared across all sink types:
 
 
 <a name="channel-format">
+
 ## Channel selection configuration
 
 Each sink can select multiple channels. The names of selected channels can
@@ -248,22 +241,22 @@ Example configurations:
     # Select just these two channels. Space is important.
     channels: [OPS, HEALTH]
 
-    # The selection is case insensitive.
+    # The selection is case-insensitive.
     channels: [ops, HeAlTh]
 
-    # same configuration, as a yaml string. Avoid space around comma
-    # if using the YAML "flowed" format.
+    # Same configuration, as a YAML string. Avoid space around comma
+    # if using the YAML "inline" format.
     channels: OPS,HEALTH
 
-    # same, as a quoted string.
+    # Same configuration, as a quoted string.
     channels: 'OPS, HEALTH'
 
-    # Same using a multi-line YAML array.
+    # Same configuration, as a multi-line YAML array.
     channels:
     - OPS
     - HEALTH
 
-It is also possible to select all channels, with the "all" keyword.
+It is also possible to select all channels, using the "all" keyword.
 For example:
 
     channels: all
@@ -279,4 +272,3 @@ that capture "everything else". For example:
     channels: all except [ops,health]
     channels: 'all except ops, health'
     channels: 'all except [ops, health]'
-

--- a/pkg/util/log/channel/channel_generated.go
+++ b/pkg/util/log/channel/channel_generated.go
@@ -4,123 +4,129 @@ package channel
 
 import "github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 
-// DEV is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// DEV is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 const DEV = logpb.Channel_DEV
 
-// OPS is the channel used to report "point" operational events,
+// OPS is used to report "point" operational events,
 // initiated by user operators or automation:
 //
-// - operator or system actions on server processes: process starts,
+// - Operator or system actions on server processes: process starts,
 //   stops, shutdowns, crashes (if they can be logged),
-//   including each time: command-line parameters, current version being run.
-// - actions that impact the topology of a cluster: node additions,
+//   including each time: command-line parameters, current version being run
+// - Actions that impact the topology of a cluster: node additions,
 //   removals, decommissions, etc.
-// - job-related initiation or termination.
-// - cluster setting changes.
-// - zone configuration changes.
+// - Job-related initiation or termination
+// - [Cluster setting](cluster-settings.html) changes
+// - [Zone configuration](configure-replication-zones.html) changes
 const OPS = logpb.Channel_OPS
 
-// HEALTH is the channel used to report "background" operational
+// HEALTH is used to report "background" operational
 // events, initiated by CockroachDB or reporting on automatic processes:
 //
-// - current resource usage, including critical resource usage.
-// - node-node connection events, including connection errors and
-//   gossip details.
-// - range and table leasing events.
-// - up-, down-replication; range unavailability.
+// - Current resource usage, including critical resource usage
+// - Node-node connection events, including connection errors and
+//   gossip details
+// - Range and table leasing events
+// - Up- and down-replication, range unavailability
 const HEALTH = logpb.Channel_HEALTH
 
-// STORAGE is the channel used to report low-level storage
+// STORAGE is used to report low-level storage
 // layer events (RocksDB/Pebble).
 const STORAGE = logpb.Channel_STORAGE
 
-// SESSIONS is the channel used to report client network activity:
+// SESSIONS is used to report client network activity when enabled via
+// the `server.auth_log.sql_connections.enabled` and/or
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
+// [cluster settings](cluster-settings.html):
 //
-// - connections opened/closed.
-// - authentication events: logins, failed attempts.
-// - session and query cancellation.
+// - Connections opened/closed
+// - Authentication events: logins, failed attempts
+// - Session and query cancellation
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 const SESSIONS = logpb.Channel_SESSIONS
 
-// SQL_SCHEMA is the channel used to report changes to the
+// SQL_SCHEMA is used to report changes to the
 // SQL logical schema, excluding privilege and ownership changes
-// (which are reported on the separate channel PRIVILEGES) and
-// zone config changes (which go to OPS).
+// (which are reported separately on the `PRIVILEGES` channel) and
+// zone configuration changes (which go to the `OPS` channel).
 //
 // This includes:
 //
-// - database/schema/table/sequence/view/type creation
-// - adding/removing/changing table columns
-// - changing sequence parameters
+// - Database/schema/table/sequence/view/type creation
+// - Adding/removing/changing table columns
+// - Changing sequence parameters
 //
-// etc., more generally changes to the schema that affect the
+// `SQL_SCHEMA` events generally comprise changes to the schema that affect the
 // functional behavior of client apps using stored objects.
 const SQL_SCHEMA = logpb.Channel_SQL_SCHEMA
 
-// USER_ADMIN is the channel used to report changes
+// USER_ADMIN is used to report changes
 // in users and roles, including:
 //
-// - users added/dropped.
-// - changes to authentication credentials, incl passwords, validity etc.
-// - role grants/revocations.
-// - role option grants/revocations.
+// - Users added/dropped
+// - Changes to authentication credentials (e.g., passwords, validity, etc.)
+// - Role grants/revocations
+// - Role option grants/revocations
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 const USER_ADMIN = logpb.Channel_USER_ADMIN
 
-// PRIVILEGES is the channel used to report data
+// PRIVILEGES is used to report data
 // authorization changes, including:
 //
-// - privilege grants/revocations on database, objects etc.
-// - object ownership changes.
+// - Privilege grants/revocations on database, objects, etc.
+// - Object ownership changes
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 const PRIVILEGES = logpb.Channel_PRIVILEGES
 
-// SENSITIVE_ACCESS is the channel used to report SQL
-// data access to sensitive data (when enabled):
+// SENSITIVE_ACCESS is used to report SQL
+// data access to sensitive data:
 //
-// - data access audit events (when table audit is enabled).
-// - SQL statements executed by users with the ADMIN bit.
-// - operations that write to `system` tables.
+// - Data access audit events (when table audit is enabled via
+//   [EXPERIMENTAL_AUDIT](experimental-audit.html))
+// - SQL statements executed by users with the admin role
+// - Operations that write to system tables
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 const SENSITIVE_ACCESS = logpb.Channel_SENSITIVE_ACCESS
 
-// SQL_EXEC is the channel used to report SQL execution on
+// SQL_EXEC is used to report SQL execution on
 // behalf of client connections:
 //
-// - logical SQL statement executions (if enabled)
-// - pgwire events (if enabled)
+// - Logical SQL statement executions (when enabled via the
+//   `sql.trace.log_statement_execute` [cluster setting](cluster-settings.html))
+// - pgwire events (when enabled)
 const SQL_EXEC = logpb.Channel_SQL_EXEC
 
-// SQL_PERF is the channel used to report SQL executions
-// that are marked to be highlighted as "out of the ordinary"
+// SQL_PERF is used to report SQL executions
+// that are marked as "out of the ordinary"
 // to facilitate performance investigations.
-// This includes the "SQL slow query log".
+// This includes the SQL "slow query log".
 //
-// Arguably, this channel overlaps with SQL_EXEC defined above.
-// However, we keep them separate for backward-compatibility
-// with previous versions, where the corresponding events
+// Arguably, this channel overlaps with `SQL_EXEC`.
+// However, we keep both channels separate for backward compatibility
+// with versions prior to v21.1, where the corresponding events
 // were redirected to separate files.
 const SQL_PERF = logpb.Channel_SQL_PERF
 
-// SQL_INTERNAL_PERF is like the SQL perf channel above but aimed at
+// SQL_INTERNAL_PERF is like the `SQL_PERF` channel, but is aimed at
 // helping developers of CockroachDB itself. It exists as a separate
-// channel so as to not pollute the SQL perf logging output with
+// channel so as to not pollute the `SQL_PERF` logging output with
 // internal troubleshooting details.
 const SQL_INTERNAL_PERF = logpb.Channel_SQL_INTERNAL_PERF

--- a/pkg/util/log/eventpb/cluster_events.pb.go
+++ b/pkg/util/log/eventpb/cluster_events.pb.go
@@ -177,7 +177,7 @@ func (m *CommonNodeDecommissionDetails) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_CommonNodeDecommissionDetails proto.InternalMessageInfo
 
-// NodeDecommissioned is recorded when a node is marked as
+// NodeDecommissioning is recorded when a node is marked as
 // decommissioning.
 type NodeDecommissioning struct {
 	CommonEventDetails            `protobuf:"bytes,1,opt,name=common,proto3,embedded=common" json:""`

--- a/pkg/util/log/eventpb/cluster_events.proto
+++ b/pkg/util/log/eventpb/cluster_events.proto
@@ -21,9 +21,9 @@ import "util/log/eventpb/events.proto";
 // Events in this category pertain to an entire cluster and are
 // not relative to any particular tenant.
 //
-// In a multi-tenant setup, the system.eventlog table for individual
+// In a multi-tenant setup, the `system.eventlog` table for individual
 // tenants cannot contain a copy of cluster-level events; conversely,
-// the system.eventlog table in the system tenant cannot contain the
+// the `system.eventlog` table in the system tenant cannot contain the
 // SQL-level events for individual tenants.
 
 // Notes to CockroachDB maintainers: refer to doc.go at the package
@@ -73,7 +73,7 @@ message CommonNodeDecommissionDetails {
   int32 target_node_id = 2 [(gogoproto.customname) = "TargetNodeID", (gogoproto.jsontag) = ",omitempty"];
 }
 
-// NodeDecommissioned is recorded when a node is marked as
+// NodeDecommissioning is recorded when a node is marked as
 // decommissioning.
 message NodeDecommissioning {
   CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];

--- a/pkg/util/log/eventpb/ddl_events.proto
+++ b/pkg/util/log/eventpb/ddl_events.proto
@@ -24,7 +24,7 @@ import "util/log/eventpb/events.proto";
 //
 // They are relative to a particular SQL tenant.
 // In a multi-tenant setup, copies of DDL-related events are preserved
-// in each tenant's own system.eventlog table.
+// in each tenant's own `system.eventlog` table.
 
 // Notes to CockroachDB maintainers: refer to doc.go at the package
 // level for more details. Beware that JSON compatibility rules apply

--- a/pkg/util/log/eventpb/gen.go
+++ b/pkg/util/log/eventpb/gen.go
@@ -540,33 +540,35 @@ func (m *{{.GoType}}) LoggingChannel() logpb.Channel { return logpb.Channel_{{.L
 {{end}}
 `,
 
-	"eventlog.md": `# Documentation for notable events
-
-Certain notable events are reported using a structured format.
+	"eventlog.md": `Certain notable events are reported using a structured format.
 Commonly, these notable events are also copied to the table
 ` + "`system.eventlog`" + `, unless the cluster setting
 ` + "`server.eventlog.enabled`" + ` is unset.
 
 Additionally, notable events are copied to specific external logging
-channels, where they can be collected for further processing.
+channels in log messages, where they can be collected for further processing.
 
 The sections below document the possible notable event types
 in this version of CockroachDB. For each event type, a table
 documents the possible fields. A field may be omitted from
 an event if its value is empty or zero.
 
-A field is also marked as “Sensitive” if it may contain
-application-specific information or PII. In that case,
+A field is also considered "Sensitive" if it may contain
+application-specific information or personally identifiable information (PII). In that case,
 the copy of the event sent to the external logging channel
-may contain redaction markers, in a way compatible
-with the redaction facilities in ` + "`debug zip` or `debug merge-log`" + `.
+will contain redaction markers in a format that is compatible
+with the redaction facilities in ` + "[`cockroach debug zip`](cockroach-debug-zip.html)" + `
+and ` + "[`cockroach debug merge-logs`](cockroach-debug-merge-logs.html)" + `,
+provided the ` + "`redactable`" + ` functionality is enabled on the logging sink.
+
+Events not documented on this page will have an unstructured format in log messages.
 
 {{range .Categories -}}
 ## {{.Title}}
 
 {{.Comment}}
 
-Events in this category are logged to channel {{.LogChannel}}.
+Events in this category are logged to the ` + "`" + `{{.LogChannel}}` + "`" + ` channel.
 
 {{range .Events}}
 ### ` + "`" + `{{.Type}}` + "`" + `

--- a/pkg/util/log/eventpb/privilege_events.pb.go
+++ b/pkg/util/log/eventpb/privilege_events.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-// CommonSQLPrivilegeEventDetails contains the fields copmmon to all
+// CommonSQLPrivilegeEventDetails contains the fields common to all
 // grant/revoke events.
 type CommonSQLPrivilegeEventDetails struct {
 	// The user/role affected by the grant or revoke operation.

--- a/pkg/util/log/eventpb/privilege_events.proto
+++ b/pkg/util/log/eventpb/privilege_events.proto
@@ -24,14 +24,14 @@ import "util/log/eventpb/events.proto";
 //
 // They are relative to a particular SQL tenant.
 // In a multi-tenant setup, copies of DDL-related events are preserved
-// in each tenant's own system.eventlog table.
+// in each tenant's own `system.eventlog` table.
 
 // Notes to CockroachDB maintainers: refer to doc.go at the package
 // level for more details. Beware that JSON compatibility rules apply
 // here, not protobuf.
 // *Really look at doc.go before modifying this file.*
 
-// CommonSQLPrivilegeEventDetails contains the fields copmmon to all
+// CommonSQLPrivilegeEventDetails contains the fields common to all
 // grant/revoke events.
 message CommonSQLPrivilegeEventDetails {
   // The user/role affected by the grant or revoke operation.

--- a/pkg/util/log/eventpb/role_events.proto
+++ b/pkg/util/log/eventpb/role_events.proto
@@ -23,7 +23,7 @@ import "util/log/eventpb/events.proto";
 //
 // They are relative to a particular SQL tenant.
 // In a multi-tenant setup, copies of DDL-related events are preserved
-// in each tenant's own system.eventlog table.
+// in each tenant's own `system.eventlog` table.
 
 // Notes to CockroachDB maintainers: refer to doc.go at the package
 // level for more details. Beware that JSON compatibility rules apply

--- a/pkg/util/log/eventpb/session_events.proto
+++ b/pkg/util/log/eventpb/session_events.proto
@@ -23,7 +23,7 @@ import "util/log/eventpb/events.proto";
 //
 // They are relative to a particular SQL tenant.
 // In a multi-tenant setup, copies of these miscellaneous events are
-// preserved in each tenant's own system.eventlog table.
+// preserved in each tenant's own `system.eventlog` table.
 
 // Notes to CockroachDB maintainers: refer to doc.go at the package
 // level for more details. Beware that JSON compatibility rules apply

--- a/pkg/util/log/eventpb/sql_audit_events.proto
+++ b/pkg/util/log/eventpb/sql_audit_events.proto
@@ -48,11 +48,11 @@ message CommonSQLExecDetails {
 // Channel: SENSITIVE_ACCESS
 //
 // Events in this category are generated when a table has been
-// marked as audited via `ALTER ... EXPERIMENTAL_AUDIT SET`.
+// marked as audited via `ALTER TABLE ... EXPERIMENTAL_AUDIT SET`.
 //
-// This feature is experimental.
+// {% include {{ page.version.version }}/misc/experimental-warning.md %}
 //
-// Note: these events are not written to `system.eventlog`, even
+// Note: These events are not written to `system.eventlog`, even
 // when the cluster setting `system.eventlog.enabled` is set. They
 // are only emitted via external logging.
 
@@ -104,7 +104,7 @@ message SlowQuery {
 // Channel: SQL_INTERNAL_PERF
 //
 // Events in this category report slow query execution by
-// internal executors, i.e. when CockroachDB internally issues
+// internal executors, i.e., when CockroachDB internally issues
 // SQL statements.
 //
 // Note: these events are not written to `system.eventlog`, even
@@ -127,7 +127,7 @@ message SlowQueryInternal {
 //
 // Events in this category report executed queries.
 //
-// Note: these events are not written to `system.eventlog`, even
+// Note: These events are not written to `system.eventlog`, even
 // when the cluster setting `system.eventlog.enabled` is set. They
 // are only emitted via external logging.
 

--- a/pkg/util/log/eventpb/zone_events.proto
+++ b/pkg/util/log/eventpb/zone_events.proto
@@ -18,16 +18,16 @@ import "util/log/eventpb/events.proto";
 // Category: Zone config events
 // Channel: OPS
 //
-// Events in this category pertain to zone config changes on
+// Events in this category pertain to zone configuration changes on
 // the SQL schema or system ranges.
 //
 // When zone configs apply to individual tables or other objects in a
 // SQL logical schema, they are relative to a particular SQL tenant.
 // In a multi-tenant setup, copies of these zone config events are preserved
-// in each tenant's own system.eventlog table.
+// in each tenant's own `system.eventlog` table.
 //
-// When they apply to cluster-level ranges (e.g.  the system zone config),
-// they are stored in the system tenant's own system.eventlog table.
+// When they apply to cluster-level ranges (e.g., the system zone config),
+// they are stored in the system tenant's own `system.eventlog` table.
 
 // TODO(knz): explore whether we should have separate notable event
 // types for table-level and cluster-level zone config changes.

--- a/pkg/util/log/format_crdb_v1.go
+++ b/pkg/util/log/format_crdb_v1.go
@@ -65,32 +65,31 @@ followed by the text of the log entry.`)
 		buf.WriteString(`
 followed by:
 
-- The logging context tags enclosed between "[" and "]", if any. It is possible
+- The logging context tags enclosed between ` + "`[`" + ` and ` + "`]`" + `, if any. It is possible
   for this to be omitted if there were no context tags.
 - the text of the log entry.`)
 	}
 
 	buf.WriteString(`
 
-Beware that the text of the log entry can span multiple lines. In particular,
-the following caveats apply:
+Beware that the text of the log entry can span multiple lines. The following caveats apply:
 
 `)
 
 	if !withCounter {
 		// If there is no counter, the format is ambiguous. Explain that.
 		buf.WriteString(`
-- the text of the log entry can start with text enclosed between "[" and "]".
-  It is not possible to distinguish between logging context tag information
-  and a "[...]" string in the main text of the log entry, if there were
-  no logging tags to start with. This means that this format is ambiguous.
-  Consider ` + "`" + formatCrdbV1WithCounter{}.formatterName() + "`" + ` for an unambiguous alternative.
+- The text of the log entry can start with text enclosed between ` + "`[`" + ` and ` + "`]`" + `.
+  If there were no logging tags to start with, it is not possible to distinguish between
+  logging context tag information and a ` + "`[...]`" + ` string in the main text of the
+  log entry. This means that this format is ambiguous. For an unambiguous alternative,
+  consider ` + "`" + formatCrdbV1WithCounter{}.formatterName() + "`" + `.
 `)
 	}
 
 	// General disclaimer about the lack of boundaries.
 	buf.WriteString(`
-- the text of the log entry can embed arbitrary application-level strings,
+- The text of the log entry can embed arbitrary application-level strings,
   including strings that represent log entries. In particular, an accident
   of implementation can cause the common entry prefix (described below)
   to also appear on a line of its own, as part of the payload of a previous
@@ -112,10 +111,10 @@ regular log entries. This header reports when the file was created,
 which parameters were used to start the server, the server identifiers
 if known, and other metadata about the running process.
 
-This header appears to be logged at severity INFO (with an I prefix at the
-start of the line) even though it does not really have a severity. The
-header is printed unconditionally even when a filter is configured to
-omit entries at the INFO level.
+- This header appears to be logged at severity ` + "`INFO`" + ` (with an ` + "`I`" + ` prefix
+  at the start of the line) even though it does not really have a severity.
+- The header is printed unconditionally even when a filter is configured to
+  omit entries at the ` + "`INFO`" + ` level.
 
 ### Common log entry prefix
 
@@ -124,30 +123,28 @@ Each line of output starts with the following prefix:
      Lyymmdd hh:mm:ss.uuuuuu goid [chan@]file:line marker`)
 
 	if withCounter {
-		buf.WriteString(`tags counter`)
+		buf.WriteString(` tags counter`)
 	}
 
 	buf.WriteString(`
 
-where the fields are defined as follows:
-
-| Field           | Description                                                       |
-|-----------------|------------------------------------------------------------------ |
-| L               | A single character, representing the log level (eg 'I' for INFO). |
-| yy              | The year (zero padded; ie 2016 is '16').                          |
-| mm              | The month (zero padded; ie May is '05').                          |
-| dd              | The day (zero padded).                                            |
-| hh:mm:ss.uuuuuu | Time in hours, minutes and fractional seconds. Timezone is UTC.   |
-| goid            | The goroutine id (omitted if zero for use by tests).              |
-| chan            | The channel number (omitted if zero for backward-compatibility).  |
-| file            | The file name where the entry originated.                         |
-| line            | The line number where the entry originated.                       |
-| marker          | Redactability marker (see below for details).                     |`)
+| Field           | Description                                                                                                               |
+|-----------------|---------------------------------------------------------------------------------------------------------------------------|
+| L               | A single character, representing the [log level](logging.html#logging-levels) (e.g., ` + "`I`" + ` for ` + "`INFO`" + `). |
+| yy              | The year (zero padded; i.e., 2016 is ` + "`16`" + `).                                                                     |
+| mm              | The month (zero padded; i.e., May is ` + "`05`" + `).                                                                     |
+| dd              | The day (zero padded).                                                                                                    |
+| hh:mm:ss.uuuuuu | Time in hours, minutes and fractional seconds. Timezone is UTC.                                                           |
+| goid            | The goroutine id (omitted if zero for use by tests).                                                                      |
+| chan            | The channel number (omitted if zero for backward compatibility).                                                          |
+| file            | The file name where the entry originated.                                                                                 |
+| line            | The line number where the entry originated.                                                                               |
+| marker          | Redactability marker ` + "` + redactableIndicator + `" + ` (see below for details).                                       |`)
 
 	if withCounter {
 		buf.WriteString(`
-| tags            | The logging tags, enclosed between "[" and "]". May be absent.    |
-| counter         | The entry counter. Always present.                                |`)
+| tags    | The logging tags, enclosed between ` + "`[`" + ` and ` + "`]`" + `. May be absent. |
+| counter | The entry counter. Always present.                                                 |`)
 	}
 
 	buf.WriteString(`
@@ -155,10 +152,12 @@ where the fields are defined as follows:
 The redactability marker can be empty; in this case, its position in the common prefix is
 a double ASCII space character which can be used to reliably identify this situation.
 
-If the marker "` + redactableIndicator + `" is present, the remainder of the log entry
-contains delimiters (` + string(redact.StartMarker()) + `...` + string(redact.EndMarker()) + `) around
+If the marker ` + "` + redactableIndicator + `" + ` is present, the remainder of the log entry
+contains delimiters (` + string(redact.StartMarker()) + "..." + string(redact.EndMarker()) + `) around
 fields that are considered sensitive. These markers are automatically recognized
-by ` + "`" + `debug zip` + "`" + ` and ` + "`" + `debug merge-logs` + "`" + ` when log redaction is requested.
+by ` + "[`cockroach debug zip`](cockroach-debug-zip.html)" + ` and ` +
+		"[`cockroach debug merge-logs`](cockroach-debug-merge-logs.html)" +
+		` when log redaction is requested.
 `)
 
 	return buf.String()

--- a/pkg/util/log/format_crdb_v2.go
+++ b/pkg/util/log/format_crdb_v2.go
@@ -45,52 +45,53 @@ Each line of output starts with the following prefix:
 
      Lyymmdd hh:mm:ss.uuuuuu goid [chan@]file:line marker [tags...] counter cont
 
-| Field           | Description                                                         |
-|-----------------|---------------------------------------------------------------------|
-| L               | A single character, representing the log level (eg 'I' for INFO).   |
-| yy              | The year (zero padded; ie 2016 is '16').                            |
-| mm              | The month (zero padded; ie May is '05').                            |
-| dd              | The day (zero padded).                                              |
-| hh:mm:ss.uuuuuu | Time in hours, minutes and fractional seconds. Timezone is UTC.     |
-| goid            | The goroutine id (zero when cannot be determined).                  |
-| chan            | The channel number (omitted if zero for backward-compatibility).    |
-| file            | The file name where the entry originated. Also see below.           |
-| line            | The line number where the entry originated.                         |
-| marker          | Redactability marker (see below for details).                       |
-| tags            | The logging tags, enclosed between "[" and "]". See below.          |
-| counter         | The optional entry counter (see below for details).                 |
-| cont            | Continuation mark for structured and multi-line entries. See below. |
+| Field           | Description                                                                                                               |
+|-----------------|---------------------------------------------------------------------------------------------------------------------------|
+| L               | A single character, representing the [log level](logging.html#logging-levels) (e.g., ` + "`I`" + ` for ` + "`INFO`" + `). |
+| yy              | The year (zero padded; i.e., 2016 is ` + "`16`" + `).                                                                     |
+| mm              | The month (zero padded; i.e., May is ` + "`05`" + `).                                                                     |
+| dd              | The day (zero padded).                                                                                                    |
+| hh:mm:ss.uuuuuu | Time in hours, minutes and fractional seconds. Timezone is UTC.                                                           |
+| goid            | The goroutine id (zero when cannot be determined).                                                                        |
+| chan            | The channel number (omitted if zero for backward compatibility).                                                          |
+| file            | The file name where the entry originated. Also see below.                                                                 |
+| line            | The line number where the entry originated.                                                                               |
+| marker          | Redactability marker "` + redactableIndicator + `" (see below for details).                                               |
+| tags            | The logging tags, enclosed between ` + "`[`" + ` and ` + "`]`" + `. See below.                                            |
+| counter         | The optional entry counter (see below for details).                                                                       |
+| cont            | Continuation mark for structured and multi-line entries. See below.                                                       |
 
 The ` + "`chan@`" + ` prefix before the file name indicates the logging channel,
-and is omitted if the channel is DEV.
+and is omitted if the channel is ` + "`DEV`" + `.
 
-The file name may be prefixed by the string "` + "`(gostd) `" + `" to indicate
+The file name may be prefixed by the string ` + "`(gostd) `" + ` to indicate
 that the log entry was produced inside the Go standard library, instead
 of a CockroachDB component. Entry parsers must be configured to ignore this prefix
 when present.
 
-The ` + "`marker`" + ` part is the redactability marker.
-The redactability marker can be empty; in this case, its position in the common prefix is
+` + "`marker`" + ` can be empty; in this case, its position in the common prefix is
 a double ASCII space character which can be used to reliably identify this situation.
-If the marker is "` + redactableIndicator + `", the remainder of the log entry
-contains delimiters (` + string(redact.StartMarker()) + `...` + string(redact.EndMarker()) + `) around
-fields that are considered sensitive. These markers are automatically recognized
-by ` + "`" + `debug zip` + "`" + ` and ` + "`" + `debug merge-logs` + "`" + ` when log redaction is requested.
+If the marker "` + redactableIndicator + `" is present, the remainder of the log entry
+contains delimiters (` + string(redact.StartMarker()) + "..." + string(redact.EndMarker()) + `)
+around fields that are considered sensitive. These markers are automatically recognized
+by ` + "[`cockroach debug zip`](cockroach-debug-zip.html)" + ` and ` +
+		"[`cockroach debug merge-logs`](cockroach-debug-merge-logs.html)" + `
+when log redaction is requested.
 
-The logging ` + "`tags`" + ` part is enclosed between square brackets ` + "`[...]`" + `,
+The logging ` + "`tags`" + ` are enclosed between square brackets ` + "`[...]`" + `,
 and the syntax ` + "`[-]`" + ` is used when there are no logging tags
 associated with the log entry.
 
-The ` + "`counter`" + ` part is numeric, and is incremented for every
+` + "`counter`" + ` is numeric, and is incremented for every
 log entry emitted to this sink. (There is thus one counter sequence per
 sink.) For entries that do not have a counter value
-associated, for example header entries in file sinks, the counter position
-in the common prefix is empty: the tags part that precedes is then
-followed by two ASCII space characters, instead of one space, the counter
+associated (e.g., header entries in file sinks), the counter position
+in the common prefix is empty: ` + "`tags`" + ` is then
+followed by two ASCII space characters, instead of one space; the ` + "`counter`" + `,
 and another space. The presence of the two ASCII spaces indicates
 reliably that no counter was present.
 
-The ` + "`cont`" + ` part is a format/continuation indicator:
+` + "`cont`" + ` is a format/continuation indicator:
 
 | Continuation indicator | ASCII | Description |
 |------------------------|-------|--|
@@ -125,23 +126,24 @@ Example long entries broken up into multiple lines:
 
 ### Backward-compatibility notes
 
-Entries in this format can be read by most crdb-v1 log parsers,
+Entries in this format can be read by most ` + "`crdb-v1`" + ` log parsers,
 in particular the one included in the DB console and
-also the ` + "`debug merge-logs`" + ` facility.
+also the [` + "`cockroach debug merge-logs`" + `](cockroach-debug-merge-logs.html)
+facility.
 
 However, implementers of previous version parsers must
 understand that the logging tags field is now always
 included, and the lack of logging tags is included
-by a tag string set to "` + "`[-]`" + `".
+by a tag string set to ` + "`[-]`" + `.
 
 Likewise, the entry counter is now also always included,
-and there is a special character after the entry counter
+and there is a special character after ` + "`counter`" + `
 to indicate whether the remainder of the line is a
 structured entry, or a continuation of a previous entry.
 
 Finally, in the previous format, structured entries
-were prefixed with the string "Structured entry:". In
-the new format, they are prefixed by the '=' continuation
+were prefixed with the string ` + "`Structured entry:`" + `. In
+the new format, they are prefixed by the ` + "`=`" + ` continuation
 indicator.
 `)
 

--- a/pkg/util/log/format_json.go
+++ b/pkg/util/log/format_json.go
@@ -129,13 +129,14 @@ Additionally, the following fields are conditionally present:
 | ` + "`stacks`" + `  | Goroutine stacks, for fatal events. |
 
 When an entry is structured, the ` + "`event`" + ` field maps to a dictionary
-whose structure is one of the documented structured events. See the reference
-documentation for structured events for a list of possible payloads.
+whose structure is one of the documented structured events. See the [reference documentation](eventlog.html)
+for structured events for a list of possible payloads.
 
-Then the entry is marked as "redactable", the ` + "`tags`, `message` and/or `event`" + ` payloads
-contain delimiters (` + string(redact.StartMarker()) + `...` + string(redact.EndMarker()) + `) around
+When the entry is marked as ` + "`redactable`" + `, the ` + "`tags`, `message`, and/or `event`" + ` payloads
+contain delimiters (` + string(redact.StartMarker()) + "..." + string(redact.EndMarker()) + `) around
 fields that are considered sensitive. These markers are automatically recognized
-by ` + "`" + `debug zip` + "`" + ` and ` + "`" + `debug merge-logs` + "`" + ` when log redaction is requested.
+by ` + "[`cockroach debug zip`](cockroach-debug-zip.html)" + ` and ` +
+		"[`cockroach debug merge-logs`](cockroach-debug-merge-logs.html)" + ` when log redaction is requested.
 
 
 `)

--- a/pkg/util/log/gen/main.go
+++ b/pkg/util/log/gen/main.go
@@ -139,7 +139,7 @@ func readInput(protoName string) (chans []info, sevs []info, err error) {
 		key := strings.Split(line, " ")[0]
 		title := strings.ReplaceAll(strings.Title(strings.ReplaceAll(strings.ToLower(key), "_", " ")), " ", "")
 		if inSevs {
-			comment := "// The " + key + " severity" + strings.TrimPrefix(rawComment, "// "+key)
+			comment := "// The `" + key + "` severity" + strings.TrimPrefix(rawComment, "// "+key)
 			sevs = append(sevs, info{
 				RawComment: rawComment,
 				Comment:    comment,
@@ -150,7 +150,7 @@ func readInput(protoName string) (chans []info, sevs []info, err error) {
 			})
 		}
 		if inChans {
-			comment := "// The " + key + " channel" + strings.TrimPrefix(rawComment, "// "+key)
+			comment := "// The `" + key + "` channel" + strings.TrimPrefix(rawComment, "// "+key)
 			chans = append(chans, info{
 				RawComment: rawComment,
 				Comment:    comment,
@@ -176,7 +176,7 @@ var templates = map[string]string{
 
 # Logging channels
 {{range .Channels}}
-## {{.NAME}}
+## ` + "`" + `{{.NAME}}` + "`" + `
 
 {{.PComment}}
 {{- end}}

--- a/pkg/util/log/log_channels_generated.go
+++ b/pkg/util/log/log_channels_generated.go
@@ -126,16 +126,17 @@ type loggerDev struct{}
 
 // Dev is a logger that logs to the DEV channel.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 var Dev loggerDev
 
 // Dev and loggerDev implement ChannelLogger.
@@ -149,19 +150,20 @@ var _ ChannelLogger = Dev
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerDev) Infof(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.INFO, channel.DEV, format, args...)
 }
@@ -172,19 +174,20 @@ func (loggerDev) Infof(ctx context.Context, format string, args ...interface{}) 
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerDev) VInfof(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.INFO, channel.DEV, format, args...)
@@ -195,19 +198,20 @@ func (loggerDev) VInfof(ctx context.Context, level Level, format string, args ..
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerDev) Info(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.INFO, channel.DEV, msg)
 }
@@ -217,19 +221,20 @@ func (loggerDev) Info(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerDev) InfofDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.INFO, channel.DEV, format, args...)
 }
@@ -240,19 +245,20 @@ func (loggerDev) InfofDepth(ctx context.Context, depth int, format string, args 
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func Infof(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.INFO, channel.DEV, format, args...)
 }
@@ -261,19 +267,20 @@ func Infof(ctx context.Context, format string, args ...interface{}) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func VInfof(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.INFO, channel.DEV, format, args...)
@@ -284,19 +291,20 @@ func VInfof(ctx context.Context, level Level, format string, args ...interface{}
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func Info(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.INFO, channel.DEV, msg)
 }
@@ -306,19 +314,20 @@ func Info(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func InfofDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.INFO, channel.DEV, format, args...)
 }
@@ -327,19 +336,20 @@ func InfofDepth(ctx context.Context, depth int, format string, args ...interface
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerDev) Warningf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.WARNING, channel.DEV, format, args...)
 }
@@ -350,19 +360,20 @@ func (loggerDev) Warningf(ctx context.Context, format string, args ...interface{
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerDev) VWarningf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.WARNING, channel.DEV, format, args...)
@@ -373,19 +384,20 @@ func (loggerDev) VWarningf(ctx context.Context, level Level, format string, args
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerDev) Warning(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.WARNING, channel.DEV, msg)
 }
@@ -395,19 +407,20 @@ func (loggerDev) Warning(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerDev) WarningfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.WARNING, channel.DEV, format, args...)
 }
@@ -418,19 +431,20 @@ func (loggerDev) WarningfDepth(ctx context.Context, depth int, format string, ar
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func Warningf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.WARNING, channel.DEV, format, args...)
 }
@@ -439,19 +453,20 @@ func Warningf(ctx context.Context, format string, args ...interface{}) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func VWarningf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.WARNING, channel.DEV, format, args...)
@@ -462,19 +477,20 @@ func VWarningf(ctx context.Context, level Level, format string, args ...interfac
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func Warning(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.WARNING, channel.DEV, msg)
 }
@@ -484,19 +500,20 @@ func Warning(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func WarningfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.WARNING, channel.DEV, format, args...)
 }
@@ -505,19 +522,20 @@ func WarningfDepth(ctx context.Context, depth int, format string, args ...interf
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerDev) Errorf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.ERROR, channel.DEV, format, args...)
@@ -529,19 +547,20 @@ func (loggerDev) Errorf(ctx context.Context, format string, args ...interface{})
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerDev) VErrorf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
@@ -553,19 +572,20 @@ func (loggerDev) VErrorf(ctx context.Context, level Level, format string, args .
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerDev) Error(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.ERROR, channel.DEV, msg)
@@ -576,19 +596,20 @@ func (loggerDev) Error(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerDev) ErrorfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.ERROR, channel.DEV, format, args...)
@@ -600,19 +621,20 @@ func (loggerDev) ErrorfDepth(ctx context.Context, depth int, format string, args
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func Errorf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.ERROR, channel.DEV, format, args...)
@@ -622,19 +644,20 @@ func Errorf(ctx context.Context, format string, args ...interface{}) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func VErrorf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
@@ -646,19 +669,20 @@ func VErrorf(ctx context.Context, level Level, format string, args ...interface{
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func Error(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.ERROR, channel.DEV, msg)
@@ -669,19 +693,20 @@ func Error(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func ErrorfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.ERROR, channel.DEV, format, args...)
@@ -691,18 +716,19 @@ func ErrorfDepth(ctx context.Context, depth int, format string, args ...interfac
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerDev) Fatalf(ctx context.Context, format string, args ...interface{}) {
@@ -715,18 +741,19 @@ func (loggerDev) Fatalf(ctx context.Context, format string, args ...interface{})
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerDev) VFatalf(ctx context.Context, level Level, format string, args ...interface{}) {
@@ -739,18 +766,19 @@ func (loggerDev) VFatalf(ctx context.Context, level Level, format string, args .
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerDev) Fatal(ctx context.Context, msg string) {
@@ -762,18 +790,19 @@ func (loggerDev) Fatal(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerDev) FatalfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
@@ -786,18 +815,19 @@ func (loggerDev) FatalfDepth(ctx context.Context, depth int, format string, args
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func Fatalf(ctx context.Context, format string, args ...interface{}) {
@@ -808,18 +838,19 @@ func Fatalf(ctx context.Context, format string, args ...interface{}) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func VFatalf(ctx context.Context, level Level, format string, args ...interface{}) {
@@ -832,18 +863,19 @@ func VFatalf(ctx context.Context, level Level, format string, args ...interface{
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func Fatal(ctx context.Context, msg string) {
@@ -855,18 +887,19 @@ func Fatal(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func FatalfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
@@ -876,16 +909,17 @@ func FatalfDepth(ctx context.Context, depth int, format string, args ...interfac
 // Shout logs to channel DEV, and also to the real stderr if logging
 // is currently redirected to a file.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 func (loggerDev) Shout(ctx context.Context, sev Severity, msg string) {
 	shoutfDepth(ctx, 1, sev, channel.DEV, msg)
 }
@@ -894,16 +928,17 @@ func (loggerDev) Shout(ctx context.Context, sev Severity, msg string) {
 // logging is currently redirected to a file. Arguments are handled in
 // the manner of fmt.Printf.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 func (loggerDev) Shoutf(ctx context.Context, sev Severity, format string, args ...interface{}) {
 	shoutfDepth(ctx, 1, sev, channel.DEV, format, args...)
 }
@@ -911,16 +946,17 @@ func (loggerDev) Shoutf(ctx context.Context, sev Severity, format string, args .
 // Shout logs to channel DEV, and also to the real stderr if logging
 // is currently redirected to a file.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 func Shout(ctx context.Context, sev Severity, msg string) {
 	shoutfDepth(ctx, 1, sev, channel.DEV, msg)
 }
@@ -929,16 +965,17 @@ func Shout(ctx context.Context, sev Severity, msg string) {
 // logging is currently redirected to a file. Arguments are handled in
 // the manner of fmt.Printf.
 //
-// The DEV channel is the channel used during development, to collect log
-// details useful for troubleshooting when it is unclear which other
-// channel to use. It is also the default logging channel in
-// CockroachDB, when the caller does not indicate a channel.
+// The `DEV` channel is used during development to collect log
+// details useful for troubleshooting that fall outside the
+// scope of other channels. It is also the default logging
+// channel for events not associated with a channel.
 //
 // This channel is special in that there are no constraints as to
 // what may or may not be logged on it. Conversely, users in
-// production deployments are invited to not collect DEV logs in
+// production deployments are invited to not collect `DEV` logs in
 // centralized logging facilities, because they likely contain
 // sensitive operational data.
+// See [Configure logs](configure-logs.html#dev-channel).
 func Shoutf(ctx context.Context, sev Severity, format string, args ...interface{}) {
 	shoutfDepth(ctx, 1, sev, channel.DEV, format, args...)
 }
@@ -948,17 +985,17 @@ type loggerOps struct{}
 
 // Ops is a logger that logs to the OPS channel.
 //
-// The OPS channel is the channel used to report "point" operational events,
+// The `OPS` channel is used to report "point" operational events,
 // initiated by user operators or automation:
 //
-// - operator or system actions on server processes: process starts,
+// - Operator or system actions on server processes: process starts,
 //   stops, shutdowns, crashes (if they can be logged),
-//   including each time: command-line parameters, current version being run.
-// - actions that impact the topology of a cluster: node additions,
+//   including each time: command-line parameters, current version being run
+// - Actions that impact the topology of a cluster: node additions,
 //   removals, decommissions, etc.
-// - job-related initiation or termination.
-// - cluster setting changes.
-// - zone configuration changes.
+// - Job-related initiation or termination
+// - [Cluster setting](cluster-settings.html) changes
+// - [Zone configuration](configure-replication-zones.html) changes
 var Ops loggerOps
 
 // Ops and loggerOps implement ChannelLogger.
@@ -972,20 +1009,20 @@ var _ ChannelLogger = Ops
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The OPS channel is the channel used to report "point" operational events,
+// The `OPS` channel is used to report "point" operational events,
 // initiated by user operators or automation:
 //
-// - operator or system actions on server processes: process starts,
+// - Operator or system actions on server processes: process starts,
 //   stops, shutdowns, crashes (if they can be logged),
-//   including each time: command-line parameters, current version being run.
-// - actions that impact the topology of a cluster: node additions,
+//   including each time: command-line parameters, current version being run
+// - Actions that impact the topology of a cluster: node additions,
 //   removals, decommissions, etc.
-// - job-related initiation or termination.
-// - cluster setting changes.
-// - zone configuration changes.
+// - Job-related initiation or termination
+// - [Cluster setting](cluster-settings.html) changes
+// - [Zone configuration](configure-replication-zones.html) changes
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerOps) Infof(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.INFO, channel.OPS, format, args...)
 }
@@ -996,20 +1033,20 @@ func (loggerOps) Infof(ctx context.Context, format string, args ...interface{}) 
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The OPS channel is the channel used to report "point" operational events,
+// The `OPS` channel is used to report "point" operational events,
 // initiated by user operators or automation:
 //
-// - operator or system actions on server processes: process starts,
+// - Operator or system actions on server processes: process starts,
 //   stops, shutdowns, crashes (if they can be logged),
-//   including each time: command-line parameters, current version being run.
-// - actions that impact the topology of a cluster: node additions,
+//   including each time: command-line parameters, current version being run
+// - Actions that impact the topology of a cluster: node additions,
 //   removals, decommissions, etc.
-// - job-related initiation or termination.
-// - cluster setting changes.
-// - zone configuration changes.
+// - Job-related initiation or termination
+// - [Cluster setting](cluster-settings.html) changes
+// - [Zone configuration](configure-replication-zones.html) changes
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerOps) VInfof(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.INFO, channel.OPS, format, args...)
@@ -1020,20 +1057,20 @@ func (loggerOps) VInfof(ctx context.Context, level Level, format string, args ..
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The OPS channel is the channel used to report "point" operational events,
+// The `OPS` channel is used to report "point" operational events,
 // initiated by user operators or automation:
 //
-// - operator or system actions on server processes: process starts,
+// - Operator or system actions on server processes: process starts,
 //   stops, shutdowns, crashes (if they can be logged),
-//   including each time: command-line parameters, current version being run.
-// - actions that impact the topology of a cluster: node additions,
+//   including each time: command-line parameters, current version being run
+// - Actions that impact the topology of a cluster: node additions,
 //   removals, decommissions, etc.
-// - job-related initiation or termination.
-// - cluster setting changes.
-// - zone configuration changes.
+// - Job-related initiation or termination
+// - [Cluster setting](cluster-settings.html) changes
+// - [Zone configuration](configure-replication-zones.html) changes
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerOps) Info(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.INFO, channel.OPS, msg)
 }
@@ -1043,20 +1080,20 @@ func (loggerOps) Info(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The OPS channel is the channel used to report "point" operational events,
+// The `OPS` channel is used to report "point" operational events,
 // initiated by user operators or automation:
 //
-// - operator or system actions on server processes: process starts,
+// - Operator or system actions on server processes: process starts,
 //   stops, shutdowns, crashes (if they can be logged),
-//   including each time: command-line parameters, current version being run.
-// - actions that impact the topology of a cluster: node additions,
+//   including each time: command-line parameters, current version being run
+// - Actions that impact the topology of a cluster: node additions,
 //   removals, decommissions, etc.
-// - job-related initiation or termination.
-// - cluster setting changes.
-// - zone configuration changes.
+// - Job-related initiation or termination
+// - [Cluster setting](cluster-settings.html) changes
+// - [Zone configuration](configure-replication-zones.html) changes
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerOps) InfofDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.INFO, channel.OPS, format, args...)
 }
@@ -1065,20 +1102,20 @@ func (loggerOps) InfofDepth(ctx context.Context, depth int, format string, args 
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The OPS channel is the channel used to report "point" operational events,
+// The `OPS` channel is used to report "point" operational events,
 // initiated by user operators or automation:
 //
-// - operator or system actions on server processes: process starts,
+// - Operator or system actions on server processes: process starts,
 //   stops, shutdowns, crashes (if they can be logged),
-//   including each time: command-line parameters, current version being run.
-// - actions that impact the topology of a cluster: node additions,
+//   including each time: command-line parameters, current version being run
+// - Actions that impact the topology of a cluster: node additions,
 //   removals, decommissions, etc.
-// - job-related initiation or termination.
-// - cluster setting changes.
-// - zone configuration changes.
+// - Job-related initiation or termination
+// - [Cluster setting](cluster-settings.html) changes
+// - [Zone configuration](configure-replication-zones.html) changes
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerOps) Warningf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.WARNING, channel.OPS, format, args...)
 }
@@ -1089,20 +1126,20 @@ func (loggerOps) Warningf(ctx context.Context, format string, args ...interface{
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The OPS channel is the channel used to report "point" operational events,
+// The `OPS` channel is used to report "point" operational events,
 // initiated by user operators or automation:
 //
-// - operator or system actions on server processes: process starts,
+// - Operator or system actions on server processes: process starts,
 //   stops, shutdowns, crashes (if they can be logged),
-//   including each time: command-line parameters, current version being run.
-// - actions that impact the topology of a cluster: node additions,
+//   including each time: command-line parameters, current version being run
+// - Actions that impact the topology of a cluster: node additions,
 //   removals, decommissions, etc.
-// - job-related initiation or termination.
-// - cluster setting changes.
-// - zone configuration changes.
+// - Job-related initiation or termination
+// - [Cluster setting](cluster-settings.html) changes
+// - [Zone configuration](configure-replication-zones.html) changes
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerOps) VWarningf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.WARNING, channel.OPS, format, args...)
@@ -1113,20 +1150,20 @@ func (loggerOps) VWarningf(ctx context.Context, level Level, format string, args
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The OPS channel is the channel used to report "point" operational events,
+// The `OPS` channel is used to report "point" operational events,
 // initiated by user operators or automation:
 //
-// - operator or system actions on server processes: process starts,
+// - Operator or system actions on server processes: process starts,
 //   stops, shutdowns, crashes (if they can be logged),
-//   including each time: command-line parameters, current version being run.
-// - actions that impact the topology of a cluster: node additions,
+//   including each time: command-line parameters, current version being run
+// - Actions that impact the topology of a cluster: node additions,
 //   removals, decommissions, etc.
-// - job-related initiation or termination.
-// - cluster setting changes.
-// - zone configuration changes.
+// - Job-related initiation or termination
+// - [Cluster setting](cluster-settings.html) changes
+// - [Zone configuration](configure-replication-zones.html) changes
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerOps) Warning(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.WARNING, channel.OPS, msg)
 }
@@ -1136,20 +1173,20 @@ func (loggerOps) Warning(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The OPS channel is the channel used to report "point" operational events,
+// The `OPS` channel is used to report "point" operational events,
 // initiated by user operators or automation:
 //
-// - operator or system actions on server processes: process starts,
+// - Operator or system actions on server processes: process starts,
 //   stops, shutdowns, crashes (if they can be logged),
-//   including each time: command-line parameters, current version being run.
-// - actions that impact the topology of a cluster: node additions,
+//   including each time: command-line parameters, current version being run
+// - Actions that impact the topology of a cluster: node additions,
 //   removals, decommissions, etc.
-// - job-related initiation or termination.
-// - cluster setting changes.
-// - zone configuration changes.
+// - Job-related initiation or termination
+// - [Cluster setting](cluster-settings.html) changes
+// - [Zone configuration](configure-replication-zones.html) changes
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerOps) WarningfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.WARNING, channel.OPS, format, args...)
 }
@@ -1158,20 +1195,20 @@ func (loggerOps) WarningfDepth(ctx context.Context, depth int, format string, ar
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The OPS channel is the channel used to report "point" operational events,
+// The `OPS` channel is used to report "point" operational events,
 // initiated by user operators or automation:
 //
-// - operator or system actions on server processes: process starts,
+// - Operator or system actions on server processes: process starts,
 //   stops, shutdowns, crashes (if they can be logged),
-//   including each time: command-line parameters, current version being run.
-// - actions that impact the topology of a cluster: node additions,
+//   including each time: command-line parameters, current version being run
+// - Actions that impact the topology of a cluster: node additions,
 //   removals, decommissions, etc.
-// - job-related initiation or termination.
-// - cluster setting changes.
-// - zone configuration changes.
+// - Job-related initiation or termination
+// - [Cluster setting](cluster-settings.html) changes
+// - [Zone configuration](configure-replication-zones.html) changes
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerOps) Errorf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.ERROR, channel.OPS, format, args...)
@@ -1183,20 +1220,20 @@ func (loggerOps) Errorf(ctx context.Context, format string, args ...interface{})
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The OPS channel is the channel used to report "point" operational events,
+// The `OPS` channel is used to report "point" operational events,
 // initiated by user operators or automation:
 //
-// - operator or system actions on server processes: process starts,
+// - Operator or system actions on server processes: process starts,
 //   stops, shutdowns, crashes (if they can be logged),
-//   including each time: command-line parameters, current version being run.
-// - actions that impact the topology of a cluster: node additions,
+//   including each time: command-line parameters, current version being run
+// - Actions that impact the topology of a cluster: node additions,
 //   removals, decommissions, etc.
-// - job-related initiation or termination.
-// - cluster setting changes.
-// - zone configuration changes.
+// - Job-related initiation or termination
+// - [Cluster setting](cluster-settings.html) changes
+// - [Zone configuration](configure-replication-zones.html) changes
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerOps) VErrorf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
@@ -1208,20 +1245,20 @@ func (loggerOps) VErrorf(ctx context.Context, level Level, format string, args .
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The OPS channel is the channel used to report "point" operational events,
+// The `OPS` channel is used to report "point" operational events,
 // initiated by user operators or automation:
 //
-// - operator or system actions on server processes: process starts,
+// - Operator or system actions on server processes: process starts,
 //   stops, shutdowns, crashes (if they can be logged),
-//   including each time: command-line parameters, current version being run.
-// - actions that impact the topology of a cluster: node additions,
+//   including each time: command-line parameters, current version being run
+// - Actions that impact the topology of a cluster: node additions,
 //   removals, decommissions, etc.
-// - job-related initiation or termination.
-// - cluster setting changes.
-// - zone configuration changes.
+// - Job-related initiation or termination
+// - [Cluster setting](cluster-settings.html) changes
+// - [Zone configuration](configure-replication-zones.html) changes
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerOps) Error(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.ERROR, channel.OPS, msg)
@@ -1232,20 +1269,20 @@ func (loggerOps) Error(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The OPS channel is the channel used to report "point" operational events,
+// The `OPS` channel is used to report "point" operational events,
 // initiated by user operators or automation:
 //
-// - operator or system actions on server processes: process starts,
+// - Operator or system actions on server processes: process starts,
 //   stops, shutdowns, crashes (if they can be logged),
-//   including each time: command-line parameters, current version being run.
-// - actions that impact the topology of a cluster: node additions,
+//   including each time: command-line parameters, current version being run
+// - Actions that impact the topology of a cluster: node additions,
 //   removals, decommissions, etc.
-// - job-related initiation or termination.
-// - cluster setting changes.
-// - zone configuration changes.
+// - Job-related initiation or termination
+// - [Cluster setting](cluster-settings.html) changes
+// - [Zone configuration](configure-replication-zones.html) changes
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerOps) ErrorfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.ERROR, channel.OPS, format, args...)
@@ -1255,19 +1292,19 @@ func (loggerOps) ErrorfDepth(ctx context.Context, depth int, format string, args
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The OPS channel is the channel used to report "point" operational events,
+// The `OPS` channel is used to report "point" operational events,
 // initiated by user operators or automation:
 //
-// - operator or system actions on server processes: process starts,
+// - Operator or system actions on server processes: process starts,
 //   stops, shutdowns, crashes (if they can be logged),
-//   including each time: command-line parameters, current version being run.
-// - actions that impact the topology of a cluster: node additions,
+//   including each time: command-line parameters, current version being run
+// - Actions that impact the topology of a cluster: node additions,
 //   removals, decommissions, etc.
-// - job-related initiation or termination.
-// - cluster setting changes.
-// - zone configuration changes.
+// - Job-related initiation or termination
+// - [Cluster setting](cluster-settings.html) changes
+// - [Zone configuration](configure-replication-zones.html) changes
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerOps) Fatalf(ctx context.Context, format string, args ...interface{}) {
@@ -1280,19 +1317,19 @@ func (loggerOps) Fatalf(ctx context.Context, format string, args ...interface{})
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The OPS channel is the channel used to report "point" operational events,
+// The `OPS` channel is used to report "point" operational events,
 // initiated by user operators or automation:
 //
-// - operator or system actions on server processes: process starts,
+// - Operator or system actions on server processes: process starts,
 //   stops, shutdowns, crashes (if they can be logged),
-//   including each time: command-line parameters, current version being run.
-// - actions that impact the topology of a cluster: node additions,
+//   including each time: command-line parameters, current version being run
+// - Actions that impact the topology of a cluster: node additions,
 //   removals, decommissions, etc.
-// - job-related initiation or termination.
-// - cluster setting changes.
-// - zone configuration changes.
+// - Job-related initiation or termination
+// - [Cluster setting](cluster-settings.html) changes
+// - [Zone configuration](configure-replication-zones.html) changes
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerOps) VFatalf(ctx context.Context, level Level, format string, args ...interface{}) {
@@ -1305,19 +1342,19 @@ func (loggerOps) VFatalf(ctx context.Context, level Level, format string, args .
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The OPS channel is the channel used to report "point" operational events,
+// The `OPS` channel is used to report "point" operational events,
 // initiated by user operators or automation:
 //
-// - operator or system actions on server processes: process starts,
+// - Operator or system actions on server processes: process starts,
 //   stops, shutdowns, crashes (if they can be logged),
-//   including each time: command-line parameters, current version being run.
-// - actions that impact the topology of a cluster: node additions,
+//   including each time: command-line parameters, current version being run
+// - Actions that impact the topology of a cluster: node additions,
 //   removals, decommissions, etc.
-// - job-related initiation or termination.
-// - cluster setting changes.
-// - zone configuration changes.
+// - Job-related initiation or termination
+// - [Cluster setting](cluster-settings.html) changes
+// - [Zone configuration](configure-replication-zones.html) changes
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerOps) Fatal(ctx context.Context, msg string) {
@@ -1329,19 +1366,19 @@ func (loggerOps) Fatal(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The OPS channel is the channel used to report "point" operational events,
+// The `OPS` channel is used to report "point" operational events,
 // initiated by user operators or automation:
 //
-// - operator or system actions on server processes: process starts,
+// - Operator or system actions on server processes: process starts,
 //   stops, shutdowns, crashes (if they can be logged),
-//   including each time: command-line parameters, current version being run.
-// - actions that impact the topology of a cluster: node additions,
+//   including each time: command-line parameters, current version being run
+// - Actions that impact the topology of a cluster: node additions,
 //   removals, decommissions, etc.
-// - job-related initiation or termination.
-// - cluster setting changes.
-// - zone configuration changes.
+// - Job-related initiation or termination
+// - [Cluster setting](cluster-settings.html) changes
+// - [Zone configuration](configure-replication-zones.html) changes
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerOps) FatalfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
@@ -1351,17 +1388,17 @@ func (loggerOps) FatalfDepth(ctx context.Context, depth int, format string, args
 // Shout logs to channel OPS, and also to the real stderr if logging
 // is currently redirected to a file.
 //
-// The OPS channel is the channel used to report "point" operational events,
+// The `OPS` channel is used to report "point" operational events,
 // initiated by user operators or automation:
 //
-// - operator or system actions on server processes: process starts,
+// - Operator or system actions on server processes: process starts,
 //   stops, shutdowns, crashes (if they can be logged),
-//   including each time: command-line parameters, current version being run.
-// - actions that impact the topology of a cluster: node additions,
+//   including each time: command-line parameters, current version being run
+// - Actions that impact the topology of a cluster: node additions,
 //   removals, decommissions, etc.
-// - job-related initiation or termination.
-// - cluster setting changes.
-// - zone configuration changes.
+// - Job-related initiation or termination
+// - [Cluster setting](cluster-settings.html) changes
+// - [Zone configuration](configure-replication-zones.html) changes
 func (loggerOps) Shout(ctx context.Context, sev Severity, msg string) {
 	shoutfDepth(ctx, 1, sev, channel.OPS, msg)
 }
@@ -1370,17 +1407,17 @@ func (loggerOps) Shout(ctx context.Context, sev Severity, msg string) {
 // logging is currently redirected to a file. Arguments are handled in
 // the manner of fmt.Printf.
 //
-// The OPS channel is the channel used to report "point" operational events,
+// The `OPS` channel is used to report "point" operational events,
 // initiated by user operators or automation:
 //
-// - operator or system actions on server processes: process starts,
+// - Operator or system actions on server processes: process starts,
 //   stops, shutdowns, crashes (if they can be logged),
-//   including each time: command-line parameters, current version being run.
-// - actions that impact the topology of a cluster: node additions,
+//   including each time: command-line parameters, current version being run
+// - Actions that impact the topology of a cluster: node additions,
 //   removals, decommissions, etc.
-// - job-related initiation or termination.
-// - cluster setting changes.
-// - zone configuration changes.
+// - Job-related initiation or termination
+// - [Cluster setting](cluster-settings.html) changes
+// - [Zone configuration](configure-replication-zones.html) changes
 func (loggerOps) Shoutf(ctx context.Context, sev Severity, format string, args ...interface{}) {
 	shoutfDepth(ctx, 1, sev, channel.OPS, format, args...)
 }
@@ -1390,14 +1427,14 @@ type loggerHealth struct{}
 
 // Health is a logger that logs to the HEALTH channel.
 //
-// The HEALTH channel is the channel used to report "background" operational
+// The `HEALTH` channel is used to report "background" operational
 // events, initiated by CockroachDB or reporting on automatic processes:
 //
-// - current resource usage, including critical resource usage.
-// - node-node connection events, including connection errors and
-//   gossip details.
-// - range and table leasing events.
-// - up-, down-replication; range unavailability.
+// - Current resource usage, including critical resource usage
+// - Node-node connection events, including connection errors and
+//   gossip details
+// - Range and table leasing events
+// - Up- and down-replication, range unavailability
 var Health loggerHealth
 
 // Health and loggerHealth implement ChannelLogger.
@@ -1411,17 +1448,17 @@ var _ ChannelLogger = Health
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The HEALTH channel is the channel used to report "background" operational
+// The `HEALTH` channel is used to report "background" operational
 // events, initiated by CockroachDB or reporting on automatic processes:
 //
-// - current resource usage, including critical resource usage.
-// - node-node connection events, including connection errors and
-//   gossip details.
-// - range and table leasing events.
-// - up-, down-replication; range unavailability.
+// - Current resource usage, including critical resource usage
+// - Node-node connection events, including connection errors and
+//   gossip details
+// - Range and table leasing events
+// - Up- and down-replication, range unavailability
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerHealth) Infof(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.INFO, channel.HEALTH, format, args...)
 }
@@ -1432,17 +1469,17 @@ func (loggerHealth) Infof(ctx context.Context, format string, args ...interface{
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The HEALTH channel is the channel used to report "background" operational
+// The `HEALTH` channel is used to report "background" operational
 // events, initiated by CockroachDB or reporting on automatic processes:
 //
-// - current resource usage, including critical resource usage.
-// - node-node connection events, including connection errors and
-//   gossip details.
-// - range and table leasing events.
-// - up-, down-replication; range unavailability.
+// - Current resource usage, including critical resource usage
+// - Node-node connection events, including connection errors and
+//   gossip details
+// - Range and table leasing events
+// - Up- and down-replication, range unavailability
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerHealth) VInfof(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.INFO, channel.HEALTH, format, args...)
@@ -1453,17 +1490,17 @@ func (loggerHealth) VInfof(ctx context.Context, level Level, format string, args
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The HEALTH channel is the channel used to report "background" operational
+// The `HEALTH` channel is used to report "background" operational
 // events, initiated by CockroachDB or reporting on automatic processes:
 //
-// - current resource usage, including critical resource usage.
-// - node-node connection events, including connection errors and
-//   gossip details.
-// - range and table leasing events.
-// - up-, down-replication; range unavailability.
+// - Current resource usage, including critical resource usage
+// - Node-node connection events, including connection errors and
+//   gossip details
+// - Range and table leasing events
+// - Up- and down-replication, range unavailability
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerHealth) Info(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.INFO, channel.HEALTH, msg)
 }
@@ -1473,17 +1510,17 @@ func (loggerHealth) Info(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The HEALTH channel is the channel used to report "background" operational
+// The `HEALTH` channel is used to report "background" operational
 // events, initiated by CockroachDB or reporting on automatic processes:
 //
-// - current resource usage, including critical resource usage.
-// - node-node connection events, including connection errors and
-//   gossip details.
-// - range and table leasing events.
-// - up-, down-replication; range unavailability.
+// - Current resource usage, including critical resource usage
+// - Node-node connection events, including connection errors and
+//   gossip details
+// - Range and table leasing events
+// - Up- and down-replication, range unavailability
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerHealth) InfofDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.INFO, channel.HEALTH, format, args...)
 }
@@ -1492,17 +1529,17 @@ func (loggerHealth) InfofDepth(ctx context.Context, depth int, format string, ar
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The HEALTH channel is the channel used to report "background" operational
+// The `HEALTH` channel is used to report "background" operational
 // events, initiated by CockroachDB or reporting on automatic processes:
 //
-// - current resource usage, including critical resource usage.
-// - node-node connection events, including connection errors and
-//   gossip details.
-// - range and table leasing events.
-// - up-, down-replication; range unavailability.
+// - Current resource usage, including critical resource usage
+// - Node-node connection events, including connection errors and
+//   gossip details
+// - Range and table leasing events
+// - Up- and down-replication, range unavailability
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerHealth) Warningf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.WARNING, channel.HEALTH, format, args...)
 }
@@ -1513,17 +1550,17 @@ func (loggerHealth) Warningf(ctx context.Context, format string, args ...interfa
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The HEALTH channel is the channel used to report "background" operational
+// The `HEALTH` channel is used to report "background" operational
 // events, initiated by CockroachDB or reporting on automatic processes:
 //
-// - current resource usage, including critical resource usage.
-// - node-node connection events, including connection errors and
-//   gossip details.
-// - range and table leasing events.
-// - up-, down-replication; range unavailability.
+// - Current resource usage, including critical resource usage
+// - Node-node connection events, including connection errors and
+//   gossip details
+// - Range and table leasing events
+// - Up- and down-replication, range unavailability
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerHealth) VWarningf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.WARNING, channel.HEALTH, format, args...)
@@ -1534,17 +1571,17 @@ func (loggerHealth) VWarningf(ctx context.Context, level Level, format string, a
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The HEALTH channel is the channel used to report "background" operational
+// The `HEALTH` channel is used to report "background" operational
 // events, initiated by CockroachDB or reporting on automatic processes:
 //
-// - current resource usage, including critical resource usage.
-// - node-node connection events, including connection errors and
-//   gossip details.
-// - range and table leasing events.
-// - up-, down-replication; range unavailability.
+// - Current resource usage, including critical resource usage
+// - Node-node connection events, including connection errors and
+//   gossip details
+// - Range and table leasing events
+// - Up- and down-replication, range unavailability
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerHealth) Warning(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.WARNING, channel.HEALTH, msg)
 }
@@ -1554,17 +1591,17 @@ func (loggerHealth) Warning(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The HEALTH channel is the channel used to report "background" operational
+// The `HEALTH` channel is used to report "background" operational
 // events, initiated by CockroachDB or reporting on automatic processes:
 //
-// - current resource usage, including critical resource usage.
-// - node-node connection events, including connection errors and
-//   gossip details.
-// - range and table leasing events.
-// - up-, down-replication; range unavailability.
+// - Current resource usage, including critical resource usage
+// - Node-node connection events, including connection errors and
+//   gossip details
+// - Range and table leasing events
+// - Up- and down-replication, range unavailability
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerHealth) WarningfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.WARNING, channel.HEALTH, format, args...)
 }
@@ -1573,17 +1610,17 @@ func (loggerHealth) WarningfDepth(ctx context.Context, depth int, format string,
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The HEALTH channel is the channel used to report "background" operational
+// The `HEALTH` channel is used to report "background" operational
 // events, initiated by CockroachDB or reporting on automatic processes:
 //
-// - current resource usage, including critical resource usage.
-// - node-node connection events, including connection errors and
-//   gossip details.
-// - range and table leasing events.
-// - up-, down-replication; range unavailability.
+// - Current resource usage, including critical resource usage
+// - Node-node connection events, including connection errors and
+//   gossip details
+// - Range and table leasing events
+// - Up- and down-replication, range unavailability
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerHealth) Errorf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.ERROR, channel.HEALTH, format, args...)
@@ -1595,17 +1632,17 @@ func (loggerHealth) Errorf(ctx context.Context, format string, args ...interface
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The HEALTH channel is the channel used to report "background" operational
+// The `HEALTH` channel is used to report "background" operational
 // events, initiated by CockroachDB or reporting on automatic processes:
 //
-// - current resource usage, including critical resource usage.
-// - node-node connection events, including connection errors and
-//   gossip details.
-// - range and table leasing events.
-// - up-, down-replication; range unavailability.
+// - Current resource usage, including critical resource usage
+// - Node-node connection events, including connection errors and
+//   gossip details
+// - Range and table leasing events
+// - Up- and down-replication, range unavailability
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerHealth) VErrorf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
@@ -1617,17 +1654,17 @@ func (loggerHealth) VErrorf(ctx context.Context, level Level, format string, arg
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The HEALTH channel is the channel used to report "background" operational
+// The `HEALTH` channel is used to report "background" operational
 // events, initiated by CockroachDB or reporting on automatic processes:
 //
-// - current resource usage, including critical resource usage.
-// - node-node connection events, including connection errors and
-//   gossip details.
-// - range and table leasing events.
-// - up-, down-replication; range unavailability.
+// - Current resource usage, including critical resource usage
+// - Node-node connection events, including connection errors and
+//   gossip details
+// - Range and table leasing events
+// - Up- and down-replication, range unavailability
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerHealth) Error(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.ERROR, channel.HEALTH, msg)
@@ -1638,17 +1675,17 @@ func (loggerHealth) Error(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The HEALTH channel is the channel used to report "background" operational
+// The `HEALTH` channel is used to report "background" operational
 // events, initiated by CockroachDB or reporting on automatic processes:
 //
-// - current resource usage, including critical resource usage.
-// - node-node connection events, including connection errors and
-//   gossip details.
-// - range and table leasing events.
-// - up-, down-replication; range unavailability.
+// - Current resource usage, including critical resource usage
+// - Node-node connection events, including connection errors and
+//   gossip details
+// - Range and table leasing events
+// - Up- and down-replication, range unavailability
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerHealth) ErrorfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.ERROR, channel.HEALTH, format, args...)
@@ -1658,16 +1695,16 @@ func (loggerHealth) ErrorfDepth(ctx context.Context, depth int, format string, a
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The HEALTH channel is the channel used to report "background" operational
+// The `HEALTH` channel is used to report "background" operational
 // events, initiated by CockroachDB or reporting on automatic processes:
 //
-// - current resource usage, including critical resource usage.
-// - node-node connection events, including connection errors and
-//   gossip details.
-// - range and table leasing events.
-// - up-, down-replication; range unavailability.
+// - Current resource usage, including critical resource usage
+// - Node-node connection events, including connection errors and
+//   gossip details
+// - Range and table leasing events
+// - Up- and down-replication, range unavailability
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerHealth) Fatalf(ctx context.Context, format string, args ...interface{}) {
@@ -1680,16 +1717,16 @@ func (loggerHealth) Fatalf(ctx context.Context, format string, args ...interface
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The HEALTH channel is the channel used to report "background" operational
+// The `HEALTH` channel is used to report "background" operational
 // events, initiated by CockroachDB or reporting on automatic processes:
 //
-// - current resource usage, including critical resource usage.
-// - node-node connection events, including connection errors and
-//   gossip details.
-// - range and table leasing events.
-// - up-, down-replication; range unavailability.
+// - Current resource usage, including critical resource usage
+// - Node-node connection events, including connection errors and
+//   gossip details
+// - Range and table leasing events
+// - Up- and down-replication, range unavailability
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerHealth) VFatalf(ctx context.Context, level Level, format string, args ...interface{}) {
@@ -1702,16 +1739,16 @@ func (loggerHealth) VFatalf(ctx context.Context, level Level, format string, arg
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The HEALTH channel is the channel used to report "background" operational
+// The `HEALTH` channel is used to report "background" operational
 // events, initiated by CockroachDB or reporting on automatic processes:
 //
-// - current resource usage, including critical resource usage.
-// - node-node connection events, including connection errors and
-//   gossip details.
-// - range and table leasing events.
-// - up-, down-replication; range unavailability.
+// - Current resource usage, including critical resource usage
+// - Node-node connection events, including connection errors and
+//   gossip details
+// - Range and table leasing events
+// - Up- and down-replication, range unavailability
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerHealth) Fatal(ctx context.Context, msg string) {
@@ -1723,16 +1760,16 @@ func (loggerHealth) Fatal(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The HEALTH channel is the channel used to report "background" operational
+// The `HEALTH` channel is used to report "background" operational
 // events, initiated by CockroachDB or reporting on automatic processes:
 //
-// - current resource usage, including critical resource usage.
-// - node-node connection events, including connection errors and
-//   gossip details.
-// - range and table leasing events.
-// - up-, down-replication; range unavailability.
+// - Current resource usage, including critical resource usage
+// - Node-node connection events, including connection errors and
+//   gossip details
+// - Range and table leasing events
+// - Up- and down-replication, range unavailability
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerHealth) FatalfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
@@ -1742,14 +1779,14 @@ func (loggerHealth) FatalfDepth(ctx context.Context, depth int, format string, a
 // Shout logs to channel HEALTH, and also to the real stderr if logging
 // is currently redirected to a file.
 //
-// The HEALTH channel is the channel used to report "background" operational
+// The `HEALTH` channel is used to report "background" operational
 // events, initiated by CockroachDB or reporting on automatic processes:
 //
-// - current resource usage, including critical resource usage.
-// - node-node connection events, including connection errors and
-//   gossip details.
-// - range and table leasing events.
-// - up-, down-replication; range unavailability.
+// - Current resource usage, including critical resource usage
+// - Node-node connection events, including connection errors and
+//   gossip details
+// - Range and table leasing events
+// - Up- and down-replication, range unavailability
 func (loggerHealth) Shout(ctx context.Context, sev Severity, msg string) {
 	shoutfDepth(ctx, 1, sev, channel.HEALTH, msg)
 }
@@ -1758,14 +1795,14 @@ func (loggerHealth) Shout(ctx context.Context, sev Severity, msg string) {
 // logging is currently redirected to a file. Arguments are handled in
 // the manner of fmt.Printf.
 //
-// The HEALTH channel is the channel used to report "background" operational
+// The `HEALTH` channel is used to report "background" operational
 // events, initiated by CockroachDB or reporting on automatic processes:
 //
-// - current resource usage, including critical resource usage.
-// - node-node connection events, including connection errors and
-//   gossip details.
-// - range and table leasing events.
-// - up-, down-replication; range unavailability.
+// - Current resource usage, including critical resource usage
+// - Node-node connection events, including connection errors and
+//   gossip details
+// - Range and table leasing events
+// - Up- and down-replication, range unavailability
 func (loggerHealth) Shoutf(ctx context.Context, sev Severity, format string, args ...interface{}) {
 	shoutfDepth(ctx, 1, sev, channel.HEALTH, format, args...)
 }
@@ -1775,7 +1812,7 @@ type loggerStorage struct{}
 
 // Storage is a logger that logs to the STORAGE channel.
 //
-// The STORAGE channel is the channel used to report low-level storage
+// The `STORAGE` channel is used to report low-level storage
 // layer events (RocksDB/Pebble).
 var Storage loggerStorage
 
@@ -1790,11 +1827,11 @@ var _ ChannelLogger = Storage
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The STORAGE channel is the channel used to report low-level storage
+// The `STORAGE` channel is used to report low-level storage
 // layer events (RocksDB/Pebble).
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerStorage) Infof(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.INFO, channel.STORAGE, format, args...)
 }
@@ -1805,11 +1842,11 @@ func (loggerStorage) Infof(ctx context.Context, format string, args ...interface
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The STORAGE channel is the channel used to report low-level storage
+// The `STORAGE` channel is used to report low-level storage
 // layer events (RocksDB/Pebble).
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerStorage) VInfof(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.INFO, channel.STORAGE, format, args...)
@@ -1820,11 +1857,11 @@ func (loggerStorage) VInfof(ctx context.Context, level Level, format string, arg
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The STORAGE channel is the channel used to report low-level storage
+// The `STORAGE` channel is used to report low-level storage
 // layer events (RocksDB/Pebble).
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerStorage) Info(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.INFO, channel.STORAGE, msg)
 }
@@ -1834,11 +1871,11 @@ func (loggerStorage) Info(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The STORAGE channel is the channel used to report low-level storage
+// The `STORAGE` channel is used to report low-level storage
 // layer events (RocksDB/Pebble).
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerStorage) InfofDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.INFO, channel.STORAGE, format, args...)
 }
@@ -1847,11 +1884,11 @@ func (loggerStorage) InfofDepth(ctx context.Context, depth int, format string, a
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The STORAGE channel is the channel used to report low-level storage
+// The `STORAGE` channel is used to report low-level storage
 // layer events (RocksDB/Pebble).
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerStorage) Warningf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.WARNING, channel.STORAGE, format, args...)
 }
@@ -1862,11 +1899,11 @@ func (loggerStorage) Warningf(ctx context.Context, format string, args ...interf
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The STORAGE channel is the channel used to report low-level storage
+// The `STORAGE` channel is used to report low-level storage
 // layer events (RocksDB/Pebble).
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerStorage) VWarningf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.WARNING, channel.STORAGE, format, args...)
@@ -1877,11 +1914,11 @@ func (loggerStorage) VWarningf(ctx context.Context, level Level, format string, 
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The STORAGE channel is the channel used to report low-level storage
+// The `STORAGE` channel is used to report low-level storage
 // layer events (RocksDB/Pebble).
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerStorage) Warning(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.WARNING, channel.STORAGE, msg)
 }
@@ -1891,11 +1928,11 @@ func (loggerStorage) Warning(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The STORAGE channel is the channel used to report low-level storage
+// The `STORAGE` channel is used to report low-level storage
 // layer events (RocksDB/Pebble).
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerStorage) WarningfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.WARNING, channel.STORAGE, format, args...)
 }
@@ -1904,11 +1941,11 @@ func (loggerStorage) WarningfDepth(ctx context.Context, depth int, format string
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The STORAGE channel is the channel used to report low-level storage
+// The `STORAGE` channel is used to report low-level storage
 // layer events (RocksDB/Pebble).
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerStorage) Errorf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.ERROR, channel.STORAGE, format, args...)
@@ -1920,11 +1957,11 @@ func (loggerStorage) Errorf(ctx context.Context, format string, args ...interfac
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The STORAGE channel is the channel used to report low-level storage
+// The `STORAGE` channel is used to report low-level storage
 // layer events (RocksDB/Pebble).
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerStorage) VErrorf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
@@ -1936,11 +1973,11 @@ func (loggerStorage) VErrorf(ctx context.Context, level Level, format string, ar
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The STORAGE channel is the channel used to report low-level storage
+// The `STORAGE` channel is used to report low-level storage
 // layer events (RocksDB/Pebble).
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerStorage) Error(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.ERROR, channel.STORAGE, msg)
@@ -1951,11 +1988,11 @@ func (loggerStorage) Error(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The STORAGE channel is the channel used to report low-level storage
+// The `STORAGE` channel is used to report low-level storage
 // layer events (RocksDB/Pebble).
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerStorage) ErrorfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.ERROR, channel.STORAGE, format, args...)
@@ -1965,10 +2002,10 @@ func (loggerStorage) ErrorfDepth(ctx context.Context, depth int, format string, 
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The STORAGE channel is the channel used to report low-level storage
+// The `STORAGE` channel is used to report low-level storage
 // layer events (RocksDB/Pebble).
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerStorage) Fatalf(ctx context.Context, format string, args ...interface{}) {
@@ -1981,10 +2018,10 @@ func (loggerStorage) Fatalf(ctx context.Context, format string, args ...interfac
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The STORAGE channel is the channel used to report low-level storage
+// The `STORAGE` channel is used to report low-level storage
 // layer events (RocksDB/Pebble).
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerStorage) VFatalf(ctx context.Context, level Level, format string, args ...interface{}) {
@@ -1997,10 +2034,10 @@ func (loggerStorage) VFatalf(ctx context.Context, level Level, format string, ar
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The STORAGE channel is the channel used to report low-level storage
+// The `STORAGE` channel is used to report low-level storage
 // layer events (RocksDB/Pebble).
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerStorage) Fatal(ctx context.Context, msg string) {
@@ -2012,10 +2049,10 @@ func (loggerStorage) Fatal(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The STORAGE channel is the channel used to report low-level storage
+// The `STORAGE` channel is used to report low-level storage
 // layer events (RocksDB/Pebble).
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerStorage) FatalfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
@@ -2025,7 +2062,7 @@ func (loggerStorage) FatalfDepth(ctx context.Context, depth int, format string, 
 // Shout logs to channel STORAGE, and also to the real stderr if logging
 // is currently redirected to a file.
 //
-// The STORAGE channel is the channel used to report low-level storage
+// The `STORAGE` channel is used to report low-level storage
 // layer events (RocksDB/Pebble).
 func (loggerStorage) Shout(ctx context.Context, sev Severity, msg string) {
 	shoutfDepth(ctx, 1, sev, channel.STORAGE, msg)
@@ -2035,7 +2072,7 @@ func (loggerStorage) Shout(ctx context.Context, sev Severity, msg string) {
 // logging is currently redirected to a file. Arguments are handled in
 // the manner of fmt.Printf.
 //
-// The STORAGE channel is the channel used to report low-level storage
+// The `STORAGE` channel is used to report low-level storage
 // layer events (RocksDB/Pebble).
 func (loggerStorage) Shoutf(ctx context.Context, sev Severity, format string, args ...interface{}) {
 	shoutfDepth(ctx, 1, sev, channel.STORAGE, format, args...)
@@ -2046,11 +2083,14 @@ type loggerSessions struct{}
 
 // Sessions is a logger that logs to the SESSIONS channel.
 //
-// The SESSIONS channel is the channel used to report client network activity:
+// The `SESSIONS` channel is used to report client network activity when enabled via
+// the `server.auth_log.sql_connections.enabled` and/or
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
+// [cluster settings](cluster-settings.html):
 //
-// - connections opened/closed.
-// - authentication events: logins, failed attempts.
-// - session and query cancellation.
+// - Connections opened/closed
+// - Authentication events: logins, failed attempts
+// - Session and query cancellation
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
@@ -2067,17 +2107,20 @@ var _ ChannelLogger = Sessions
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SESSIONS channel is the channel used to report client network activity:
+// The `SESSIONS` channel is used to report client network activity when enabled via
+// the `server.auth_log.sql_connections.enabled` and/or
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
+// [cluster settings](cluster-settings.html):
 //
-// - connections opened/closed.
-// - authentication events: logins, failed attempts.
-// - session and query cancellation.
+// - Connections opened/closed
+// - Authentication events: logins, failed attempts
+// - Session and query cancellation
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerSessions) Infof(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.INFO, channel.SESSIONS, format, args...)
 }
@@ -2088,17 +2131,20 @@ func (loggerSessions) Infof(ctx context.Context, format string, args ...interfac
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SESSIONS channel is the channel used to report client network activity:
+// The `SESSIONS` channel is used to report client network activity when enabled via
+// the `server.auth_log.sql_connections.enabled` and/or
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
+// [cluster settings](cluster-settings.html):
 //
-// - connections opened/closed.
-// - authentication events: logins, failed attempts.
-// - session and query cancellation.
+// - Connections opened/closed
+// - Authentication events: logins, failed attempts
+// - Session and query cancellation
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerSessions) VInfof(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.INFO, channel.SESSIONS, format, args...)
@@ -2109,17 +2155,20 @@ func (loggerSessions) VInfof(ctx context.Context, level Level, format string, ar
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The SESSIONS channel is the channel used to report client network activity:
+// The `SESSIONS` channel is used to report client network activity when enabled via
+// the `server.auth_log.sql_connections.enabled` and/or
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
+// [cluster settings](cluster-settings.html):
 //
-// - connections opened/closed.
-// - authentication events: logins, failed attempts.
-// - session and query cancellation.
+// - Connections opened/closed
+// - Authentication events: logins, failed attempts
+// - Session and query cancellation
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerSessions) Info(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.INFO, channel.SESSIONS, msg)
 }
@@ -2129,17 +2178,20 @@ func (loggerSessions) Info(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SESSIONS channel is the channel used to report client network activity:
+// The `SESSIONS` channel is used to report client network activity when enabled via
+// the `server.auth_log.sql_connections.enabled` and/or
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
+// [cluster settings](cluster-settings.html):
 //
-// - connections opened/closed.
-// - authentication events: logins, failed attempts.
-// - session and query cancellation.
+// - Connections opened/closed
+// - Authentication events: logins, failed attempts
+// - Session and query cancellation
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerSessions) InfofDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.INFO, channel.SESSIONS, format, args...)
 }
@@ -2148,17 +2200,20 @@ func (loggerSessions) InfofDepth(ctx context.Context, depth int, format string, 
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SESSIONS channel is the channel used to report client network activity:
+// The `SESSIONS` channel is used to report client network activity when enabled via
+// the `server.auth_log.sql_connections.enabled` and/or
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
+// [cluster settings](cluster-settings.html):
 //
-// - connections opened/closed.
-// - authentication events: logins, failed attempts.
-// - session and query cancellation.
+// - Connections opened/closed
+// - Authentication events: logins, failed attempts
+// - Session and query cancellation
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerSessions) Warningf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.WARNING, channel.SESSIONS, format, args...)
 }
@@ -2169,17 +2224,20 @@ func (loggerSessions) Warningf(ctx context.Context, format string, args ...inter
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SESSIONS channel is the channel used to report client network activity:
+// The `SESSIONS` channel is used to report client network activity when enabled via
+// the `server.auth_log.sql_connections.enabled` and/or
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
+// [cluster settings](cluster-settings.html):
 //
-// - connections opened/closed.
-// - authentication events: logins, failed attempts.
-// - session and query cancellation.
+// - Connections opened/closed
+// - Authentication events: logins, failed attempts
+// - Session and query cancellation
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerSessions) VWarningf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.WARNING, channel.SESSIONS, format, args...)
@@ -2190,17 +2248,20 @@ func (loggerSessions) VWarningf(ctx context.Context, level Level, format string,
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The SESSIONS channel is the channel used to report client network activity:
+// The `SESSIONS` channel is used to report client network activity when enabled via
+// the `server.auth_log.sql_connections.enabled` and/or
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
+// [cluster settings](cluster-settings.html):
 //
-// - connections opened/closed.
-// - authentication events: logins, failed attempts.
-// - session and query cancellation.
+// - Connections opened/closed
+// - Authentication events: logins, failed attempts
+// - Session and query cancellation
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerSessions) Warning(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.WARNING, channel.SESSIONS, msg)
 }
@@ -2210,17 +2271,20 @@ func (loggerSessions) Warning(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SESSIONS channel is the channel used to report client network activity:
+// The `SESSIONS` channel is used to report client network activity when enabled via
+// the `server.auth_log.sql_connections.enabled` and/or
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
+// [cluster settings](cluster-settings.html):
 //
-// - connections opened/closed.
-// - authentication events: logins, failed attempts.
-// - session and query cancellation.
+// - Connections opened/closed
+// - Authentication events: logins, failed attempts
+// - Session and query cancellation
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerSessions) WarningfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.WARNING, channel.SESSIONS, format, args...)
 }
@@ -2229,17 +2293,20 @@ func (loggerSessions) WarningfDepth(ctx context.Context, depth int, format strin
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SESSIONS channel is the channel used to report client network activity:
+// The `SESSIONS` channel is used to report client network activity when enabled via
+// the `server.auth_log.sql_connections.enabled` and/or
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
+// [cluster settings](cluster-settings.html):
 //
-// - connections opened/closed.
-// - authentication events: logins, failed attempts.
-// - session and query cancellation.
+// - Connections opened/closed
+// - Authentication events: logins, failed attempts
+// - Session and query cancellation
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSessions) Errorf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.ERROR, channel.SESSIONS, format, args...)
@@ -2251,17 +2318,20 @@ func (loggerSessions) Errorf(ctx context.Context, format string, args ...interfa
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SESSIONS channel is the channel used to report client network activity:
+// The `SESSIONS` channel is used to report client network activity when enabled via
+// the `server.auth_log.sql_connections.enabled` and/or
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
+// [cluster settings](cluster-settings.html):
 //
-// - connections opened/closed.
-// - authentication events: logins, failed attempts.
-// - session and query cancellation.
+// - Connections opened/closed
+// - Authentication events: logins, failed attempts
+// - Session and query cancellation
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSessions) VErrorf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
@@ -2273,17 +2343,20 @@ func (loggerSessions) VErrorf(ctx context.Context, level Level, format string, a
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The SESSIONS channel is the channel used to report client network activity:
+// The `SESSIONS` channel is used to report client network activity when enabled via
+// the `server.auth_log.sql_connections.enabled` and/or
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
+// [cluster settings](cluster-settings.html):
 //
-// - connections opened/closed.
-// - authentication events: logins, failed attempts.
-// - session and query cancellation.
+// - Connections opened/closed
+// - Authentication events: logins, failed attempts
+// - Session and query cancellation
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSessions) Error(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.ERROR, channel.SESSIONS, msg)
@@ -2294,17 +2367,20 @@ func (loggerSessions) Error(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SESSIONS channel is the channel used to report client network activity:
+// The `SESSIONS` channel is used to report client network activity when enabled via
+// the `server.auth_log.sql_connections.enabled` and/or
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
+// [cluster settings](cluster-settings.html):
 //
-// - connections opened/closed.
-// - authentication events: logins, failed attempts.
-// - session and query cancellation.
+// - Connections opened/closed
+// - Authentication events: logins, failed attempts
+// - Session and query cancellation
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSessions) ErrorfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.ERROR, channel.SESSIONS, format, args...)
@@ -2314,16 +2390,19 @@ func (loggerSessions) ErrorfDepth(ctx context.Context, depth int, format string,
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SESSIONS channel is the channel used to report client network activity:
+// The `SESSIONS` channel is used to report client network activity when enabled via
+// the `server.auth_log.sql_connections.enabled` and/or
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
+// [cluster settings](cluster-settings.html):
 //
-// - connections opened/closed.
-// - authentication events: logins, failed attempts.
-// - session and query cancellation.
+// - Connections opened/closed
+// - Authentication events: logins, failed attempts
+// - Session and query cancellation
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSessions) Fatalf(ctx context.Context, format string, args ...interface{}) {
@@ -2336,16 +2415,19 @@ func (loggerSessions) Fatalf(ctx context.Context, format string, args ...interfa
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SESSIONS channel is the channel used to report client network activity:
+// The `SESSIONS` channel is used to report client network activity when enabled via
+// the `server.auth_log.sql_connections.enabled` and/or
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
+// [cluster settings](cluster-settings.html):
 //
-// - connections opened/closed.
-// - authentication events: logins, failed attempts.
-// - session and query cancellation.
+// - Connections opened/closed
+// - Authentication events: logins, failed attempts
+// - Session and query cancellation
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSessions) VFatalf(ctx context.Context, level Level, format string, args ...interface{}) {
@@ -2358,16 +2440,19 @@ func (loggerSessions) VFatalf(ctx context.Context, level Level, format string, a
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The SESSIONS channel is the channel used to report client network activity:
+// The `SESSIONS` channel is used to report client network activity when enabled via
+// the `server.auth_log.sql_connections.enabled` and/or
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
+// [cluster settings](cluster-settings.html):
 //
-// - connections opened/closed.
-// - authentication events: logins, failed attempts.
-// - session and query cancellation.
+// - Connections opened/closed
+// - Authentication events: logins, failed attempts
+// - Session and query cancellation
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSessions) Fatal(ctx context.Context, msg string) {
@@ -2379,16 +2464,19 @@ func (loggerSessions) Fatal(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SESSIONS channel is the channel used to report client network activity:
+// The `SESSIONS` channel is used to report client network activity when enabled via
+// the `server.auth_log.sql_connections.enabled` and/or
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
+// [cluster settings](cluster-settings.html):
 //
-// - connections opened/closed.
-// - authentication events: logins, failed attempts.
-// - session and query cancellation.
+// - Connections opened/closed
+// - Authentication events: logins, failed attempts
+// - Session and query cancellation
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSessions) FatalfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
@@ -2398,11 +2486,14 @@ func (loggerSessions) FatalfDepth(ctx context.Context, depth int, format string,
 // Shout logs to channel SESSIONS, and also to the real stderr if logging
 // is currently redirected to a file.
 //
-// The SESSIONS channel is the channel used to report client network activity:
+// The `SESSIONS` channel is used to report client network activity when enabled via
+// the `server.auth_log.sql_connections.enabled` and/or
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
+// [cluster settings](cluster-settings.html):
 //
-// - connections opened/closed.
-// - authentication events: logins, failed attempts.
-// - session and query cancellation.
+// - Connections opened/closed
+// - Authentication events: logins, failed attempts
+// - Session and query cancellation
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
@@ -2414,11 +2505,14 @@ func (loggerSessions) Shout(ctx context.Context, sev Severity, msg string) {
 // logging is currently redirected to a file. Arguments are handled in
 // the manner of fmt.Printf.
 //
-// The SESSIONS channel is the channel used to report client network activity:
+// The `SESSIONS` channel is used to report client network activity when enabled via
+// the `server.auth_log.sql_connections.enabled` and/or
+// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
+// [cluster settings](cluster-settings.html):
 //
-// - connections opened/closed.
-// - authentication events: logins, failed attempts.
-// - session and query cancellation.
+// - Connections opened/closed
+// - Authentication events: logins, failed attempts
+// - Session and query cancellation
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
@@ -2431,18 +2525,18 @@ type loggerSqlSchema struct{}
 
 // SqlSchema is a logger that logs to the SQL_SCHEMA channel.
 //
-// The SQL_SCHEMA channel is the channel used to report changes to the
+// The `SQL_SCHEMA` channel is used to report changes to the
 // SQL logical schema, excluding privilege and ownership changes
-// (which are reported on the separate channel PRIVILEGES) and
-// zone config changes (which go to OPS).
+// (which are reported separately on the `PRIVILEGES` channel) and
+// zone configuration changes (which go to the `OPS` channel).
 //
 // This includes:
 //
-// - database/schema/table/sequence/view/type creation
-// - adding/removing/changing table columns
-// - changing sequence parameters
+// - Database/schema/table/sequence/view/type creation
+// - Adding/removing/changing table columns
+// - Changing sequence parameters
 //
-// etc., more generally changes to the schema that affect the
+// `SQL_SCHEMA` events generally comprise changes to the schema that affect the
 // functional behavior of client apps using stored objects.
 var SqlSchema loggerSqlSchema
 
@@ -2457,22 +2551,22 @@ var _ ChannelLogger = SqlSchema
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_SCHEMA channel is the channel used to report changes to the
+// The `SQL_SCHEMA` channel is used to report changes to the
 // SQL logical schema, excluding privilege and ownership changes
-// (which are reported on the separate channel PRIVILEGES) and
-// zone config changes (which go to OPS).
+// (which are reported separately on the `PRIVILEGES` channel) and
+// zone configuration changes (which go to the `OPS` channel).
 //
 // This includes:
 //
-// - database/schema/table/sequence/view/type creation
-// - adding/removing/changing table columns
-// - changing sequence parameters
+// - Database/schema/table/sequence/view/type creation
+// - Adding/removing/changing table columns
+// - Changing sequence parameters
 //
-// etc., more generally changes to the schema that affect the
+// `SQL_SCHEMA` events generally comprise changes to the schema that affect the
 // functional behavior of client apps using stored objects.
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerSqlSchema) Infof(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.INFO, channel.SQL_SCHEMA, format, args...)
 }
@@ -2483,22 +2577,22 @@ func (loggerSqlSchema) Infof(ctx context.Context, format string, args ...interfa
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_SCHEMA channel is the channel used to report changes to the
+// The `SQL_SCHEMA` channel is used to report changes to the
 // SQL logical schema, excluding privilege and ownership changes
-// (which are reported on the separate channel PRIVILEGES) and
-// zone config changes (which go to OPS).
+// (which are reported separately on the `PRIVILEGES` channel) and
+// zone configuration changes (which go to the `OPS` channel).
 //
 // This includes:
 //
-// - database/schema/table/sequence/view/type creation
-// - adding/removing/changing table columns
-// - changing sequence parameters
+// - Database/schema/table/sequence/view/type creation
+// - Adding/removing/changing table columns
+// - Changing sequence parameters
 //
-// etc., more generally changes to the schema that affect the
+// `SQL_SCHEMA` events generally comprise changes to the schema that affect the
 // functional behavior of client apps using stored objects.
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerSqlSchema) VInfof(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.INFO, channel.SQL_SCHEMA, format, args...)
@@ -2509,22 +2603,22 @@ func (loggerSqlSchema) VInfof(ctx context.Context, level Level, format string, a
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The SQL_SCHEMA channel is the channel used to report changes to the
+// The `SQL_SCHEMA` channel is used to report changes to the
 // SQL logical schema, excluding privilege and ownership changes
-// (which are reported on the separate channel PRIVILEGES) and
-// zone config changes (which go to OPS).
+// (which are reported separately on the `PRIVILEGES` channel) and
+// zone configuration changes (which go to the `OPS` channel).
 //
 // This includes:
 //
-// - database/schema/table/sequence/view/type creation
-// - adding/removing/changing table columns
-// - changing sequence parameters
+// - Database/schema/table/sequence/view/type creation
+// - Adding/removing/changing table columns
+// - Changing sequence parameters
 //
-// etc., more generally changes to the schema that affect the
+// `SQL_SCHEMA` events generally comprise changes to the schema that affect the
 // functional behavior of client apps using stored objects.
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerSqlSchema) Info(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.INFO, channel.SQL_SCHEMA, msg)
 }
@@ -2534,22 +2628,22 @@ func (loggerSqlSchema) Info(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_SCHEMA channel is the channel used to report changes to the
+// The `SQL_SCHEMA` channel is used to report changes to the
 // SQL logical schema, excluding privilege and ownership changes
-// (which are reported on the separate channel PRIVILEGES) and
-// zone config changes (which go to OPS).
+// (which are reported separately on the `PRIVILEGES` channel) and
+// zone configuration changes (which go to the `OPS` channel).
 //
 // This includes:
 //
-// - database/schema/table/sequence/view/type creation
-// - adding/removing/changing table columns
-// - changing sequence parameters
+// - Database/schema/table/sequence/view/type creation
+// - Adding/removing/changing table columns
+// - Changing sequence parameters
 //
-// etc., more generally changes to the schema that affect the
+// `SQL_SCHEMA` events generally comprise changes to the schema that affect the
 // functional behavior of client apps using stored objects.
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerSqlSchema) InfofDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.INFO, channel.SQL_SCHEMA, format, args...)
 }
@@ -2558,22 +2652,22 @@ func (loggerSqlSchema) InfofDepth(ctx context.Context, depth int, format string,
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_SCHEMA channel is the channel used to report changes to the
+// The `SQL_SCHEMA` channel is used to report changes to the
 // SQL logical schema, excluding privilege and ownership changes
-// (which are reported on the separate channel PRIVILEGES) and
-// zone config changes (which go to OPS).
+// (which are reported separately on the `PRIVILEGES` channel) and
+// zone configuration changes (which go to the `OPS` channel).
 //
 // This includes:
 //
-// - database/schema/table/sequence/view/type creation
-// - adding/removing/changing table columns
-// - changing sequence parameters
+// - Database/schema/table/sequence/view/type creation
+// - Adding/removing/changing table columns
+// - Changing sequence parameters
 //
-// etc., more generally changes to the schema that affect the
+// `SQL_SCHEMA` events generally comprise changes to the schema that affect the
 // functional behavior of client apps using stored objects.
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerSqlSchema) Warningf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.WARNING, channel.SQL_SCHEMA, format, args...)
 }
@@ -2584,22 +2678,22 @@ func (loggerSqlSchema) Warningf(ctx context.Context, format string, args ...inte
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_SCHEMA channel is the channel used to report changes to the
+// The `SQL_SCHEMA` channel is used to report changes to the
 // SQL logical schema, excluding privilege and ownership changes
-// (which are reported on the separate channel PRIVILEGES) and
-// zone config changes (which go to OPS).
+// (which are reported separately on the `PRIVILEGES` channel) and
+// zone configuration changes (which go to the `OPS` channel).
 //
 // This includes:
 //
-// - database/schema/table/sequence/view/type creation
-// - adding/removing/changing table columns
-// - changing sequence parameters
+// - Database/schema/table/sequence/view/type creation
+// - Adding/removing/changing table columns
+// - Changing sequence parameters
 //
-// etc., more generally changes to the schema that affect the
+// `SQL_SCHEMA` events generally comprise changes to the schema that affect the
 // functional behavior of client apps using stored objects.
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerSqlSchema) VWarningf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.WARNING, channel.SQL_SCHEMA, format, args...)
@@ -2610,22 +2704,22 @@ func (loggerSqlSchema) VWarningf(ctx context.Context, level Level, format string
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The SQL_SCHEMA channel is the channel used to report changes to the
+// The `SQL_SCHEMA` channel is used to report changes to the
 // SQL logical schema, excluding privilege and ownership changes
-// (which are reported on the separate channel PRIVILEGES) and
-// zone config changes (which go to OPS).
+// (which are reported separately on the `PRIVILEGES` channel) and
+// zone configuration changes (which go to the `OPS` channel).
 //
 // This includes:
 //
-// - database/schema/table/sequence/view/type creation
-// - adding/removing/changing table columns
-// - changing sequence parameters
+// - Database/schema/table/sequence/view/type creation
+// - Adding/removing/changing table columns
+// - Changing sequence parameters
 //
-// etc., more generally changes to the schema that affect the
+// `SQL_SCHEMA` events generally comprise changes to the schema that affect the
 // functional behavior of client apps using stored objects.
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerSqlSchema) Warning(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.WARNING, channel.SQL_SCHEMA, msg)
 }
@@ -2635,22 +2729,22 @@ func (loggerSqlSchema) Warning(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_SCHEMA channel is the channel used to report changes to the
+// The `SQL_SCHEMA` channel is used to report changes to the
 // SQL logical schema, excluding privilege and ownership changes
-// (which are reported on the separate channel PRIVILEGES) and
-// zone config changes (which go to OPS).
+// (which are reported separately on the `PRIVILEGES` channel) and
+// zone configuration changes (which go to the `OPS` channel).
 //
 // This includes:
 //
-// - database/schema/table/sequence/view/type creation
-// - adding/removing/changing table columns
-// - changing sequence parameters
+// - Database/schema/table/sequence/view/type creation
+// - Adding/removing/changing table columns
+// - Changing sequence parameters
 //
-// etc., more generally changes to the schema that affect the
+// `SQL_SCHEMA` events generally comprise changes to the schema that affect the
 // functional behavior of client apps using stored objects.
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerSqlSchema) WarningfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.WARNING, channel.SQL_SCHEMA, format, args...)
 }
@@ -2659,22 +2753,22 @@ func (loggerSqlSchema) WarningfDepth(ctx context.Context, depth int, format stri
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_SCHEMA channel is the channel used to report changes to the
+// The `SQL_SCHEMA` channel is used to report changes to the
 // SQL logical schema, excluding privilege and ownership changes
-// (which are reported on the separate channel PRIVILEGES) and
-// zone config changes (which go to OPS).
+// (which are reported separately on the `PRIVILEGES` channel) and
+// zone configuration changes (which go to the `OPS` channel).
 //
 // This includes:
 //
-// - database/schema/table/sequence/view/type creation
-// - adding/removing/changing table columns
-// - changing sequence parameters
+// - Database/schema/table/sequence/view/type creation
+// - Adding/removing/changing table columns
+// - Changing sequence parameters
 //
-// etc., more generally changes to the schema that affect the
+// `SQL_SCHEMA` events generally comprise changes to the schema that affect the
 // functional behavior of client apps using stored objects.
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSqlSchema) Errorf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.ERROR, channel.SQL_SCHEMA, format, args...)
@@ -2686,22 +2780,22 @@ func (loggerSqlSchema) Errorf(ctx context.Context, format string, args ...interf
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_SCHEMA channel is the channel used to report changes to the
+// The `SQL_SCHEMA` channel is used to report changes to the
 // SQL logical schema, excluding privilege and ownership changes
-// (which are reported on the separate channel PRIVILEGES) and
-// zone config changes (which go to OPS).
+// (which are reported separately on the `PRIVILEGES` channel) and
+// zone configuration changes (which go to the `OPS` channel).
 //
 // This includes:
 //
-// - database/schema/table/sequence/view/type creation
-// - adding/removing/changing table columns
-// - changing sequence parameters
+// - Database/schema/table/sequence/view/type creation
+// - Adding/removing/changing table columns
+// - Changing sequence parameters
 //
-// etc., more generally changes to the schema that affect the
+// `SQL_SCHEMA` events generally comprise changes to the schema that affect the
 // functional behavior of client apps using stored objects.
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSqlSchema) VErrorf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
@@ -2713,22 +2807,22 @@ func (loggerSqlSchema) VErrorf(ctx context.Context, level Level, format string, 
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The SQL_SCHEMA channel is the channel used to report changes to the
+// The `SQL_SCHEMA` channel is used to report changes to the
 // SQL logical schema, excluding privilege and ownership changes
-// (which are reported on the separate channel PRIVILEGES) and
-// zone config changes (which go to OPS).
+// (which are reported separately on the `PRIVILEGES` channel) and
+// zone configuration changes (which go to the `OPS` channel).
 //
 // This includes:
 //
-// - database/schema/table/sequence/view/type creation
-// - adding/removing/changing table columns
-// - changing sequence parameters
+// - Database/schema/table/sequence/view/type creation
+// - Adding/removing/changing table columns
+// - Changing sequence parameters
 //
-// etc., more generally changes to the schema that affect the
+// `SQL_SCHEMA` events generally comprise changes to the schema that affect the
 // functional behavior of client apps using stored objects.
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSqlSchema) Error(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.ERROR, channel.SQL_SCHEMA, msg)
@@ -2739,22 +2833,22 @@ func (loggerSqlSchema) Error(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_SCHEMA channel is the channel used to report changes to the
+// The `SQL_SCHEMA` channel is used to report changes to the
 // SQL logical schema, excluding privilege and ownership changes
-// (which are reported on the separate channel PRIVILEGES) and
-// zone config changes (which go to OPS).
+// (which are reported separately on the `PRIVILEGES` channel) and
+// zone configuration changes (which go to the `OPS` channel).
 //
 // This includes:
 //
-// - database/schema/table/sequence/view/type creation
-// - adding/removing/changing table columns
-// - changing sequence parameters
+// - Database/schema/table/sequence/view/type creation
+// - Adding/removing/changing table columns
+// - Changing sequence parameters
 //
-// etc., more generally changes to the schema that affect the
+// `SQL_SCHEMA` events generally comprise changes to the schema that affect the
 // functional behavior of client apps using stored objects.
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSqlSchema) ErrorfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.ERROR, channel.SQL_SCHEMA, format, args...)
@@ -2764,21 +2858,21 @@ func (loggerSqlSchema) ErrorfDepth(ctx context.Context, depth int, format string
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_SCHEMA channel is the channel used to report changes to the
+// The `SQL_SCHEMA` channel is used to report changes to the
 // SQL logical schema, excluding privilege and ownership changes
-// (which are reported on the separate channel PRIVILEGES) and
-// zone config changes (which go to OPS).
+// (which are reported separately on the `PRIVILEGES` channel) and
+// zone configuration changes (which go to the `OPS` channel).
 //
 // This includes:
 //
-// - database/schema/table/sequence/view/type creation
-// - adding/removing/changing table columns
-// - changing sequence parameters
+// - Database/schema/table/sequence/view/type creation
+// - Adding/removing/changing table columns
+// - Changing sequence parameters
 //
-// etc., more generally changes to the schema that affect the
+// `SQL_SCHEMA` events generally comprise changes to the schema that affect the
 // functional behavior of client apps using stored objects.
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSqlSchema) Fatalf(ctx context.Context, format string, args ...interface{}) {
@@ -2791,21 +2885,21 @@ func (loggerSqlSchema) Fatalf(ctx context.Context, format string, args ...interf
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_SCHEMA channel is the channel used to report changes to the
+// The `SQL_SCHEMA` channel is used to report changes to the
 // SQL logical schema, excluding privilege and ownership changes
-// (which are reported on the separate channel PRIVILEGES) and
-// zone config changes (which go to OPS).
+// (which are reported separately on the `PRIVILEGES` channel) and
+// zone configuration changes (which go to the `OPS` channel).
 //
 // This includes:
 //
-// - database/schema/table/sequence/view/type creation
-// - adding/removing/changing table columns
-// - changing sequence parameters
+// - Database/schema/table/sequence/view/type creation
+// - Adding/removing/changing table columns
+// - Changing sequence parameters
 //
-// etc., more generally changes to the schema that affect the
+// `SQL_SCHEMA` events generally comprise changes to the schema that affect the
 // functional behavior of client apps using stored objects.
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSqlSchema) VFatalf(ctx context.Context, level Level, format string, args ...interface{}) {
@@ -2818,21 +2912,21 @@ func (loggerSqlSchema) VFatalf(ctx context.Context, level Level, format string, 
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The SQL_SCHEMA channel is the channel used to report changes to the
+// The `SQL_SCHEMA` channel is used to report changes to the
 // SQL logical schema, excluding privilege and ownership changes
-// (which are reported on the separate channel PRIVILEGES) and
-// zone config changes (which go to OPS).
+// (which are reported separately on the `PRIVILEGES` channel) and
+// zone configuration changes (which go to the `OPS` channel).
 //
 // This includes:
 //
-// - database/schema/table/sequence/view/type creation
-// - adding/removing/changing table columns
-// - changing sequence parameters
+// - Database/schema/table/sequence/view/type creation
+// - Adding/removing/changing table columns
+// - Changing sequence parameters
 //
-// etc., more generally changes to the schema that affect the
+// `SQL_SCHEMA` events generally comprise changes to the schema that affect the
 // functional behavior of client apps using stored objects.
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSqlSchema) Fatal(ctx context.Context, msg string) {
@@ -2844,21 +2938,21 @@ func (loggerSqlSchema) Fatal(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_SCHEMA channel is the channel used to report changes to the
+// The `SQL_SCHEMA` channel is used to report changes to the
 // SQL logical schema, excluding privilege and ownership changes
-// (which are reported on the separate channel PRIVILEGES) and
-// zone config changes (which go to OPS).
+// (which are reported separately on the `PRIVILEGES` channel) and
+// zone configuration changes (which go to the `OPS` channel).
 //
 // This includes:
 //
-// - database/schema/table/sequence/view/type creation
-// - adding/removing/changing table columns
-// - changing sequence parameters
+// - Database/schema/table/sequence/view/type creation
+// - Adding/removing/changing table columns
+// - Changing sequence parameters
 //
-// etc., more generally changes to the schema that affect the
+// `SQL_SCHEMA` events generally comprise changes to the schema that affect the
 // functional behavior of client apps using stored objects.
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSqlSchema) FatalfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
@@ -2868,18 +2962,18 @@ func (loggerSqlSchema) FatalfDepth(ctx context.Context, depth int, format string
 // Shout logs to channel SQL_SCHEMA, and also to the real stderr if logging
 // is currently redirected to a file.
 //
-// The SQL_SCHEMA channel is the channel used to report changes to the
+// The `SQL_SCHEMA` channel is used to report changes to the
 // SQL logical schema, excluding privilege and ownership changes
-// (which are reported on the separate channel PRIVILEGES) and
-// zone config changes (which go to OPS).
+// (which are reported separately on the `PRIVILEGES` channel) and
+// zone configuration changes (which go to the `OPS` channel).
 //
 // This includes:
 //
-// - database/schema/table/sequence/view/type creation
-// - adding/removing/changing table columns
-// - changing sequence parameters
+// - Database/schema/table/sequence/view/type creation
+// - Adding/removing/changing table columns
+// - Changing sequence parameters
 //
-// etc., more generally changes to the schema that affect the
+// `SQL_SCHEMA` events generally comprise changes to the schema that affect the
 // functional behavior of client apps using stored objects.
 func (loggerSqlSchema) Shout(ctx context.Context, sev Severity, msg string) {
 	shoutfDepth(ctx, 1, sev, channel.SQL_SCHEMA, msg)
@@ -2889,18 +2983,18 @@ func (loggerSqlSchema) Shout(ctx context.Context, sev Severity, msg string) {
 // logging is currently redirected to a file. Arguments are handled in
 // the manner of fmt.Printf.
 //
-// The SQL_SCHEMA channel is the channel used to report changes to the
+// The `SQL_SCHEMA` channel is used to report changes to the
 // SQL logical schema, excluding privilege and ownership changes
-// (which are reported on the separate channel PRIVILEGES) and
-// zone config changes (which go to OPS).
+// (which are reported separately on the `PRIVILEGES` channel) and
+// zone configuration changes (which go to the `OPS` channel).
 //
 // This includes:
 //
-// - database/schema/table/sequence/view/type creation
-// - adding/removing/changing table columns
-// - changing sequence parameters
+// - Database/schema/table/sequence/view/type creation
+// - Adding/removing/changing table columns
+// - Changing sequence parameters
 //
-// etc., more generally changes to the schema that affect the
+// `SQL_SCHEMA` events generally comprise changes to the schema that affect the
 // functional behavior of client apps using stored objects.
 func (loggerSqlSchema) Shoutf(ctx context.Context, sev Severity, format string, args ...interface{}) {
 	shoutfDepth(ctx, 1, sev, channel.SQL_SCHEMA, format, args...)
@@ -2911,13 +3005,13 @@ type loggerUserAdmin struct{}
 
 // UserAdmin is a logger that logs to the USER_ADMIN channel.
 //
-// The USER_ADMIN channel is the channel used to report changes
+// The `USER_ADMIN` channel is used to report changes
 // in users and roles, including:
 //
-// - users added/dropped.
-// - changes to authentication credentials, incl passwords, validity etc.
-// - role grants/revocations.
-// - role option grants/revocations.
+// - Users added/dropped
+// - Changes to authentication credentials (e.g., passwords, validity, etc.)
+// - Role grants/revocations
+// - Role option grants/revocations
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
@@ -2934,19 +3028,19 @@ var _ ChannelLogger = UserAdmin
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The USER_ADMIN channel is the channel used to report changes
+// The `USER_ADMIN` channel is used to report changes
 // in users and roles, including:
 //
-// - users added/dropped.
-// - changes to authentication credentials, incl passwords, validity etc.
-// - role grants/revocations.
-// - role option grants/revocations.
+// - Users added/dropped
+// - Changes to authentication credentials (e.g., passwords, validity, etc.)
+// - Role grants/revocations
+// - Role option grants/revocations
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerUserAdmin) Infof(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.INFO, channel.USER_ADMIN, format, args...)
 }
@@ -2957,19 +3051,19 @@ func (loggerUserAdmin) Infof(ctx context.Context, format string, args ...interfa
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The USER_ADMIN channel is the channel used to report changes
+// The `USER_ADMIN` channel is used to report changes
 // in users and roles, including:
 //
-// - users added/dropped.
-// - changes to authentication credentials, incl passwords, validity etc.
-// - role grants/revocations.
-// - role option grants/revocations.
+// - Users added/dropped
+// - Changes to authentication credentials (e.g., passwords, validity, etc.)
+// - Role grants/revocations
+// - Role option grants/revocations
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerUserAdmin) VInfof(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.INFO, channel.USER_ADMIN, format, args...)
@@ -2980,19 +3074,19 @@ func (loggerUserAdmin) VInfof(ctx context.Context, level Level, format string, a
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The USER_ADMIN channel is the channel used to report changes
+// The `USER_ADMIN` channel is used to report changes
 // in users and roles, including:
 //
-// - users added/dropped.
-// - changes to authentication credentials, incl passwords, validity etc.
-// - role grants/revocations.
-// - role option grants/revocations.
+// - Users added/dropped
+// - Changes to authentication credentials (e.g., passwords, validity, etc.)
+// - Role grants/revocations
+// - Role option grants/revocations
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerUserAdmin) Info(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.INFO, channel.USER_ADMIN, msg)
 }
@@ -3002,19 +3096,19 @@ func (loggerUserAdmin) Info(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The USER_ADMIN channel is the channel used to report changes
+// The `USER_ADMIN` channel is used to report changes
 // in users and roles, including:
 //
-// - users added/dropped.
-// - changes to authentication credentials, incl passwords, validity etc.
-// - role grants/revocations.
-// - role option grants/revocations.
+// - Users added/dropped
+// - Changes to authentication credentials (e.g., passwords, validity, etc.)
+// - Role grants/revocations
+// - Role option grants/revocations
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerUserAdmin) InfofDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.INFO, channel.USER_ADMIN, format, args...)
 }
@@ -3023,19 +3117,19 @@ func (loggerUserAdmin) InfofDepth(ctx context.Context, depth int, format string,
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The USER_ADMIN channel is the channel used to report changes
+// The `USER_ADMIN` channel is used to report changes
 // in users and roles, including:
 //
-// - users added/dropped.
-// - changes to authentication credentials, incl passwords, validity etc.
-// - role grants/revocations.
-// - role option grants/revocations.
+// - Users added/dropped
+// - Changes to authentication credentials (e.g., passwords, validity, etc.)
+// - Role grants/revocations
+// - Role option grants/revocations
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerUserAdmin) Warningf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.WARNING, channel.USER_ADMIN, format, args...)
 }
@@ -3046,19 +3140,19 @@ func (loggerUserAdmin) Warningf(ctx context.Context, format string, args ...inte
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The USER_ADMIN channel is the channel used to report changes
+// The `USER_ADMIN` channel is used to report changes
 // in users and roles, including:
 //
-// - users added/dropped.
-// - changes to authentication credentials, incl passwords, validity etc.
-// - role grants/revocations.
-// - role option grants/revocations.
+// - Users added/dropped
+// - Changes to authentication credentials (e.g., passwords, validity, etc.)
+// - Role grants/revocations
+// - Role option grants/revocations
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerUserAdmin) VWarningf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.WARNING, channel.USER_ADMIN, format, args...)
@@ -3069,19 +3163,19 @@ func (loggerUserAdmin) VWarningf(ctx context.Context, level Level, format string
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The USER_ADMIN channel is the channel used to report changes
+// The `USER_ADMIN` channel is used to report changes
 // in users and roles, including:
 //
-// - users added/dropped.
-// - changes to authentication credentials, incl passwords, validity etc.
-// - role grants/revocations.
-// - role option grants/revocations.
+// - Users added/dropped
+// - Changes to authentication credentials (e.g., passwords, validity, etc.)
+// - Role grants/revocations
+// - Role option grants/revocations
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerUserAdmin) Warning(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.WARNING, channel.USER_ADMIN, msg)
 }
@@ -3091,19 +3185,19 @@ func (loggerUserAdmin) Warning(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The USER_ADMIN channel is the channel used to report changes
+// The `USER_ADMIN` channel is used to report changes
 // in users and roles, including:
 //
-// - users added/dropped.
-// - changes to authentication credentials, incl passwords, validity etc.
-// - role grants/revocations.
-// - role option grants/revocations.
+// - Users added/dropped
+// - Changes to authentication credentials (e.g., passwords, validity, etc.)
+// - Role grants/revocations
+// - Role option grants/revocations
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerUserAdmin) WarningfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.WARNING, channel.USER_ADMIN, format, args...)
 }
@@ -3112,19 +3206,19 @@ func (loggerUserAdmin) WarningfDepth(ctx context.Context, depth int, format stri
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The USER_ADMIN channel is the channel used to report changes
+// The `USER_ADMIN` channel is used to report changes
 // in users and roles, including:
 //
-// - users added/dropped.
-// - changes to authentication credentials, incl passwords, validity etc.
-// - role grants/revocations.
-// - role option grants/revocations.
+// - Users added/dropped
+// - Changes to authentication credentials (e.g., passwords, validity, etc.)
+// - Role grants/revocations
+// - Role option grants/revocations
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerUserAdmin) Errorf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.ERROR, channel.USER_ADMIN, format, args...)
@@ -3136,19 +3230,19 @@ func (loggerUserAdmin) Errorf(ctx context.Context, format string, args ...interf
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The USER_ADMIN channel is the channel used to report changes
+// The `USER_ADMIN` channel is used to report changes
 // in users and roles, including:
 //
-// - users added/dropped.
-// - changes to authentication credentials, incl passwords, validity etc.
-// - role grants/revocations.
-// - role option grants/revocations.
+// - Users added/dropped
+// - Changes to authentication credentials (e.g., passwords, validity, etc.)
+// - Role grants/revocations
+// - Role option grants/revocations
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerUserAdmin) VErrorf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
@@ -3160,19 +3254,19 @@ func (loggerUserAdmin) VErrorf(ctx context.Context, level Level, format string, 
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The USER_ADMIN channel is the channel used to report changes
+// The `USER_ADMIN` channel is used to report changes
 // in users and roles, including:
 //
-// - users added/dropped.
-// - changes to authentication credentials, incl passwords, validity etc.
-// - role grants/revocations.
-// - role option grants/revocations.
+// - Users added/dropped
+// - Changes to authentication credentials (e.g., passwords, validity, etc.)
+// - Role grants/revocations
+// - Role option grants/revocations
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerUserAdmin) Error(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.ERROR, channel.USER_ADMIN, msg)
@@ -3183,19 +3277,19 @@ func (loggerUserAdmin) Error(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The USER_ADMIN channel is the channel used to report changes
+// The `USER_ADMIN` channel is used to report changes
 // in users and roles, including:
 //
-// - users added/dropped.
-// - changes to authentication credentials, incl passwords, validity etc.
-// - role grants/revocations.
-// - role option grants/revocations.
+// - Users added/dropped
+// - Changes to authentication credentials (e.g., passwords, validity, etc.)
+// - Role grants/revocations
+// - Role option grants/revocations
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerUserAdmin) ErrorfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.ERROR, channel.USER_ADMIN, format, args...)
@@ -3205,18 +3299,18 @@ func (loggerUserAdmin) ErrorfDepth(ctx context.Context, depth int, format string
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The USER_ADMIN channel is the channel used to report changes
+// The `USER_ADMIN` channel is used to report changes
 // in users and roles, including:
 //
-// - users added/dropped.
-// - changes to authentication credentials, incl passwords, validity etc.
-// - role grants/revocations.
-// - role option grants/revocations.
+// - Users added/dropped
+// - Changes to authentication credentials (e.g., passwords, validity, etc.)
+// - Role grants/revocations
+// - Role option grants/revocations
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerUserAdmin) Fatalf(ctx context.Context, format string, args ...interface{}) {
@@ -3229,18 +3323,18 @@ func (loggerUserAdmin) Fatalf(ctx context.Context, format string, args ...interf
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The USER_ADMIN channel is the channel used to report changes
+// The `USER_ADMIN` channel is used to report changes
 // in users and roles, including:
 //
-// - users added/dropped.
-// - changes to authentication credentials, incl passwords, validity etc.
-// - role grants/revocations.
-// - role option grants/revocations.
+// - Users added/dropped
+// - Changes to authentication credentials (e.g., passwords, validity, etc.)
+// - Role grants/revocations
+// - Role option grants/revocations
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerUserAdmin) VFatalf(ctx context.Context, level Level, format string, args ...interface{}) {
@@ -3253,18 +3347,18 @@ func (loggerUserAdmin) VFatalf(ctx context.Context, level Level, format string, 
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The USER_ADMIN channel is the channel used to report changes
+// The `USER_ADMIN` channel is used to report changes
 // in users and roles, including:
 //
-// - users added/dropped.
-// - changes to authentication credentials, incl passwords, validity etc.
-// - role grants/revocations.
-// - role option grants/revocations.
+// - Users added/dropped
+// - Changes to authentication credentials (e.g., passwords, validity, etc.)
+// - Role grants/revocations
+// - Role option grants/revocations
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerUserAdmin) Fatal(ctx context.Context, msg string) {
@@ -3276,18 +3370,18 @@ func (loggerUserAdmin) Fatal(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The USER_ADMIN channel is the channel used to report changes
+// The `USER_ADMIN` channel is used to report changes
 // in users and roles, including:
 //
-// - users added/dropped.
-// - changes to authentication credentials, incl passwords, validity etc.
-// - role grants/revocations.
-// - role option grants/revocations.
+// - Users added/dropped
+// - Changes to authentication credentials (e.g., passwords, validity, etc.)
+// - Role grants/revocations
+// - Role option grants/revocations
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerUserAdmin) FatalfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
@@ -3297,13 +3391,13 @@ func (loggerUserAdmin) FatalfDepth(ctx context.Context, depth int, format string
 // Shout logs to channel USER_ADMIN, and also to the real stderr if logging
 // is currently redirected to a file.
 //
-// The USER_ADMIN channel is the channel used to report changes
+// The `USER_ADMIN` channel is used to report changes
 // in users and roles, including:
 //
-// - users added/dropped.
-// - changes to authentication credentials, incl passwords, validity etc.
-// - role grants/revocations.
-// - role option grants/revocations.
+// - Users added/dropped
+// - Changes to authentication credentials (e.g., passwords, validity, etc.)
+// - Role grants/revocations
+// - Role option grants/revocations
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
@@ -3315,13 +3409,13 @@ func (loggerUserAdmin) Shout(ctx context.Context, sev Severity, msg string) {
 // logging is currently redirected to a file. Arguments are handled in
 // the manner of fmt.Printf.
 //
-// The USER_ADMIN channel is the channel used to report changes
+// The `USER_ADMIN` channel is used to report changes
 // in users and roles, including:
 //
-// - users added/dropped.
-// - changes to authentication credentials, incl passwords, validity etc.
-// - role grants/revocations.
-// - role option grants/revocations.
+// - Users added/dropped
+// - Changes to authentication credentials (e.g., passwords, validity, etc.)
+// - Role grants/revocations
+// - Role option grants/revocations
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
@@ -3334,11 +3428,11 @@ type loggerPrivileges struct{}
 
 // Privileges is a logger that logs to the PRIVILEGES channel.
 //
-// The PRIVILEGES channel is the channel used to report data
+// The `PRIVILEGES` channel is used to report data
 // authorization changes, including:
 //
-// - privilege grants/revocations on database, objects etc.
-// - object ownership changes.
+// - Privilege grants/revocations on database, objects, etc.
+// - Object ownership changes
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
@@ -3355,17 +3449,17 @@ var _ ChannelLogger = Privileges
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The PRIVILEGES channel is the channel used to report data
+// The `PRIVILEGES` channel is used to report data
 // authorization changes, including:
 //
-// - privilege grants/revocations on database, objects etc.
-// - object ownership changes.
+// - Privilege grants/revocations on database, objects, etc.
+// - Object ownership changes
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerPrivileges) Infof(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.INFO, channel.PRIVILEGES, format, args...)
 }
@@ -3376,17 +3470,17 @@ func (loggerPrivileges) Infof(ctx context.Context, format string, args ...interf
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The PRIVILEGES channel is the channel used to report data
+// The `PRIVILEGES` channel is used to report data
 // authorization changes, including:
 //
-// - privilege grants/revocations on database, objects etc.
-// - object ownership changes.
+// - Privilege grants/revocations on database, objects, etc.
+// - Object ownership changes
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerPrivileges) VInfof(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.INFO, channel.PRIVILEGES, format, args...)
@@ -3397,17 +3491,17 @@ func (loggerPrivileges) VInfof(ctx context.Context, level Level, format string, 
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The PRIVILEGES channel is the channel used to report data
+// The `PRIVILEGES` channel is used to report data
 // authorization changes, including:
 //
-// - privilege grants/revocations on database, objects etc.
-// - object ownership changes.
+// - Privilege grants/revocations on database, objects, etc.
+// - Object ownership changes
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerPrivileges) Info(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.INFO, channel.PRIVILEGES, msg)
 }
@@ -3417,17 +3511,17 @@ func (loggerPrivileges) Info(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The PRIVILEGES channel is the channel used to report data
+// The `PRIVILEGES` channel is used to report data
 // authorization changes, including:
 //
-// - privilege grants/revocations on database, objects etc.
-// - object ownership changes.
+// - Privilege grants/revocations on database, objects, etc.
+// - Object ownership changes
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerPrivileges) InfofDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.INFO, channel.PRIVILEGES, format, args...)
 }
@@ -3436,17 +3530,17 @@ func (loggerPrivileges) InfofDepth(ctx context.Context, depth int, format string
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The PRIVILEGES channel is the channel used to report data
+// The `PRIVILEGES` channel is used to report data
 // authorization changes, including:
 //
-// - privilege grants/revocations on database, objects etc.
-// - object ownership changes.
+// - Privilege grants/revocations on database, objects, etc.
+// - Object ownership changes
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerPrivileges) Warningf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.WARNING, channel.PRIVILEGES, format, args...)
 }
@@ -3457,17 +3551,17 @@ func (loggerPrivileges) Warningf(ctx context.Context, format string, args ...int
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The PRIVILEGES channel is the channel used to report data
+// The `PRIVILEGES` channel is used to report data
 // authorization changes, including:
 //
-// - privilege grants/revocations on database, objects etc.
-// - object ownership changes.
+// - Privilege grants/revocations on database, objects, etc.
+// - Object ownership changes
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerPrivileges) VWarningf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.WARNING, channel.PRIVILEGES, format, args...)
@@ -3478,17 +3572,17 @@ func (loggerPrivileges) VWarningf(ctx context.Context, level Level, format strin
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The PRIVILEGES channel is the channel used to report data
+// The `PRIVILEGES` channel is used to report data
 // authorization changes, including:
 //
-// - privilege grants/revocations on database, objects etc.
-// - object ownership changes.
+// - Privilege grants/revocations on database, objects, etc.
+// - Object ownership changes
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerPrivileges) Warning(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.WARNING, channel.PRIVILEGES, msg)
 }
@@ -3498,17 +3592,17 @@ func (loggerPrivileges) Warning(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The PRIVILEGES channel is the channel used to report data
+// The `PRIVILEGES` channel is used to report data
 // authorization changes, including:
 //
-// - privilege grants/revocations on database, objects etc.
-// - object ownership changes.
+// - Privilege grants/revocations on database, objects, etc.
+// - Object ownership changes
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerPrivileges) WarningfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.WARNING, channel.PRIVILEGES, format, args...)
 }
@@ -3517,17 +3611,17 @@ func (loggerPrivileges) WarningfDepth(ctx context.Context, depth int, format str
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The PRIVILEGES channel is the channel used to report data
+// The `PRIVILEGES` channel is used to report data
 // authorization changes, including:
 //
-// - privilege grants/revocations on database, objects etc.
-// - object ownership changes.
+// - Privilege grants/revocations on database, objects, etc.
+// - Object ownership changes
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerPrivileges) Errorf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.ERROR, channel.PRIVILEGES, format, args...)
@@ -3539,17 +3633,17 @@ func (loggerPrivileges) Errorf(ctx context.Context, format string, args ...inter
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The PRIVILEGES channel is the channel used to report data
+// The `PRIVILEGES` channel is used to report data
 // authorization changes, including:
 //
-// - privilege grants/revocations on database, objects etc.
-// - object ownership changes.
+// - Privilege grants/revocations on database, objects, etc.
+// - Object ownership changes
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerPrivileges) VErrorf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
@@ -3561,17 +3655,17 @@ func (loggerPrivileges) VErrorf(ctx context.Context, level Level, format string,
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The PRIVILEGES channel is the channel used to report data
+// The `PRIVILEGES` channel is used to report data
 // authorization changes, including:
 //
-// - privilege grants/revocations on database, objects etc.
-// - object ownership changes.
+// - Privilege grants/revocations on database, objects, etc.
+// - Object ownership changes
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerPrivileges) Error(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.ERROR, channel.PRIVILEGES, msg)
@@ -3582,17 +3676,17 @@ func (loggerPrivileges) Error(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The PRIVILEGES channel is the channel used to report data
+// The `PRIVILEGES` channel is used to report data
 // authorization changes, including:
 //
-// - privilege grants/revocations on database, objects etc.
-// - object ownership changes.
+// - Privilege grants/revocations on database, objects, etc.
+// - Object ownership changes
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerPrivileges) ErrorfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.ERROR, channel.PRIVILEGES, format, args...)
@@ -3602,16 +3696,16 @@ func (loggerPrivileges) ErrorfDepth(ctx context.Context, depth int, format strin
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The PRIVILEGES channel is the channel used to report data
+// The `PRIVILEGES` channel is used to report data
 // authorization changes, including:
 //
-// - privilege grants/revocations on database, objects etc.
-// - object ownership changes.
+// - Privilege grants/revocations on database, objects, etc.
+// - Object ownership changes
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerPrivileges) Fatalf(ctx context.Context, format string, args ...interface{}) {
@@ -3624,16 +3718,16 @@ func (loggerPrivileges) Fatalf(ctx context.Context, format string, args ...inter
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The PRIVILEGES channel is the channel used to report data
+// The `PRIVILEGES` channel is used to report data
 // authorization changes, including:
 //
-// - privilege grants/revocations on database, objects etc.
-// - object ownership changes.
+// - Privilege grants/revocations on database, objects, etc.
+// - Object ownership changes
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerPrivileges) VFatalf(ctx context.Context, level Level, format string, args ...interface{}) {
@@ -3646,16 +3740,16 @@ func (loggerPrivileges) VFatalf(ctx context.Context, level Level, format string,
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The PRIVILEGES channel is the channel used to report data
+// The `PRIVILEGES` channel is used to report data
 // authorization changes, including:
 //
-// - privilege grants/revocations on database, objects etc.
-// - object ownership changes.
+// - Privilege grants/revocations on database, objects, etc.
+// - Object ownership changes
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerPrivileges) Fatal(ctx context.Context, msg string) {
@@ -3667,16 +3761,16 @@ func (loggerPrivileges) Fatal(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The PRIVILEGES channel is the channel used to report data
+// The `PRIVILEGES` channel is used to report data
 // authorization changes, including:
 //
-// - privilege grants/revocations on database, objects etc.
-// - object ownership changes.
+// - Privilege grants/revocations on database, objects, etc.
+// - Object ownership changes
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerPrivileges) FatalfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
@@ -3686,11 +3780,11 @@ func (loggerPrivileges) FatalfDepth(ctx context.Context, depth int, format strin
 // Shout logs to channel PRIVILEGES, and also to the real stderr if logging
 // is currently redirected to a file.
 //
-// The PRIVILEGES channel is the channel used to report data
+// The `PRIVILEGES` channel is used to report data
 // authorization changes, including:
 //
-// - privilege grants/revocations on database, objects etc.
-// - object ownership changes.
+// - Privilege grants/revocations on database, objects, etc.
+// - Object ownership changes
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
@@ -3702,11 +3796,11 @@ func (loggerPrivileges) Shout(ctx context.Context, sev Severity, msg string) {
 // logging is currently redirected to a file. Arguments are handled in
 // the manner of fmt.Printf.
 //
-// The PRIVILEGES channel is the channel used to report data
+// The `PRIVILEGES` channel is used to report data
 // authorization changes, including:
 //
-// - privilege grants/revocations on database, objects etc.
-// - object ownership changes.
+// - Privilege grants/revocations on database, objects, etc.
+// - Object ownership changes
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
@@ -3719,12 +3813,13 @@ type loggerSensitiveAccess struct{}
 
 // SensitiveAccess is a logger that logs to the SENSITIVE_ACCESS channel.
 //
-// The SENSITIVE_ACCESS channel is the channel used to report SQL
-// data access to sensitive data (when enabled):
+// The `SENSITIVE_ACCESS` channel is used to report SQL
+// data access to sensitive data:
 //
-// - data access audit events (when table audit is enabled).
-// - SQL statements executed by users with the ADMIN bit.
-// - operations that write to `system` tables.
+// - Data access audit events (when table audit is enabled via
+//   [EXPERIMENTAL_AUDIT](experimental-audit.html))
+// - SQL statements executed by users with the admin role
+// - Operations that write to system tables
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
@@ -3741,18 +3836,19 @@ var _ ChannelLogger = SensitiveAccess
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SENSITIVE_ACCESS channel is the channel used to report SQL
-// data access to sensitive data (when enabled):
+// The `SENSITIVE_ACCESS` channel is used to report SQL
+// data access to sensitive data:
 //
-// - data access audit events (when table audit is enabled).
-// - SQL statements executed by users with the ADMIN bit.
-// - operations that write to `system` tables.
+// - Data access audit events (when table audit is enabled via
+//   [EXPERIMENTAL_AUDIT](experimental-audit.html))
+// - SQL statements executed by users with the admin role
+// - Operations that write to system tables
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerSensitiveAccess) Infof(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.INFO, channel.SENSITIVE_ACCESS, format, args...)
 }
@@ -3763,18 +3859,19 @@ func (loggerSensitiveAccess) Infof(ctx context.Context, format string, args ...i
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SENSITIVE_ACCESS channel is the channel used to report SQL
-// data access to sensitive data (when enabled):
+// The `SENSITIVE_ACCESS` channel is used to report SQL
+// data access to sensitive data:
 //
-// - data access audit events (when table audit is enabled).
-// - SQL statements executed by users with the ADMIN bit.
-// - operations that write to `system` tables.
+// - Data access audit events (when table audit is enabled via
+//   [EXPERIMENTAL_AUDIT](experimental-audit.html))
+// - SQL statements executed by users with the admin role
+// - Operations that write to system tables
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerSensitiveAccess) VInfof(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.INFO, channel.SENSITIVE_ACCESS, format, args...)
@@ -3785,18 +3882,19 @@ func (loggerSensitiveAccess) VInfof(ctx context.Context, level Level, format str
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The SENSITIVE_ACCESS channel is the channel used to report SQL
-// data access to sensitive data (when enabled):
+// The `SENSITIVE_ACCESS` channel is used to report SQL
+// data access to sensitive data:
 //
-// - data access audit events (when table audit is enabled).
-// - SQL statements executed by users with the ADMIN bit.
-// - operations that write to `system` tables.
+// - Data access audit events (when table audit is enabled via
+//   [EXPERIMENTAL_AUDIT](experimental-audit.html))
+// - SQL statements executed by users with the admin role
+// - Operations that write to system tables
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerSensitiveAccess) Info(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.INFO, channel.SENSITIVE_ACCESS, msg)
 }
@@ -3806,18 +3904,19 @@ func (loggerSensitiveAccess) Info(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SENSITIVE_ACCESS channel is the channel used to report SQL
-// data access to sensitive data (when enabled):
+// The `SENSITIVE_ACCESS` channel is used to report SQL
+// data access to sensitive data:
 //
-// - data access audit events (when table audit is enabled).
-// - SQL statements executed by users with the ADMIN bit.
-// - operations that write to `system` tables.
+// - Data access audit events (when table audit is enabled via
+//   [EXPERIMENTAL_AUDIT](experimental-audit.html))
+// - SQL statements executed by users with the admin role
+// - Operations that write to system tables
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerSensitiveAccess) InfofDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.INFO, channel.SENSITIVE_ACCESS, format, args...)
 }
@@ -3826,18 +3925,19 @@ func (loggerSensitiveAccess) InfofDepth(ctx context.Context, depth int, format s
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SENSITIVE_ACCESS channel is the channel used to report SQL
-// data access to sensitive data (when enabled):
+// The `SENSITIVE_ACCESS` channel is used to report SQL
+// data access to sensitive data:
 //
-// - data access audit events (when table audit is enabled).
-// - SQL statements executed by users with the ADMIN bit.
-// - operations that write to `system` tables.
+// - Data access audit events (when table audit is enabled via
+//   [EXPERIMENTAL_AUDIT](experimental-audit.html))
+// - SQL statements executed by users with the admin role
+// - Operations that write to system tables
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerSensitiveAccess) Warningf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.WARNING, channel.SENSITIVE_ACCESS, format, args...)
 }
@@ -3848,18 +3948,19 @@ func (loggerSensitiveAccess) Warningf(ctx context.Context, format string, args .
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SENSITIVE_ACCESS channel is the channel used to report SQL
-// data access to sensitive data (when enabled):
+// The `SENSITIVE_ACCESS` channel is used to report SQL
+// data access to sensitive data:
 //
-// - data access audit events (when table audit is enabled).
-// - SQL statements executed by users with the ADMIN bit.
-// - operations that write to `system` tables.
+// - Data access audit events (when table audit is enabled via
+//   [EXPERIMENTAL_AUDIT](experimental-audit.html))
+// - SQL statements executed by users with the admin role
+// - Operations that write to system tables
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerSensitiveAccess) VWarningf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.WARNING, channel.SENSITIVE_ACCESS, format, args...)
@@ -3870,18 +3971,19 @@ func (loggerSensitiveAccess) VWarningf(ctx context.Context, level Level, format 
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The SENSITIVE_ACCESS channel is the channel used to report SQL
-// data access to sensitive data (when enabled):
+// The `SENSITIVE_ACCESS` channel is used to report SQL
+// data access to sensitive data:
 //
-// - data access audit events (when table audit is enabled).
-// - SQL statements executed by users with the ADMIN bit.
-// - operations that write to `system` tables.
+// - Data access audit events (when table audit is enabled via
+//   [EXPERIMENTAL_AUDIT](experimental-audit.html))
+// - SQL statements executed by users with the admin role
+// - Operations that write to system tables
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerSensitiveAccess) Warning(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.WARNING, channel.SENSITIVE_ACCESS, msg)
 }
@@ -3891,18 +3993,19 @@ func (loggerSensitiveAccess) Warning(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SENSITIVE_ACCESS channel is the channel used to report SQL
-// data access to sensitive data (when enabled):
+// The `SENSITIVE_ACCESS` channel is used to report SQL
+// data access to sensitive data:
 //
-// - data access audit events (when table audit is enabled).
-// - SQL statements executed by users with the ADMIN bit.
-// - operations that write to `system` tables.
+// - Data access audit events (when table audit is enabled via
+//   [EXPERIMENTAL_AUDIT](experimental-audit.html))
+// - SQL statements executed by users with the admin role
+// - Operations that write to system tables
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerSensitiveAccess) WarningfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.WARNING, channel.SENSITIVE_ACCESS, format, args...)
 }
@@ -3911,18 +4014,19 @@ func (loggerSensitiveAccess) WarningfDepth(ctx context.Context, depth int, forma
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SENSITIVE_ACCESS channel is the channel used to report SQL
-// data access to sensitive data (when enabled):
+// The `SENSITIVE_ACCESS` channel is used to report SQL
+// data access to sensitive data:
 //
-// - data access audit events (when table audit is enabled).
-// - SQL statements executed by users with the ADMIN bit.
-// - operations that write to `system` tables.
+// - Data access audit events (when table audit is enabled via
+//   [EXPERIMENTAL_AUDIT](experimental-audit.html))
+// - SQL statements executed by users with the admin role
+// - Operations that write to system tables
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSensitiveAccess) Errorf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.ERROR, channel.SENSITIVE_ACCESS, format, args...)
@@ -3934,18 +4038,19 @@ func (loggerSensitiveAccess) Errorf(ctx context.Context, format string, args ...
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SENSITIVE_ACCESS channel is the channel used to report SQL
-// data access to sensitive data (when enabled):
+// The `SENSITIVE_ACCESS` channel is used to report SQL
+// data access to sensitive data:
 //
-// - data access audit events (when table audit is enabled).
-// - SQL statements executed by users with the ADMIN bit.
-// - operations that write to `system` tables.
+// - Data access audit events (when table audit is enabled via
+//   [EXPERIMENTAL_AUDIT](experimental-audit.html))
+// - SQL statements executed by users with the admin role
+// - Operations that write to system tables
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSensitiveAccess) VErrorf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
@@ -3957,18 +4062,19 @@ func (loggerSensitiveAccess) VErrorf(ctx context.Context, level Level, format st
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The SENSITIVE_ACCESS channel is the channel used to report SQL
-// data access to sensitive data (when enabled):
+// The `SENSITIVE_ACCESS` channel is used to report SQL
+// data access to sensitive data:
 //
-// - data access audit events (when table audit is enabled).
-// - SQL statements executed by users with the ADMIN bit.
-// - operations that write to `system` tables.
+// - Data access audit events (when table audit is enabled via
+//   [EXPERIMENTAL_AUDIT](experimental-audit.html))
+// - SQL statements executed by users with the admin role
+// - Operations that write to system tables
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSensitiveAccess) Error(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.ERROR, channel.SENSITIVE_ACCESS, msg)
@@ -3979,18 +4085,19 @@ func (loggerSensitiveAccess) Error(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SENSITIVE_ACCESS channel is the channel used to report SQL
-// data access to sensitive data (when enabled):
+// The `SENSITIVE_ACCESS` channel is used to report SQL
+// data access to sensitive data:
 //
-// - data access audit events (when table audit is enabled).
-// - SQL statements executed by users with the ADMIN bit.
-// - operations that write to `system` tables.
+// - Data access audit events (when table audit is enabled via
+//   [EXPERIMENTAL_AUDIT](experimental-audit.html))
+// - SQL statements executed by users with the admin role
+// - Operations that write to system tables
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSensitiveAccess) ErrorfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.ERROR, channel.SENSITIVE_ACCESS, format, args...)
@@ -4000,17 +4107,18 @@ func (loggerSensitiveAccess) ErrorfDepth(ctx context.Context, depth int, format 
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SENSITIVE_ACCESS channel is the channel used to report SQL
-// data access to sensitive data (when enabled):
+// The `SENSITIVE_ACCESS` channel is used to report SQL
+// data access to sensitive data:
 //
-// - data access audit events (when table audit is enabled).
-// - SQL statements executed by users with the ADMIN bit.
-// - operations that write to `system` tables.
+// - Data access audit events (when table audit is enabled via
+//   [EXPERIMENTAL_AUDIT](experimental-audit.html))
+// - SQL statements executed by users with the admin role
+// - Operations that write to system tables
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSensitiveAccess) Fatalf(ctx context.Context, format string, args ...interface{}) {
@@ -4023,17 +4131,18 @@ func (loggerSensitiveAccess) Fatalf(ctx context.Context, format string, args ...
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SENSITIVE_ACCESS channel is the channel used to report SQL
-// data access to sensitive data (when enabled):
+// The `SENSITIVE_ACCESS` channel is used to report SQL
+// data access to sensitive data:
 //
-// - data access audit events (when table audit is enabled).
-// - SQL statements executed by users with the ADMIN bit.
-// - operations that write to `system` tables.
+// - Data access audit events (when table audit is enabled via
+//   [EXPERIMENTAL_AUDIT](experimental-audit.html))
+// - SQL statements executed by users with the admin role
+// - Operations that write to system tables
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSensitiveAccess) VFatalf(ctx context.Context, level Level, format string, args ...interface{}) {
@@ -4046,17 +4155,18 @@ func (loggerSensitiveAccess) VFatalf(ctx context.Context, level Level, format st
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The SENSITIVE_ACCESS channel is the channel used to report SQL
-// data access to sensitive data (when enabled):
+// The `SENSITIVE_ACCESS` channel is used to report SQL
+// data access to sensitive data:
 //
-// - data access audit events (when table audit is enabled).
-// - SQL statements executed by users with the ADMIN bit.
-// - operations that write to `system` tables.
+// - Data access audit events (when table audit is enabled via
+//   [EXPERIMENTAL_AUDIT](experimental-audit.html))
+// - SQL statements executed by users with the admin role
+// - Operations that write to system tables
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSensitiveAccess) Fatal(ctx context.Context, msg string) {
@@ -4068,17 +4178,18 @@ func (loggerSensitiveAccess) Fatal(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SENSITIVE_ACCESS channel is the channel used to report SQL
-// data access to sensitive data (when enabled):
+// The `SENSITIVE_ACCESS` channel is used to report SQL
+// data access to sensitive data:
 //
-// - data access audit events (when table audit is enabled).
-// - SQL statements executed by users with the ADMIN bit.
-// - operations that write to `system` tables.
+// - Data access audit events (when table audit is enabled via
+//   [EXPERIMENTAL_AUDIT](experimental-audit.html))
+// - SQL statements executed by users with the admin role
+// - Operations that write to system tables
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSensitiveAccess) FatalfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
@@ -4088,12 +4199,13 @@ func (loggerSensitiveAccess) FatalfDepth(ctx context.Context, depth int, format 
 // Shout logs to channel SENSITIVE_ACCESS, and also to the real stderr if logging
 // is currently redirected to a file.
 //
-// The SENSITIVE_ACCESS channel is the channel used to report SQL
-// data access to sensitive data (when enabled):
+// The `SENSITIVE_ACCESS` channel is used to report SQL
+// data access to sensitive data:
 //
-// - data access audit events (when table audit is enabled).
-// - SQL statements executed by users with the ADMIN bit.
-// - operations that write to `system` tables.
+// - Data access audit events (when table audit is enabled via
+//   [EXPERIMENTAL_AUDIT](experimental-audit.html))
+// - SQL statements executed by users with the admin role
+// - Operations that write to system tables
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
@@ -4105,12 +4217,13 @@ func (loggerSensitiveAccess) Shout(ctx context.Context, sev Severity, msg string
 // logging is currently redirected to a file. Arguments are handled in
 // the manner of fmt.Printf.
 //
-// The SENSITIVE_ACCESS channel is the channel used to report SQL
-// data access to sensitive data (when enabled):
+// The `SENSITIVE_ACCESS` channel is used to report SQL
+// data access to sensitive data:
 //
-// - data access audit events (when table audit is enabled).
-// - SQL statements executed by users with the ADMIN bit.
-// - operations that write to `system` tables.
+// - Data access audit events (when table audit is enabled via
+//   [EXPERIMENTAL_AUDIT](experimental-audit.html))
+// - SQL statements executed by users with the admin role
+// - Operations that write to system tables
 //
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
@@ -4123,11 +4236,12 @@ type loggerSqlExec struct{}
 
 // SqlExec is a logger that logs to the SQL_EXEC channel.
 //
-// The SQL_EXEC channel is the channel used to report SQL execution on
+// The `SQL_EXEC` channel is used to report SQL execution on
 // behalf of client connections:
 //
-// - logical SQL statement executions (if enabled)
-// - pgwire events (if enabled)
+// - Logical SQL statement executions (when enabled via the
+//   `sql.trace.log_statement_execute` [cluster setting](cluster-settings.html))
+// - pgwire events (when enabled)
 var SqlExec loggerSqlExec
 
 // SqlExec and loggerSqlExec implement ChannelLogger.
@@ -4141,14 +4255,15 @@ var _ ChannelLogger = SqlExec
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_EXEC channel is the channel used to report SQL execution on
+// The `SQL_EXEC` channel is used to report SQL execution on
 // behalf of client connections:
 //
-// - logical SQL statement executions (if enabled)
-// - pgwire events (if enabled)
+// - Logical SQL statement executions (when enabled via the
+//   `sql.trace.log_statement_execute` [cluster setting](cluster-settings.html))
+// - pgwire events (when enabled)
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerSqlExec) Infof(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.INFO, channel.SQL_EXEC, format, args...)
 }
@@ -4159,14 +4274,15 @@ func (loggerSqlExec) Infof(ctx context.Context, format string, args ...interface
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_EXEC channel is the channel used to report SQL execution on
+// The `SQL_EXEC` channel is used to report SQL execution on
 // behalf of client connections:
 //
-// - logical SQL statement executions (if enabled)
-// - pgwire events (if enabled)
+// - Logical SQL statement executions (when enabled via the
+//   `sql.trace.log_statement_execute` [cluster setting](cluster-settings.html))
+// - pgwire events (when enabled)
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerSqlExec) VInfof(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.INFO, channel.SQL_EXEC, format, args...)
@@ -4177,14 +4293,15 @@ func (loggerSqlExec) VInfof(ctx context.Context, level Level, format string, arg
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The SQL_EXEC channel is the channel used to report SQL execution on
+// The `SQL_EXEC` channel is used to report SQL execution on
 // behalf of client connections:
 //
-// - logical SQL statement executions (if enabled)
-// - pgwire events (if enabled)
+// - Logical SQL statement executions (when enabled via the
+//   `sql.trace.log_statement_execute` [cluster setting](cluster-settings.html))
+// - pgwire events (when enabled)
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerSqlExec) Info(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.INFO, channel.SQL_EXEC, msg)
 }
@@ -4194,14 +4311,15 @@ func (loggerSqlExec) Info(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_EXEC channel is the channel used to report SQL execution on
+// The `SQL_EXEC` channel is used to report SQL execution on
 // behalf of client connections:
 //
-// - logical SQL statement executions (if enabled)
-// - pgwire events (if enabled)
+// - Logical SQL statement executions (when enabled via the
+//   `sql.trace.log_statement_execute` [cluster setting](cluster-settings.html))
+// - pgwire events (when enabled)
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerSqlExec) InfofDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.INFO, channel.SQL_EXEC, format, args...)
 }
@@ -4210,14 +4328,15 @@ func (loggerSqlExec) InfofDepth(ctx context.Context, depth int, format string, a
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_EXEC channel is the channel used to report SQL execution on
+// The `SQL_EXEC` channel is used to report SQL execution on
 // behalf of client connections:
 //
-// - logical SQL statement executions (if enabled)
-// - pgwire events (if enabled)
+// - Logical SQL statement executions (when enabled via the
+//   `sql.trace.log_statement_execute` [cluster setting](cluster-settings.html))
+// - pgwire events (when enabled)
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerSqlExec) Warningf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.WARNING, channel.SQL_EXEC, format, args...)
 }
@@ -4228,14 +4347,15 @@ func (loggerSqlExec) Warningf(ctx context.Context, format string, args ...interf
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_EXEC channel is the channel used to report SQL execution on
+// The `SQL_EXEC` channel is used to report SQL execution on
 // behalf of client connections:
 //
-// - logical SQL statement executions (if enabled)
-// - pgwire events (if enabled)
+// - Logical SQL statement executions (when enabled via the
+//   `sql.trace.log_statement_execute` [cluster setting](cluster-settings.html))
+// - pgwire events (when enabled)
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerSqlExec) VWarningf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.WARNING, channel.SQL_EXEC, format, args...)
@@ -4246,14 +4366,15 @@ func (loggerSqlExec) VWarningf(ctx context.Context, level Level, format string, 
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The SQL_EXEC channel is the channel used to report SQL execution on
+// The `SQL_EXEC` channel is used to report SQL execution on
 // behalf of client connections:
 //
-// - logical SQL statement executions (if enabled)
-// - pgwire events (if enabled)
+// - Logical SQL statement executions (when enabled via the
+//   `sql.trace.log_statement_execute` [cluster setting](cluster-settings.html))
+// - pgwire events (when enabled)
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerSqlExec) Warning(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.WARNING, channel.SQL_EXEC, msg)
 }
@@ -4263,14 +4384,15 @@ func (loggerSqlExec) Warning(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_EXEC channel is the channel used to report SQL execution on
+// The `SQL_EXEC` channel is used to report SQL execution on
 // behalf of client connections:
 //
-// - logical SQL statement executions (if enabled)
-// - pgwire events (if enabled)
+// - Logical SQL statement executions (when enabled via the
+//   `sql.trace.log_statement_execute` [cluster setting](cluster-settings.html))
+// - pgwire events (when enabled)
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerSqlExec) WarningfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.WARNING, channel.SQL_EXEC, format, args...)
 }
@@ -4279,14 +4401,15 @@ func (loggerSqlExec) WarningfDepth(ctx context.Context, depth int, format string
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_EXEC channel is the channel used to report SQL execution on
+// The `SQL_EXEC` channel is used to report SQL execution on
 // behalf of client connections:
 //
-// - logical SQL statement executions (if enabled)
-// - pgwire events (if enabled)
+// - Logical SQL statement executions (when enabled via the
+//   `sql.trace.log_statement_execute` [cluster setting](cluster-settings.html))
+// - pgwire events (when enabled)
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSqlExec) Errorf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.ERROR, channel.SQL_EXEC, format, args...)
@@ -4298,14 +4421,15 @@ func (loggerSqlExec) Errorf(ctx context.Context, format string, args ...interfac
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_EXEC channel is the channel used to report SQL execution on
+// The `SQL_EXEC` channel is used to report SQL execution on
 // behalf of client connections:
 //
-// - logical SQL statement executions (if enabled)
-// - pgwire events (if enabled)
+// - Logical SQL statement executions (when enabled via the
+//   `sql.trace.log_statement_execute` [cluster setting](cluster-settings.html))
+// - pgwire events (when enabled)
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSqlExec) VErrorf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
@@ -4317,14 +4441,15 @@ func (loggerSqlExec) VErrorf(ctx context.Context, level Level, format string, ar
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The SQL_EXEC channel is the channel used to report SQL execution on
+// The `SQL_EXEC` channel is used to report SQL execution on
 // behalf of client connections:
 //
-// - logical SQL statement executions (if enabled)
-// - pgwire events (if enabled)
+// - Logical SQL statement executions (when enabled via the
+//   `sql.trace.log_statement_execute` [cluster setting](cluster-settings.html))
+// - pgwire events (when enabled)
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSqlExec) Error(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.ERROR, channel.SQL_EXEC, msg)
@@ -4335,14 +4460,15 @@ func (loggerSqlExec) Error(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_EXEC channel is the channel used to report SQL execution on
+// The `SQL_EXEC` channel is used to report SQL execution on
 // behalf of client connections:
 //
-// - logical SQL statement executions (if enabled)
-// - pgwire events (if enabled)
+// - Logical SQL statement executions (when enabled via the
+//   `sql.trace.log_statement_execute` [cluster setting](cluster-settings.html))
+// - pgwire events (when enabled)
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSqlExec) ErrorfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.ERROR, channel.SQL_EXEC, format, args...)
@@ -4352,13 +4478,14 @@ func (loggerSqlExec) ErrorfDepth(ctx context.Context, depth int, format string, 
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_EXEC channel is the channel used to report SQL execution on
+// The `SQL_EXEC` channel is used to report SQL execution on
 // behalf of client connections:
 //
-// - logical SQL statement executions (if enabled)
-// - pgwire events (if enabled)
+// - Logical SQL statement executions (when enabled via the
+//   `sql.trace.log_statement_execute` [cluster setting](cluster-settings.html))
+// - pgwire events (when enabled)
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSqlExec) Fatalf(ctx context.Context, format string, args ...interface{}) {
@@ -4371,13 +4498,14 @@ func (loggerSqlExec) Fatalf(ctx context.Context, format string, args ...interfac
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_EXEC channel is the channel used to report SQL execution on
+// The `SQL_EXEC` channel is used to report SQL execution on
 // behalf of client connections:
 //
-// - logical SQL statement executions (if enabled)
-// - pgwire events (if enabled)
+// - Logical SQL statement executions (when enabled via the
+//   `sql.trace.log_statement_execute` [cluster setting](cluster-settings.html))
+// - pgwire events (when enabled)
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSqlExec) VFatalf(ctx context.Context, level Level, format string, args ...interface{}) {
@@ -4390,13 +4518,14 @@ func (loggerSqlExec) VFatalf(ctx context.Context, level Level, format string, ar
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The SQL_EXEC channel is the channel used to report SQL execution on
+// The `SQL_EXEC` channel is used to report SQL execution on
 // behalf of client connections:
 //
-// - logical SQL statement executions (if enabled)
-// - pgwire events (if enabled)
+// - Logical SQL statement executions (when enabled via the
+//   `sql.trace.log_statement_execute` [cluster setting](cluster-settings.html))
+// - pgwire events (when enabled)
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSqlExec) Fatal(ctx context.Context, msg string) {
@@ -4408,13 +4537,14 @@ func (loggerSqlExec) Fatal(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_EXEC channel is the channel used to report SQL execution on
+// The `SQL_EXEC` channel is used to report SQL execution on
 // behalf of client connections:
 //
-// - logical SQL statement executions (if enabled)
-// - pgwire events (if enabled)
+// - Logical SQL statement executions (when enabled via the
+//   `sql.trace.log_statement_execute` [cluster setting](cluster-settings.html))
+// - pgwire events (when enabled)
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSqlExec) FatalfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
@@ -4424,11 +4554,12 @@ func (loggerSqlExec) FatalfDepth(ctx context.Context, depth int, format string, 
 // Shout logs to channel SQL_EXEC, and also to the real stderr if logging
 // is currently redirected to a file.
 //
-// The SQL_EXEC channel is the channel used to report SQL execution on
+// The `SQL_EXEC` channel is used to report SQL execution on
 // behalf of client connections:
 //
-// - logical SQL statement executions (if enabled)
-// - pgwire events (if enabled)
+// - Logical SQL statement executions (when enabled via the
+//   `sql.trace.log_statement_execute` [cluster setting](cluster-settings.html))
+// - pgwire events (when enabled)
 func (loggerSqlExec) Shout(ctx context.Context, sev Severity, msg string) {
 	shoutfDepth(ctx, 1, sev, channel.SQL_EXEC, msg)
 }
@@ -4437,11 +4568,12 @@ func (loggerSqlExec) Shout(ctx context.Context, sev Severity, msg string) {
 // logging is currently redirected to a file. Arguments are handled in
 // the manner of fmt.Printf.
 //
-// The SQL_EXEC channel is the channel used to report SQL execution on
+// The `SQL_EXEC` channel is used to report SQL execution on
 // behalf of client connections:
 //
-// - logical SQL statement executions (if enabled)
-// - pgwire events (if enabled)
+// - Logical SQL statement executions (when enabled via the
+//   `sql.trace.log_statement_execute` [cluster setting](cluster-settings.html))
+// - pgwire events (when enabled)
 func (loggerSqlExec) Shoutf(ctx context.Context, sev Severity, format string, args ...interface{}) {
 	shoutfDepth(ctx, 1, sev, channel.SQL_EXEC, format, args...)
 }
@@ -4451,14 +4583,14 @@ type loggerSqlPerf struct{}
 
 // SqlPerf is a logger that logs to the SQL_PERF channel.
 //
-// The SQL_PERF channel is the channel used to report SQL executions
-// that are marked to be highlighted as "out of the ordinary"
+// The `SQL_PERF` channel is used to report SQL executions
+// that are marked as "out of the ordinary"
 // to facilitate performance investigations.
-// This includes the "SQL slow query log".
+// This includes the SQL "slow query log".
 //
-// Arguably, this channel overlaps with SQL_EXEC defined above.
-// However, we keep them separate for backward-compatibility
-// with previous versions, where the corresponding events
+// Arguably, this channel overlaps with `SQL_EXEC`.
+// However, we keep both channels separate for backward compatibility
+// with versions prior to v21.1, where the corresponding events
 // were redirected to separate files.
 var SqlPerf loggerSqlPerf
 
@@ -4473,18 +4605,18 @@ var _ ChannelLogger = SqlPerf
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_PERF channel is the channel used to report SQL executions
-// that are marked to be highlighted as "out of the ordinary"
+// The `SQL_PERF` channel is used to report SQL executions
+// that are marked as "out of the ordinary"
 // to facilitate performance investigations.
-// This includes the "SQL slow query log".
+// This includes the SQL "slow query log".
 //
-// Arguably, this channel overlaps with SQL_EXEC defined above.
-// However, we keep them separate for backward-compatibility
-// with previous versions, where the corresponding events
+// Arguably, this channel overlaps with `SQL_EXEC`.
+// However, we keep both channels separate for backward compatibility
+// with versions prior to v21.1, where the corresponding events
 // were redirected to separate files.
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerSqlPerf) Infof(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.INFO, channel.SQL_PERF, format, args...)
 }
@@ -4495,18 +4627,18 @@ func (loggerSqlPerf) Infof(ctx context.Context, format string, args ...interface
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_PERF channel is the channel used to report SQL executions
-// that are marked to be highlighted as "out of the ordinary"
+// The `SQL_PERF` channel is used to report SQL executions
+// that are marked as "out of the ordinary"
 // to facilitate performance investigations.
-// This includes the "SQL slow query log".
+// This includes the SQL "slow query log".
 //
-// Arguably, this channel overlaps with SQL_EXEC defined above.
-// However, we keep them separate for backward-compatibility
-// with previous versions, where the corresponding events
+// Arguably, this channel overlaps with `SQL_EXEC`.
+// However, we keep both channels separate for backward compatibility
+// with versions prior to v21.1, where the corresponding events
 // were redirected to separate files.
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerSqlPerf) VInfof(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.INFO, channel.SQL_PERF, format, args...)
@@ -4517,18 +4649,18 @@ func (loggerSqlPerf) VInfof(ctx context.Context, level Level, format string, arg
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The SQL_PERF channel is the channel used to report SQL executions
-// that are marked to be highlighted as "out of the ordinary"
+// The `SQL_PERF` channel is used to report SQL executions
+// that are marked as "out of the ordinary"
 // to facilitate performance investigations.
-// This includes the "SQL slow query log".
+// This includes the SQL "slow query log".
 //
-// Arguably, this channel overlaps with SQL_EXEC defined above.
-// However, we keep them separate for backward-compatibility
-// with previous versions, where the corresponding events
+// Arguably, this channel overlaps with `SQL_EXEC`.
+// However, we keep both channels separate for backward compatibility
+// with versions prior to v21.1, where the corresponding events
 // were redirected to separate files.
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerSqlPerf) Info(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.INFO, channel.SQL_PERF, msg)
 }
@@ -4538,18 +4670,18 @@ func (loggerSqlPerf) Info(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_PERF channel is the channel used to report SQL executions
-// that are marked to be highlighted as "out of the ordinary"
+// The `SQL_PERF` channel is used to report SQL executions
+// that are marked as "out of the ordinary"
 // to facilitate performance investigations.
-// This includes the "SQL slow query log".
+// This includes the SQL "slow query log".
 //
-// Arguably, this channel overlaps with SQL_EXEC defined above.
-// However, we keep them separate for backward-compatibility
-// with previous versions, where the corresponding events
+// Arguably, this channel overlaps with `SQL_EXEC`.
+// However, we keep both channels separate for backward compatibility
+// with versions prior to v21.1, where the corresponding events
 // were redirected to separate files.
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerSqlPerf) InfofDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.INFO, channel.SQL_PERF, format, args...)
 }
@@ -4558,18 +4690,18 @@ func (loggerSqlPerf) InfofDepth(ctx context.Context, depth int, format string, a
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_PERF channel is the channel used to report SQL executions
-// that are marked to be highlighted as "out of the ordinary"
+// The `SQL_PERF` channel is used to report SQL executions
+// that are marked as "out of the ordinary"
 // to facilitate performance investigations.
-// This includes the "SQL slow query log".
+// This includes the SQL "slow query log".
 //
-// Arguably, this channel overlaps with SQL_EXEC defined above.
-// However, we keep them separate for backward-compatibility
-// with previous versions, where the corresponding events
+// Arguably, this channel overlaps with `SQL_EXEC`.
+// However, we keep both channels separate for backward compatibility
+// with versions prior to v21.1, where the corresponding events
 // were redirected to separate files.
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerSqlPerf) Warningf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.WARNING, channel.SQL_PERF, format, args...)
 }
@@ -4580,18 +4712,18 @@ func (loggerSqlPerf) Warningf(ctx context.Context, format string, args ...interf
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_PERF channel is the channel used to report SQL executions
-// that are marked to be highlighted as "out of the ordinary"
+// The `SQL_PERF` channel is used to report SQL executions
+// that are marked as "out of the ordinary"
 // to facilitate performance investigations.
-// This includes the "SQL slow query log".
+// This includes the SQL "slow query log".
 //
-// Arguably, this channel overlaps with SQL_EXEC defined above.
-// However, we keep them separate for backward-compatibility
-// with previous versions, where the corresponding events
+// Arguably, this channel overlaps with `SQL_EXEC`.
+// However, we keep both channels separate for backward compatibility
+// with versions prior to v21.1, where the corresponding events
 // were redirected to separate files.
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerSqlPerf) VWarningf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.WARNING, channel.SQL_PERF, format, args...)
@@ -4602,18 +4734,18 @@ func (loggerSqlPerf) VWarningf(ctx context.Context, level Level, format string, 
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The SQL_PERF channel is the channel used to report SQL executions
-// that are marked to be highlighted as "out of the ordinary"
+// The `SQL_PERF` channel is used to report SQL executions
+// that are marked as "out of the ordinary"
 // to facilitate performance investigations.
-// This includes the "SQL slow query log".
+// This includes the SQL "slow query log".
 //
-// Arguably, this channel overlaps with SQL_EXEC defined above.
-// However, we keep them separate for backward-compatibility
-// with previous versions, where the corresponding events
+// Arguably, this channel overlaps with `SQL_EXEC`.
+// However, we keep both channels separate for backward compatibility
+// with versions prior to v21.1, where the corresponding events
 // were redirected to separate files.
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerSqlPerf) Warning(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.WARNING, channel.SQL_PERF, msg)
 }
@@ -4623,18 +4755,18 @@ func (loggerSqlPerf) Warning(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_PERF channel is the channel used to report SQL executions
-// that are marked to be highlighted as "out of the ordinary"
+// The `SQL_PERF` channel is used to report SQL executions
+// that are marked as "out of the ordinary"
 // to facilitate performance investigations.
-// This includes the "SQL slow query log".
+// This includes the SQL "slow query log".
 //
-// Arguably, this channel overlaps with SQL_EXEC defined above.
-// However, we keep them separate for backward-compatibility
-// with previous versions, where the corresponding events
+// Arguably, this channel overlaps with `SQL_EXEC`.
+// However, we keep both channels separate for backward compatibility
+// with versions prior to v21.1, where the corresponding events
 // were redirected to separate files.
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerSqlPerf) WarningfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.WARNING, channel.SQL_PERF, format, args...)
 }
@@ -4643,18 +4775,18 @@ func (loggerSqlPerf) WarningfDepth(ctx context.Context, depth int, format string
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_PERF channel is the channel used to report SQL executions
-// that are marked to be highlighted as "out of the ordinary"
+// The `SQL_PERF` channel is used to report SQL executions
+// that are marked as "out of the ordinary"
 // to facilitate performance investigations.
-// This includes the "SQL slow query log".
+// This includes the SQL "slow query log".
 //
-// Arguably, this channel overlaps with SQL_EXEC defined above.
-// However, we keep them separate for backward-compatibility
-// with previous versions, where the corresponding events
+// Arguably, this channel overlaps with `SQL_EXEC`.
+// However, we keep both channels separate for backward compatibility
+// with versions prior to v21.1, where the corresponding events
 // were redirected to separate files.
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSqlPerf) Errorf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.ERROR, channel.SQL_PERF, format, args...)
@@ -4666,18 +4798,18 @@ func (loggerSqlPerf) Errorf(ctx context.Context, format string, args ...interfac
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_PERF channel is the channel used to report SQL executions
-// that are marked to be highlighted as "out of the ordinary"
+// The `SQL_PERF` channel is used to report SQL executions
+// that are marked as "out of the ordinary"
 // to facilitate performance investigations.
-// This includes the "SQL slow query log".
+// This includes the SQL "slow query log".
 //
-// Arguably, this channel overlaps with SQL_EXEC defined above.
-// However, we keep them separate for backward-compatibility
-// with previous versions, where the corresponding events
+// Arguably, this channel overlaps with `SQL_EXEC`.
+// However, we keep both channels separate for backward compatibility
+// with versions prior to v21.1, where the corresponding events
 // were redirected to separate files.
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSqlPerf) VErrorf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
@@ -4689,18 +4821,18 @@ func (loggerSqlPerf) VErrorf(ctx context.Context, level Level, format string, ar
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The SQL_PERF channel is the channel used to report SQL executions
-// that are marked to be highlighted as "out of the ordinary"
+// The `SQL_PERF` channel is used to report SQL executions
+// that are marked as "out of the ordinary"
 // to facilitate performance investigations.
-// This includes the "SQL slow query log".
+// This includes the SQL "slow query log".
 //
-// Arguably, this channel overlaps with SQL_EXEC defined above.
-// However, we keep them separate for backward-compatibility
-// with previous versions, where the corresponding events
+// Arguably, this channel overlaps with `SQL_EXEC`.
+// However, we keep both channels separate for backward compatibility
+// with versions prior to v21.1, where the corresponding events
 // were redirected to separate files.
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSqlPerf) Error(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.ERROR, channel.SQL_PERF, msg)
@@ -4711,18 +4843,18 @@ func (loggerSqlPerf) Error(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_PERF channel is the channel used to report SQL executions
-// that are marked to be highlighted as "out of the ordinary"
+// The `SQL_PERF` channel is used to report SQL executions
+// that are marked as "out of the ordinary"
 // to facilitate performance investigations.
-// This includes the "SQL slow query log".
+// This includes the SQL "slow query log".
 //
-// Arguably, this channel overlaps with SQL_EXEC defined above.
-// However, we keep them separate for backward-compatibility
-// with previous versions, where the corresponding events
+// Arguably, this channel overlaps with `SQL_EXEC`.
+// However, we keep both channels separate for backward compatibility
+// with versions prior to v21.1, where the corresponding events
 // were redirected to separate files.
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSqlPerf) ErrorfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.ERROR, channel.SQL_PERF, format, args...)
@@ -4732,17 +4864,17 @@ func (loggerSqlPerf) ErrorfDepth(ctx context.Context, depth int, format string, 
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_PERF channel is the channel used to report SQL executions
-// that are marked to be highlighted as "out of the ordinary"
+// The `SQL_PERF` channel is used to report SQL executions
+// that are marked as "out of the ordinary"
 // to facilitate performance investigations.
-// This includes the "SQL slow query log".
+// This includes the SQL "slow query log".
 //
-// Arguably, this channel overlaps with SQL_EXEC defined above.
-// However, we keep them separate for backward-compatibility
-// with previous versions, where the corresponding events
+// Arguably, this channel overlaps with `SQL_EXEC`.
+// However, we keep both channels separate for backward compatibility
+// with versions prior to v21.1, where the corresponding events
 // were redirected to separate files.
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSqlPerf) Fatalf(ctx context.Context, format string, args ...interface{}) {
@@ -4755,17 +4887,17 @@ func (loggerSqlPerf) Fatalf(ctx context.Context, format string, args ...interfac
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_PERF channel is the channel used to report SQL executions
-// that are marked to be highlighted as "out of the ordinary"
+// The `SQL_PERF` channel is used to report SQL executions
+// that are marked as "out of the ordinary"
 // to facilitate performance investigations.
-// This includes the "SQL slow query log".
+// This includes the SQL "slow query log".
 //
-// Arguably, this channel overlaps with SQL_EXEC defined above.
-// However, we keep them separate for backward-compatibility
-// with previous versions, where the corresponding events
+// Arguably, this channel overlaps with `SQL_EXEC`.
+// However, we keep both channels separate for backward compatibility
+// with versions prior to v21.1, where the corresponding events
 // were redirected to separate files.
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSqlPerf) VFatalf(ctx context.Context, level Level, format string, args ...interface{}) {
@@ -4778,17 +4910,17 @@ func (loggerSqlPerf) VFatalf(ctx context.Context, level Level, format string, ar
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The SQL_PERF channel is the channel used to report SQL executions
-// that are marked to be highlighted as "out of the ordinary"
+// The `SQL_PERF` channel is used to report SQL executions
+// that are marked as "out of the ordinary"
 // to facilitate performance investigations.
-// This includes the "SQL slow query log".
+// This includes the SQL "slow query log".
 //
-// Arguably, this channel overlaps with SQL_EXEC defined above.
-// However, we keep them separate for backward-compatibility
-// with previous versions, where the corresponding events
+// Arguably, this channel overlaps with `SQL_EXEC`.
+// However, we keep both channels separate for backward compatibility
+// with versions prior to v21.1, where the corresponding events
 // were redirected to separate files.
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSqlPerf) Fatal(ctx context.Context, msg string) {
@@ -4800,17 +4932,17 @@ func (loggerSqlPerf) Fatal(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_PERF channel is the channel used to report SQL executions
-// that are marked to be highlighted as "out of the ordinary"
+// The `SQL_PERF` channel is used to report SQL executions
+// that are marked as "out of the ordinary"
 // to facilitate performance investigations.
-// This includes the "SQL slow query log".
+// This includes the SQL "slow query log".
 //
-// Arguably, this channel overlaps with SQL_EXEC defined above.
-// However, we keep them separate for backward-compatibility
-// with previous versions, where the corresponding events
+// Arguably, this channel overlaps with `SQL_EXEC`.
+// However, we keep both channels separate for backward compatibility
+// with versions prior to v21.1, where the corresponding events
 // were redirected to separate files.
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSqlPerf) FatalfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
@@ -4820,14 +4952,14 @@ func (loggerSqlPerf) FatalfDepth(ctx context.Context, depth int, format string, 
 // Shout logs to channel SQL_PERF, and also to the real stderr if logging
 // is currently redirected to a file.
 //
-// The SQL_PERF channel is the channel used to report SQL executions
-// that are marked to be highlighted as "out of the ordinary"
+// The `SQL_PERF` channel is used to report SQL executions
+// that are marked as "out of the ordinary"
 // to facilitate performance investigations.
-// This includes the "SQL slow query log".
+// This includes the SQL "slow query log".
 //
-// Arguably, this channel overlaps with SQL_EXEC defined above.
-// However, we keep them separate for backward-compatibility
-// with previous versions, where the corresponding events
+// Arguably, this channel overlaps with `SQL_EXEC`.
+// However, we keep both channels separate for backward compatibility
+// with versions prior to v21.1, where the corresponding events
 // were redirected to separate files.
 func (loggerSqlPerf) Shout(ctx context.Context, sev Severity, msg string) {
 	shoutfDepth(ctx, 1, sev, channel.SQL_PERF, msg)
@@ -4837,14 +4969,14 @@ func (loggerSqlPerf) Shout(ctx context.Context, sev Severity, msg string) {
 // logging is currently redirected to a file. Arguments are handled in
 // the manner of fmt.Printf.
 //
-// The SQL_PERF channel is the channel used to report SQL executions
-// that are marked to be highlighted as "out of the ordinary"
+// The `SQL_PERF` channel is used to report SQL executions
+// that are marked as "out of the ordinary"
 // to facilitate performance investigations.
-// This includes the "SQL slow query log".
+// This includes the SQL "slow query log".
 //
-// Arguably, this channel overlaps with SQL_EXEC defined above.
-// However, we keep them separate for backward-compatibility
-// with previous versions, where the corresponding events
+// Arguably, this channel overlaps with `SQL_EXEC`.
+// However, we keep both channels separate for backward compatibility
+// with versions prior to v21.1, where the corresponding events
 // were redirected to separate files.
 func (loggerSqlPerf) Shoutf(ctx context.Context, sev Severity, format string, args ...interface{}) {
 	shoutfDepth(ctx, 1, sev, channel.SQL_PERF, format, args...)
@@ -4855,9 +4987,9 @@ type loggerSqlInternalPerf struct{}
 
 // SqlInternalPerf is a logger that logs to the SQL_INTERNAL_PERF channel.
 //
-// The SQL_INTERNAL_PERF channel is like the SQL perf channel above but aimed at
+// The `SQL_INTERNAL_PERF` channel is like the `SQL_PERF` channel, but is aimed at
 // helping developers of CockroachDB itself. It exists as a separate
-// channel so as to not pollute the SQL perf logging output with
+// channel so as to not pollute the `SQL_PERF` logging output with
 // internal troubleshooting details.
 var SqlInternalPerf loggerSqlInternalPerf
 
@@ -4872,13 +5004,13 @@ var _ ChannelLogger = SqlInternalPerf
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_INTERNAL_PERF channel is like the SQL perf channel above but aimed at
+// The `SQL_INTERNAL_PERF` channel is like the `SQL_PERF` channel, but is aimed at
 // helping developers of CockroachDB itself. It exists as a separate
-// channel so as to not pollute the SQL perf logging output with
+// channel so as to not pollute the `SQL_PERF` logging output with
 // internal troubleshooting details.
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerSqlInternalPerf) Infof(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.INFO, channel.SQL_INTERNAL_PERF, format, args...)
 }
@@ -4889,13 +5021,13 @@ func (loggerSqlInternalPerf) Infof(ctx context.Context, format string, args ...i
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_INTERNAL_PERF channel is like the SQL perf channel above but aimed at
+// The `SQL_INTERNAL_PERF` channel is like the `SQL_PERF` channel, but is aimed at
 // helping developers of CockroachDB itself. It exists as a separate
-// channel so as to not pollute the SQL perf logging output with
+// channel so as to not pollute the `SQL_PERF` logging output with
 // internal troubleshooting details.
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerSqlInternalPerf) VInfof(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.INFO, channel.SQL_INTERNAL_PERF, format, args...)
@@ -4906,13 +5038,13 @@ func (loggerSqlInternalPerf) VInfof(ctx context.Context, level Level, format str
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The SQL_INTERNAL_PERF channel is like the SQL perf channel above but aimed at
+// The `SQL_INTERNAL_PERF` channel is like the `SQL_PERF` channel, but is aimed at
 // helping developers of CockroachDB itself. It exists as a separate
-// channel so as to not pollute the SQL perf logging output with
+// channel so as to not pollute the `SQL_PERF` logging output with
 // internal troubleshooting details.
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerSqlInternalPerf) Info(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.INFO, channel.SQL_INTERNAL_PERF, msg)
 }
@@ -4922,13 +5054,13 @@ func (loggerSqlInternalPerf) Info(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_INTERNAL_PERF channel is like the SQL perf channel above but aimed at
+// The `SQL_INTERNAL_PERF` channel is like the `SQL_PERF` channel, but is aimed at
 // helping developers of CockroachDB itself. It exists as a separate
-// channel so as to not pollute the SQL perf logging output with
+// channel so as to not pollute the `SQL_PERF` logging output with
 // internal troubleshooting details.
 //
-// The INFO severity is used for informational messages, when no action
-// is required as a result.
+// The `INFO` severity is used for informational messages that do not
+// require action.
 func (loggerSqlInternalPerf) InfofDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.INFO, channel.SQL_INTERNAL_PERF, format, args...)
 }
@@ -4937,13 +5069,13 @@ func (loggerSqlInternalPerf) InfofDepth(ctx context.Context, depth int, format s
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_INTERNAL_PERF channel is like the SQL perf channel above but aimed at
+// The `SQL_INTERNAL_PERF` channel is like the `SQL_PERF` channel, but is aimed at
 // helping developers of CockroachDB itself. It exists as a separate
-// channel so as to not pollute the SQL perf logging output with
+// channel so as to not pollute the `SQL_PERF` logging output with
 // internal troubleshooting details.
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerSqlInternalPerf) Warningf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.WARNING, channel.SQL_INTERNAL_PERF, format, args...)
 }
@@ -4954,13 +5086,13 @@ func (loggerSqlInternalPerf) Warningf(ctx context.Context, format string, args .
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_INTERNAL_PERF channel is like the SQL perf channel above but aimed at
+// The `SQL_INTERNAL_PERF` channel is like the `SQL_PERF` channel, but is aimed at
 // helping developers of CockroachDB itself. It exists as a separate
-// channel so as to not pollute the SQL perf logging output with
+// channel so as to not pollute the `SQL_PERF` logging output with
 // internal troubleshooting details.
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerSqlInternalPerf) VWarningf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		logfDepth(ctx, 1, severity.WARNING, channel.SQL_INTERNAL_PERF, format, args...)
@@ -4971,13 +5103,13 @@ func (loggerSqlInternalPerf) VWarningf(ctx context.Context, level Level, format 
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The SQL_INTERNAL_PERF channel is like the SQL perf channel above but aimed at
+// The `SQL_INTERNAL_PERF` channel is like the `SQL_PERF` channel, but is aimed at
 // helping developers of CockroachDB itself. It exists as a separate
-// channel so as to not pollute the SQL perf logging output with
+// channel so as to not pollute the `SQL_PERF` logging output with
 // internal troubleshooting details.
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerSqlInternalPerf) Warning(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.WARNING, channel.SQL_INTERNAL_PERF, msg)
 }
@@ -4987,13 +5119,13 @@ func (loggerSqlInternalPerf) Warning(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_INTERNAL_PERF channel is like the SQL perf channel above but aimed at
+// The `SQL_INTERNAL_PERF` channel is like the `SQL_PERF` channel, but is aimed at
 // helping developers of CockroachDB itself. It exists as a separate
-// channel so as to not pollute the SQL perf logging output with
+// channel so as to not pollute the `SQL_PERF` logging output with
 // internal troubleshooting details.
 //
-// The WARNING severity is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// The `WARNING` severity is used for situations which may require special handling,
+// where normal operation is expected to resume automatically.
 func (loggerSqlInternalPerf) WarningfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.WARNING, channel.SQL_INTERNAL_PERF, format, args...)
 }
@@ -5002,13 +5134,13 @@ func (loggerSqlInternalPerf) WarningfDepth(ctx context.Context, depth int, forma
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_INTERNAL_PERF channel is like the SQL perf channel above but aimed at
+// The `SQL_INTERNAL_PERF` channel is like the `SQL_PERF` channel, but is aimed at
 // helping developers of CockroachDB itself. It exists as a separate
-// channel so as to not pollute the SQL perf logging output with
+// channel so as to not pollute the `SQL_PERF` logging output with
 // internal troubleshooting details.
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSqlInternalPerf) Errorf(ctx context.Context, format string, args ...interface{}) {
 	logfDepth(ctx, 1, severity.ERROR, channel.SQL_INTERNAL_PERF, format, args...)
@@ -5020,13 +5152,13 @@ func (loggerSqlInternalPerf) Errorf(ctx context.Context, format string, args ...
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_INTERNAL_PERF channel is like the SQL perf channel above but aimed at
+// The `SQL_INTERNAL_PERF` channel is like the `SQL_PERF` channel, but is aimed at
 // helping developers of CockroachDB itself. It exists as a separate
-// channel so as to not pollute the SQL perf logging output with
+// channel so as to not pollute the `SQL_PERF` logging output with
 // internal troubleshooting details.
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSqlInternalPerf) VErrorf(ctx context.Context, level Level, format string, args ...interface{}) {
 	if VDepth(level, 1) {
@@ -5038,13 +5170,13 @@ func (loggerSqlInternalPerf) VErrorf(ctx context.Context, level Level, format st
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The SQL_INTERNAL_PERF channel is like the SQL perf channel above but aimed at
+// The `SQL_INTERNAL_PERF` channel is like the `SQL_PERF` channel, but is aimed at
 // helping developers of CockroachDB itself. It exists as a separate
-// channel so as to not pollute the SQL perf logging output with
+// channel so as to not pollute the `SQL_PERF` logging output with
 // internal troubleshooting details.
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSqlInternalPerf) Error(ctx context.Context, msg string) {
 	logfDepth(ctx, 1, severity.ERROR, channel.SQL_INTERNAL_PERF, msg)
@@ -5055,13 +5187,13 @@ func (loggerSqlInternalPerf) Error(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_INTERNAL_PERF channel is like the SQL perf channel above but aimed at
+// The `SQL_INTERNAL_PERF` channel is like the `SQL_PERF` channel, but is aimed at
 // helping developers of CockroachDB itself. It exists as a separate
-// channel so as to not pollute the SQL perf logging output with
+// channel so as to not pollute the `SQL_PERF` logging output with
 // internal troubleshooting details.
 //
-// The ERROR severity is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// The `ERROR` severity is used for situations that require special handling,
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSqlInternalPerf) ErrorfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
 	logfDepth(ctx, depth+1, severity.ERROR, channel.SQL_INTERNAL_PERF, format, args...)
@@ -5071,12 +5203,12 @@ func (loggerSqlInternalPerf) ErrorfDepth(ctx context.Context, depth int, format 
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_INTERNAL_PERF channel is like the SQL perf channel above but aimed at
+// The `SQL_INTERNAL_PERF` channel is like the `SQL_PERF` channel, but is aimed at
 // helping developers of CockroachDB itself. It exists as a separate
-// channel so as to not pollute the SQL perf logging output with
+// channel so as to not pollute the `SQL_PERF` logging output with
 // internal troubleshooting details.
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSqlInternalPerf) Fatalf(ctx context.Context, format string, args ...interface{}) {
@@ -5089,12 +5221,12 @@ func (loggerSqlInternalPerf) Fatalf(ctx context.Context, format string, args ...
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_INTERNAL_PERF channel is like the SQL perf channel above but aimed at
+// The `SQL_INTERNAL_PERF` channel is like the `SQL_PERF` channel, but is aimed at
 // helping developers of CockroachDB itself. It exists as a separate
-// channel so as to not pollute the SQL perf logging output with
+// channel so as to not pollute the `SQL_PERF` logging output with
 // internal troubleshooting details.
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSqlInternalPerf) VFatalf(ctx context.Context, level Level, format string, args ...interface{}) {
@@ -5107,12 +5239,12 @@ func (loggerSqlInternalPerf) VFatalf(ctx context.Context, level Level, format st
 // It extracts log tags from the context and logs them along with the given
 // message.
 //
-// The SQL_INTERNAL_PERF channel is like the SQL perf channel above but aimed at
+// The `SQL_INTERNAL_PERF` channel is like the `SQL_PERF` channel, but is aimed at
 // helping developers of CockroachDB itself. It exists as a separate
-// channel so as to not pollute the SQL perf logging output with
+// channel so as to not pollute the `SQL_PERF` logging output with
 // internal troubleshooting details.
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSqlInternalPerf) Fatal(ctx context.Context, msg string) {
@@ -5124,12 +5256,12 @@ func (loggerSqlInternalPerf) Fatal(ctx context.Context, msg string) {
 // It extracts log tags from the context and logs them along with the given
 // message. Arguments are handled in the manner of fmt.Printf.
 //
-// The SQL_INTERNAL_PERF channel is like the SQL perf channel above but aimed at
+// The `SQL_INTERNAL_PERF` channel is like the `SQL_PERF` channel, but is aimed at
 // helping developers of CockroachDB itself. It exists as a separate
-// channel so as to not pollute the SQL perf logging output with
+// channel so as to not pollute the `SQL_PERF` logging output with
 // internal troubleshooting details.
 //
-// The FATAL severity is used for situations that require an immedate, hard
+// The `FATAL` severity is used for situations that require an immedate, hard
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSqlInternalPerf) FatalfDepth(ctx context.Context, depth int, format string, args ...interface{}) {
@@ -5139,9 +5271,9 @@ func (loggerSqlInternalPerf) FatalfDepth(ctx context.Context, depth int, format 
 // Shout logs to channel SQL_INTERNAL_PERF, and also to the real stderr if logging
 // is currently redirected to a file.
 //
-// The SQL_INTERNAL_PERF channel is like the SQL perf channel above but aimed at
+// The `SQL_INTERNAL_PERF` channel is like the `SQL_PERF` channel, but is aimed at
 // helping developers of CockroachDB itself. It exists as a separate
-// channel so as to not pollute the SQL perf logging output with
+// channel so as to not pollute the `SQL_PERF` logging output with
 // internal troubleshooting details.
 func (loggerSqlInternalPerf) Shout(ctx context.Context, sev Severity, msg string) {
 	shoutfDepth(ctx, 1, sev, channel.SQL_INTERNAL_PERF, msg)
@@ -5151,9 +5283,9 @@ func (loggerSqlInternalPerf) Shout(ctx context.Context, sev Severity, msg string
 // logging is currently redirected to a file. Arguments are handled in
 // the manner of fmt.Printf.
 //
-// The SQL_INTERNAL_PERF channel is like the SQL perf channel above but aimed at
+// The `SQL_INTERNAL_PERF` channel is like the `SQL_PERF` channel, but is aimed at
 // helping developers of CockroachDB itself. It exists as a separate
-// channel so as to not pollute the SQL perf logging output with
+// channel so as to not pollute the `SQL_PERF` logging output with
 // internal troubleshooting details.
 func (loggerSqlInternalPerf) Shoutf(ctx context.Context, sev Severity, format string, args ...interface{}) {
 	shoutfDepth(ctx, 1, sev, channel.SQL_INTERNAL_PERF, format, args...)

--- a/pkg/util/log/logconfig/config.go
+++ b/pkg/util/log/logconfig/config.go
@@ -175,7 +175,7 @@ type SinkConfig struct {
 // StderrSinkConfig represents the configuration for the stderr sink.
 //
 // User-facing documentation follows.
-// TITLE: standard error stream
+// TITLE: Standard error stream
 //
 // The standard error output stream of the running `cockroach`
 // process.
@@ -187,28 +187,25 @@ type SinkConfig struct {
 //        stderr:           # standard error sink configuration starts here
 //           channels: DEV
 //
-// Note: the server start-up messages are still emitted at the start
-// of the standard error stream even when logging to stderr is
-// enabled.  This makes it generally difficult to automate integration
-// with log analyzers. Generally, we recommend operators to either use
-// file logging or native network logging instead of using standard
-// error when integrating with automated monitoring software.
+// {{site.data.alerts.callout_info}}
+// The server start-up messages are still emitted at the start of the standard error
+// stream even when logging to `stderr` is enabled. This makes it generally difficult
+// to automate integration of `stderr` with log analyzers. Generally, we recommend using
+// [file logging](#output-to-files) or [network logging](#output-to-fluentd-compatible-log-collectors)
+// instead of `stderr` when integrating with automated monitoring software.
+// {{site.data.alerts.end}}
 //
-// Note: it is not possible to enable the "redactable" parameter on
-// the stderr sink if the "capture-stray-errors" functionality
-// (i.e. capturing stray error information to files) is disabled.
+// It is not possible to enable the `redactable` parameter on the `stderr` sink if
+// `capture-stray-errors` (i.e., capturing stray error information to files) is disabled.
+// This is because when `capture-stray-errors` is disabled, the process's standard error stream
+// can contain an arbitrary interleaving of [logging events](eventlog.html) and stray
+// errors. It is possible for stray error output to interfere with redaction markers
+// and remove the guarantees that information outside of redaction markers does not
+// contain sensitive information.
 //
-// This is because when "capture-stray-errors" is disabled, the
-// process' standard error stream can contain an arbitrary
-// interleaving of logging events and stray errors; in particular, it
-// is possible for stray error output to interfere with redaction
-// markers and remove the guarantees that information outside of
-// redaction markers does not contain sensitive information.
-//
-// Note: for a similar reason, no guarantees of parsability of the output
-// format is available when the "capture-stray-errors" functionality
-// is disabled, since the standard error stream can then contain an
-// arbitrary interleaving of non-formatted error data.
+// For a similar reason, no guarantee of parsability of the output format is available
+// when `capture-stray-errors` is disabled, since the standard error stream can then
+// contain an arbitrary interleaving of non-formatted error data.
 //
 type StderrSinkConfig struct {
 	// Channels is the list of logging channels that use this sink.
@@ -234,18 +231,19 @@ type FluentDefaults struct {
 // FluentSinkConfig represents the configuration for one fluentd sink.
 //
 // User-facing documentation follows.
-// TITLE: output to Fluentd-compatible log collectors
+// TITLE: Output to Fluentd-compatible log collectors
 //
 // This sink type causes logging data to be sent over the network, to
 // a log collector that can ingest log data in a
 // [Fluentd](https://www.fluentd.org)-compatible protocol.
 //
-// Note that TLS is not supported yet: the connection to the log
-// collector is neither authenticated nor encrypted. Given that
-// logging events may contain sensitive information, care should be
-// taken to keep the log collector and the CockroachDB node close
-// together on a private network, or connect them using a secure
-// VPN. TLS support may be added at a later date.
+// {{site.data.alerts.callout_danger}}
+// TLS is not supported yet: the connection to the log collector is neither
+// authenticated nor encrypted. Given that logging events may contain sensitive
+// information, care should be taken to keep the log collector and the CockroachDB
+// node close together on a private network, or connect them using a secure VPN.
+// TLS support may be added at a later date.
+// {{site.data.alerts.end}}
 //
 // At the time of this writing, a Fluent sink buffers at most one log
 // entry and retries sending the event at most one time if a network
@@ -253,7 +251,7 @@ type FluentDefaults struct {
 // of the Fluentd collector after a configuration change under light
 // logging activity. If the server is unavailable for too long, or if
 // more than one error is encountered, an error is reported to the
-// process' standard error output with a copy of the logging event and
+// process's standard error output with a copy of the logging event and
 // the logging event is dropped.
 //
 // The configuration key under the `sinks` key in the YAML
@@ -265,9 +263,7 @@ type FluentDefaults struct {
 //              channels: HEALTH
 //              address: 127.0.0.1:5170
 //
-// A cascading defaults mechanism is available for configurations:
-// every new server sink configured automatically inherits the
-// configurations set in the `fluent-defaults` section.
+// Every new server sink configured automatically inherits the configurations set in the `fluent-defaults` section.
 //
 // For example:
 //
@@ -284,10 +280,11 @@ type FluentDefaults struct {
 // The default output format for Fluent sinks is
 // `json-fluent-compact`. The `fluent` variants of the JSON formats
 // include a `tag` field as required by the Fluentd protocol, which
-// the non-`fluent` JSON format variants do not include.
+// the non-`fluent` JSON [format variants](logformats.html) do not include.
 //
-// Users are invited to peruse the `check-log-config` tool to
-// verify the effect of defaults inheritance.
+// {{site.data.alerts.callout_info}}
+// Run `cockroach debug check-log-config` to verify the effect of defaults inheritance.
+// {{site.data.alerts.end}}
 //
 type FluentSinkConfig struct {
 	// Channels is the list of logging channels that use this sink.
@@ -347,12 +344,10 @@ type FileDefaults struct {
 // FileSinkConfig represents the configuration for one file sink.
 //
 // User-facing documentation follows.
-// TITLE: output to files
+// TITLE: Output to files
 //
-// Files under a configurable logging directory.
-//
-// This sink type causes logging data to be captured into *file groups*,
-// one group per configured sink.
+// This sink type causes logging data to be captured into log files in a
+// configurable logging directory.
 //
 // The configuration key under the `sinks` key in the YAML
 // configuration is `file-groups`. Example configuration:
@@ -363,22 +358,18 @@ type FileDefaults struct {
 //              channels: HEALTH
 //
 // Each generated log file is prefixed by the name of the process,
-// followed by the name of the group, separated by a hyphen.  For
-// example, the group `health` will generate files named
-// `cockroach-health.XXX.log`, assuming the process is named
-// `cockroach`. (A user can influence the prefix by renaming the
-// program executable.)
+// followed by the name of the group, separated by a hyphen. For example,
+// the group `health` will generate files named `cockroach-health.XXX.log`,
+// assuming the process is named `cockroach`. (A user can influence the
+// prefix by renaming the program executable.)
 //
 // The files are named so that a lexicographical sort of the
 // directory contents presents the file in creation order.
 //
-// Additionally, every time a new log file is generated,
-// a shorthand symbolic link (e.g. `cockroach-health.log`)
-// is maintain to point to the latest file.
+// A symlink (e.g. `cockroach-health.log`) for each group points to the latest generated log file.
 //
-// Regarding configuration, a cascading defaults mechanism is
-// available: every new file group sink configured automatically
-// inherits the configurations set in the `file-defaults` section.
+// Every new file group sink configured automatically inherits
+// the configurations set in the `file-defaults` section.
 //
 // For example:
 //
@@ -396,8 +387,9 @@ type FileDefaults struct {
 //             # Example override:
 //             dir: health-logs # override the default 'logs'
 //
-// Users are invited to peruse the `check-log-config` tool to
-// verify the effect of defaults inheritance.
+// {{site.data.alerts.callout_success}}
+// Run `cockroach debug check-log-config` to verify the effect of defaults inheritance.
+// {{site.data.alerts.end}}
 //
 type FileSinkConfig struct {
 	// Channels is the list of logging channels that use this sink.

--- a/pkg/util/log/logconfig/gen.go
+++ b/pkg/util/log/logconfig/gen.go
@@ -303,6 +303,7 @@ Configuration options shared across all sink types:
 {{end}}
 
 <a name="channel-format">
+
 ## Channel selection configuration
 
 Each sink can select multiple channels. The names of selected channels can
@@ -313,22 +314,22 @@ Example configurations:
     # Select just these two channels. Space is important.
     channels: [OPS, HEALTH]
 
-    # The selection is case insensitive.
+    # The selection is case-insensitive.
     channels: [ops, HeAlTh]
 
-    # same configuration, as a yaml string. Avoid space around comma
-    # if using the YAML "flowed" format.
+    # Same configuration, as a YAML string. Avoid space around comma
+    # if using the YAML "inline" format.
     channels: OPS,HEALTH
 
-    # same, as a quoted string.
+    # Same configuration, as a quoted string.
     channels: 'OPS, HEALTH'
 
-    # Same using a multi-line YAML array.
+    # Same configuration, as a multi-line YAML array.
     channels:
     - OPS
     - HEALTH
 
-It is also possible to select all channels, with the "all" keyword.
+It is also possible to select all channels, using the "all" keyword.
 For example:
 
     channels: all
@@ -344,5 +345,4 @@ that capture "everything else". For example:
     channels: all except [ops,health]
     channels: 'all except ops, health'
     channels: 'all except [ops, health]'
-
 `

--- a/pkg/util/log/logpb/log.pb.go
+++ b/pkg/util/log/logpb/log.pb.go
@@ -33,14 +33,14 @@ const (
 	// UNKNOWN is populated into decoded log entries when the
 	// severity could not be determined.
 	Severity_UNKNOWN Severity = 0
-	// INFO is used for informational messages, when no action
-	// is required as a result.
+	// INFO is used for informational messages that do not
+	// require action.
 	Severity_INFO Severity = 1
 	// WARNING is used for situations which may require special handling,
-	// while normal operation is expected to resume automatically.
+	// where normal operation is expected to resume automatically.
 	Severity_WARNING Severity = 2
 	// ERROR is used for situations that require special handling,
-	// when normal operation could not proceed as expected.
+	// where normal operation could not proceed as expected.
 	// Other operations can continue mostly unaffected.
 	Severity_ERROR Severity = 3
 	// FATAL is used for situations that require an immedate, hard
@@ -95,113 +95,119 @@ func (Severity) EnumDescriptor() ([]byte, []int) {
 type Channel int32
 
 const (
-	// DEV is the channel used during development, to collect log
-	// details useful for troubleshooting when it is unclear which other
-	// channel to use. It is also the default logging channel in
-	// CockroachDB, when the caller does not indicate a channel.
+	// DEV is used during development to collect log
+	// details useful for troubleshooting that fall outside the
+	// scope of other channels. It is also the default logging
+	// channel for events not associated with a channel.
 	//
 	// This channel is special in that there are no constraints as to
 	// what may or may not be logged on it. Conversely, users in
-	// production deployments are invited to not collect DEV logs in
+	// production deployments are invited to not collect `DEV` logs in
 	// centralized logging facilities, because they likely contain
 	// sensitive operational data.
+	// See [Configure logs](configure-logs.html#dev-channel).
 	Channel_DEV Channel = 0
-	// OPS is the channel used to report "point" operational events,
+	// OPS is used to report "point" operational events,
 	// initiated by user operators or automation:
 	//
-	// - operator or system actions on server processes: process starts,
+	// - Operator or system actions on server processes: process starts,
 	//   stops, shutdowns, crashes (if they can be logged),
-	//   including each time: command-line parameters, current version being run.
-	// - actions that impact the topology of a cluster: node additions,
+	//   including each time: command-line parameters, current version being run
+	// - Actions that impact the topology of a cluster: node additions,
 	//   removals, decommissions, etc.
-	// - job-related initiation or termination.
-	// - cluster setting changes.
-	// - zone configuration changes.
+	// - Job-related initiation or termination
+	// - [Cluster setting](cluster-settings.html) changes
+	// - [Zone configuration](configure-replication-zones.html) changes
 	Channel_OPS Channel = 1
-	// HEALTH is the channel used to report "background" operational
+	// HEALTH is used to report "background" operational
 	// events, initiated by CockroachDB or reporting on automatic processes:
 	//
-	// - current resource usage, including critical resource usage.
-	// - node-node connection events, including connection errors and
-	//   gossip details.
-	// - range and table leasing events.
-	// - up-, down-replication; range unavailability.
+	// - Current resource usage, including critical resource usage
+	// - Node-node connection events, including connection errors and
+	//   gossip details
+	// - Range and table leasing events
+	// - Up- and down-replication, range unavailability
 	Channel_HEALTH Channel = 2
-	// STORAGE is the channel used to report low-level storage
+	// STORAGE is used to report low-level storage
 	// layer events (RocksDB/Pebble).
 	Channel_STORAGE Channel = 3
-	// SESSIONS is the channel used to report client network activity:
+	// SESSIONS is used to report client network activity when enabled via
+	// the `server.auth_log.sql_connections.enabled` and/or
+	// `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
+	// [cluster settings](cluster-settings.html):
 	//
-	// - connections opened/closed.
-	// - authentication events: logins, failed attempts.
-	// - session and query cancellation.
+	// - Connections opened/closed
+	// - Authentication events: logins, failed attempts
+	// - Session and query cancellation
 	//
 	// This is typically configured in "audit" mode, with event
 	// numbering and synchronous writes.
 	Channel_SESSIONS Channel = 4
-	// SQL_SCHEMA is the channel used to report changes to the
+	// SQL_SCHEMA is used to report changes to the
 	// SQL logical schema, excluding privilege and ownership changes
-	// (which are reported on the separate channel PRIVILEGES) and
-	// zone config changes (which go to OPS).
+	// (which are reported separately on the `PRIVILEGES` channel) and
+	// zone configuration changes (which go to the `OPS` channel).
 	//
 	// This includes:
 	//
-	// - database/schema/table/sequence/view/type creation
-	// - adding/removing/changing table columns
-	// - changing sequence parameters
+	// - Database/schema/table/sequence/view/type creation
+	// - Adding/removing/changing table columns
+	// - Changing sequence parameters
 	//
-	// etc., more generally changes to the schema that affect the
+	// `SQL_SCHEMA` events generally comprise changes to the schema that affect the
 	// functional behavior of client apps using stored objects.
 	Channel_SQL_SCHEMA Channel = 5
-	// USER_ADMIN is the channel used to report changes
+	// USER_ADMIN is used to report changes
 	// in users and roles, including:
 	//
-	// - users added/dropped.
-	// - changes to authentication credentials, incl passwords, validity etc.
-	// - role grants/revocations.
-	// - role option grants/revocations.
+	// - Users added/dropped
+	// - Changes to authentication credentials (e.g., passwords, validity, etc.)
+	// - Role grants/revocations
+	// - Role option grants/revocations
 	//
 	// This is typically configured in "audit" mode, with event
 	// numbering and synchronous writes.
 	Channel_USER_ADMIN Channel = 6
-	// PRIVILEGES is the channel used to report data
+	// PRIVILEGES is used to report data
 	// authorization changes, including:
 	//
-	// - privilege grants/revocations on database, objects etc.
-	// - object ownership changes.
+	// - Privilege grants/revocations on database, objects, etc.
+	// - Object ownership changes
 	//
 	// This is typically configured in "audit" mode, with event
 	// numbering and synchronous writes.
 	Channel_PRIVILEGES Channel = 7
-	// SENSITIVE_ACCESS is the channel used to report SQL
-	// data access to sensitive data (when enabled):
+	// SENSITIVE_ACCESS is used to report SQL
+	// data access to sensitive data:
 	//
-	// - data access audit events (when table audit is enabled).
-	// - SQL statements executed by users with the ADMIN bit.
-	// - operations that write to `system` tables.
+	// - Data access audit events (when table audit is enabled via
+	//   [EXPERIMENTAL_AUDIT](experimental-audit.html))
+	// - SQL statements executed by users with the admin role
+	// - Operations that write to system tables
 	//
 	// This is typically configured in "audit" mode, with event
 	// numbering and synchronous writes.
 	Channel_SENSITIVE_ACCESS Channel = 8
-	// SQL_EXEC is the channel used to report SQL execution on
+	// SQL_EXEC is used to report SQL execution on
 	// behalf of client connections:
 	//
-	// - logical SQL statement executions (if enabled)
-	// - pgwire events (if enabled)
+	// - Logical SQL statement executions (when enabled via the
+	//   `sql.trace.log_statement_execute` [cluster setting](cluster-settings.html))
+	// - pgwire events (when enabled)
 	Channel_SQL_EXEC Channel = 9
-	// SQL_PERF is the channel used to report SQL executions
-	// that are marked to be highlighted as "out of the ordinary"
+	// SQL_PERF is used to report SQL executions
+	// that are marked as "out of the ordinary"
 	// to facilitate performance investigations.
-	// This includes the "SQL slow query log".
+	// This includes the SQL "slow query log".
 	//
-	// Arguably, this channel overlaps with SQL_EXEC defined above.
-	// However, we keep them separate for backward-compatibility
-	// with previous versions, where the corresponding events
+	// Arguably, this channel overlaps with `SQL_EXEC`.
+	// However, we keep both channels separate for backward compatibility
+	// with versions prior to v21.1, where the corresponding events
 	// were redirected to separate files.
 	Channel_SQL_PERF Channel = 10
-	// SQL_INTERNAL_PERF is like the SQL perf channel above but aimed at
+	// SQL_INTERNAL_PERF is like the `SQL_PERF` channel, but is aimed at
 	// helping developers of CockroachDB itself. It exists as a separate
-	// channel so as to not pollute the SQL perf logging output with
+	// channel so as to not pollute the `SQL_PERF` logging output with
 	// internal troubleshooting details.
 	Channel_SQL_INTERNAL_PERF Channel = 11
 )
@@ -275,7 +281,7 @@ type Entry struct {
 	// It is incremented for every use of the logger where the entry was
 	// produced.
 	Counter uint64 `protobuf:"varint,8,opt,name=counter,proto3" json:"counter,omitempty"`
-	// Redactable is true iff the message and tags fields include markers
+	// Redactable is true if the message and tags fields include markers
 	// to delineate sensitive information. In that case, confidentiality
 	// can be obtained by only stripping away the data within this
 	// marker. If redactable is false or unknown, the message should be

--- a/pkg/util/log/logpb/log.proto
+++ b/pkg/util/log/logpb/log.proto
@@ -22,14 +22,14 @@ enum Severity {
   // UNKNOWN is populated into decoded log entries when the
   // severity could not be determined.
   UNKNOWN = 0;
-  // INFO is used for informational messages, when no action
-  // is required as a result.
+  // INFO is used for informational messages that do not
+  // require action.
   INFO = 1;
   // WARNING is used for situations which may require special handling,
-  // while normal operation is expected to resume automatically.
+  // where normal operation is expected to resume automatically.
   WARNING = 2;
   // ERROR is used for situations that require special handling,
-  // when normal operation could not proceed as expected.
+  // where normal operation could not proceed as expected.
   // Other operations can continue mostly unaffected.
   ERROR = 3;
   // FATAL is used for situations that require an immedate, hard
@@ -54,124 +54,130 @@ enum Severity {
 // Note: do not forget to run gen.sh (go generate) when
 // changing this list or the explanatory comments.
 enum Channel {
-  // DEV is the channel used during development, to collect log
-  // details useful for troubleshooting when it is unclear which other
-  // channel to use. It is also the default logging channel in
-  // CockroachDB, when the caller does not indicate a channel.
+  // DEV is used during development to collect log
+  // details useful for troubleshooting that fall outside the
+  // scope of other channels. It is also the default logging
+  // channel for events not associated with a channel.
   //
   // This channel is special in that there are no constraints as to
   // what may or may not be logged on it. Conversely, users in
-  // production deployments are invited to not collect DEV logs in
+  // production deployments are invited to not collect `DEV` logs in
   // centralized logging facilities, because they likely contain
   // sensitive operational data.
+  // See [Configure logs](configure-logs.html#dev-channel).
   DEV = 0;
 
-  // OPS is the channel used to report "point" operational events,
+  // OPS is used to report "point" operational events,
   // initiated by user operators or automation:
   //
-  // - operator or system actions on server processes: process starts,
+  // - Operator or system actions on server processes: process starts,
   //   stops, shutdowns, crashes (if they can be logged),
-  //   including each time: command-line parameters, current version being run.
-  // - actions that impact the topology of a cluster: node additions,
+  //   including each time: command-line parameters, current version being run
+  // - Actions that impact the topology of a cluster: node additions,
   //   removals, decommissions, etc.
-  // - job-related initiation or termination.
-  // - cluster setting changes.
-  // - zone configuration changes.
+  // - Job-related initiation or termination
+  // - [Cluster setting](cluster-settings.html) changes
+  // - [Zone configuration](configure-replication-zones.html) changes
   OPS = 1;
 
-  // HEALTH is the channel used to report "background" operational
+  // HEALTH is used to report "background" operational
   // events, initiated by CockroachDB or reporting on automatic processes:
   //
-  // - current resource usage, including critical resource usage.
-  // - node-node connection events, including connection errors and
-  //   gossip details.
-  // - range and table leasing events.
-  // - up-, down-replication; range unavailability.
+  // - Current resource usage, including critical resource usage
+  // - Node-node connection events, including connection errors and
+  //   gossip details
+  // - Range and table leasing events
+  // - Up- and down-replication, range unavailability
   HEALTH = 2;
 
-  // STORAGE is the channel used to report low-level storage
+  // STORAGE is used to report low-level storage
   // layer events (RocksDB/Pebble).
   STORAGE = 3;
 
-  // SESSIONS is the channel used to report client network activity:
+  // SESSIONS is used to report client network activity when enabled via
+  // the `server.auth_log.sql_connections.enabled` and/or
+  // `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)
+  // [cluster settings](cluster-settings.html):
   //
-  // - connections opened/closed.
-  // - authentication events: logins, failed attempts.
-  // - session and query cancellation.
+  // - Connections opened/closed
+  // - Authentication events: logins, failed attempts
+  // - Session and query cancellation
   //
   // This is typically configured in "audit" mode, with event
   // numbering and synchronous writes.
   SESSIONS = 4;
 
-  // SQL_SCHEMA is the channel used to report changes to the
+  // SQL_SCHEMA is used to report changes to the
   // SQL logical schema, excluding privilege and ownership changes
-  // (which are reported on the separate channel PRIVILEGES) and
-  // zone config changes (which go to OPS).
+  // (which are reported separately on the `PRIVILEGES` channel) and
+  // zone configuration changes (which go to the `OPS` channel).
   //
   // This includes:
   //
-  // - database/schema/table/sequence/view/type creation
-  // - adding/removing/changing table columns
-  // - changing sequence parameters
+  // - Database/schema/table/sequence/view/type creation
+  // - Adding/removing/changing table columns
+  // - Changing sequence parameters
   //
-  // etc., more generally changes to the schema that affect the
+  // `SQL_SCHEMA` events generally comprise changes to the schema that affect the
   // functional behavior of client apps using stored objects.
   SQL_SCHEMA = 5;
 
-  // USER_ADMIN is the channel used to report changes
+  // USER_ADMIN is used to report changes
   // in users and roles, including:
   //
-  // - users added/dropped.
-  // - changes to authentication credentials, incl passwords, validity etc.
-  // - role grants/revocations.
-  // - role option grants/revocations.
+  // - Users added/dropped
+  // - Changes to authentication credentials (e.g., passwords, validity, etc.)
+  // - Role grants/revocations
+  // - Role option grants/revocations
   //
   // This is typically configured in "audit" mode, with event
   // numbering and synchronous writes.
   USER_ADMIN = 6;
 
-  // PRIVILEGES is the channel used to report data
+  // PRIVILEGES is used to report data
   // authorization changes, including:
   //
-  // - privilege grants/revocations on database, objects etc.
-  // - object ownership changes.
+  // - Privilege grants/revocations on database, objects, etc.
+  // - Object ownership changes
   //
   // This is typically configured in "audit" mode, with event
   // numbering and synchronous writes.
   PRIVILEGES = 7;
 
-  // SENSITIVE_ACCESS is the channel used to report SQL
-  // data access to sensitive data (when enabled):
+  // SENSITIVE_ACCESS is used to report SQL
+  // data access to sensitive data:
   //
-  // - data access audit events (when table audit is enabled).
-  // - SQL statements executed by users with the ADMIN bit.
-  // - operations that write to `system` tables.
+  // - Data access audit events (when table audit is enabled via
+  //   [EXPERIMENTAL_AUDIT](experimental-audit.html))
+  // - SQL statements executed by users with the admin role
+  // - Operations that write to system tables
   //
   // This is typically configured in "audit" mode, with event
   // numbering and synchronous writes.
   SENSITIVE_ACCESS = 8;
 
-  // SQL_EXEC is the channel used to report SQL execution on
+  // SQL_EXEC is used to report SQL execution on
   // behalf of client connections:
   //
-  // - logical SQL statement executions (if enabled)
-  // - pgwire events (if enabled)
+  // - Logical SQL statement executions (when enabled via the
+  //   `sql.trace.log_statement_execute` [cluster setting](cluster-settings.html))
+  // - pgwire events (when enabled)
   SQL_EXEC = 9;
 
-  // SQL_PERF is the channel used to report SQL executions
-  // that are marked to be highlighted as "out of the ordinary"
+  // SQL_PERF is used to report SQL executions
+  // that are marked as "out of the ordinary"
   // to facilitate performance investigations.
-  // This includes the "SQL slow query log".
+  // This includes the SQL "slow query log".
   //
-  // Arguably, this channel overlaps with SQL_EXEC defined above.
-  // However, we keep them separate for backward-compatibility
-  // with previous versions, where the corresponding events
+  // Arguably, this channel overlaps with `SQL_EXEC`.
+  // However, we keep both channels separate for backward compatibility
+  // with versions prior to v21.1, where the corresponding events
   // were redirected to separate files.
   SQL_PERF = 10;
 
-  // SQL_INTERNAL_PERF is like the SQL perf channel above but aimed at
+  // SQL_INTERNAL_PERF is like the `SQL_PERF` channel, but is aimed at
   // helping developers of CockroachDB itself. It exists as a separate
-  // channel so as to not pollute the SQL perf logging output with
+  // channel so as to not pollute the `SQL_PERF` logging output with
   // internal troubleshooting details.
   SQL_INTERNAL_PERF = 11;
 }
@@ -210,7 +216,7 @@ message Entry {
   // produced.
   uint64 counter = 8;
 
-  // Redactable is true iff the message and tags fields include markers
+  // Redactable is true if the message and tags fields include markers
   // to delineate sensitive information. In that case, confidentiality
   // can be obtained by only stripping away the data within this
   // marker. If redactable is false or unknown, the message should be

--- a/pkg/util/log/severity/severity_generated.go
+++ b/pkg/util/log/severity/severity_generated.go
@@ -8,16 +8,16 @@ import "github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 // severity could not be determined.
 const UNKNOWN = logpb.Severity_UNKNOWN
 
-// INFO is used for informational messages, when no action
-// is required as a result.
+// INFO is used for informational messages that do not
+// require action.
 const INFO = logpb.Severity_INFO
 
 // WARNING is used for situations which may require special handling,
-// while normal operation is expected to resume automatically.
+// where normal operation is expected to resume automatically.
 const WARNING = logpb.Severity_WARNING
 
 // ERROR is used for situations that require special handling,
-// when normal operation could not proceed as expected.
+// where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 const ERROR = logpb.Severity_ERROR
 


### PR DESCRIPTION
The auto-generated docs at https://github.com/cockroachdb/cockroach/tree/master/docs/generated will be used as includes on the public docs site. This PR makes copyedits and some corrections to the text.

- In the log format docs, I added formatting that I think will add code ticks to field names. In some cases (e.g., ‹...›) I may  not have done this correctly.
- The structured event description for `node_decommissioning` is not appearing correctly in eventlog.md. The generated sentence for this event does not match the corresponding line in the other event descriptions. I fixed a typo where this was written as "NodeDecommissioned" but I'm not sure if that fixes the issue.
- In a few cases I pasted lines that were much longer than what was originally in the commented-out blocks. I hope this doesn't break the generation!

Release note: none