### PR TITLE
release-21.1: colexecjoin: fix the merge joiner in some cases

### DIFF
--- a/pkg/sql/colexec/colexecjoin/BUILD.bazel
+++ b/pkg/sql/colexec/colexecjoin/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/sql/execinfrapb",
         "//pkg/sql/sem/tree",  # keep
         "//pkg/sql/types",
+        "//pkg/util",
         "//pkg/util/duration",  # keep
         "//pkg/util/mon",
         "@com_github_cockroachdb_apd_v2//:apd",  # keep


### PR DESCRIPTION
Backport 1/1 commits from #62785.

/cc @cockroachdb/release

---

Previously, we were incorrectly updating the internal state of
`circularGroupsBuffer` when we needed to expand the buffer size. The bug
was introduced several months ago (during 21.1 cycle) when we made the
buffer grow dynamically. As it turns out, the bug is easily caught by
our unit tests if we randomize the initial buffer size.

Fixes: #62520.

Release note (bug fix): CockroachDB could previously return incorrect
results in some cases when executing the merge join operation via the
vectorized engine. The bug is only present in 21.1 test releases.
