### PR TITLE
roachprod: desupport aws-cli 1.0

### DIFF
--- a/pkg/cmd/roachprod/vm/aws/aws.go
+++ b/pkg/cmd/roachprod/vm/aws/aws.go
@@ -37,30 +37,50 @@ const ProviderName = "aws"
 // init will inject the AWS provider into vm.Providers, but only
 // if the aws tool is available on the local path.
 func init() {
-	const unimplemented = "please install the AWS CLI utilities version 1 " +
+	// aws-cli version 1 automatically base64 encodes the string passed as --public-key-material.
+	// Version 2 supports file:// and fileb:// prefixes for text and binary files.
+	// The latter prefix will base64-encode the file contents. See
+	// https://docs.aws.amazon.//com/cli/latest/userguide/cliv2-migration.html#cliv2-migration-binaryparam
+	const unsupportedAwsCliVersionPrefix = "aws-cli/1."
+	const unimplemented = "please install the AWS CLI utilities version 2+ " +
 		"(https://docs.aws.amazon.com/cli/latest/userguide/installing.html)"
 	const noCredentials = "missing AWS credentials, expected ~/.aws/credentials file or AWS_ACCESS_KEY_ID env var"
 
 	var p vm.Provider = &Provider{}
-	if _, err := exec.LookPath("aws"); err == nil {
-		// NB: This is a bit hacky, but using something like `aws iam get-user` is
-		// slow and not something we want to do at startup.
-		haveCredentials := func() bool {
-			const credFile = "${HOME}/.aws/credentials"
-			if _, err := os.Stat(os.ExpandEnv(credFile)); err == nil {
-				return true
-			}
-			if os.Getenv("AWS_ACCESS_KEY_ID") != "" {
-				return true
-			}
+
+	haveRequiredVersion := func() bool {
+		cmd := exec.Command("aws", "--version")
+		output, err := cmd.Output()
+		if err != nil {
 			return false
 		}
-
-		if !haveCredentials() {
-			p = flagstub.New(p, noCredentials)
+		if strings.HasPrefix(string(output), unsupportedAwsCliVersionPrefix) {
+			return false
 		}
-	} else {
+		return true
+	}
+	if !haveRequiredVersion() {
 		p = flagstub.New(p, unimplemented)
+		vm.Providers[ProviderName] = p
+		return
+	}
+
+	// NB: This is a bit hacky, but using something like `aws iam get-user` is
+	// slow and not something we want to do at startup.
+	haveCredentials := func() bool {
+		const credFile = "${HOME}/.aws/credentials"
+		if _, err := os.Stat(os.ExpandEnv(credFile)); err == nil {
+			return true
+		}
+		if os.Getenv("AWS_ACCESS_KEY_ID") != "" {
+			return true
+		}
+		return false
+	}
+	if !haveCredentials() {
+		p = flagstub.New(p, noCredentials)
+		vm.Providers[ProviderName] = p
+		return
 	}
 
 	vm.Providers[ProviderName] = p

--- a/pkg/cmd/roachprod/vm/aws/keys.go
+++ b/pkg/cmd/roachprod/vm/aws/keys.go
@@ -50,7 +50,7 @@ func (p *Provider) sshKeyExists(keyName string, region string) (bool, error) {
 // sshKeyImport takes the user's local, public SSH key and imports it into the ec2 region so that
 // we can create new hosts with it.
 func (p *Provider) sshKeyImport(keyName string, region string) error {
-	keyBytes, err := ioutil.ReadFile(os.ExpandEnv(sshPublicKeyFile))
+	_, err := os.Stat(os.ExpandEnv(sshPublicKeyFile))
 	if err != nil {
 		if oserror.IsNotExist(err) {
 			return errors.Wrapf(err, "please run ssh-keygen externally to create your %s file", sshPublicKeyFile)
@@ -66,7 +66,7 @@ func (p *Provider) sshKeyImport(keyName string, region string) error {
 		"ec2", "import-key-pair",
 		"--region", region,
 		"--key-name", keyName,
-		"--public-key-material", string(keyBytes),
+		"--public-key-material", fmt.Sprintf("fileb://%s", sshPublicKeyFile),
 	}
 	err = p.runJSONCommand(args, &data)
 	// If two roachprod instances run at the same time with the same key, they may


### PR DESCRIPTION
Previously, we required `aws-cli` 1.0 in order to properly import ssh
keys. After the keys are imported the `import-key-pair` is never called,
until one changes their ssh keys, so it was possible to upgrade to
`aws-cli` 2 and never hit the issue.

Installing an older version of aws-cli is a bit inconvenient and may
lead to various issues in the future.

aws-cli 2.0 accepts `file://` and `fileb://` prefixes to indicate
whether the file contents are text or binary. The latter tells the tools
to implicitly base64encode the contents, similar to aws-cli 1.0
behaviour (which was not obvious).

Fixes #52989

Release note: None