### PR TITLE
sql: drain instead of hard shutdown in DistSQLReceiver.Push

### DIFF
--- a/pkg/ccl/backupccl/backup_processor_planning.go
+++ b/pkg/ccl/backupccl/backup_processor_planning.go
@@ -179,6 +179,7 @@ func distBackup(
 		nil,   /* clockUpdater */
 		evalCtx.Tracing,
 		evalCtx.ExecCfg.ContentionRegistry,
+		nil, /* testingPushCallback */
 	)
 	defer recv.Release()
 

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -218,6 +218,7 @@ func distRestore(
 		nil,   /* clockUpdater */
 		evalCtx.Tracing,
 		evalCtx.ExecCfg.ContentionRegistry,
+		nil, /* testingPushCallback */
 	)
 	defer recv.Release()
 

--- a/pkg/ccl/changefeedccl/changefeeddist/distflow.go
+++ b/pkg/ccl/changefeedccl/changefeeddist/distflow.go
@@ -113,6 +113,7 @@ func StartDistChangefeed(
 		nil, /* clockUpdater */
 		evalCtx.Tracing,
 		execCtx.ExecCfg().ContentionRegistry,
+		nil, /* testingPushCallback */
 	)
 	defer recv.Release()
 

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
@@ -131,6 +131,7 @@ func distStreamIngest(
 		nil, /* clockUpdater */
 		evalCtx.Tracing,
 		execCfg.ContentionRegistry,
+		nil, /* testingPushCallback */
 	)
 	defer recv.Release()
 

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -569,6 +569,7 @@ go_test(
         "//pkg/testutils",
         "//pkg/testutils/buildutil",
         "//pkg/testutils/jobutils",
+        "//pkg/testutils/pgtest",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",

--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -240,6 +240,7 @@ func runPlanInsidePlan(
 		params.ExecCfg().Clock,
 		params.p.extendedEvalCtx.Tracing,
 		params.p.ExecCfg().ContentionRegistry,
+		nil, /* testingPushCallback */
 	)
 	defer recv.Release()
 

--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -251,10 +251,7 @@ func runPlanInsidePlan(
 		plan.subqueryPlans,
 		recv,
 	) {
-		if err := rowResultWriter.Err(); err != nil {
-			return err
-		}
-		return recv.commErr
+		return rowResultWriter.Err()
 	}
 
 	// Make a copy of the EvalContext so it can be safely modified.
@@ -273,10 +270,7 @@ func runPlanInsidePlan(
 	params.p.extendedEvalCtx.ExecCfg.DistSQLPlanner.PlanAndRun(
 		params.ctx, evalCtx, planCtx, params.p.Txn(), plan.main, recv,
 	)()
-	if recv.commErr != nil {
-		return recv.commErr
-	}
-	return rowResultWriter.err
+	return rowResultWriter.Err()
 }
 
 func (a *applyJoinNode) Values() tree.Datums {

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1092,6 +1092,7 @@ func (sc *SchemaChanger) distIndexBackfill(
 		sc.clock,
 		evalCtx.Tracing,
 		sc.execCfg.ContentionRegistry,
+		nil, /* testingPushCallback */
 	)
 	defer recv.Release()
 
@@ -1311,6 +1312,7 @@ func (sc *SchemaChanger) distBackfill(
 				sc.clock,
 				evalCtx.Tracing,
 				sc.execCfg.ContentionRegistry,
+				nil, /* testingPushCallback */
 			)
 			defer recv.Release()
 

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/explain"
 	"github.com/cockroachdb/cockroach/pkg/sql/paramparse"
@@ -30,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
@@ -985,6 +987,10 @@ func (ex *connExecutor) execWithDistSQLEngine(
 	distribute bool,
 	progressAtomic *uint64,
 ) (topLevelQueryStats, error) {
+	var testingPushCallback func(rowenc.EncDatumRow, *execinfrapb.ProducerMetadata)
+	if ex.server.cfg.TestingKnobs.DistSQLReceiverPushCallbackFactory != nil {
+		testingPushCallback = ex.server.cfg.TestingKnobs.DistSQLReceiverPushCallbackFactory(planner.stmt.SQL)
+	}
 	recv := MakeDistSQLReceiver(
 		ctx, res, stmtType,
 		ex.server.cfg.RangeDescriptorCache,
@@ -992,6 +998,7 @@ func (ex *connExecutor) execWithDistSQLEngine(
 		ex.server.cfg.Clock,
 		&ex.sessionTracing,
 		ex.server.cfg.ContentionRegistry,
+		testingPushCallback,
 	)
 	recv.progressAtomic = progressAtomic
 	defer recv.Release()

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -267,13 +267,14 @@ func TestDistSQLReceiverUpdatesCaches(t *testing.T) {
 	rangeCache := rangecache.NewRangeCache(st, nil /* db */, size, stopper)
 	r := MakeDistSQLReceiver(
 		ctx,
-		nil, /* resultWriter */
+		&errOnlyResultWriter{}, /* resultWriter */
 		tree.Rows,
 		rangeCache,
 		nil, /* txn */
 		nil, /* clockUpdater */
 		&SessionTracing{},
 		nil, /* contentionRegistry */
+		nil, /* testingPushCallback */
 	)
 
 	replicas := []roachpb.ReplicaDescriptor{{ReplicaID: 1}, {ReplicaID: 2}, {ReplicaID: 3}}

--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -302,6 +302,7 @@ func DistIngest(
 		nil, /* clockUpdater */
 		evalCtx.Tracing,
 		evalCtx.ExecCfg.ContentionRegistry,
+		nil, /* testingPushCallback */
 	)
 	defer recv.Release()
 

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -279,6 +279,7 @@ func (dsp *DistSQLPlanner) planAndRunCreateStats(
 		evalCtx.ExecCfg.Clock,
 		evalCtx.Tracing,
 		evalCtx.ExecCfg.ContentionRegistry,
+		nil, /* testingPushCallback */
 	)
 	defer recv.Release()
 

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -451,6 +451,12 @@ type DistSQLReceiver struct {
 	contendedQueryMetric *metric.Counter
 	// contentionRegistry is a Registry that contention events are added to.
 	contentionRegistry *contention.Registry
+
+	testingKnobs struct {
+		// pushCallback, if set, will be called every time DistSQLReceiver.Push
+		// is called, with the same arguments.
+		pushCallback func(rowenc.EncDatumRow, *execinfrapb.ProducerMetadata)
+	}
 }
 
 // rowResultWriter is a subset of CommandResult to be used with the
@@ -546,6 +552,7 @@ func MakeDistSQLReceiver(
 	clockUpdater clockUpdater,
 	tracing *SessionTracing,
 	contentionRegistry *contention.Registry,
+	testingPushCallback func(rowenc.EncDatumRow, *execinfrapb.ProducerMetadata),
 ) *DistSQLReceiver {
 	consumeCtx, cleanup := tracing.TraceExecConsume(ctx)
 	r := receiverSyncPool.Get().(*DistSQLReceiver)
@@ -560,6 +567,7 @@ func MakeDistSQLReceiver(
 		tracing:            tracing,
 		contentionRegistry: contentionRegistry,
 	}
+	r.testingKnobs.pushCallback = testingPushCallback
 	return r
 }
 
@@ -590,14 +598,26 @@ func (r *DistSQLReceiver) clone() *DistSQLReceiver {
 // SetError provides a convenient way for a client to pass in an error, thus
 // pretending that a query execution error happened. The error is passed along
 // to the resultWriter.
+//
+// The status of DistSQLReceiver is updated accordingly.
 func (r *DistSQLReceiver) SetError(err error) {
 	r.resultWriter.SetError(err)
+	// If we encountered an error, we will transition to draining unless we were
+	// canceled.
+	if r.ctx.Err() != nil {
+		r.status = execinfra.ConsumerClosed
+	} else {
+		r.status = execinfra.DrainRequested
+	}
 }
 
 // Push is part of the RowReceiver interface.
 func (r *DistSQLReceiver) Push(
 	row rowenc.EncDatumRow, meta *execinfrapb.ProducerMetadata,
 ) execinfra.ConsumerStatus {
+	if r.testingKnobs.pushCallback != nil {
+		r.testingKnobs.pushCallback(row, meta)
+	}
 	if meta != nil {
 		if metaWriter, ok := r.resultWriter.(MetadataResultWriter); ok {
 			metaWriter.AddMeta(r.ctx, meta)
@@ -606,11 +626,11 @@ func (r *DistSQLReceiver) Push(
 			if r.txn != nil {
 				if r.txn.ID() == meta.LeafTxnFinalState.Txn.ID {
 					if err := r.txn.UpdateRootWithLeafFinalState(r.ctx, meta.LeafTxnFinalState); err != nil {
-						r.resultWriter.SetError(err)
+						r.SetError(err)
 					}
 				}
 			} else {
-				r.resultWriter.SetError(
+				r.SetError(
 					errors.Errorf("received a leaf final state (%s); but have no root", meta.LeafTxnFinalState))
 			}
 		}
@@ -635,7 +655,7 @@ func (r *DistSQLReceiver) Push(
 						}
 					}
 				}
-				r.resultWriter.SetError(meta.Err)
+				r.SetError(meta.Err)
 			}
 		}
 		if len(meta.Ranges) > 0 {
@@ -678,11 +698,7 @@ func (r *DistSQLReceiver) Push(
 		return r.status
 	}
 	if r.resultWriter.Err() == nil && r.ctx.Err() != nil {
-		r.resultWriter.SetError(r.ctx.Err())
-	}
-	if r.resultWriter.Err() != nil {
-		// TODO(andrei): We should drain here if we weren't canceled.
-		return execinfra.ConsumerClosed
+		r.SetError(r.ctx.Err())
 	}
 	if r.status != execinfra.NeedMoreRows {
 		return r.status
@@ -706,7 +722,7 @@ func (r *DistSQLReceiver) Push(
 	// planNodeToRowSource is not set up to handle decoding the row.
 	if r.noColsRequired {
 		r.row = []tree.Datum{}
-		r.status = execinfra.ConsumerClosed
+		r.status = execinfra.DrainRequested
 	} else {
 		if r.row == nil {
 			r.row = make(tree.Datums, len(row))
@@ -714,26 +730,27 @@ func (r *DistSQLReceiver) Push(
 		for i, encDatum := range row {
 			err := encDatum.EnsureDecoded(r.outputTypes[i], &r.alloc)
 			if err != nil {
-				r.resultWriter.SetError(err)
-				r.status = execinfra.ConsumerClosed
+				r.SetError(err)
 				return r.status
 			}
 			r.row[i] = encDatum.Datum
 		}
 	}
 	r.tracing.TraceExecRowsResult(r.ctx, r.row)
-	// Note that AddRow accounts for the memory used by the Datums.
 	if commErr := r.resultWriter.AddRow(r.ctx, r.row); commErr != nil {
-		// ErrLimitedResultClosed is not a real error, it is a
-		// signal to stop distsql and return success to the client.
-		if !errors.Is(commErr, ErrLimitedResultClosed) {
+		if errors.Is(commErr, ErrLimitedResultClosed) {
+			// ErrLimitedResultClosed is not a real error, it is a signal to
+			// stop distsql and return success to the client (that's why we
+			// don't set the error on the resultWriter).
+			r.status = execinfra.DrainRequested
+		} else {
 			// Set the error on the resultWriter too, for the convenience of some of the
 			// clients. If clients don't care to differentiate between communication
 			// errors and query execution errors, they can simply inspect
 			// resultWriter.Err(). Also, this function itself doesn't care about the
 			// distinction and just uses resultWriter.Err() to see if we're still
 			// accepting results.
-			r.resultWriter.SetError(commErr)
+			r.SetError(commErr)
 
 			// We don't need to shut down the connection
 			// if there's a portal-related error. This is
@@ -746,10 +763,6 @@ func (r *DistSQLReceiver) Push(
 				r.commErr = commErr
 			}
 		}
-		// TODO(andrei): We should drain here. Metadata from this query would be
-		// useful, particularly as it was likely a large query (since AddRow()
-		// above failed, presumably with an out-of-memory error).
-		r.status = execinfra.ConsumerClosed
 	}
 	return r.status
 }

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -63,6 +63,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/querycache"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
@@ -971,6 +972,12 @@ type ExecutorTestingKnobs struct {
 	// ForceRealTracingSpans, if set, forces the use of real (i.e. not no-op)
 	// tracing spans for every statement.
 	ForceRealTracingSpans bool
+
+	// DistSQLReceiverPushCallbackFactory, if set, will be called every time a
+	// DistSQLReceiver is created for a new query execution, and it should
+	// return, possibly nil, a callback that will be called every time
+	// DistSQLReceiver.Push is called.
+	DistSQLReceiverPushCallbackFactory func(query string) func(rowenc.EncDatumRow, *execinfrapb.ProducerMetadata)
 }
 
 // PGWireTestingKnobs contains knobs for the pgwire module.

--- a/pkg/sql/index_backfiller.go
+++ b/pkg/sql/index_backfiller.go
@@ -152,6 +152,7 @@ func (ib *IndexBackfillPlanner) plan(
 			ib.execCfg.Clock,
 			evalCtx.Tracing,
 			ib.execCfg.ContentionRegistry,
+			nil, /* testingPushCallback */
 		)
 		defer recv.Release()
 		evalCtxCopy := evalCtx

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -300,6 +300,7 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 			// other fields are used.
 			&SessionTracing{},
 			sc.execCfg.ContentionRegistry,
+			nil, /* testingPushCallback */
 		)
 		defer recv.Release()
 

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -315,9 +315,6 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 					if planAndRunErr = rw.Err(); planAndRunErr != nil {
 						return
 					}
-					if planAndRunErr = recv.commErr; planAndRunErr != nil {
-						return
-					}
 				}
 			}
 
@@ -333,9 +330,6 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 			PlanAndRunCTAS(ctx, sc.distSQLPlanner, localPlanner,
 				txn, isLocal, localPlanner.curPlan.main, out, recv)
 			if planAndRunErr = rw.Err(); planAndRunErr != nil {
-				return
-			}
-			if planAndRunErr = recv.commErr; planAndRunErr != nil {
 				return
 			}
 		})

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -493,6 +493,7 @@ func scrubRunDistSQL(
 		p.ExecCfg().Clock,
 		p.extendedEvalCtx.Tracing,
 		p.ExecCfg().ContentionRegistry,
+		nil, /* testingPushCallback */
 	)
 	defer recv.Release()
 

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -139,6 +139,7 @@ func (dsp *DistSQLPlanner) Exec(
 		execCfg.Clock,
 		p.ExtendedEvalContext().Tracing,
 		execCfg.ContentionRegistry,
+		nil, /* testingPushCallback */
 	)
 	defer recv.Release()
 


### PR DESCRIPTION
**sql: drain instead of hard shutdown in DistSQLReceiver.Push**

Previously, when the DistSQLReceiver encountered an error or received
enough rows to satisfy its consumer, it would transition to
`ConsumerClosed` status. I believe this is an incorrect behavior, and in
almost all cases we actually must transition to draining (we already had
several TODOs to do that), the only exception is if we're canceled
(indicated by an error on the context).

My reasoning is that there are certain types of metadata (like
LeafTxnFinalState) that must be received by the gateway to achieve the
correctness, yet that metadata is only collected in the draining state,
so if we go from `NeedMoreRows` to `ConsumerClosed`, we don't get
a chance to collect that meta.

As a concrete example, consider the way we implemented portals with
limits - some SELECT query reads some rows, once the portal limit is
satisfied, an error is returned from `AddRow`, this will currently cause
us to perform a hard shutdown of the flow, and we end up not collecting
spans to refresh. I believe it is a no bueno, and it is confirmed by
a unit test (that we don't drain the required metadata).

This commit fixes this problem by transitioning to draining in all cases
except when the context has an error.

Release note: None

**sql: do not check commErr redundantly in several places**

Previously, several clients of DistSQLReceiver were redundantly checking
`commErr`. The only client that needs to distinguish between the
communication and query execution errors is the main path of
`connExecutor.execWithDistSQLEngine`, and now it is the only one to do
so. Additionally, improve some comments.

Release note: None