### PR TITLE
release-21.1: Fix some nilness linter findings

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1698,7 +1698,7 @@ WHERE t.status NOT IN ('RANGE_CONSISTENT', 'RANGE_INDETERMINATE')`)
 	for rows.Next() {
 		var rangeID int32
 		var prettyKey, status, detail string
-		if scanErr := rows.Scan(&rangeID, &prettyKey, &status, &detail); err != nil {
+		if scanErr := rows.Scan(&rangeID, &prettyKey, &status, &detail); scanErr != nil {
 			return scanErr
 		}
 		finalErr = errors.CombineErrors(finalErr,

--- a/pkg/cmd/smithtest/main.go
+++ b/pkg/cmd/smithtest/main.go
@@ -188,9 +188,6 @@ func (s WorkerSetup) run(ctx context.Context, rnd *rand.Rand) error {
 				return errors.Wrap(err, "connector error")
 			}
 			db = gosql.OpenDB(connector)
-			if err != nil {
-				return errors.Wrap(err, "connect")
-			}
 			fmt.Println("connected to", match[1])
 			break
 		}

--- a/pkg/geo/geomfn/linestring.go
+++ b/pkg/geo/geomfn/linestring.go
@@ -91,9 +91,6 @@ func LineLocatePoint(line geo.Geometry, point geo.Geometry) (float64, error) {
 	}
 
 	p := closestT.(*geom.Point)
-	if err != nil {
-		return 0, err
-	}
 
 	lineStart := geom.Coord{lineString.Coord(0).X(), lineString.Coord(0).Y()}
 	// build new line segment to the closest point we found

--- a/pkg/jobs/job_scheduler.go
+++ b/pkg/jobs/job_scheduler.go
@@ -88,7 +88,7 @@ SELECT
 FROM %s S
 WHERE next_run < %s
 ORDER BY random()
-%s 
+%s
 FOR UPDATE`, env.SystemJobsTableName(), CreatedByScheduledJobs,
 		StatusSucceeded, StatusCanceled, StatusFailed,
 		env.ScheduledJobsTableName(), env.NowExpr(), limitClause)
@@ -313,7 +313,7 @@ func (s *jobScheduler) executeSchedules(
 			return s.processSchedule(ctx, schedule, numRunning, stats, txn)
 		}); processErr != nil {
 			if errors.HasType(processErr, (*savePointError)(nil)) {
-				return errors.Wrapf(err, "savepoint error for schedule %d", schedule.ScheduleID())
+				return errors.Wrapf(processErr, "savepoint error for schedule %d", schedule.ScheduleID())
 			}
 
 			// Failed to process schedule.

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1212,7 +1212,7 @@ func (r *Registry) stepThroughStateMachine(
 		jm.ResumeFailed.Inc(1)
 		if sErr := (*InvalidStatusError)(nil); errors.As(err, &sErr) {
 			if sErr.status != StatusCancelRequested && sErr.status != StatusPauseRequested {
-				return errors.NewAssertionErrorWithWrappedErrf(jobErr,
+				return errors.NewAssertionErrorWithWrappedErrf(sErr,
 					"job %d: unexpected status %s provided for a running job", job.ID(), sErr.status)
 			}
 			return sErr
@@ -1293,8 +1293,7 @@ func (r *Registry) stepThroughStateMachine(
 			errors.Wrapf(err, "job %d: cannot be reverted, manual cleanup may be required", job.ID()))
 	case StatusFailed:
 		if jobErr == nil {
-			return errors.NewAssertionErrorWithWrappedErrf(jobErr,
-				"job %d: has StatusFailed but no error was provided", job.ID())
+			return errors.AssertionFailedf("job %d: has StatusFailed but no error was provided", job.ID())
 		}
 		if err := job.failed(ctx, nil /* txn */, jobErr, nil /* fn */); err != nil {
 			// If we can't transactionally mark the job as failed then it will be

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -272,13 +272,11 @@ func (s *initServer) ServeAndWait(
 					return nil, false, err
 				}
 
-				if err != nil {
-					// We expect the join RPC to blindly retry on all
-					// "connection" errors save for one above. If we're
-					// here, we failed to initialize our first store after a
-					// successful join attempt.
-					return nil, false, errors.NewAssertionErrorWithWrappedErrf(err, "unexpected error: %v", err)
-				}
+				// We expect the join RPC to blindly retry on all
+				// "connection" errors save for one above. If we're
+				// here, we failed to initialize our first store after a
+				// successful join attempt.
+				return nil, false, errors.NewAssertionErrorWithWrappedErrf(err, "unexpected error: %v", err)
 			}
 
 			state := result.state

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -276,7 +276,7 @@ func (s *initServer) ServeAndWait(
 				// "connection" errors save for one above. If we're
 				// here, we failed to initialize our first store after a
 				// successful join attempt.
-				return nil, false, errors.NewAssertionErrorWithWrappedErrf(err, "unexpected error: %v", err)
+				return nil, false, errors.NewAssertionErrorWithWrappedErrf(err, "unexpected error")
 			}
 
 			state := result.state

--- a/pkg/server/init_handshake.go
+++ b/pkg/server/init_handshake.go
@@ -348,15 +348,13 @@ func (t *tlsInitHandshaker) getPeerCACert(
 		return nodeHostnameAndCA{}, err
 	}
 
-	// Read and validate server provided ack.
-	// HMAC(hostname + server CA public certificate, secretToken)
-	var msg nodeHostnameAndCA
-	if err != nil {
-		return nodeHostnameAndCA{}, err
-	}
 	if res.StatusCode != 200 {
 		return nodeHostnameAndCA{}, errors.Errorf("unexpected error returned from peer: HTTP %d", res.StatusCode)
 	}
+
+	// Read and validate server provided ack.
+	// HMAC(hostname + server CA public certificate, secretToken)
+	var msg nodeHostnameAndCA
 	if err := json.NewDecoder(res.Body).Decode(&msg); err != nil {
 		return nodeHostnameAndCA{}, err
 	}

--- a/pkg/sql/alter_sequence.go
+++ b/pkg/sql/alter_sequence.go
@@ -74,9 +74,6 @@ func (n *alterSequenceNode) startExec(params runParams) error {
 	}
 	opts := desc.SequenceOpts
 	seqValueKey := params.p.ExecCfg().Codec.SequenceKey(uint32(desc.ID))
-	if err != nil {
-		return err
-	}
 
 	getSequenceValue := func() (int64, error) {
 		kv, err := params.p.txn.Get(params.ctx, seqValueKey)

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -634,9 +634,6 @@ func (n *alterTableNode) startExec(params runParams) error {
 				descriptorChanged = true
 			}
 
-			if err != nil {
-				return err
-			}
 			if err := params.p.removeColumnComment(params.ctx, n.tableDesc.ID, colToDrop.GetID()); err != nil {
 				return err
 			}

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -133,10 +133,6 @@ func (b *Builder) analyzeOrderByIndex(
 	for i, n := 0, index.KeyColumnCount(); i < n; i++ {
 		// Columns which are indexable are always orderable.
 		col := index.Column(i)
-		if err != nil {
-			panic(err)
-		}
-
 		desc := col.Descending
 
 		// DESC inverts the order of the index.

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -289,7 +289,8 @@ func (c *conn) serveImpl(
 		// we only need the minimum to make pgx happy.
 		var err error
 		for param, value := range testingStatusReportParams {
-			if err := c.sendParamStatus(param, value); err != nil {
+			err = c.sendParamStatus(param, value)
+			if err != nil {
 				break
 			}
 		}

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -1706,10 +1706,6 @@ func (o KVOptions) ToRoleOptions(
 				if err != nil {
 					return nil, err
 				}
-
-				if err != nil {
-					return nil, err
-				}
 				roleOptions[i] = roleoption.RoleOption{
 					Option: option, Value: strFn, HasValue: true,
 				}

--- a/pkg/storage/cloudimpl/workload_storage.go
+++ b/pkg/storage/cloudimpl/workload_storage.go
@@ -76,7 +76,7 @@ func makeWorkloadStorage(
 		}
 	}
 	if s.table.Name == `` {
-		return nil, errors.Wrapf(err, `unknown table %s for generator %s`, conf.Table, meta.Name)
+		return nil, errors.Errorf(`unknown table %s for generator %s`, conf.Table, meta.Name)
 	}
 	return s, nil
 }

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -1196,9 +1196,6 @@ func EncodeGeoDescending(b []byte, curveIndex uint64, so *geopb.SpatialObject) (
 	}
 	n := len(b)
 	b = encodeBytesAscendingWithTerminator(b, data, ascendingGeoEscapes.escapedTerm)
-	if err != nil {
-		return nil, err
-	}
 	onesComplement(b[n:])
 	return b, nil
 }

--- a/pkg/util/json/encoded.go
+++ b/pkg/util/json/encoded.go
@@ -428,18 +428,18 @@ func (j *jsonEncoded) FetchValKey(key string) (JSON, error) {
 		// or maybe there's something fancier we could do if we know the locations
 		// of the offsets by strategically positioning our binary search guesses to
 		// land on them.
-		var err error
+		var searchErr error
 		i := sort.Search(j.containerLen, func(idx int) bool {
 			data, _, err := j.objectGetNthDataRange(idx)
 			if err != nil {
+				searchErr = err
 				return false
 			}
 			return string(data) >= key
 		})
-		if err != nil {
-			return nil, err
+		if searchErr != nil {
+			return nil, searchErr
 		}
-
 		// The sort.Search API implies that we have to double-check if the key we
 		// landed on is the one we were searching for in the first place.
 		if i >= j.containerLen {


### PR DESCRIPTION
Backport 2/6 commits from #61608.

I've backported just the fixes from 61608 rather than the linter addition
as well to avoid having to introduce dependency bumps.

/cc @cockroachdb/release

---

This fixes an assortment of minor issues found by the nilness linter.

Most appear to be err checks that were simply copy and pasted but 
were no longer needed.

Release note: None
