### PR TITLE
release-20.1: opt: fix internal error when calculating stats for mutation passthrough cols

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats/update
+++ b/pkg/sql/opt/memo/testdata/stats/update
@@ -123,3 +123,90 @@ update xyz
       │         └── false [type=bool]
       └── projections
            └── 'foo' [as=column7:7, type=string]
+
+# Regression test for #62692. Ensure we don't error when calculating stats for
+# mutation passthrough columns
+
+exec-ddl
+CREATE TABLE parent (p INT PRIMARY KEY)
+----
+
+exec-ddl
+CREATE TABLE child (x INT, c INT REFERENCES parent (p))
+----
+
+build
+WITH q AS (UPDATE child SET c = p FROM parent WHERE p = 1 RETURNING p) SELECT * FROM q WHERE p = 1
+----
+with &2 (q)
+ ├── columns: p:10(int!null)
+ ├── side-effects, mutations
+ ├── stats: [rows=1000, distinct(10)=1, null(10)=0]
+ ├── fd: ()-->(10)
+ ├── project
+ │    ├── columns: parent.p:7(int)
+ │    ├── side-effects, mutations
+ │    ├── stats: [rows=1000, distinct(7)=1, null(7)=0]
+ │    ├── fd: ()-->(7)
+ │    └── update child
+ │         ├── columns: x:1(int) c:2(int!null) rowid:3(int!null) parent.p:7(int)
+ │         ├── fetch columns: x:4(int) c:5(int) rowid:6(int)
+ │         ├── update-mapping:
+ │         │    └── parent.p:7 => c:2
+ │         ├── input binding: &1
+ │         ├── side-effects, mutations
+ │         ├── stats: [rows=1000, distinct(7)=1, null(7)=0]
+ │         ├── key: (3)
+ │         ├── fd: ()-->(2,7), (2)==(7), (7)==(2), (3)-->(1)
+ │         ├── select
+ │         │    ├── columns: x:4(int) c:5(int) rowid:6(int!null) parent.p:7(int!null)
+ │         │    ├── stats: [rows=1000, distinct(7)=1, null(7)=0]
+ │         │    ├── key: (6)
+ │         │    ├── fd: ()-->(7), (6)-->(4,5)
+ │         │    ├── inner-join (cross)
+ │         │    │    ├── columns: x:4(int) c:5(int) rowid:6(int!null) parent.p:7(int!null)
+ │         │    │    ├── stats: [rows=1000000, distinct(6)=1000, null(6)=0, distinct(7)=1000, null(7)=0]
+ │         │    │    ├── key: (6,7)
+ │         │    │    ├── fd: (6)-->(4,5)
+ │         │    │    ├── scan child
+ │         │    │    │    ├── columns: x:4(int) c:5(int) rowid:6(int!null)
+ │         │    │    │    ├── stats: [rows=1000, distinct(6)=1000, null(6)=0]
+ │         │    │    │    ├── key: (6)
+ │         │    │    │    └── fd: (6)-->(4,5)
+ │         │    │    ├── scan parent
+ │         │    │    │    ├── columns: parent.p:7(int!null)
+ │         │    │    │    ├── stats: [rows=1000, distinct(7)=1000, null(7)=0]
+ │         │    │    │    └── key: (7)
+ │         │    │    └── filters (true)
+ │         │    └── filters
+ │         │         └── parent.p:7 = 1 [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
+ │         └── f-k-checks
+ │              └── f-k-checks-item: child(c) -> parent(p)
+ │                   └── anti-join (hash)
+ │                        ├── columns: p:8(int!null)
+ │                        ├── stats: [rows=1e-10]
+ │                        ├── fd: ()-->(8)
+ │                        ├── with-scan &1
+ │                        │    ├── columns: p:8(int!null)
+ │                        │    ├── mapping:
+ │                        │    │    └──  parent.p:7(int) => p:8(int)
+ │                        │    ├── stats: [rows=1000, distinct(8)=1, null(8)=0]
+ │                        │    └── fd: ()-->(8)
+ │                        ├── scan parent
+ │                        │    ├── columns: parent.p:9(int!null)
+ │                        │    ├── stats: [rows=1000, distinct(9)=1000, null(9)=0]
+ │                        │    └── key: (9)
+ │                        └── filters
+ │                             └── p:8 = parent.p:9 [type=bool, outer=(8,9), constraints=(/8: (/NULL - ]; /9: (/NULL - ]), fd=(8)==(9), (9)==(8)]
+ └── select
+      ├── columns: p:10(int!null)
+      ├── stats: [rows=1000, distinct(10)=1, null(10)=0]
+      ├── fd: ()-->(10)
+      ├── with-scan &2 (q)
+      │    ├── columns: p:10(int)
+      │    ├── mapping:
+      │    │    └──  parent.p:7(int) => p:10(int)
+      │    ├── stats: [rows=1000, distinct(10)=1, null(10)=0]
+      │    └── fd: ()-->(10)
+      └── filters
+           └── p:10 = 1 [type=bool, outer=(10), constraints=(/10: [/1 - /1]; tight), fd=()-->(10)]


### PR DESCRIPTION
Backport 1/1 commits from #62921.

/cc @cockroachdb/release

---

Prior to this commit, an attempt to calculate statistics for a passthrough
column in a mutation would cause an error, since passthrough columns were
inadvertently ignored by the `MapToInputCols` function. This commit fixes
the problem by updating `MapToInputCols` so that it checks whether any of the
given columns are in `PassthroughCols` before trying to map them to a table
column.

Fixes #62692

Release note (bug fix): Fixed an internal error that could occur during
planning when a query used the output of an UPDATE's RETURNING clause,
and one or more of the columns in the RETURNING clause were from a table
specified in the FROM clause of the UPDATE (i.e., not from the table being
updated).
