### PR TITLE
tenantrate: switch to a single token bucket

### DIFF
--- a/pkg/kv/kvserver/tenantrate/BUILD.bazel
+++ b/pkg/kv/kvserver/tenantrate/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
     embed = [":tenantrate"],
     deps = [
         "//pkg/roachpb",
+        "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/testutils",
         "//pkg/util/leaktest",

--- a/pkg/kv/kvserver/tenantrate/helpers_test.go
+++ b/pkg/kv/kvserver/tenantrate/helpers_test.go
@@ -10,40 +10,51 @@
 
 package tenantrate
 
-import "github.com/cockroachdb/cockroach/pkg/settings/cluster"
+import "github.com/cockroachdb/cockroach/pkg/settings"
 
-// OverrideSettingsWithRateLimits utilizes LimitConfigs from the values stored in the
-// settings.
-func OverrideSettingsWithRateLimits(settings *cluster.Settings, rl LimitConfigs) {
-	readRequestRateLimit.Override(&settings.SV, float64(rl.ReadRequests.Rate))
-	readRequestBurstLimit.Override(&settings.SV, rl.ReadRequests.Burst)
-	writeRequestRateLimit.Override(&settings.SV, float64(rl.WriteRequests.Rate))
-	writeRequestBurstLimit.Override(&settings.SV, rl.WriteRequests.Burst)
-	readRateLimit.Override(&settings.SV, int64(rl.ReadBytes.Rate))
-	readBurstLimit.Override(&settings.SV, rl.ReadBytes.Burst)
-	writeRateLimit.Override(&settings.SV, int64(rl.WriteBytes.Rate))
-	writeBurstLimit.Override(&settings.SV, rl.WriteBytes.Burst)
+// SettingValues is a struct that can be populated from test files, via YAML.
+type SettingValues struct {
+	Rate  float64
+	Burst float64
+
+	Read  Factors
+	Write Factors
 }
 
-// DefaultLimitConfigs returns the configuration that corresponds to the default
+// Factors for reads and writes.
+type Factors struct {
+	Base    float64
+	PerByte float64
+}
+
+// OverrideSettings sets the cluster setting according to the given
+// settingValues.
+//
+// Uninitialized (zero) values are ignored.
+func OverrideSettings(sv *settings.Values, vals SettingValues) {
+	override := func(setting *settings.FloatSetting, val float64) {
+		if val != 0 {
+			setting.Override(sv, val)
+		}
+	}
+	override(kvcuRateLimit, vals.Rate)
+	override(kvcuBurstLimitSeconds, vals.Burst/kvcuRateLimit.Get(sv))
+
+	override(readRequestCost, vals.Read.Base)
+	override(readCostPerMB, vals.Read.PerByte*1024*1024)
+	override(writeRequestCost, vals.Write.Base)
+	override(writeCostPerMB, vals.Write.PerByte*1024*1024)
+}
+
+// DefaultConfig returns the configuration that corresponds to the default
 // setting values.
-func DefaultLimitConfigs() LimitConfigs {
-	return LimitConfigs{
-		ReadRequests: LimitConfig{
-			Rate:  Limit(readRequestRateLimit.Default()),
-			Burst: readRequestBurstLimit.Default(),
-		},
-		WriteRequests: LimitConfig{
-			Rate:  Limit(writeRequestRateLimit.Default()),
-			Burst: writeRequestBurstLimit.Default(),
-		},
-		ReadBytes: LimitConfig{
-			Rate:  Limit(readRateLimit.Default()),
-			Burst: readBurstLimit.Default(),
-		},
-		WriteBytes: LimitConfig{
-			Rate:  Limit(writeRateLimit.Default()),
-			Burst: writeBurstLimit.Default(),
-		},
+func DefaultConfig() Config {
+	return Config{
+		Rate:              kvcuRateLimit.Default(),
+		Burst:             kvcuRateLimit.Default() * kvcuBurstLimitSeconds.Default(),
+		ReadRequestUnits:  readRequestCost.Default(),
+		ReadUnitsPerByte:  readCostPerMB.Default() / (1024 * 1024),
+		WriteRequestUnits: writeRequestCost.Default(),
+		WriteUnitsPerByte: writeCostPerMB.Default() / (1024 * 1024),
 	}
 }

--- a/pkg/kv/kvserver/tenantrate/testdata/basic
+++ b/pkg/kv/kvserver/tenantrate/testdata/basic
@@ -1,8 +1,8 @@
 init
-readrequests:  { rate: 1, burst: 2 }
-writerequests: { rate: 1, burst: 2 }
-readbytes:     { rate: 1024, burst: 2048 }
-writebytes:    { rate: 1024, burst: 2048 }
+rate:  1
+burst: 2
+read:  { base: 1, perbyte: 1 }
+write: { base: 1, perbyte: 1 }
 ----
 00:00:00.000
 
@@ -13,35 +13,33 @@ get_tenants
 ----
 [2#2, 3#1, 5#3, system#1]
 
-# Launch four requests on behalf of tenant 2, one on behalf of 3, and one on
+# Launch two requests on behalf of tenant 2, one on behalf of 3, and one on
 # behalf of the system tenant.
 
 launch
 - { id: g0, tenant: 1 }
 - { id: g1, tenant: 2 }
-- { id: g2, tenant: 2 }
-- { id: g3, tenant: 2, iswrite: true }
-- { id: g4, tenant: 2, iswrite: true }
-- { id: g5, tenant: 3 }
+- { id: g2, tenant: 2, iswrite: true }
+- { id: g3, tenant: 3 }
 ----
-[g0@system, g1@2, g2@2, g3@2, g4@2, g5@3]
+[g0@system, g1@2, g2@2, g3@3]
 
 # Ensure that none of the above requests get blocked because they use less
 # than the configured burst for their respective limiters.
 
 await
-[g0, g1, g2, g3, g4, g5]
+[g0, g1, g2, g3]
 ----
 []
 
-# Launch another read and another write request on behalf of tenant 2, it will
-# block due to the request rate limit.
+# Launch another read and another write request on behalf of tenant 2; they
+# will block because the burst limit only supports two requests.
 
 launch
-- { id: g6, tenant: 2 }
-- { id: g7, tenant: 2, iswrite: true }
+- { id: g4, tenant: 2 }
+- { id: g5, tenant: 2, iswrite: true }
 ----
-[g6@2, g7@2]
+[g4@2, g5@2]
 
 # Ensure that it the above request was blocked by observing the timer it creates
 # to wait for available quota.
@@ -69,13 +67,13 @@ kv_tenant_rate_limit_current_blocked{tenant_id="system"} 0
 metrics
 kv_tenant_rate_limit_.*_requests_admitted
 ----
-kv_tenant_rate_limit_read_requests_admitted 4
-kv_tenant_rate_limit_read_requests_admitted{tenant_id="2"} 2
+kv_tenant_rate_limit_read_requests_admitted 3
+kv_tenant_rate_limit_read_requests_admitted{tenant_id="2"} 1
 kv_tenant_rate_limit_read_requests_admitted{tenant_id="3"} 1
 kv_tenant_rate_limit_read_requests_admitted{tenant_id="5"} 0
 kv_tenant_rate_limit_read_requests_admitted{tenant_id="system"} 1
-kv_tenant_rate_limit_write_requests_admitted 2
-kv_tenant_rate_limit_write_requests_admitted{tenant_id="2"} 2
+kv_tenant_rate_limit_write_requests_admitted 1
+kv_tenant_rate_limit_write_requests_admitted{tenant_id="2"} 1
 kv_tenant_rate_limit_write_requests_admitted{tenant_id="3"} 0
 kv_tenant_rate_limit_write_requests_admitted{tenant_id="5"} 0
 kv_tenant_rate_limit_write_requests_admitted{tenant_id="system"} 0
@@ -94,16 +92,17 @@ metrics
 ----
 
 
-# Advance time to the timer deadline.
+# Advance time to the point where there should be enough units for both
+# requests to go through.
 
 advance
-1s1ms
+2s1ms
 ----
-00:00:01.001
+00:00:02.001
 
 # Observe that the blocked requests are now unblocked.
 
 await
-[g6, g7]
+[g4,g5]
 ----
 []

--- a/pkg/kv/kvserver/tenantrate/testdata/burst
+++ b/pkg/kv/kvserver/tenantrate/testdata/burst
@@ -2,10 +2,10 @@
 # into debt.
 
 init
-readrequests:  { rate: 1, burst: 2 }
-writerequests: { rate: 1, burst: 2 }
-readbytes:     { rate: 1024, burst: 2048 }
-writebytes:    { rate: 10, burst: 20 }
+rate:  1
+burst: 2
+read:  { base: 1, perbyte: 0.1 }
+write: { base: 1, perbyte: 0.1 }
 ----
 00:00:00.000
 
@@ -16,11 +16,11 @@ get_tenants
 ----
 [2#1]
 
-# Launch a request for tenant 2 that consumes more write bytes than the burst
+# Launch a write request for tenant 2 that needs 3 units, more than the burst
 # limit. This will not block but will put the limiter into debt.
 
 launch
-- { id: g1, tenant: 2, iswrite: true, writebytes: 30 }
+- { id: g1, tenant: 2, iswrite: true, writebytes: 20 }
 ----
 [g1@2]
 
@@ -29,14 +29,13 @@ await
 ----
 []
 
-# Launch another request which will block until there is sufficient write
-# quota available. This will be 2s because we're in debt 10 and the rate is
-# 10/s.
+# Launch another request which will block until there is 1 unit available.
+# This will be 2s because we're in debt 1 and the rate is 1/s.
 
 launch
-- { id: g1, tenant: 2, iswrite: true, writebytes: 10 }
+- { id: g2, tenant: 2, iswrite: true, writebytes: 0 }
 ----
-[g1@2]
+[g2@2]
 
 # Observe that the request indeed sees two seconds of waiting.
 
@@ -59,18 +58,18 @@ advance
 # Ensure that the request is indeed unblocked.
 
 await
-- g1
+- g2
 ----
 []
 
 # Test that when consuming more than burst that we wait for the token bucket to
-# be full. At time 4s the token bucket will be full. When requesting 30, which
-# is above the burst of 20, we'll need to wait for the bucket to be full.
+# be full. At time 4s the token bucket will be full. When requesting 4, which
+# is above the burst of 2, we'll need to wait for the bucket to be full.
 
 launch
-- { id: g1,  tenant: 2, iswrite: true, writebytes: 30 }
+- { id: g3,  tenant: 2, iswrite: true, writebytes: 30 }
 ----
-[g1@2]
+[g3@2]
 
 # Verify that the timer exists to avoid races setting the timer and advancing
 # time.
@@ -85,6 +84,6 @@ advance
 00:00:04.000
 
 await
-- g1
+- g3
 ----
 []

--- a/pkg/kv/kvserver/tenantrate/testdata/cancel
+++ b/pkg/kv/kvserver/tenantrate/testdata/cancel
@@ -1,10 +1,10 @@
 # This tests cancellation and unblocking subsequent requests.
 
 init
-readrequests:  { rate: 1, burst: 2 }
-writerequests: { rate: 1, burst: 2 }
-readbytes:     { rate: 1024, burst: 2048 }
-writebytes:    { rate: 1024, burst: 2048 }
+rate:  2
+burst: 4
+read:  { base: 1, perbyte: 0.1 }
+write: { base: 1, perbyte: 0.1 }
 ----
 00:00:00.000
 
@@ -13,10 +13,10 @@ get_tenants
 ----
 [2#1]
 
-# Launch a request to consume half of the 1024 capacity.
+# Launch a request to consume one unit.
 
 launch
-- { id: g1, tenant: 2, iswrite: true, writebytes: 1024 }
+- { id: g1, tenant: 2, iswrite: true, writebytes: 0 }
 ----
 [g1@2]
 
@@ -28,7 +28,7 @@ await
 # Launch a request requiring more quota than exists.
 
 launch
-- { id: g2, tenant: 2, iswrite: true, writebytes: 1536 }
+- { id: g2, tenant: 2, iswrite: true, writebytes: 100 }
 ----
 [g2@2]
 
@@ -41,7 +41,7 @@ timers
 # Launch another request which could be fulfilled by the existing quota.
 
 launch
-- { id: g3, tenant: 2, iswrite: true, writebytes: 1024 }
+- { id: g3, tenant: 2, iswrite: true, writebytes: 0 }
 ----
 [g2@2, g3@2]
 

--- a/pkg/kv/kvserver/tenantrate/testdata/estimate_iops
+++ b/pkg/kv/kvserver/tenantrate/testdata/estimate_iops
@@ -2,48 +2,48 @@ estimate_iops
 readpercentage: 100
 readsize: 4096
 ----
-Read-only workload (4.0 KiB reads): 128 sustained IOPS, 512 burst.
+Read-only workload (4.0 KiB reads): 271 sustained IOPS, 2706 burst.
 
 estimate_iops
 readpercentage: 100
 readsize: 65536
 ----
-Read-only workload (64 KiB reads): 16 sustained IOPS, 256 burst.
+Read-only workload (64 KiB reads): 151 sustained IOPS, 1509 burst.
 
 estimate_iops
 readpercentage: 100
 readsize: 1048576
 ----
-Read-only workload (1.0 MiB reads): 1.0 sustained IOPS, 16 burst.
+Read-only workload (1.0 MiB reads): 19 sustained IOPS, 187 burst.
 
 estimate_iops
 readpercentage: 0
 writesize: 4096
 ----
-Write-only workload (4.0 KiB writes): 128 sustained IOPS, 512 burst.
+Write-only workload (4.0 KiB writes): 78 sustained IOPS, 780 burst.
 
 estimate_iops
 readpercentage: 0
 writesize: 65536
 ----
-Write-only workload (64 KiB writes): 8.0 sustained IOPS, 128 burst.
+Write-only workload (64 KiB writes): 7.7 sustained IOPS, 77 burst.
 
 estimate_iops
 readpercentage: 0
 writesize: 1048576
 ----
-Write-only workload (1.0 MiB writes): 0.5 sustained IOPS, 8.0 burst.
+Write-only workload (1.0 MiB writes): 0.5 sustained IOPS, 5.0 burst.
 
 estimate_iops
 readpercentage: 50
 readsize: 4096
 writesize: 4096
 ----
-Mixed workload (50% reads; 4.0 KiB reads; 4.0 KiB writes): 256 sustained IOPS, 1024 burst.
+Mixed workload (50% reads; 4.0 KiB reads; 4.0 KiB writes): 121 sustained IOPS, 1212 burst.
 
 estimate_iops
 readpercentage: 90
 readsize: 4096
 writesize: 4096
 ----
-Mixed workload (90% reads; 4.0 KiB reads; 4.0 KiB writes): 142 sustained IOPS, 569 burst.
+Mixed workload (90% reads; 4.0 KiB reads; 4.0 KiB writes): 217 sustained IOPS, 2171 burst.

--- a/pkg/kv/kvserver/tenantrate/testdata/reads
+++ b/pkg/kv/kvserver/tenantrate/testdata/reads
@@ -2,8 +2,10 @@
 # into debt
 
 init
-readrequests: { rate: 1, burst: 2 }
-readbytes:    { rate: 10, burst: 100 }
+rate:  2
+burst: 4
+read:  { base: 1, perbyte: 0.1 }
+write: { base: 1, perbyte: 0.1 }
 ----
 00:00:00.000
 
@@ -13,12 +15,12 @@ get_tenants
 ----
 [2#1, system#1]
 
-# Read the entire burst worth of bytes plus 4 which should put the limiter
-# in debt by 4. Also record a system read. We'll verify both show up in metrics.
+# Read the entire burst worth of bytes plus 0.4 which should put the limiter
+# in debt by 0.4. Also record a system read. We'll verify both show up in metrics.
 
 record_read
+- { tenant: 2, readbytes: 34 }
 - { tenant: 1, readbytes: 10 }
-- { tenant: 2, readbytes: 104 }
 ----
 []
 
@@ -27,12 +29,11 @@ record_read
 metrics
 kv_tenant_rate_limit_read_bytes_admitted
 ----
-kv_tenant_rate_limit_read_bytes_admitted 114
-kv_tenant_rate_limit_read_bytes_admitted{tenant_id="2"} 104
+kv_tenant_rate_limit_read_bytes_admitted 44
+kv_tenant_rate_limit_read_bytes_admitted{tenant_id="2"} 34
 kv_tenant_rate_limit_read_bytes_admitted{tenant_id="system"} 10
 
-# Launch a request which will block on the lack of available readbytes as it
-# tries to read its 1 courtesy byte.
+# Launch a request which will block because it needs 1 unit.
 
 launch
 - { id: g1, tenant: 2 }
@@ -41,12 +42,12 @@ launch
 
 timers
 ----
-00:00:00.500
+00:00:00.200
 
-# Record more reads, putting the limiter further into debt
+# Record more reads, putting the limiter further into debt.
 
 record_read
-- { tenant: 2, readbytes: 5 }
+- { tenant: 2, readbytes: 16 }
 ----
 [g1@2]
 
@@ -56,22 +57,22 @@ record_read
 
 timers
 ----
-00:00:00.500
+00:00:00.200
 
 # Note that the head of the queue notices the removal of readbytes and sets a
 # new timer.
 
 advance
-501ms
+201ms
 ----
-00:00:00.501
+00:00:00.201
 
 timers
 ----
 00:00:01.000
 
 advance
-500ms
+800ms
 ----
 00:00:01.001
 
@@ -79,7 +80,6 @@ await
 - g1
 ----
 []
-
 
 
 

--- a/pkg/kv/kvserver/tenantrate/testdata/update
+++ b/pkg/kv/kvserver/tenantrate/testdata/update
@@ -1,10 +1,10 @@
 # Test updating the configuration of the rate limiter.
 
 init
-readrequests:  { rate: 1, burst: 2 }
-writerequests: { rate: 1, burst: 2 }
-readbytes:     { rate: 1024, burst: 2048 }
-writebytes:    { rate: 10, burst: 20 }
+rate:  2
+burst: 4
+read:  { base: 1, perbyte: 0.1 }
+write: { base: 1, perbyte: 0.1 }
 ----
 00:00:00.000
 
@@ -13,10 +13,10 @@ get_tenants
 ----
 [2#1]
 
-# Launch a request that puts the limiter in debt by 10.
+# Launch a request that puts the limiter in debt by 2.
 
 launch
-- { id: g1, tenant: 2, iswrite: true, writebytes: 30 }
+- { id: g1, tenant: 2, iswrite: true, writebytes: 50 }
 ----
 [g1@2]
 
@@ -25,11 +25,11 @@ await
 ----
 []
 
-# Launch a request that will require 20, it will need to block for 3s to deal
+# Launch a request that will require 4, it will need to block for 3s to deal
 # with the current debt.
 
 launch
-- { id: g1, tenant: 2, iswrite: true, writebytes: 20 }
+- { id: g1, tenant: 2, iswrite: true, writebytes: 30 }
 ----
 [g1@2]
 
@@ -50,7 +50,8 @@ advance
 # Update the settings to double the writebytes rate.
 
 update_settings
-writebytes: { rate: 20, burst: 10 }
+rate:  4
+burst: 2
 ----
 00:00:01.000
 
@@ -58,17 +59,16 @@ writebytes: { rate: 20, burst: 10 }
 
 timers
 ----
-00:00:01.500
+00:00:02.000
 
 # Advance to the timer and observe that the request is unblocked.
 
 advance
-500ms
+1s
 ----
-00:00:01.500
+00:00:02.000
 
 await
 - g1
 ----
 []
-

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1470,29 +1470,8 @@ func (t *logicTest) newCluster(serverArgs TestServerArgs) {
 
 		// Increase tenant rate limits for faster tests.
 		conn := t.cluster.ServerConn(0)
-		for _, settingName := range []string{
-			"kv.tenant_rate_limiter.read_requests.rate_limit",
-			"kv.tenant_rate_limiter.read_requests.burst_limit",
-			"kv.tenant_rate_limiter.write_requests.rate_limit",
-			"kv.tenant_rate_limiter.write_requests.burst_limit",
-		} {
-			if _, err := conn.Exec(
-				fmt.Sprintf("SET CLUSTER SETTING %s = %d", settingName, 100000),
-			); err != nil {
-				t.Fatal(err)
-			}
-		}
-		for _, settingName := range []string{
-			"kv.tenant_rate_limiter.read_bytes.rate_limit",
-			"kv.tenant_rate_limiter.read_bytes.burst_limit",
-			"kv.tenant_rate_limiter.write_bytes.rate_limit",
-			"kv.tenant_rate_limiter.write_bytes.burst_limit",
-		} {
-			if _, err := conn.Exec(
-				fmt.Sprintf("SET CLUSTER SETTING %s = '1GB'", settingName),
-			); err != nil {
-				t.Fatal(err)
-			}
+		if _, err := conn.Exec("SET CLUSTER SETTING kv.tenant_rate_limiter.rate_limit = 100000"); err != nil {
+			t.Fatal(err)
 		}
 	}
 

--- a/pkg/util/quotapool/BUILD.bazel
+++ b/pkg/util/quotapool/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "intpool.go",
         "notify_queue.go",
         "quotapool.go",
+        "token_bucket.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/quotapool",
     visibility = ["//visibility:public"],
@@ -29,6 +30,7 @@ go_test(
         "intpool_test.go",
         "node_size_test.go",
         "notify_queue_test.go",
+        "token_bucket_test.go",
     ],
     embed = [":quotapool"],
     deps = [

--- a/pkg/util/quotapool/quotapool.go
+++ b/pkg/util/quotapool/quotapool.go
@@ -216,6 +216,13 @@ func (qp *AbstractPool) Acquire(ctx context.Context, r Request) (err error) {
 		return err
 	}
 
+	if qp.config.onWaitStart != nil {
+		qp.config.onWaitStart(ctx, qp.name, r)
+	}
+	if qp.config.onWaitFinish != nil {
+		defer qp.config.onWaitFinish(ctx, qp.name, r)
+	}
+
 	// Set up the infrastructure to report slow requests.
 	var slowTimer timeutil.TimerI
 	var slowTimerC <-chan time.Time

--- a/pkg/util/quotapool/token_bucket.go
+++ b/pkg/util/quotapool/token_bucket.go
@@ -1,0 +1,116 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package quotapool
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// Tokens are abstract units (usually units of work).
+type Tokens float64
+
+// TokensPerSecond is the rate of token replenishment.
+type TokensPerSecond float64
+
+// TokenBucket implements the basic accounting for a token bucket.
+//
+// A token bucket has a rate of replenishment and a burst limit. Tokens are
+// replenished over time, up to the burst limit.
+//
+// The token bucket keeps track of the current amount and updates it as time
+// passes. The bucket can go into debt (i.e. negative current amount).
+type TokenBucket struct {
+	rate       TokensPerSecond
+	burst      Tokens
+	timeSource timeutil.TimeSource
+
+	current     Tokens
+	lastUpdated time.Time
+}
+
+// Init the token bucket.
+func (tb *TokenBucket) Init(rate TokensPerSecond, burst Tokens, timeSource timeutil.TimeSource) {
+	*tb = TokenBucket{
+		rate:        rate,
+		burst:       burst,
+		timeSource:  timeSource,
+		current:     burst,
+		lastUpdated: timeSource.Now(),
+	}
+}
+
+// update moves the time forward, accounting for the replenishment since the
+// last update.
+func (tb *TokenBucket) update() {
+	now := tb.timeSource.Now()
+	if since := now.Sub(tb.lastUpdated); since > 0 {
+		tb.current += Tokens(float64(tb.rate) * since.Seconds())
+
+		if tb.current > tb.burst {
+			tb.current = tb.burst
+		}
+		tb.lastUpdated = now
+	}
+}
+
+// UpdateConfig updates the rate and burst limits. The change in burst will be
+// applied to the current token quantity. For example, if the RateLimiter
+// currently had 5 available tokens and the burst is updated from 10 to 20, the
+// amount will increase to 15. Similarly, if the burst is decreased by 10, the
+// current quota will decrease accordingly, potentially putting the limiter into
+// debt.
+func (tb *TokenBucket) UpdateConfig(rate TokensPerSecond, burst Tokens) {
+	tb.update()
+
+	burstDelta := burst - tb.burst
+	tb.rate = rate
+	tb.burst = burst
+
+	tb.current += burstDelta
+}
+
+// Adjust returns tokens to the bucket (positive delta) or accounts for a debt
+// of tokens (negative delta).
+func (tb *TokenBucket) Adjust(delta Tokens) {
+	tb.update()
+	tb.current += delta
+	if tb.current > tb.burst {
+		tb.current = tb.burst
+	}
+}
+
+// TryToFulfill either removes the given amount if is available, or returns a
+// time after which the request should be retried.
+func (tb *TokenBucket) TryToFulfill(amount Tokens) (fulfilled bool, tryAgainAfter time.Duration) {
+	tb.update()
+
+	// Deal with the case where the request is larger than the burst size. In
+	// this case we'll allow the acquisition to complete if and when the current
+	// value is equal to the burst. If the acquisition succeeds, it will put the
+	// limiter into debt.
+	want := amount
+	if want > tb.burst {
+		want = tb.burst
+	}
+	if delta := want - tb.current; delta > 0 {
+		// Compute the time it will take to get to the needed capacity.
+		timeDelta := time.Duration((float64(delta) * float64(time.Second)) / float64(tb.rate))
+		if timeDelta < time.Nanosecond {
+			timeDelta = time.Nanosecond
+		}
+		return false, timeDelta
+	}
+
+	tb.current -= amount
+	return true, 0
+}

--- a/pkg/util/quotapool/token_bucket_test.go
+++ b/pkg/util/quotapool/token_bucket_test.go
@@ -1,0 +1,88 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package quotapool
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+func TestTokenBucket(t *testing.T) {
+	t0 := time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
+	mt := timeutil.NewManualTime(t0)
+
+	var tb TokenBucket
+	tb.Init(10, 20, mt)
+
+	check := func(expected Tokens) {
+		t.Helper()
+		const eps = 1e-10
+		tb.update()
+		if delta := tb.current - expected; delta > eps || delta < -eps {
+			t.Fatalf("expected current amount %v, got %v", expected, tb.current)
+		}
+	}
+
+	checkFulfill := func(amount Tokens, expected time.Duration) {
+		t.Helper()
+		ok, tryAgainAfter := tb.TryToFulfill(amount)
+		if ok {
+			if expected != 0 {
+				t.Fatalf("expected not to be fulfilled")
+			}
+		} else {
+			if expected == 0 {
+				t.Fatalf("expected to be fulfilled")
+			} else if tryAgainAfter.Round(time.Microsecond) != expected.Round(time.Microsecond) {
+				t.Fatalf("expected tryAgainAfter %v, got %v", expected, tryAgainAfter)
+			}
+		}
+	}
+
+	check(20)
+	tb.Adjust(-10)
+	check(10)
+	tb.Adjust(5)
+	check(15)
+	tb.Adjust(20)
+	check(20)
+
+	mt.Advance(time.Second)
+	check(20)
+	tb.Adjust(-15)
+	check(5)
+
+	mt.Advance(time.Second)
+	check(15)
+	mt.Advance(time.Second)
+	check(20)
+
+	checkFulfill(15, 0)
+	checkFulfill(15, time.Second)
+
+	mt.Advance(10 * time.Second)
+	// Now put the bucket into debt with a huge ask.
+	checkFulfill(120, 0)
+	checkFulfill(10, 11*time.Second)
+
+	mt.Advance(100 * time.Second)
+
+	// A full bucket should remain full.
+	tb.UpdateConfig(100, 1000)
+	checkFulfill(1000, 0)
+	checkFulfill(100, 1*time.Second)
+
+	tb.UpdateConfig(10, 20)
+	check(-980)
+	checkFulfill(20, 100*time.Second)
+}


### PR DESCRIPTION
Tenant rate limiting currently uses four separate token buckets, each
with its own rate and burst limits. In this commit we switch to a
single shared token bucket (see #55114 for motivation).

We use a "cost model" to map read and write requests to "KV Compute
Units". Requests have a base cost plus a per-byte cost. The details
are documented in settings.go. The values were chosen based on
experiments ran by Nathan:
https://docs.google.com/spreadsheets/d/1PPlIcKnusOqWtBoOZVd9xBEMPe5Ss1FgrJlYFgpQZaM/edit#gid=735409177

The rate was chosen so that it maps to 20% of 1 KV vCPU. This keeps
the rate limit on small requests roughly the same as before
(especially on mixed workloads).

The largest departure from the previous limits is that we allow much
more read bytes (the per-byte cost of reads is small in the cost
model). If we were to keep close to the previous limits, the value of
kv.tenant_rate_limiter.read_cost_per_megabyte would be 200 instead of
10.  Perhaps we want to be more conservative here and make this
value somewhere in-between?

Fixes #55114.

Release note: None