### PR TITLE
release-20.2: kvserver: add hidden cluster setting kv.gc.intent_age_threshold

### DIFF
--- a/pkg/cli/debug_test.go
+++ b/pkg/cli/debug_test.go
@@ -447,3 +447,15 @@ func TestParseGossipValues(t *testing.T) {
 			len(debugLines), len(gossipInfo.Infos), debugOutput, strings.Join(gossipInfoKeys, "\n"))
 	}
 }
+
+func TestParsePositiveDuration(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	duration, _ := parsePositiveDuration("1h")
+	if duration != time.Hour {
+		t.Errorf("Expected %v, got %v", time.Hour, duration)
+	}
+	_, err := parsePositiveDuration("-5m")
+	if err == nil {
+		t.Errorf("Expected to fail parsing negative duration -5m")
+	}
+}

--- a/pkg/kv/kvserver/gc/gc.go
+++ b/pkg/kv/kvserver/gc/gc.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/abortspan"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
@@ -37,15 +38,25 @@ import (
 )
 
 const (
-	// IntentAgeThreshold is the threshold after which an extant intent
-	// will be resolved.
-	IntentAgeThreshold = 2 * time.Hour // 2 hour
-
 	// KeyVersionChunkBytes is the threshold size for splitting
 	// GCRequests into multiple batches. The goal is that the evaluated
 	// Raft command for each GCRequest does not significantly exceed
 	// this threshold.
 	KeyVersionChunkBytes = base.ChunkRaftCommandThresholdBytes
+)
+
+// IntentAgeThreshold is the threshold after which an extant intent
+// will be resolved.
+var IntentAgeThreshold = settings.RegisterValidatedDurationSetting(
+	"kv.gc.intent_age_threshold",
+	"intents older than this threshold will be resolved when encountered by the GC queue",
+	2*time.Hour,
+	func(d time.Duration) error {
+		if d < 2*time.Minute {
+			return errors.New("intent age threshold must be >= 2 minutes")
+		}
+		return nil
+	},
 )
 
 // CalculateThreshold calculates the GC threshold given the policy and the
@@ -159,6 +170,7 @@ func Run(
 	desc *roachpb.RangeDescriptor,
 	snap storage.Reader,
 	now, newThreshold hlc.Timestamp,
+	intentAgeThreshold time.Duration,
 	policy zonepb.GCPolicy,
 	gcer GCer,
 	cleanupIntentsFn CleanupIntentsFunc,
@@ -182,7 +194,8 @@ func Run(
 	// Maps from txn ID to txn and intent key slice.
 	txnMap := map[uuid.UUID]*roachpb.Transaction{}
 	intentKeyMap := map[uuid.UUID][]roachpb.Key{}
-	err := processReplicatedKeyRange(ctx, desc, snap, now, newThreshold, gcer, txnMap, intentKeyMap, &info)
+	err := processReplicatedKeyRange(ctx, desc, snap, now, newThreshold, intentAgeThreshold, gcer, txnMap, intentKeyMap,
+		&info)
 	if err != nil {
 		return Info{}, err
 	}
@@ -233,6 +246,7 @@ func processReplicatedKeyRange(
 	snap storage.Reader,
 	now hlc.Timestamp,
 	threshold hlc.Timestamp,
+	intentAgeThreshold time.Duration,
 	gcer GCer,
 	txnMap map[uuid.UUID]*roachpb.Transaction,
 	intentKeyMap map[uuid.UUID][]roachpb.Key,
@@ -240,7 +254,7 @@ func processReplicatedKeyRange(
 ) error {
 	var alloc bufalloc.ByteAllocator
 	// Compute intent expiration (intent age at which we attempt to resolve).
-	intentExp := now.Add(-IntentAgeThreshold.Nanoseconds(), 0)
+	intentExp := now.Add(-intentAgeThreshold.Nanoseconds(), 0)
 	handleIntent := func(md *storage.MVCCKeyValue) {
 		meta := &enginepb.MVCCMetadata{}
 		if err := protoutil.Unmarshal(md.Value, meta); err != nil {

--- a/pkg/kv/kvserver/gc/gc_old_test.go
+++ b/pkg/kv/kvserver/gc/gc_old_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
@@ -44,6 +45,7 @@ func runGCOld(
 	snap storage.Reader,
 	now hlc.Timestamp,
 	_ hlc.Timestamp, // exists to make signature match RunGC
+	intentAgeThreshold time.Duration,
 	policy zonepb.GCPolicy,
 	gcer GCer,
 	cleanupIntentsFn CleanupIntentsFunc,
@@ -55,7 +57,7 @@ func runGCOld(
 	defer iter.Close()
 
 	// Compute intent expiration (intent age at which we attempt to resolve).
-	intentExp := now.Add(-IntentAgeThreshold.Nanoseconds(), 0)
+	intentExp := now.Add(-intentAgeThreshold.Nanoseconds(), 0)
 	txnExp := now.Add(-kvserverbase.TxnCleanupThreshold.Nanoseconds(), 0)
 
 	gc := MakeGarbageCollector(now, policy)

--- a/pkg/kv/kvserver/gc/gc_test.go
+++ b/pkg/kv/kvserver/gc/gc_test.go
@@ -18,8 +18,10 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -88,4 +90,57 @@ func TestBatchingInlineGCer(t *testing.T) {
 	// Reset itself properly.
 	require.Nil(t, m.gcKeys)
 	require.Zero(t, m.size)
+}
+
+// TestIntentAgeThresholdSetting verifies that the GC intent resolution threshold can be
+// adjusted. It uses short and long threshold to verify that intents inserted between two
+// thresholds are not considered for resolution when threshold is high (1st attempt) and
+// considered when threshold is low (2nd attempt).
+func TestIntentAgeThresholdSetting(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	eng := storage.NewDefaultInMem()
+	defer eng.Close()
+
+	// Test event timeline.
+	now := 3 * time.Hour
+	intentShortThreshold := 5 * time.Minute
+	intentLongThreshold := 2 * time.Hour
+	intentTs := now - (intentShortThreshold+intentLongThreshold)/2
+
+	// Prepare test intents in MVCC.
+	key := []byte("b")
+	value := roachpb.Value{RawBytes: []byte("0123456789")}
+	intentHlc := hlc.Timestamp{
+		WallTime: intentTs.Nanoseconds(),
+	}
+	txn := roachpb.MakeTransaction("txn", key, roachpb.NormalUserPriority, intentHlc, 1000)
+	require.NoError(t, storage.MVCCPut(ctx, eng, nil, key, intentHlc, value, &txn))
+	require.NoError(t, eng.Flush())
+
+	// Prepare test fixtures for GC run.
+	desc := roachpb.RangeDescriptor{
+		StartKey: roachpb.RKey("a"),
+		EndKey:   roachpb.RKey("z"),
+	}
+	policy := zonepb.GCPolicy{TTLSeconds: 1}
+	snap := eng.NewSnapshot()
+	nowTs := hlc.Timestamp{
+		WallTime: now.Nanoseconds(),
+	}
+	fakeGCer := makeFakeGCer()
+
+	// Test GC desired behavior.
+	info, err := Run(ctx, &desc, snap, nowTs, nowTs, intentLongThreshold, policy, &fakeGCer, fakeGCer.resolveIntents,
+		fakeGCer.resolveIntentsAsync)
+	require.NoError(t, err, "GC Run shouldn't fail")
+	assert.Zero(t, info.IntentsConsidered,
+		"Expected no intents considered by GC with default threshold")
+
+	info, err = Run(ctx, &desc, snap, nowTs, nowTs, intentShortThreshold, policy, &fakeGCer, fakeGCer.resolveIntents,
+		fakeGCer.resolveIntentsAsync)
+	require.NoError(t, err, "GC Run shouldn't fail")
+	assert.Equal(t, 1, info.IntentsConsidered,
+		"Expected 1 intents considered by GC with short threshold")
 }

--- a/pkg/kv/kvserver/gc_queue.go
+++ b/pkg/kv/kvserver/gc_queue.go
@@ -462,7 +462,9 @@ func (gcq *gcQueue) process(
 	snap := repl.store.Engine().NewSnapshot()
 	defer snap.Close()
 
-	info, err := gc.Run(ctx, desc, snap, gcTimestamp, newThreshold, *zone.GC,
+	intentAgeThreshold := gc.IntentAgeThreshold.Get(&repl.store.ClusterSettings().SV)
+
+	info, err := gc.Run(ctx, desc, snap, gcTimestamp, newThreshold, intentAgeThreshold, *zone.GC,
 		&replicaGCer{repl: repl},
 		func(ctx context.Context, intents []roachpb.Intent) error {
 			intentCount, err := repl.store.intentResolver.

--- a/pkg/kv/kvserver/gc_queue_test.go
+++ b/pkg/kv/kvserver/gc_queue_test.go
@@ -432,15 +432,17 @@ func TestGCQueueProcess(t *testing.T) {
 	defer stopper.Stop(ctx)
 	tc.Start(t, stopper)
 
+	const intentAgeThreshold = 2 * time.Hour
+
 	tc.manualClock.Increment(48 * 60 * 60 * 1e9) // 2d past the epoch
 	now := tc.Clock().Now().WallTime
 
-	ts1 := makeTS(now-2*24*60*60*1e9+1, 0)                        // 2d old (add one nanosecond so we're not using zero timestamp)
-	ts2 := makeTS(now-25*60*60*1e9, 0)                            // GC will occur at time=25 hours
-	ts2m1 := ts2.Prev()                                           // ts2 - 1 so we have something not right at the GC time
-	ts3 := makeTS(now-gc.IntentAgeThreshold.Nanoseconds(), 0)     // 2h old
-	ts4 := makeTS(now-(gc.IntentAgeThreshold.Nanoseconds()-1), 0) // 2h-1ns old
-	ts5 := makeTS(now-1e9, 0)                                     // 1s old
+	ts1 := makeTS(now-2*24*60*60*1e9+1, 0)                     // 2d old (add one nanosecond so we're not using zero timestamp)
+	ts2 := makeTS(now-25*60*60*1e9, 0)                         // GC will occur at time=25 hours
+	ts2m1 := ts2.Prev()                                        // ts2 - 1 so we have something not right at the GC time
+	ts3 := makeTS(now-intentAgeThreshold.Nanoseconds(), 0)     // 2h old
+	ts4 := makeTS(now-(intentAgeThreshold.Nanoseconds()-1), 0) // 2h-1ns old
+	ts5 := makeTS(now-1e9, 0)                                  // 1s old
 	key1 := roachpb.Key("a")
 	key2 := roachpb.Key("b")
 	key3 := roachpb.Key("c")
@@ -569,7 +571,7 @@ func TestGCQueueProcess(t *testing.T) {
 
 		now := tc.Clock().Now()
 		newThreshold := gc.CalculateThreshold(now, *zone.GC)
-		return gc.Run(ctx, desc, snap, now, newThreshold, *zone.GC,
+		return gc.Run(ctx, desc, snap, now, newThreshold, intentAgeThreshold, *zone.GC,
 			gc.NoopGCer{},
 			func(ctx context.Context, intents []roachpb.Intent) error {
 				return nil
@@ -931,7 +933,8 @@ func TestGCQueueIntentResolution(t *testing.T) {
 		newTransaction("txn1", roachpb.Key("0-0"), 1, tc.Clock()),
 		newTransaction("txn2", roachpb.Key("1-0"), 1, tc.Clock()),
 	}
-	intentResolveTS := makeTS(now-gc.IntentAgeThreshold.Nanoseconds(), 0)
+	intentAgeThreshold := gc.IntentAgeThreshold.Get(&tc.repl.store.ClusterSettings().SV)
+	intentResolveTS := makeTS(now-intentAgeThreshold.Nanoseconds(), 0)
 	txns[0].ReadTimestamp = intentResolveTS
 	txns[0].WriteTimestamp = intentResolveTS
 	// The MinTimestamp is used by pushers that don't find a transaction record to

--- a/pkg/settings/bool.go
+++ b/pkg/settings/bool.go
@@ -44,6 +44,14 @@ func (*BoolSetting) Typ() string {
 	return "b"
 }
 
+// Default returns default value for setting.
+func (b *BoolSetting) Default() bool {
+	return b.defaultValue
+}
+
+// Defeat the linter.
+var _ = (*BoolSetting).Default
+
 // Override changes the setting without validation and also overrides the
 // default value.
 //

--- a/pkg/settings/duration.go
+++ b/pkg/settings/duration.go
@@ -64,6 +64,14 @@ func (*DurationSetting) Typ() string {
 	return "d"
 }
 
+// Default returns default value for setting.
+func (d *DurationSetting) Default() time.Duration {
+	return d.defaultValue
+}
+
+// Defeat the linter.
+var _ = (*DurationSetting).Default
+
 // Validate that a value conforms with the validation function.
 func (d *DurationSetting) Validate(v time.Duration) error {
 	if d.validateFn != nil {

--- a/pkg/settings/float.go
+++ b/pkg/settings/float.go
@@ -51,6 +51,9 @@ func (*FloatSetting) Typ() string {
 	return "f"
 }
 
+// Defeat the linter.
+var _ = (*FloatSetting).Default
+
 // Override changes the setting panicking if validation fails and also overrides
 // the default value.
 //

--- a/pkg/settings/int.go
+++ b/pkg/settings/int.go
@@ -47,6 +47,9 @@ func (*IntSetting) Typ() string {
 	return "i"
 }
 
+// Defeat the linter.
+var _ = (*IntSetting).Default
+
 // Validate that a value conforms with the validation function.
 func (i *IntSetting) Validate(v int64) error {
 	if i.validateFn != nil {

--- a/pkg/settings/string.go
+++ b/pkg/settings/string.go
@@ -42,6 +42,14 @@ func (*StringSetting) Typ() string {
 	return "s"
 }
 
+// Default returns default value for setting.
+func (s *StringSetting) Default() string {
+	return s.defaultValue
+}
+
+// Defeat the linter.
+var _ = (*StringSetting).Default
+
 // Get retrieves the string value in the setting.
 func (s *StringSetting) Get(sv *Values) string {
 	loaded := sv.getGeneric(s.slotIdx)


### PR DESCRIPTION
Backport 2/2 commits from #62519.

/cc @cockroachdb/release

---

Added hidden cluster setting to change intent age threshold.

Fixes #61654
 
Setting is read on queue level and passed to GC as an arg. This is done to avoid passing cluster setting to GC directly as it currently decoupled from the cluster infrastructure.

