### PR TITLE
bazel: dump all test output for failed tests to the teamcity build log

### DIFF
--- a/.bazelrc.ci
+++ b/.bazelrc.ci
@@ -5,5 +5,8 @@
 # Ref: https://github.com/bazelbuild/rules_go/pull/2456
 test --test_env=GO_TEST_WRAP_TESTV=1
 
+# Dump all output for failed tests to the build log.
+test --test_output=errors
+
 # Adding building info
 build --stamp --workspace_status_command=$(pwd)/build-rev.sh


### PR DESCRIPTION
The current behavior doesn't necessarily capture *every* bit of the test
output -- some stuff can be left out, especially if the failure is not
associated with any particular failing test. This command-line flag will
cause *all* output to be printed to the log.

Release note: None