### PR TITLE
roachtest: don't call t.Fatal in FailOnReplicaDivergence

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1751,7 +1751,10 @@ func (c *cluster) FailOnReplicaDivergence(ctx context.Context, t *test) {
 			return c.CheckReplicaDivergenceOnDB(ctx, db)
 		},
 	); err != nil {
-		t.Fatal(err)
+		// NB: we don't call t.Fatal() here because this method is
+		// for use by the test harness beyond the point at which
+		// it can interpret `t.Fatal`.
+		t.printAndFail(0, err)
 	}
 }
 


### PR DESCRIPTION
In #61990 we had this method catch a stats divergence on teardown in an
otherwise successful test. The call to `t.Fatal` in that method
unfortunately prevented the logs from being collected, which is not
helpful.

Release note: None
