### PR TITLE
release-21.1: sql: Re-enable multi_region_backup test

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_backup
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_backup
@@ -1,7 +1,5 @@
 # LogicTest: multiregion-9node-3region-3azs
 
-skip flaky # see #60773
-
 query TTTT
 SHOW REGIONS
 ----


### PR DESCRIPTION
Backport 1/1 commits from #62954.

/cc @cockroachdb/release

---

With #60835 merged, this test no longer flakes. I've stressed it on my
GCE worker now for a while an it's all good.

Resolves #60773.

Release note: None
