### PR TITLE
release-21.1: build: add a script for RandomSyntaxTests

### DIFF
--- a/build/teamcity-random-syntax.sh
+++ b/build/teamcity-random-syntax.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "${0}")/teamcity-support.sh"
+
+tc_prepare
+
+export TMPDIR=$PWD/artifacts/test
+mkdir -p "$TMPDIR"
+
+
+tc_start_block "Run Random Syntax tests"
+run_json_test build/builder.sh stdbuf -oL -eL make test \
+  PKG=./pkg/sql/tests \
+  TESTS=TestRandomSyntax \
+  TESTFLAGS='-v -rsg=5m -rsg-routines=8 -rsg-exec-timeout=1m' \
+  TESTTIMEOUT=1h
+tc_end_block "Run Random Syntax tests"


### PR DESCRIPTION
Backport 1/1 commits from #62641.

/cc @cockroachdb/release

---

This is being run with an old TeamCity job that uses outdated
conventions.

The job is here
https://teamcity.cockroachdb.com/admin/editRunType.html?id=buildType:Cockroach_Nightlies_RandomSyntaxTests&runnerId=RUNNER_38&cameFromUrl=%2Fadmin%2FeditBuildRunners.html%3Fid%3DbuildType%253ACockroach_Nightlies_RandomSyntaxTests%26init%3D1&cameFromTitle=

Release note: None
