### PR TITLE
release-20.2: colexecerror: catch panics from packages in sql/sem folder

### DIFF
--- a/pkg/sql/colexecbase/colexecerror/error.go
+++ b/pkg/sql/colexecbase/colexecerror/error.go
@@ -92,12 +92,18 @@ func CatchVectorizedRuntimeError(operation func()) (retErr error) {
 	return retErr
 }
 
+// We use the approach of allow-listing the packages the panics from which are
+// safe to catch (which is the case when the code doesn't update shared state
+// and doesn't manipulate locks).
+//
+// Multiple actual packages can have the same prefix as a single constant string
+// defined below, but all of such packages are allowed to be caught from.
 const (
 	colPackagesPrefix      = "github.com/cockroachdb/cockroach/pkg/col"
 	execinfraPackagePrefix = "github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	sqlColPackagesPrefix   = "github.com/cockroachdb/cockroach/pkg/sql/col"
 	sqlRowPackagesPrefix   = "github.com/cockroachdb/cockroach/pkg/sql/row"
-	treePackagePrefix      = "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	sqlSemPackagesPrefix   = "github.com/cockroachdb/cockroach/pkg/sql/sem"
 )
 
 // shouldCatchPanic checks whether the panic that was emitted from
@@ -126,7 +132,7 @@ func shouldCatchPanic(panicEmittedFrom string) bool {
 		strings.HasPrefix(panicEmittedFrom, execinfraPackagePrefix) ||
 		strings.HasPrefix(panicEmittedFrom, sqlColPackagesPrefix) ||
 		strings.HasPrefix(panicEmittedFrom, sqlRowPackagesPrefix) ||
-		strings.HasPrefix(panicEmittedFrom, treePackagePrefix)
+		strings.HasPrefix(panicEmittedFrom, sqlSemPackagesPrefix)
 }
 
 // StorageError is an error that was created by a component below the sql


### PR DESCRIPTION
Backport 1/1 commits from #62889.

/cc @cockroachdb/release

---

Previously, we would only catch panics from `sql/sem/tree` package.
Recently sqlsmith encountered a crash because of a panic in
`sql/sem/builtins` package, and I believe it is reasonable to catch
panics from that package as well as from `sql/sem/transform`, so we will
now be catching based on `sql/sem` prefix.

Addresses: #62846.

Release note: None
