### PR TITLE
build: refactor `teamcity-weekly-roachtest.sh` to depend on common code

### DIFF
--- a/build/release/teamcity-support.sh
+++ b/build/release/teamcity-support.sh
@@ -1,9 +1,13 @@
 # Common helpers for teamcity-*.sh scripts.
 
+# root is the absolute path to the root directory of the repository.
+root=$(cd "$(dirname "$0")/../.." && pwd)
+source "$root/build/teamcity-common-support.sh"
+
 remove_files_on_exit() {
-  rm -f .google-credentials.json
   rm -f .cockroach-teamcity-key
   rm -rf ~/.docker
+  common_support_remove_files_on_exit
 }
 trap remove_files_on_exit EXIT
 
@@ -13,15 +17,6 @@ tc_start_block() {
 
 tc_end_block() {
   echo "##teamcity[blockClosed name='$1']"
-}
-
-log_into_gcloud() {
-  if [[ "${google_credentials}" ]]; then
-    echo "${google_credentials}" > .google-credentials.json
-    gcloud auth activate-service-account --key-file=.google-credentials.json
-  else
-    echo 'warning: `google_credentials` not set' >&2
-  fi
 }
 
 docker_login_with_google() {

--- a/build/teamcity-common-support.sh
+++ b/build/teamcity-common-support.sh
@@ -1,0 +1,15 @@
+# Common logic shared by build/teamcity-support.sh and build/release/teamcity-support.sh.
+
+# Call this to clean up after using any other functions from this file.
+common_support_remove_files_on_exit() {
+  rm -f .google-credentials.json
+}
+
+log_into_gcloud() {
+  if [[ "${google_credentials}" ]]; then
+    echo "${google_credentials}" > .google-credentials.json
+    gcloud auth activate-service-account --key-file=.google-credentials.json
+  else
+    echo 'warning: `google_credentials` not set' >&2
+  fi
+}

--- a/build/teamcity-support.sh
+++ b/build/teamcity-support.sh
@@ -3,6 +3,14 @@
 # root is the absolute path to the root directory of the repository.
 root=$(cd "$(dirname "$0")/.." && pwd)
 
+source "$root/build/teamcity-common-support.sh"
+
+remove_files_on_exit() {
+  rm -f ~/.ssh/id_rsa{,.pub}
+  common_support_remove_files_on_exit
+}
+trap remove_files_on_exit EXIT
+
 # maybe_ccache turns on ccache to speed up compilation, but only for PR builds.
 # This speeds up the CI cycle for developers while preventing ccache from
 # corrupting a release build.
@@ -282,4 +290,10 @@ tc_prepare() {
   run mkdir -p artifacts
   maybe_ccache
   tc_end_block "Prepare environment"
+}
+
+generate_ssh_key() {
+  if [[ ! -f ~/.ssh/id_rsa.pub ]]; then
+    ssh-keygen -q -N "" -f ~/.ssh/id_rsa
+  fi
 }

--- a/build/teamcity-weekly-roachtest.sh
+++ b/build/teamcity-weekly-roachtest.sh
@@ -5,20 +5,13 @@
 
 set -euo pipefail
 
-if [[ "$GOOGLE_EPHEMERAL_CREDENTIALS" ]]; then
-  echo "$GOOGLE_EPHEMERAL_CREDENTIALS" > creds.json
-  gcloud auth activate-service-account --key-file=creds.json
-  export ROACHPROD_USER=teamcity
-else
-  echo 'warning: GOOGLE_EPHEMERAL_CREDENTIALS not set' >&2
-  echo "Assuming that you've run \`gcloud auth login\` from inside the builder." >&2
-fi
+google_credentials="$GOOGLE_EPHEMERAL_CREDENTIALS"
+source "$(dirname "${0}")/teamcity-support.sh"
+log_into_gcloud
 
 set -x
 
-if [[ ! -f ~/.ssh/id_rsa.pub ]]; then
-  ssh-keygen -q -N "" -f ~/.ssh/id_rsa
-fi
+generate_ssh_key
 
 export PATH=$PATH:$(go env GOPATH)/bin
 


### PR DESCRIPTION
We can use the helper functionality here to log into `gcloud`, and the
helper code will clean the credentials up after the fact.

Also use the same pattern to clean up the SSH key after the job exits --
an alternative was also putting this into `teamcity-support.sh`, but
this pattern didn't really seem generally useful enough to bless by
putting it in a common library.

Release note: None