### PR TITLE
release-21.1: *: improve handling of permanent errors

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -406,7 +406,9 @@ github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRx
 github.com/gofrs/uuid v3.3.0+incompatible h1:8K4tyRfvU1CYPgJsveYFQMhpFd/wXNM7iK6rR7UHz84=
 github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/googleapis v0.0.0-20180223154316-0cd9801be74a/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
+github.com/gogo/googleapis v1.2.0 h1:Z0v3OJDotX9ZBpdz2V+AI7F4fITSZhVE5mg6GQppwMM=
 github.com/gogo/googleapis v1.2.0/go.mod h1:Njal3psf3qN6dwBtQfUmBZh2ybovJ0tlu3o/AC7HYjU=
+github.com/gogo/status v1.1.0 h1:+eIkrewn5q6b30y+g/BJINVVdi2xH7je5MPJ3ZPK3JA=
 github.com/gogo/status v1.1.0/go.mod h1:BFv9nrluPLmrS0EmGVvLaPNmRosr9KapBYd5/hpY1WM=
 github.com/golang-commonmark/html v0.0.0-20180910111043-7d7c804e1d46 h1:FeNEDxIy7XouGTJKiJ9Ze5vUbcAIW/FRhQbtKBNmEz8=
 github.com/golang-commonmark/html v0.0.0-20180910111043-7d7c804e1d46/go.mod h1:LVbxopYhspqklDpfaS/qDc6HhWwkpF1ptTj3vMFRoSQ=

--- a/pkg/kv/BUILD.bazel
+++ b/pkg/kv/BUILD.bazel
@@ -57,6 +57,7 @@ go_test(
         "//pkg/keys",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/kvserverbase",
+        "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/roachpb",
         "//pkg/security",
         "//pkg/security/securitytest",
@@ -77,5 +78,7 @@ go_test(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_gogo_protobuf//proto",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
     ],
 )

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -1482,7 +1482,7 @@ func (ds *DistSender) sendPartialBatch(
 				// order to return the most recent error when we are out of retries.
 				pErr = roachpb.NewError(err)
 				if !rangecache.IsRangeLookupErrorRetryable(err) {
-					return response{pErr: roachpb.NewError(err)}
+					return response{pErr: pErr}
 				}
 				continue
 			}

--- a/pkg/kv/kvserver/liveness/BUILD.bazel
+++ b/pkg/kv/kvserver/liveness/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/storage",
         "//pkg/util/contextutil",
+        "//pkg/util/grpcutil",
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/metric",

--- a/pkg/kv/kvserver/liveness/liveness.go
+++ b/pkg/kv/kvserver/liveness/liveness.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
+	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -333,6 +334,9 @@ func (nl *NodeLiveness) SetDraining(
 		if err := nl.setDrainingInternal(ctx, oldLivenessRec, drain, reporter); err != nil {
 			if log.V(1) {
 				log.Infof(ctx, "attempting to set liveness draining status to %v: %v", drain, err)
+			}
+			if grpcutil.IsAuthError(err) {
+				return err
 			}
 			continue
 		}
@@ -697,6 +701,9 @@ func (nl *NodeLiveness) Start(ctx context.Context, opts NodeLivenessStartOptions
 							liveness, err := nl.getLivenessFromKV(ctx, nodeID)
 							if err != nil {
 								log.Infof(ctx, "unable to get liveness record from KV: %s", err)
+								if grpcutil.IsAuthError(err) {
+									return err
+								}
 								continue
 							}
 							oldLiveness = liveness

--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
         "@com_github_cockroachdb_apd_v2//:apd",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//errorspb",
+        "@com_github_cockroachdb_errors//extgrpc",
         "@com_github_cockroachdb_redact//:redact",
         "@io_etcd_go_etcd_raft_v3//raftpb",
     ],
@@ -96,6 +97,7 @@ go_library(
         "@com_github_cockroachdb_apd_v2//:apd",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//errorspb",
+        "@com_github_cockroachdb_errors//extgrpc",
         "@com_github_cockroachdb_redact//:redact",
         "@io_etcd_go_etcd_raft_v3//raftpb",
     ],
@@ -152,6 +154,8 @@ go_test(
         "@io_etcd_go_etcd_raft_v3//quorum",
         "@io_etcd_go_etcd_raft_v3//raftpb",
         "@io_etcd_go_etcd_raft_v3//tracker",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
     ],
 )
 

--- a/pkg/roachpb/errors.go
+++ b/pkg/roachpb/errors.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/errorspb"
+	_ "github.com/cockroachdb/errors/extgrpc" // register EncodeError support for gRPC Status
 	"github.com/cockroachdb/redact"
 )
 

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -43,12 +43,10 @@ import (
 	"golang.org/x/sync/syncmap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/encoding"
 	encodingproto "google.golang.org/grpc/encoding/proto"
 	"google.golang.org/grpc/metadata"
-	grpcstatus "google.golang.org/grpc/status"
 )
 
 func init() {
@@ -1063,7 +1061,7 @@ func (ctx *Context) grpcDialNodeInternal(
 			if err := ctx.Stopper.RunAsyncTask(
 				ctx.masterCtx, "rpc.Context: grpc heartbeat", func(masterCtx context.Context) {
 					err := ctx.runHeartbeat(conn, target, redialChan)
-					if err != nil && !grpcutil.IsClosedConnection(err) {
+					if err != nil && !grpcutil.IsClosedConnection(err) && !grpcutil.IsAuthError(err) {
 						log.Health.Errorf(masterCtx, "removing connection to %s due to error: %s", target, err)
 					}
 					ctx.removeConn(conn, thisConnKeys...)
@@ -1179,7 +1177,7 @@ func (ctx *Context) runHeartbeat(
 				err = ping(goCtx)
 			}
 
-			if s, ok := grpcstatus.FromError(errors.UnwrapAll(err)); ok && s.Code() == codes.PermissionDenied {
+			if grpcutil.IsAuthError(err) {
 				returnErr = true
 			}
 

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -60,6 +60,9 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func getAdminJSONProto(
@@ -2081,5 +2084,171 @@ func TestDecommissionSelf(t *testing.T) {
 			liveness, ok := srv.NodeLiveness().(*liveness.NodeLiveness).GetLiveness(srv.NodeID())
 			return ok && liveness.Membership == expect
 		}, 5*time.Second, 100*time.Millisecond, "timed out waiting for node %v status %v", i, expect)
+	}
+}
+
+func TestAdminDecommissionedOperations(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tc := serverutils.StartNewTestCluster(t, 2, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual, // saves time
+		ServerArgs: base.TestServerArgs{
+			Insecure: true, // allows admin client without setting up certs
+		},
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	scratchKey := tc.ScratchRange(t)
+	scratchRange := tc.LookupRangeOrFatal(t, scratchKey)
+	require.Len(t, scratchRange.InternalReplicas, 1)
+	require.Equal(t, tc.Server(0).NodeID(), scratchRange.InternalReplicas[0].NodeID)
+
+	// Decommission server 1 and wait for it to lose cluster access.
+	srv := tc.Server(0)
+	decomSrv := tc.Server(1)
+	for _, status := range []livenesspb.MembershipStatus{
+		livenesspb.MembershipStatus_DECOMMISSIONING, livenesspb.MembershipStatus_DECOMMISSIONED,
+	} {
+		require.NoError(t, srv.Decommission(ctx, status, []roachpb.NodeID{decomSrv.NodeID()}))
+	}
+
+	require.Eventually(t, func() bool {
+		_, err := decomSrv.DB().Scan(ctx, keys.MinKey, keys.MaxKey, 0)
+		s, ok := status.FromError(errors.UnwrapAll(err))
+		return ok && s.Code() == codes.PermissionDenied
+	}, 10*time.Second, 100*time.Millisecond, "timed out waiting for server to lose cluster access")
+
+	// Set up an admin client.
+	conn, err := grpc.Dial(decomSrv.ServingRPCAddr(), grpc.WithInsecure())
+	require.NoError(t, err)
+	defer func() {
+		_ = conn.Close() // nolint:grpcconnclose
+	}()
+	adminClient := serverpb.NewAdminClient(conn)
+
+	// Run some operations on the decommissioned node. The ones that require
+	// access to the cluster should fail, other should succeed. We're mostly
+	// concerned with making sure they return rather than hang due to internal
+	// retries.
+	testcases := []struct {
+		name       string
+		expectCode codes.Code
+		op         func(serverpb.AdminClient) error
+	}{
+		{"Cluster", codes.OK, func(c serverpb.AdminClient) error {
+			_, err := c.Cluster(ctx, &serverpb.ClusterRequest{})
+			return err
+		}},
+		{"Databases", codes.Internal, func(c serverpb.AdminClient) error {
+			_, err := c.Databases(ctx, &serverpb.DatabasesRequest{})
+			return err
+		}},
+		{"DatabaseDetails", codes.Internal, func(c serverpb.AdminClient) error {
+			_, err := c.DatabaseDetails(ctx, &serverpb.DatabaseDetailsRequest{Database: "foo"})
+			return err
+		}},
+		{"DataDistribution", codes.Internal, func(c serverpb.AdminClient) error {
+			_, err := c.DataDistribution(ctx, &serverpb.DataDistributionRequest{})
+			return err
+		}},
+		{"Decommission", codes.Unknown, func(c serverpb.AdminClient) error {
+			_, err := c.Decommission(ctx, &serverpb.DecommissionRequest{
+				NodeIDs:          []roachpb.NodeID{srv.NodeID(), decomSrv.NodeID()},
+				TargetMembership: livenesspb.MembershipStatus_DECOMMISSIONED,
+			})
+			return err
+		}},
+		{"DecommissionStatus", codes.Unknown, func(c serverpb.AdminClient) error {
+			_, err := c.DecommissionStatus(ctx, &serverpb.DecommissionStatusRequest{
+				NodeIDs: []roachpb.NodeID{srv.NodeID(), decomSrv.NodeID()},
+			})
+			return err
+		}},
+		{"EnqueueRange", codes.Internal, func(c serverpb.AdminClient) error {
+			_, err := c.EnqueueRange(ctx, &serverpb.EnqueueRangeRequest{
+				RangeID: scratchRange.RangeID,
+				Queue:   "replicaGC",
+			})
+			return err
+		}},
+		{"Events", codes.Internal, func(c serverpb.AdminClient) error {
+			_, err := c.Events(ctx, &serverpb.EventsRequest{})
+			return err
+		}},
+		{"Health", codes.OK, func(c serverpb.AdminClient) error {
+			_, err := c.Health(ctx, &serverpb.HealthRequest{})
+			return err
+		}},
+		{"Jobs", codes.Internal, func(c serverpb.AdminClient) error {
+			_, err := c.Jobs(ctx, &serverpb.JobsRequest{})
+			return err
+		}},
+		{"Liveness", codes.OK, func(c serverpb.AdminClient) error {
+			_, err := c.Liveness(ctx, &serverpb.LivenessRequest{})
+			return err
+		}},
+		{"Locations", codes.Internal, func(c serverpb.AdminClient) error {
+			_, err := c.Locations(ctx, &serverpb.LocationsRequest{})
+			return err
+		}},
+		{"NonTableStats", codes.Internal, func(c serverpb.AdminClient) error {
+			_, err := c.NonTableStats(ctx, &serverpb.NonTableStatsRequest{})
+			return err
+		}},
+		{"QueryPlan", codes.OK, func(c serverpb.AdminClient) error {
+			_, err := c.QueryPlan(ctx, &serverpb.QueryPlanRequest{Query: "SELECT 1"})
+			return err
+		}},
+		{"RangeLog", codes.Internal, func(c serverpb.AdminClient) error {
+			_, err := c.RangeLog(ctx, &serverpb.RangeLogRequest{})
+			return err
+		}},
+		{"Settings", codes.OK, func(c serverpb.AdminClient) error {
+			_, err := c.Settings(ctx, &serverpb.SettingsRequest{})
+			return err
+		}},
+		{"TableStats", codes.Internal, func(c serverpb.AdminClient) error {
+			_, err := c.TableStats(ctx, &serverpb.TableStatsRequest{Database: "foo", Table: "bar"})
+			return err
+		}},
+		{"TableDetails", codes.Internal, func(c serverpb.AdminClient) error {
+			_, err := c.TableDetails(ctx, &serverpb.TableDetailsRequest{Database: "foo", Table: "bar"})
+			return err
+		}},
+		{"Users", codes.Internal, func(c serverpb.AdminClient) error {
+			_, err := c.Users(ctx, &serverpb.UsersRequest{})
+			return err
+		}},
+		// We drain at the end, since it may evict us.
+		{"Drain", codes.Unknown, func(c serverpb.AdminClient) error {
+			stream, err := c.Drain(ctx, &serverpb.DrainRequest{DoDrain: true})
+			if err != nil {
+				return err
+			}
+			_, err = stream.Recv()
+			return err
+		}},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var err error
+			require.Eventually(t, func() bool {
+				err = tc.op(adminClient)
+				if tc.expectCode == codes.OK {
+					require.NoError(t, err)
+					return true
+				}
+				s, ok := status.FromError(errors.UnwrapAll(err))
+				if s == nil || !ok {
+					return false
+				}
+				require.Equal(t, tc.expectCode, s.Code())
+				return true
+			}, 10*time.Second, 100*time.Millisecond, "timed out waiting for gRPC error, got %s", err)
+		})
 	}
 }

--- a/pkg/server/connectivity_test.go
+++ b/pkg/server/connectivity_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
@@ -370,42 +371,31 @@ func TestDecommissionedNodeCannotConnect(t *testing.T) {
 			clusterSrv := tc.Server(idx)
 
 			// Within a short period of time, the cluster (n1, n2) will refuse to reach out to n3.
-			{
-				_, err := clusterSrv.RPCContext().GRPCDialNode(
-					decomSrv.RPCAddr(), decomSrv.NodeID(), rpc.DefaultClass,
-				).Connect(ctx)
-				s, ok := grpcstatus.FromError(errors.UnwrapAll(err))
-				if !ok || s.Code() != codes.PermissionDenied {
-					return errors.Errorf("expected permission denied for n%d->n%d, got %v", clusterSrv.NodeID(), decomSrv.NodeID(), err)
-				}
+			_, err := clusterSrv.RPCContext().GRPCDialNode(
+				decomSrv.RPCAddr(), decomSrv.NodeID(), rpc.DefaultClass,
+			).Connect(ctx)
+			s, ok := grpcstatus.FromError(errors.UnwrapAll(err))
+			if !ok || s.Code() != codes.PermissionDenied {
+				return errors.Errorf("expected permission denied for n%d->n%d, got %v", clusterSrv.NodeID(), decomSrv.NodeID(), err)
 			}
 
 			// And similarly, n3 will be refused by n1, n2.
-			{
-				_, err := decomSrv.RPCContext().GRPCDialNode(
-					clusterSrv.RPCAddr(), decomSrv.NodeID(), rpc.DefaultClass,
-				).Connect(ctx)
-				s, ok := grpcstatus.FromError(errors.UnwrapAll(err))
-				if !ok || s.Code() != codes.PermissionDenied {
-					return errors.Errorf("expected permission denied for n%d->n%d, got %v", decomSrv.NodeID(), clusterSrv.NodeID(), err)
-				}
+			_, err = decomSrv.RPCContext().GRPCDialNode(
+				clusterSrv.RPCAddr(), decomSrv.NodeID(), rpc.DefaultClass,
+			).Connect(ctx)
+			s, ok = grpcstatus.FromError(errors.UnwrapAll(err))
+			if !ok || s.Code() != codes.PermissionDenied {
+				return errors.Errorf("expected permission denied for n%d->n%d, got %v", decomSrv.NodeID(), clusterSrv.NodeID(), err)
 			}
+		}
+
+		// Trying to scan the scratch range from the decommissioned node should
+		// now result in a permission denied error.
+		_, err := decomSrv.DB().Scan(ctx, scratchKey, keys.MaxKey, 1)
+		s, ok := grpcstatus.FromError(errors.UnwrapAll(err))
+		if !ok || s.Code() != codes.PermissionDenied {
+			return errors.Errorf("expected permission denied for scan, got %v", err)
 		}
 		return nil
 	})
-
-	// Trying to scan the scratch range via the decommissioned node should
-	// now result in a permission denied error.
-	//
-	// TODO(erikgrinaker): until cockroachdb/errors preserves grpcstatus.Error
-	// across errors.EncodeError() we'll have to disable this, since the return
-	// code isn't preserved, and since some internal calls (notably RangeLookup
-	// via RangeIterator) end up retrying indefinitely because it can't detect
-	// the error code. See: https://github.com/cockroachdb/cockroach/issues/61470
-	//_, err := decomSrv.DB().Scan(ctx, scratchKey, keys.MaxKey, 1)
-	//require.Error(t, err)
-	//err = errors.UnwrapAll(err)
-	//s, ok := grpcstatus.FromError(err)
-	//require.True(t, ok, "expected gRPC error, got %T (%v)", err, err)
-	//require.Equal(t, codes.PermissionDenied, s.Code(), "expected permission denied error")
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -40,9 +40,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -60,6 +62,8 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // TestSelfBootstrap verifies operation when no bootstrap hosts have
@@ -1163,4 +1167,65 @@ func TestDecommissionNodeStatus(t *testing.T) {
 	entry, err := srv.DB().Get(ctx, keys.NodeStatusKey(decomNodeID))
 	require.NoError(t, err)
 	require.Nil(t, entry.Value, "found stale node status entry for node %d", decomNodeID)
+}
+
+func TestSQLDecommissioned(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tc := serverutils.StartNewTestCluster(t, 2, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual, // saves time
+		ServerArgs: base.TestServerArgs{
+			Insecure: true, // to set up a simple SQL client
+		},
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	// Decommission server 1 and wait for it to lose cluster access.
+	srv := tc.Server(0)
+	decomSrv := tc.Server(1)
+	for _, status := range []livenesspb.MembershipStatus{
+		livenesspb.MembershipStatus_DECOMMISSIONING, livenesspb.MembershipStatus_DECOMMISSIONED,
+	} {
+		require.NoError(t, srv.Decommission(ctx, status, []roachpb.NodeID{decomSrv.NodeID()}))
+	}
+
+	require.Eventually(t, func() bool {
+		_, err := decomSrv.DB().Scan(ctx, keys.MinKey, keys.MaxKey, 0)
+		s, ok := status.FromError(errors.UnwrapAll(err))
+		return ok && s.Code() == codes.PermissionDenied
+	}, 10*time.Second, 100*time.Millisecond, "timed out waiting for server to lose cluster access")
+
+	// Tests SQL access. We're mostly concerned with these operations returning
+	// fast rather than hanging indefinitely due to internal retries. We both
+	// try the internal executor, to check that the internal structured error is
+	// propagated correctly, and also from a client to make sure the error is
+	// propagated all the way.
+	require.Eventually(t, func() bool {
+		sqlExec := decomSrv.InternalExecutor().(*sql.InternalExecutor)
+
+		datums, err := sqlExec.QueryBuffered(ctx, "", nil, "SELECT 1")
+		require.NoError(t, err)
+		require.Equal(t, []tree.Datums{{tree.NewDInt(1)}}, datums)
+
+		_, err = sqlExec.QueryBuffered(ctx, "", nil, "SELECT * FROM crdb_internal.tables")
+		if err == nil {
+			return false
+		}
+		s, ok := status.FromError(errors.UnwrapAll(err))
+		require.True(t, ok, "expected gRPC status error, got %T: %s", err, err)
+		require.Equal(t, codes.PermissionDenied, s.Code())
+
+		sqlClient, err := serverutils.OpenDBConnE(decomSrv.ServingSQLAddr(), "", true, tc.Stopper())
+		require.NoError(t, err)
+
+		var result int
+		err = sqlClient.QueryRow("SELECT 1").Scan(&result)
+		require.NoError(t, err)
+		require.Equal(t, 1, result)
+
+		_, err = sqlClient.Query("SELECT * FROM crdb_internal.tables")
+		return err != nil
+	}, 10*time.Second, 100*time.Millisecond, "timed out waiting for queries to error")
 }

--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqlutil",
+        "//pkg/util/grpcutil",
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/log/logcrash",

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
@@ -310,6 +311,9 @@ func (s storage) release(ctx context.Context, stopper *stop.Stopper, lease *stor
 		)
 		if err != nil {
 			log.Warningf(ctx, "error releasing lease %q: %s", lease, err)
+			if grpcutil.IsAuthError(err) {
+				return
+			}
 			firstAttempt = false
 			continue
 		}


### PR DESCRIPTION
Backport 2/2 commits from #62608.

Kept as draft until 21.1.1, to let the changes bake on `master` for a bit.

/cc @cockroachdb/release

---

***: improve handling of permanent errors**

RPC errors are normally retried. However, in some cases the errors are
permanent such that retries are futile, and this can cause operations to
appear to hang as they keep retrying -- e.g. when running operations on
a decommissioned node. There is already some detection of permanent
errors, but it is incomplete.

This patch attempts to improve coverage of permanent errors, in
particular in the context of decommissioned nodes, and adds test cases
for these scenarios.

Release note: None

**roachpb: propagate gRPC Status errors across Error**

`roachpb.Error` uses `errors.EncodeError()` and `errors.DecodeError()`
to preserve the original structured error. Unfortunately, these did not
handle gRPC `Status` errors, resulting in a generic unstructured error
after decoding. Since this is used while propagating errors through the
KV layer, it could prevent detection of the original error type.

Support for gRPC Status encoding was added in cockroachdb/errors 1.8.3,
this patch registers the error en/decoder such that these errors are
preserved across `roachpb.Error`. A later patch will extend existing
error handling code to make better use of these.

Release note: None

Resolves #62233, resolves #61470. Touches #56208.

Decommissioned nodes will keep running a bunch of async processes that
try (and fail) to communicate with the cluster. These have not been
addressed here, see #62693.
