### PR TITLE
release-21.1: ccl/changfeedccl: fix changefeed processors shutdown

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -502,7 +502,7 @@ func (ca *changeAggregator) maybeFlush(resolvedSpan *jobspb.ResolvedSpan) error 
 // ConsumerClosed is part of the RowSource interface.
 func (ca *changeAggregator) ConsumerClosed() {
 	// The consumer is done, Next() will not be called again.
-	ca.InternalClose()
+	ca.close()
 }
 
 type kvEventProducer interface {
@@ -1374,7 +1374,7 @@ func (cf *changeFrontier) maybeLogBehindSpan(frontierChanged bool) (isBehind boo
 // ConsumerClosed is part of the RowSource interface.
 func (cf *changeFrontier) ConsumerClosed() {
 	// The consumer is done, Next() will not be called again.
-	cf.InternalClose()
+	cf.close()
 }
 
 // isSinkless returns true if this changeFrontier is sinkless and thus does not


### PR DESCRIPTION
Backport 1/1 commits from #63037.

/cc @cockroachdb/release

---

Previously, changefeed processors were incorrectly shut down when
`ConsumerClosed` is called. The previous implementation simply called
`InternalClose`, yet both the frontier and the aggregators have
non-trivial cleanup to do, so they must call their own `close` methods
which is now done. The impact was that some goroutines could have ended
up leaking.

Release note: None
