### PR TITLE
colexecutils: optimize the deselector a bit for zero batch

### DIFF
--- a/pkg/sql/colexec/colexecutils/deselector.go
+++ b/pkg/sql/colexec/colexecutils/deselector.go
@@ -66,7 +66,7 @@ func (p *deselectorOp) Next(ctx context.Context) coldata.Batch {
 		p.inputTypes, p.output, 1 /* minCapacity */, maxBatchMemSize,
 	)
 	batch := p.Input.Next(ctx)
-	if batch.Selection() == nil {
+	if batch.Selection() == nil || batch.Length() == 0 {
 		return batch
 	}
 	p.output, _ = p.allocator.ResetMaybeReallocate(


### PR DESCRIPTION
Zero length batch is special in the vectorized engine. Once we receive
it from the input, in the vast majority of cases we don't need to do any
processing in the operator. Previously, the deselector would still do
some stuff even for zero batch, and now it'll short-circuit as most
operators do.

Release note: None