### PR TITLE
release-21.1: add crdb_internal.validate_multi_region_zone_configs builtin

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -873,6 +873,16 @@ has no relationship with the commit order of concurrent transactions.</p>
 <table>
 <thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
 <tbody>
+<tr><td><a name="crdb_internal.filter_multiregion_fields_from_zone_config_sql"></a><code>crdb_internal.filter_multiregion_fields_from_zone_config_sql(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Takes in a CONFIGURE ZONE SQL statement and returns a modified
+SQL statement omitting multi-region related zone configuration fields.
+If the CONFIGURE ZONE statement can be inferred by the database’s or
+table’s zone configuration this will return NULL.</p>
+</span></td></tr>
+<tr><td><a name="crdb_internal.validate_multi_region_zone_configs"></a><code>crdb_internal.validate_multi_region_zone_configs() &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Validates all multi-region zone configurations are correctly setup
+for the current database, including all tables, indexes and partitions underneath.
+Returns an error if validation fails. This builtin uses un-leased versions of the
+each descriptor, requiring extra round trips.</p>
+</span></td></tr>
 <tr><td><a name="default_to_database_primary_region"></a><code>default_to_database_primary_region(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the given region if the region has been added to the current database.
 Otherwise, this will return the primary region of the current database.
 This will error if the current database is not a multi-region database.</p>
@@ -2371,11 +2381,6 @@ The swap_ordinate_string parameter is a 2-character string naming the ordinates 
 <tr><td><a name="convert_from"></a><code>convert_from(str: <a href="bytes.html">bytes</a>, enc: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Decode the bytes in <code>str</code> into a string using encoding <code>enc</code>. Supports encodings ‘UTF8’ and ‘LATIN1’.</p>
 </span></td></tr>
 <tr><td><a name="convert_to"></a><code>convert_to(str: <a href="string.html">string</a>, enc: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Encode the string <code>str</code> as a byte array using encoding <code>enc</code>. Supports encodings ‘UTF8’ and ‘LATIN1’.</p>
-</span></td></tr>
-<tr><td><a name="crdb_internal.filter_multiregion_fields_from_zone_config_sql"></a><code>crdb_internal.filter_multiregion_fields_from_zone_config_sql(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Takes in a CONFIGURE ZONE SQL statement and returns a modified
-SQL statement omitting multi-region related zone configuration fields.
-If the CONFIGURE ZONE statement can be inferred by the database’s or
-table’s zone configuration this will return NULL.</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.show_create_all_tables"></a><code>crdb_internal.show_create_all_tables(database_name: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns rows of CREATE table statements followed by
 ALTER table statements that add table constraints. The rows are ordered

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -223,6 +223,13 @@ func (so *importSequenceOperators) CurrentDatabaseRegionConfig(
 	return nil, errors.WithStack(errSequenceOperators)
 }
 
+// ValidateAllMultiRegionZoneConfigsInCurrentDatabase is part of the tree.EvalDatabase interface.
+func (so *importSequenceOperators) ValidateAllMultiRegionZoneConfigsInCurrentDatabase(
+	_ context.Context,
+) error {
+	return errors.WithStack(errSequenceOperators)
+}
+
 // Implements the tree.EvalDatabase interface.
 func (so *importSequenceOperators) ParseQualifiedTableName(sql string) (*tree.TableName, error) {
 	name, err := parser.ParseTableName(sql)

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
@@ -8,10 +8,16 @@ ca-central-1    {ca-az1,ca-az2,ca-az3}  {}  {}
 us-east-1       {us-az1,us-az2,us-az3}  {}  {}
 
 statement ok
+SELECT crdb_internal.validate_multi_region_zone_configs()
+
+statement ok
 CREATE DATABASE "mr-zone-configs" primary region "ca-central-1" regions "ap-southeast-2", "us-east-1"
 
 statement ok
 use "mr-zone-configs"
+
+statement ok
+SELECT crdb_internal.validate_multi_region_zone_configs()
 
 statement ok
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING gc.ttlseconds = 5
@@ -31,6 +37,9 @@ DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USIN
                             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
                             voter_constraints = '[+region=ca-central-1]',
                             lease_preferences = '[[+region=ca-central-1]]'
+
+statement ok
+SELECT crdb_internal.validate_multi_region_zone_configs()
 
 statement error attempting to modify protected field "num_voters" of a multi-region zone configuration
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING num_voters = 5
@@ -52,6 +61,9 @@ statement ok
 SET override_multi_region_zone_config = true;
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING num_voters = 5;
 SET override_multi_region_zone_config = false
+
+statement error zone configuration for database "mr-zone-configs" contains incorrectly configured field "num_voters"
+SELECT crdb_internal.validate_multi_region_zone_configs()
 
 query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
@@ -308,6 +320,9 @@ CREATE TABLE regional_by_table (
 statement ok
 ALTER table regional_by_row CONFIGURE ZONE USING gc.ttlseconds = 10
 
+statement ok
+SELECT crdb_internal.validate_multi_region_zone_configs()
+
 statement error attempting to modify protected field "num_replicas" of a multi-region zone configuration
 ALTER table regional_by_row CONFIGURE ZONE USING num_replicas = 10
 
@@ -315,6 +330,9 @@ statement ok
 SET override_multi_region_zone_config = true;
 ALTER table regional_by_row CONFIGURE ZONE USING num_replicas = 10;
 SET override_multi_region_zone_config = false
+
+statement error zone configuration for table regional_by_row contains incorrectly configured field "num_replicas"
+SELECT crdb_internal.validate_multi_region_zone_configs()
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
@@ -361,7 +379,7 @@ num_voters = 3,
 voter_constraints = '[+region=us-east-1]',
 lease_preferences = '[[+region=us-east-1]]'  regional_by_row@regional_by_row_i_idx  us-east-1
 
-statement error attempting to update zone configuration for table "regional_by_row" which contains modified field "num_replicas"
+statement error attempting to update zone configuration for table regional_by_row which contains modified field "num_replicas"
 ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY TABLE
 
 statement ok
@@ -423,6 +441,9 @@ statement ok
 ALTER TABLE regional_by_row SET LOCALITY GLOBAL
 
 statement ok
+SELECT crdb_internal.validate_multi_region_zone_configs()
+
+statement ok
 SET override_multi_region_zone_config = true;
 ALTER index regional_by_row@primary CONFIGURE ZONE USING num_replicas = 10;
 SET override_multi_region_zone_config = false
@@ -430,7 +451,10 @@ SET override_multi_region_zone_config = false
 statement ok
 ALTER TABLE regional_by_row SET LOCALITY GLOBAL
 
-statement error attempting to update zone configuration for table "regional_by_row" which contains a zone configuration on index "primary"
+statement error zone configuration for index regional_by_row@"primary" contains incorrectly configured field "num_replicas"
+SELECT crdb_internal.validate_multi_region_zone_configs()
+
+statement error attempting to update zone configuration for index regional_by_row@"primary" which contains modified field "num_replicas"
 ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY ROW
 
 statement ok
@@ -465,7 +489,7 @@ INDEX regional_by_row_as@primary  ALTER INDEX regional_by_row_as@primary CONFIGU
                                   voter_constraints = '[+region=us-east-1]',
                                   lease_preferences = '[[+region=us-east-1]]'
 
-statement error attempting to update zone configuration for table "regional_by_row_as" which contains a zone configuration on index "primary" with multi-region field "num_replicas" set
+statement error attempting to update zone configuration for index regional_by_row_as@"primary" which contains modified field "num_replicas"
 ALTER TABLE regional_by_row_as SET LOCALITY REGIONAL BY ROW
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
@@ -435,10 +435,46 @@ TABLE regional_by_row  ALTER TABLE regional_by_row CONFIGURE ZONE USING
                        lease_preferences = '[[+region=us-east-1]]'
 
 statement ok
-ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY ROW
+DROP TABLE regional_by_row; CREATE TABLE regional_by_row (
+  pk INT PRIMARY KEY,
+  i INT,
+  INDEX idx(i),
+  FAMILY (pk, i)
+) LOCALITY REGIONAL BY ROW
 
 statement ok
+ALTER PARTITION "ap-southeast-2" OF INDEX regional_by_row@idx CONFIGURE ZONE USING gc.ttlseconds = 10;
+ALTER INDEX regional_by_row@idx CONFIGURE ZONE USING gc.ttlseconds = 10
+
+statement ok
+SELECT crdb_internal.validate_multi_region_zone_configs()
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER PARTITION "ap-southeast-2" OF INDEX regional_by_row@idx CONFIGURE ZONE USING num_replicas = 10;
+SET override_multi_region_zone_config = false
+
+statement error zone configuration for partition "ap-southeast-2" of regional_by_row@idx contains incorrectly configured field "num_replicas"
+SELECT crdb_internal.validate_multi_region_zone_configs()
+
+statement error attempting to update zone configuration for partition "ap-southeast-2" of regional_by_row@idx which contains modified field "num_replicas"
 ALTER TABLE regional_by_row SET LOCALITY GLOBAL
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER PARTITION "ap-southeast-2" OF INDEX regional_by_row@idx CONFIGURE ZONE DISCARD;
+SET override_multi_region_zone_config = false
+
+statement error missing zone configuration for partition "ap-southeast-2" of regional_by_row@idx
+SELECT crdb_internal.validate_multi_region_zone_configs()
+
+statement error attempting to update zone config which is missing an expected zone configuration for partition "ap-southeast-2" of regional_by_row@idx
+ALTER TABLE regional_by_row SET LOCALITY GLOBAL
+
+statement ok
+SET override_multi_region_zone_config = true;
+ALTER TABLE regional_by_row SET LOCALITY GLOBAL;
+SET override_multi_region_zone_config = false
 
 statement ok
 SELECT crdb_internal.validate_multi_region_zone_configs()
@@ -448,13 +484,13 @@ SET override_multi_region_zone_config = true;
 ALTER index regional_by_row@primary CONFIGURE ZONE USING num_replicas = 10;
 SET override_multi_region_zone_config = false
 
-statement ok
+statement error attempting to update zone config which contains an extra zone configuration for index regional_by_row@"primary"
 ALTER TABLE regional_by_row SET LOCALITY GLOBAL
 
-statement error zone configuration for index regional_by_row@"primary" contains incorrectly configured field "num_replicas"
+statement error extraneous zone configuration for index regional_by_row@"primary"
 SELECT crdb_internal.validate_multi_region_zone_configs()
 
-statement error attempting to update zone configuration for index regional_by_row@"primary" which contains modified field "num_replicas"
+statement error attempting to update zone config which contains an extra zone configuration for index regional_by_row@"primary"
 ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY ROW
 
 statement ok
@@ -489,7 +525,7 @@ INDEX regional_by_row_as@primary  ALTER INDEX regional_by_row_as@primary CONFIGU
                                   voter_constraints = '[+region=us-east-1]',
                                   lease_preferences = '[[+region=us-east-1]]'
 
-statement error attempting to update zone configuration for index regional_by_row_as@"primary" which contains modified field "num_replicas"
+statement error attempting to update zone config which contains an extra zone configuration for index regional_by_row_as@"primary"
 ALTER TABLE regional_by_row_as SET LOCALITY REGIONAL BY ROW
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -1601,6 +1601,9 @@ DATABASE add_regions  ALTER DATABASE add_regions CONFIGURE ZONE USING
 statement ok
 ALTER DATABASE add_regions ADD REGION "us-east-1"
 
+statement ok
+SELECT crdb_internal.validate_multi_region_zone_configs()
+
 query TT
 SHOW CREATE TABLE regional_by_row
 ----

--- a/pkg/sql/alter_table_locality.go
+++ b/pkg/sql/alter_table_locality.go
@@ -470,13 +470,13 @@ func (n *alterTableSetLocalityNode) startExec(params runParams) error {
 		),
 	)
 
-	toRegionalByRow := newLocality.LocalityLevel == tree.LocalityLevelRow
+	// We should check index zone configs if moving to REGIONAL BY ROW.
+	checkIndexZoneConfigs := newLocality.LocalityLevel == tree.LocalityLevelRow
 	if err := params.p.validateZoneConfigForMultiRegionTableWasNotModifiedByUser(
 		params.ctx,
 		n.dbDesc,
 		n.tableDesc,
-		toRegionalByRow,
-		ApplyZoneConfigForMultiRegionTableOptionTableAndIndexes,
+		checkIndexZoneConfigs,
 	); err != nil {
 		return err
 	}

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -51,6 +51,13 @@ func (so *DummySequenceOperators) CurrentDatabaseRegionConfig(
 	return nil, errors.WithStack(errSequenceOperators)
 }
 
+// ValidateAllMultiRegionZoneConfigsInCurrentDatabase is part of the tree.EvalDatabase interface.
+func (so *DummySequenceOperators) ValidateAllMultiRegionZoneConfigsInCurrentDatabase(
+	_ context.Context,
+) error {
+	return errors.WithStack(errSequenceOperators)
+}
+
 // ParseQualifiedTableName is part of the tree.EvalDatabase interface.
 func (so *DummySequenceOperators) ParseQualifiedTableName(sql string) (*tree.TableName, error) {
 	return nil, errors.WithStack(errSequenceOperators)
@@ -184,6 +191,13 @@ func (ep *DummyEvalPlanner) CurrentDatabaseRegionConfig(
 	_ context.Context,
 ) (tree.DatabaseRegionConfig, error) {
 	return nil, errors.WithStack(errEvalPlanner)
+}
+
+// ValidateAllMultiRegionZoneConfigsInCurrentDatabase is part of the tree.EvalDatabase interface.
+func (ep *DummyEvalPlanner) ValidateAllMultiRegionZoneConfigsInCurrentDatabase(
+	_ context.Context,
+) error {
+	return errors.WithStack(errEvalPlanner)
 }
 
 // ParseQualifiedTableName is part of the tree.EvalDatabase interface.

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -5027,8 +5027,28 @@ the locality flag on node startup. Returns an error if no region is set.`,
 			tree.VolatilityStable,
 		),
 	),
+	"crdb_internal.validate_multi_region_zone_configs": makeBuiltin(
+		tree.FunctionProperties{Category: categoryMultiRegion},
+		tree.Overload{
+			Types:      tree.ArgTypes{},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				if err := evalCtx.Sequence.ValidateAllMultiRegionZoneConfigsInCurrentDatabase(
+					evalCtx.Context,
+				); err != nil {
+					return nil, err
+				}
+				return tree.MakeDBool(true), nil
+			},
+			Info: `Validates all multi-region zone configurations are correctly setup
+			for the current database, including all tables, indexes and partitions underneath.
+			Returns an error if validation fails. This builtin uses un-leased versions of the
+			each descriptor, requiring extra round trips.`,
+			Volatility: tree.VolatilityVolatile,
+		},
+	),
 	"crdb_internal.filter_multiregion_fields_from_zone_config_sql": makeBuiltin(
-		tree.FunctionProperties{},
+		tree.FunctionProperties{Category: categoryMultiRegion},
 		stringOverload1(
 			func(evalCtx *tree.EvalContext, s string) (tree.Datum, error) {
 				stmt, err := parser.ParseOne(s)

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3017,6 +3017,11 @@ type EvalDatabase interface {
 	// session database.
 	CurrentDatabaseRegionConfig(ctx context.Context) (DatabaseRegionConfig, error)
 
+	// ValidateAllMultiRegionZoneConfigsInCurrentDatabase validates whether the current
+	// database's multi-region zone configs are correctly setup. This includes
+	// all tables within the database.
+	ValidateAllMultiRegionZoneConfigsInCurrentDatabase(ctx context.Context) error
+
 	// ParseQualifiedTableName parses a SQL string of the form
 	// `[ database_name . ] [ schema_name . ] table_name`.
 	// NB: this is deprecated! Use parser.ParseQualifiedTableName when possible.


### PR DESCRIPTION
Backport:
  * 1/1 commits from "sql: add crdb_internal.validate_multi_region_zone_configs builtin" (#62780)
  * 1/1 commits from "zonepb: make subzone DiffWithZone more accurate" (#62839)

Please see individual PRs for details.

/cc @cockroachdb/release
