### PR TITLE
bazel: mark pprofui test as being broken in Bazel

### DIFF
--- a/pkg/server/debug/pprofui/BUILD.bazel
+++ b/pkg/server/debug/pprofui/BUILD.bazel
@@ -29,4 +29,5 @@ go_test(
     size = "small",
     srcs = ["server_test.go"],
     embed = [":pprofui"],
+    tags = ["broken_in_bazel"],
 )


### PR DESCRIPTION
The failure looks like this:

```
=== RUN   TestServer/0
    server_test.go:51: body does not contain "pprof</a></h1>": neither $XDG_CONFIG_HOME nor $HOME are defined
=== RUN   TestServer/1
    server_test.go:51: body does not contain "pprof</a></h1>": neither $XDG_CONFIG_HOME nor $HOME are defined
=== RUN   TestServer/2
    server_test.go:51: body does not contain "pprof</a></h1>": neither $XDG_CONFIG_HOME nor $HOME are defined
```

Release note: None