### PR TITLE
tracing: fix OpenTracing traces across nodes

### DIFF
--- a/pkg/util/tracing/span_options.go
+++ b/pkg/util/tracing/span_options.go
@@ -66,6 +66,16 @@ func (opts *spanOptions) shadowTrTyp() (string, bool) {
 	return "", false
 }
 
+func (opts *spanOptions) shadowContext() opentracing.SpanContext {
+	if opts.Parent != nil && opts.Parent.i.ot.shadowSpan != nil {
+		return opts.Parent.i.ot.shadowSpan.Context()
+	}
+	if opts.RemoteParent != nil && opts.RemoteParent.shadowCtx != nil {
+		return opts.RemoteParent.shadowCtx
+	}
+	return nil
+}
+
 // SpanOption is the interface satisfied by options to `Tracer.StartSpan`.
 // A synopsis of the options follows. For details, see their comments.
 //

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -325,13 +325,7 @@ func (t *Tracer) startSpanGeneric(
 		// for the new span to avoid compat issues between the
 		// two underlying tracers.
 		if ok2 && (!ok1 || typ1 == typ2) {
-			var shadowCtx opentracing.SpanContext
-			if opts.Parent != nil && opts.Parent.i.ot.shadowSpan != nil {
-				shadowCtx = opts.Parent.i.ot.shadowSpan.Context()
-			} else if opts.RemoteParent != nil && opts.RemoteParent.shadowCtx != nil {
-				shadowCtx = opts.RemoteParent.shadowCtx
-			}
-			ot = makeShadowSpan(shadowTr, shadowCtx, opts.RefType, opName, startTime)
+			ot = makeShadowSpan(shadowTr, opts.shadowContext(), opts.RefType, opName, startTime)
 			// If LogTags are given, pass them as tags to the shadow span.
 			// Regular tags are populated later, via the top-level Span.
 			if opts.LogTags != nil {

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -328,6 +328,8 @@ func (t *Tracer) startSpanGeneric(
 			var shadowCtx opentracing.SpanContext
 			if opts.Parent != nil && opts.Parent.i.ot.shadowSpan != nil {
 				shadowCtx = opts.Parent.i.ot.shadowSpan.Context()
+			} else if opts.RemoteParent != nil && opts.RemoteParent.shadowCtx != nil {
+				shadowCtx = opts.RemoteParent.shadowCtx
 			}
 			ot = makeShadowSpan(shadowTr, shadowCtx, opts.RefType, opName, startTime)
 			// If LogTags are given, pass them as tags to the shadow span.


### PR DESCRIPTION
"Shadow traces" (OpenTracing) were broken at node boundaries because the
server shadow span was not using the remote span context.
I believe this was broken in #56109.

Fixes #62702

Release note (bug fix): OpenTracing traces work correctly again across
nodes. The client and server spans for RPCs are once again part of the
same trace instead of the server being a root span erroneously.