### PR TITLE
release-20.2: roachtest: handle transient error when downloading bumptime

### DIFF
--- a/pkg/cmd/roachtest/clock_util.go
+++ b/pkg/cmd/roachtest/clock_util.go
@@ -66,6 +66,9 @@ func (oi *offsetInjector) deploy(ctx context.Context) error {
 	if err := oi.c.RunL(ctx, oi.c.l,
 		oi.c.All(),
 		"curl",
+		"--retry", "3",
+		"--fail",
+		"--show-error",
 		"-kO",
 		"https://raw.githubusercontent.com/cockroachdb/jepsen/master/cockroachdb/resources/bumptime.c",
 	); err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #62027.

/cc @cockroachdb/release

---

By default, `curl` will return with exit code zero even in cases where
the server returned HTTP 500 or other error codes. This can cause
confusing failures where we "successfully" download a file containing
an error message and then try to compile it.

This adds `--retry 3 --fail --show-error` to the curl command line so
that transient errors are retried automatically and so that they
result in a non-zero exit code if the retries don't work.

We have other invocations of curl that can probably use similar
arguments. 

Release note: None
