### PR TITLE
sql: add an internal table showing lost table descriptors

### DIFF
--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -73,6 +73,7 @@ table_name NOT IN (
 	'forward_dependencies',
 	'index_columns',
 	'interleaved',
+	'lost_descriptors_with_data',
 	'table_columns',
 	'table_indexes',
 	'table_row_statistics',

--- a/pkg/sql/catalog/catconstants/constants.go
+++ b/pkg/sql/catalog/catconstants/constants.go
@@ -81,6 +81,7 @@ const (
 	CrdbInternalClusterDatabasePrivilegesTableID
 	CrdbInternalInterleaved
 	CrdbInternalCrossDbRefrences
+	CrdbInternalLostTableDescriptors
 	InformationSchemaID
 	InformationSchemaAdministrableRoleAuthorizationsID
 	InformationSchemaApplicableRolesID

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -131,6 +131,7 @@ var crdbInternal = virtualSchema{
 		catconstants.CrdbInternalClusterDatabasePrivilegesTableID: crdbInternalClusterDatabasePrivilegesTable,
 		catconstants.CrdbInternalInterleaved:                      crdbInternalInterleaved,
 		catconstants.CrdbInternalCrossDbRefrences:                 crdbInternalCrossDbReferences,
+		catconstants.CrdbInternalLostTableDescriptors:             crdbLostTableDescriptors,
 	},
 	validWithNoDatabaseContext: true,
 }
@@ -4376,5 +4377,111 @@ CREATE TABLE crdb_internal.cross_db_references (
 				}
 				return nil
 			})
+	},
+}
+
+var crdbLostTableDescriptors = virtualSchemaTable{
+	comment: `virtual table with table descriptors that still have data`,
+	schema: `
+CREATE TABLE crdb_internal.lost_descriptors_with_data (
+	descID
+		INTEGER NOT NULL
+);`,
+	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+		maxDescIDKeyVal, err := p.extendedEvalCtx.DB.Get(context.Background(), p.extendedEvalCtx.Codec.DescIDSequenceKey())
+		if err != nil {
+			return err
+		}
+		maxDescID, err := maxDescIDKeyVal.Value.GetInt()
+		if err != nil {
+			return err
+		}
+		// Get all descriptors which will be used to determine
+		// which ones are missing.
+		descriptors, err := catalogkv.GetAllDescriptorsUnvalidated(ctx, p.txn, p.extendedEvalCtx.Codec)
+		if err != nil {
+			return err
+		}
+		descriptorMap := make(map[descpb.ID]catalog.Descriptor)
+		for _, desc := range descriptors {
+			descriptorMap[desc.GetID()] = desc
+		}
+		// Generate large batches of scans over the keyspace,
+		// so that we minimize scans. We will issue individual
+		// scans if there is data in a given descriptor range.
+		unusedDescSpan := roachpb.Span{}
+		descStart := 0
+		descEnd := 0
+		scanAndGenerateRows := func() error {
+			if unusedDescSpan.Key == nil {
+				return nil
+			}
+			b := kv.Batch{}
+			b.Header.MaxSpanRequestKeys = 1
+			scanRequest := roachpb.NewScan(unusedDescSpan.Key, unusedDescSpan.EndKey, false).(*roachpb.ScanRequest)
+			scanRequest.ScanFormat = roachpb.BATCH_RESPONSE
+			b.AddRawRequest(scanRequest)
+			err = p.extendedEvalCtx.DB.Run(ctx, &b)
+			if err != nil {
+				return err
+			}
+			// Check the descriptors inside this range for
+			// data.
+			res := b.RawResponse().Responses[0].GetScan()
+			if res.NumKeys > 0 {
+				b = kv.Batch{}
+				b.Header.MaxSpanRequestKeys = 1
+				for descID := descStart; descID <= descEnd; descID++ {
+					prefix := p.extendedEvalCtx.Codec.TablePrefix(uint32(descID))
+					scanRequest := roachpb.NewScan(prefix, prefix.PrefixEnd(), false).(*roachpb.ScanRequest)
+					scanRequest.ScanFormat = roachpb.BATCH_RESPONSE
+					b.AddRawRequest(scanRequest)
+				}
+				err = p.extendedEvalCtx.DB.Run(ctx, &b)
+				if err != nil {
+					return err
+				}
+				for idx := range b.RawResponse().Responses {
+					res := b.RawResponse().Responses[idx].GetScan()
+					if res.NumKeys == 0 {
+						continue
+					}
+					// Add a row if any key came back
+					if err := addRow(tree.NewDInt(tree.DInt(idx + descStart))); err != nil {
+						return err
+					}
+				}
+			}
+			unusedDescSpan = roachpb.Span{}
+			descStart = 0
+			descEnd = 0
+			return nil
+		}
+		// Loop over every possible descriptor ID
+		for id := keys.MinUserDescID; id < int(maxDescID); id++ {
+			// Skip over descriptors that are known
+			if _, ok := descriptorMap[descpb.ID(id)]; ok {
+				err := scanAndGenerateRows()
+				if err != nil {
+					return err
+				}
+				continue
+			}
+			// Update our span range to include this
+			// descriptor.
+			prefix := p.extendedEvalCtx.Codec.TablePrefix(uint32(id))
+			if unusedDescSpan.Key == nil {
+				descStart = id
+				unusedDescSpan.Key = prefix
+			}
+			descEnd = id
+			unusedDescSpan.EndKey = prefix.PrefixEnd()
+
+		}
+		err = scanAndGenerateRows()
+		if err != nil {
+			return err
+		}
+		return nil
 	},
 }

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -39,6 +39,7 @@ crdb_internal  jobs                         table  NULL  NULL  NULL
 crdb_internal  kv_node_status               table  NULL  NULL  NULL
 crdb_internal  kv_store_status              table  NULL  NULL  NULL
 crdb_internal  leases                       table  NULL  NULL  NULL
+crdb_internal  lost_descriptors_with_data   table  NULL  NULL  NULL
 crdb_internal  node_build_info              table  NULL  NULL  NULL
 crdb_internal  node_contention_events       table  NULL  NULL  NULL
 crdb_internal  node_inflight_trace_spans    table  NULL  NULL  NULL

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
@@ -53,6 +53,7 @@ crdb_internal  jobs                         table  NULL  NULL  NULL
 crdb_internal  kv_node_status               table  NULL  NULL  NULL
 crdb_internal  kv_store_status              table  NULL  NULL  NULL
 crdb_internal  leases                       table  NULL  NULL  NULL
+crdb_internal  lost_descriptors_with_data   table  NULL  NULL  NULL
 crdb_internal  node_build_info              table  NULL  NULL  NULL
 crdb_internal  node_contention_events       table  NULL  NULL  NULL
 crdb_internal  node_inflight_trace_spans    table  NULL  NULL  NULL

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -535,6 +535,11 @@ CREATE TABLE crdb_internal.leases (
    expiration TIMESTAMP NOT NULL,
    deleted BOOL NOT NULL
 )  {}  {}
+CREATE TABLE crdb_internal.lost_descriptors_with_data (
+   descid INT8 NOT NULL
+)  CREATE TABLE crdb_internal.lost_descriptors_with_data (
+   descid INT8 NOT NULL
+)  {}  {}
 CREATE TABLE crdb_internal.node_build_info (
    node_id INT8 NOT NULL,
    field STRING NOT NULL,

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -51,6 +51,7 @@ test           crdb_internal       jobs                                   public
 test           crdb_internal       kv_node_status                         public   SELECT
 test           crdb_internal       kv_store_status                        public   SELECT
 test           crdb_internal       leases                                 public   SELECT
+test           crdb_internal       lost_descriptors_with_data             public   SELECT
 test           crdb_internal       node_build_info                        public   SELECT
 test           crdb_internal       node_contention_events                 public   SELECT
 test           crdb_internal       node_inflight_trace_spans              public   SELECT

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -303,6 +303,7 @@ crdb_internal       jobs
 crdb_internal       kv_node_status
 crdb_internal       kv_store_status
 crdb_internal       leases
+crdb_internal       lost_descriptors_with_data
 crdb_internal       node_build_info
 crdb_internal       node_contention_events
 crdb_internal       node_inflight_trace_spans
@@ -498,6 +499,7 @@ jobs
 kv_node_status
 kv_store_status
 leases
+lost_descriptors_with_data
 node_build_info
 node_contention_events
 node_inflight_trace_spans
@@ -712,6 +714,7 @@ system         crdb_internal       jobs                                   SYSTEM
 system         crdb_internal       kv_node_status                         SYSTEM VIEW  NO                  1
 system         crdb_internal       kv_store_status                        SYSTEM VIEW  NO                  1
 system         crdb_internal       leases                                 SYSTEM VIEW  NO                  1
+system         crdb_internal       lost_descriptors_with_data             SYSTEM VIEW  NO                  1
 system         crdb_internal       node_build_info                        SYSTEM VIEW  NO                  1
 system         crdb_internal       node_contention_events                 SYSTEM VIEW  NO                  1
 system         crdb_internal       node_inflight_trace_spans              SYSTEM VIEW  NO                  1
@@ -2020,6 +2023,7 @@ NULL     public   system         crdb_internal       jobs                       
 NULL     public   system         crdb_internal       kv_node_status                         SELECT          NULL          YES
 NULL     public   system         crdb_internal       kv_store_status                        SELECT          NULL          YES
 NULL     public   system         crdb_internal       leases                                 SELECT          NULL          YES
+NULL     public   system         crdb_internal       lost_descriptors_with_data             SELECT          NULL          YES
 NULL     public   system         crdb_internal       node_build_info                        SELECT          NULL          YES
 NULL     public   system         crdb_internal       node_contention_events                 SELECT          NULL          YES
 NULL     public   system         crdb_internal       node_inflight_trace_spans              SELECT          NULL          YES
@@ -2460,6 +2464,7 @@ NULL     public   system         crdb_internal       jobs                       
 NULL     public   system         crdb_internal       kv_node_status                         SELECT          NULL          YES
 NULL     public   system         crdb_internal       kv_store_status                        SELECT          NULL          YES
 NULL     public   system         crdb_internal       leases                                 SELECT          NULL          YES
+NULL     public   system         crdb_internal       lost_descriptors_with_data             SELECT          NULL          YES
 NULL     public   system         crdb_internal       node_build_info                        SELECT          NULL          YES
 NULL     public   system         crdb_internal       node_contention_events                 SELECT          NULL          YES
 NULL     public   system         crdb_internal       node_inflight_trace_spans              SELECT          NULL          YES

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1124,14 +1124,14 @@ FROM pg_catalog.pg_depend
 ORDER BY objid
 ----
 classid     objid       objsubid  refclassid  refobjid   refobjsubid  deptype
-4294967206  58          0         4294967206  55         1            n
-4294967206  58          0         4294967206  55         2            n
-4294967206  58          0         4294967206  55         3            n
-4294967206  58          0         4294967206  55         4            n
-4294967203  2143281868  0         4294967206  450499961  0            n
-4294967203  2355671820  0         4294967206  0          0            n
-4294967203  3911002394  0         4294967206  0          0            n
-4294967203  4089604113  0         4294967206  450499960  0            n
+4294967205  58          0         4294967205  55         1            n
+4294967205  58          0         4294967205  55         2            n
+4294967205  58          0         4294967205  55         3            n
+4294967205  58          0         4294967205  55         4            n
+4294967202  2143281868  0         4294967205  450499961  0            n
+4294967202  2355671820  0         4294967205  0          0            n
+4294967202  3911002394  0         4294967205  0          0            n
+4294967202  4089604113  0         4294967205  450499960  0            n
 
 # Some entries in pg_depend are dependency links from the pg_constraint system
 # table to the pg_class system table. Other entries are links to pg_class when it is
@@ -1144,8 +1144,8 @@ JOIN pg_class cla ON classid=cla.oid
 JOIN pg_class refcla ON refclassid=refcla.oid
 ----
 classid     refclassid  tablename      reftablename
-4294967206  4294967206  pg_class       pg_class
-4294967203  4294967206  pg_constraint  pg_class
+4294967205  4294967205  pg_class       pg_class
+4294967202  4294967205  pg_constraint  pg_class
 
 # Some entries in pg_depend are foreign key constraints that reference an index
 # in pg_class. Other entries are table-view dependencies
@@ -1861,165 +1861,166 @@ SELECT objoid, classoid, objsubid, regexp_replace(description, e'\n.*', '') AS d
   FROM pg_catalog.pg_description
 ----
 objoid      classoid    objsubid  description
-4294967294  4294967206  0         backward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
-4294967292  4294967206  0         built-in functions (RAM/static)
-4294967291  4294967206  0         contention information (cluster RPC; expensive!)
-4294967249  4294967206  0         virtual table with database privileges
-4294967290  4294967206  0         running queries visible by current user (cluster RPC; expensive!)
-4294967288  4294967206  0         running sessions visible to current user (cluster RPC; expensive!)
-4294967287  4294967206  0         cluster settings (RAM)
-4294967289  4294967206  0         running user transactions visible by the current user (cluster RPC; expensive!)
-4294967286  4294967206  0         CREATE and ALTER statements for all tables accessible by current user in current database (KV scan)
-4294967285  4294967206  0         CREATE statements for all user defined types accessible by the current user in current database (KV scan)
-4294967247  4294967206  0         virtual table with cross db references
-4294967284  4294967206  0         databases accessible by the current user (KV scan)
-4294967283  4294967206  0         telemetry counters (RAM; local node only)
-4294967282  4294967206  0         forward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
-4294967280  4294967206  0         locally known gossiped health alerts (RAM; local node only)
-4294967279  4294967206  0         locally known gossiped node liveness (RAM; local node only)
-4294967278  4294967206  0         locally known edges in the gossip network (RAM; local node only)
-4294967281  4294967206  0         locally known gossiped node details (RAM; local node only)
-4294967277  4294967206  0         index columns for all indexes accessible by current user in current database (KV scan)
-4294967248  4294967206  0         virtual table with interleaved table information
-4294967250  4294967206  0         virtual table to validate descriptors
-4294967275  4294967206  0         decoded job metadata from system.jobs (KV scan)
-4294967274  4294967206  0         node details across the entire cluster (cluster RPC; expensive!)
-4294967273  4294967206  0         store details and status (cluster RPC; expensive!)
-4294967272  4294967206  0         acquired table leases (RAM; local node only)
-4294967293  4294967206  0         detailed identification strings (RAM, local node only)
-4294967271  4294967206  0         contention information (RAM; local node only)
-4294967276  4294967206  0         in-flight spans (RAM; local node only)
-4294967267  4294967206  0         current values for metrics (RAM; local node only)
-4294967270  4294967206  0         running queries visible by current user (RAM; local node only)
-4294967262  4294967206  0         server parameters, useful to construct connection URLs (RAM, local node only)
-4294967268  4294967206  0         running sessions visible by current user (RAM; local node only)
-4294967258  4294967206  0         statement statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
-4294967253  4294967206  0         finer-grained transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
-4294967269  4294967206  0         running user transactions visible by the current user (RAM; local node only)
-4294967252  4294967206  0         per-application transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
-4294967266  4294967206  0         defined partitions for all tables/indexes accessible by the current user in the current database (KV scan)
-4294967265  4294967206  0         comments for predefined virtual tables (RAM/static)
-4294967264  4294967206  0         range metadata without leaseholder details (KV join; expensive!)
-4294967261  4294967206  0         ongoing schema changes, across all descriptors accessible by current user (KV scan; expensive!)
-4294967260  4294967206  0         session trace accumulated so far (RAM)
-4294967259  4294967206  0         session variables (RAM)
-4294967257  4294967206  0         details for all columns accessible by current user in current database (KV scan)
-4294967256  4294967206  0         indexes accessible by current user in current database (KV scan)
-4294967254  4294967206  0         stats for all tables accessible by current user in current database as of 10s ago
-4294967255  4294967206  0         table descriptors accessible by current user, including non-public and virtual (KV scan; expensive!)
-4294967251  4294967206  0         decoded zone configurations from system.zones (KV scan)
-4294967245  4294967206  0         roles for which the current user has admin option
-4294967244  4294967206  0         roles available to the current user
-4294967243  4294967206  0         character sets available in the current database
-4294967242  4294967206  0         check constraints
-4294967241  4294967206  0         identifies which character set the available collations are
-4294967240  4294967206  0         shows the collations available in the current database
-4294967239  4294967206  0         column privilege grants (incomplete)
-4294967237  4294967206  0         columns with user defined types
-4294967238  4294967206  0         table and view columns (incomplete)
-4294967236  4294967206  0         columns usage by constraints
-4294967235  4294967206  0         roles for the current user
-4294967234  4294967206  0         column usage by indexes and key constraints
-4294967233  4294967206  0         built-in function parameters (empty - introspection not yet supported)
-4294967232  4294967206  0         foreign key constraints
-4294967231  4294967206  0         privileges granted on table or views (incomplete; see also information_schema.table_privileges; may contain excess users or roles)
-4294967230  4294967206  0         built-in functions (empty - introspection not yet supported)
-4294967228  4294967206  0         schema privileges (incomplete; may contain excess users or roles)
-4294967229  4294967206  0         database schemas (may contain schemata without permission)
-4294967226  4294967206  0         sequences
-4294967227  4294967206  0         exposes the session variables.
-4294967225  4294967206  0         index metadata and statistics (incomplete)
-4294967224  4294967206  0         table constraints
-4294967223  4294967206  0         privileges granted on table or views (incomplete; may contain excess users or roles)
-4294967222  4294967206  0         tables and views
-4294967221  4294967206  0         type privileges (incomplete; may contain excess users or roles)
-4294967219  4294967206  0         grantable privileges (incomplete)
-4294967220  4294967206  0         views (incomplete)
-4294967217  4294967206  0         aggregated built-in functions (incomplete)
-4294967216  4294967206  0         index access methods (incomplete)
-4294967215  4294967206  0         pg_amop was created for compatibility and is currently unimplemented
-4294967214  4294967206  0         pg_amproc was created for compatibility and is currently unimplemented
-4294967213  4294967206  0         column default values
-4294967212  4294967206  0         table columns (incomplete - see also information_schema.columns)
-4294967210  4294967206  0         role membership
-4294967211  4294967206  0         authorization identifiers - differs from postgres as we do not display passwords,
-4294967209  4294967206  0         pg_available_extension_versions was created for compatibility and is currently unimplemented
-4294967208  4294967206  0         available extensions
-4294967207  4294967206  0         casts (empty - needs filling out)
-4294967206  4294967206  0         tables and relation-like objects (incomplete - see also information_schema.tables/sequences/views)
-4294967205  4294967206  0         available collations (incomplete)
-4294967204  4294967206  0         pg_config was created for compatibility and is currently unimplemented
-4294967203  4294967206  0         table constraints (incomplete - see also information_schema.table_constraints)
-4294967202  4294967206  0         encoding conversions (empty - unimplemented)
-4294967201  4294967206  0         pg_cursors was created for compatibility and is currently unimplemented
-4294967200  4294967206  0         available databases (incomplete)
-4294967199  4294967206  0         pg_db_role_setting was created for compatibility and is currently unimplemented
-4294967198  4294967206  0         default ACLs (empty - unimplemented)
-4294967197  4294967206  0         dependency relationships (incomplete)
-4294967196  4294967206  0         object comments
-4294967195  4294967206  0         enum types and labels (empty - feature does not exist)
-4294967194  4294967206  0         event triggers (empty - feature does not exist)
-4294967193  4294967206  0         installed extensions (empty - feature does not exist)
-4294967192  4294967206  0         pg_file_settings was created for compatibility and is currently unimplemented
-4294967191  4294967206  0         foreign data wrappers (empty - feature does not exist)
-4294967190  4294967206  0         foreign servers (empty - feature does not exist)
-4294967189  4294967206  0         foreign tables (empty  - feature does not exist)
-4294967188  4294967206  0         pg_group was created for compatibility and is currently unimplemented
-4294967187  4294967206  0         pg_hba_file_rules was created for compatibility and is currently unimplemented
-4294967186  4294967206  0         indexes (incomplete)
-4294967185  4294967206  0         index creation statements
-4294967184  4294967206  0         table inheritance hierarchy (empty - feature does not exist)
-4294967183  4294967206  0         available languages (empty - feature does not exist)
-4294967182  4294967206  0         pg_largeobject was created for compatibility and is currently unimplemented
-4294967181  4294967206  0         locks held by active processes (empty - feature does not exist)
-4294967180  4294967206  0         available materialized views (empty - feature does not exist)
-4294967179  4294967206  0         available namespaces (incomplete; namespaces and databases are congruent in CockroachDB)
-4294967178  4294967206  0         opclass (empty - Operator classes not supported yet)
-4294967177  4294967206  0         operators (incomplete)
-4294967176  4294967206  0         pg_opfamily was created for compatibility and is currently unimplemented
-4294967175  4294967206  0         pg_policies was created for compatibility and is currently unimplemented
-4294967174  4294967206  0         prepared statements
-4294967173  4294967206  0         prepared transactions (empty - feature does not exist)
-4294967172  4294967206  0         built-in functions (incomplete)
-4294967170  4294967206  0         pg_publication was created for compatibility and is currently unimplemented
-4294967171  4294967206  0         pg_publication_rel was created for compatibility and is currently unimplemented
-4294967169  4294967206  0         pg_publication_tables was created for compatibility and is currently unimplemented
-4294967168  4294967206  0         range types (empty - feature does not exist)
-4294967167  4294967206  0         pg_replication_origin was created for compatibility and is currently unimplemented
-4294967166  4294967206  0         rewrite rules (empty - feature does not exist)
-4294967165  4294967206  0         database roles
-4294967164  4294967206  0         pg_rules was created for compatibility and is currently unimplemented
-4294967162  4294967206  0         security labels (empty - feature does not exist)
-4294967163  4294967206  0         security labels (empty)
-4294967161  4294967206  0         sequences (see also information_schema.sequences)
-4294967160  4294967206  0         session variables (incomplete)
-4294967159  4294967206  0         pg_shadow was created for compatibility and is currently unimplemented
-4294967156  4294967206  0         shared dependencies (empty - not implemented)
-4294967158  4294967206  0         shared object comments
-4294967155  4294967206  0         pg_shmem_allocations was created for compatibility and is currently unimplemented
-4294967157  4294967206  0         shared security labels (empty - feature not supported)
-4294967154  4294967206  0         backend access statistics (empty - monitoring works differently in CockroachDB)
-4294967153  4294967206  0         pg_statistic_ext was created for compatibility and is currently unimplemented
-4294967152  4294967206  0         pg_subscription was created for compatibility and is currently unimplemented
-4294967151  4294967206  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
-4294967150  4294967206  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
-4294967149  4294967206  0         pg_timezone_abbrevs was created for compatibility and is currently unimplemented
-4294967148  4294967206  0         pg_timezone_names was created for compatibility and is currently unimplemented
-4294967147  4294967206  0         pg_transform was created for compatibility and is currently unimplemented
-4294967146  4294967206  0         triggers (empty - feature does not exist)
-4294967144  4294967206  0         pg_ts_config was created for compatibility and is currently unimplemented
-4294967145  4294967206  0         pg_ts_config_map was created for compatibility and is currently unimplemented
-4294967143  4294967206  0         pg_ts_dict was created for compatibility and is currently unimplemented
-4294967142  4294967206  0         pg_ts_parser was created for compatibility and is currently unimplemented
-4294967141  4294967206  0         pg_ts_template was created for compatibility and is currently unimplemented
-4294967140  4294967206  0         scalar types (incomplete)
-4294967137  4294967206  0         database users
-4294967139  4294967206  0         local to remote user mapping (empty - feature does not exist)
-4294967138  4294967206  0         pg_user_mappings was created for compatibility and is currently unimplemented
-4294967136  4294967206  0         view definitions (incomplete - see also information_schema.views)
-4294967134  4294967206  0         Shows all defined geography columns. Matches PostGIS' geography_columns functionality.
-4294967133  4294967206  0         Shows all defined geometry columns. Matches PostGIS' geometry_columns functionality.
-4294967132  4294967206  0         Shows all defined Spatial Reference Identifiers (SRIDs). Matches PostGIS' spatial_ref_sys table.
+4294967294  4294967205  0         backward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
+4294967292  4294967205  0         built-in functions (RAM/static)
+4294967291  4294967205  0         contention information (cluster RPC; expensive!)
+4294967249  4294967205  0         virtual table with database privileges
+4294967290  4294967205  0         running queries visible by current user (cluster RPC; expensive!)
+4294967288  4294967205  0         running sessions visible to current user (cluster RPC; expensive!)
+4294967287  4294967205  0         cluster settings (RAM)
+4294967289  4294967205  0         running user transactions visible by the current user (cluster RPC; expensive!)
+4294967286  4294967205  0         CREATE and ALTER statements for all tables accessible by current user in current database (KV scan)
+4294967285  4294967205  0         CREATE statements for all user defined types accessible by the current user in current database (KV scan)
+4294967247  4294967205  0         virtual table with cross db references
+4294967284  4294967205  0         databases accessible by the current user (KV scan)
+4294967283  4294967205  0         telemetry counters (RAM; local node only)
+4294967282  4294967205  0         forward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
+4294967280  4294967205  0         locally known gossiped health alerts (RAM; local node only)
+4294967279  4294967205  0         locally known gossiped node liveness (RAM; local node only)
+4294967278  4294967205  0         locally known edges in the gossip network (RAM; local node only)
+4294967281  4294967205  0         locally known gossiped node details (RAM; local node only)
+4294967277  4294967205  0         index columns for all indexes accessible by current user in current database (KV scan)
+4294967248  4294967205  0         virtual table with interleaved table information
+4294967250  4294967205  0         virtual table to validate descriptors
+4294967275  4294967205  0         decoded job metadata from system.jobs (KV scan)
+4294967274  4294967205  0         node details across the entire cluster (cluster RPC; expensive!)
+4294967273  4294967205  0         store details and status (cluster RPC; expensive!)
+4294967272  4294967205  0         acquired table leases (RAM; local node only)
+4294967246  4294967205  0         virtual table with table descriptors that still have data
+4294967293  4294967205  0         detailed identification strings (RAM, local node only)
+4294967271  4294967205  0         contention information (RAM; local node only)
+4294967276  4294967205  0         in-flight spans (RAM; local node only)
+4294967267  4294967205  0         current values for metrics (RAM; local node only)
+4294967270  4294967205  0         running queries visible by current user (RAM; local node only)
+4294967262  4294967205  0         server parameters, useful to construct connection URLs (RAM, local node only)
+4294967268  4294967205  0         running sessions visible by current user (RAM; local node only)
+4294967258  4294967205  0         statement statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
+4294967253  4294967205  0         finer-grained transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
+4294967269  4294967205  0         running user transactions visible by the current user (RAM; local node only)
+4294967252  4294967205  0         per-application transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
+4294967266  4294967205  0         defined partitions for all tables/indexes accessible by the current user in the current database (KV scan)
+4294967265  4294967205  0         comments for predefined virtual tables (RAM/static)
+4294967264  4294967205  0         range metadata without leaseholder details (KV join; expensive!)
+4294967261  4294967205  0         ongoing schema changes, across all descriptors accessible by current user (KV scan; expensive!)
+4294967260  4294967205  0         session trace accumulated so far (RAM)
+4294967259  4294967205  0         session variables (RAM)
+4294967257  4294967205  0         details for all columns accessible by current user in current database (KV scan)
+4294967256  4294967205  0         indexes accessible by current user in current database (KV scan)
+4294967254  4294967205  0         stats for all tables accessible by current user in current database as of 10s ago
+4294967255  4294967205  0         table descriptors accessible by current user, including non-public and virtual (KV scan; expensive!)
+4294967251  4294967205  0         decoded zone configurations from system.zones (KV scan)
+4294967244  4294967205  0         roles for which the current user has admin option
+4294967243  4294967205  0         roles available to the current user
+4294967242  4294967205  0         character sets available in the current database
+4294967241  4294967205  0         check constraints
+4294967240  4294967205  0         identifies which character set the available collations are
+4294967239  4294967205  0         shows the collations available in the current database
+4294967238  4294967205  0         column privilege grants (incomplete)
+4294967236  4294967205  0         columns with user defined types
+4294967237  4294967205  0         table and view columns (incomplete)
+4294967235  4294967205  0         columns usage by constraints
+4294967234  4294967205  0         roles for the current user
+4294967233  4294967205  0         column usage by indexes and key constraints
+4294967232  4294967205  0         built-in function parameters (empty - introspection not yet supported)
+4294967231  4294967205  0         foreign key constraints
+4294967230  4294967205  0         privileges granted on table or views (incomplete; see also information_schema.table_privileges; may contain excess users or roles)
+4294967229  4294967205  0         built-in functions (empty - introspection not yet supported)
+4294967227  4294967205  0         schema privileges (incomplete; may contain excess users or roles)
+4294967228  4294967205  0         database schemas (may contain schemata without permission)
+4294967225  4294967205  0         sequences
+4294967226  4294967205  0         exposes the session variables.
+4294967224  4294967205  0         index metadata and statistics (incomplete)
+4294967223  4294967205  0         table constraints
+4294967222  4294967205  0         privileges granted on table or views (incomplete; may contain excess users or roles)
+4294967221  4294967205  0         tables and views
+4294967220  4294967205  0         type privileges (incomplete; may contain excess users or roles)
+4294967218  4294967205  0         grantable privileges (incomplete)
+4294967219  4294967205  0         views (incomplete)
+4294967216  4294967205  0         aggregated built-in functions (incomplete)
+4294967215  4294967205  0         index access methods (incomplete)
+4294967214  4294967205  0         pg_amop was created for compatibility and is currently unimplemented
+4294967213  4294967205  0         pg_amproc was created for compatibility and is currently unimplemented
+4294967212  4294967205  0         column default values
+4294967211  4294967205  0         table columns (incomplete - see also information_schema.columns)
+4294967209  4294967205  0         role membership
+4294967210  4294967205  0         authorization identifiers - differs from postgres as we do not display passwords,
+4294967208  4294967205  0         pg_available_extension_versions was created for compatibility and is currently unimplemented
+4294967207  4294967205  0         available extensions
+4294967206  4294967205  0         casts (empty - needs filling out)
+4294967205  4294967205  0         tables and relation-like objects (incomplete - see also information_schema.tables/sequences/views)
+4294967204  4294967205  0         available collations (incomplete)
+4294967203  4294967205  0         pg_config was created for compatibility and is currently unimplemented
+4294967202  4294967205  0         table constraints (incomplete - see also information_schema.table_constraints)
+4294967201  4294967205  0         encoding conversions (empty - unimplemented)
+4294967200  4294967205  0         pg_cursors was created for compatibility and is currently unimplemented
+4294967199  4294967205  0         available databases (incomplete)
+4294967198  4294967205  0         pg_db_role_setting was created for compatibility and is currently unimplemented
+4294967197  4294967205  0         default ACLs (empty - unimplemented)
+4294967196  4294967205  0         dependency relationships (incomplete)
+4294967195  4294967205  0         object comments
+4294967194  4294967205  0         enum types and labels (empty - feature does not exist)
+4294967193  4294967205  0         event triggers (empty - feature does not exist)
+4294967192  4294967205  0         installed extensions (empty - feature does not exist)
+4294967191  4294967205  0         pg_file_settings was created for compatibility and is currently unimplemented
+4294967190  4294967205  0         foreign data wrappers (empty - feature does not exist)
+4294967189  4294967205  0         foreign servers (empty - feature does not exist)
+4294967188  4294967205  0         foreign tables (empty  - feature does not exist)
+4294967187  4294967205  0         pg_group was created for compatibility and is currently unimplemented
+4294967186  4294967205  0         pg_hba_file_rules was created for compatibility and is currently unimplemented
+4294967185  4294967205  0         indexes (incomplete)
+4294967184  4294967205  0         index creation statements
+4294967183  4294967205  0         table inheritance hierarchy (empty - feature does not exist)
+4294967182  4294967205  0         available languages (empty - feature does not exist)
+4294967181  4294967205  0         pg_largeobject was created for compatibility and is currently unimplemented
+4294967180  4294967205  0         locks held by active processes (empty - feature does not exist)
+4294967179  4294967205  0         available materialized views (empty - feature does not exist)
+4294967178  4294967205  0         available namespaces (incomplete; namespaces and databases are congruent in CockroachDB)
+4294967177  4294967205  0         opclass (empty - Operator classes not supported yet)
+4294967176  4294967205  0         operators (incomplete)
+4294967175  4294967205  0         pg_opfamily was created for compatibility and is currently unimplemented
+4294967174  4294967205  0         pg_policies was created for compatibility and is currently unimplemented
+4294967173  4294967205  0         prepared statements
+4294967172  4294967205  0         prepared transactions (empty - feature does not exist)
+4294967171  4294967205  0         built-in functions (incomplete)
+4294967169  4294967205  0         pg_publication was created for compatibility and is currently unimplemented
+4294967170  4294967205  0         pg_publication_rel was created for compatibility and is currently unimplemented
+4294967168  4294967205  0         pg_publication_tables was created for compatibility and is currently unimplemented
+4294967167  4294967205  0         range types (empty - feature does not exist)
+4294967166  4294967205  0         pg_replication_origin was created for compatibility and is currently unimplemented
+4294967165  4294967205  0         rewrite rules (empty - feature does not exist)
+4294967164  4294967205  0         database roles
+4294967163  4294967205  0         pg_rules was created for compatibility and is currently unimplemented
+4294967161  4294967205  0         security labels (empty - feature does not exist)
+4294967162  4294967205  0         security labels (empty)
+4294967160  4294967205  0         sequences (see also information_schema.sequences)
+4294967159  4294967205  0         session variables (incomplete)
+4294967158  4294967205  0         pg_shadow was created for compatibility and is currently unimplemented
+4294967155  4294967205  0         shared dependencies (empty - not implemented)
+4294967157  4294967205  0         shared object comments
+4294967154  4294967205  0         pg_shmem_allocations was created for compatibility and is currently unimplemented
+4294967156  4294967205  0         shared security labels (empty - feature not supported)
+4294967153  4294967205  0         backend access statistics (empty - monitoring works differently in CockroachDB)
+4294967152  4294967205  0         pg_statistic_ext was created for compatibility and is currently unimplemented
+4294967151  4294967205  0         pg_subscription was created for compatibility and is currently unimplemented
+4294967150  4294967205  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
+4294967149  4294967205  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
+4294967148  4294967205  0         pg_timezone_abbrevs was created for compatibility and is currently unimplemented
+4294967147  4294967205  0         pg_timezone_names was created for compatibility and is currently unimplemented
+4294967146  4294967205  0         pg_transform was created for compatibility and is currently unimplemented
+4294967145  4294967205  0         triggers (empty - feature does not exist)
+4294967143  4294967205  0         pg_ts_config was created for compatibility and is currently unimplemented
+4294967144  4294967205  0         pg_ts_config_map was created for compatibility and is currently unimplemented
+4294967142  4294967205  0         pg_ts_dict was created for compatibility and is currently unimplemented
+4294967141  4294967205  0         pg_ts_parser was created for compatibility and is currently unimplemented
+4294967140  4294967205  0         pg_ts_template was created for compatibility and is currently unimplemented
+4294967139  4294967205  0         scalar types (incomplete)
+4294967136  4294967205  0         database users
+4294967138  4294967205  0         local to remote user mapping (empty - feature does not exist)
+4294967137  4294967205  0         pg_user_mappings was created for compatibility and is currently unimplemented
+4294967135  4294967205  0         view definitions (incomplete - see also information_schema.views)
+4294967133  4294967205  0         Shows all defined geography columns. Matches PostGIS' geography_columns functionality.
+4294967132  4294967205  0         Shows all defined geometry columns. Matches PostGIS' geometry_columns functionality.
+4294967131  4294967205  0         Shows all defined Spatial Reference Identifiers (SRIDs). Matches PostGIS' spatial_ref_sys table.
 
 ## pg_catalog.pg_shdescription
 
@@ -3205,7 +3206,7 @@ indoption
 query TTI
 SELECT database_name, descriptor_name, descriptor_id from test.crdb_internal.create_statements where descriptor_name = 'pg_views'
 ----
-test  pg_views  4294967136
+test  pg_views  4294967135
 
 # Verify INCLUDED columns appear in pg_index. See issue #59563
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/schema_repair
+++ b/pkg/sql/logictest/testdata/logic_test/schema_repair
@@ -1,3 +1,121 @@
+subtest lost-table-data
+
+statement ok
+CREATE TABLE corruptdesc (v INT8)
+
+statement ok
+CREATE TABLE lostdata (v INT8)
+
+statement ok
+INSERT INTO lostdata VALUES (3);
+
+statement ok
+INSERT INTO lostdata VALUES (5);
+
+statement ok
+INSERT INTO lostdata VALUES (23);
+
+let $t_id
+SELECT id FROM system.namespace WHERE name = 'lostdata';
+
+let $corrupt_id
+SELECT id FROM system.namespace WHERE name = 'corruptdesc';
+
+let $parentID
+select pid from system.namespace2 as n(pid,psid,name,id) where id=$t_id;
+
+let $parentSchemaID
+select psid from system.namespace2 as n(pid,psid,name,id)  where id=$t_id;
+
+query I
+SELECT * FROM crdb_internal.lost_descriptors_with_data;
+----
+
+# Lost descriptor
+let $json_t
+WITH
+	descs
+		AS (
+			SELECT
+				id,
+				crdb_internal.pb_to_json(
+					'cockroach.sql.sqlbase.Descriptor',
+					descriptor
+				)
+					AS descriptor
+			FROM
+				system.descriptor
+		)
+SELECT
+	descriptor
+FROM
+	descs
+WHERE
+	id = $t_id;
+
+# Intentionally corrupt descriptor
+let $json_corrupt
+WITH
+  descs
+    AS (
+      SELECT
+        id,
+        crdb_internal.pb_to_json(
+          'cockroach.sql.sqlbase.Descriptor',
+          descriptor
+        )
+          AS descriptor
+      FROM
+        system.descriptor
+    )
+SELECT
+  descriptor
+FROM
+  descs
+WHERE
+  id = $corrupt_id;
+
+# Delete our corrupt descriptor
+query B
+SELECT * FROM ROWS FROM (crdb_internal.unsafe_delete_descriptor($corrupt_id));
+----
+true
+
+# Force delete the descriptor
+query B
+SELECT * FROM ROWS FROM (crdb_internal.unsafe_delete_descriptor($t_id));
+----
+true
+
+# Corrupt the descriptor with fake ID's
+let $json_t_corrupt
+SELECT CAST(replace('$json_corrupt','"name": "corruptdesc",', '') AS JSONB)
+
+# Inject our corrupt descriptor with the wrong ID
+statement ok
+SELECT * FROM crdb_internal.unsafe_upsert_descriptor($corrupt_id, crdb_internal.json_to_pb( 'cockroach.sql.sqlbase.Descriptor','$json_t_corrupt'), true)
+
+
+query I
+SELECT count(*) FROM crdb_internal.lost_descriptors_with_data WHERE descid = $t_id;
+----
+1
+
+query I
+SELECT count(*) FROM crdb_internal.lost_descriptors_with_data WHERE descid != $t_id
+----
+0
+
+statement ok
+SELECT * FROM crdb_internal.unsafe_upsert_descriptor($t_id, crdb_internal.json_to_pb( 'cockroach.sql.sqlbase.Descriptor','$json_t'))
+
+# Recover the corrupted descriptor
+statement ok
+SELECT * FROM crdb_internal.unsafe_upsert_descriptor($corrupt_id, crdb_internal.json_to_pb( 'cockroach.sql.sqlbase.Descriptor','$json_corrupt'), true)
+
+statement ok
+SELECT * FROM corruptdesc;
+
 # Test the crdb_internal.force_delete_table_data function
 subtest force-delete-data
 

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -560,6 +560,7 @@ jobs                                   NULL
 kv_node_status                         NULL
 kv_store_status                        NULL
 leases                                 NULL
+lost_descriptors_with_data             NULL
 node_build_info                        NULL
 node_contention_events                 NULL
 node_inflight_trace_spans              NULL


### PR DESCRIPTION
Fixes: #62800
Previously, there was no way of knowing if any data was left
over by table descriptors that were force delete via internal
functions. This was problematic, since these tables could
still have data left over in storage, even though the descriptors
were cleaned up. We added a builtin to clear this data, but we
have no way of knowing which descriptors have leaked data. To
address this a new internal table
crdb_internal.lost_descriptors_with_data.

Release note (sql change): Added crdb_internal.lost_descriptors_with_data
to show descriptors that have no entries but data left behind.