### PR TITLE
release-21.1: sql: remove three KV lookups from pg_catalog queries

### DIFF
--- a/pkg/bench/ddl_analysis/orm_queries_bench_test.go
+++ b/pkg/bench/ddl_analysis/orm_queries_bench_test.go
@@ -135,6 +135,30 @@ WHERE
   OR t.typinput = 'array_in(cstring,oid,integer)'::REGPROCEDURE
   OR t.typelem != 0`,
 		},
+
+		{
+			name:  "pg_type",
+			setup: `CREATE TABLE t1(a int primary key, b int);`,
+			stmt:  `SELECT * FROM pg_type`,
+		},
+
+		{
+			name:  "pg_class",
+			setup: `CREATE TABLE t1(a int primary key, b int);`,
+			stmt:  `SELECT * FROM pg_class`,
+		},
+
+		{
+			name:  "pg_namespace",
+			setup: `CREATE TABLE t1(a int primary key, b int);`,
+			stmt:  `SELECT * FROM pg_namespace`,
+		},
+
+		{
+			name:  "pg_attribute",
+			setup: `CREATE TABLE t1(a int primary key, b int);`,
+			stmt:  `SELECT * FROM pg_attribute`,
+		},
 	}
 
 	RunRoundTripBenchmark(b, tests)

--- a/pkg/bench/ddl_analysis/testdata/benchmark_expectations
+++ b/pkg/bench/ddl_analysis/testdata/benchmark_expectations
@@ -52,10 +52,14 @@ exp,benchmark
 42,Grant/grant_all_on_3_tables
 21,GrantRole/grant_1_role
 24,GrantRole/grant_2_roles
-3,ORMQueries/activerecord_type_introspection_query
+2,ORMQueries/activerecord_type_introspection_query
 2,ORMQueries/django_table_introspection_1_table
 2,ORMQueries/django_table_introspection_4_tables
 2,ORMQueries/django_table_introspection_8_tables
+2,ORMQueries/pg_attribute
+2,ORMQueries/pg_class
+2,ORMQueries/pg_namespace
+2,ORMQueries/pg_type
 24,Revoke/revoke_all_on_1_table
 33,Revoke/revoke_all_on_2_tables
 42,Revoke/revoke_all_on_3_tables

--- a/pkg/bench/ddl_analysis/testdata/benchmark_expectations
+++ b/pkg/bench/ddl_analysis/testdata/benchmark_expectations
@@ -52,7 +52,7 @@ exp,benchmark
 42,Grant/grant_all_on_3_tables
 21,GrantRole/grant_1_role
 24,GrantRole/grant_2_roles
-4,ORMQueries/activerecord_type_introspection_query
+3,ORMQueries/activerecord_type_introspection_query
 2,ORMQueries/django_table_introspection_1_table
 2,ORMQueries/django_table_introspection_4_tables
 2,ORMQueries/django_table_introspection_8_tables

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1797,7 +1797,7 @@ func forEachSchema(
 	}
 	for i := range userDefinedSchemas {
 		desc := userDefinedSchemas[i]
-		canSeeDescriptor, err := userCanSeeDescriptor(ctx, p, desc, false /* allowAdding */)
+		canSeeDescriptor, err := userCanSeeDescriptor(ctx, p, desc, db, false /* allowAdding */)
 		if err != nil {
 			return err
 		}
@@ -1867,7 +1867,7 @@ func forEachDatabaseDesc(
 
 	// Ignore databases that the user cannot see.
 	for _, dbDesc := range dbDescs {
-		canSeeDescriptor, err := userCanSeeDescriptor(ctx, p, dbDesc, false /* allowAdding */)
+		canSeeDescriptor, err := userCanSeeDescriptor(ctx, p, dbDesc, nil /* parentDBDesc */, false /* allowAdding */)
 		if err != nil {
 			return err
 		}
@@ -1894,23 +1894,19 @@ func forEachTypeDesc(
 	if err != nil {
 		return err
 	}
-	schemaNames, err := getSchemaNames(ctx, p, dbContext)
-	if err != nil {
-		return err
-	}
 	lCtx := newInternalLookupCtx(ctx, descs, dbContext,
 		catalogkv.NewOneLevelUncachedDescGetter(p.txn, p.execCfg.Codec))
 	for _, id := range lCtx.typIDs {
 		typ := lCtx.typDescs[id]
-		dbDesc, parentExists := lCtx.dbDescs[typ.ParentID]
-		if !parentExists {
+		dbDesc, err := lCtx.getDatabaseByID(typ.GetParentID())
+		if err != nil {
 			continue
 		}
-		scName, ok := schemaNames[typ.GetParentSchemaID()]
+		scName, ok := lCtx.schemaNames[typ.GetParentSchemaID()]
 		if !ok {
 			return errors.AssertionFailedf("schema id %d not found", typ.GetParentSchemaID())
 		}
-		canSeeDescriptor, err := userCanSeeDescriptor(ctx, p, typ, false /* allowAdding */)
+		canSeeDescriptor, err := userCanSeeDescriptor(ctx, p, typ, dbDesc, false /* allowAdding */)
 		if err != nil {
 			return err
 		}
@@ -2082,26 +2078,26 @@ func forEachTypeDescWithTableLookupInternalFromDescriptors(
 
 	for _, typID := range lCtx.typIDs {
 		typDesc := lCtx.typDescs[typID]
-		canSeeDescriptor, err := userCanSeeDescriptor(ctx, p, typDesc, allowAdding)
+		if typDesc.Dropped() {
+			continue
+		}
+		dbDesc, err := lCtx.getDatabaseByID(typDesc.GetParentID())
 		if err != nil {
 			return err
 		}
-		if typDesc.Dropped() || !canSeeDescriptor {
+		canSeeDescriptor, err := userCanSeeDescriptor(ctx, p, typDesc, dbDesc, allowAdding)
+		if err != nil {
+			return err
+		}
+		if !canSeeDescriptor {
 			continue
 		}
-		var scName string
-		dbDesc, parentExists := lCtx.dbDescs[typDesc.GetParentID()]
-		if parentExists {
-			var ok bool
-			scName, ok = lCtx.schemaNames[typDesc.GetParentSchemaID()]
-			if !ok {
-				return errors.AssertionFailedf("schema id %d not found", typDesc.GetParentSchemaID())
-			}
-			if err := fn(dbDesc, scName, typDesc, lCtx); err != nil {
-				return err
-			}
-		} else {
-			return errors.AssertionFailedf("database id %d not found", typDesc.GetParentID())
+		scName, ok := lCtx.schemaNames[typDesc.GetParentSchemaID()]
+		if !ok {
+			return errors.AssertionFailedf("schema id %d not found", typDesc.GetParentSchemaID())
+		}
+		if err := fn(dbDesc, scName, typDesc, lCtx); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -2155,7 +2151,8 @@ func forEachTableDescWithTableLookupInternalFromDescriptors(
 	// Physical descriptors next.
 	for _, tbID := range lCtx.tbIDs {
 		table := lCtx.tbDescs[tbID]
-		canSeeDescriptor, err := userCanSeeDescriptor(ctx, p, table, allowAdding)
+		dbDesc, parentExists := lCtx.dbDescs[table.GetParentID()]
+		canSeeDescriptor, err := userCanSeeDescriptor(ctx, p, table, dbDesc, allowAdding)
 		if err != nil {
 			return err
 		}
@@ -2163,7 +2160,6 @@ func forEachTableDescWithTableLookupInternalFromDescriptors(
 			continue
 		}
 		var scName string
-		dbDesc, parentExists := lCtx.dbDescs[table.GetParentID()]
 		if parentExists {
 			var ok bool
 			scName, ok = lCtx.schemaNames[table.GetParentSchemaID()]
@@ -2294,25 +2290,19 @@ func forEachRoleMembership(
 }
 
 func userCanSeeDescriptor(
-	ctx context.Context, p *planner, desc catalog.Descriptor, allowAdding bool,
+	ctx context.Context, p *planner, desc, parentDBDesc catalog.Descriptor, allowAdding bool,
 ) (bool, error) {
 	if !descriptorIsVisible(desc, allowAdding) {
 		return false, nil
 	}
 
-	found, dbDesc, err := p.Descriptors().GetImmutableDatabaseByID(
-		ctx, p.Txn(), desc.GetParentID(), tree.DatabaseLookupFlags{Required: false},
-	)
-	if err != nil {
-		return false, err
-	}
 	// TODO(richardjcai): We may possibly want to remove the ability to view
 	// the descriptor if they have any privilege on the descriptor and only
 	// allow the descriptor to be viewed if they have CONNECT on the DB. #59827.
 	canSeeDescriptor := p.CheckAnyPrivilege(ctx, desc) == nil
 	// Users can see objects in the database if they have connect privilege.
-	if found {
-		canSeeDescriptor = canSeeDescriptor || p.CheckPrivilege(ctx, dbDesc, privilege.CONNECT) == nil
+	if parentDBDesc != nil {
+		canSeeDescriptor = canSeeDescriptor || p.CheckPrivilege(ctx, parentDBDesc, privilege.CONNECT) == nil
 	}
 	return canSeeDescriptor, nil
 }

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1067,7 +1067,7 @@ func makeAllRelationsVirtualTableWithDescriptorIDIndex(
 					}
 					// Don't include tables that aren't in the current database unless
 					// they're virtual, dropped tables, or ones that the user can't see.
-					canSeeDescriptor, err := userCanSeeDescriptor(ctx, p, table, true /*allowAdding*/)
+					canSeeDescriptor, err := userCanSeeDescriptor(ctx, p, table, db, true /*allowAdding*/)
 					if err != nil {
 						return false, err
 					}
@@ -2461,14 +2461,9 @@ https://www.postgresql.org/docs/9.5/catalog-pg-type.html`,
 				}
 
 				// Now generate rows for user defined types in this database.
-				return forEachTypeDesc(ctx, p, dbContext, func(_ *dbdesc.Immutable, _ string, typDesc *typedesc.Immutable) error {
-					sc, err := p.Descriptors().GetImmutableSchemaByID(
-						ctx, p.txn, typDesc.ParentSchemaID, tree.SchemaLookupFlags{})
-					if err != nil {
-						return err
-					}
-					nspOid := h.NamespaceOid(db.GetID(), sc.Name)
-					typ, err := typDesc.MakeTypesT(ctx, tree.NewUnqualifiedTypeName(tree.Name(typDesc.GetName())), p)
+				return forEachTypeDesc(ctx, p, db, func(_ *dbdesc.Immutable, scName string, typDesc *typedesc.Immutable) error {
+					nspOid := h.NamespaceOid(db.GetID(), scName)
+					typ, err := typDesc.MakeTypesT(ctx, tree.NewQualifiedTypeName(db.Name, scName, typDesc.GetName()), p)
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
Backport 2/2 commits from #62216.

/cc @cockroachdb/release

---

Use the descriptors that have already been fetched, instead of
re-getting them.

Release note: None
