### PR TITLE
release-21.1: kvserver/closedts: optimize sidetransport closer

### DIFF
--- a/pkg/kv/kvserver/closedts/sidetransport/sender_test.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/sender_test.go
@@ -51,15 +51,12 @@ var _ Replica = &mockReplica{}
 
 func (m *mockReplica) StoreID() roachpb.StoreID    { return m.storeID }
 func (m *mockReplica) GetRangeID() roachpb.RangeID { return m.rangeID }
-func (m *mockReplica) Desc() *roachpb.RangeDescriptor {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return &m.mu.desc
-}
 func (m *mockReplica) BumpSideTransportClosed(
 	_ context.Context, _ hlc.ClockTimestamp, _ [roachpb.MAX_CLOSED_TIMESTAMP_POLICY]hlc.Timestamp,
-) (bool, ctpb.LAI, roachpb.RangeClosedTimestampPolicy) {
-	return m.canBump, m.lai, m.policy
+) (bool, ctpb.LAI, roachpb.RangeClosedTimestampPolicy, *roachpb.RangeDescriptor) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.canBump, m.lai, m.policy, &m.mu.desc
 }
 
 func (m *mockReplica) removeReplica(nid roachpb.NodeID) {

--- a/pkg/kv/kvserver/replica_closedts_test.go
+++ b/pkg/kv/kvserver/replica_closedts_test.go
@@ -259,7 +259,7 @@ func TestBumpSideTransportClosed(t *testing.T) {
 				var targets [roachpb.MAX_CLOSED_TIMESTAMP_POLICY]hlc.Timestamp
 				targets[roachpb.LAG_BY_CLUSTER_SETTING] = a.target.Add(-1, 0)
 				return nil, nil, testutils.SucceedsSoonError(func() error {
-					ok, _, _ := a.repl.BumpSideTransportClosed(ctx, a.now, targets)
+					ok, _, _, _ := a.repl.BumpSideTransportClosed(ctx, a.now, targets)
 					if !ok {
 						return errors.New("bumping side-transport unexpectedly failed")
 					}
@@ -276,7 +276,7 @@ func TestBumpSideTransportClosed(t *testing.T) {
 				var targets [roachpb.MAX_CLOSED_TIMESTAMP_POLICY]hlc.Timestamp
 				targets[roachpb.LAG_BY_CLUSTER_SETTING] = a.target
 				return nil, nil, testutils.SucceedsSoonError(func() error {
-					ok, _, _ := a.repl.BumpSideTransportClosed(ctx, a.now, targets)
+					ok, _, _, _ := a.repl.BumpSideTransportClosed(ctx, a.now, targets)
 					if !ok {
 						return errors.New("bumping side-transport unexpectedly failed")
 					}
@@ -293,7 +293,7 @@ func TestBumpSideTransportClosed(t *testing.T) {
 				var targets [roachpb.MAX_CLOSED_TIMESTAMP_POLICY]hlc.Timestamp
 				targets[roachpb.LAG_BY_CLUSTER_SETTING] = a.target.Add(1, 0)
 				return nil, nil, testutils.SucceedsSoonError(func() error {
-					ok, _, _ := a.repl.BumpSideTransportClosed(ctx, a.now, targets)
+					ok, _, _, _ := a.repl.BumpSideTransportClosed(ctx, a.now, targets)
 					if !ok {
 						return errors.New("bumping side-transport unexpectedly failed")
 					}
@@ -393,14 +393,14 @@ func TestBumpSideTransportClosed(t *testing.T) {
 			// would be a serious bug.
 			if exp {
 				testutils.SucceedsSoon(t, func() error {
-					ok, _, _ := repl.BumpSideTransportClosed(ctx, now, targets)
+					ok, _, _, _ := repl.BumpSideTransportClosed(ctx, now, targets)
 					if !ok {
 						return errors.New("bumping side-transport unexpectedly failed")
 					}
 					return nil
 				})
 			} else {
-				ok, _, _ := repl.BumpSideTransportClosed(ctx, now, targets)
+				ok, _, _, _ := repl.BumpSideTransportClosed(ctx, now, targets)
 				require.False(t, ok)
 			}
 
@@ -462,7 +462,7 @@ func BenchmarkBumpSideTransportClosed(b *testing.B) {
 		targets[roachpb.LAG_BY_CLUSTER_SETTING] = now.ToTimestamp()
 
 		// Perform the call.
-		ok, _, _ := r.BumpSideTransportClosed(ctx, now, targets)
+		ok, _, _, _ := r.BumpSideTransportClosed(ctx, now, targets)
 		if !ok {
 			b.Fatal("BumpSideTransportClosed unexpectedly failed")
 		}


### PR DESCRIPTION
Backport 1/1 commits from #61580.

Backporting not because this is strictly needed, but because this patch is tiny and is all on new code in 21.1, and I don't want to break otherwise clean future backports for patches on these files code.

/cc @cockroachdb/release

---

The sidetransport sender periodically loops through all the tracked
ranges and checks if it can advance their closedts. This patch makes the
hot loop a little more efficient by collapsing two operations that used
to take the replica lock separately: getting its descriptor and checking
the bump.

Also another small change - learners are considered among the followers
or a range that need closed ts communicated to them. There was no good
reason to exclude them, and including them is a bit more efficient.

Release note: None
Release justification: Improvement to very new functionality.
