### PR TITLE
cli: fix demo --global latencies

### DIFF
--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -105,14 +105,23 @@ func insertPair(pair regionPair, latency int) {
 	regionToLatency[pair.regionB] = latency
 }
 
+// Round-trip latencies collected from http://cloudping.co on 2019-09-11.
+var regionRoundTripLatencies = map[regionPair]int{
+	{regionA: "us-east1", regionB: "us-west1"}:     66,
+	{regionA: "us-east1", regionB: "europe-west1"}: 64,
+	{regionA: "us-west1", regionB: "europe-west1"}: 146,
+}
+
+var regionOneWayLatencies = make(map[regionPair]int)
+
 func init() {
+	// We record one-way latencies next, because the logic in our delayingConn
+	// and delayingListener is in terms of one-way network delays.
+	for pair, latency := range regionRoundTripLatencies {
+		regionOneWayLatencies[pair] = latency / 2
+	}
 	regionToRegionToLatency = make(map[string]map[string]int)
-	// Latencies collected from http://cloudping.co on 2019-09-11.
-	for pair, latency := range map[regionPair]int{
-		{regionA: "us-east1", regionB: "us-west1"}:     66,
-		{regionA: "us-east1", regionB: "europe-west1"}: 64,
-		{regionA: "us-west1", regionB: "europe-west1"}: 146,
-	} {
+	for pair, latency := range regionOneWayLatencies {
 		insertPair(pair, latency)
 		insertPair(regionPair{
 			regionA: pair.regionB,


### PR DESCRIPTION
Fixes #62542

Previously, the --global flag to demo had some inconsistent behavior:
some of the time, the actual "global" latencies were double what we
would expect. The reason for this was that we were accidentally only
introducing a delay on one of the sides of the connection, some of the
time.

The fix was to change a method to use a pointer receiver :)

Release note (cli change): fix the artificial latencies introduced by
the --global flag to demo.