### PR TITLE
bazel: upgrade gazelle to latest release version

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -4027,14 +4027,6 @@ def go_deps():
     )
 
     go_repository(
-        name = "in_gopkg_yaml_v2",
-        build_file_proto_mode = "disable_global",
-        importpath = "gopkg.in/yaml.v2",
-        replace = "github.com/cockroachdb/yaml",
-        sum = "h1:EqoCicA1pbWWDGniFxhTElh2hvui7E7tEvuBNJSDn3A=",
-        version = "v0.0.0-20180705215940-0e2822948641",
-    )
-    go_repository(
         name = "in_gopkg_yaml_v3",
         build_file_proto_mode = "disable_global",
         importpath = "gopkg.in/yaml.v3",
@@ -4338,13 +4330,6 @@ def go_deps():
         importpath = "golang.org/x/time",
         sum = "h1:/5xXl8Y5W96D+TtHSlonuFqGHIWVuyCkGJLwGh9JJFs=",
         version = "v0.0.0-20191024005414-555d28b269f0",
-    )
-    go_repository(
-        name = "org_golang_x_xerrors",
-        build_file_proto_mode = "disable_global",
-        importpath = "golang.org/x/xerrors",
-        sum = "h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=",
-        version = "v0.0.0-20200804184101-5ec99f83aff1",
     )
     go_repository(
         name = "org_gonum_v1_gonum",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,12 +25,9 @@ http_archive(
 
 # Load gazelle. This lets us auto-generate BUILD.bazel files throughout the
 # repo.
-#
-# TODO(irfansharif): Point to a proper bazelle-gazelle release once
-# https://github.com/bazelbuild/bazel-gazelle/pull/933 lands upstream.
 git_repository(
     name = "bazel_gazelle",
-    commit = "493b9adf67665beede36502c2094496af9f245a3",
+    commit = "e9091445339de2ba7c01c3561f751b64a7fab4a5",
     remote = "https://github.com/bazelbuild/bazel-gazelle",
 )
 
@@ -55,6 +52,14 @@ go_repository(
     importpath = "golang.org/x/tools",
     sum = "h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=",
     version = "v0.1.0",
+)
+
+go_repository(
+    name = "org_golang_x_xerrors",
+    build_file_proto_mode = "disable_global",
+    importpath = "golang.org/x/xerrors",
+    sum = "h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=",
+    version = "v0.0.0-20200804184101-5ec99f83aff1",
 )
 
 go_repository(
@@ -88,6 +93,15 @@ go_repository(
     importpath = "google.golang.org/genproto",
     sum = "h1:PDIOdWxZ8eRizhKa1AAvY53xsvLB1cWorMjslvY3VA8=",
     version = "v0.0.0-20200825200019-8632dd797987",
+)
+
+go_repository(
+    name = "in_gopkg_yaml_v2",
+    build_file_proto_mode = "disable_global",
+    importpath = "gopkg.in/yaml.v2",
+    replace = "github.com/cockroachdb/yaml",
+    sum = "h1:EqoCicA1pbWWDGniFxhTElh2hvui7E7tEvuBNJSDn3A=",
+    version = "v0.0.0-20180705215940-0e2822948641",
 )
 
 # Load the go dependencies and invoke them.

--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -241,9 +241,6 @@ go_library(
         "@io_bazel_rules_go//go/platform:linux": [
             "@org_golang_x_sys//unix",
         ],
-        "@io_bazel_rules_go//go/platform:nacl": [
-            "@org_golang_x_sys//unix",
-        ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "@org_golang_x_sys//unix",
         ],

--- a/pkg/geo/geos/BUILD.bazel
+++ b/pkg/geo/geos/BUILD.bazel
@@ -36,9 +36,6 @@ go_library(
         "@io_bazel_rules_go//go/platform:linux": [
             "-ldl",
         ],
-        "@io_bazel_rules_go//go/platform:nacl": [
-            "-ldl",
-        ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "-ldl",
         ],

--- a/pkg/security/BUILD.bazel
+++ b/pkg/security/BUILD.bazel
@@ -119,10 +119,6 @@ go_test(
             "//pkg/util/log/eventpb",
             "@org_golang_x_sys//unix",
         ],
-        "@io_bazel_rules_go//go/platform:nacl": [
-            "//pkg/util/log/eventpb",
-            "@org_golang_x_sys//unix",
-        ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "//pkg/util/log/eventpb",
             "@org_golang_x_sys//unix",

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -217,9 +217,6 @@ go_library(
         "@io_bazel_rules_go//go/platform:linux": [
             "@org_golang_x_sys//unix",
         ],
-        "@io_bazel_rules_go//go/platform:nacl": [
-            "@org_golang_x_sys//unix",
-        ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "@org_golang_x_sys//unix",
         ],

--- a/pkg/server/status/BUILD.bazel
+++ b/pkg/server/status/BUILD.bazel
@@ -93,9 +93,6 @@ go_library(
         "@io_bazel_rules_go//go/platform:linux": [
             "@com_github_shirou_gopsutil//disk",
         ],
-        "@io_bazel_rules_go//go/platform:nacl": [
-            "@com_github_shirou_gopsutil//disk",
-        ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "@com_github_shirou_gopsutil//disk",
         ],

--- a/pkg/util/log/BUILD.bazel
+++ b/pkg/util/log/BUILD.bazel
@@ -98,9 +98,6 @@ go_library(
         "@io_bazel_rules_go//go/platform:linux": [
             "@org_golang_x_sys//unix",
         ],
-        "@io_bazel_rules_go//go/platform:nacl": [
-            "@org_golang_x_sys//unix",
-        ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "@org_golang_x_sys//unix",
         ],

--- a/pkg/util/log/logcrash/BUILD.bazel
+++ b/pkg/util/log/logcrash/BUILD.bazel
@@ -74,9 +74,6 @@ go_test(
         "@io_bazel_rules_go//go/platform:linux": [
             "@org_golang_x_sys//unix",
         ],
-        "@io_bazel_rules_go//go/platform:nacl": [
-            "@org_golang_x_sys//unix",
-        ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "@org_golang_x_sys//unix",
         ],

--- a/pkg/util/sdnotify/BUILD.bazel
+++ b/pkg/util/sdnotify/BUILD.bazel
@@ -50,9 +50,6 @@ go_test(
         "@io_bazel_rules_go//go/platform:linux": [
             "//pkg/util/log",
         ],
-        "@io_bazel_rules_go//go/platform:nacl": [
-            "//pkg/util/log",
-        ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "//pkg/util/log",
         ],

--- a/pkg/util/sysutil/BUILD.bazel
+++ b/pkg/util/sysutil/BUILD.bazel
@@ -41,9 +41,6 @@ go_library(
         "@io_bazel_rules_go//go/platform:linux": [
             "@org_golang_x_sys//unix",
         ],
-        "@io_bazel_rules_go//go/platform:nacl": [
-            "@org_golang_x_sys//unix",
-        ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "@org_golang_x_sys//unix",
         ],
@@ -98,9 +95,6 @@ go_test(
             "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
-            "@org_golang_x_sys//unix",
-        ],
-        "@io_bazel_rules_go//go/platform:nacl": [
             "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:netbsd": [

--- a/pkg/workload/cli/BUILD.bazel
+++ b/pkg/workload/cli/BUILD.bazel
@@ -56,9 +56,6 @@ go_library(
         "@io_bazel_rules_go//go/platform:linux": [
             "@org_golang_x_sys//unix",
         ],
-        "@io_bazel_rules_go//go/platform:nacl": [
-            "@org_golang_x_sys//unix",
-        ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "@org_golang_x_sys//unix",
         ],


### PR DESCRIPTION
Also move the declaration of `in_gopkg_yaml_v2` and
`org_golang_x_xerrors` so Gazelle doesn't override them.

Release note: None