### PR TITLE
changefeedccl: Disable sinkful changefeeds when external io is disabled.

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -273,6 +273,10 @@ func changefeedPlanHook(
 			details.Opts[changefeedbase.OptKeyInValue] = ``
 		}
 
+		if !unspecifiedSink && p.ExecCfg().ExternalIODirConfig.DisableOutbound {
+			return errors.Errorf("Outbound IO is disabled by configuration, cannot create changefeed into %s", parsedSink.Scheme)
+		}
+
 		// Feature telemetry
 		telemetrySink := parsedSink.Scheme
 		if telemetrySink == `` {


### PR DESCRIPTION
Connectivity errors are not friendly, so fail faster.
This PR errors out when any sink URI is specified in a context where
external-io-disabled=true. In theory some sinks could work locally,
e.g. SQL sink going to the same tenant, but I don't think that works
with their current implementations.

![image](https://user-images.githubusercontent.com/1795573/112693841-b383f280-8e57-11eb-9353-b75bfbb6f6ea.png)


Release note (enterprise change): Fail fast when cdc writes are blocked

Closes #62675