### PR TITLE
bazel: bump changefeedccl test size

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -101,7 +101,7 @@ go_library(
 
 go_test(
     name = "changefeedccl_test",
-    size = "medium",
+    size = "large",
     srcs = [
         "avro_test.go",
         "bench_test.go",


### PR DESCRIPTION
This timed out in CI at `medium`:
https://teamcity.cockroachdb.com/viewLog.html?buildId=2818330&buildTypeId=Cockroach_UnitTests_BazelUnitTests&tab=buildResultsDiv

Release note: None