### PR TITLE
release-21.1: roachtest: remove cdc/poller/rangefeed=false

### DIFF
--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -610,20 +610,6 @@ func registerCDC(r *testRegistry) {
 		},
 	})
 	r.Add(testSpec{
-		Name:    "cdc/poller/rangefeed=false",
-		Owner:   OwnerCDC,
-		Cluster: makeClusterSpec(4, cpu(16)),
-		Run: func(ctx context.Context, t *test, c *cluster) {
-			cdcBasicTest(ctx, t, c, cdcTestArgs{
-				workloadType:             tpccWorkloadType,
-				tpccWarehouseCount:       1000,
-				workloadDuration:         "30m",
-				targetInitialScanLatency: 30 * time.Minute,
-				targetSteadyLatency:      2 * time.Minute,
-			})
-		},
-	})
-	r.Add(testSpec{
 		Name:    "cdc/sink-chaos",
 		Owner:   `cdc`,
 		Cluster: makeClusterSpec(4, cpu(16)),


### PR DESCRIPTION
Backport 1/1 commits from #62744.

/cc @cockroachdb/release

---

Closes #62064. This isn't fixed, but consolidating to #61992.

This should have been removed in 8a81eac. The test is now effectively
identical to `cdc/tpcc-1000`, just less aggressive in its assertions.
