### PR TITLE
cli: fix \demo shutdown with --global

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -1075,6 +1075,9 @@ func getClientGRPCConn(
 		Stopper:    stopper,
 		Settings:   cfg.Settings,
 	})
+	if cfg.TestingKnobs.Server != nil {
+		rpcContext.Knobs = cfg.TestingKnobs.Server.(*server.TestingKnobs).ContextTestingKnobs
+	}
 	addr, err := addrWithDefaultHost(cfg.AdvertiseAddr)
 	if err != nil {
 		stopper.Stop(ctx)


### PR DESCRIPTION
Previously, it crashed due to not setting up the demo's rpc context to
include the artificial latency map.

Release note: None