### PR TITLE
bench,sql: add logScope to some benchmarks

### DIFF
--- a/pkg/bench/bench_test.go
+++ b/pkg/bench/bench_test.go
@@ -1119,6 +1119,7 @@ func runBenchmarkWideTable(b *testing.B, db *sqlutils.SQLRunner, count int, bigC
 // BenchmarkVecSkipScan benchmarks the vectorized engine's performance
 // when skipping unneeded key values in the decoding process.
 func BenchmarkVecSkipScan(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	benchmarkCockroach(b, func(b *testing.B, db *sqlutils.SQLRunner) {
 		create := `
 CREATE TABLE bench.scan(
@@ -1183,6 +1184,7 @@ func BenchmarkWideTableIgnoreColumns(b *testing.B) {
 // benchmark (and get memory allocation statistics for) the planning process.
 func BenchmarkPlanning(b *testing.B) {
 	skip.UnderShort(b)
+	defer log.Scope(b).Close(b)
 	ForEachDB(b, func(b *testing.B, db *sqlutils.SQLRunner) {
 		db.Exec(b, `CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT, INDEX(b), UNIQUE INDEX(c))`)
 

--- a/pkg/sql/colcontainer/BUILD.bazel
+++ b/pkg/sql/colcontainer/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
         "//pkg/testutils/skip",
         "//pkg/util/humanizeutil",
         "//pkg/util/leaktest",
+        "//pkg/util/log",
         "//pkg/util/mon",
         "//pkg/util/randutil",
         "@com_github_marusama_semaphore//:semaphore",

--- a/pkg/sql/colcontainer/diskqueue_test.go
+++ b/pkg/sql/colcontainer/diskqueue_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/stretchr/testify/require"
 )
@@ -209,6 +210,7 @@ var (
 // BenchmarkDiskQueue benchmarks a queue with parameters provided through flags.
 func BenchmarkDiskQueue(b *testing.B) {
 	skip.UnderShort(b)
+	defer log.Scope(b).Close(b)
 
 	bufSize, err := humanizeutil.ParseBytes(*bufferSizeBytes)
 	if err != nil {

--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -887,6 +887,7 @@ func benchmarkAggregateFunction(
 	distinctProb float64,
 	numInputRows int,
 ) {
+	defer log.Scope(b).Close(b)
 	if groupSize > numInputRows {
 		// In this case all tuples will be part of the same group, and we have
 		// likely already benchmarked such scenario with this value of

--- a/pkg/sql/colexec/and_or_projection_test.go
+++ b/pkg/sql/colexec/and_or_projection_test.go
@@ -222,6 +222,7 @@ func TestAndOrOps(t *testing.T) {
 func benchmarkLogicalProjOp(
 	b *testing.B, operation string, useSelectionVector bool, hasNulls bool,
 ) {
+	defer log.Scope(b).Close(b)
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)

--- a/pkg/sql/colexec/builtin_funcs_test.go
+++ b/pkg/sql/colexec/builtin_funcs_test.go
@@ -87,6 +87,7 @@ func TestBasicBuiltinFunctions(t *testing.T) {
 }
 
 func benchmarkBuiltinFunctions(b *testing.B, useSelectionVector bool, hasNulls bool) {
+	defer log.Scope(b).Close(b)
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)
@@ -157,6 +158,7 @@ func BenchmarkBuiltinFunctions(b *testing.B) {
 // Perform a comparison between the default substring operator
 // and the specialized operator.
 func BenchmarkCompareSpecializedOperators(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	ctx := context.Background()
 	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(ctx)

--- a/pkg/sql/colexec/colexecbase/cast_test.go
+++ b/pkg/sql/colexec/colexecbase/cast_test.go
@@ -158,6 +158,7 @@ func TestRandomizedCast(t *testing.T) {
 }
 
 func BenchmarkCastOp(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)

--- a/pkg/sql/colexec/colexecbase/ordinality_test.go
+++ b/pkg/sql/colexec/colexecbase/ordinality_test.go
@@ -77,6 +77,7 @@ func TestOrdinality(t *testing.T) {
 }
 
 func BenchmarkOrdinality(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_test.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_test.go
@@ -175,6 +175,7 @@ func newBatchOfRepeatedIntRows(
 }
 
 func BenchmarkMergeJoiner(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	ctx := context.Background()
 	const nCols = 1
 	sourceTypes := []*types.T{types.Int}

--- a/pkg/sql/colexec/colexecproj/default_cmp_op_test.go
+++ b/pkg/sql/colexec/colexecproj/default_cmp_op_test.go
@@ -119,6 +119,7 @@ func TestDefaultCmpProjOps(t *testing.T) {
 }
 
 func BenchmarkDefaultCmpProjOp(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)

--- a/pkg/sql/colexec/colexecproj/projection_ops_test.go
+++ b/pkg/sql/colexec/colexecproj/projection_ops_test.go
@@ -344,6 +344,7 @@ func benchmarkProjOp(
 
 func BenchmarkProjOp(b *testing.B) {
 	skip.UnderShort(b)
+	defer log.Scope(b).Close(b)
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)

--- a/pkg/sql/colexec/colexecsel/like_ops_test.go
+++ b/pkg/sql/colexec/colexecsel/like_ops_test.go
@@ -102,6 +102,7 @@ func TestLikeOperators(t *testing.T) {
 }
 
 func BenchmarkLikeOps(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	rng, _ := randutil.NewPseudoRand()
 	ctx := context.Background()
 

--- a/pkg/sql/colexec/colexecsel/selection_ops_test.go
+++ b/pkg/sql/colexec/colexecsel/selection_ops_test.go
@@ -156,6 +156,7 @@ func TestGetSelectionOperator(t *testing.T) {
 }
 
 func benchmarkSelLTInt64Int64ConstOp(b *testing.B, useSelectionVector bool, hasNulls bool) {
+	defer log.Scope(b).Close(b)
 	ctx := context.Background()
 
 	typs := []*types.T{types.Int}
@@ -213,6 +214,7 @@ func BenchmarkSelLTInt64Int64ConstOp(b *testing.B) {
 }
 
 func benchmarkSelLTInt64Int64Op(b *testing.B, useSelectionVector bool, hasNulls bool) {
+	defer log.Scope(b).Close(b)
 	ctx := context.Background()
 
 	typs := []*types.T{types.Int, types.Int}

--- a/pkg/sql/colexec/colexecutils/deselector_test.go
+++ b/pkg/sql/colexec/colexecutils/deselector_test.go
@@ -79,6 +79,7 @@ func TestDeselector(t *testing.T) {
 }
 
 func BenchmarkDeselector(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	rng, _ := randutil.NewPseudoRand()
 	ctx := context.Background()
 

--- a/pkg/sql/colexec/columnarizer_test.go
+++ b/pkg/sql/colexec/columnarizer_test.go
@@ -130,6 +130,7 @@ func TestColumnarizerDrainsAndClosesInput(t *testing.T) {
 }
 
 func BenchmarkColumnarize(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	types := []*types.T{types.Int, types.Int}
 	nRows := 10000
 	nCols := 2

--- a/pkg/sql/colexec/crossjoiner_test.go
+++ b/pkg/sql/colexec/crossjoiner_test.go
@@ -399,6 +399,7 @@ func TestCrossJoiner(t *testing.T) {
 }
 
 func BenchmarkCrossJoiner(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)

--- a/pkg/sql/colexec/distinct_test.go
+++ b/pkg/sql/colexec/distinct_test.go
@@ -342,6 +342,7 @@ func runDistinctBenchmarks(
 }
 
 func BenchmarkDistinct(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	ctx := context.Background()
 
 	distinctConstructors := []func(*colmem.Allocator, colexecop.Operator, []uint32, int, []*types.T) (colexecop.Operator, error){

--- a/pkg/sql/colexec/external_hash_joiner_test.go
+++ b/pkg/sql/colexec/external_hash_joiner_test.go
@@ -207,6 +207,7 @@ func newIntColumns(nCols int, length int) []coldata.Vec {
 }
 
 func BenchmarkExternalHashJoiner(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)

--- a/pkg/sql/colexec/hashjoiner_test.go
+++ b/pkg/sql/colexec/hashjoiner_test.go
@@ -1032,6 +1032,7 @@ func TestHashJoiner(t *testing.T) {
 }
 
 func BenchmarkHashJoiner(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	ctx := context.Background()
 	nCols := 4
 	sourceTypes := make([]*types.T, nCols)

--- a/pkg/sql/colexec/materializer_test.go
+++ b/pkg/sql/colexec/materializer_test.go
@@ -102,6 +102,7 @@ func TestColumnarizeMaterialize(t *testing.T) {
 }
 
 func BenchmarkMaterializer(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)
@@ -229,6 +230,7 @@ func TestMaterializerNextErrorAfterConsumerDone(t *testing.T) {
 }
 
 func BenchmarkColumnarizeMaterialize(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	types := []*types.T{types.Int, types.Int}
 	nRows := 10000
 	nCols := 2

--- a/pkg/sql/colexec/offset_test.go
+++ b/pkg/sql/colexec/offset_test.go
@@ -67,6 +67,7 @@ func TestOffset(t *testing.T) {
 }
 
 func BenchmarkOffset(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	ctx := context.Background()
 	typs := []*types.T{types.Int, types.Int, types.Int}
 	batch := testAllocator.NewMemBatchWithMaxCapacity(typs)

--- a/pkg/sql/colexec/ordered_synchronizer_test.go
+++ b/pkg/sql/colexec/ordered_synchronizer_test.go
@@ -198,6 +198,7 @@ func TestOrderedSyncRandomInput(t *testing.T) {
 }
 
 func BenchmarkOrderedSynchronizer(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	ctx := context.Background()
 
 	numInputs := int64(3)

--- a/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
@@ -195,6 +195,7 @@ func TestUnorderedSynchronizerNoLeaksOnError(t *testing.T) {
 }
 
 func BenchmarkParallelUnorderedSynchronizer(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	const numInputs = 6
 
 	typs := []*types.T{types.Int}

--- a/pkg/sql/colexec/select_in_test.go
+++ b/pkg/sql/colexec/select_in_test.go
@@ -99,6 +99,7 @@ func TestSelectInInt64(t *testing.T) {
 }
 
 func benchmarkSelectInInt64(b *testing.B, useSelectionVector bool, hasNulls bool) {
+	defer log.Scope(b).Close(b)
 	ctx := context.Background()
 	typs := []*types.T{types.Int}
 	batch := testAllocator.NewMemBatchWithMaxCapacity(typs)

--- a/pkg/sql/colexec/sort_chunks_test.go
+++ b/pkg/sql/colexec/sort_chunks_test.go
@@ -238,6 +238,7 @@ func TestSortChunksRandomized(t *testing.T) {
 }
 
 func BenchmarkSortChunks(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	rng, _ := randutil.NewPseudoRand()
 	ctx := context.Background()
 

--- a/pkg/sql/colexec/sort_test.go
+++ b/pkg/sql/colexec/sort_test.go
@@ -280,6 +280,7 @@ func TestAllSpooler(t *testing.T) {
 }
 
 func BenchmarkSort(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	rng, _ := randutil.NewPseudoRand()
 	ctx := context.Background()
 	k := uint64(128)
@@ -332,6 +333,7 @@ func BenchmarkSort(b *testing.B) {
 }
 
 func BenchmarkAllSpooler(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	rng, _ := randutil.NewPseudoRand()
 	ctx := context.Background()
 

--- a/pkg/sql/colflow/colrpc/BUILD.bazel
+++ b/pkg/sql/colflow/colrpc/BUILD.bazel
@@ -55,6 +55,7 @@ go_test(
         "//pkg/testutils",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
+        "//pkg/util/log",
         "//pkg/util/mon",
         "//pkg/util/randutil",
         "//pkg/util/stop",

--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -549,6 +550,7 @@ func TestOutboxInboxMetadataPropagation(t *testing.T) {
 }
 
 func BenchmarkOutboxInbox(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	ctx := context.Background()
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)

--- a/pkg/sql/rowexec/aggregator_test.go
+++ b/pkg/sql/rowexec/aggregator_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 type aggTestSpec struct {
@@ -395,6 +396,7 @@ func TestAggregator(t *testing.T) {
 }
 
 func BenchmarkAggregation(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	const numCols = 1
 	const numRows = 1000
 
@@ -451,6 +453,7 @@ func BenchmarkAggregation(b *testing.B) {
 }
 
 func BenchmarkCountRows(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	spec := &execinfrapb.AggregatorSpec{
 		Aggregations: []execinfrapb.AggregatorSpec_Aggregation{
 			{
@@ -487,6 +490,7 @@ func BenchmarkCountRows(b *testing.B) {
 }
 
 func BenchmarkGrouping(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	const numCols = 1
 	const numRows = 1000
 
@@ -520,6 +524,7 @@ func BenchmarkGrouping(b *testing.B) {
 }
 
 func benchmarkAggregationWithGrouping(b *testing.B, numOrderedCols int) {
+	defer log.Scope(b).Close(b)
 	const numCols = 3
 	const groupSize = 10
 	var groupedCols = [2]int{0, 1}

--- a/pkg/sql/rowexec/distinct_test.go
+++ b/pkg/sql/rowexec/distinct_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 func TestDistinct(t *testing.T) {
@@ -313,6 +314,7 @@ func TestDistinct(t *testing.T) {
 }
 
 func benchmarkDistinct(b *testing.B, orderedColumns []uint32) {
+	defer log.Scope(b).Close(b)
 	const numCols = 2
 
 	ctx := context.Background()

--- a/pkg/sql/rowexec/filterer_test.go
+++ b/pkg/sql/rowexec/filterer_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 func TestFilterer(t *testing.T) {
@@ -112,6 +113,7 @@ func TestFilterer(t *testing.T) {
 }
 
 func BenchmarkFilterer(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	const numRows = 1 << 16
 
 	ctx := context.Background()

--- a/pkg/sql/rowexec/hashjoiner_test.go
+++ b/pkg/sql/rowexec/hashjoiner_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
 
@@ -1448,6 +1449,7 @@ func TestHashJoinerDrainAfterBuildPhaseError(t *testing.T) {
 // variable size. There is a 1:1 relationship between the rows of each table.
 // TODO(asubiotto): More complex benchmarks.
 func BenchmarkHashJoiner(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)

--- a/pkg/sql/rowexec/mergejoiner_test.go
+++ b/pkg/sql/rowexec/mergejoiner_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 type mergeJoinerTestCase struct {
@@ -845,6 +846,7 @@ func TestConsumerClosed(t *testing.T) {
 }
 
 func BenchmarkMergeJoiner(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)

--- a/pkg/sql/rowexec/noop_test.go
+++ b/pkg/sql/rowexec/noop_test.go
@@ -21,9 +21,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 func BenchmarkNoop(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	const numRows = 1 << 16
 
 	ctx := context.Background()

--- a/pkg/sql/rowexec/ordinality_test.go
+++ b/pkg/sql/rowexec/ordinality_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 func TestOrdinality(t *testing.T) {
@@ -150,6 +151,7 @@ func TestOrdinality(t *testing.T) {
 }
 
 func BenchmarkOrdinality(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	const numCols = 2
 
 	ctx := context.Background()

--- a/pkg/sql/rowexec/project_set_test.go
+++ b/pkg/sql/rowexec/project_set_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 func TestProjectSet(t *testing.T) {
@@ -121,6 +122,7 @@ func TestProjectSet(t *testing.T) {
 
 func BenchmarkProjectSet(b *testing.B) {
 	defer leaktest.AfterTest(b)()
+	defer log.Scope(b).Close(b)
 
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)

--- a/pkg/sql/rowexec/sorter_test.go
+++ b/pkg/sql/rowexec/sorter_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
@@ -402,6 +403,7 @@ var twoColOrdering = execinfrapb.ConvertToSpecOrdering(colinfo.ColumnOrdering{
 
 // BenchmarkSortAll times how long it takes to sort an input of varying length.
 func BenchmarkSortAll(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	const numCols = 2
 
 	ctx := context.Background()
@@ -444,6 +446,7 @@ func BenchmarkSortAll(b *testing.B) {
 // BenchmarkSortLimit times how long it takes to sort a fixed size input with
 // varying limits.
 func BenchmarkSortLimit(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	const numCols = 2
 
 	ctx := context.Background()
@@ -490,6 +493,7 @@ func BenchmarkSortLimit(b *testing.B) {
 // BenchmarkSortChunks times how long it takes to sort an input which is already
 // sorted on a prefix.
 func BenchmarkSortChunks(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	const numCols = 2
 
 	ctx := context.Background()

--- a/pkg/sql/rowexec/values_test.go
+++ b/pkg/sql/rowexec/values_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
@@ -95,6 +96,7 @@ func TestValuesProcessor(t *testing.T) {
 }
 
 func BenchmarkValuesProcessor(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	const numCols = 2
 
 	ctx := context.Background()

--- a/pkg/sql/rowexec/windower_test.go
+++ b/pkg/sql/rowexec/windower_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 )
 
@@ -156,6 +157,7 @@ func windows(windowTestSpecs []windowTestSpec) ([]execinfrapb.WindowerSpec, erro
 }
 
 func BenchmarkWindower(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	const numCols = 3
 	const numRows = 100000
 


### PR DESCRIPTION
This commits adds `defer log.Scope(b).Close(b)` to some benchmarks in
`bench`, `colexec`, and `rowexec` packages. Note that in some cases this
might not matter, but I didn't think through each carefully since it
shouldn't do any harm.

Release note: None