### PR TITLE
roachpb: fix Bazel dependency issue with string tests

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -127,6 +127,7 @@ ALL_TESTS = [
     "//pkg/migration/migrationmanager:migrationmanager_test",
     "//pkg/migration/migrations:migrations_test",
     "//pkg/roachpb:roachpb_test",
+    "//pkg/roachpb:string_test",
     "//pkg/rpc/nodedialer:nodedialer_test",
     "//pkg/rpc:rpc_test",
     "//pkg/security:security_test",

--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -1,3 +1,5 @@
+# gazelle:exclude string_test.go
+
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
@@ -116,17 +118,13 @@ go_test(
         "metadata_replicas_test.go",
         "metadata_test.go",
         "span_group_test.go",
-        "string_test.go",
         "tenant_test.go",
         "version_test.go",
     ],
     embed = [":roachpb"],
-    tags = ["broken_in_bazel"],
     deps = [
         "//pkg/cli/exit",
-        "//pkg/keys",
         "//pkg/kv/kvserver/concurrency/lock",
-        "//pkg/roachpb",
         "//pkg/storage/enginepb",
         "//pkg/testutils/buildutil",
         "//pkg/testutils/zerofields",
@@ -152,6 +150,24 @@ go_test(
         "@io_etcd_go_etcd_raft_v3//quorum",
         "@io_etcd_go_etcd_raft_v3//raftpb",
         "@io_etcd_go_etcd_raft_v3//tracker",
+    ],
+)
+
+# keep
+go_test(
+    name = "string_test",
+    size = "small",
+    srcs = ["string_test.go"],
+    deps = [
+        ":roachpb",
+        "//pkg/cli/exit",
+        "//pkg/keys",
+        "//pkg/kv/kvserver/concurrency/lock",
+        "//pkg/storage/enginepb",
+        "//pkg/util/hlc",
+        "//pkg/util/uuid",
+        "@com_github_cockroachdb_redact//:redact",
+        "@com_github_stretchr_testify//require",
     ],
 )
 

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -12,7 +12,6 @@ package roachpb
 
 import (
 	"bytes"
-	"fmt"
 	"math"
 	"math/rand"
 	"reflect"
@@ -1620,17 +1619,6 @@ func TestValuePrettyPrint(t *testing.T) {
 		}
 	}
 }
-
-func TestKeyFormat(t *testing.T) {
-	const sample = "\xbd\xb2\x3d\xbc\x20\xe2\x8c\x98"
-	k := Key(sample)
-	expected := ` /Table/53/42/"=\xbc ⌘"`
-	actual := fmt.Sprintf(" %s", k)
-	if expected != actual {
-		t.Errorf("String formatting of key: got %q expected %q", actual, expected)
-	}
-}
-
 func TestUpdateObservedTimestamps(t *testing.T) {
 	f := func(nodeID NodeID, walltime int64) ObservedTimestamp {
 		return ObservedTimestamp{

--- a/pkg/roachpb/main_test.go
+++ b/pkg/roachpb/main_test.go
@@ -7,6 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
-package roachpb_test
+package roachpb
 
 import _ "github.com/cockroachdb/cockroach/pkg/util/log" // for flags

--- a/pkg/roachpb/metadata_test.go
+++ b/pkg/roachpb/metadata_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/redact"
 	"github.com/stretchr/testify/require"
 )
 
@@ -77,28 +76,6 @@ func TestRangeDescriptorFindReplica(t *testing.T) {
 		} else if a != e {
 			t.Errorf("%d: expected to find %+v in %+v for store %d; got %+v", i, e, desc, e.StoreID, a)
 		}
-	}
-}
-
-func TestRangeDescriptorSafeMessage(t *testing.T) {
-	desc := RangeDescriptor{
-		RangeID:  1,
-		StartKey: RKey("c"),
-		EndKey:   RKey("g"),
-		InternalReplicas: []ReplicaDescriptor{
-			{NodeID: 1, StoreID: 1},
-			{NodeID: 2, StoreID: 2},
-			{NodeID: 3, StoreID: 3},
-		},
-	}
-
-	const expStr = `r1:‹{c-g}› [(n1,s1):?, (n2,s2):?, (n3,s3):?, next=0, gen=0]`
-
-	if str := redact.Sprint(desc); str != expStr {
-		t.Errorf(
-			"expected meta: %s\n"+
-				"got:          %s",
-			expStr, str)
 	}
 }
 

--- a/pkg/roachpb/string_test.go
+++ b/pkg/roachpb/string_test.go
@@ -90,3 +90,27 @@ func TestBatchRequestString(t *testing.T) {
 		require.EqualValues(t, exp, act)
 	}
 }
+
+func TestKeyString(t *testing.T) {
+	require.Equal(t,
+		`/Table/53/42/"=\xbc ⌘"`,
+		roachpb.Key("\xbd\xb2\x3d\xbc\x20\xe2\x8c\x98").String())
+}
+
+func TestRangeDescriptorStringRedact(t *testing.T) {
+	desc := roachpb.RangeDescriptor{
+		RangeID:  1,
+		StartKey: roachpb.RKey("c"),
+		EndKey:   roachpb.RKey("g"),
+		InternalReplicas: []roachpb.ReplicaDescriptor{
+			{NodeID: 1, StoreID: 1},
+			{NodeID: 2, StoreID: 2},
+			{NodeID: 3, StoreID: 3},
+		},
+	}
+
+	require.EqualValues(t,
+		`r1:‹{c-g}› [(n1,s1):?, (n2,s2):?, (n3,s3):?, next=0, gen=0]`,
+		redact.Sprint(desc),
+	)
+}


### PR DESCRIPTION
`roachpb` string formatting tests need to import `keys` to enable string
formatting for `roachpb.Key`, which in turn imports `roachpb` itself.
These tests therefore use the `roachpb_test` package to avoid a circular
dependency, while the other tests use the `roachpb` package.  However,
Bazel does not support this dependency structure where an "external
test" has a transitive dependency which also depends on the package
being tested.

This patch splits out the string formatting tests into a separate Bazel
target to avoid the dependency issue. Since some tests in the main
`roachpb` package also implicitly depended on the key formatting
registration via the `keys` import in `roachpb_test` they had to
be moved to `string_test.go` as well.

Resolves #61357.

Release note: None