### PR TITLE
geo/geomfn: add point in polygon optimization to st_contains, st_within

### DIFF
--- a/pkg/geo/geomfn/binary_predicates_test.go
+++ b/pkg/geo/geomfn/binary_predicates_test.go
@@ -413,6 +413,9 @@ func TestWithin(t *testing.T) {
 		{leftRectPoint, leftRect, true},
 		{leftRectMultiPoint, leftRect, true},
 		{leftRectMultiPoint, leftRectWithHole, false},
+		{leftRectHoleEdgePoint, leftRectWithHole, false},
+		{leftRectEdgePoint, leftRectWithHole, false},
+		{leftRectEdgeMultiPoint, leftRectWithHole, true},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
This patch improves the performance of st_contains
and st_within for the common use case of testing
whether a (multi)polygon contains a (multi)point.

Release note: None