### PR TITLE
importccl: clear range when reverting IMPORT INTO of empty tables

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -2349,6 +2349,7 @@ func (r *importResumer) dropTables(
 	ctx context.Context, txn *kv.Txn, descsCol *descs.Collection, execCfg *sql.ExecutorConfig,
 ) error {
 	details := r.job.Details().(jobspb.ImportDetails)
+	dropTime := int64(1)
 
 	// If the prepare step of the import job was not completed then the
 	// descriptors do not need to be rolled back as the txn updating them never
@@ -2403,13 +2404,16 @@ func (r *importResumer) dropTables(
 	}
 
 	for i := range empty {
+		// Set a DropTime on the table descriptor to differentiate it from an
+		// older-format (v1.1) descriptor. This enables ClearTableData to use a
+		// RangeClear for faster data removal, rather than removing by chunks.
+		empty[i].TableDesc().DropTime = dropTime
 		if err := gcjob.ClearTableData(ctx, execCfg.DB, execCfg.DistSender, execCfg.Codec, empty[i]); err != nil {
 			return errors.Wrapf(err, "clearing data for table %d", empty[i].GetID())
 		}
 	}
 
 	b := txn.NewBatch()
-	dropTime := int64(1)
 	tablesToGC := make([]descpb.ID, 0, len(details.Tables))
 	for _, tbl := range details.Tables {
 		newTableDesc, err := descsCol.GetMutableTableVersionByID(ctx, tbl.Desc.ID, txn)


### PR DESCRIPTION
Previously, when we would clear the data from an empty table when
reverting the drop time on the table descriptor was not set. This lead
to the range being cleared in the old (and slower) chunked table
deletion.

This change not only means that we should expect a performance
improvement when reverting IMPORT INTOs that were into empty tables, but
also a stability improvement. Previously, we've seen errors due to node
failures while clearing the data in empty tables. The fast path should
be resilient to such errors as those errors should be retried in
DistSender (either while iterating the ranges, or issuing the clear
range requiest).

Release note (bug fix): Improve reslience of IMPORT INTO reverting data
during node failures. This change should also bring a performance
improvement of reverting IM