### PR TITLE
release-21.1: sqlsmith: add support for ALTER TYPE ... DROP VALUE

### DIFF
--- a/pkg/internal/sqlsmith/alter.go
+++ b/pkg/internal/sqlsmith/alter.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	alters               = append(append(altersTableExistence, altersExistingTable...), altersTypeExistence...)
+	alters               = append(append(append(altersTableExistence, altersExistingTable...), altersTypeExistence...), altersExistingTypes...)
 	altersTableExistence = []statementWeight{
 		{10, makeCreateTable},
 		{2, makeCreateSchema},
@@ -40,6 +40,9 @@ var (
 	}
 	altersTypeExistence = []statementWeight{
 		{5, makeCreateType},
+	}
+	altersExistingTypes = []statementWeight{
+		{5, makeAlterTypeDropValue},
 	}
 )
 
@@ -341,4 +344,17 @@ func makeRenameIndex(s *Smither) (tree.Statement, bool) {
 func makeCreateType(s *Smither) (tree.Statement, bool) {
 	name := s.name("typ")
 	return rowenc.RandCreateType(s.rnd, string(name), letters), true
+}
+
+func makeAlterTypeDropValue(s *Smither) (tree.Statement, bool) {
+	enumVal, udtName, ok := s.getRandUserDefinedTypeLabel()
+	if !ok {
+		return nil, false
+	}
+	return &tree.AlterType{
+		Type: udtName.ToUnresolvedObjectName(),
+		Cmd: &tree.AlterTypeDropValue{
+			Val: *enumVal,
+		},
+	}, ok
 }

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -261,12 +261,14 @@ var DisableDDLs = simpleOption("disable DDLs", func(s *Smither) {
 // OnlyNoDropDDLs causes the Smither to only emit DDLs, but won't ever drop
 // a table.
 var OnlyNoDropDDLs = simpleOption("only DDLs", func(s *Smither) {
-	s.stmtWeights = append([]statementWeight{
+	s.stmtWeights = append(append([]statementWeight{
 		{1, makeBegin},
 		{2, makeRollback},
 		{6, makeCommit},
 	},
 		altersExistingTable...,
+	),
+		altersExistingTypes...,
 	)
 })
 

--- a/pkg/internal/sqlsmith/type.go
+++ b/pkg/internal/sqlsmith/type.go
@@ -79,7 +79,7 @@ func (s *Smither) makeDesiredTypes() []*types.T {
 }
 
 type typeInfo struct {
-	udts        map[types.UserDefinedTypeName]*types.T
+	udts        map[tree.TypeName]*types.T
 	seedTypes   []*types.T
 	scalarTypes []*types.T
 }
@@ -88,10 +88,7 @@ type typeInfo struct {
 func (s *Smither) ResolveType(
 	_ context.Context, name *tree.UnresolvedObjectName,
 ) (*types.T, error) {
-	key := types.UserDefinedTypeName{
-		Name:   name.Object(),
-		Schema: name.Schema(),
-	}
+	key := tree.MakeSchemaQualifiedTypeName(name.Schema(), name.Object())
 	res, ok := s.types.udts[key]
 	if !ok {
 		return nil, errors.Newf("type name %s not found by smither", name.Object())

--- a/pkg/workload/sqlsmith/sqlsmith.go
+++ b/pkg/workload/sqlsmith/sqlsmith.go
@@ -72,7 +72,11 @@ func (g *sqlSmith) Flags() workload.Flags { return g.flags }
 func (g *sqlSmith) Hooks() workload.Hooks {
 	return workload.Hooks{
 		PreCreate: func(db *gosql.DB) error {
-			if _, err := db.Exec(`SET CLUSTER SETTING sql.defaults.interleaved_tables.enabled = true`); err != nil {
+			if _, err := db.Exec(`
+SET CLUSTER SETTING sql.defaults.interleaved_tables.enabled = true;
+SET CLUSTER SETTING sql.defaults.drop_enum_value.enabled = true;
+SET enable_drop_enum_value = true;
+`); err != nil {
 				return err
 			}
 			return nil


### PR DESCRIPTION
Backport 1/1 commits from #62883.

/cc @cockroachdb/release

---

Now that `ALTER TYPE ... DROP VALUE` is a thing, let's add it to SQL
Smith.

Closes #62812

Release note: None
