### PR TITLE
release-21.1: roachtest: fix log depth for test status

### DIFF
--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -181,9 +181,9 @@ func (t *test) status(ctx context.Context, id int64, args ...interface{}) {
 	}
 	if !t.l.closed() {
 		if id == t.runnerID {
-			t.l.PrintfCtxDepth(ctx, 2, "test status: %s", msg)
+			t.l.PrintfCtxDepth(ctx, 3, "test status: %s", msg)
 		} else {
-			t.l.PrintfCtxDepth(ctx, 2, "test worker status: %s", msg)
+			t.l.PrintfCtxDepth(ctx, 3, "test worker status: %s", msg)
 		}
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #61940.

/cc @cockroachdb/release

---

The number of stack frames to be skipped was not computed correctly when
t.Status() was logging. All the messages indicated that they were coming
from the t.Status() function, instead of indicating the caller.

Release note: None
