### PR TITLE
release-21.1: ui: show internal statements with option all

### DIFF
--- a/pkg/ui/src/views/statements/statements.spec.tsx
+++ b/pkg/ui/src/views/statements/statements.spec.tsx
@@ -65,7 +65,7 @@ describe("selectStatements", () => {
     assert.deepEqual(actualFingerprints, expectedFingerprints);
   });
 
-  it("returns the statements without Internal for default ALL filter", () => {
+  it("returns the statements with Internal for default ALL filter", () => {
     const stmtA = makeFingerprint(1);
     const stmtB = makeFingerprint(2, INTERNAL_STATEMENT_PREFIX);
     const stmtC = makeFingerprint(3, INTERNAL_STATEMENT_PREFIX);
@@ -75,7 +75,7 @@ describe("selectStatements", () => {
 
     const result = selectStatements(state, props);
 
-    assert.equal(result.length, 2);
+    assert.equal(result.length, 3);
   });
 
   it("coalesces statements from different apps", () => {

--- a/pkg/ui/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/src/views/statements/statementsPage.tsx
@@ -78,7 +78,7 @@ export const selectStatements = createSelector(
     const isInternal = (statement: ExecutionStatistics) =>
       statement.app.startsWith(state.data.internal_app_name_prefix);
 
-    if (app) {
+    if (app && app !== "All") {
       let criteria = decodeURIComponent(app);
       let showInternal = false;
       if (criteria === "(unset)") {
@@ -90,10 +90,6 @@ export const selectStatements = createSelector(
       statements = statements.filter(
         (statement: ExecutionStatistics) =>
           (showInternal && isInternal(statement)) || statement.app === criteria,
-      );
-    } else {
-      statements = statements.filter(
-        (statement: ExecutionStatistics) => !isInternal(statement),
       );
     }
 


### PR DESCRIPTION
Backport 1/1 commits from #62661.

/cc @cockroachdb/release

---

Currently on the statements page if the filter selected is `all`, is not showing internal statements
With this fix all statements (internal and from applications) are shown with the `all` filter selected

Release note: Show internal statements on Statements page with filter All selected

Release justification: Bug fixes (Category 2). When the filter all is selected on the statements page, it should show all statements. Currently only showing non-internal. It's a minor fix with low-risk
