### PR TITLE
roachtest/bank: fix monkeys

### DIFF
--- a/pkg/cmd/roachtest/acceptance.go
+++ b/pkg/cmd/roachtest/acceptance.go
@@ -31,10 +31,12 @@ func registerAcceptance(r *testRegistry) {
 		{name: "bank/node-restart", fn: runBankNodeRestart},
 		{
 			name: "bank/zerosum-splits", fn: runBankNodeZeroSum,
-			skip: "https://github.com/cockroachdb/cockroach/issues/33683 (runs into " +
-				" various errors during its rebalances, see IsExpectedRelocateError)",
+			skip: "https://github.com/cockroachdb/cockroach/issues/62749",
 		},
-		// {"bank/zerosum-restart", runBankZeroSumRestart},
+		{
+			name: "bank/zerosum-restart", fn: runBankZeroSumRestart,
+			skip: "https://github.com/cockroachdb/cockroach/issues/62751",
+		},
 		{name: "build-info", fn: runBuildInfo},
 		{name: "build-analyze", fn: runBuildAnalyze},
 		{name: "cli/node-status", fn: runCLINodeStatus},

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -268,7 +268,7 @@ func (t *test) Skipf(format string, args ...interface{}) {
 // stack traces and such.
 //
 // ATTENTION: Since this calls panic(errTestFatal), it should only be called
-// from a test's closure. The test runner itself should never call this.
+// from a test's main goroutine. The test runner itself should never call this.
 func (t *test) Fatal(args ...interface{}) {
 	t.fatalfInner("" /* format */, args...)
 }
@@ -283,7 +283,11 @@ func (t *test) FailNow() {
 	t.Fatal()
 }
 
-// Errorf implements the TestingT interface.
+// Errorf implements the TestingT interface. It calls t.Fatalf, so it needs to
+// be called on the test's main goroutine.
+//
+// TODO(andrei): It's bad that this calls t.Fatalf(); we should allow this
+// function to be called from any goroutine.
 func (t *test) Errorf(format string, args ...interface{}) {
 	t.Fatalf(format, args...)
 }


### PR DESCRIPTION
The bank family of tests has a chaos monkey and a split monkey. Error
handling was differently broken in both these monkeys:

- the chaos monkey was calling t.Fatal on a goroutine, which leads to
  the test runner exiting and leaking clusters.
- the split monkey was trying to pipe its errors to the main goroutine
  through a buffered channel, except that channel was dimensioned for errors
  coming from "clients", not from this monkey. I think this monkey's send
  was a potential deadlock.

Release note: None