### PR TITLE
colflow: get the correct latency from remote nodes

### DIFF
--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -828,7 +828,9 @@ func (s *vectorizedFlowCreator) setupInput(
 				return nil, nil, nil, nil, err
 			}
 
-			latency, err := s.nodeDialer.Latency(inputStream.TargetNodeID)
+			// Retrieve the latency from the origin node (the one that has the
+			// outbox).
+			latency, err := s.nodeDialer.Latency(inputStream.OriginNodeID)
 			if err != nil {
 				// If an error occurred, latency's nil value of 0 is used. If latency is
 				// 0, it is not included in the displayed stats for EXPLAIN ANALYZE


### PR DESCRIPTION
Fixes: #60621.

Release note (bug fix): Previously, CockroachDB would incorrectly
calculate the latency from the remote nodes when the latency info was
shown on the EXPLAIN ANALYZE (DISTSQL) diagrams.