### PR TITLE
release-21.1: sql: fix error when adding and dropping a constraint in same txn.

### DIFF
--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -1283,7 +1283,6 @@ func (desc *Mutable) DropConstraint(
 				return nil
 			}
 		}
-		return errors.AssertionFailedf("constraint %q not found on table %q", name, desc.Name)
 
 	case descpb.ConstraintTypeCheck:
 		if detail.CheckConstraint.Validity == descpb.ConstraintValidity_Validating {
@@ -1310,7 +1309,6 @@ func (desc *Mutable) DropConstraint(
 				return nil
 			}
 		}
-		return errors.Errorf("constraint %q not found on table %q", name, desc.Name)
 
 	case descpb.ConstraintTypeFK:
 		if detail.FK.Validity == descpb.ConstraintValidity_Validating {
@@ -1343,13 +1341,29 @@ func (desc *Mutable) DropConstraint(
 				return nil
 			}
 		}
-		return errors.AssertionFailedf("constraint %q not found on table %q", name, desc.Name)
 
 	default:
 		return unimplemented.Newf(fmt.Sprintf("drop-constraint-%s", detail.Kind),
 			"constraint %q has unsupported type", tree.ErrNameString(name))
 	}
 
+	// Check if the constraint can be found in a mutation, complain appropriately.
+	for i := range desc.Mutations {
+		m := &desc.Mutations[i]
+		if m.GetConstraint() != nil && m.GetConstraint().Name == name {
+			switch m.Direction {
+			case descpb.DescriptorMutation_ADD:
+				return unimplemented.NewWithIssueDetailf(42844,
+					"drop-constraint-mutation",
+					"constraint %q in the middle of being added, try again later", name)
+			case descpb.DescriptorMutation_DROP:
+				return unimplemented.NewWithIssueDetailf(42844,
+					"drop-constraint-mutation",
+					"constraint %q in the middle of being dropped", name)
+			}
+		}
+	}
+	return errors.AssertionFailedf("constraint %q not found on table %q", name, desc.Name)
 }
 
 // RenameConstraint renames a constraint.

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1732,3 +1732,34 @@ ALTER TABLE t61762 ADD COLUMN v OIDVECTOR
 
 statement error VECTOR column types are unsupported
 ALTER TABLE t61762 ADD COLUMN v INT2VECTOR
+
+# Regression test for #60786. Handle in-transaction constraint ADD+DROP correctly.
+subtest regression_60786
+
+statement ok
+CREATE TABLE t60786(i INT PRIMARY KEY);
+
+statement error pgcode 0A000 constraint "fk" in the middle of being added, try again later
+BEGIN;
+CREATE TABLE child_60786(i INT PRIMARY KEY);
+ALTER TABLE t60786 ADD CONSTRAINT fk FOREIGN KEY (i) REFERENCES child_60786(i) NOT VALID;
+ALTER TABLE t60786 DROP CONSTRAINT fk CASCADE
+
+statement ok
+ROLLBACK
+
+statement error pgcode 0A000 constraint "ck" in the middle of being added, try again later
+BEGIN;
+ALTER TABLE t60786 ADD CONSTRAINT ck CHECK(i > 0) NOT VALID;
+ALTER TABLE t60786 DROP CONSTRAINT ck CASCADE
+
+statement ok
+ROLLBACK
+
+statement error pgcode 0A000 constraint "uq" in the middle of being added, try again later
+BEGIN;
+ALTER TABLE t60786 ADD CONSTRAINT uq UNIQUE WITHOUT INDEX(i) NOT VALID;
+ALTER TABLE t60786 DROP CONSTRAINT uq CASCADE
+
+statement ok
+ROLLBACK


### PR DESCRIPTION
Backport 1/1 commits from #62732.

/cc @cockroachdb/release

---

This commit fixes a bug in which an internal error would be returned
when dropping a foreign key currently in the table's mutations slice.
Instead, we return a more appropriate unimplemented error.

Fixes #60786.

Release note (bug fix): Dropping a foreign key that was added in the
same transaction no longer triggers an internal error. This bug has been
present since at least version 20.1.
