### PR TITLE
ccl/importccl: skip TestImportIntoCSV

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -2600,6 +2600,7 @@ func TestExportImportRoundTrip(t *testing.T) {
 // -> Rollback of a failed IMPORT INTO
 func TestImportIntoCSV(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 62853, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	skip.UnderShort(t)


### PR DESCRIPTION
Refs: #62853

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None