### PR TITLE
roachtest: run against a set of existing clusters

### DIFF
--- a/pkg/cmd/roachtest/example.go
+++ b/pkg/cmd/roachtest/example.go
@@ -1,0 +1,39 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// This file contains dummy tests, to be used for testing the test runner by
+// hand. These tests do not have the "default" tag, so they are not generally
+// run by roachtest invocations. You have to ask for them explicitly with
+// `roachtest run tag:dummy`.
+
+package main
+
+import "context"
+
+func registerExample(r *testRegistry) {
+	clusterSpec := makeClusterSpec(1, cpu(4))
+	r.Add(testSpec{
+		Name:    "dummy/pass",
+		Owner:   OwnerKV,
+		Tags:    []string{`dummy`},
+		Cluster: clusterSpec,
+		Run: func(ctx context.Context, t *test, c *cluster) {
+		},
+	})
+	r.Add(testSpec{
+		Name:    "dummy/fail",
+		Owner:   OwnerKV,
+		Tags:    []string{`dummy`},
+		Cluster: clusterSpec,
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			t.Fatal("example failure")
+		},
+	})
+}

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -71,9 +71,7 @@ func main() {
 
 	rootCmd.PersistentFlags().StringVarP(
 		&clusterName, "cluster", "c", "",
-		"Comma-separated list of names existing cluster to use for running tests. "+
-			"If fewer than --parallelism names are specified, then the parallelism "+
-			"is capped to the number of clusters specified.")
+		"Name of existing cluster to use for running tests. --parallelism=1 must be set.")
 	rootCmd.PersistentFlags().BoolVarP(
 		&local, "local", "l", local, "run tests locally")
 	rootCmd.PersistentFlags().StringVarP(

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -104,6 +104,7 @@ func registerTests(r *testRegistry) {
 	registerYCSB(r)
 	registerTPCHBench(r)
 	registerOverload(r)
+	registerExample(r)
 }
 
 func registerBenchmarks(r *testRegistry) {

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -486,6 +486,7 @@ func (r *testRunner) runWorker(
 		}
 		testL.close()
 		if err != nil || t.Failed() {
+			l.Printf("failed 1")
 			failureMsg := fmt.Sprintf("%s (%d) - ", testToRun.spec.Name, testToRun.runNum)
 			if err != nil {
 				failureMsg += fmt.Sprintf("%+v", err)
@@ -494,12 +495,14 @@ func (r *testRunner) runWorker(
 			}
 
 			if debug {
+				l.Printf("failed -debug")
 				// Save the cluster for future debugging.
 				c.Save(ctx, failureMsg, l)
 
 				// Continue with a fresh cluster.
 				c = nil
 			} else {
+				l.Printf("failed - destroy")
 				// On any test failure or error, we destroy the cluster. We could be
 				// more selective, but this sounds safer.
 				l.PrintfCtx(ctx, "destroying cluster %s because: %s", c, failureMsg)

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -125,8 +125,7 @@ func TestRunnerRun(t *testing.T) {
 				cpuQuota:                  1000,
 				keepClustersOnTestFailure: false,
 			}
-			err := runner.Run(ctx, tests, 1, /* count */
-				defaultParallelism, copt, "" /* artifactsDir */, lopt)
+			err := runner.Run(ctx, tests, 1 /* count */, defaultParallelism, copt, lopt)
 
 			if !testutils.IsError(err, c.expErr) {
 				t.Fatalf("expected err: %q, but found %v. Filters: %s", c.expErr, err, c.filters)
@@ -181,8 +180,7 @@ func TestRunnerTestTimeout(t *testing.T) {
 			<-ctx.Done()
 		},
 	}
-	err := runner.Run(ctx, []testSpec{test}, 1, /* count */
-		defaultParallelism, copt, "" /* artifactsDir */, lopt)
+	err := runner.Run(ctx, []testSpec{test}, 1 /* count */, defaultParallelism, copt, lopt)
 	if !testutils.IsError(err, "some tests failed") {
 		t.Fatalf("expected error \"some tests failed\", got: %v", err)
 	}
@@ -318,8 +316,7 @@ func TestRegistryMinVersion(t *testing.T) {
 			}
 			cr := newClusterRegistry()
 			runner := newTestRunner(cr, r.buildVersion)
-			err = runner.Run(ctx, tests, 1, /* count */
-				defaultParallelism, copt, "" /* artifactsDir */, lopt)
+			err = runner.Run(ctx, tests, 1 /* count */, defaultParallelism, copt, lopt)
 			if !testutils.IsError(err, c.expErr) {
 				t.Fatalf("expected err: %q, got: %v", c.expErr, err)
 			}


### PR DESCRIPTION
Before this patch, you could specify one cluster with `roachprod run
--cluster=foo --parallelism=1`, and tests would run one at a time
against that one cluster. All the tests needed to be compatible with the
spec of the existing cluster.

This patch adds --existing-clusters-name=foo-
--existing-clusters-count=n. Clusters foo-[1..n] are expected to exist.
Tests will run against these clusters.  There's also a new
--wipe-before-reuse[=false], which can be used to inhibit the wiping of
clusters in between passing tests.  The idea is to pre-create a bunch of
clusters, perhaps load them with data once, and then run tests against
them repeatedly.

 --parallelism is supported; it gets effectively truncated it it's > n.
The clusters can have different specs, and each test will find a cluster
that matches what the test wants. The runner will fail if there's no
cluster available for a test. The clusters are not destroyed when tests
fail or when the test runner exits. If combined with --debug, clusters
are not reused after a failed test.

The patch also adds a generic --test-flags that can be used to pass
options to tests. The tpccbench tests are taught to recognize the
"skip-cluster-create" option and skip some initialization, such that it
runs on a cluster that was already initialized.

With all this I can run tpccbench over and over on a pool of existing,
pre-loaded clusters without having each test do the slow loading of
data.

Release note: None