### PR TITLE
ccl/bulk-io: clean up the processors a bit

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -138,12 +138,6 @@ func (bp *backupDataProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Producer
 	return nil, bp.DrainHelper()
 }
 
-// ConsumerClosed is part of the RowSource interface.
-func (bp *backupDataProcessor) ConsumerClosed() {
-	// The consumer is done, Next() will not be called again.
-	bp.InternalClose()
-}
-
 type spanAndTime struct {
 	// spanIdx is a unique identifier of this object.
 	spanIdx    int

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -152,11 +152,6 @@ func (rd *restoreDataProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Produce
 	return nil, &execinfrapb.ProducerMetadata{BulkProcessorProgress: &prog}
 }
 
-// ConsumerClosed is part of the RowSource interface.
-func (rd *restoreDataProcessor) ConsumerClosed() {
-	rd.InternalClose()
-}
-
 func init() {
 	rowexec.NewRestoreDataProcessor = newRestoreDataProcessor
 }

--- a/pkg/ccl/importccl/import_processor.go
+++ b/pkg/ccl/importccl/import_processor.go
@@ -146,12 +146,6 @@ func (idp *readImportDataProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Pro
 	}, nil
 }
 
-// ConsumerClosed is part of the RowSource interface.
-func (idp *readImportDataProcessor) ConsumerClosed() {
-	// The consumer is done, Next() will not be called again.
-	idp.InternalClose()
-}
-
 func injectTimeIntoEvalCtx(ctx *tree.EvalContext, walltime int64) {
 	sec := walltime / int64(time.Second)
 	nsec := walltime % int64(time.Second)

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
@@ -177,9 +177,3 @@ func (sf *streamIngestionFrontier) maybeMoveFrontier(
 	sf.frontier.Forward(span, resolved)
 	return prevResolved.Less(sf.frontier.Frontier())
 }
-
-// ConsumerClosed is part of the RowSource interface.
-func (sf *streamIngestionFrontier) ConsumerClosed() {
-	// The consumer is done, Next() will not be called again.
-	sf.InternalClose()
-}

--- a/pkg/sql/execinfra/base.go
+++ b/pkg/sql/execinfra/base.go
@@ -153,6 +153,10 @@ type RowSource interface {
 	// before Next indicates that there are no more rows, ConsumerDone() and/or
 	// ConsumerClosed() must be called; it is a no-op to call these methods after
 	// all the rows were consumed (i.e. after Next() returned an empty row).
+	//
+	// Processors that embed ProcessorBase can delegate the implementation to
+	// the latter if they only need to perform trivial cleanup (calling
+	// ProcessorBase.InternalClose).
 	ConsumerClosed()
 }
 


### PR DESCRIPTION
This commit removes some redundant implementations of `ConsumerClosed`
method that simply call `InternalClose` - the reason is that it is the
default implementation provided by the `ProcessorBase`.

Release note: None