### PR TITLE
release-21.1: backupccl: stop disallowing overlap when merging backup spans

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -360,10 +360,9 @@ func spansForAllTableIndexes(
 	})
 
 	// Attempt to merge any contiguous spans generated from the tables and revs.
-	mergedSpans, distinct := roachpb.MergeSpans(spans)
-	if !distinct {
-		return nil, errors.NewAssertionErrorWithWrappedErrf(errors.New("expected all resolved spans for the BACKUP to be distinct"), "IndexSpan")
-	}
+	// No need to check if the spans are distinct, since some of the merged
+	// indexes may overlap between different revisions of the same descriptor.
+	mergedSpans, _ := roachpb.MergeSpans(spans)
 
 	knobs := execCfg.BackupRestoreTestingKnobs
 	if knobs != nil && knobs.CaptureResolvedTableDescSpans != nil {

--- a/pkg/ccl/backupccl/testdata/backup-restore/revision_history
+++ b/pkg/ccl/backupccl/testdata/backup-restore/revision_history
@@ -1,0 +1,17 @@
+new-server name=s1
+----
+
+# Regression test for #62738.
+# The latest version of this descriptor will have indexes 1 and 3 visible.
+# Since there is no data in index 2 and it is dropped it will merge these
+# indexes to backup the span /Table/55/{1-4}. The earlier revision of the
+# descriptor will add the span for index 2 /Table/55/{2-3}. These spans should
+# be allowed to overlap.
+exec-sql
+CREATE DATABASE d;
+CREATE TABLE d.t (a INT PRIMARY KEY, b INT, c INT);
+CREATE INDEX test_idx_2 ON d.t(b);
+CREATE INDEX test_idx_3 ON d.t(c);
+DROP INDEX d.test_idx_2;
+BACKUP DATABASE d INTO 'nodelocal://0/my_backups' WITH revision_history;
+----


### PR DESCRIPTION
Backport 1/1 commits from #63086.

/cc @cockroachdb/release

---

Backup spans, as accumulated by walking through the revisions of a
descriptor may overlap with eachother. Backup should not produce an
error in the cases that they do.

Fixes https://github.com/cockroachdb/cockroach/issues/62738.

Release note (bug fix): Fixes a bug present in earlier 21.1 versions
where BACKUPs would produce an error when they should be able to backup
the underlying data.
