### PR TITLE
sql: disallow dropping enum values used in default/computed columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type
@@ -374,22 +374,20 @@ statement ok
 INSERT INTO uses_alphabets_2 VALUES(1);
 
 # e was inserted as the default value, so we shouldn't be able to remove it.
-statement error pq: could not remove enum value "e" as it is being used by "uses_alphabets_2"
+statement error pq: could not remove enum value "e" as it is being used in a default expresion of "uses_alphabets_2"
 ALTER TYPE alphabets DROP VALUE 'e'
 
 statement ok
 TRUNCATE uses_alphabets_2
 
-statement ok
+statement error pq: could not remove enum value "e" as it is being used in a default expresion of "uses_alphabets_2"
 ALTER TYPE alphabets DROP VALUE 'e'
 
-statement error pq: could not find \[160\] in enum "public.alphabets"
+statement ok
 INSERT INTO uses_alphabets_2 VALUES(1);
 
-# Even though the default expr no longer works, we should be able to explicitly
-# insert a value.
 statement ok
-INSERT INTO uses_alphabets_2 VALUES (1, 'f')
+INSERT INTO uses_alphabets_2 VALUES (2, 'f')
 
 # Dropping the column should work.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1385,3 +1385,94 @@ query T
 SELECT * from arr_t5
 ----
 {a,b}
+
+
+# Test that if an enum value is being used by a default expression
+# or computed column, we disallow dropping it.
+subtest drop_used_enum_values
+
+statement ok
+SET enable_drop_enum_value = true
+
+statement ok
+CREATE TYPE default_abc AS ENUM ('a', 'b', 'c')
+
+statement ok
+CREATE TYPE default_abc2 AS ENUM('a', 'b', 'c')
+
+statement ok
+CREATE TABLE t (k INT PRIMARY KEY, v default_abc DEFAULT 'a')
+
+statement error pq: could not remove enum value "a" as it is being used in a default expresion of "t"
+ALTER TYPE default_abc DROP VALUE 'a'
+
+statement ok
+ALTER TYPE default_abc2 DROP VALUE 'a'
+
+statement ok
+CREATE TABLE t2 (k INT PRIMARY KEY, v string DEFAULT 'b'::default_abc::string)
+
+statement error pq: could not remove enum value "b" as it is being used in a default expresion of "t2"
+ALTER TYPE default_abc DROP VALUE 'b'
+
+statement ok
+ALTER TYPE default_abc DROP VALUE 'c'
+
+statement ok
+CREATE TABLE t3 (
+  x _default_abc2 DEFAULT ARRAY['b'::default_abc2],
+  y string DEFAULT ARRAY['c':::default_abc2][1]::string)
+
+statement error could not remove enum value "b" as it is being used in a default expresion of "t3"
+ALTER TYPE default_abc2 DROP VALUE 'b'
+
+statement error could not remove enum value "c" as it is being used in a default expresion of "t3"
+ALTER TYPE default_abc2 DROP VALUE 'c'
+
+statement ok
+CREATE TYPE default_abc3 AS ENUM ('a', 'b', 'c')
+
+statement ok
+CREATE TABLE t4 (
+  x default_abc3[] DEFAULT '{a}'::default_abc3[],
+  y string DEFAULT '{b}'::_default_abc3::string,
+  z default_abc3 DEFAULT ('{a, b, c}'::default_abc3[])[3])
+
+statement error could not remove enum value "a" as it is being used in a default expresion of "t4"
+ALTER TYPE default_abc3 DROP VALUE 'a'
+
+statement error could not remove enum value "b" as it is being used in a default expresion of "t4"
+ALTER TYPE default_abc3 DROP VALUE 'b'
+
+statement error could not remove enum value "c" as it is being used in a default expresion of "t4"
+ALTER TYPE default_abc3 DROP VALUE 'c'
+
+statement ok
+CREATE TYPE computed_abc AS ENUM ('a', 'b', 'c')
+
+statement ok
+CREATE TYPE computed_abc2 AS ENUM ('a', 'b', 'c')
+
+statement ok
+CREATE TABLE t5 (k INT PRIMARY KEY, y computed_abc AS ('a') STORED)
+
+statement error pq: could not remove enum value "a" as it is being used in a computed column of "t5"
+ALTER TYPE computed_abc DROP VALUE 'a'
+
+statement ok
+CREATE TABLE t6 (k INT PRIMARY KEY, y string AS ('b'::computed_abc::string) STORED)
+
+statement error pq: could not remove enum value "b" as it is being used in a computed column of "t6"
+ALTER TYPE computed_abc DROP VALUE 'b'
+
+statement ok
+ALTER TYPE computed_abc DROP VALUE 'c'
+
+statement ok
+CREATE TABLE t7 (x _computed_abc2 AS (ARRAY['a'::computed_abc2]) STORED, y computed_abc2[] AS (ARRAY['b':::computed_abc2]) STORED)
+
+statement error could not remove enum value "a" as it is being used in a computed column of "t7"
+ALTER TYPE computed_abc2 DROP VALUE 'a'
+
+statement error could not remove enum value "b" as it is being used in a computed column of "t7"
+ALTER TYPE computed_abc2 DROP VALUE 'b'


### PR DESCRIPTION
Previously, users could drop enum values
being used in default expressions or computed
columns, since we did not perform any checks beforehand.
This meant that default expressions and computed columns
could become corrupted after making such a drop.
This patch addresses this by walking default expressions
and computed columns when an enum member is dropped, and
disallows the drop if it finds any usages.

Partially fixes https://github.com/cockroachdb/cockroach/issues/59807 (this PR addresses the issue
in default/computed columns, and https://github.com/cockroachdb/cockroach/pull/62736 addresses the 
issue in views).

Release note: None