### PR TITLE
bazel: expose bazel build info (cgoTargetTriple)

### DIFF
--- a/build-rev.sh
+++ b/build-rev.sh
@@ -19,6 +19,18 @@ GIT_COMMIT=$(git rev-parse HEAD)
 GIT_TAG=$(git describe --tags --dirty --match=v[0-9]* 2> /dev/null || git rev-parse --short HEAD;)
 GIT_UTCTIME=$(date -u '+%Y/%m/%d %H:%M:%S')
 
+# TODO(alanmas): So far HOST_TRIPLE is "hardcoded" but
+# we need to ensure it gets set correctly as we continue to port things to Bazel.
+# TODO(alanmas): As we don’t have a release pipeline set up for Bazel-built cockroach binaries yet
+# we are not taking care of:
+# - github.com/cockroachdb/cockroach/pkg/build.channel
+# - github.com/cockroachdb/cockroach/pkg/util/log.crashReportEnv
+# we need to keep this on track to work on them as soon as we release our pipeline.
+
+HOST_TRIPLE="x86_64-pc-linux-gnu"
+
+TARGET_TRIPLE=${HOST_TRIPLE}
+
 # Prefix with STABLE_ so that these values are saved to stable-status.txt
 # instead of volatile-status.txt.
 # Stamped rules will be retriggered by changes to stable-status.txt, but not by
@@ -28,4 +40,5 @@ STABLE_BUILD_GIT_COMMIT ${GIT_COMMIT-}
 STABLE_BUILD_GIT_TAG ${GIT_TAG-}
 STABLE_BUILD_GIT_UTCTIME ${GIT_UTCTIME-}
 STABLE_BUILD_GIT_BUILD_TYPE ${GIT_BUILD_TYPE-}
+STABLE_BUILD_TARGET_TRIPLE ${TARGET_TRIPLE-}
 EOF

--- a/pkg/build/BUILD.bazel
+++ b/pkg/build/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "github.com/cockroachdb/cockroach/pkg/build.tag": "{STABLE_BUILD_GIT_TAG}",
         "github.com/cockroachdb/cockroach/pkg/build.utcTime": "{STABLE_BUILD_GIT_UTCTIME}",
         "github.com/cockroachdb/cockroach/pkg/build.typ": "{STABLE_BUILD_GIT_BUILD_TYPE}",
+        "github.com/cockroachdb/cockroach/pkg/build.cgoTargetTriple": "{STABLE_BUILD_TARGET_TRIPLE}",
     },
     deps = [
         "//pkg/util/envutil",


### PR DESCRIPTION
As second part of the work related to #60963 We'd like the cockroach-short binary that CI makes to expose some of the Build Info stuff that we've been missing up to now.
We are adding the info that includes:

- github.com/cockroachdb/cockroach/pkg/build.cgoTargetTriple

So far we are "hardcoding" the values, but we added a TODO note inside build-rev.sh script to follow this up.

Release note: None

Release justification: non-production code changes