### PR TITLE
opt: speed up new init pattern

### DIFF
--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -96,12 +96,6 @@ type interner struct {
 	cache internCache
 }
 
-// Clear clears all interned expressions. Expressions interned before the call
-// to Clear will not be connected to expressions interned after.
-func (in *interner) Clear() {
-	in.cache.Clear()
-}
-
 // Count returns the number of expressions that have been interned.
 func (in *interner) Count() int {
 	return in.cache.Count()
@@ -188,11 +182,6 @@ func (c *internCache) Item() interface{} {
 // Count returns the number of items in the cache.
 func (c *internCache) Count() int {
 	return len(c.cache)
-}
-
-// Clear clears all items in the cache.
-func (c *internCache) Clear() {
-	c.cache = nil
 }
 
 // Start prepares to look up an item in the cache by its hash value. It must be

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -169,7 +169,6 @@ func (m *Memo) Init(evalCtx *tree.EvalContext) {
 	// reused. Field reuse must be explicit.
 	*m = Memo{
 		metadata:                m.metadata,
-		interner:                m.interner,
 		reorderJoinsLimit:       evalCtx.SessionData.ReorderJoinsLimit,
 		zigzagJoinEnabled:       evalCtx.SessionData.ZigzagJoinEnabled,
 		useHistograms:           evalCtx.SessionData.OptimizerUseHistograms,
@@ -180,7 +179,6 @@ func (m *Memo) Init(evalCtx *tree.EvalContext) {
 		saveTablesPrefix:        evalCtx.SessionData.SaveTablesPrefix,
 	}
 	m.metadata.Init()
-	m.interner.Clear()
 	m.logPropsBuilder.init(evalCtx, m)
 }
 
@@ -235,7 +233,7 @@ func (m *Memo) SetRoot(e RelExpr, phys *physical.Required) {
 	// the memory used by the interner.
 	if m.IsOptimized() {
 		m.logPropsBuilder.clear()
-		m.interner.Clear()
+		m.interner = interner{}
 	}
 }
 

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -151,42 +151,45 @@ func (n *MDDepName) equals(other *MDDepName) bool {
 func (md *Metadata) Init() {
 	// Clear the metadata objects to release memory (this clearing pattern is
 	// optimized by Go).
-	// TODO(mgartner): determine if the new clearing pattern is still optimized
-	// by Go. Look at original commit message and assembly.
-	for i := range md.schemas {
-		md.schemas[i] = nil
+	schemas := md.schemas
+	for i := range schemas {
+		schemas[i] = nil
 	}
 
-	for i := range md.cols {
-		md.cols[i] = ColumnMeta{}
+	cols := md.cols
+	for i := range cols {
+		cols[i] = ColumnMeta{}
 	}
 
-	for i := range md.tables {
-		md.tables[i] = TableMeta{}
+	tables := md.tables
+	for i := range tables {
+		tables[i] = TableMeta{}
 	}
 
-	for i := range md.sequences {
-		md.sequences[i] = nil
+	sequences := md.sequences
+	for i := range sequences {
+		sequences[i] = nil
 	}
 
-	for i := range md.deps {
-		md.deps[i] = mdDep{}
+	deps := md.deps
+	for i := range deps {
+		deps[i] = mdDep{}
 	}
 
-	for i := range md.views {
-		md.views[i] = nil
+	views := md.views
+	for i := range views {
+		views[i] = nil
 	}
 
 	// This initialization pattern ensures that fields are not unwittingly
 	// reused. Field reuse must be explicit.
-	*md = Metadata{
-		schemas:   md.schemas[:0],
-		cols:      md.cols[:0],
-		tables:    md.tables[:0],
-		sequences: md.sequences[:0],
-		deps:      md.deps[:0],
-		views:     md.views[:0],
-	}
+	*md = Metadata{}
+	md.schemas = schemas[:0]
+	md.cols = cols[:0]
+	md.tables = tables[:0]
+	md.sequences = sequences[:0]
+	md.deps = deps[:0]
+	md.views = views[:0]
 }
 
 // CopyFrom initializes the metadata with a copy of the provided metadata.


### PR DESCRIPTION
A new initialization pattern was introduced in #58386 which makes
inadvertently reusing struct fields less likely. This pattern incurs a
slight overhead over the previous pattern which shows up in optimizer
micro-benchmarks. This commit makes a few changes to reduce the
overhead, but not completely eliminate it. The overhead is on the order
of tens of nanoseconds, so it should not be a huge concern.

The speedup of this change on the kv-read benchmark is shown below:

    name                              old time/op  new time/op  delta
    kv-read/Parse              2.82ns ± 5%  2.60ns ± 0%   -7.59%  (p=0.008 n=5+5)
    kv-read/OptBuild           8.81µs ± 1%  7.97µs ± 4%   -9.57%  (p=0.008 n=5+5)
    kv-read/Normalize          8.87µs ± 7%  7.80µs ± 2%  -12.08%  (p=0.008 n=5+5)
    kv-read/Explore            14.9µs ± 1%  14.6µs ± 1%   -1.96%  (p=0.008 n=5+5)
    kv-read/ExecBuild          16.2µs ± 1%  16.2µs ± 1%     ~     (p=0.222 n=5+5)
    kv-read-no-prep/Parse      14.6µs ± 2%  14.4µs ± 1%     ~     (p=0.222 n=5+5)
    kv-read-no-prep/OptBuild   40.3µs ± 4%  38.9µs ± 1%     ~     (p=0.095 n=5+5)
    kv-read-no-prep/Normalize  42.2µs ± 1%  40.7µs ± 1%   -3.44%  (p=0.008 n=5+5)
    kv-read-no-prep/Explore    52.0µs ± 4%  50.2µs ± 1%   -3.37%  (p=0.008 n=5+5)
    kv-read-no-prep/ExecBuild  53.7µs ± 2%  51.7µs ± 1%   -3.79%  (p=0.008 n=5+5)
    kv-read-const/Parse        2.64ns ± 2%  2.62ns ± 1%     ~     (p=0.135 n=5+5)
    kv-read-const/OptBuild      208ns ± 2%   206ns ± 2%     ~     (p=0.659 n=5+5)
    kv-read-const/Normalize     204ns ± 1%   201ns ± 1%   -1.86%  (p=0.016 n=5+5)
    kv-read-const/Explore       225ns ± 3%   229ns ± 6%     ~     (p=0.579 n=5+5)
    kv-read-const/ExecBuild     829ns ± 8%   810ns ± 3%     ~     (p=0.841 n=5+5)

Release note: None