### PR TITLE
release-20.1: build: use -json for RandomSyntax test

### DIFF
--- a/build/teamcity-random-syntax.sh
+++ b/build/teamcity-random-syntax.sh
@@ -14,6 +14,7 @@ tc_start_block "Run Random Syntax tests"
 USE_BUILDER_IMAGE=20210205-000935 run_json_test build/builder.sh stdbuf -oL -eL make test \
   PKG=./pkg/sql/tests \
   TESTS=TestRandomSyntax \
+  GOTESTFLAGS=-json \
   TESTFLAGS='-v -rsg=5m -rsg-routines=8 -rsg-exec-timeout=1m' \
   TESTTIMEOUT=1h
 tc_end_block "Run Random Syntax tests"


### PR DESCRIPTION
Backport 1/1 commits from #62872.

/cc @cockroachdb/release

---

I'm hoping this will help out with an issue where the test failures seem
to be missing helpful logs.

Release note: None
