### PR TITLE
kvnemesis: support non-voting replicas

### DIFF
--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -269,16 +269,8 @@ func getRangeDesc(ctx context.Context, key roachpb.Key, dbs ...*kv.DB) roachpb.R
 
 func newGetReplicasFn(dbs ...*kv.DB) GetReplicasFn {
 	ctx := context.Background()
-	return func(key roachpb.Key) []roachpb.ReplicationTarget {
+	return func(key roachpb.Key) []roachpb.ReplicaDescriptor {
 		desc := getRangeDesc(ctx, key, dbs...)
-		replicas := desc.Replicas().Descriptors()
-		targets := make([]roachpb.ReplicationTarget, len(replicas))
-		for i, replica := range replicas {
-			targets[i] = roachpb.ReplicationTarget{
-				NodeID:  replica.NodeID,
-				StoreID: replica.StoreID,
-			}
-		}
-		return targets
+		return desc.Replicas().Descriptors()
 	}
 }

--- a/pkg/kv/kvnemesis/generator_test.go
+++ b/pkg/kv/kvnemesis/generator_test.go
@@ -69,8 +69,8 @@ func TestRandStep(t *testing.T) {
 	config := newAllOperationsConfig()
 	config.NumNodes, config.NumReplicas = 2, 1
 	rng, _ := randutil.NewPseudoRand()
-	getReplicasFn := func(_ roachpb.Key) []roachpb.ReplicationTarget {
-		return make([]roachpb.ReplicationTarget, rng.Intn(2)+1)
+	getReplicasFn := func(_ roachpb.Key) []roachpb.ReplicaDescriptor {
+		return make([]roachpb.ReplicaDescriptor, rng.Intn(2)+1)
 	}
 	g, err := MakeGenerator(config, getReplicasFn)
 	require.NoError(t, err)

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -436,6 +436,23 @@ func (r ReplicaDescriptor) GetType() ReplicaType {
 	return *r.Type
 }
 
+// GetTarget returns the ReplicationTarget of this ReplicaDescriptor.
+func (r ReplicaDescriptor) GetTarget() ReplicationTarget {
+	return ReplicationTarget{
+		NodeID:  r.NodeID,
+		StoreID: r.StoreID,
+	}
+}
+
+// GetRemoveOp returns the ReplicaChangeType that would remove the replica
+// corresponding to this ReplicaDescriptor.
+func (r ReplicaDescriptor) GetRemoveOp() ReplicaChangeType {
+	if r.GetType() == NON_VOTER {
+		return REMOVE_NON_VOTER
+	}
+	return REMOVE_VOTER
+}
+
 // SafeValue implements the redact.SafeValue interface.
 func (r ReplicaType) SafeValue() {}
 


### PR DESCRIPTION
Previously, kvnemesis only dealt with voting replicas. This commit adds
support in the kvnemesis op-generator to randomly add and remove
non-voting replicas.

Resolves #59060

Release note: None