### PR TITLE
roachtest/tpccbench: small cleanup

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -815,9 +815,6 @@ func runTPCCBench(ctx context.Context, t *test, c *cluster, b tpccBenchSpec) {
 
 		// If we're running chaos in this configuration, modify this config.
 		if b.Chaos {
-			// Increase the load generation duration.
-			loadDur = 10 * time.Minute
-
 			// Kill one node at a time.
 			ch := Chaos{
 				Timer:   Periodic{Period: 90 * time.Second, DownTime: 5 * time.Second},


### PR DESCRIPTION
Remove redundant load duration. It was set above to the same value.

Release note: None