### PR TITLE
release-21.1: colexecerror: catch panics from packages in sql/sem folder

### DIFF
--- a/pkg/sql/colexecerror/error.go
+++ b/pkg/sql/colexecerror/error.go
@@ -92,12 +92,18 @@ func CatchVectorizedRuntimeError(operation func()) (retErr error) {
 	return retErr
 }
 
+// We use the approach of allow-listing the packages the panics from which are
+// safe to catch (which is the case when the code doesn't update shared state
+// and doesn't manipulate locks).
+//
+// Multiple actual packages can have the same prefix as a single constant string
+// defined below, but all of such packages are allowed to be caught from.
 const (
 	colPackagesPrefix      = "github.com/cockroachdb/cockroach/pkg/col"
 	execinfraPackagePrefix = "github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	sqlColPackagesPrefix   = "github.com/cockroachdb/cockroach/pkg/sql/col"
 	sqlRowPackagesPrefix   = "github.com/cockroachdb/cockroach/pkg/sql/row"
-	treePackagePrefix      = "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	sqlSemPackagesPrefix   = "github.com/cockroachdb/cockroach/pkg/sql/sem"
 )
 
 // shouldCatchPanic checks whether the panic that was emitted from
@@ -126,7 +132,7 @@ func shouldCatchPanic(panicEmittedFrom string) bool {
 		strings.HasPrefix(panicEmittedFrom, execinfraPackagePrefix) ||
 		strings.HasPrefix(panicEmittedFrom, sqlColPackagesPrefix) ||
 		strings.HasPrefix(panicEmittedFrom, sqlRowPackagesPrefix) ||
-		strings.HasPrefix(panicEmittedFrom, treePackagePrefix)
+		strings.HasPrefix(panicEmittedFrom, sqlSemPackagesPrefix)
 }
 
 // StorageError is an error that was created by a component below the sql

--- a/pkg/sql/colexecerror/error.go
+++ b/pkg/sql/colexecerror/error.go
@@ -122,10 +122,10 @@ func shouldCatchPanic(panicEmittedFrom string) bool {
 		// unchanged by the higher-level catchers.
 		return false
 	}
-	const nonVectorizedTestPrefix = "github.com/cockroachdb/cockroach/pkg/sql/colexecerror.NonVectorizedTestPanic"
-	if strings.HasPrefix(panicEmittedFrom, nonVectorizedTestPrefix) {
-		// This panic came from NonVectorizedTestPanic() method and should not
-		// be caught for testing purposes.
+	const nonCatchablePanicPrefix = "github.com/cockroachdb/cockroach/pkg/sql/colexecerror.NonCatchablePanic"
+	if strings.HasPrefix(panicEmittedFrom, nonCatchablePanicPrefix) {
+		// This panic came from NonCatchablePanic() method and should not be
+		// caught.
 		return false
 	}
 	return strings.HasPrefix(panicEmittedFrom, colPackagesPrefix) ||
@@ -200,9 +200,10 @@ func ExpectedError(err error) {
 	panic(newNotInternalError(err))
 }
 
-// NonVectorizedTestPanic is the equivalent of Golang's 'panic' word that should
-// be used by the testing code within the vectorized engine to simulate a panic
-// that occurs outside of the engine (and, thus, should not be caught).
-func NonVectorizedTestPanic(object interface{}) {
+// NonCatchablePanic is the equivalent of Golang's 'panic' word that can be used
+// in order to crash the goroutine. It could be used by the testing code within
+// the vectorized engine to simulate a panic that occurs outside of the engine
+// (and, thus, should not be caught).
+func NonCatchablePanic(object interface{}) {
 	panic(object)
 }

--- a/pkg/sql/colexecerror/error_test.go
+++ b/pkg/sql/colexecerror/error_test.go
@@ -34,7 +34,7 @@ func TestCatchVectorizedRuntimeError(t *testing.T) {
 	require.Panics(t, func() {
 		require.NoError(t, colexecerror.CatchVectorizedRuntimeError(func() {
 			require.NoError(t, colexecerror.CatchVectorizedRuntimeError(func() {
-				colexecerror.NonVectorizedTestPanic(errors.New("should not be caught"))
+				colexecerror.NonCatchablePanic(errors.New("should not be caught"))
 			}))
 		}))
 	})
@@ -62,15 +62,15 @@ func TestCatchVectorizedRuntimeError(t *testing.T) {
 	require.False(t, strings.Contains(notAnnotatedErr.Error(), annotationText))
 }
 
-// TestNonVectorizedTestPanicIsNotCaught verifies that panics emitted via
-// NonVectorizedTestPanic() method are not caught by the catcher.
-func TestNonVectorizedTestPanicIsNotCaught(t *testing.T) {
+// TestNonCatchablePanicIsNotCaught verifies that panics emitted via
+// NonCatchablePanic() method are not caught by the catcher.
+func TestNonCatchablePanicIsNotCaught(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
 	require.Panics(t, func() {
 		require.NoError(t, colexecerror.CatchVectorizedRuntimeError(func() {
-			colexecerror.NonVectorizedTestPanic("should panic")
+			colexecerror.NonCatchablePanic("should panic")
 		}))
 	})
 }

--- a/pkg/sql/colflow/vectorized_panic_propagation_test.go
+++ b/pkg/sql/colflow/vectorized_panic_propagation_test.go
@@ -179,7 +179,7 @@ func (e *testNonVectorizedPanicEmitter) Init() {
 func (e *testNonVectorizedPanicEmitter) Next(ctx context.Context) coldata.Batch {
 	if !e.emitBatch {
 		e.emitBatch = true
-		colexecerror.NonVectorizedTestPanic("")
+		colexecerror.NonCatchablePanic("")
 	}
 
 	e.emitBatch = false

--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//pkg/sql/catalog/catalogkv",
         "//pkg/sql/catalog/catconstants",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/colexecerror",
         "//pkg/sql/lex",
         "//pkg/sql/lexbase",
         "//pkg/sql/paramparse",

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -4059,6 +4060,12 @@ may increase either contention or retry errors, or both.`,
 					return nil, err
 				}
 				msg := string(*args[0].(*tree.DString))
+				// Use a special method to panic in order to go around the
+				// vectorized panic-catcher (which would catch the panic from
+				// Golang's 'panic' and would convert it into an internal
+				// error).
+				colexecerror.NonCatchablePanic(msg)
+				// This code is unreachable.
 				panic(msg)
 			},
 			Info:       "This function is used only by CockroachDB's developers for testing purposes.",


### PR DESCRIPTION
Backport 1/1 commits from #62889.
Backport 1/1 commits from #63178.

/cc @cockroachdb/release

---

Previously, we would only catch panics from `sql/sem/tree` package.
Recently sqlsmith encountered a crash because of a panic in
`sql/sem/builtins` package, and I believe it is reasonable to catch
panics from that package as well as from `sql/sem/transform`, so we will
now be catching based on `sql/sem` prefix.

Addresses: #62846.

Release note: None

**sem/builtins: vectorized engine no longer catches crdb_internal.force_panic**

Previously, when executing `crdb_internal.force_panic` builtin, if it
was executed via the vectorized engine, we would catch the panic and
convert it into an internal error instead. This is undesirable and is
now fixed.

Release note: None
