### PR TITLE
release-21.1: compare_test: check for backends being ready

### DIFF
--- a/pkg/compose/compare/compare/compare_test.go
+++ b/pkg/compose/compare/compare/compare_test.go
@@ -27,7 +27,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
 	"github.com/cockroachdb/cockroach/pkg/sql/mutations"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/jackc/pgx/v4"
 )
 
 var (
@@ -102,6 +104,17 @@ func TestCompare(t *testing.T) {
 	}
 
 	ctx := context.Background()
+
+	// docker-compose requires us to manually check for when a container
+	// is ready to receive connections.
+	// See https://docs.docker.com/compose/startup-order/
+	for name, uri := range uris {
+		testutils.SucceedsSoon(t, func() error {
+			_, err := pgx.Connect(ctx, uri.addr)
+			return err
+		})
+	}
+
 	for confName, config := range configs {
 		t.Run(confName, func(t *testing.T) {
 			rng, _ := randutil.NewPseudoRand()

--- a/pkg/compose/compare/docker-compose.yml
+++ b/pkg/compose/compare/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   postgres:
-    image: postgis/postgis:11-3.0
+    image: postgis/postgis:13-3.1
     environment:
       - POSTGRES_INITDB_ARGS=--locale=C
       - POSTGRES_HOST_AUTH_METHOD=trust


### PR DESCRIPTION
Backport 1/1 commits from #62682.

/cc @cockroachdb/release

---

Release note: None
