### PR TITLE
release-21.1: sql: gate global_reads zone attribute on cluster version and enterprise license

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_mixed_20.2_21.1
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_mixed_20.2_21.1
@@ -26,3 +26,21 @@ CREATE TABLE t()
 
 statement error cannot alter a table's LOCALITY if its database is not multi-region enabled
 ALTER TABLE t SET LOCALITY REGIONAL BY ROW
+
+statement error pgcode 0A000 global_reads cannot be used until cluster version is finalized
+ALTER TABLE t CONFIGURE ZONE USING global_reads = true
+
+statement error pgcode 0A000 global_reads cannot be used until cluster version is finalized
+ALTER TABLE t CONFIGURE ZONE USING global_reads = false
+
+statement error pgcode 0A000 num_voters cannot be used until cluster version is finalized
+ALTER TABLE t CONFIGURE ZONE USING num_voters = 3
+
+statement error pgcode 0A000 num_voters cannot be used until cluster version is finalized
+ALTER TABLE t CONFIGURE ZONE USING num_voters = 0
+
+statement error pgcode 0A000 voter_constraints cannot be used until cluster version is finalized
+ALTER TABLE t CONFIGURE ZONE USING voter_constraints = '[+region=us-east-1]'
+
+statement error pgcode 0A000 voter_constraints cannot be used until cluster version is finalized
+ALTER TABLE t CONFIGURE ZONE USING voter_constraints = ''

--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -1126,3 +1126,32 @@ ALTER PARTITION p3 OF INDEX test.public.t@i2 CONFIGURE ZONE USING
   gc.ttlseconds = 15411;
 ALTER PARTITION p4 OF INDEX test.public.t@i2 CONFIGURE ZONE USING
   gc.ttlseconds = 15418
+
+# Test that the global_reads attribute can be set with an enterprise license.
+# This same test fails in pkg/sql/logictest/testdata/logic_test/zone_config.
+statement ok
+CREATE TABLE global (id INT PRIMARY KEY)
+
+statement ok
+ALTER TABLE global CONFIGURE ZONE USING global_reads = true
+
+# This should reflect in the metrics.
+query T
+SELECT feature_name FROM crdb_internal.feature_usage
+WHERE feature_name IN (
+  'sql.schema.zone_config.table.global_reads'
+) AND usage_count > 0 ORDER BY feature_name
+----
+sql.schema.zone_config.table.global_reads
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE global
+----
+TABLE global  ALTER TABLE global CONFIGURE ZONE USING
+              range_min_bytes = 134217728,
+              range_max_bytes = 536870912,
+              gc.ttlseconds = 90000,
+              global_reads = true,
+              num_replicas = 7,
+              constraints = '[]',
+              lease_preferences = '[]'

--- a/pkg/ccl/multiregionccl/multiregion_test.go
+++ b/pkg/ccl/multiregionccl/multiregion_test.go
@@ -114,3 +114,46 @@ CREATE TABLE t4 () LOCALITY REGIONAL BY ROW
 		}
 	})
 }
+
+func TestGlobalReadsAfterEnterpriseDisabled(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	defer utilccl.TestingEnableEnterprise()()
+
+	_, sqlDB, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
+		t, 1 /* numServers */, base.TestingKnobs{}, nil, /* baseDir */
+	)
+	defer cleanup()
+
+	for _, setupQuery := range []string{
+		`CREATE DATABASE test`,
+		`USE test`,
+		`CREATE TABLE t1 ()`,
+		`CREATE TABLE t2 ()`,
+	} {
+		_, err := sqlDB.Exec(setupQuery)
+		require.NoError(t, err)
+	}
+
+	// Can set global_reads with enterprise license enabled.
+	_, err := sqlDB.Exec(`ALTER TABLE t1 CONFIGURE ZONE USING global_reads = true`)
+	require.NoError(t, err)
+
+	_, err = sqlDB.Exec(`ALTER TABLE t2 CONFIGURE ZONE USING global_reads = true`)
+	require.NoError(t, err)
+
+	// Can unset global_reads with enterprise license enabled.
+	_, err = sqlDB.Exec(`ALTER TABLE t1 CONFIGURE ZONE USING global_reads = false`)
+	require.NoError(t, err)
+
+	defer utilccl.TestingDisableEnterprise()()
+
+	// Cannot set global_reads with enterprise license disabled.
+	_, err = sqlDB.Exec(`ALTER TABLE t1 CONFIGURE ZONE USING global_reads = true`)
+	require.Error(t, err)
+	require.Regexp(t, "use of global_reads requires an enterprise license", err)
+
+	// Can unset global_reads with enterprise license disabled.
+	_, err = sqlDB.Exec(`ALTER TABLE t2 CONFIGURE ZONE USING global_reads = false`)
+	require.NoError(t, err)
+}

--- a/pkg/sql/logictest/testdata/logic_test/zone_config
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config
@@ -75,7 +75,6 @@ ALTER TABLE a CONFIGURE ZONE USING
   range_min_bytes = 200000 + 1,
   range_max_bytes = 300000 + 1,
   gc.ttlseconds = 3000 + 600,
-  global_reads = true,
   num_replicas = floor(1.2)::int,
   constraints = '[+region=test]',
   lease_preferences = '[[+region=test]]'
@@ -87,14 +86,12 @@ WHERE feature_name IN (
   'sql.schema.zone_config.table.range_min_bytes',
   'sql.schema.zone_config.table.range_max_bytes',
   'sql.schema.zone_config.table.gc.ttlseconds',
-  'sql.schema.zone_config.table.global_reads',
   'sql.schema.zone_config.table.num_replicas',
   'sql.schema.zone_config.table.constraints'
 ) AND usage_count > 0 ORDER BY feature_name
 ----
 sql.schema.zone_config.table.constraints
 sql.schema.zone_config.table.gc.ttlseconds
-sql.schema.zone_config.table.global_reads
 sql.schema.zone_config.table.num_replicas
 sql.schema.zone_config.table.range_max_bytes
 sql.schema.zone_config.table.range_min_bytes
@@ -106,7 +103,6 @@ SELECT zone_id, raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR TABLE a]
     range_min_bytes = 200001,
     range_max_bytes = 300001,
     gc.ttlseconds = 3600,
-    global_reads = true,
     num_replicas = 1,
     constraints = '[+region=test]',
     lease_preferences = '[[+region=test]]'
@@ -122,7 +118,6 @@ SELECT zone_id, raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR TABLE a]
     range_min_bytes = 200001,
     range_max_bytes = 400000,
     gc.ttlseconds = 3600,
-    global_reads = true,
     num_replicas = 1,
     constraints = '[+region=test]',
     lease_preferences = '[[+region=test]]'
@@ -159,7 +154,6 @@ SELECT zone_id, raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR TABLE a]
     range_min_bytes = 200001,
     range_max_bytes = 400000,
     gc.ttlseconds = 3600,
-    global_reads = true,
     num_replicas = 1,
     constraints = '[+region=test]',
     lease_preferences = '[[+region=test]]'
@@ -265,6 +259,10 @@ SELECT zone_id, raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR TABLE a]
     constraints = '[]',
     voter_constraints = '{+region=test: 1}',
     lease_preferences = '[]'
+
+# Check that global_reads cannot be set without a CCL binary and enterprise license.
+statement error OSS binaries do not include enterprise features
+ALTER TABLE a CONFIGURE ZONE USING global_reads = true
 
 # Check entities for which we can set zone configs.
 subtest test_entity_validity


### PR DESCRIPTION
Backport 1/1 commits from #62764.

/cc @cockroachdb/release

---

Fixes #61039.

This commit gates the use of the global_reads zone configuration
attribute on the cluster version and on the use of an enterprise
license.

The first half of this is necessary for correctness. The second half is
not, because follower reads won't be served from global read followers
without an enterprise license, but a check when the zone configs are set
improves UX.
