### PR TITLE
tenantrate: add "test" that reports IOPS estimations

### DIFF
--- a/pkg/kv/kvserver/tenantrate/BUILD.bazel
+++ b/pkg/kv/kvserver/tenantrate/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v2//:yaml_v2",
     ],

--- a/pkg/kv/kvserver/tenantrate/helpers_test.go
+++ b/pkg/kv/kvserver/tenantrate/helpers_test.go
@@ -24,3 +24,26 @@ func OverrideSettingsWithRateLimits(settings *cluster.Settings, rl LimitConfigs)
 	writeRateLimit.Override(&settings.SV, int64(rl.WriteBytes.Rate))
 	writeBurstLimit.Override(&settings.SV, rl.WriteBytes.Burst)
 }
+
+// DefaultLimitConfigs returns the configuration that corresponds to the default
+// setting values.
+func DefaultLimitConfigs() LimitConfigs {
+	return LimitConfigs{
+		ReadRequests: LimitConfig{
+			Rate:  Limit(readRequestRateLimit.Default()),
+			Burst: readRequestBurstLimit.Default(),
+		},
+		WriteRequests: LimitConfig{
+			Rate:  Limit(writeRequestRateLimit.Default()),
+			Burst: writeRequestBurstLimit.Default(),
+		},
+		ReadBytes: LimitConfig{
+			Rate:  Limit(readRateLimit.Default()),
+			Burst: readBurstLimit.Default(),
+		},
+		WriteBytes: LimitConfig{
+			Rate:  Limit(writeRateLimit.Default()),
+			Burst: writeBurstLimit.Default(),
+		},
+	}
+}

--- a/pkg/kv/kvserver/tenantrate/testdata/estimate_iops
+++ b/pkg/kv/kvserver/tenantrate/testdata/estimate_iops
@@ -1,0 +1,49 @@
+estimate_iops
+readpercentage: 100
+readsize: 4096
+----
+Read-only workload (4.0 KiB reads): 128 sustained IOPS, 512 burst.
+
+estimate_iops
+readpercentage: 100
+readsize: 65536
+----
+Read-only workload (64 KiB reads): 16 sustained IOPS, 256 burst.
+
+estimate_iops
+readpercentage: 100
+readsize: 1048576
+----
+Read-only workload (1.0 MiB reads): 1.0 sustained IOPS, 16 burst.
+
+estimate_iops
+readpercentage: 0
+writesize: 4096
+----
+Write-only workload (4.0 KiB writes): 128 sustained IOPS, 512 burst.
+
+estimate_iops
+readpercentage: 0
+writesize: 65536
+----
+Write-only workload (64 KiB writes): 8.0 sustained IOPS, 128 burst.
+
+estimate_iops
+readpercentage: 0
+writesize: 1048576
+----
+Write-only workload (1.0 MiB writes): 0.5 sustained IOPS, 8.0 burst.
+
+estimate_iops
+readpercentage: 50
+readsize: 4096
+writesize: 4096
+----
+Mixed workload (50% reads; 4.0 KiB reads; 4.0 KiB writes): 256 sustained IOPS, 1024 burst.
+
+estimate_iops
+readpercentage: 90
+readsize: 4096
+writesize: 4096
+----
+Mixed workload (90% reads; 4.0 KiB reads; 4.0 KiB writes): 142 sustained IOPS, 569 burst.


### PR DESCRIPTION
This change adds a "test" facility which takes the description of a
uniform workload (read percentage, read size, write size) and prints
out an estimation of the sustained IOPS and burst IO. This will allow
a better understanding of how changes to the settings or the mechanism
translate into IOPS changes.

Release note: None