### PR TITLE
cli: fix the handling of environment variables

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -79,26 +79,36 @@ func Main() {
 }
 
 func doMain(cmd *cobra.Command, cmdName string) error {
-	if cmd != nil && !cmdHasCustomLoggingSetup(cmd) {
-		// the customLoggingSetupCmds do their own calls to setupLogging().
-		//
-		// We use a PreRun function, to ensure setupLogging() is only
-		// called after the command line flags have been parsed.
-		//
-		// NB: we cannot use PersistentPreRunE,like in flags.go, because
-		// overriding that here will prevent the persistent pre-run from
-		// running on parent commands. (See the difference between PreRun
-		// and PersistentPreRun in `(*cobra.Command) execute()`.)
-		wrapped := cmd.PreRunE
-		cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
-			if wrapped != nil {
-				if err := wrapped(cmd, args); err != nil {
-					return err
-				}
-			}
+	if cmd != nil {
+		// Apply the configuration defaults from environment variables.
+		// This must occur before the parameters are parsed by cobra, so
+		// that the command-line flags can override the defaults in
+		// environment variables.
+		if err := processEnvVarDefaults(cmd); err != nil {
+			return err
+		}
 
-			return setupLogging(context.Background(), cmd,
-				false /* isServerCmd */, true /* applyConfig */)
+		if !cmdHasCustomLoggingSetup(cmd) {
+			// the customLoggingSetupCmds do their own calls to setupLogging().
+			//
+			// We use a PreRun function, to ensure setupLogging() is only
+			// called after the command line flags have been parsed.
+			//
+			// NB: we cannot use PersistentPreRunE,like in flags.go, because
+			// overriding that here will prevent the persistent pre-run from
+			// running on parent commands. (See the difference between PreRun
+			// and PersistentPreRun in `(*cobra.Command) execute()`.)
+			wrapped := cmd.PreRunE
+			cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+				if wrapped != nil {
+					if err := wrapped(cmd, args); err != nil {
+						return err
+					}
+				}
+
+				return setupLogging(context.Background(), cmd,
+					false /* isServerCmd */, true /* applyConfig */)
+			}
 		}
 	}
 

--- a/pkg/cli/interactive_tests/test_flags.tcl
+++ b/pkg/cli/interactive_tests/test_flags.tcl
@@ -125,6 +125,18 @@ interrupt
 eexpect ":/# "
 end_test
 
+start_test "Check that an invalid URL in the env var produces a reasonable error"
+send "export COCKROACH_URL=invalid_url;\r"
+eexpect ":/# "
+send "$argv sql\r"
+eexpect "ERROR"
+eexpect "setting --url from COCKROACH_URL"
+eexpect "invalid argument"
+eexpect "URL scheme must be"
+eexpect ":/# "
+end_test
+
+
 stop_server $argv
 
 send "exit 0\r"


### PR DESCRIPTION
Fixes #62904. 

For context, the configuration applies as follows:

- first, hard-coded defaults (from `cli/context.go`)
- then, environment variables,
- then, command-line flags,
- then, overrides in the initialization code.

Prior to this patch, the code to apply defaults from environment
variables was broken.

To understand why, consider that certain flags are defined with *different
configuration code* but with *the same env var*. For example, the
parsing of the env var `COCKROACH_URL` is different
between `cockroach sql` and `cockroach debug gossip-values`, because
the two commands have different restrictions on the URL

Prior to this patch, the env var initialization code for *all*
sub-commands was invoked upon invocation of *each* sub-command. If,
for example, the user invoked `cockroach sql`, the initialization code
for both `sql` and `debug gossip-values` would run side by side. This
is incorrect, because the validation rules for one command may not be
valid for another. This would yield e.g. the following confusing
situation:

```
COCKROACH_URL='postgres://demo:demo31541@127.0.0.1:26257?sslmode=require' ./cockroach sql
panic: setting --url from COCKROACH_URL: command "gossip-values" only supports sslmode=disable or sslmode=verify-full
```

This patch fixes that by ensuring the env var defaults only apply to
the specific command being run.

A side benefit of the patch is that it also ensures that env vars do
not apply to unit tests. This makes test results more reliable.


Release note (bug fix): The application of environment variables
to populate defaults for certain command-line flag, for example
`COCKROACH_URL` for `--url`, has been fixed.