### PR TITLE
release-21.1: go.mod: bump etcd/raft to pick up proto size improvements

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -387,8 +387,8 @@ def go_deps():
         name = "com_github_certifi_gocertifi",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/certifi/gocertifi",
-        sum = "h1:xvUo53O5MRZhVMJAxWCJcS5HHrqAiAG9SJ1LpMu6aAI=",
-        version = "v0.0.0-20191021191039-0944d244cd40",
+        sum = "h1:uH66TXeswKn5PW5zdZ39xEwfS9an067BirqA+P4QaLI=",
+        version = "v0.0.0-20200922220541-2c3bb06c6054",
     )
     go_repository(
         name = "com_github_cespare_xxhash_v2",
@@ -3730,8 +3730,8 @@ def go_deps():
         patches = [
             "@cockroach//build/patches:io_etcd_go_etcd_raft_v3.patch",
         ],
-        sum = "h1:W9sYVQfb5q8/WMnlTkjpYK8CwMfGCU6Tp9mR+Qm6NFU=",
-        version = "v3.0.0-20210215124703-719f6ce06fbc",
+        sum = "h1:aRP8pJvbOsFy8SaZ0tcWeV4RYTlp8ZIWS49usJjO4Ac=",
+        version = "v3.0.0-20210320072418-e51c697ec6e8",
     )
     go_repository(
         name = "io_k8s_api",

--- a/go.mod
+++ b/go.mod
@@ -144,7 +144,7 @@ require (
 	github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad
 	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c
 	github.com/zabawaba99/go-gitignore v0.0.0-20200117185801-39e6bddfb292
-	go.etcd.io/etcd/raft/v3 v3.0.0-20210215124703-719f6ce06fbc
+	go.etcd.io/etcd/raft/v3 v3.0.0-20210320072418-e51c697ec6e8
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 	golang.org/x/exp v0.0.0-20210212053707-62dc52270d37
 	golang.org/x/lint v0.0.0-20200130185559-910be7a94367

--- a/go.sum
+++ b/go.sum
@@ -165,6 +165,7 @@ github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QH
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
+github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
@@ -1007,8 +1008,8 @@ go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738 h1:VcrIfasaLFkyjk6KNlXQSzO+B0
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.etcd.io/etcd/pkg/v3 v3.0.0-20201109164711-01844fd28560 h1:U/PIBuOTa8JXLPKF81Xh7xhIjA0jbpyqFWUPIiT4Ilc=
 go.etcd.io/etcd/pkg/v3 v3.0.0-20201109164711-01844fd28560/go.mod h1:0HiXlybqS+XtfgnNkiEZWwGXYYEhWsWL8fDVdZzb7is=
-go.etcd.io/etcd/raft/v3 v3.0.0-20210215124703-719f6ce06fbc h1:W9sYVQfb5q8/WMnlTkjpYK8CwMfGCU6Tp9mR+Qm6NFU=
-go.etcd.io/etcd/raft/v3 v3.0.0-20210215124703-719f6ce06fbc/go.mod h1:lOAojD+joNvQ+1WBvyjLbjEwCDgymdjYYZdkI6uddZ4=
+go.etcd.io/etcd/raft/v3 v3.0.0-20210320072418-e51c697ec6e8 h1:aRP8pJvbOsFy8SaZ0tcWeV4RYTlp8ZIWS49usJjO4Ac=
+go.etcd.io/etcd/raft/v3 v3.0.0-20210320072418-e51c697ec6e8/go.mod h1:i+srOieUHQl4y/EwlGOpuYtoKG7nb2uhtA/hrFsFTsc=
 go.mongodb.org/mongo-driver v1.0.3/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.mongodb.org/mongo-driver v1.1.1/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.mongodb.org/mongo-driver v1.1.2/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=

--- a/pkg/kv/kvserver/below_raft_protos_test.go
+++ b/pkg/kv/kvserver/below_raft_protos_test.go
@@ -83,12 +83,9 @@ var belowRaftGoldenProtos = map[reflect.Type]fixture{
 	reflect.TypeOf(&raftpb.HardState{}): {
 		populatedConstructor: func(r *rand.Rand) protoutil.Message {
 			type expectedHardState struct {
-				Term                 uint64
-				Vote                 uint64
-				Commit               uint64
-				XXX_NoUnkeyedLiteral struct{}
-				XXX_unrecognized     []byte
-				XXX_sizecache        int32
+				Term   uint64
+				Vote   uint64
+				Commit uint64
 			}
 			// Conversion fails if new fields are added to `HardState`, in which case this method
 			// and the expected sums should be updated.
@@ -96,10 +93,9 @@ var belowRaftGoldenProtos = map[reflect.Type]fixture{
 
 			n := r.Uint64()
 			return &raftpb.HardState{
-				Term:             n % 3,
-				Vote:             n % 7,
-				Commit:           n % 11,
-				XXX_unrecognized: nil,
+				Term:   n % 3,
+				Vote:   n % 7,
+				Commit: n % 11,
 			}
 		},
 		emptySum:     13621293256077144893,


### PR DESCRIPTION
Backport 1/1 commits from #62819.

/cc @cockroachdb/release

---

This commit picks up https://github.com/etcd-io/etcd/pull/12790, which resolves a regression observed in #62212.

Picks up the following four commits, each of which I've reviewed for safety:
- https://github.com/etcd-io/etcd/commit/87258efd90224bc8b59e000f75fe07fdeab68e2d
- https://github.com/etcd-io/etcd/commit/2c2456bf3d5655763e9518037113244539616d3e
- https://github.com/etcd-io/etcd/commit/ebc01743df5bbb75e062a88606d5f14935ecc3cd
- https://github.com/etcd-io/etcd/commit/e51c697ec6e8f44b5a0a455c8fada484db4633af

```
name                  old time/op    new time/op    delta
EntryCache-16            114µs ± 7%      96µs ±12%  -15.29%  (p=0.000 n=19+19)
EntryCacheClearTo-16    37.7µs ± 4%    34.9µs ± 4%   -7.55%  (p=0.000 n=17+18)

name                  old alloc/op   new alloc/op   delta
EntryCacheClearTo-16    1.28kB ± 0%    0.77kB ± 0%  -40.00%  (p=0.000 n=20+20)
EntryCache-16           83.3kB ± 0%    50.0kB ± 0%  -39.95%  (p=0.000 n=19+20)

name                  old allocs/op  new allocs/op  delta
EntryCache-16             3.00 ± 0%      3.00 ± 0%     ~     (all equal)
EntryCacheClearTo-16      1.00 ± 0%      1.00 ± 0%     ~     (all equal)
```
