### PR TITLE
sql: serialize user defined types in views

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -105,4 +105,4 @@ trace.datadog.project	string	CockroachDB	the project under which traces will be 
 trace.debug.enable	boolean	false	if set, traces for recent requests can be seen at https://<ui>/debug/requests
 trace.lightstep.token	string		if set, traces go to Lightstep using this token
 trace.zipkin.collector	string		if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'). Only one tracer can be configured at a time.
-version	version	20.2-50	set the active cluster version in the format '<major>.<minor>'
+version	version	20.2-52	set the active cluster version in the format '<major>.<minor>'

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -107,6 +107,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen at https://<ui>/debug/requests</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'). Only one tracer can be configured at a time.</td></tr>
-<tr><td><code>version</code></td><td>version</td><td><code>20.2-50</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>version</td><td><code>20.2-52</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -278,6 +278,9 @@ const (
 	// JoinTokensTable adds the system table for storing ephemeral generated
 	// join tokens.
 	JoinTokensTable
+	// SerializeViewUDTs serializes user defined types used in views to allow
+	// for renaming of the referenced types.
+	SerializeViewUDTs
 
 	// Step (1): Add new versions here.
 )
@@ -483,6 +486,10 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 	{
 		Key:     JoinTokensTable,
 		Version: roachpb.Version{Major: 20, Minor: 2, Internal: 50},
+	},
+	{
+		Key:     SerializeViewUDTs, // TODO (ericw): Change this version after 21.2 is added.
+		Version: roachpb.Version{Major: 20, Minor: 2, Internal: 52},
 	},
 	// Step (2): Add new versions here.
 })

--- a/pkg/clusterversion/key_string.go
+++ b/pkg/clusterversion/key_string.go
@@ -53,11 +53,12 @@ func _() {
 	_ = x[NonVotingReplicas-42]
 	_ = x[ProtectedTsMetaPrivilegesMigration-43]
 	_ = x[JoinTokensTable-44]
+	_ = x[SerializeViewUDTs-45]
 }
 
-const _Key_name = "NamespaceTableWithSchemasStart20_2GeospatialTypeEnumsRangefeedLeasesAlterColumnTypeGeneralAlterSystemJobsAddCreatedByColumnsAddScheduledJobsTableUserDefinedSchemasNoOriginFKIndexesNodeMembershipStatusMinPasswordLengthAbortSpanBytesAlterSystemJobsAddSqllivenessColumnsAddNewSystemSqllivenessTableMaterializedViewsBox2DTypeUpdateScheduledJobsSchemaCreateLoginPrivilegeHBAForNonTLSV20_2Start21_1EmptyArraysInInvertedIndexesUniqueWithoutIndexConstraintsVirtualComputedColumnsCPutInlineReplicaVersionsreplacedTruncatedAndRangeAppliedStateMigrationreplacedPostTruncatedAndRangeAppliedStateMigrationNewSchemaChangerLongRunningMigrationsTruncatedAndRangeAppliedStateMigrationPostTruncatedAndRangeAppliedStateMigrationSeparatedIntentsTracingVerbosityIndependentSemanticsSequencesRegclassImplicitColumnPartitioningMultiRegionFeaturesClosedTimestampsRaftTransportChangefeedsSupportPrimaryIndexChangesNamespaceTableWithSchemasMigrationForeignKeyRepresentationMigrationPriorReadSummariesNonVotingReplicasProtectedTsMetaPrivilegesMigrationJoinTokensTable"
+const _Key_name = "NamespaceTableWithSchemasStart20_2GeospatialTypeEnumsRangefeedLeasesAlterColumnTypeGeneralAlterSystemJobsAddCreatedByColumnsAddScheduledJobsTableUserDefinedSchemasNoOriginFKIndexesNodeMembershipStatusMinPasswordLengthAbortSpanBytesAlterSystemJobsAddSqllivenessColumnsAddNewSystemSqllivenessTableMaterializedViewsBox2DTypeUpdateScheduledJobsSchemaCreateLoginPrivilegeHBAForNonTLSV20_2Start21_1EmptyArraysInInvertedIndexesUniqueWithoutIndexConstraintsVirtualComputedColumnsCPutInlineReplicaVersionsreplacedTruncatedAndRangeAppliedStateMigrationreplacedPostTruncatedAndRangeAppliedStateMigrationNewSchemaChangerLongRunningMigrationsTruncatedAndRangeAppliedStateMigrationPostTruncatedAndRangeAppliedStateMigrationSeparatedIntentsTracingVerbosityIndependentSemanticsSequencesRegclassImplicitColumnPartitioningMultiRegionFeaturesClosedTimestampsRaftTransportChangefeedsSupportPrimaryIndexChangesNamespaceTableWithSchemasMigrationForeignKeyRepresentationMigrationPriorReadSummariesNonVotingReplicasProtectedTsMetaPrivilegesMigrationJoinTokensTableSerializeViewUDTs"
 
-var _Key_index = [...]uint16{0, 25, 34, 48, 53, 68, 90, 124, 145, 163, 180, 200, 217, 231, 295, 312, 321, 346, 366, 378, 383, 392, 420, 449, 471, 481, 496, 542, 592, 608, 629, 667, 709, 725, 761, 778, 804, 823, 852, 889, 923, 956, 974, 991, 1025, 1040}
+var _Key_index = [...]uint16{0, 25, 34, 48, 53, 68, 90, 124, 145, 163, 180, 200, 217, 231, 295, 312, 321, 346, 366, 378, 383, 392, 420, 449, 471, 481, 496, 542, 592, 608, 629, 667, 709, 725, 761, 778, 804, 823, 852, 889, 923, 956, 974, 991, 1025, 1040, 1057}
 
 func (i Key) String() string {
 	if i < 0 || i >= Key(len(_Key_index)-1) {

--- a/pkg/sql/logictest/testdata/logic_test/alter_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type
@@ -367,7 +367,7 @@ statement ok
 CREATE VIEW v as SELECT 'd':::alphabets;
 CREATE TABLE uses_alphabets_2(k INT PRIMARY KEY, v alphabets DEFAULT 'e');
 
-statement error pq: could not validate removal of enum value "d": count-value-usage: enum value "d" is not yet public
+statement error pq: could not remove enum value "d" as it is being used in view "v"
 ALTER TYPE alphabets DROP VALUE 'd'
 
 statement ok
@@ -512,7 +512,7 @@ ALTER TYPE enum_60004 DROP VALUE 'b'
 statement ok
 CREATE VIEW v_60004 AS SELECT ARRAY['c']:::_enum_60004 AS v;
 
-statement error count-array-type-value-usage: enum value "c" is not yet public
+statement error pq: could not remove enum value "c" as it is being used in view "v_60004"
 ALTER TYPE enum_60004 DROP VALUE 'c'
 
 subtest regression_60004_complex
@@ -569,6 +569,7 @@ ALTER TYPE alphabets_60004 DROP VALUE 'a'
 statement ok
 ALTER TYPE alphabets_60004 DROP VALUE 'b'
 
+
 subtest if_not_exists
 
 statement ok
@@ -578,3 +579,34 @@ query T noticetrace
 CREATE TYPE IF NOT EXISTS ifNotExists AS ENUM();
 ----
 NOTICE: type "ifnotexists" already exists, skipping
+
+
+# Test dropping enums used in views is disallowed.
+subtest drop_enum_value_in_view
+
+statement ok
+CREATE TYPE abc AS ENUM ('a', 'b', 'c')
+
+statement ok
+CREATE VIEW abc_view AS (SELECT k FROM (SELECT 'a'::abc AS k))
+
+statement error pq: could not remove enum value "a" as it is being used in view "abc_view"
+ALTER TYPE abc DROP VALUE 'a'
+
+statement ok
+CREATE VIEW abc_view2 AS (SELECT 'a'::abc < 'b'::abc)
+
+statement error pq: could not remove enum value "b" as it is being used in view "abc_view2"
+ALTER TYPE abc DROP VALUE 'b'
+
+statement ok
+ALTER TYPE abc DROP VALUE 'c'
+
+statement ok
+CREATE TYPE bar AS ENUM ('b', 'a', 'r')
+
+statement ok
+CREATE VIEW bar_view AS (SELECT ARRAY['b'::bar])
+
+statement error pq: could not remove enum value "b" as it is being used in view "bar_view"
+ALTER TYPE bar DROP VALUE 'b'

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -1002,3 +1002,107 @@ ALTER TYPE typ2 RENAME TO typ3
 
 statement error cannot drop type "typ3" because other objects \(\[db2.public.v3\]\) still depend on it
 DROP TYPE typ3
+
+
+# Test that user defined types used in views can be renamed without corrupting the view.
+subtest view_user_defined_types_renames
+
+statement ok
+CREATE TYPE view_typ AS ENUM('a', 'b')
+
+statement ok
+CREATE VIEW v8 AS SELECT 'a'::view_typ
+
+statement ok
+ALTER TYPE view_typ RENAME TO view_typ_new
+
+query TT
+SHOW CREATE VIEW v8
+----
+v8  CREATE VIEW public.v8 (view_typ) AS SELECT 'a':::public.view_typ_new
+
+query T
+SELECT * FROM v8
+----
+a
+
+statement ok
+CREATE VIEW v9 AS (SELECT 'a'::view_typ_new < 'a'::view_typ_new AS k)
+
+statement ok
+ALTER TYPE view_typ_new RENAME TO view_typ
+
+query TT
+SHOW CREATE VIEW v9
+----
+v9  CREATE VIEW public.v9 (k) AS (SELECT 'a':::public.view_typ < 'a':::public.view_typ AS k)
+
+query B
+SELECT * FROM v9
+----
+false
+
+statement ok
+CREATE VIEW v10 AS (SELECT k FROM (SELECT 'a'::view_typ AS k))
+
+statement ok
+ALTER TYPE view_typ RENAME TO view_type_new
+
+query TT
+SHOW CREATE VIEW v10
+----
+v10  CREATE VIEW public.v10 (k) AS (SELECT k FROM (SELECT 'a':::public.view_type_new AS k))
+
+query T
+SELECT * FROM v10
+----
+a
+
+statement ok
+CREATE VIEW v11 AS (SELECT 'a'::view_type_new AS k UNION SELECT 'b'::view_type_new)
+
+statement ok
+ALTER TYPE view_type_new RENAME TO view_type
+
+query TT
+SHOW CREATE VIEW v11
+----
+v11  CREATE VIEW public.v11 (k) AS (SELECT 'a':::public.view_type AS k UNION SELECT 'b':::public.view_type)
+
+query T
+SELECT * FROM v11 ORDER BY k
+----
+a
+b
+
+statement ok
+CREATE VIEW v12 AS (SELECT ARRAY['a'::view_type, 'b'::view_type])
+
+statement ok
+ALTER TYPE view_type RENAME TO view_type_new
+
+query TT
+SHOW CREATE VIEW v12
+----
+v12  CREATE VIEW public.v12 ("array") AS (SELECT ARRAY['a':::public.view_type_new, 'b':::public.view_type_new]:::public.view_type_new[])
+
+query T
+SELECT * FROM v12
+----
+{a,b}
+
+statement ok
+CREATE VIEW v13 AS (SELECT ('{a, b}'::view_type_new[])[2])
+
+statement ok
+ALTER TYPE view_type_new RENAME TO view_type
+
+query TT
+SHOW CREATE VIEW v13
+----
+v13  CREATE VIEW public.v13 (view_type_new) AS (SELECT ('{a, b}':::STRING::public.view_type[])[2:::INT8])
+
+query T
+SELECT * FROM v13
+----
+b

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -963,7 +963,7 @@ func (node *Array) Format(ctx *FmtCtx) {
 	if ctx.HasFlags(FmtParsable) && node.typ != nil {
 		if node.typ.ArrayContents().Family() != types.UnknownFamily {
 			ctx.WriteString(":::")
-			ctx.Buffer.WriteString(node.typ.SQLString())
+			ctx.FormatTypeReference(node.typ)
 		}
 	}
 }

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
@@ -107,24 +108,34 @@ func ShowCreateView(
 	f.WriteString(") AS ")
 
 	// Convert sequences referenced by ID in the view back to their names.
-	decodedViewQuery, err := formatViewQueryForDisplay(ctx, semaCtx, desc)
+	typeReplacedViewQuery, err := formatViewQueryTypesForDisplay(ctx, semaCtx, desc)
 	if err != nil {
 		log.Warningf(ctx,
-			"error converting sequence IDs to names for view %s (%v): %+v",
+			"error deserializing user defined types for view %s (%v): %+v",
 			desc.GetName(), desc.GetID(), err)
 		f.WriteString(desc.GetViewQuery())
 	} else {
-		f.WriteString(decodedViewQuery)
+		// Deserialize user-defined types in the view query.
+		sequenceReplacedViewQuery, err := formatViewQuerySequencesForDisplay(
+			ctx, semaCtx, typeReplacedViewQuery)
+		if err != nil {
+			log.Warningf(ctx,
+				"error converting sequence IDs to names for view %s (%v): %+v",
+				desc.GetName(), desc.GetID(), err)
+			f.WriteString(typeReplacedViewQuery)
+		} else {
+			f.WriteString(sequenceReplacedViewQuery)
+		}
 	}
+
 	return f.CloseAndGetString(), nil
 }
 
-// formatViewQueryForDisplay formats the given viewQuery by
-// parsing it into a statement, walking the statement and
-// looking for any IDs in the statement, and replacing the
-// IDs with the descriptor's fully qualified name.
-func formatViewQueryForDisplay(
-	ctx context.Context, semaCtx *tree.SemaContext, desc catalog.TableDescriptor,
+// formatViewQuerySequencesForDisplay walks the view query and
+// looks for sequence IDs in the statement. If it finds any,
+// it will replace the IDs with the descriptor's fully qualified name.
+func formatViewQuerySequencesForDisplay(
+	ctx context.Context, semaCtx *tree.SemaContext, viewQuery string,
 ) (string, error) {
 	replaceFunc := func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
 		newExpr, err = schemaexpr.ReplaceIDsWithFQNames(ctx, expr, semaCtx)
@@ -132,6 +143,50 @@ func formatViewQueryForDisplay(
 			return false, expr, err
 		}
 		return false, newExpr, nil
+	}
+
+	stmt, err := parser.ParseOne(viewQuery)
+	if err != nil {
+		return "", err
+	}
+
+	newStmt, err := tree.SimpleStmtVisit(stmt.AST, replaceFunc)
+	if err != nil {
+		return "", err
+	}
+	return newStmt.String(), nil
+}
+
+// formatViewQueryTypesForDisplay walks the view query and
+// look for serialized user-defined types. If it finds any,
+// it will deserialize it to display its name.
+func formatViewQueryTypesForDisplay(
+	ctx context.Context, semaCtx *tree.SemaContext, desc catalog.TableDescriptor,
+) (string, error) {
+	replaceFunc := func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
+		switch n := expr.(type) {
+		case *tree.AnnotateTypeExpr, *tree.CastExpr:
+			texpr, err := tree.TypeCheck(ctx, n, semaCtx, types.Any)
+			if err != nil {
+				return false, expr, err
+			}
+			if !texpr.ResolvedType().UserDefined() {
+				return true, expr, nil
+			}
+
+			formattedExpr, err := schemaexpr.FormatExprForDisplay(
+				ctx, desc, expr.String(), semaCtx, tree.FmtParsable)
+			if err != nil {
+				return false, expr, err
+			}
+			newExpr, err = parser.ParseExpr(formattedExpr)
+			if err != nil {
+				return false, expr, err
+			}
+			return false, newExpr, nil
+		default:
+			return true, expr, nil
+		}
 	}
 
 	viewQuery := desc.GetViewQuery()


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/49962.

Previously, we did not serialize user defined types
in views. This meant that when a view used a
user defined type and that type was renamed, the
view query would be corrupted.
Now that we can walk view queries, this patch
addresses this issue by walking view queries
and serializing any user defined types, so that
renames do not corrupt the view.
This PR borrows the type serializing logic
from https://github.com/cockroachdb/cockroach/pull/49565.

This PR also fixes part of https://github.com/cockroachdb/cockroach/issues/59807.
Previously, users could drop an enum value being used in a view. 
This PR addresses this by walking the view query when an enum 
value is dropped, and checking if it's in use.

Release note: None