### PR TITLE
kvserver: simplify and document handling of ReplicaPlaceholder

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -1499,7 +1500,12 @@ func TestReplicateAfterRemoveAndSplit(t *testing.T) {
 	tc.AddAndStartServer(t, stickyServerArgs[2])
 
 	// Try to up-replicate the RHS of the split to store 2.
-	if _, err := tc.AddVoters(splitKey, tc.Target(3)); !testutils.IsError(err, kvserver.IntersectingSnapshotMsg) {
+	// Don't use tc.AddVoter because we expect a retriable error and want it
+	// returned to us.
+	if _, err := tc.Servers[0].DB().AdminChangeReplicas(
+		ctx, splitKey, tc.LookupRangeOrFatal(t, splitKey),
+		roachpb.MakeReplicationChanges(roachpb.ADD_VOTER, tc.Target(3)),
+	); !kvserver.IsRetriableReplicationChangeError(err) {
 		t.Fatalf("unexpected error %v", err)
 	}
 
@@ -1507,6 +1513,7 @@ func TestReplicateAfterRemoveAndSplit(t *testing.T) {
 	// to store 2 will cause the obsolete replica to be GC'd allowing a
 	// subsequent replication to succeed.
 	tc.GetFirstStoreFromServer(t, 3).SetReplicaGCQueueActive(true)
+	tc.AddVotersOrFatal(t, splitKey, tc.Target(3))
 }
 
 // Test that when a Raft group is not able to establish a quorum, its Raft log
@@ -2492,6 +2499,9 @@ func TestReportUnreachableRemoveRace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	rng, seed := randutil.NewTestPseudoRand()
+	t.Logf("seed is %d", seed)
+
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, 3,
 		base.TestClusterArgs{
@@ -2502,54 +2512,78 @@ func TestReportUnreachableRemoveRace(t *testing.T) {
 	tc.AddVotersOrFatal(t, key, tc.Targets(1, 2)...)
 	require.NoError(t, tc.WaitForVoters(key, tc.Targets(1, 2)...))
 
-outer:
 	for i := 0; i < 5; i++ {
-		for leaderIdx := range tc.Servers {
-			repl := tc.GetFirstStoreFromServer(t, leaderIdx).LookupReplica(roachpb.RKey(key))
-			require.NotNil(t, repl)
-			if repl.RaftStatus().SoftState.RaftState == raft.StateLeader {
-				for replicaIdx := range tc.Servers {
-					if replicaIdx == leaderIdx {
-						continue
-					}
-					repDesc, err := repl.GetReplicaDescriptor()
-					if err != nil {
-						t.Fatal(err)
-					}
-					if lease, _ := repl.GetLease(); lease.Replica.Equal(repDesc) {
-						tc.TransferRangeLeaseOrFatal(t, *repl.Desc(), tc.Target(replicaIdx))
-					}
-					tc.RemoveVotersOrFatal(t, key, tc.Target(leaderIdx))
-					// We want to stop all nodes from talking to the replicaIdx, so need
-					// to trip the breaker on all servers but it.
-					for i := range tc.Servers {
-						if i != replicaIdx {
-							cb := tc.Servers[i].RaftTransport().GetCircuitBreaker(tc.Target(replicaIdx).NodeID, rpc.DefaultClass)
-							cb.Break()
-						}
-					}
-					time.Sleep(tc.GetFirstStoreFromServer(t, replicaIdx).GetStoreConfig().CoalescedHeartbeatsInterval)
-					for i := range tc.Servers {
-						if i != replicaIdx {
-							cb := tc.Servers[i].RaftTransport().GetCircuitBreaker(tc.Target(replicaIdx).NodeID, rpc.DefaultClass)
-							cb.Reset()
-						}
-					}
-					// Make sure the old replica was actually removed, before we try to re-adding it.
-					testutils.SucceedsSoon(t, func() error {
-						if oldRepl := tc.GetFirstStoreFromServer(t, leaderIdx).LookupReplica(roachpb.RKey(key)); oldRepl != nil {
-							return errors.Errorf("Expected replica %s to be removed", oldRepl)
-						}
-						return nil
-					})
-					tc.AddVotersOrFatal(t, key, tc.Target(leaderIdx))
-					require.NoError(t, tc.WaitForVoters(key, tc.Target(leaderIdx)))
-					continue outer
+		// Find the Raft leader.
+		var leaderIdx int
+		var leaderRepl *kvserver.Replica
+		testutils.SucceedsSoon(t, func() error {
+			for idx := range tc.Servers {
+				repl := tc.GetFirstStoreFromServer(t, idx).LookupReplica(roachpb.RKey(key))
+				require.NotNil(t, repl)
+				if repl.RaftStatus().SoftState.RaftState == raft.StateLeader {
+					leaderIdx = idx
+					leaderRepl = repl
+					return nil
 				}
-				t.Fatal("could not find raft replica")
+			}
+			return errors.New("no Raft leader found")
+		})
+
+		// Raft leader found. Make sure it doesn't have the lease (transferring it
+		// away if necessary, which entails picking a random other node and sending
+		// the lease to it). We'll also partition this random node away from the rest
+		// as this was (way back) how we triggered problems with coalesced heartbeats.
+		partitionedMaybeLeaseholderIdx := (leaderIdx + 1 + rng.Intn(tc.NumServers()-1)) % tc.NumServers()
+		t.Logf("leader is idx=%d, partitioning idx=%d", leaderIdx, partitionedMaybeLeaseholderIdx)
+		leaderRepDesc, err := leaderRepl.GetReplicaDescriptor()
+		require.NoError(t, err)
+		if lease, _ := leaderRepl.GetLease(); lease.OwnedBy(leaderRepDesc.StoreID) {
+			tc.TransferRangeLeaseOrFatal(t, *leaderRepl.Desc(), tc.Target(partitionedMaybeLeaseholderIdx))
+		}
+
+		// Remove the raft leader.
+		t.Logf("removing leader")
+		tc.RemoveVotersOrFatal(t, key, tc.Target(leaderIdx))
+
+		// Pseudo-partition partitionedMaybeLeaseholderIdx away from everyone else. We do this by tripping
+		// the circuit breaker on all other nodes.
+		t.Logf("partitioning")
+		for i := range tc.Servers {
+			if i != partitionedMaybeLeaseholderIdx {
+				cb := tc.Servers[i].RaftTransport().GetCircuitBreaker(tc.Target(partitionedMaybeLeaseholderIdx).NodeID, rpc.DefaultClass)
+				cb.Break()
 			}
 		}
-		i-- // try again
+
+		// Wait out the heartbeat interval and resolve the partition.
+		heartbeatInterval := tc.GetFirstStoreFromServer(t, partitionedMaybeLeaseholderIdx).GetStoreConfig().CoalescedHeartbeatsInterval
+		time.Sleep(heartbeatInterval)
+		t.Logf("resolving partition")
+		for i := range tc.Servers {
+			if i != partitionedMaybeLeaseholderIdx {
+				cb := tc.Servers[i].RaftTransport().GetCircuitBreaker(tc.Target(partitionedMaybeLeaseholderIdx).NodeID, rpc.DefaultClass)
+				cb.Reset()
+			}
+		}
+
+		t.Logf("waiting for replicaGC of removed leader replica")
+		// Make sure the old replica was actually removed by replicaGC, before we
+		// try to re-add it. Otherwise the addition below might fail. One shot here
+		// is often enough, but not always; in the worst case we need to wait out
+		// something on the order of a election timeout plus
+		// ReplicaGCQueueSuspectTimeout before replicaGC will be attempted (and will
+		// then succeed on the first try).
+		testutils.SucceedsSoon(t, func() error {
+			s := tc.GetFirstStoreFromServer(t, leaderIdx)
+			s.MustForceReplicaGCScanAndProcess()
+			if oldRepl := tc.GetFirstStoreFromServer(t, leaderIdx).LookupReplica(roachpb.RKey(key)); oldRepl != nil {
+				return errors.Errorf("Expected replica %s to be removed", oldRepl)
+			}
+			return nil
+		})
+		t.Logf("re-adding leader")
+		tc.AddVotersOrFatal(t, key, tc.Target(leaderIdx))
+		require.NoError(t, tc.WaitForVoters(key, tc.Target(leaderIdx)))
 	}
 }
 
@@ -4873,6 +4907,7 @@ func TestProcessSplitAfterRightHandSideHasBeenRemoved(t *testing.T) {
 		require.NoError(t, db.Run(ctx, b))
 	}
 	ensureNoTombstone := func(t *testing.T, store *kvserver.Store, rangeID roachpb.RangeID) {
+		t.Helper()
 		var tombstone roachpb.RangeTombstone
 		tombstoneKey := keys.RangeTombstoneKey(rangeID)
 		ok, err := storage.MVCCGetProto(
@@ -5040,7 +5075,10 @@ func TestProcessSplitAfterRightHandSideHasBeenRemoved(t *testing.T) {
 		// Unsuccessful because the RHS will not accept the learner snapshot
 		// and will be rolled back. Nevertheless it will have learned that it
 		// has been removed at the old replica ID.
-		_, err = tc.AddVoters(keyB, tc.Target(0))
+		_, err = tc.Servers[0].DB().AdminChangeReplicas(
+			ctx, keyB, tc.LookupRangeOrFatal(t, keyB),
+			roachpb.MakeReplicationChanges(roachpb.ADD_VOTER, tc.Target(0)),
+		)
 		require.True(t, kvserver.IsRetriableReplicationChangeError(err), err)
 
 		// Without a partitioned RHS we'll end up always writing a tombstone here because
@@ -5090,7 +5128,10 @@ func TestProcessSplitAfterRightHandSideHasBeenRemoved(t *testing.T) {
 		// Unsuccessfuly because the RHS will not accept the learner snapshot
 		// and will be rolled back. Nevertheless it will have learned that it
 		// has been removed at the old replica ID.
-		_, err = tc.AddVoters(keyB, tc.Target(0))
+		_, err = tc.Servers[0].DB().AdminChangeReplicas(
+			ctx, keyB, tc.LookupRangeOrFatal(t, keyB),
+			roachpb.MakeReplicationChanges(roachpb.ADD_VOTER, tc.Target(0)),
+		)
 		require.True(t, kvserver.IsRetriableReplicationChangeError(err), err)
 
 		// Without a partitioned RHS we'll end up always writing a tombstone here because
@@ -5158,10 +5199,15 @@ func TestProcessSplitAfterRightHandSideHasBeenRemoved(t *testing.T) {
 		// Remove and re-add the RHS to create a new uninitialized replica at
 		// a higher replica ID. This will lead to a tombstone being written.
 		tc.RemoveVotersOrFatal(t, keyB, tc.Target(0))
-		// Unsuccessful because the RHS will not accept the learner snapshot
-		// and will be rolled back. Nevertheless it will have learned that it
-		// has been removed at the old replica ID.
-		_, err = tc.AddVoters(keyB, tc.Target(0))
+		// Unsuccessful because the RHS will not accept the learner snapshot and
+		// will be rolled back. Nevertheless it will have learned that it has been
+		// removed at the old replica ID. We don't use tc.AddVoters because that
+		// will retry until it runs out of time, since we're creating a
+		// retriable-looking situation here that will persist.
+		_, err = tc.Servers[0].DB().AdminChangeReplicas(
+			ctx, keyB, tc.LookupRangeOrFatal(t, keyB),
+			roachpb.MakeReplicationChanges(roachpb.ADD_VOTER, tc.Target(0)),
+		)
 		require.True(t, kvserver.IsRetriableReplicationChangeError(err), err)
 		// Ensure that the replica exists with the higher replica ID.
 		repl, err := tc.GetFirstStoreFromServer(t, 0).GetReplica(rhsInfo.Desc.RangeID)
@@ -5219,7 +5265,13 @@ func TestProcessSplitAfterRightHandSideHasBeenRemoved(t *testing.T) {
 		// Unsuccessfuly because the RHS will not accept the learner snapshot
 		// and will be rolled back. Nevertheless it will have learned that it
 		// has been removed at the old replica ID.
-		_, err = tc.AddVoters(keyB, tc.Target(0))
+		//
+		// Not using tc.AddVoters because we expect an error, but that error
+		// would be retried internally.
+		_, err = tc.Servers[0].DB().AdminChangeReplicas(
+			ctx, keyB, tc.LookupRangeOrFatal(t, keyB),
+			roachpb.MakeReplicationChanges(roachpb.ADD_VOTER, tc.Target(0)),
+		)
 		require.True(t, kvserver.IsRetriableReplicationChangeError(err), err)
 		// Ensure that there's no tombstone.
 		// The RHS on store 0 never should have heard about its original ID.

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -3308,7 +3308,9 @@ func TestSplitTriggerMeetsUnexpectedReplicaID(t *testing.T) {
 	// second node).
 	g := ctxgroup.WithContext(ctx)
 	g.GoCtx(func(ctx context.Context) error {
-		_, err := tc.AddVoters(k, tc.Target(1))
+		_, err := tc.Servers[0].DB().AdminChangeReplicas(
+			ctx, k, tc.LookupRangeOrFatal(t, k), roachpb.MakeReplicationChanges(roachpb.ADD_VOTER, tc.Target(1)),
+		)
 		return err
 	})
 
@@ -3343,7 +3345,9 @@ func TestSplitTriggerMeetsUnexpectedReplicaID(t *testing.T) {
 	// Now repeatedly re-add the learner on the rhs, so it has a
 	// different replicaID than the split trigger expects.
 	add := func() {
-		_, err := tc.AddVoters(kRHS, tc.Target(1))
+		_, err := tc.Servers[0].DB().AdminChangeReplicas(
+			ctx, kRHS, tc.LookupRangeOrFatal(t, kRHS), roachpb.MakeReplicationChanges(roachpb.ADD_VOTER, tc.Target(1)),
+		)
 		// The "snapshot intersects existing range" error is expected if the store
 		// has not heard a raft message addressed to a later replica ID while the
 		// "was not found on" error is expected if the store has heard that it has

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -73,7 +73,7 @@ type nonDeterministicFailure struct {
 
 // The provided format string should be safe for reporting.
 func makeNonDeterministicFailure(format string, args ...interface{}) error {
-	err := errors.Newf(format, args...)
+	err := errors.AssertionFailedWithDepthf(1, format, args...)
 	return &nonDeterministicFailure{
 		wrapped:  err,
 		safeExpl: err.Error(),

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"math"
 	"strconv"
-	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -515,6 +514,7 @@ type IncomingSnapshot struct {
 	// See the comment on VersionUnreplicatedRaftTruncatedState for details.
 	UsesUnreplicatedTruncatedState bool
 	snapType                       SnapshotRequest_Type
+	placeholder                    *ReplicaPlaceholder
 }
 
 func (s *IncomingSnapshot) String() string {
@@ -737,11 +737,11 @@ func clearRangeData(
 	return nil
 }
 
-// applySnapshot updates the replica and its store based on the given snapshot
-// and associated HardState. All snapshots must pass through Raft for
-// correctness, i.e. the parameters to this method must be taken from a
-// raft.Ready. Any replicas specified in subsumedRepls will be destroyed
-// atomically with the application of the snapshot.
+// applySnapshot updates the replica and its store based on the given
+// (non-empty) snapshot and associated HardState. All snapshots must pass
+// through Raft for correctness, i.e. the parameters to this method must be
+// taken from a raft.Ready. Any replicas specified in subsumedRepls will be
+// destroyed atomically with the application of the snapshot.
 //
 // If there is a placeholder associated with r, applySnapshot will remove that
 // placeholder from the store if and only if it does not return an error.
@@ -755,7 +755,7 @@ func clearRangeData(
 func (r *Replica) applySnapshot(
 	ctx context.Context,
 	inSnap IncomingSnapshot,
-	snap raftpb.Snapshot,
+	nonemptySnap raftpb.Snapshot,
 	hs raftpb.HardState,
 	subsumedRepls []*Replica,
 ) (err error) {
@@ -792,25 +792,11 @@ func (r *Replica) applySnapshot(
 		}
 	}()
 
-	if raft.IsEmptySnap(snap) {
-		// Raft discarded the snapshot, indicating that our local state is
-		// already ahead of what the snapshot provides. But we count it for
-		// stats (see the defer above).
-		//
-		// Since we're not returning an error, we're responsible for removing any
-		// placeholder that might exist.
-		r.store.mu.Lock()
-		if r.store.removePlaceholderLocked(ctx, r.RangeID) {
-			atomic.AddInt32(&r.store.counts.filledPlaceholders, 1)
-		}
-		r.store.mu.Unlock()
-		return nil
-	}
 	if raft.IsEmptyHardState(hs) {
 		// Raft will never provide an empty HardState if it is providing a
 		// nonempty snapshot because we discard snapshots that do not increase
 		// the commit index.
-		log.Fatalf(ctx, "found empty HardState for non-empty Snapshot %+v", snap)
+		log.Fatalf(ctx, "found empty HardState for non-empty Snapshot %+v", nonemptySnap)
 	}
 
 	var stats struct {
@@ -820,7 +806,7 @@ func (r *Replica) applySnapshot(
 		ingestion time.Time
 	}
 	log.Infof(ctx, "applying snapshot of type %s [id=%s index=%d]", inSnap.snapType,
-		inSnap.SnapUUID.Short(), snap.Metadata.Index)
+		inSnap.SnapUUID.Short(), nonemptySnap.Metadata.Index)
 	defer func(start time.Time) {
 		now := timeutil.Now()
 		totalLog := fmt.Sprintf(
@@ -842,7 +828,7 @@ func (r *Replica) applySnapshot(
 		)
 		log.Infof(
 			ctx, "applied snapshot of type %s [%s%s%sid=%s index=%d]", inSnap.snapType, totalLog,
-			subsumedReplicasLog, ingestionLog, inSnap.SnapUUID.Short(), snap.Metadata.Index,
+			subsumedReplicasLog, ingestionLog, inSnap.SnapUUID.Short(), nonemptySnap.Metadata.Index,
 		)
 	}(timeutil.Now())
 
@@ -909,9 +895,9 @@ func (r *Replica) applySnapshot(
 		}
 	}
 
-	if s.RaftAppliedIndex != snap.Metadata.Index {
+	if s.RaftAppliedIndex != nonemptySnap.Metadata.Index {
 		log.Fatalf(ctx, "snapshot RaftAppliedIndex %d doesn't match its metadata index %d",
-			s.RaftAppliedIndex, snap.Metadata.Index)
+			s.RaftAppliedIndex, nonemptySnap.Metadata.Index)
 	}
 
 	if expLen := s.RaftAppliedIndex - s.TruncatedState.Index; expLen != uint64(len(inSnap.LogEntries)) {
@@ -981,8 +967,11 @@ func (r *Replica) applySnapshot(
 
 	r.store.mu.Lock()
 	r.mu.Lock()
-	if r.store.removePlaceholderLocked(ctx, r.RangeID) {
-		atomic.AddInt32(&r.store.counts.filledPlaceholders, 1)
+	if inSnap.placeholder != nil {
+		_, err := r.store.removePlaceholderLocked(ctx, inSnap.placeholder, removePlaceholderFilled)
+		if err != nil {
+			log.Fatalf(ctx, "unable to remove placeholder: %s", err)
+		}
 	}
 	r.setDescLockedRaftMuLocked(ctx, s.Desc)
 	if err := r.store.maybeMarkReplicaInitializedLockedReplLocked(ctx, r); err != nil {

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -654,6 +654,7 @@ func getNonVoterNodeIDs(rangeDesc roachpb.RangeDescriptor) (result []roachpb.Nod
 // from voter to non-voter.
 func TestReplicateQueueSwapVotersWithNonVoters(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	serverArgs := make(map[int]base.TestServerArgs)

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -604,12 +604,16 @@ type Store struct {
 	}
 
 	counts struct {
-		// Number of placeholders removed due to error.
-		removedPlaceholders int32
-		// Number of placeholders successfully filled by a snapshot.
+		// Number of placeholders removed due to error. Not a good fit for meaningful
+		// metrics, as snapshots to initialized ranges don't get a placeholder.
+		failedPlaceholders int32
+		// Number of placeholders successfully filled by a snapshot. Not a good fit
+		// for meaningful metrics, as snapshots to initialized ranges don't get a
+		// placeholder.
 		filledPlaceholders int32
 		// Number of placeholders removed due to a snapshot that was dropped by
-		// raft.
+		// raft. Not a good fit for meaningful metrics, as snapshots to initialized
+		// ranges don't get a placeholder.
 		droppedPlaceholders int32
 	}
 

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -12,7 +12,6 @@ package kvserver
 
 import (
 	"context"
-	"sync/atomic"
 	"time"
 	"unsafe"
 
@@ -270,6 +269,9 @@ func (s *Store) processRaftRequestWithReplica(
 // handle any updated Raft Ready state. It also adds and later removes the
 // (potentially) necessary placeholder to protect against concurrent access to
 // the keyspace encompassed by the snapshot but not yet guarded by the replica.
+//
+// If (and only if) no error is returned, the placeholder (if any) in inSnap
+// will have been removed.
 func (s *Store) processRaftSnapshotRequest(
 	ctx context.Context, snapHeader *SnapshotRequest_Header, inSnap IncomingSnapshot,
 ) *roachpb.Error {
@@ -285,52 +287,27 @@ func (s *Store) processRaftSnapshotRequest(
 			log.Fatalf(ctx, "expected snapshot: %+v", snapHeader.RaftMessageRequest)
 		}
 
-		// Check to see if a snapshot can be applied. Snapshots can always be applied
-		// to initialized replicas. Note that if we add a placeholder we need to
-		// already be holding Replica.raftMu in order to prevent concurrent
-		// raft-ready processing of uninitialized replicas.
-		var addedPlaceholder bool
-		var removePlaceholder bool
-		if err := func() error {
-			s.mu.Lock()
-			defer s.mu.Unlock()
-			placeholder, err := s.canApplySnapshotLocked(ctx, snapHeader)
-			if err != nil {
-				// If we cannot accept the snapshot, return an error before
-				// passing it to RawNode.Step, since our error handling options
-				// past that point are limited.
-				log.Infof(ctx, "cannot apply snapshot: %s", err)
-				return err
-			}
-
-			if placeholder != nil {
-				// NB: The placeholder added here is either removed below after a
-				// preemptive snapshot is applied or after the next call to
-				// Replica.handleRaftReady. Note that we can only get here if the
-				// replica doesn't exist or is uninitialized.
-				if err := s.addPlaceholderLocked(placeholder); err != nil {
-					log.Fatalf(ctx, "could not add vetted placeholder %s: %+v", placeholder, err)
+		var stats handleRaftReadyStats
+		typ := removePlaceholderFailed
+		defer func() {
+			// In the typical case, handleRaftReadyRaftMuLocked calls through to
+			// applySnapshot which will apply the snapshot and also converts the
+			// placeholder entry (if any) to the now-initialized replica. However we
+			// may also error out below, or raft may also ignore the snapshot, and so
+			// the placeholder would remain.
+			//
+			// NB: it's unclear in which case we could actually get raft to ignore a
+			// snapshot attached to a placeholder. A placeholder existing implies that
+			// the snapshot is targeting an uninitialized replica. The only known reason
+			// for raft to ignore a snapshot is if it doesn't move the applied index
+			// forward, but an uninitialized replica's applied index is zero (and a
+			// snapshot's is at least raftInitialLogIndex).
+			if inSnap.placeholder != nil {
+				if _, err := s.removePlaceholder(ctx, inSnap.placeholder, typ); err != nil {
+					log.Fatalf(ctx, "unable to remove placeholder: %s", err)
 				}
-				addedPlaceholder = true
 			}
-			return nil
-		}(); err != nil {
-			return roachpb.NewError(err)
-		}
-
-		if addedPlaceholder {
-			// If we added a placeholder remove it before we return unless some other
-			// part of the code takes ownership of the removal (indicated by setting
-			// removePlaceholder to false).
-			removePlaceholder = true
-			defer func() {
-				if removePlaceholder {
-					if s.removePlaceholder(ctx, snapHeader.RaftMessageRequest.RangeID) {
-						atomic.AddInt32(&s.counts.removedPlaceholders, 1)
-					}
-				}
-			}()
-		}
+		}()
 
 		if snapHeader.RaftMessageRequest.Message.From == snapHeader.RaftMessageRequest.Message.To {
 			// This is a special case exercised during recovery from loss of quorum.
@@ -355,9 +332,24 @@ func (s *Store) processRaftSnapshotRequest(
 			return roachpb.NewError(err)
 		}
 
-		_, expl, err := r.handleRaftReadyRaftMuLocked(ctx, inSnap)
+		// We've handed the snapshot to Raft, which will typically apply it (in
+		// which case the placeholder, if any, is removed by the time
+		// handleRaftReadyRaftMuLocked returns. We handle the other case in a
+		// defer() above. Note that we could infer when the placeholder should still
+		// be there based on `stats.snap.applied`	but it is a questionable use of
+		// stats and more susceptible to bugs.
+		typ = removePlaceholderDropped
+		var expl string
+		var err error
+		stats, expl, err = r.handleRaftReadyRaftMuLocked(ctx, inSnap)
+		if !stats.snap.applied {
+			// This line would be hit if a snapshot was sent when it isn't necessary
+			// (i.e. follower was able to catch up via the log in the interim) or when
+			// multiple snapshots raced (as is possible when raft leadership changes
+			// and both the old and new leaders send snapshots).
+			log.Infof(ctx, "ignored stale snapshot at index %d", snapHeader.RaftMessageRequest.Message.Snapshot.Metadata.Index)
+		}
 		maybeFatalOnRaftReadyErr(ctx, expl, err)
-		removePlaceholder = false
 		return nil
 	})
 }
@@ -521,7 +513,7 @@ func (s *Store) processReady(ctx context.Context, rangeID roachpb.RangeID) {
 	ctx = r.raftSchedulerCtx(ctx)
 	start := timeutil.Now()
 	stats, expl, err := r.handleRaftReady(ctx, noSnap)
-	removed := maybeFatalOnRaftReadyErr(ctx, expl, err)
+	maybeFatalOnRaftReadyErr(ctx, expl, err)
 	elapsed := timeutil.Since(start)
 	s.metrics.RaftWorkingDurationNanos.Inc(elapsed.Nanoseconds())
 	s.metrics.RaftHandleReadyLatency.RecordValue(elapsed.Nanoseconds())
@@ -532,21 +524,6 @@ func (s *Store) processReady(ctx context.Context, rangeID roachpb.RangeID) {
 	if elapsed >= defaultReplicaRaftMuWarnThreshold {
 		log.Warningf(ctx, "handle raft ready: %.1fs [applied=%d, batches=%d, state_assertions=%d]",
 			elapsed.Seconds(), stats.entriesProcessed, stats.batchesProcessed, stats.stateAssertions)
-	}
-	if !removed && !r.IsInitialized() {
-		// Only an uninitialized replica can have a placeholder since, by
-		// definition, an initialized replica will be present in the
-		// replicasByKey map. While the replica will usually consume the
-		// placeholder itself, that isn't guaranteed and so this invocation
-		// here is crucial (i.e. don't remove it).
-		//
-		// We need to hold raftMu here to prevent removing a placeholder that is
-		// actively being used by Store.processRaftRequest.
-		r.raftMu.Lock()
-		if s.removePlaceholder(ctx, r.RangeID) {
-			atomic.AddInt32(&s.counts.droppedPlaceholders, 1)
-		}
-		r.raftMu.Unlock()
 	}
 }
 

--- a/pkg/kv/kvserver/store_remove_replica.go
+++ b/pkg/kv/kvserver/store_remove_replica.go
@@ -167,6 +167,12 @@ func (s *Store) removeInitializedReplicaRaftMuLocked(
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.unlinkReplicaByRangeIDLocked(ctx, rep.RangeID)
+	// There can't be a placeholder, as the replica is still in replicasByKey
+	// and it is initialized. (A placeholder would also be in replicasByKey
+	// and overlap the replica, which is impossible).
+	if ph, ok := s.mu.replicaPlaceholders[rep.RangeID]; ok {
+		log.Fatalf(ctx, "initialized replica %s unexpectedly had a placeholder: %+v", rep, ph)
+	}
 	if it := s.mu.replicasByKey.DeleteReplica(ctx, rep); it.repl != rep {
 		// We already checked that our replica was present in replicasByKey
 		// above. Nothing should have been able to change that.
@@ -175,7 +181,6 @@ func (s *Store) removeInitializedReplicaRaftMuLocked(
 	if it := s.getOverlappingKeyRangeLocked(desc); it.item != nil {
 		log.Fatalf(ctx, "corrupted replicasByKey map: %s and %s overlapped", rep, it.item)
 	}
-	delete(s.mu.replicaPlaceholders, rep.RangeID)
 	// TODO(peter): Could release s.mu.Lock() here.
 	s.maybeGossipOnCapacityChange(ctx, rangeRemoveEvent)
 	s.scanner.RemoveReplica(rep)
@@ -241,14 +246,6 @@ func (s *Store) removeUninitializedReplicaRaftMuLocked(
 		log.Fatalf(ctx, "uninitialized replica %v was unexpectedly replaced", existing)
 	}
 
-	// Only an uninitialized replica can have a placeholder since, by
-	// definition, an initialized replica will be present in the
-	// replicasByKey map. While the replica will usually consume the
-	// placeholder itself, that isn't guaranteed and so this invocation
-	// here is crucial (i.e. don't remove it).
-	if s.removePlaceholderLocked(ctx, rep.RangeID) {
-		atomic.AddInt32(&s.counts.droppedPlaceholders, 1)
-	}
 	s.unlinkReplicaByRangeIDLocked(ctx, rep.RangeID)
 }
 
@@ -268,30 +265,113 @@ func (s *Store) unlinkReplicaByRangeIDLocked(ctx context.Context, rangeID roachp
 	s.unregisterLeaseholderByID(ctx, rangeID)
 }
 
-// removePlaceholder removes a placeholder for the specified range if it
-// exists, returning true if a placeholder was present and removed and false
-// otherwise. Requires that the raftMu of the replica whose place is being held
-// is locked.
-func (s *Store) removePlaceholder(ctx context.Context, rngID roachpb.RangeID) bool {
+// removePlaceholder removes a placeholder for the specified range.
+// Requires that the raftMu of the replica whose place is being held
+// is locked. See removePlaceholderType for existence semantics.
+func (s *Store) removePlaceholder(
+	ctx context.Context, ph *ReplicaPlaceholder, typ removePlaceholderType,
+) (removed bool, _ error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.removePlaceholderLocked(ctx, rngID)
+	return s.removePlaceholderLocked(ctx, ph, typ)
 }
 
-// removePlaceholderLocked removes the specified placeholder. Requires that
-// Store.mu and the raftMu of the replica whose place is being held are locked.
-func (s *Store) removePlaceholderLocked(ctx context.Context, rngID roachpb.RangeID) bool {
-	placeholder, ok := s.mu.replicaPlaceholders[rngID]
-	if !ok {
-		return false
+type removePlaceholderType byte
+
+const (
+	// The placeholder was filled, i.e. the snapshot was applied successfully.
+	// This is only legal to use when the placeholder exists, and so in particular
+	// it can't be invoked multiple times.
+	removePlaceholderFilled removePlaceholderType = iota
+	// Raft didn't apply snapshot. Note that this is only counting snapshots
+	// that raft dropped in the presence of a placeholder, which means snapshots
+	// that targeted an uninitialized replica. There is currently no reason for
+	// those to ever be dropped, if anything snapshots that get dropped would
+	// target an already initialized replica, but those will not augment the
+	// metric related to this const.
+	//
+	// This type allows idempotent deletion, i.e. it can be invoked even if the
+	// placeholder has already been filled or removed before, simplifying the
+	// cleanup on failed operations.
+	removePlaceholderDropped
+	// The snapshot never got to raft, i.e. failed during receipt, for example.
+	// This does not account for failed snapshots targeting initialized replicas.
+	//
+	// This type allows idempotent deletion, i.e. it can be invoked even if the
+	// placeholder has already been filled or removed before, simplifying the
+	// cleanup on failed operations.
+	removePlaceholderFailed
+)
+
+// removePlaceholderLocked removes a placeholder for the specified range.
+// Requires that the raftMu of the replica whose place is being held
+// is locked. See removePlaceholderType for existence semantics.
+//
+// If typ is removePlaceholderFilled, an error is returned unless `removed`
+// is true. For the other types, removal is idempotent.
+func (s *Store) removePlaceholderLocked(
+	ctx context.Context, inPH *ReplicaPlaceholder, typ removePlaceholderType,
+) (removed bool, _ error) {
+	wasTainted := !atomic.CompareAndSwapInt32(&inPH.tainted, 0, 1)
+	idempotent := wasTainted && typ == removePlaceholderFailed || typ == removePlaceholderDropped
+	if wasTainted {
+		// The placeholder was already tainted, i.e. it was passed to
+		// removePlaceholderLocked before.
+		if !idempotent {
+			// We need the placeholder to exist, but it's already gone. This is a bug.
+			return false, errors.AssertionFailedf(
+				"attempt to remove already removed placeholder %+v", inPH,
+			)
+		}
+		// Continue so that we can verify that the placeholder is indeed gone.
 	}
+
+	rngID := inPH.Desc().RangeID
+	placeholder, ok := s.mu.replicaPlaceholders[rngID]
+
+	if wasTainted != !ok {
+		return false, errors.AssertionFailedf("expected placeholder to exist: %t but found in store: %t", !wasTainted, ok)
+	}
+
+	if !ok {
+		// The placeholder is not in the store, but that's ok since wasTainted is
+		// thus true (since we got here) and this implies that idempotent==true
+		// (again since we made it here).
+		return false, nil
+	}
+
+	if placeholder != inPH {
+		if idempotent {
+			// In idempotent mode, the placeholder was not in the store before, so
+			// nothing would have prevented another placeholder for the same range to
+			// slip in.
+			return false, nil
+		}
+		// The placeholder acts as a lock, and when we're filling or dropping it we
+		// only do so once, so how would we now see a different placeholder from the
+		// one we previously inserted? There must be a bug.
+		return false, errors.AssertionFailedf(
+			"placeholder %s is being dropped or filled, but store has conflicting placeholder %s",
+			inPH, placeholder,
+		)
+	}
+
+	// Remove the placeholder from the store.
+
 	if it := s.mu.replicasByKey.DeletePlaceholder(ctx, placeholder); it.ph != placeholder {
-		log.Fatalf(ctx, "r%d: placeholder %v not found, got %+v", rngID, placeholder, it)
-		return true // unreachable
+		return false, errors.AssertionFailedf("placeholder %v not found, got %+v", placeholder, it)
 	}
 	delete(s.mu.replicaPlaceholders, rngID)
 	if it := s.getOverlappingKeyRangeLocked(&placeholder.rangeDesc); it.item != nil {
-		log.Fatalf(ctx, "corrupted replicasByKey map: %s and %s overlapped", it.ph, it.item)
+		return false, errors.AssertionFailedf("corrupted replicasByKey map: %s and %s overlapped", it.ph, it.item)
 	}
-	return true
+	switch typ {
+	case removePlaceholderDropped:
+		atomic.AddInt32(&s.counts.droppedPlaceholders, 1)
+	case removePlaceholderFailed:
+		atomic.AddInt32(&s.counts.failedPlaceholders, 1)
+	case removePlaceholderFilled:
+		atomic.AddInt32(&s.counts.filledPlaceholders, 1)
+	}
+	return true, nil
 }

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -46,7 +46,7 @@ const (
 	storeDrainingMsg        = "store is draining"
 
 	// IntersectingSnapshotMsg is part of the error message returned from
-	// canApplySnapshotLocked and is exposed here so testing can rely on it.
+	// canAcceptSnapshotLocked and is exposed here so testing can rely on it.
 	IntersectingSnapshotMsg = "snapshot intersects existing range"
 )
 
@@ -581,14 +581,14 @@ func (s *Store) reserveSnapshot(
 	}, "", nil
 }
 
-// canApplySnapshotLocked returns (_, nil) if the snapshot can be applied to
+// canAcceptSnapshotLocked returns (_, nil) if the snapshot can be applied to
 // this store's replica (i.e. the snapshot is not from an older incarnation of
-// the replica) and a placeholder can be added to the replicasByKey map (if
-// necessary). If a placeholder is required, it is returned as the first value.
+// the replica) and a placeholder that can be (but is not yet) added to the
+// replicasByKey map (if necessary).
 //
-// Both the store mu (and the raft mu for an existing replica if there is one)
+// Both the store mu and the raft mu for the existing replica (which must exist)
 // must be held.
-func (s *Store) canApplySnapshotLocked(
+func (s *Store) canAcceptSnapshotLocked(
 	ctx context.Context, snapHeader *SnapshotRequest_Header,
 ) (*ReplicaPlaceholder, error) {
 	if snapHeader.IsPreemptive() {
@@ -604,7 +604,7 @@ func (s *Store) canApplySnapshotLocked(
 		int64(desc.RangeID),
 	)
 	if !ok {
-		return nil, errors.Errorf("canApplySnapshotLocked requires a replica present")
+		return nil, errors.Errorf("canAcceptSnapshotLocked requires a replica present")
 	}
 	existingRepl := (*Replica)(v)
 	// The raftMu is held which allows us to use the existing replica as a
@@ -662,7 +662,7 @@ func (s *Store) checkSnapshotOverlapLocked(
 	// NB: this check seems redundant since placeholders are also represented in
 	// replicasByKey (and thus returned in getOverlappingKeyRangeLocked).
 	if exRng, ok := s.mu.replicaPlaceholders[desc.RangeID]; ok {
-		return errors.Errorf("%s: canApplySnapshotLocked: cannot add placeholder, have an existing placeholder %s %v", s, exRng, snapHeader.RaftMessageRequest.FromReplica)
+		return errors.Errorf("%s: canAcceptSnapshotLocked: cannot add placeholder, have an existing placeholder %s %v", s, exRng, snapHeader.RaftMessageRequest.FromReplica)
 	}
 
 	// TODO(benesch): consider discovering and GC'ing *all* overlapping ranges,
@@ -712,37 +712,6 @@ func (s *Store) checkSnapshotOverlapLocked(
 	return nil
 }
 
-// shouldAcceptSnapshotData is an optimization to check whether we should even
-// bother to read the data for an incoming snapshot. If the snapshot overlaps an
-// existing replica or placeholder, we'd error during application anyway, so do
-// it before transferring all the data. This method is a guess and may have
-// false positives. If the snapshot should be rejected, an error is returned
-// with a description of why. Otherwise, nil means we should accept the
-// snapshot.
-func (s *Store) shouldAcceptSnapshotData(
-	ctx context.Context, snapHeader *SnapshotRequest_Header,
-) error {
-	if snapHeader.IsPreemptive() {
-		return errors.AssertionFailedf(`expected a raft or learner snapshot`)
-	}
-	pErr := s.withReplicaForRequest(
-		ctx, &snapHeader.RaftMessageRequest, func(ctx context.Context, r *Replica) *roachpb.Error {
-			ctx = r.AnnotateCtx(ctx)
-			// If the current replica is not initialized then we should accept this
-			// snapshot if it doesn't overlap existing ranges.
-			if !r.IsInitialized() {
-				s.mu.Lock()
-				defer s.mu.Unlock()
-				return roachpb.NewError(s.checkSnapshotOverlapLocked(ctx, snapHeader))
-			}
-			// If the current range is initialized then we need to accept this
-			// snapshot.
-			return nil
-		},
-	)
-	return pErr.GoError()
-}
-
 // receiveSnapshot receives an incoming snapshot via a pre-opened GRPC stream.
 func (s *Store) receiveSnapshot(
 	ctx context.Context, header *SnapshotRequest_Header, stream incomingSnapshotStream,
@@ -777,16 +746,40 @@ func (s *Store) receiveSnapshot(
 	}
 	defer cleanup()
 
-	// Check to see if the snapshot can be applied but don't attempt to add
-	// a placeholder here, because we're not holding the replica's raftMu.
-	// We'll perform this check again later after receiving the rest of the
-	// snapshot data - this is purely an optimization to prevent downloading
-	// a snapshot that we know we won't be able to apply.
-	if err := s.shouldAcceptSnapshotData(ctx, header); err != nil {
-		return sendSnapshotError(stream,
-			errors.Wrapf(err, "%s,r%d: cannot apply snapshot", s, header.State.Desc.RangeID),
-		)
+	// The comment on ReplicaPlaceholder motivates and documents
+	// ReplicaPlaceholder semantics. Please be familiar with them
+	// before making any changes.
+	var placeholder *ReplicaPlaceholder
+	if pErr := s.withReplicaForRequest(
+		ctx, &header.RaftMessageRequest, func(ctx context.Context, r *Replica,
+		) *roachpb.Error {
+			var err error
+			s.mu.Lock()
+			defer s.mu.Unlock()
+			placeholder, err = s.canAcceptSnapshotLocked(ctx, header)
+			if err != nil {
+				return roachpb.NewError(err)
+			}
+			if placeholder != nil {
+				if err := s.addPlaceholderLocked(placeholder); err != nil {
+					return roachpb.NewError(err)
+				}
+			}
+			return nil
+		}); pErr != nil {
+		log.Infof(ctx, "cannot accept snapshot: %s", pErr)
+		return pErr.GoError()
 	}
+
+	defer func() {
+		if placeholder != nil {
+			// Remove the placeholder, if it's still there. Most of the time it will
+			// have been filled and this is a no-op.
+			if _, err := s.removePlaceholder(ctx, placeholder, removePlaceholderFailed); err != nil {
+				log.Fatalf(ctx, "unable to remove placeholder: %s", err)
+			}
+		}
+	}()
 
 	// Determine which snapshot strategy the sender is using to send this
 	// snapshot. If we don't know how to handle the specified strategy, return
@@ -823,10 +816,10 @@ func (s *Store) receiveSnapshot(
 	if err != nil {
 		return err
 	}
+	inSnap.placeholder = placeholder
 	if err := s.processRaftSnapshotRequest(ctx, header, inSnap); err != nil {
 		return sendSnapshotError(stream, errors.Wrap(err.GoError(), "failed to apply snapshot"))
 	}
-
 	return stream.Send(&SnapshotResponse{Status: SnapshotResponse_APPLIED})
 }
 

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -18,6 +18,7 @@ import (
 	"math/rand"
 	"reflect"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -2636,37 +2637,72 @@ func TestStoreRangePlaceholders(t *testing.T) {
 		},
 	}
 
+	check := func(exp string) {
+		exp = strings.TrimSpace(exp)
+		t.Helper()
+		act := strings.TrimSpace(s.mu.replicasByKey.String())
+		require.Equal(t, exp, act)
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	// Test that simple insertion works.
-	if err := s.addPlaceholderLocked(placeholder1); err != nil {
-		t.Fatalf("could not add placeholder to empty store, got %s", err)
+	require.NoError(t, s.addPlaceholderLocked(placeholder1))
+	require.NoError(t, s.addPlaceholderLocked(placeholder2))
+
+	check(`
+[] - [99] (/Min - "c")
+[99] - [100] ("c" - "d")
+[100] - [255 255] ("d" - /Max)`)
+
+	checkErr := func(re string) func(bool, error) {
+		t.Helper()
+		return func(removed bool, err error) {
+			require.True(t, testutils.IsError(err, re), "expected to match %s: %v", re, err)
+			require.False(t, removed)
+		}
 	}
-	if err := s.addPlaceholderLocked(placeholder2); err != nil {
-		t.Fatalf("could not add non-overlapping placeholder, got %s", err)
+	checkRemoved := func(removed bool, nilErr error) {
+		t.Helper()
+		require.NoError(t, nilErr)
+		require.True(t, removed)
+	}
+	checkNotRemoved := func(removed bool, nilErr error) {
+		t.Helper()
+		require.NoError(t, nilErr)
+		require.False(t, removed)
 	}
 
 	// Test that simple deletion works.
-	if !s.removePlaceholderLocked(ctx, placeholder1.rangeDesc.RangeID) {
-		t.Fatalf("could not remove placeholder that was present")
-	}
+	checkRemoved(s.removePlaceholderLocked(ctx, placeholder1, removePlaceholderFailed))
+
+	check(`
+[] - [99] (/Min - "c")
+[100] - [255 255] ("d" - /Max)`)
 
 	// Test cannot double insert the same placeholder.
-	if err := s.addPlaceholderLocked(placeholder1); err != nil {
-		t.Fatalf("could not re-add placeholder after removal, got %s", err)
-	}
+	placeholder1.tainted = 0 // reset for re-use
+	require.NoError(t, s.addPlaceholderLocked(placeholder1))
 	if err := s.addPlaceholderLocked(placeholder1); !testutils.IsError(err, ".*overlaps with existing") {
 		t.Fatalf("should not be able to add ReplicaPlaceholder for the same key twice, got: %+v", err)
 	}
 
-	// Test cannot double delete a placeholder.
-	if !s.removePlaceholderLocked(ctx, placeholder1.rangeDesc.RangeID) {
-		t.Fatalf("could not remove placeholder that was present")
-	}
-	if s.removePlaceholderLocked(ctx, placeholder1.rangeDesc.RangeID) {
-		t.Fatalf("successfully removed placeholder that was not present")
-	}
+	// Test double deletion of a placeholder.
+	checkRemoved(s.removePlaceholderLocked(ctx, placeholder1, removePlaceholderFilled))
+	checkNotRemoved(s.removePlaceholderLocked(ctx, placeholder1, removePlaceholderFailed))
+	checkNotRemoved(s.removePlaceholderLocked(ctx, placeholder1, removePlaceholderDropped))
+	checkErr(`attempt to remove already removed placeholder`)(s.removePlaceholderLocked(
+		ctx, placeholder1, removePlaceholderFilled,
+	))
+	placeholder1.tainted = 0 // pretend it wasn't already deleted
+	checkErr(`expected placeholder to exist: true but found in store: false`)(s.removePlaceholderLocked(
+		ctx, placeholder1, removePlaceholderDropped,
+	))
+
+	check(`
+[] - [99] (/Min - "c")
+[100] - [255 255] ("d" - /Max)`)
 
 	// This placeholder overlaps with an existing replica.
 	placeholder1 = &ReplicaPlaceholder{
@@ -2677,15 +2713,20 @@ func TestStoreRangePlaceholders(t *testing.T) {
 		},
 	}
 
-	// Test that placeholder cannot clobber existing replica.
-	if err := s.addPlaceholderLocked(placeholder1); !testutils.IsError(err, ".*overlaps with existing") {
-		t.Fatalf("should not be able to add ReplicaPlaceholder when Replica already exists, got: %+v", err)
+	addPH := func(ph *ReplicaPlaceholder) (bool, error) {
+		return false, s.addPlaceholderLocked(ph)
 	}
 
+	// Test that placeholder cannot clobber existing replica.
+	checkErr(`.*overlaps with existing`)(addPH(placeholder1))
+
 	// Test that Placeholder deletion doesn't delete replicas.
-	if s.removePlaceholderLocked(ctx, repID) {
-		t.Fatalf("should not be able to process removeReplicaPlaceholder for a RangeID where a Replica exists")
-	}
+	placeholder1.tainted = 0
+	checkErr(`expected placeholder to exist: true`)(s.removePlaceholderLocked(ctx, placeholder1, removePlaceholderFilled))
+	checkNotRemoved(s.removePlaceholderLocked(ctx, placeholder1, removePlaceholderFailed))
+	check(`
+[] - [99] (/Min - "c")
+[100] - [255 255] ("d" - /Max)`)
 }
 
 // Test that we remove snapshot placeholders when raft ignores the
@@ -2763,11 +2804,23 @@ func TestStoreRemovePlaceholderOnRaftIgnored(t *testing.T) {
 			},
 		},
 	}
+
+	placeholder := &ReplicaPlaceholder{rangeDesc: *repl1.Desc()}
+
+	{
+		s.mu.Lock()
+		err := s.addPlaceholderLocked(placeholder)
+		s.mu.Unlock()
+		require.NoError(t, err)
+	}
+
 	if err := s.processRaftSnapshotRequest(ctx, req,
 		IncomingSnapshot{
-			SnapUUID: uuid.MakeV4(),
-			State:    &kvserverpb.ReplicaState{Desc: repl1.Desc()},
-		}); err != nil {
+			SnapUUID:    uuid.MakeV4(),
+			State:       &kvserverpb.ReplicaState{Desc: repl1.Desc()},
+			placeholder: placeholder,
+		},
+	); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -116,7 +116,56 @@ type StoreTestingKnobs struct {
 	// DisableTimeSeriesMaintenanceQueue disables the time series maintenance
 	// queue.
 	DisableTimeSeriesMaintenanceQueue bool
-	// DisableRaftSnapshotQueue disables the raft snapshot queue.
+	// DisableRaftSnapshotQueue disables the raft snapshot queue. Use this
+	// sparingly, as it tends to produce flaky tests during up-replication where
+	// the explicit learner snapshot gets lost. Since uninitialized replicas
+	// reject the raft leader's MsgApp with a rejection that hints at index zero,
+	// Raft will always want to send another snapshot if it gets to talk to the
+	// follower before it applied the snapshot. In the common case, the mechanism
+	// we have to suppress raft snapshots while an explicit snapshot is in flight
+	// avoids the duplication of work. However, in the uncommon case, the raft
+	// leader is on a different store and so no suppression takes place. This
+	// duplication is avoided by turning the raft snapshot queue off, but
+	// unfortunately there are certain conditions under which the explicit
+	// snapshot may fail to produce the desired result of an initialized follower
+	// which the leader will append to.
+	//
+	// For example, if there is a term change between when the snapshot is
+	// constructed and received, the follower will silently drop the snapshot
+	// without signaling an error to the sender, i.e. the leader. (To work around
+	// that, once could adjust the term for the message in that case in
+	// `(*Replica).stepRaftGroup` to prevent the message from getting dropped).
+	//
+	// Another problem is that the snapshot may apply but fail to inform the
+	// leader of this fact. Once a Raft leader has determined that a follower
+	// needs a snapshot, it will keep asking for a snapshot to be sent until a) a
+	// call to .ReportSnapshotStatus acks that a snapshot got applied, or b) an
+	// MsgAppResp is received from from the follower acknowledging an index
+	// *greater than or equal to the PendingSnapshotIndex* it tracks for that
+	// follower (such an MsgAppResp is emitted in response to applying the
+	// snapshot), whichever occurs first.
+	//
+	//
+	// However, neither may happen despite the snapshot applying successfully. The
+	// call to `ReportSnapshotStatus` may not occur on the correct Replica, since
+	// Raft leader can change during replication operations, and MsgAppResp can
+	// get dropped. Even if the MsgAppResp does get to the leader, the contained
+	// index (which is the index of the snapshot that got applied) may be less
+	// than the index at which the leader asked for a snapshot (since the applied
+	// snapshot is an external snapshot, and may have been initiated before the
+	// raft leader even wanted a snapshot) - again leaving the leader to continue
+	// asking for a snapshot. Lastly, even if we improved the raft code to accept
+	// all snapshots that allow it to continue replicating the log, there may have
+	// been a log truncation separating the snapshot from the log.
+	//
+	// Either way, the result in all of the rare cases above this is that an
+	// additional snapshot must be sent from the Raft snapshot queue until the
+	// leader will include the follower in log replication. It is thus ill-advised
+	// to turn the snap queue off except when this is known to be a good idea.
+	//
+	// An example of a test that becomes flaky with this set to false is
+	// TestReportUnreachableRemoveRace, though it needs a 20-node roachprod-stress
+	// cluster to reliably reproduce this within a few minutes.
 	DisableRaftSnapshotQueue bool
 	// DisableConsistencyQueue disables the consistency checker.
 	DisableConsistencyQueue bool

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -592,18 +592,41 @@ func (tc *TestCluster) Targets(serverIdxs ...int) []roachpb.ReplicationTarget {
 func (tc *TestCluster) changeReplicas(
 	changeType roachpb.ReplicaChangeType, startKey roachpb.RKey, targets ...roachpb.ReplicationTarget,
 ) (roachpb.RangeDescriptor, error) {
+	tc.t.Helper()
 	ctx := context.TODO()
-	var beforeDesc roachpb.RangeDescriptor
-	if err := tc.Servers[0].DB().GetProto(
-		ctx, keys.RangeDescriptorKey(startKey), &beforeDesc,
-	); err != nil {
-		return roachpb.RangeDescriptor{}, errors.Wrap(err, "range descriptor lookup error")
+
+	var returnErr error
+	var desc *roachpb.RangeDescriptor
+	if err := testutils.SucceedsSoonError(func() error {
+		tc.t.Helper()
+		var beforeDesc roachpb.RangeDescriptor
+		if err := tc.Servers[0].DB().GetProto(
+			ctx, keys.RangeDescriptorKey(startKey), &beforeDesc,
+		); err != nil {
+			return errors.Wrap(err, "range descriptor lookup error")
+		}
+		var err error
+		desc, err = tc.Servers[0].DB().AdminChangeReplicas(
+			ctx, startKey.AsRawKey(), beforeDesc, roachpb.MakeReplicationChanges(changeType, targets...),
+		)
+		if kvserver.IsRetriableReplicationChangeError(err) {
+			tc.t.Logf("encountered retriable replication change error: %v", err)
+			return err
+		}
+		// Don't return blindly - if this isn't an error we think is related to a
+		// replication error that we can retry, save the error to the outer scope
+		// and return nil.
+		returnErr = err
+		return nil
+	}); err != nil {
+		returnErr = err
 	}
-	desc, err := tc.Servers[0].DB().AdminChangeReplicas(
-		ctx, startKey.AsRawKey(), beforeDesc, roachpb.MakeReplicationChanges(changeType, targets...),
-	)
-	if err != nil {
-		return roachpb.RangeDescriptor{}, errors.Wrap(err, "AdminChangeReplicas error")
+
+	if returnErr != nil {
+		// We mark the error as Handled so that tests that wanted the error in the
+		// first attempt but spent a while spinning in the retry loop above will
+		// fail. These should invoke ChangeReplicas directly.
+		return roachpb.RangeDescriptor{}, errors.Handled(errors.Wrap(returnErr, "AdminChangeReplicas error"))
 	}
 	return *desc, nil
 }


### PR DESCRIPTION
This commit cleans up the handling of ReplicaPlaceholder and documents their
semantics better. I embarked on this while looking into an unrelated test
flake. It occurred to me that we were not installing placeholders before the
snapshot transfer, but only after. This seems like a bad idea now that our
average snapshot size has gone up, as placeholders help avoid duplicate work;
we now install them before accepting the range data.

In practice, we currently only allow once snapshot inflight per store, so it
is not clear that that improvement is buying us anything. I think that the
improved clarity in this commit will, though.

Concretely, we now have two simple rules for placeholders:

1. they only exist for uninitialized replicas (and must exist for those, or we
   can end up with overlapping replicas)
2. you write it --> you (and *only* you) remove it.


1 was true before but the documentation was not clear. 2. was not true, as
there were a few out-of-band places that removed placeholders (and didn't
clearly explain why - sounded like we were previously leaking placeholders,
maybe @ajwerner remembers?).

There's also a bit of extra cleanup that clarifies things - for example, since
caller to `applySnapshot` already checked for an empty snapshot, the
placeholder removal within it effectively dead code and is now removed. Also,
in receiveSnapshot, there was an optimistic check that allowed us to discard
snapshots early. It was always confusing to keep track of which one is which
and now that we've lifted the authoritative check to the top of
receiveSnapshot, we got to delete the other one.

Release note: None
