### PR TITLE
release-21.1: sqlsmith;mutations: blitz to fix Postgres compare_test bugs

### DIFF
--- a/pkg/compose/compare/compare/compare_test.go
+++ b/pkg/compose/compare/compare/compare_test.go
@@ -27,7 +27,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
 	"github.com/cockroachdb/cockroach/pkg/sql/mutations"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/jackc/pgx/v4"
 )
 
 var (
@@ -102,6 +104,17 @@ func TestCompare(t *testing.T) {
 	}
 
 	ctx := context.Background()
+
+	// docker-compose requires us to manually check for when a container
+	// is ready to receive connections.
+	// See https://docs.docker.com/compose/startup-order/
+	for name, uri := range uris {
+		testutils.SucceedsSoon(t, func() error {
+			_, err := pgx.Connect(ctx, uri.addr)
+			return err
+		})
+	}
+
 	for confName, config := range configs {
 		t.Run(confName, func(t *testing.T) {
 			rng, _ := randutil.NewPseudoRand()

--- a/pkg/compose/compare/compare/compare_test.go
+++ b/pkg/compose/compare/compare/compare_test.go
@@ -69,9 +69,10 @@ func TestCompare(t *testing.T) {
 	}
 	configs := map[string]testConfig{
 		"postgres": {
-			setup:         sqlsmith.Setups["rand-tables"],
-			setupMutators: []rowenc.Mutator{mutations.PostgresCreateTableMutator},
-			opts:          []sqlsmith.SmitherOption{sqlsmith.PostgresMode()},
+			setup:           sqlsmith.Setups["rand-tables"],
+			setupMutators:   []rowenc.Mutator{mutations.PostgresCreateTableMutator},
+			opts:            []sqlsmith.SmitherOption{sqlsmith.PostgresMode()},
+			ignoreSQLErrors: true,
 			conns: []testConn{
 				{
 					name:     "cockroach1",
@@ -84,8 +85,9 @@ func TestCompare(t *testing.T) {
 			},
 		},
 		"mutators": {
-			setup: sqlsmith.Setups["rand-tables"],
-			opts:  []sqlsmith.SmitherOption{sqlsmith.CompareMode()},
+			setup:           sqlsmith.Setups["rand-tables"],
+			opts:            []sqlsmith.SmitherOption{sqlsmith.CompareMode()},
+			ignoreSQLErrors: true,
 			conns: []testConn{
 				{
 					name:     "cockroach1",
@@ -121,12 +123,14 @@ func TestCompare(t *testing.T) {
 
 	for confName, config := range configs {
 		t.Run(confName, func(t *testing.T) {
+			t.Logf("starting test: %s", confName)
 			rng, _ := randutil.NewPseudoRand()
 			setup := config.setup(rng)
 			setup, _ = mutations.ApplyString(rng, setup, config.setupMutators...)
 
 			conns := map[string]cmpconn.Conn{}
 			for _, testCn := range config.conns {
+				t.Logf("initializing connection: %s", testCn.name)
 				uri, ok := uris[testCn.name]
 				if !ok {
 					t.Fatalf("bad connection name: %s", testCn.name)
@@ -157,13 +161,13 @@ func TestCompare(t *testing.T) {
 			for {
 				select {
 				case <-until:
+					t.Logf("done with test: %s", confName)
 					return
 				default:
 				}
 				query := smither.Generate()
-				query, _ = mutations.ApplyString(rng, query, mutations.PostgresMutator)
 				if err := cmpconn.CompareConns(
-					ctx, time.Second*30, conns, "" /* prep */, query, true, /* ignoreSQLErrors */
+					ctx, time.Second*30, conns, "" /* prep */, query, config.ignoreSQLErrors,
 				); err != nil {
 					path := filepath.Join(*flagArtifacts, confName+".log")
 					if err := ioutil.WriteFile(path, []byte(err.Error()), 0666); err != nil {
@@ -185,10 +189,11 @@ func TestCompare(t *testing.T) {
 }
 
 type testConfig struct {
-	opts          []sqlsmith.SmitherOption
-	conns         []testConn
-	setup         sqlsmith.Setup
-	setupMutators []rowenc.Mutator
+	opts            []sqlsmith.SmitherOption
+	conns           []testConn
+	setup           sqlsmith.Setup
+	setupMutators   []rowenc.Mutator
+	ignoreSQLErrors bool
 }
 
 type testConn struct {

--- a/pkg/compose/compare/compare/compare_test.go
+++ b/pkg/compose/compare/compare/compare_test.go
@@ -109,6 +109,7 @@ func TestCompare(t *testing.T) {
 	// is ready to receive connections.
 	// See https://docs.docker.com/compose/startup-order/
 	for name, uri := range uris {
+		t.Logf("Checking connection to: %s", name)
 		testutils.SucceedsSoon(t, func() error {
 			_, err := pgx.Connect(ctx, uri.addr)
 			return err

--- a/pkg/compose/compare/compare/compare_test.go
+++ b/pkg/compose/compare/compare/compare_test.go
@@ -47,6 +47,9 @@ func TestCompare(t *testing.T) {
 			init: []string{
 				"drop schema if exists public cascade",
 				"create schema public",
+				"CREATE EXTENSION IF NOT EXISTS postgis",
+				"CREATE EXTENSION IF NOT EXISTS postgis_topology",
+				"CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;",
 			},
 		},
 		"cockroach1": {

--- a/pkg/compose/compare/docker-compose.yml
+++ b/pkg/compose/compare/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   postgres:
-    image: postgis/postgis:11-3.0
+    image: postgis/postgis:13-3.1
     environment:
       - POSTGRES_INITDB_ARGS=--locale=C
       - POSTGRES_HOST_AUTH_METHOD=trust

--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -560,7 +560,13 @@ func (s *Smither) makeSelectClause(
 			// either reference a group by column or a non-group by
 			// column in an aggregate function. It's also possible
 			// the where and order by exprs are not correct.
-			groupByRefs := fromRefs.extend()
+			var groupByRefs colRefs
+			for _, r := range fromRefs {
+				if s.postgres && r.typ.Family() == types.Box2DFamily {
+					continue
+				}
+				groupByRefs = append(groupByRefs, r)
+			}
 			s.rnd.Shuffle(len(groupByRefs), func(i, j int) {
 				groupByRefs[i], groupByRefs[j] = groupByRefs[j], groupByRefs[i]
 			})
@@ -670,8 +676,14 @@ func makeSelect(s *Smither) (tree.Statement, bool) {
 	if s.outputSort {
 		order := make(tree.OrderBy, len(refs))
 		for i, r := range refs {
+			var expr tree.Expr = r.item
+			// PostGIS cannot order box2d types, so we cast to string so the
+			// order is deterministic.
+			if s.postgres && r.typ.Family() == types.Box2DFamily {
+				expr = &tree.CastExpr{Expr: r.item, Type: types.String}
+			}
 			order[i] = &tree.Order{
-				Expr:       r.item,
+				Expr:       expr,
 				NullsOrder: tree.NullsFirst,
 			}
 		}
@@ -1104,6 +1116,10 @@ func (s *Smither) makeOrderBy(refs colRefs) tree.OrderBy {
 		ref := refs[s.rnd.Intn(len(refs))]
 		// We don't support order by jsonb columns.
 		if ref.typ.Family() == types.JsonFamily {
+			continue
+		}
+		// PostGIS cannot order box2d types.
+		if s.postgres && ref.typ.Family() == types.Box2DFamily {
 			continue
 		}
 		ob = append(ob, &tree.Order{

--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -297,6 +297,14 @@ func makeBinOp(s *Smither, typ *types.T, refs colRefs) (tree.TypedExpr, bool) {
 			return nil, false
 		}
 	}
+	if s.postgres && (op.Operator == tree.Minus || op.Operator == tree.Plus) {
+		if op.LeftType == types.Int && op.RightType == types.Date {
+			op.LeftType = types.Int4
+		}
+		if op.LeftType == types.Date && op.RightType == types.Int {
+			op.RightType = types.Int4
+		}
+	}
 	left := makeScalar(s, op.LeftType, refs)
 	right := makeScalar(s, op.RightType, refs)
 	return castType(

--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -329,6 +329,15 @@ var ignorePostgresBinOps = map[binOpTriple]bool{
 	{types.FloatFamily, tree.Mult, types.DateFamily}: true,
 	{types.DateFamily, tree.Mult, types.FloatFamily}: true,
 	{types.DateFamily, tree.Div, types.FloatFamily}:  true,
+
+	// Postgres does not have separate floor division operator.
+	{types.IntFamily, tree.FloorDiv, types.IntFamily}:         true,
+	{types.FloatFamily, tree.FloorDiv, types.FloatFamily}:     true,
+	{types.DecimalFamily, tree.FloorDiv, types.DecimalFamily}: true,
+	{types.DecimalFamily, tree.FloorDiv, types.IntFamily}:     true,
+	{types.IntFamily, tree.FloorDiv, types.DecimalFamily}:     true,
+
+	{types.FloatFamily, tree.Mod, types.FloatFamily}: true,
 }
 
 func makeFunc(s *Smither, ctx Context, typ *types.T, refs colRefs) (tree.TypedExpr, bool) {

--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -369,6 +369,10 @@ func makeFunc(s *Smither, ctx Context, typ *types.T, refs colRefs) (tree.TypedEx
 
 	args := make(tree.TypedExprs, 0)
 	for _, argTyp := range fn.overload.Types.Types() {
+		// Postgres is picky about having Int4 arguments instead of Int8.
+		if s.postgres && argTyp.Family() == types.IntFamily {
+			argTyp = types.Int4
+		}
 		var arg tree.TypedExpr
 		// If we're a GROUP BY or window function, try to choose a col ref for the arguments.
 		if class == tree.AggregateClass || class == tree.WindowClass {

--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -397,10 +397,9 @@ func makeFunc(s *Smither, ctx Context, typ *types.T, refs colRefs) (tree.TypedEx
 			var ok bool
 			arg, ok = makeColRef(s, argTyp, refs)
 			if !ok {
-				// If we can't find a col ref for our
-				// aggregate function, try again with
-				// a non-aggregate.
-				return makeFunc(s, emptyCtx, typ, refs)
+				// If we can't find a col ref for our aggregate function, just use a
+				// constant.
+				arg = makeConstExpr(s, typ, refs)
 			}
 		}
 		if arg == nil {

--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -277,6 +277,9 @@ ORDER BY
 		// All non virtual tables contain implicit system columns.
 		for i := range colinfo.AllSystemColumnDescs {
 			col := &colinfo.AllSystemColumnDescs[i]
+			if s.postgres && col.ID == colinfo.MVCCTimestampColumnID {
+				continue
+			}
 			currentCols = append(currentCols, &tree.ColumnTableDef{
 				Name: tree.Name(col.Name),
 				Type: col.Type,

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -366,8 +366,21 @@ var PostgresMode = multiOption(
 	// Some func impls differ from postgres, so skip them here.
 	// #41709
 	IgnoreFNs("^sha"),
+	IgnoreFNs("^isnan"),
+	IgnoreFNs("^crc32c"),
+	IgnoreFNs("^fnv32a"),
+	IgnoreFNs("^experimental_"),
+	IgnoreFNs("^json_set"),
+	IgnoreFNs("^concat_agg"),
+	IgnoreFNs("^to_english"),
+	IgnoreFNs("^substr$"),
 	// We use e'XX' instead of E'XX' for hex strings, so ignore these.
 	IgnoreFNs("^quote"),
 	// We have some differences here with empty string and "default"; skip until fixed.
 	IgnoreFNs("^pg_collation_for"),
+	// Postgres does not have the `.*_escape` functions.
+	IgnoreFNs("_escape$"),
+	// Some spatial functions are CockroachDB-specific.
+	IgnoreFNs("st_.*withinexclusive$"),
+	IgnoreFNs("^postgis_.*_build_date"),
 )

--- a/pkg/sql/mutations/mutations.go
+++ b/pkg/sql/mutations/mutations.go
@@ -768,25 +768,6 @@ func postgresCreateTableMutator(
 						Storing:  def.Storing,
 					})
 					changed = true
-				case *tree.ColumnTableDef:
-					colType := tree.MustBeStaticallyKnownType(def.Type)
-					switch colType.Family() {
-					case types.GeometryFamily, types.GeographyFamily, types.Box2DFamily:
-						// PostgreSQL does not have any spatial types. Turn them into
-						// String types.
-						def.Type = types.String
-						mutated = append(mutated, &tree.AlterTable{
-							Table: stmt.Table.ToUnresolvedObjectName(),
-							Cmds: tree.AlterTableCmds{
-								&tree.AlterTableAlterColumnType{
-									Column: def.Name,
-									ToType: types.String,
-								},
-							},
-						})
-						changed = true
-					}
-					newdefs = append(newdefs, def)
 				default:
 					newdefs = append(newdefs, def)
 				}

--- a/pkg/sql/mutations/mutations.go
+++ b/pkg/sql/mutations/mutations.go
@@ -719,6 +719,10 @@ func postgresCreateTableMutator(
 		mutated = append(mutated, stmt)
 		switch stmt := stmt.(type) {
 		case *tree.CreateTable:
+			if stmt.Interleave != nil {
+				stmt.Interleave = nil
+				changed = true
+			}
 			// Get all the column types first.
 			colTypes := make(map[string]*types.T)
 			for _, def := range stmt.Defs {
@@ -734,34 +738,61 @@ func postgresCreateTableMutator(
 				case *tree.IndexTableDef:
 					// Postgres doesn't support indexes in CREATE TABLE, so split them out
 					// to their own statement.
+					var newCols tree.IndexElemList
+					for _, col := range def.Columns {
+						// Postgres doesn't support box2d as a btree index key.
+						colTypeFamily := colTypes[string(col.Column)].Family()
+						if colTypeFamily == types.Box2DFamily {
+							changed = true
+						} else {
+							newCols = append(newCols, col)
+						}
+					}
+					if len(newCols) == 0 {
+						// Break without adding this index at all.
+						break
+					}
+					def.Columns = newCols
 					// TODO(rafi): Postgres supports inverted indexes with a different
 					// syntax than Cockroach. Maybe we could add it later.
-					// The syntax is `CREATE INDEX name ON table USING gin(column`.
+					// The syntax is `CREATE INDEX name ON table USING gin(column)`.
 					if !def.Inverted {
 						mutated = append(mutated, &tree.CreateIndex{
 							Name:     def.Name,
 							Table:    stmt.Table,
 							Inverted: def.Inverted,
-							Columns:  def.Columns,
+							Columns:  newCols,
 							Storing:  def.Storing,
 						})
 						changed = true
 					}
 				case *tree.UniqueConstraintTableDef:
+					var newCols tree.IndexElemList
+					for _, col := range def.Columns {
+						// Postgres doesn't support box2d as a btree index key.
+						colTypeFamily := colTypes[string(col.Column)].Family()
+						if colTypeFamily == types.Box2DFamily {
+							changed = true
+						} else {
+							newCols = append(newCols, col)
+						}
+					}
+					if len(newCols) == 0 {
+						// Break without adding this index at all.
+						break
+					}
+					def.Columns = newCols
 					if def.PrimaryKey {
-						// Postgres doesn't support descending PKs.
 						for i, col := range def.Columns {
+							// Postgres doesn't support descending PKs.
 							if col.Direction != tree.DefaultDirection {
 								def.Columns[i].Direction = tree.DefaultDirection
 								changed = true
 							}
 						}
 						if def.Name != "" {
-							// Unset Name here because
-							// constraint names cannot
-							// be shared among tables,
-							// so multiple PK constraints
-							// named "primary" is an error.
+							// Unset Name here because constraint names cannot be shared among
+							// tables, so multiple PK constraints named "primary" is an error.
 							def.Name = ""
 							changed = true
 						}
@@ -773,7 +804,7 @@ func postgresCreateTableMutator(
 						Table:    stmt.Table,
 						Unique:   true,
 						Inverted: def.Inverted,
-						Columns:  def.Columns,
+						Columns:  newCols,
 						Storing:  def.Storing,
 					})
 					changed = true

--- a/pkg/sql/mutations/mutations.go
+++ b/pkg/sql/mutations/mutations.go
@@ -633,6 +633,7 @@ func postgresMutator(rng *rand.Rand, q string) string {
 		"INT4":    "INT8",
 		"STORING": "INCLUDE",
 		" AS (":   " GENERATED ALWAYS AS (",
+		",)":      ")",
 	} {
 		q = strings.Replace(q, from, to, -1)
 	}

--- a/pkg/sql/rowenc/testutils.go
+++ b/pkg/sql/rowenc/testutils.go
@@ -1379,6 +1379,7 @@ func getTableInfoFromDDLStatements(stmts []tree.Statement) map[tree.Name]tableIn
 					// can only reference tables that already exist.
 					if refTableInfo, ok := tables[ast.Table.ObjectName]; ok {
 						refTableInfo.refColsLists = append(refTableInfo.refColsLists, ast.ToCols)
+						tables[ast.Table.ObjectName] = refTableInfo
 					}
 				}
 			}
@@ -1393,6 +1394,7 @@ func getTableInfoFromDDLStatements(stmts []tree.Statement) map[tree.Name]tableIn
 						// statements come after CREATE statements.
 						if info, ok := tables[constraintDef.Table.ObjectName]; ok {
 							info.refColsLists = append(info.refColsLists, constraintDef.ToCols)
+							tables[constraintDef.Table.ObjectName] = info
 						}
 					}
 				}


### PR DESCRIPTION
Backport:
  * 1/1 commits from "compare_test: check for backends being ready" (#62682)
  * 16/16 commits from "sqlsmith;mutations: blitz to fix Postgres compare_test bugs" (#62706)

Please see individual PRs for details.

/cc @cockroachdb/release
