### PR TITLE
release-21.1: sql: improve statisticsMutator

### DIFF
--- a/pkg/sql/mutations/BUILD.bazel
+++ b/pkg/sql/mutations/BUILD.bazel
@@ -9,7 +9,9 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/mutations",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/geo/geoindex",
         "//pkg/sql/catalog/colinfo",
+        "//pkg/sql/catalog/descpb",
         "//pkg/sql/parser",
         "//pkg/sql/rowenc",
         "//pkg/sql/sem/tree",


### PR DESCRIPTION
Backport 2/2 commits from #62173.

/cc @cockroachdb/release

---

#### sql: refactor statisticsMutator

Release note: None

#### sql: generate random inverted index histograms in statisticsMutator

Fixes #62133

Release note: None
