### PR TITLE
cli/demo: avoid stray goroutines when shutting down a transient cluster

### DIFF
--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -94,6 +94,10 @@ type regionPair struct {
 	regionB string
 }
 
+// regionToRegionToLatency maps region pairs to a latency in milliseconds.
+// Note: there are multiple places in the code where the integer
+// here is converted to a time.Duration. If/when the unit is changed,
+// be careful to update all of them.
 var regionToRegionToLatency map[string]map[string]int
 
 func insertPair(pair regionPair, latency int) {
@@ -106,6 +110,10 @@ func insertPair(pair regionPair, latency int) {
 }
 
 // Round-trip latencies collected from http://cloudping.co on 2019-09-11.
+// The unit is milliseconds.
+// Note: there are multiple places in the code where the integer
+// here is converted to a time.Duration. If/when the unit is changed,
+// be careful to update all of them.
 var regionRoundTripLatencies = map[regionPair]int{
 	{regionA: "us-east1", regionB: "us-west1"}:     66,
 	{regionA: "us-east1", regionB: "europe-west1"}: 64,

--- a/pkg/cli/demo_cluster.go
+++ b/pkg/cli/demo_cluster.go
@@ -63,6 +63,24 @@ type transientCluster struct {
 	adminUser     security.SQLUsername
 
 	stickyEngineRegistry server.StickyInMemEnginesRegistry
+
+	// delayWaitAtEnd is an additional delay to wait for when shutting
+	// down a transient cluster.
+	//
+	// This is needed because when using simulated non-local latencies,
+	// there will be pending HTTP connection goroutines waiting for the
+	// TCP connection to close, which in turn needs to wait for a
+	// network roundtrip.
+	//
+	// (See the code in `(*Transport) queueForDial()` and `dialConnFor()` in
+	// net/http/transport.go.)
+	//
+	// If left running beyond the termination of the transient cluster,
+	// these goroutines can cause hard-to-understand error messages in
+	// logs.
+	// Also, unit tests would fail because the goroutine leak checker in
+	// unit tests would become confused.
+	delayWaitAtEnd time.Duration
 }
 
 func (c *transientCluster) checkConfigAndSetupLogging(
@@ -243,6 +261,7 @@ func (c *transientCluster) start(
 		if demoCtx.simulateLatency {
 			// Now, all servers have been started enough to know their own RPC serving
 			// addresses, but nothing else. Assemble the artificial latency map.
+			maxLatency := 0
 			log.Infof(phaseCtx, "initializing latency map")
 			for i, serv := range c.servers {
 				latencyMap := serv.Cfg.TestingKnobs.Server.(*server.TestingKnobs).ContextTestingKnobs.ArtificialLatencyMap
@@ -264,8 +283,16 @@ func (c *transientCluster) start(
 					}
 					latency := srcLocalityMap[dstLocality]
 					latencyMap[dst.ServingRPCAddr()] = latency
+
+					if latency > maxLatency {
+						maxLatency = latency
+					}
 				}
 			}
+
+			// Ensure we have enough termination delay at the end.
+			// See the comment on .delayWaitAtEnd for details.
+			c.delayWaitAtEnd = time.Duration(maxLatency) * time.Millisecond * 2 /* 2 for roundrip */
 		}
 	}
 
@@ -622,6 +649,9 @@ func (c *transientCluster) cleanup(ctx context.Context) {
 			_ = err
 		}
 	}
+
+	// Give enough time for connection goroutines to terminate.
+	time.Sleep(c.delayWaitAtEnd)
 }
 
 // DrainAndShutdown will gracefully attempt to drain a node in the cluster, and


### PR DESCRIPTION
Needed for #62435.

See this comment in `transientCluster struct`:

```go
	// delayWaitAtEnd is an additional delay to wait for when shutting
	// down a transient cluster.
	//
	// This is needed because when using simulated non-local latencies,
	// there will be pending HTTP connection goroutines waiting for the
	// TCP connection to close, which in turn needs to wait for a
	// network roundtrip.
	//
	// (See the code in `(*Transport) queueForDial()` and `dialConnFor()` in
	// net/http/transport.go.)
	//
	// If left running beyond the termination of the transient cluster,
	// these goroutines can cause hard-to-understand error messages in
	// logs.
	// Also, unit tests would fail because the goroutine leak checker in
	// unit tests would become confused.
	delayWaitAtEnd time.Duration
```

