### PR TITLE
sql: return an error when looking up hashed password returned no rows

### DIFF
--- a/pkg/sql/user_test.go
+++ b/pkg/sql/user_test.go
@@ -130,7 +130,7 @@ GRANT ALL ON DATABASE defaultdb TO foo`); err != nil {
 		}
 	}()
 
-	// Configure the login timeout to just 1s.
+	// Configure the login timeout to just 200ms.
 	if _, err := db.Exec(`SET CLUSTER SETTING server.user_login.timeout = '200ms'`); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Previously, when retrieving a user and its password we could encounter
a situation when the query against `system.users` table returned no
rows. I believe an error should be returned in such case. My guess is
that it is possible that because we use `QueryRowEx` to get the hashed
password, the expectation was that an error is returned if no row is
produced, but that's not the case. Now we will return an error in such
scenario.

Fixes: #62948

Release note: None