### PR TITLE
console: filter out stats referencing dead nodes

### DIFF
--- a/pkg/ui/src/views/reports/containers/network/index.tsx
+++ b/pkg/ui/src/views/reports/containers/network/index.tsx
@@ -427,6 +427,12 @@ export class Network extends React.Component<NetworkProps, INetworkState> {
         .keys()
         .map((nodeIDb) => Number.parseInt(nodeIDb, 10))
         .difference(healthyIDs)
+        // It's possible for the activity list to contain nodes
+        // that are no longer in our list of known nodes in
+        // `identityByID`. We ensure via the filter below
+        // that we only access nodes we have data for to
+        // prevent unrecoverable error states.
+        .filter((id) => identityByID.has(id))
         .map((nodeIDb) => ({
           from: identityByID.get(nodeIDa),
           to: identityByID.get(nodeIDb),


### PR DESCRIPTION
Previously, nodes could reference nodes we didn't know about in their
stats protos. Our frontend wouldn't know those nodeIDs because they
weren't in the list of known nodes that were returned from the DB and
would fail to render the network stats table.

Now we filter out any nodeIDs that are unknown to us so that we don't
render a broken table.

This is meant to be a targeted fix for a specific problem. Future work
will be done that addresses properly accounting for the various node
liveness states that have been changed on the backend and have not been
fully accounted for in the frontend.

Resolves #59322

Release note (ui change): Fixes a bug where nodes would reference dead
cluster nodes in their network stats and cause the network DB Console
page to crash.