### PR TITLE
bazel: point to our fork of `rules_go` rather than upstream

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,13 +10,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 # Load go bazel tools. This gives us access to the go bazel SDK/toolchains.
-http_archive(
+git_repository(
     name = "io_bazel_rules_go",
-    sha256 = "7c10271940c6bce577d51a075ae77728964db285dac0a46614a7934dc34303e6",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.26.0/rules_go-v0.26.0.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.26.0/rules_go-v0.26.0.tar.gz",
-    ],
+    commit = "2fe8a6256c818840cc9a10cf3f366d8410437245",
+    remote = "https://github.com/cockroachdb/rules_go",
 )
 
 # Like the above, but for nodeJS.


### PR DESCRIPTION
We want the test runner to be verbose about the actual exit code
returned by failing tests; so I added [a commit](https://github.com/cockroachdb/rules_go/commit/2fe8a6256c818840cc9a10cf3f366d8410437245)
to do this, and we point to this commit in `WORKSPACE`.

Release note: None