### PR TITLE
workload: hide tpcc --interleaved

### DIFF
--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -172,6 +172,9 @@ var tpccMeta = workload.Meta{
 		g.flags.BoolVar(&g.fks, `fks`, true, `Add the foreign keys`)
 		g.flags.BoolVar(&g.deprecatedFkIndexes, `deprecated-fk-indexes`, false, `Add deprecated foreign keys (needed when running against v20.1 or below clusters)`)
 		g.flags.BoolVar(&g.interleaved, `interleaved`, false, `Use interleaved tables`)
+		if err := g.Flags().MarkHidden("interleaved"); err != nil {
+			panic(errors.Wrap(err, "no interleaved flag?"))
+		}
 
 		g.flags.StringVar(&g.mix, `mix`,
 			`newOrder=10,payment=10,orderStatus=1,delivery=1,stockLevel=1`,


### PR DESCRIPTION
Closes #62609.

We're working on deprecating interleaved tables, so removing
--interleaved as a public flag to the tpcc workload.

Release note: None