### PR TITLE
release-21.1: backupccl: Add `as_json` option to `SHOW BACKUP`

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -72,6 +72,7 @@ go_library(
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/physicalplan",
         "//pkg/sql/privilege",
+        "//pkg/sql/protoreflect",
         "//pkg/sql/roleoption",
         "//pkg/sql/rowenc",
         "//pkg/sql/rowexec",

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -60,6 +60,7 @@ const (
 	backupOptEncPassphrase   = "encryption_passphrase"
 	backupOptEncKMS          = "kms"
 	backupOptWithPrivileges  = "privileges"
+	backupOptAsJSON          = "as_json"
 	localityURLParam         = "COCKROACH_LOCALITY"
 	defaultLocalityValue     = "default"
 )

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/protoreflect"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -93,6 +94,7 @@ func showBackupPlanHook(
 		backupOptEncPassphrase:  sql.KVStringOptRequireValue,
 		backupOptEncKMS:         sql.KVStringOptRequireValue,
 		backupOptWithPrivileges: sql.KVStringOptRequireNoValue,
+		backupOptAsJSON:         sql.KVStringOptRequireNoValue,
 	}
 	optsFn, err := p.TypeAsStringOpts(ctx, backup.Options, expected)
 	if err != nil {
@@ -103,12 +105,18 @@ func showBackupPlanHook(
 		return nil, nil, nil, false, err
 	}
 
+	if _, asJSON := opts[backupOptAsJSON]; asJSON {
+		backup.Details = tree.BackupManifestAsJSON
+	}
+
 	var shower backupShower
 	switch backup.Details {
 	case tree.BackupRangeDetails:
 		shower = backupShowerRanges
 	case tree.BackupFileDetails:
 		shower = backupShowerFiles
+	case tree.BackupManifestAsJSON:
+		shower = jsonShower
 	default:
 		shower = backupShowerDefault(ctx, p, backup.ShouldIncludeSchemas, opts)
 	}
@@ -499,6 +507,24 @@ var backupShowerFiles = backupShower{
 					tree.NewDInt(tree.DInt(file.EntryCounts.Rows)),
 				})
 			}
+		}
+		return rows, nil
+	},
+}
+
+var jsonShower = backupShower{
+	header: colinfo.ResultColumns{
+		{Name: "manifest", Typ: types.Jsonb},
+	},
+
+	fn: func(manifests []BackupManifest) ([]tree.Datums, error) {
+		rows := make([]tree.Datums, len(manifests))
+		for i, manifest := range manifests {
+			j, err := protoreflect.MessageToJSON(&manifest, true)
+			if err != nil {
+				return nil, err
+			}
+			rows[i] = tree.Datums{tree.NewDJSON(j)}
 		}
 		return rows, nil
 	},

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -83,6 +83,8 @@ const (
 	BackupRangeDetails
 	// BackupFileDetails identifies a SHOW BACKUP FILES statement.
 	BackupFileDetails
+	// BackupManifestAsJSON displays full backup manifest as json
+	BackupManifestAsJSON
 )
 
 // ShowBackup represents a SHOW BACKUP statement.


### PR DESCRIPTION
Backport 1/1 commits from #62628.

/cc @cockroachdb/release

---

Add `as_json` option to `SHOW BACKUP` command which
renders backup manifest as JSONB value.

Release Notes: New as_json option which renders backup manifest
as JSON value.
