### PR TITLE
cli/demo: avoid depending on demoCtx in demo_cluster.go

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"net/url"
 	"os"
-	"strconv"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -528,40 +527,28 @@ func setSqlfmtContextDefaults() {
 // demoCtx captures the command-line parameters of the `demo` command.
 // See below for defaults.
 var demoCtx struct {
-	nodes                     int
-	sqlPoolMemorySize         int64
-	cacheSize                 int64
+	transientClusterConfig
+
 	disableTelemetry          bool
 	disableLicenseAcquisition bool
 	noExampleDatabase         bool
 	runWorkload               bool
-	localities                demoLocalityList
 	geoPartitionedReplicas    bool
-	simulateLatency           bool
 	transientCluster          *transientCluster
-	insecure                  bool
-	sqlPort                   int
-	httpPort                  int
 }
 
 // setDemoContextDefaults set the default values in demoCtx.  This
 // function is called by initCLIDefaults() and thus re-called in every
 // test that exercises command-line parsing.
 func setDemoContextDefaults() {
-	demoCtx.nodes = 1
-	demoCtx.sqlPoolMemorySize = 128 << 20 // 128MB, chosen to fit 9 nodes on 2GB machine.
-	demoCtx.cacheSize = 64 << 20          // 64MB, chosen to fit 9 nodes on 2GB machine.
+	demoCtx.transientClusterConfig = defaultTransientClusterConfig()
+
 	demoCtx.noExampleDatabase = false
-	demoCtx.simulateLatency = false
 	demoCtx.runWorkload = false
-	demoCtx.localities = nil
 	demoCtx.geoPartitionedReplicas = false
 	demoCtx.disableTelemetry = false
 	demoCtx.disableLicenseAcquisition = false
 	demoCtx.transientCluster = nil
-	demoCtx.insecure = false
-	demoCtx.sqlPort, _ = strconv.Atoi(base.DefaultPort)
-	demoCtx.httpPort, _ = strconv.Atoi(base.DefaultHTTPPort)
 }
 
 // stmtDiagCtx captures the command-line parameters of the 'statement-diag'

--- a/pkg/cli/demo_test.go
+++ b/pkg/cli/demo_test.go
@@ -87,11 +87,13 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
-			demoCtxTemp := demoCtx
-			demoCtx.sqlPoolMemorySize = tc.sqlPoolMemorySize
-			demoCtx.cacheSize = tc.cacheSize
+			cfg := demoCtx.transientClusterConfig
+			cfg.sqlPoolMemorySize = tc.sqlPoolMemorySize
+			cfg.cacheSize = tc.cacheSize
+			cfg.sqlFirstPort = 1234
+			cfg.httpFirstPort = 4567
 
-			actual := testServerArgsForTransientCluster(unixSocketDetails{}, tc.nodeID, tc.joinAddr, "", 1234, 4567, stickyEnginesRegistry)
+			actual := testServerArgsForTransientCluster(cfg, unixSocketDetails{}, tc.nodeID, tc.joinAddr, "", stickyEnginesRegistry)
 			stopper := actual.Stopper
 			defer stopper.Stop(context.Background())
 
@@ -107,9 +109,6 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 			actual.StoreSpecs = nil
 
 			assert.Equal(t, tc.expected, actual)
-
-			// Restore demoCtx state after each test.
-			demoCtx = demoCtxTemp
 		})
 	}
 }

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -727,7 +727,7 @@ func init() {
 		// ./cockroach demo movr --nodes=3.
 		f := demoCmd.PersistentFlags()
 
-		intFlag(f, &demoCtx.nodes, cliflags.DemoNodes)
+		intFlag(f, &demoCtx.numNodes, cliflags.DemoNodes)
 		boolFlag(f, &demoCtx.runWorkload, cliflags.RunDemoWorkload)
 		varFlag(f, &demoCtx.localities, cliflags.DemoNodeLocality)
 		boolFlag(f, &demoCtx.geoPartitionedReplicas, cliflags.DemoGeoPartitionedReplicas)
@@ -754,8 +754,8 @@ func init() {
 		// sharing a variable between both.
 		stringFlag(f, &startCtx.geoLibsDir, cliflags.GeoLibsDir)
 
-		intFlag(f, &demoCtx.sqlPort, cliflags.DemoSQLPort)
-		intFlag(f, &demoCtx.httpPort, cliflags.DemoHTTPPort)
+		intFlag(f, &demoCtx.sqlFirstPort, cliflags.DemoSQLPort)
+		intFlag(f, &demoCtx.httpFirstPort, cliflags.DemoHTTPPort)
 	}
 
 	// statement-diag command.


### PR DESCRIPTION
Needed for #62435. 

This ensures that all the functional parameters in
`cli/demo_cluster.go` are passed either as arguments or as a config
struct.

This makes the code easier to understand overall by reducing the
dependencies on global variables.

Release note: None