### PR TITLE
log/logconfig: change exit-on-error to default to true for stderr

### DIFF
--- a/pkg/util/log/logconfig/config.go
+++ b/pkg/util/log/logconfig/config.go
@@ -37,7 +37,6 @@ const DefaultFluentFormat = `json-fluent-compact`
 // DefaultConfig returns a suitable default configuration when logging
 // is meant to primarily go to files.
 func DefaultConfig() (c Config) {
-	// TODO(knz): The default for 'stderr:exit-on-error' should probably be 'false'.
 	const defaultConfig = `
 file-defaults:
     filter: INFO
@@ -59,7 +58,7 @@ sinks:
     format: ` + DefaultStderrFormat + `
     redactable: true
     channels: all
-    exit-on-error: true
+    exit-on-error: false
 capture-stray-errors:
   enable: true
 `


### PR DESCRIPTION
This change unearths runtime out-of-memory errors. Before this change, a
runtime-detected failure to allocate memory would not make it to the logs.

This was tested by injecting a rapid memory leak into the process and
determining first that it was not present in logs and then with this
change that the stack traces were present in the stderr log.

I'm omitting a release note primarily because I do not know how to frame one.

Relates to debugging #62320.

Release note: None