### PR TITLE
release-21.1: colfetcher: use the limit hint to size the batch

### DIFF
--- a/pkg/sql/colfetcher/vectorized_batch_size_test.go
+++ b/pkg/sql/colfetcher/vectorized_batch_size_test.go
@@ -28,57 +28,92 @@ import (
 )
 
 // TestScanBatchSize tests that the the cfetcher's dynamic batch size algorithm
-// uses the optimizer's estimated row count for its initial batch size. This
-// test sets up a scan against a table with a known row count, and makes sure
-// that the optimizer uses its statistics to produce an estimated row count that
-// is equal to the number of rows in the table, allowing the fetcher to create
-// a single batch for the scan.
+// uses the limit hint or the optimizer's estimated row count for its initial
+// batch size. This test sets up a scan against a table with a known row count,
+// and either
+// - disables stats collection and uses a hard limit
+// or
+// - makes sure that the optimizer uses its statistics to produce an estimated
+//   row count that is equal to the number of rows in the table
+// allowing the fetcher to create a single batch for the scan.
 func TestScanBatchSize(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	skip.UnderMetamorphic(t, "This test doesn't work with metamorphic batch sizes.")
 
-	testClusterArgs := base.TestClusterArgs{
-		ReplicationMode: base.ReplicationAuto,
+	for _, tc := range []struct {
+		needsStats bool
+		query      string
+	}{
+		{
+			needsStats: false,
+			query:      "SELECT * FROM t LIMIT 511",
+		},
+		{
+			needsStats: true,
+			query:      "SELECT * FROM t",
+		},
+	} {
+		testScanBatchSize(t, tc.needsStats, tc.query)
 	}
-	tc := testcluster.StartTestCluster(t, 1, testClusterArgs)
-	ctx := context.Background()
-	defer tc.Stopper().Stop(ctx)
+}
 
-	conn := tc.Conns[0]
+func testScanBatchSize(t *testing.T, needsStats bool, query string) {
+	t.Run(query, func(t *testing.T) {
+		testClusterArgs := base.TestClusterArgs{
+			ReplicationMode: base.ReplicationAuto,
+		}
+		tc := testcluster.StartTestCluster(t, 1, testClusterArgs)
+		ctx := context.Background()
+		defer tc.Stopper().Stop(ctx)
 
-	_, err := conn.ExecContext(ctx, `CREATE TABLE t (a PRIMARY KEY) AS SELECT generate_series(1, 511); ANALYZE t`)
-	assert.NoError(t, err)
+		conn := tc.Conns[0]
 
-	testutils.SucceedsSoon(t, func() error {
-		rows, err := conn.QueryContext(ctx, `EXPLAIN ANALYZE (VERBOSE, DISTSQL) SELECT * FROM t`)
-		assert.NoError(t, err)
-		batchCountRegex := regexp.MustCompile(`vectorized batch count: (\d+)`)
-		var found, failed bool
-		var foundBatches int
-		var sb strings.Builder
-		for rows.Next() {
-			var res string
-			assert.NoError(t, rows.Scan(&res))
-			sb.WriteString(res)
-			sb.WriteByte('\n')
-			matches := batchCountRegex.FindStringSubmatch(res)
-			if len(matches) == 0 {
-				continue
-			}
-			foundBatches, err = strconv.Atoi(matches[1])
+		if !needsStats {
+			// Disable auto stats before creating a table.
+			_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled=false`)
 			assert.NoError(t, err)
-			if foundBatches != 1 {
-				failed = true
+		}
+
+		_, err := conn.ExecContext(ctx, `CREATE TABLE t (a PRIMARY KEY) AS SELECT generate_series(1, 511)`)
+		assert.NoError(t, err)
+
+		if needsStats {
+			// This test needs the stats info, so analyze the table.
+			_, err := conn.ExecContext(ctx, `ANALYZE t`)
+			assert.NoError(t, err)
+		}
+
+		testutils.SucceedsSoon(t, func() error {
+			rows, err := conn.QueryContext(ctx, `EXPLAIN ANALYZE (VERBOSE, DISTSQL) `+query)
+			assert.NoError(t, err)
+			batchCountRegex := regexp.MustCompile(`vectorized batch count: (\d+)`)
+			var found, failed bool
+			var foundBatches int
+			var sb strings.Builder
+			for rows.Next() {
+				var res string
+				assert.NoError(t, rows.Scan(&res))
+				sb.WriteString(res)
+				sb.WriteByte('\n')
+				matches := batchCountRegex.FindStringSubmatch(res)
+				if len(matches) == 0 {
+					continue
+				}
+				foundBatches, err = strconv.Atoi(matches[1])
+				assert.NoError(t, err)
+				if foundBatches != 1 {
+					failed = true
+				}
+				found = true
 			}
-			found = true
-		}
-		if failed {
-			return fmt.Errorf("should use just 1 batch to scan 511 rows, found %d:\n%s", foundBatches, sb.String())
-		}
-		if !found {
-			t.Fatalf("expected to find a vectorized batch count; found nothing. text:\n%s", sb.String())
-		}
-		return nil
+			if failed {
+				return fmt.Errorf("should use just 1 batch to scan 511 rows, found %d:\n%s", foundBatches, sb.String())
+			}
+			if !found {
+				t.Fatalf("expected to find a vectorized batch count; found nothing. text:\n%s", sb.String())
+			}
+			return nil
+		})
 	})
 }


### PR DESCRIPTION
Backport 1/1 commits from #63020.

/cc @cockroachdb/release

---

We recently merged a couple of commits to take advantage of the
optimizer-driven estimated row count that will be output by the cfetcher
and of the limit hint when available. However, one scenario was
overlooked - if there is no estimate but the limit hint is available, we
don't use the latter to size the original batch, and now we do.

As an additional optimization this commit refactors the initial state of
the state machine so that we didn't allocate the output batch in the
constructor of the ColBatchScan but do it only on the very first call
to `NextBatch`. This was prompted by the fact that the limit hint is
currently only set in `StartScan` which is called in
`ColBatchScan.Init`, so without some changes, in the case when the limit
hint can be used to size the batch we would allocate a redundant batch
of size one in `NewColBatchScan`. I also think that the new initial
state of the state machine makes a bit more sense to me.

Additionally, this commit generalizes the logic to keep track of the
limit hint as "remaining rows to be fetched."

Addresses: #62212.

Release note: None (this is a follow-up to a recently merged commit that
had a release note)
