### PR TITLE
release-20.2: sql: fix error when adding and dropping a constraint in same txn.

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1407,3 +1407,26 @@ CREATE TABLE t54629 (c INT NOT NULL, UNIQUE INDEX (c));
 ALTER TABLE t54629 ADD CONSTRAINT pk PRIMARY KEY (c);
 INSERT INTO t54629 VALUES (1);
 DELETE FROM t54629 WHERE c = 1;
+
+# Regression test for #60786. Handle in-transaction constraint ADD+DROP correctly.
+subtest regression_60786
+
+statement ok
+CREATE TABLE t60786(i INT PRIMARY KEY);
+
+statement error pgcode 0A000 constraint "fk" in the middle of being added, try again later
+BEGIN;
+CREATE TABLE child_60786(i INT PRIMARY KEY);
+ALTER TABLE t60786 ADD CONSTRAINT fk FOREIGN KEY (i) REFERENCES child_60786(i) NOT VALID;
+ALTER TABLE t60786 DROP CONSTRAINT fk CASCADE
+
+statement ok
+ROLLBACK
+
+statement error pgcode 0A000 constraint "ck" in the middle of being added, try again later
+BEGIN;
+ALTER TABLE t60786 ADD CONSTRAINT ck CHECK(i > 0) NOT VALID;
+ALTER TABLE t60786 DROP CONSTRAINT ck CASCADE
+
+statement ok
+ROLLBACK


### PR DESCRIPTION
Backport 1/1 commits from #62732.

/cc @cockroachdb/release

---

This commit fixes a bug in which an internal error would be returned
when dropping a foreign key currently in the table's mutations slice.
Instead, we return a more appropriate unimplemented error.

Fixes #60786.

Release note (bug fix): Dropping a foreign key that was added in the
same transaction no longer triggers an internal error. This bug has been
present since at least version 20.1.
