### PR TITLE
roachprod: use additional SSH identities for logs command

### DIFF
--- a/pkg/cmd/roachprod/install/cluster_synced.go
+++ b/pkg/cmd/roachprod/install/cluster_synced.go
@@ -1218,7 +1218,8 @@ func (c *SyncedCluster) Logs(
 				"-o ControlMaster=auto "+
 				"-o ControlPath=~/.ssh/%r@%h:%p "+
 				"-o UserKnownHostsFile=/dev/null "+
-				"-o ControlPersist=2m")
+				"-o ControlPersist=2m "+
+				strings.Join(sshAuthArgs(), " "))
 			// Use rsync-path flag to sudo into user if different from sshUser.
 			if user != "" && user != sshUser {
 				rsyncArgs = append(rsyncArgs, "--rsync-path",

--- a/pkg/cmd/roachprod/install/session.go
+++ b/pkg/cmd/roachprod/install/session.go
@@ -213,6 +213,7 @@ var sshAuthArgsOnce sync.Once
 func sshAuthArgs() []string {
 	sshAuthArgsOnce.Do(func() {
 		paths := []string{
+			filepath.Join(config.OSUser.HomeDir, ".ssh", "id_ed25519"),
 			filepath.Join(config.OSUser.HomeDir, ".ssh", "id_rsa"),
 			filepath.Join(config.OSUser.HomeDir, ".ssh", "google_compute_engine"),
 		}


### PR DESCRIPTION
**roachprod: use additional SSH identities for logs command**

`roachprod logs` would fail with a public key authentication error on
GCE because the gcloud private key is located under
`~/.ssh/google_compute_engine` but this was not passed to the `rsync`
command used to retrieve logs.

This patch injects detected SSH private key identities into the
`rsync` command used for `logs`.

Release note: None

**roachprod: use id_25519 SSH identity as well**

This patch detects and uses an `id_25519` SSH private key if present,
which was previously ignored.

Release note: None