### PR TITLE
bazel: add simple toolchain for development on macos x86_64

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -163,3 +163,8 @@ git_repository(
 load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
 
 rules_foreign_cc_dependencies()
+
+# Load custom toolchains.
+load("//build:toolchains/REPOSITORIES.bzl", "toolchain_dependencies")
+
+toolchain_dependencies()

--- a/build/toolchains/REPOSITORIES.bzl
+++ b/build/toolchains/REPOSITORIES.bzl
@@ -1,0 +1,5 @@
+load("//build:toolchains/dev/darwin-x86_64/toolchain.bzl",
+     _dev_darwin_x86_repo = "dev_darwin_x86_repo")
+
+def toolchain_dependencies():
+    _dev_darwin_x86_repo(name = "toolchain_dev_darwin_x86-64")

--- a/build/toolchains/dev/darwin-x86_64/BUILD.darwin-x86_64
+++ b/build/toolchains/dev/darwin-x86_64/BUILD.darwin-x86_64
@@ -1,0 +1,71 @@
+package(default_visibility = ["//visibility:public"])
+
+# Ref:
+# - https://docs.bazel.build/versions/master/tutorial/cc-toolchain-config.html
+# - https://docs.bazel.build/versions/master/toolchains.html
+
+load(":cc_toolchain_config.bzl", "cc_toolchain_config")
+
+cc_toolchain_suite(
+    name = "suite",
+    toolchains = {
+        "darwin": ":toolchain",
+    },
+)
+
+cc_toolchain_config(name = "toolchain_config")
+
+filegroup(name = "empty")
+
+filegroup(
+    name = "all_files",
+    srcs = [
+        ":compiler_files",
+        ":linker_files",
+        ":objcopy_files",
+        ":strip_files",
+    ],
+)
+
+filegroup(
+    name = "compiler_files",
+    srcs = [
+        "bin/clang",
+        "bin/clang++",
+    ],
+)
+
+filegroup(
+    name = "linker_files",
+    srcs = [
+        "bin/clang",
+        "bin/llvm-ar",
+    ],
+)
+
+filegroup(
+    name = "objcopy_files",
+    srcs = [
+        "bin/llvm-objcopy",
+    ],
+)
+
+filegroup(
+    name = "strip_files",
+    srcs = [
+        "bin/llvm-strip",
+    ],
+)
+
+cc_toolchain(
+    name = "toolchain",
+    toolchain_identifier = "darwin-clang-dev-toolchain",
+    toolchain_config = ":toolchain_config",
+    all_files = ":all_files",
+    compiler_files = ":compiler_files",
+    dwp_files = ":empty",
+    linker_files = ":linker_files",
+    objcopy_files = ":objcopy_files",
+    strip_files = ":strip_files",
+    supports_param_files = 0,
+)

--- a/build/toolchains/dev/darwin-x86_64/README.md
+++ b/build/toolchains/dev/darwin-x86_64/README.md
@@ -1,0 +1,12 @@
+This directory defines a simple macOS toolchain for development based on
+Clang 10.0. It can be enabled by adding
+
+    build --crosstool_top=@toolchain_dev_darwin_x86-64//:suite
+
+to your `.bazelrc.user`. Note that a full XCode installation (not just
+command-line tools) is required.
+
+For the definition of the repo containing the toolchain, check out
+`toolchain.bzl`. This uses `BUILD.darwin-x86_64` and
+`cc_toolchain_config.bzl.tmpl` as templates to populate the `BUILD` and
+`cc_toolchain_config.bzl` files in the new repo.

--- a/build/toolchains/dev/darwin-x86_64/cc_toolchain_config.bzl.tmpl
+++ b/build/toolchains/dev/darwin-x86_64/cc_toolchain_config.bzl.tmpl
@@ -1,0 +1,140 @@
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+load("@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
+     "feature",
+     "flag_group",
+     "flag_set",
+     "tool_path")
+
+all_compile_actions = [
+    ACTION_NAMES.c_compile,
+    ACTION_NAMES.cpp_compile,
+    ACTION_NAMES.linkstamp_compile,
+    ACTION_NAMES.assemble,
+    ACTION_NAMES.preprocess_assemble,
+    ACTION_NAMES.cpp_header_parsing,
+    ACTION_NAMES.cpp_module_compile,
+    ACTION_NAMES.cpp_module_codegen,
+    ACTION_NAMES.clif_match,
+    ACTION_NAMES.lto_backend,
+]
+
+all_link_actions = [
+    ACTION_NAMES.cpp_link_executable,
+    ACTION_NAMES.cpp_link_dynamic_library,
+    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+]
+
+def _impl(ctx):
+    tool_paths = [
+        tool_path(
+            name = "gcc",
+            path = "bin/clang",
+        ),
+        tool_path(
+            name = "ld",
+            path = "bin/ld.lld",
+        ),
+        tool_path(
+            name = "cpp",
+            path = "bin/clang++",
+        ),
+        tool_path(
+            name = "gcov",
+            path = "bin/llvm-profdata",
+        ),
+        tool_path(
+            name = "nm",
+            path = "bin/llvm-nm",
+        ),
+        tool_path(
+            name = "objdump",
+            path = "bin/llvm-objdump",
+        ),
+        tool_path(
+            name = "strip",
+            path = "bin/llvm-strip",
+        ),
+        tool_path(
+            name = "ar",
+            path = "/usr/bin/libtool",
+        ),
+    ]
+
+    opt_feature = feature(name = "opt")
+    fastbuild_feature = feature(name = "fastbuild")
+    dbg_feature = feature(name = "dbg")
+
+    supports_pic_feature = feature(name = "supports_pic", enabled = True)
+    supports_dynamic_linker_feature = feature(name = "supports_dynamic_linker", enabled = False)
+
+    default_compile_flags = feature(
+        name = "default_compile_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = ([
+                    flag_group(
+                        flags = [
+                            "-g1",
+                            "-Wall",
+                            "-I%{repo_path}/include/c++/v1",
+                        ],
+                    ),
+                ]),
+            ),
+        ],
+    )
+
+    default_linker_flags = feature(
+        name = "default_linker_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = ([
+                    flag_group(
+                        flags = [
+                            "-lstdc++",
+                        ],
+                    ),
+                ]),
+            ),
+        ],
+    )
+
+    features = [
+        opt_feature,
+        fastbuild_feature,
+        dbg_feature,
+        supports_pic_feature,
+        supports_dynamic_linker_feature,
+        default_compile_flags,
+        default_linker_flags,
+    ]
+
+    return cc_common.create_cc_toolchain_config_info(
+        ctx = ctx,
+        features = features,
+        toolchain_identifier = "darwin-clang-dev-toolchain",
+        host_system_name = "x86_64-apple-macosx",
+        target_system_name = "x86_64-apple-macosx",
+        target_cpu = "darwin",
+        target_libc = "macosx",
+        compiler = "clang",
+        abi_version = "darwin_x86_64",
+        abi_libc_version = "darwin_x86_64",
+        tool_paths = tool_paths,
+        cxx_builtin_include_directories = [
+            "%sysroot%/usr/include",
+            "%{repo_path}/lib/clang/10.0.0/include",
+            "%{repo_path}/include/c++/v1",
+        ],
+        builtin_sysroot = "%{sdk_path}",
+    )
+
+cc_toolchain_config = rule(
+    implementation = _impl,
+    attrs = {},
+    provides = [CcToolchainConfigInfo],
+)

--- a/build/toolchains/dev/darwin-x86_64/toolchain.bzl
+++ b/build/toolchains/dev/darwin-x86_64/toolchain.bzl
@@ -1,0 +1,37 @@
+def _impl(rctx):
+    # If this doesn't succeed, we won't be able to get the sysroot.
+    result = rctx.execute(["/usr/bin/xcodebuild", "-version"])
+    if result.return_code:
+        fail("XCode appears to not be installed: Got stdout {0}, stderr {1}".format(
+            result.stdout, result.stderr))
+
+    rctx.download_and_extract(
+        url = [
+            "https://storage.googleapis.com/public-bazel-artifacts/toolchains/clang/10.0.0/clang%2Bllvm-10.0.0-x86_64-apple-darwin.tar.xz",
+        ],
+        sha256 = "633a833396bf2276094c126b072d52b59aca6249e7ce8eae14c728016edb5e61",
+        stripPrefix = "clang+llvm-10.0.0-x86_64-apple-darwin/",
+    )
+
+    # We need the path to the macOS SDK to use as the sysroot.
+    result = rctx.execute(["/usr/bin/xcrun", "--sdk", "macosx", "--show-sdk-path"])
+    if result.return_code:
+        fail("Could not find path to macOS SDK: Got stdout {0}, stderr {1}".format(
+            result.stdout, result.stderr))
+    sdk_path = result.stdout.strip()
+    repo_path = str(rctx.path(""))
+
+    rctx.template("BUILD",
+                  Label("@cockroach//build:toolchains/dev/darwin-x86_64/BUILD.darwin-x86_64"),
+                  executable = False)
+    rctx.template("cc_toolchain_config.bzl",
+                  Label("@cockroach//build:toolchains/dev/darwin-x86_64/cc_toolchain_config.bzl.tmpl"),
+                  substitutions = {
+                      "%{repo_path}": repo_path,
+                      "%{sdk_path}": sdk_path,
+                  },
+                  executable = False)
+
+dev_darwin_x86_repo = repository_rule(
+    implementation = _impl,
+)


### PR DESCRIPTION
This can be enabled with

    build --crosstool_top=@toolchain_dev_darwin_x86-64//:suite

in `.bazelrc.user`.

We implement this by mirroring the download of
`clang%2Bllvm-10.0.0-x86_64-apple-darwin.tar.xz` into our own
`public-bazel-artifacts` GCP storage bucket, and implementing a simple
toolchain following the documentation:

* https://docs.bazel.build/versions/master/toolchains.html
* https://docs.bazel.build/versions/master/tutorial/cc-toolchain-config.html

The toolchain depends on the macOS SDK that's globally installed, so
XCode must be installed for this to work.

Release note: None