### PR TITLE
sql: add cluster setting to enable TBI during RevertRange

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -134,7 +134,8 @@ func (s *streamIngestionResumer) revertToCutoverTimestamp(
 					Key:    span.Key,
 					EndKey: span.EndKey,
 				},
-				TargetTime: sp.StreamIngest.CutoverTime,
+				TargetTime:                          sp.StreamIngest.CutoverTime,
+				EnableTimeBoundIteratorOptimization: true,
 			})
 		}
 		b.Header.MaxSpanRequestKeys = sql.RevertTableDefaultBatchSize

--- a/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
@@ -154,7 +154,9 @@ func TestCmdRevertRange(t *testing.T) {
 					defer batch.Close()
 
 					req := roachpb.RevertRangeRequest{
-						RequestHeader: roachpb.RequestHeader{Key: startKey, EndKey: endKey}, TargetTime: tc.ts,
+						RequestHeader:                       roachpb.RequestHeader{Key: startKey, EndKey: endKey},
+						TargetTime:                          tc.ts,
+						EnableTimeBoundIteratorOptimization: true,
 					}
 					cArgs.Stats = &enginepb.MVCCStats{}
 					cArgs.Args = &req
@@ -228,7 +230,9 @@ func TestCmdRevertRange(t *testing.T) {
 					defer batch.Close()
 					cArgs.Stats = &enginepb.MVCCStats{}
 					req := roachpb.RevertRangeRequest{
-						RequestHeader: roachpb.RequestHeader{Key: startKey, EndKey: endKey}, TargetTime: tc.ts,
+						RequestHeader:                       roachpb.RequestHeader{Key: startKey, EndKey: endKey},
+						TargetTime:                          tc.ts,
+						EnableTimeBoundIteratorOptimization: true,
 					}
 					cArgs.Args = &req
 					var resumes int

--- a/pkg/sql/revert_test.go
+++ b/pkg/sql/revert_test.go
@@ -139,8 +139,9 @@ func TestRevertGCThreshold(t *testing.T) {
 	kvDB := tc.Server(0).DB()
 
 	req := &roachpb.RevertRangeRequest{
-		RequestHeader: roachpb.RequestHeader{Key: keys.UserTableDataMin, EndKey: keys.MaxKey},
-		TargetTime:    hlc.Timestamp{WallTime: -1},
+		RequestHeader:                       roachpb.RequestHeader{Key: keys.UserTableDataMin, EndKey: keys.MaxKey},
+		TargetTime:                          hlc.Timestamp{WallTime: -1},
+		EnableTimeBoundIteratorOptimization: true,
 	}
 	_, pErr := kv.SendWrapped(ctx, kvDB.NonTransactionalSender(), req)
 	if !testutils.IsPError(pErr, "must be after replica GC threshold") {


### PR DESCRIPTION
This change adds a cluster setting:
`kv.bulk_io_write.revert_range_time_bound_iterator_enabled`
that defaults to true. This is used by IMPORT and cluster
streaming revert range requests.

Release note (sql change): Add cluster setting
`kv.bulk_io_write.revert_range_time_bound_iterator_enabled`
that defaults to true, and enables TBI optimization for revert range.