### PR TITLE
[release-21.1] vendor: Bump pebble to b49f2eeba24b

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -525,8 +525,8 @@ def go_deps():
         name = "com_github_cockroachdb_pebble",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/pebble",
-        sum = "h1:eDPZb4vP/jcgEAh/IRShMewRVlwqAUNv73BBZnhw/yI=",
-        version = "v0.0.0-20210310192349-958290ba5bd6",
+        sum = "h1:OyhxDJwrC2nToGdjT0O3vn5LNiC3AWzfNeOKtcg4PyU=",
+        version = "v0.0.0-20210326183201-b49f2eeba24b",
     )
     go_repository(
         name = "com_github_cockroachdb_redact",

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20210310192349-958290ba5bd6
+	github.com/cockroachdb/pebble v0.0.0-20210326183201-b49f2eeba24b
 	github.com/cockroachdb/redact v1.0.9
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,8 @@ github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249 h1:pZu
 github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249/go.mod h1:UJ0EZAp832vCd54Wev9N1BMKEyvcZ5+IM0AwDrnlkEc=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20210310192349-958290ba5bd6 h1:eDPZb4vP/jcgEAh/IRShMewRVlwqAUNv73BBZnhw/yI=
-github.com/cockroachdb/pebble v0.0.0-20210310192349-958290ba5bd6/go.mod h1:1XpB4cLQcF189RAcWi4gUc110zJgtOfT7SVNGY8sOe0=
+github.com/cockroachdb/pebble v0.0.0-20210326183201-b49f2eeba24b h1:OyhxDJwrC2nToGdjT0O3vn5LNiC3AWzfNeOKtcg4PyU=
+github.com/cockroachdb/pebble v0.0.0-20210326183201-b49f2eeba24b/go.mod h1:1XpB4cLQcF189RAcWi4gUc110zJgtOfT7SVNGY8sOe0=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.0.9 h1:sjlUvGorKMIVQfo+w2RqDi5eewCHn453C/vdIXMzjzI=
 github.com/cockroachdb/redact v1.0.9/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=


### PR DESCRIPTION
Changes pulled in:

```
b49f2eeba24bb225582de9dbd71e35d645960256 *: Skip first iteration of read sample
bc446105db6a3ab399bc9c273a7101ca7bc758bb db: optimize levelIter for non-matching bloom filter
68086bf1b3a17bdecde7678f795be746d8feedc6 db: enhance Iterator with limited iteration mode
```

Release note (performance improvement): Address a performance regression
from a past change regarding read-triggered compactions.