### PR TITLE
sql: Add telemetry for multi-region IMPORT

### DIFF
--- a/pkg/ccl/importccl/BUILD.bazel
+++ b/pkg/ccl/importccl/BUILD.bazel
@@ -62,6 +62,7 @@ go_library(
         "//pkg/sql/rowexec",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
+        "//pkg/sql/sqltelemetry",
         "//pkg/sql/types",
         "//pkg/storage/cloud",
         "//pkg/storage/cloudimpl",

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -52,6 +52,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -1909,6 +1910,18 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 						schemaMetadata)
 					if err != nil {
 						return err
+					}
+
+					// Telemetry for multi-region.
+					for _, table := range preparedDetails.Tables {
+						_, dbDesc, err := descsCol.GetImmutableDatabaseByID(
+							ctx, txn, table.Desc.GetParentID(), tree.DatabaseLookupFlags{Required: true})
+						if err != nil {
+							return err
+						}
+						if dbDesc.IsMultiRegion() {
+							telemetry.Inc(sqltelemetry.ImportIntoMultiRegionDatabaseCounter)
+						}
 					}
 
 					// Update the job details now that the schemas and table descs have

--- a/pkg/ccl/telemetryccl/testdata/telemetry/multiregion
+++ b/pkg/ccl/telemetryccl/testdata/telemetry/multiregion
@@ -339,6 +339,18 @@ exec
 ALTER TABLE t6 SET LOCALITY REGIONAL BY ROW AS "cr"
 ----
 
+exec
+USE survive_region;
+CREATE TABLE t7 (a INT);
+INSERT INTO t7 VALUES (1),(2),(3);
+EXPORT INTO CSV 'nodelocal://0/t7' FROM TABLE t7;
+----
+
+feature-counters
+IMPORT INTO t7 CSV DATA ('nodelocal://0/t7/export*.csv')
+----
+sql.multiregion.import  1
+
 # Test for locality optimized search counter.
 feature-allowlist
 sql.plan.opt.locality-optimized-search
@@ -346,10 +358,11 @@ sql.plan.opt.locality-optimized-search
 
 exec
 USE survive_region;
-CREATE TABLE t7 (a INT PRIMARY KEY) LOCALITY REGIONAL BY ROW
+CREATE TABLE t8 (a INT PRIMARY KEY) LOCALITY REGIONAL BY ROW
 ----
 
 feature-usage
-SELECT * FROM t7 WHERE a = 1
+SELECT * FROM t8 WHERE a = 1
 ----
 sql.plan.opt.locality-optimized-search
+

--- a/pkg/sql/sqltelemetry/multiregion.go
+++ b/pkg/sql/sqltelemetry/multiregion.go
@@ -50,6 +50,12 @@ var (
 	AlterDatabaseDropPrimaryRegionCounter = telemetry.GetCounterOnce(
 		"sql.multiregion.drop_primary_region",
 	)
+
+	// ImportIntoMultiRegionDatabaseCounter is to be incremented when an import
+	// statement is run against a multi-region database.
+	ImportIntoMultiRegionDatabaseCounter = telemetry.GetCounterOnce(
+		"sql.multiregion.import",
+	)
 )
 
 // CreateDatabaseSurvivalGoalCounter is to be incremented when the survival goal

--- a/pkg/sql/sqltestutils/BUILD.bazel
+++ b/pkg/sql/sqltestutils/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/sql/catalog/catconstants",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/tests",
+        "//pkg/testutils",
         "//pkg/testutils/diagutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",


### PR DESCRIPTION
Previously there was no telemetry information for IMPORTing into a
multi-region databases. This commit adds the required telemetry for
multi-region IMPORT.

Release note: None