### PR TITLE
bulkio: Rework scheduled job test.

### DIFF
--- a/pkg/jobs/scheduled_job_executor_test.go
+++ b/pkg/jobs/scheduled_job_executor_test.go
@@ -72,9 +72,10 @@ func TestScheduledJobExecutorRegistration(t *testing.T) {
 	instance := newStatusTrackingExecutor()
 	defer registerScopedScheduledJobExecutor(executorName, instance)()
 
-	registered, err := newScheduledJobExecutor(executorName)
+	registered, created, err := GetScheduledJobExecutor(executorName)
 	require.NoError(t, err)
 	require.Equal(t, instance, registered)
+	require.True(t, created)
 }
 
 func TestJobTerminationNotification(t *testing.T) {

--- a/pkg/jobs/testutils_test.go
+++ b/pkg/jobs/testutils_test.go
@@ -149,7 +149,10 @@ func registerScopedScheduledJobExecutor(name string, ex ScheduledJobExecutor) fu
 			return ex, nil
 		})
 	return func() {
-		delete(registeredExecutorFactories, name)
+		executorRegistry.Lock()
+		defer executorRegistry.Unlock()
+		delete(executorRegistry.factories, name)
+		delete(executorRegistry.executors, name)
 	}
 }
 


### PR DESCRIPTION
Rework `TestTransientTxnErrors` to be much simpler and faster.
Instead of creating multiple go routines that try to race
with each other to cause txn restarts, create a simple schedule
that we can manaully synchronize with the test to cause the same
condition.

Unskip this test under race since it now takes 250ms instead of
4-5 seconds.

Fix executor registration mechanism (used in tests) so that defer'ed
cleanup does not race when running multiple test.count executions.

Fixes #62230

Release Notes: None