### PR TITLE
geo: minor performance improvement for looping over edges

### DIFF
--- a/pkg/geo/geodist/geodist.go
+++ b/pkg/geo/geodist/geodist.go
@@ -182,7 +182,7 @@ func ShapeDistance(c DistanceCalculator, a Shape, b Shape) (bool, error) {
 // It will only check the V1 of each edge and assumes the first edge start does not need the distance
 // to be computed.
 func onPointToEdgesExceptFirstEdgeStart(c DistanceCalculator, a Point, b shapeWithEdges) bool {
-	for edgeIdx := 0; edgeIdx < b.NumEdges(); edgeIdx++ {
+	for edgeIdx, bNumEdges := 0, b.NumEdges(); edgeIdx < bNumEdges; edgeIdx++ {
 		edge := b.Edge(edgeIdx)
 		// Check against all V1 of every edge.
 		if c.DistanceUpdater().Update(a, edge.V1) {
@@ -253,7 +253,7 @@ func onPointToPolygon(c DistanceCalculator, a Point, b Polygon) bool {
 // only looking at the edges.
 // Returns true if the calling function should early exit.
 func onShapeEdgesToShapeEdges(c DistanceCalculator, a shapeWithEdges, b shapeWithEdges) bool {
-	for aEdgeIdx := 0; aEdgeIdx < a.NumEdges(); aEdgeIdx++ {
+	for aEdgeIdx, aNumEdges := 0, a.NumEdges(); aEdgeIdx < aNumEdges; aEdgeIdx++ {
 		aEdge := a.Edge(aEdgeIdx)
 		var crosser EdgeCrosser
 		// MaxDistance: the max distance between 2 edges is the maximum of the distance across
@@ -264,7 +264,7 @@ func onShapeEdgesToShapeEdges(c DistanceCalculator, a shapeWithEdges, b shapeWit
 		if !c.DistanceUpdater().IsMaxDistance() && c.BoundingBoxIntersects() {
 			crosser = c.NewEdgeCrosser(aEdge, b.Edge(0).V0)
 		}
-		for bEdgeIdx := 0; bEdgeIdx < b.NumEdges(); bEdgeIdx++ {
+		for bEdgeIdx, bNumEdges := 0, b.NumEdges(); bEdgeIdx < bNumEdges; bEdgeIdx++ {
 			bEdge := b.Edge(bEdgeIdx)
 			if crosser != nil {
 				// If the edges cross, the distance is 0.

--- a/pkg/geo/geogfn/covers.go
+++ b/pkg/geo/geogfn/covers.go
@@ -148,7 +148,7 @@ func polylineCoversPoint(a *s2.Polyline, b s2.Point) bool {
 // If true, it will also return an index of the start of the edge where there
 // was an intersection.
 func polylineCoversPointWithIdx(a *s2.Polyline, b s2.Point) (bool, int) {
-	for edgeIdx := 0; edgeIdx < a.NumEdges(); edgeIdx++ {
+	for edgeIdx, aNumEdges := 0, a.NumEdges(); edgeIdx < aNumEdges; edgeIdx++ {
 		if edgeCoversPoint(a.Edge(edgeIdx), b) {
 			return true, edgeIdx
 		}
@@ -283,7 +283,7 @@ func polygonCoversPolyline(a *s2.Polygon, b *s2.Polyline) bool {
 func polygonIntersectsPolylineEdge(a *s2.Polygon, b *s2.Polyline) bool {
 	// Avoid using NumEdges / Edge of the Polygon type as it is not O(1).
 	for _, loop := range a.Loops() {
-		for loopEdgeIdx := 0; loopEdgeIdx < loop.NumEdges(); loopEdgeIdx++ {
+		for loopEdgeIdx, loopNumEdges := 0, loop.NumEdges(); loopEdgeIdx < loopNumEdges; loopEdgeIdx++ {
 			loopEdge := loop.Edge(loopEdgeIdx)
 			crosser := s2.NewChainEdgeCrosser(loopEdge.V0, loopEdge.V1, (*b)[0])
 			for _, nextVertex := range (*b)[1:] {

--- a/pkg/geo/geogfn/intersects.go
+++ b/pkg/geo/geogfn/intersects.go
@@ -94,7 +94,7 @@ func singleRegionIntersects(aRegion s2.Region, bRegion s2.Region) (bool, error) 
 // polylineIntersectsPolyline returns whether polyline a intersects with
 // polyline b.
 func polylineIntersectsPolyline(a *s2.Polyline, b *s2.Polyline) bool {
-	for aEdgeIdx := 0; aEdgeIdx < a.NumEdges(); aEdgeIdx++ {
+	for aEdgeIdx, aNumEdges := 0, a.NumEdges(); aEdgeIdx < aNumEdges; aEdgeIdx++ {
 		edge := a.Edge(aEdgeIdx)
 		crosser := s2.NewChainEdgeCrosser(edge.V0, edge.V1, (*b)[0])
 		for _, nextVertex := range (*b)[1:] {
@@ -122,7 +122,7 @@ func polygonIntersectsPolyline(a *s2.Polygon, b *s2.Polyline) bool {
 	// This technique works for holes touching, or holes touching the exterior
 	// as the point in which the holes touch is considered an intersection.
 	for _, loop := range a.Loops() {
-		for loopEdgeIdx := 0; loopEdgeIdx < loop.NumEdges(); loopEdgeIdx++ {
+		for loopEdgeIdx, loopNumEdges := 0, loop.NumEdges(); loopEdgeIdx < loopNumEdges; loopEdgeIdx++ {
 			loopEdge := loop.Edge(loopEdgeIdx)
 			crosser := s2.NewChainEdgeCrosser(loopEdge.V0, loopEdge.V1, (*b)[0])
 			for _, nextVertex := range (*b)[1:] {

--- a/pkg/geo/geogfn/topology_operations.go
+++ b/pkg/geo/geogfn/topology_operations.go
@@ -73,7 +73,7 @@ func Centroid(g geo.Geography, useSphereOrSpheroid UseSphereOrSpheroid) (geo.Geo
 			//  * Calculate the mid-points and length/angle for all the edges.
 			//  * The centroid of (Multi)LineString will be a weighted average of mid-points
 			//    of all the edges, where each mid-points is weighted by its length/angle.
-			for edgeIdx := 0; edgeIdx < region.NumEdges(); edgeIdx++ {
+			for edgeIdx, regionNumEdges := 0, region.NumEdges(); edgeIdx < regionNumEdges; edgeIdx++ {
 				var edgeWeight float64
 				eV0 := region.Edge(edgeIdx).V0
 				eV1 := region.Edge(edgeIdx).V1

--- a/pkg/geo/geogfn/unary_operators.go
+++ b/pkg/geo/geogfn/unary_operators.go
@@ -172,7 +172,7 @@ func length(
 			if useSphereOrSpheroid == UseSpheroid {
 				totalLength += spheroid.InverseBatch((*region))
 			} else {
-				for edgeIdx := 0; edgeIdx < region.NumEdges(); edgeIdx++ {
+				for edgeIdx, regionNumEdges := 0, region.NumEdges(); edgeIdx < regionNumEdges; edgeIdx++ {
 					edge := region.Edge(edgeIdx)
 					totalLength += s2.ChordAngleBetweenPoints(edge.V0, edge.V1).Angle().Radians()
 				}
@@ -182,7 +182,7 @@ func length(
 				if useSphereOrSpheroid == UseSpheroid {
 					totalLength += spheroid.InverseBatch(loop.Vertices())
 				} else {
-					for edgeIdx := 0; edgeIdx < loop.NumEdges(); edgeIdx++ {
+					for edgeIdx, loopNumEdges := 0, loop.NumEdges(); edgeIdx < loopNumEdges; edgeIdx++ {
 						edge := loop.Edge(edgeIdx)
 						totalLength += s2.ChordAngleBetweenPoints(edge.V0, edge.V1).Angle().Radians()
 					}


### PR DESCRIPTION
This patch slightly improves the performance of many
spatial builtins by storing the number of edges used
in the loop conditions of for loops into a variable.
We discovered this was taking a lot of time when
profiling the point-in-polygon optimization.

Release note: None