### PR TITLE
colexec: wrap DrainMeta with panic-catcher and protect columnarizer

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -81,7 +81,7 @@ func wrapRowSources(
 			c.MarkAsRemovedFromFlow()
 			toWrapInputs = append(toWrapInputs, c.Input())
 		} else {
-			var metadataSources execinfrapb.MetadataSources
+			var metadataSources colexecop.MetadataSources
 			if len(args.MetadataSources) > i {
 				// In some testing paths, MetadataSources might be left unset,
 				// so we check whether the slice has ith element. In the
@@ -616,7 +616,7 @@ func (r opResult) createAndWrapRowSource(
 	if args.TestingKnobs.PlanInvariantsCheckers {
 		r.Op = colexec.NewInvariantsChecker(r.Op)
 	}
-	r.MetadataSources = append(r.MetadataSources, r.Op.(execinfrapb.MetadataSource))
+	r.MetadataSources = append(r.MetadataSources, r.Op.(colexecop.MetadataSource))
 	r.ToClose = append(r.ToClose, c)
 	r.Releasables = append(r.Releasables, releasables...)
 	return nil
@@ -765,7 +765,7 @@ func NewColOperator(
 				result.Op = colexec.NewInvariantsChecker(result.Op)
 			}
 			result.KVReader = scanOp
-			result.MetadataSources = append(result.MetadataSources, result.Op.(execinfrapb.MetadataSource))
+			result.MetadataSources = append(result.MetadataSources, result.Op.(colexecop.MetadataSource))
 			result.Releasables = append(result.Releasables, scanOp)
 
 			// We want to check for cancellation once per input batch, and

--- a/pkg/sql/colexec/colexecargs/op_creation.go
+++ b/pkg/sql/colexec/colexecargs/op_creation.go
@@ -43,7 +43,7 @@ type NewColOperatorArgs struct {
 	// NewColOperator call creates a colexec.Materializer, then it will take
 	// over the responsibility of draining the sources; otherwise, they will be
 	// returned in NewColOperatorResult.
-	MetadataSources []execinfrapb.MetadataSources
+	MetadataSources []colexecop.MetadataSources
 	DiskQueueCfg    colcontainer.DiskQueueCfg
 	FDSemaphore     semaphore.Semaphore
 	ExprHelper      *ExprHelper
@@ -97,7 +97,7 @@ type NewColOperatorResult struct {
 	// created during NewColOperator call, but it also might include all of the
 	// sources from NewColOperatorArgs.MetadataSources if no metadata draining
 	// component was created.
-	MetadataSources execinfrapb.MetadataSources
+	MetadataSources colexecop.MetadataSources
 	// ToClose is a slice of components that need to be Closed.
 	ToClose     []colexecop.Closer
 	OpMonitors  []*mon.BytesMonitor

--- a/pkg/sql/colexec/colexectestutils/utils.go
+++ b/pkg/sql/colexec/colexectestutils/utils.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -1476,4 +1477,15 @@ func GenerateBatchSize() int {
 		return sizesToChooseFrom[rng.Intn(len(sizesToChooseFrom))]
 	}
 	return coldata.BatchSize()
+}
+
+// CallbackMetadataSource is a utility struct that implements the
+// colexecop.MetadataSource interface by calling a provided callback.
+type CallbackMetadataSource struct {
+	DrainMetaCb func(context.Context) []execinfrapb.ProducerMetadata
+}
+
+// DrainMeta is part of the colexecop.MetadataSource interface.
+func (s CallbackMetadataSource) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
+	return s.DrainMetaCb(ctx)
 }

--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -249,6 +249,13 @@ func (c *Columnarizer) DrainMeta(ctx context.Context) []execinfrapb.ProducerMeta
 	if c.removedFromFlow {
 		return nil
 	}
+	if c.initStatus == colexecop.OperatorNotInitialized {
+		// The columnarizer wasn't initialized, so the wrapped processors might
+		// not have been started leaving them in an unsafe to drain state, so
+		// we skip the draining. Mostly likely this happened because a panic was
+		// encountered in Init.
+		return c.accumulatedMeta
+	}
 	c.MoveToDraining(nil /* err */)
 	for {
 		meta := c.DrainHelper()

--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -239,12 +239,11 @@ func (c *Columnarizer) Run(context.Context) {
 }
 
 var (
-	_ colexecop.Operator         = &Columnarizer{}
-	_ execinfrapb.MetadataSource = &Columnarizer{}
-	_ colexecop.Closer           = &Columnarizer{}
+	_ colexecop.DrainableOperator = &Columnarizer{}
+	_ colexecop.Closer            = &Columnarizer{}
 )
 
-// DrainMeta is part of the MetadataSource interface.
+// DrainMeta is part of the colexecop.MetadataSource interface.
 func (c *Columnarizer) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
 	if c.removedFromFlow {
 		return nil

--- a/pkg/sql/colexec/invariants_checker.go
+++ b/pkg/sql/colexec/invariants_checker.go
@@ -29,18 +29,17 @@ type InvariantsChecker struct {
 	colexecop.NonExplainable
 
 	initStatus     colexecop.OperatorInitStatus
-	metadataSource execinfrapb.MetadataSource
+	metadataSource colexecop.MetadataSource
 }
 
-var _ colexecop.Operator = &InvariantsChecker{}
-var _ execinfrapb.MetadataSource
+var _ colexecop.DrainableOperator = &InvariantsChecker{}
 
 // NewInvariantsChecker creates a new InvariantsChecker.
 func NewInvariantsChecker(input colexecop.Operator) *InvariantsChecker {
 	c := &InvariantsChecker{
 		OneInputNode: colexecop.OneInputNode{Input: input},
 	}
-	if ms, ok := input.(execinfrapb.MetadataSource); ok {
+	if ms, ok := input.(colexecop.MetadataSource); ok {
 		c.metadataSource = ms
 	}
 	return c
@@ -99,7 +98,7 @@ func (i *InvariantsChecker) Next(ctx context.Context) coldata.Batch {
 	return b
 }
 
-// DrainMeta implements the execinfrapb.MetadataSource interface.
+// DrainMeta implements the colexecop.MetadataSource interface.
 func (i *InvariantsChecker) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
 	if shortCircuit := i.assertInitWasCalled(); shortCircuit {
 		return nil

--- a/pkg/sql/colexec/materializer.go
+++ b/pkg/sql/colexec/materializer.go
@@ -274,7 +274,7 @@ func (m *Materializer) Start(ctx context.Context) {
 		m.MoveToDraining(err)
 	} else {
 		// Note that we intentionally only start the drain helper if
-		// initialization was successful - no starting the helper will tell it
+		// initialization was successful - not starting the helper will tell it
 		// to not drain the metadata sources (which have not been properly
 		// initialized).
 		m.drainHelper.Start(ctx)

--- a/pkg/sql/colexec/materializer.go
+++ b/pkg/sql/colexec/materializer.go
@@ -77,7 +77,7 @@ type drainHelper struct {
 	ctx context.Context
 
 	getStats func() []*execinfrapb.ComponentStats
-	sources  execinfrapb.MetadataSources
+	sources  colexecop.MetadataSources
 
 	bufferedMeta []execinfrapb.ProducerMetadata
 }
@@ -92,7 +92,7 @@ var drainHelperPool = sync.Pool{
 }
 
 func newDrainHelper(
-	getStats func() []*execinfrapb.ComponentStats, sources execinfrapb.MetadataSources,
+	getStats func() []*execinfrapb.ComponentStats, sources colexecop.MetadataSources,
 ) *drainHelper {
 	d := drainHelperPool.Get().(*drainHelper)
 	d.getStats = getStats
@@ -199,7 +199,7 @@ func NewMaterializer(
 	typs []*types.T,
 	output execinfra.RowReceiver,
 	getStats func() []*execinfrapb.ComponentStats,
-	metadataSources []execinfrapb.MetadataSource,
+	metadataSources []colexecop.MetadataSource,
 	toClose []colexecop.Closer,
 	cancelFlow func() context.CancelFunc,
 ) (*Materializer, error) {

--- a/pkg/sql/colexec/materializer_test.go
+++ b/pkg/sql/colexec/materializer_test.go
@@ -189,7 +189,7 @@ func TestMaterializerNextErrorAfterConsumerDone(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	testError := errors.New("test-induced error")
-	metadataSource := &execinfrapb.CallbackMetadataSource{DrainMetaCb: func(_ context.Context) []execinfrapb.ProducerMetadata {
+	metadataSource := &colexectestutils.CallbackMetadataSource{DrainMetaCb: func(_ context.Context) []execinfrapb.ProducerMetadata {
 		colexecerror.InternalError(testError)
 		// Unreachable
 		return nil
@@ -209,7 +209,7 @@ func TestMaterializerNextErrorAfterConsumerDone(t *testing.T) {
 		nil, /* typ */
 		nil, /* output */
 		nil, /* getStats */
-		[]execinfrapb.MetadataSource{metadataSource},
+		[]colexecop.MetadataSource{metadataSource},
 		nil, /* toClose */
 		nil, /* cancelFlow */
 	)

--- a/pkg/sql/colexec/parallel_unordered_synchronizer.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer.go
@@ -109,7 +109,7 @@ func (s *ParallelUnorderedSynchronizer) Child(nth int, verbose bool) execinfra.O
 
 // SynchronizerInput is a wrapper over a colexecop.Operator that a
 // synchronizer goroutine will be calling Next on. An accompanying
-// []execinfrapb.MetadataSource may also be specified, in which case
+// colexecop.MetadataSources may also be specified, in which case
 // DrainMeta will be called from the same goroutine.
 type SynchronizerInput struct {
 	// Op is the input Operator.
@@ -123,7 +123,7 @@ type SynchronizerInput struct {
 	StatsCollectors []VectorizedStatsCollector
 	// MetadataSources are metadata sources in the input tree that should be
 	// drained in the same goroutine as Op.
-	MetadataSources execinfrapb.MetadataSources
+	MetadataSources colexecop.MetadataSources
 	// ToClose are Closers in the input tree that should be closed in the same
 	// goroutine as Op.
 	ToClose colexecop.Closers
@@ -358,7 +358,7 @@ func (s *ParallelUnorderedSynchronizer) notifyInputToReadNextBatch(inputIdx int)
 	}
 }
 
-// DrainMeta is part of the MetadataSource interface.
+// DrainMeta is part of the colexecop.MetadataSource interface.
 func (s *ParallelUnorderedSynchronizer) DrainMeta(
 	ctx context.Context,
 ) []execinfrapb.ProducerMetadata {

--- a/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldatatestutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexectestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
@@ -59,8 +60,8 @@ func TestParallelUnorderedSynchronizer(t *testing.T) {
 		source.ResetBatchesToReturn(numBatches)
 		inputs[i].Op = source
 		inputIdx := i
-		inputs[i].MetadataSources = []execinfrapb.MetadataSource{
-			execinfrapb.CallbackMetadataSource{DrainMetaCb: func(_ context.Context) []execinfrapb.ProducerMetadata {
+		inputs[i].MetadataSources = []colexecop.MetadataSource{
+			colexectestutils.CallbackMetadataSource{DrainMetaCb: func(_ context.Context) []execinfrapb.ProducerMetadata {
 				return []execinfrapb.ProducerMetadata{{Err: errors.Errorf("input %d test-induced metadata", inputIdx)}}
 			}},
 		}

--- a/pkg/sql/colexec/serial_unordered_synchronizer.go
+++ b/pkg/sql/colexec/serial_unordered_synchronizer.go
@@ -77,7 +77,7 @@ func (s *SerialUnorderedSynchronizer) Next(ctx context.Context) coldata.Batch {
 	}
 }
 
-// DrainMeta is part of the MetadataSource interface.
+// DrainMeta is part of the colexecop.MetadataSource interface.
 func (s *SerialUnorderedSynchronizer) DrainMeta(
 	ctx context.Context,
 ) []execinfrapb.ProducerMetadata {

--- a/pkg/sql/colexec/serial_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/serial_unordered_synchronizer_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldatatestutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexectestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -44,8 +45,8 @@ func TestSerialUnorderedSynchronizer(t *testing.T) {
 		inputIdx := i
 		inputs[i] = SynchronizerInput{
 			Op: source,
-			MetadataSources: []execinfrapb.MetadataSource{
-				execinfrapb.CallbackMetadataSource{
+			MetadataSources: []colexecop.MetadataSource{
+				colexectestutils.CallbackMetadataSource{
 					DrainMetaCb: func(_ context.Context) []execinfrapb.ProducerMetadata {
 						return []execinfrapb.ProducerMetadata{{Err: errors.Errorf("input %d test-induced metadata", inputIdx)}}
 					},

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -119,7 +119,7 @@ func (s *ColBatchScan) Next(ctx context.Context) coldata.Batch {
 	return bat
 }
 
-// DrainMeta is part of the MetadataSource interface.
+// DrainMeta is part of the colexecop.MetadataSource interface.
 func (s *ColBatchScan) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
 	s.mu.Lock()
 	initialized := s.mu.init

--- a/pkg/sql/colflow/colrpc/BUILD.bazel
+++ b/pkg/sql/colflow/colrpc/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
         "//pkg/col/colserde",
         "//pkg/roachpb",
         "//pkg/settings/cluster",
+        "//pkg/sql/colexec/colexectestutils",
         "//pkg/sql/colexec/colexecutils",
         "//pkg/sql/colexecerror",
         "//pkg/sql/colexecop",

--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldatatestutils"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexectestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
@@ -504,8 +505,8 @@ func TestOutboxInboxMetadataPropagation(t *testing.T) {
 			}
 			outbox, err := NewOutbox(
 				colmem.NewAllocator(ctx, &outboxMemAcc, coldata.StandardColumnFactory),
-				input, typs, nil /* getStats */, []execinfrapb.MetadataSource{
-					execinfrapb.CallbackMetadataSource{
+				input, typs, nil /* getStats */, []colexecop.MetadataSource{
+					colexectestutils.CallbackMetadataSource{
 						DrainMetaCb: func(context.Context) []execinfrapb.ProducerMetadata {
 							return expectedMetadata
 						},

--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -52,7 +52,7 @@ type Outbox struct {
 
 	// draining is an atomic that represents whether the Outbox is draining.
 	draining        uint32
-	metadataSources []execinfrapb.MetadataSource
+	metadataSources execinfrapb.MetadataSources
 	// closers is a slice of Closers that need to be Closed on termination.
 	closers colexecop.Closers
 
@@ -307,10 +307,8 @@ func (o *Outbox) sendMetadata(ctx context.Context, stream flowStreamClient, errT
 			},
 		})
 	}
-	for _, src := range o.metadataSources {
-		for _, meta := range src.DrainMeta(ctx) {
-			msg.Data.Metadata = append(msg.Data.Metadata, execinfrapb.LocalMetaToRemoteProducerMeta(ctx, meta))
-		}
+	for _, meta := range o.metadataSources.DrainMeta(ctx) {
+		msg.Data.Metadata = append(msg.Data.Metadata, execinfrapb.LocalMetaToRemoteProducerMeta(ctx, meta))
 	}
 	if len(msg.Data.Metadata) == 0 {
 		return nil

--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -52,7 +52,7 @@ type Outbox struct {
 
 	// draining is an atomic that represents whether the Outbox is draining.
 	draining        uint32
-	metadataSources execinfrapb.MetadataSources
+	metadataSources colexecop.MetadataSources
 	// closers is a slice of Closers that need to be Closed on termination.
 	closers colexecop.Closers
 
@@ -81,7 +81,7 @@ func NewOutbox(
 	input colexecop.Operator,
 	typs []*types.T,
 	getStats func() []*execinfrapb.ComponentStats,
-	metadataSources []execinfrapb.MetadataSource,
+	metadataSources []colexecop.MetadataSource,
 	toClose []colexecop.Closer,
 ) (*Outbox, error) {
 	c, err := colserde.NewArrowBatchConverter(typs)

--- a/pkg/sql/colflow/colrpc/outbox_test.go
+++ b/pkg/sql/colflow/colrpc/outbox_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexectestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
@@ -91,8 +92,8 @@ func TestOutboxDrainsMetadataSources(t *testing.T) {
 	// uint32 that is set atomically when the outbox drains a metadata source.
 	newOutboxWithMetaSources := func(allocator *colmem.Allocator) (*Outbox, *uint32, error) {
 		var sourceDrained uint32
-		outbox, err := NewOutbox(allocator, input, typs, nil /* getStats */, []execinfrapb.MetadataSource{
-			execinfrapb.CallbackMetadataSource{
+		outbox, err := NewOutbox(allocator, input, typs, nil /* getStats */, []colexecop.MetadataSource{
+			colexectestutils.CallbackMetadataSource{
 				DrainMetaCb: func(context.Context) []execinfrapb.ProducerMetadata {
 					atomic.StoreUint32(&sourceDrained, 1)
 					return nil

--- a/pkg/sql/colflow/routers.go
+++ b/pkg/sql/colflow/routers.go
@@ -413,9 +413,9 @@ type HashRouter struct {
 	// execinfrapb.ProducerMetadata object. This will be done right before
 	// draining metadataSources.
 	getStats func() []*execinfrapb.ComponentStats
-	// metadataSources is a slice of execinfrapb.MetadataSources that need to be
+	// metadataSources is a slice of colexecop.MetadataSources that need to be
 	// drained when the HashRouter terminates.
-	metadataSources execinfrapb.MetadataSources
+	metadataSources colexecop.MetadataSources
 	// closers is a slice of Closers that need to be closed when the hash router
 	// terminates.
 	closers colexecop.Closers
@@ -466,7 +466,7 @@ func NewHashRouter(
 	fdSemaphore semaphore.Semaphore,
 	diskAccounts []*mon.BoundAccount,
 	getStats func() []*execinfrapb.ComponentStats,
-	toDrain []execinfrapb.MetadataSource,
+	toDrain []colexecop.MetadataSource,
 	toClose []colexecop.Closer,
 ) (*HashRouter, []colexecop.DrainableOperator) {
 	if diskQueueCfg.CacheMode != colcontainer.DiskQueueCacheModeDefault {
@@ -507,7 +507,7 @@ func newHashRouterWithOutputs(
 	unblockEventsChan <-chan struct{},
 	outputs []routerOutput,
 	getStats func() []*execinfrapb.ComponentStats,
-	toDrain []execinfrapb.MetadataSource,
+	toDrain []colexecop.MetadataSource,
 	toClose []colexecop.Closer,
 ) *HashRouter {
 	r := &HashRouter{

--- a/pkg/sql/colflow/routers_test.go
+++ b/pkg/sql/colflow/routers_test.go
@@ -1085,8 +1085,8 @@ func TestHashRouterRandom(t *testing.T) {
 					unblockEventsChan,
 					outputs,
 					nil, /* getStats */
-					[]execinfrapb.MetadataSource{
-						execinfrapb.CallbackMetadataSource{
+					[]colexecop.MetadataSource{
+						colexectestutils.CallbackMetadataSource{
 							DrainMetaCb: func(_ context.Context) []execinfrapb.ProducerMetadata {
 								return []execinfrapb.ProducerMetadata{{Err: errors.New(hashRouterMetadataMsg)}}
 							},

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 type callbackRemoteComponentCreator struct {
-	newOutboxFn func(*colmem.Allocator, colexecop.Operator, []*types.T, []execinfrapb.MetadataSource) (*colrpc.Outbox, error)
+	newOutboxFn func(*colmem.Allocator, colexecop.Operator, []*types.T, []colexecop.MetadataSource) (*colrpc.Outbox, error)
 	newInboxFn  func(allocator *colmem.Allocator, typs []*types.T, streamID execinfrapb.StreamID) (*colrpc.Inbox, error)
 }
 
@@ -45,7 +45,7 @@ func (c callbackRemoteComponentCreator) newOutbox(
 	input colexecop.Operator,
 	typs []*types.T,
 	_ func() []*execinfrapb.ComponentStats,
-	metadataSources []execinfrapb.MetadataSource,
+	metadataSources []colexecop.MetadataSource,
 	_ []colexecop.Closer,
 ) (*colrpc.Outbox, error) {
 	return c.newOutboxFn(allocator, input, typs, metadataSources)
@@ -194,7 +194,7 @@ func TestDrainOnlyInputDAG(t *testing.T) {
 			allocator *colmem.Allocator,
 			op colexecop.Operator,
 			typs []*types.T,
-			sources []execinfrapb.MetadataSource,
+			sources []colexecop.MetadataSource,
 		) (*colrpc.Outbox, error) {
 			require.False(t, outboxCreated)
 			outboxCreated = true

--- a/pkg/sql/colflow/vectorized_meta_propagation_test.go
+++ b/pkg/sql/colflow/vectorized_meta_propagation_test.go
@@ -79,7 +79,7 @@ func TestVectorizedMetaPropagation(t *testing.T) {
 		types,
 		nil, /* output */
 		nil, /* getStats */
-		[]execinfrapb.MetadataSource{col},
+		[]colexecop.MetadataSource{col},
 		nil, /* toClose */
 		nil, /* cancelFlow */
 	)

--- a/pkg/sql/execinfrapb/BUILD.bazel
+++ b/pkg/sql/execinfrapb/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/schemaexpr",
         "//pkg/sql/catalog/tabledesc",
+        "//pkg/sql/colexecerror",
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",

--- a/pkg/sql/execinfrapb/BUILD.bazel
+++ b/pkg/sql/execinfrapb/BUILD.bazel
@@ -28,7 +28,6 @@ go_library(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/schemaexpr",
         "//pkg/sql/catalog/tabledesc",
-        "//pkg/sql/colexecerror",
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",

--- a/pkg/sql/execinfrapb/data.go
+++ b/pkg/sql/execinfrapb/data.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -318,37 +317,4 @@ func LocalMetaToRemoteProducerMeta(
 		panic("unhandled field in local meta or all fields are nil")
 	}
 	return rpm
-}
-
-// MetadataSource is an interface implemented by processors and columnar
-// operators that can produce metadata.
-type MetadataSource interface {
-	// DrainMeta returns all the metadata produced by the processor or operator.
-	// It will be called exactly once, usually, when the processor or operator
-	// has finished doing its computations. This is a signal that the output
-	// requires no more rows to be returned.
-	// Implementers can choose what to do on subsequent calls (if such occur).
-	// TODO(yuzefovich): modify the contract to require returning nil on all
-	// calls after the first one.
-	DrainMeta(context.Context) []ProducerMetadata
-}
-
-// MetadataSources is a slice of MetadataSource.
-type MetadataSources []MetadataSource
-
-// DrainMeta calls DrainMeta on all MetadataSources and returns a single slice
-// with all the accumulated metadata. Note that this method wraps the draining
-// with the panic-catcher so that the callers don't have to.
-func (s MetadataSources) DrainMeta(ctx context.Context) []ProducerMetadata {
-	var result []ProducerMetadata
-	if err := colexecerror.CatchVectorizedRuntimeError(func() {
-		for _, src := range s {
-			result = append(result, src.DrainMeta(ctx)...)
-		}
-	}); err != nil {
-		meta := GetProducerMeta()
-		meta.Err = err
-		result = append(result, *meta)
-	}
-	return result
 }

--- a/pkg/sql/execinfrapb/testutils.go
+++ b/pkg/sql/execinfrapb/testutils.go
@@ -30,17 +30,6 @@ import (
 	"google.golang.org/grpc"
 )
 
-// CallbackMetadataSource is a utility struct that implements the MetadataSource
-// interface by calling a provided callback.
-type CallbackMetadataSource struct {
-	DrainMetaCb func(context.Context) []ProducerMetadata
-}
-
-// DrainMeta is part of the MetadataSource interface.
-func (s CallbackMetadataSource) DrainMeta(ctx context.Context) []ProducerMetadata {
-	return s.DrainMetaCb(ctx)
-}
-
 func newInsecureRPCContext(stopper *stop.Stopper) *rpc.Context {
 	return rpc.NewContext(rpc.ContextOptions{
 		TenantID:   roachpb.SystemTenantID,

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -163,7 +163,6 @@ type invertedJoiner struct {
 
 var _ execinfra.Processor = &invertedJoiner{}
 var _ execinfra.RowSource = &invertedJoiner{}
-var _ execinfrapb.MetadataSource = &invertedJoiner{}
 var _ execinfra.OpNode = &invertedJoiner{}
 
 const invertedJoinerProcName = "inverted joiner"
@@ -797,11 +796,6 @@ func (ij *invertedJoiner) generateMeta(ctx context.Context) []execinfrapb.Produc
 		trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{LeafTxnFinalState: tfs})
 	}
 	return trailingMeta
-}
-
-// DrainMeta is part of the MetadataSource interface.
-func (ij *invertedJoiner) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
-	return ij.generateMeta(ctx)
 }
 
 // ChildCount is part of the execinfra.OpNode interface.

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -146,7 +146,6 @@ type joinReader struct {
 
 var _ execinfra.Processor = &joinReader{}
 var _ execinfra.RowSource = &joinReader{}
-var _ execinfrapb.MetadataSource = &joinReader{}
 var _ execinfra.OpNode = &joinReader{}
 
 const joinReaderProcName = "join reader"
@@ -761,11 +760,6 @@ func (jr *joinReader) generateMeta(ctx context.Context) []execinfrapb.ProducerMe
 		trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{LeafTxnFinalState: tfs})
 	}
 	return trailingMeta
-}
-
-// DrainMeta is part of the MetadataSource interface.
-func (jr *joinReader) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
-	return jr.generateMeta(ctx)
 }
 
 // ChildCount is part of the execinfra.OpNode interface.

--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -1411,7 +1411,7 @@ func BenchmarkJoinReader(b *testing.B) {
 								if !spilled && jr.(*joinReader).Spilled() {
 									spilled = true
 								}
-								meta := output.DrainMeta(ctx)
+								meta := output.bufferedMeta
 								if len(meta) != 1 || meta[0].Metrics == nil {
 									// Expect a single metadata payload with Metrics set.
 									b.Fatalf("unexpected metadata: %v", meta)

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -54,7 +54,6 @@ type tableReader struct {
 
 var _ execinfra.Processor = &tableReader{}
 var _ execinfra.RowSource = &tableReader{}
-var _ execinfrapb.MetadataSource = &tableReader{}
 var _ execinfra.Releasable = &tableReader{}
 var _ execinfra.OpNode = &tableReader{}
 
@@ -310,11 +309,6 @@ func (tr *tableReader) generateMeta(ctx context.Context) []execinfrapb.ProducerM
 	meta.Metrics.BytesRead = tr.fetcher.GetBytesRead()
 	meta.Metrics.RowsRead = tr.rowsRead
 	return append(trailingMeta, *meta)
-}
-
-// DrainMeta is part of the MetadataSource interface.
-func (tr *tableReader) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
-	return tr.generateMeta(ctx)
 }
 
 // ChildCount is part of the execinfra.OpNode interface.

--- a/pkg/sql/rowexec/utils_test.go
+++ b/pkg/sql/rowexec/utils_test.go
@@ -155,7 +155,7 @@ type rowDisposer struct {
 
 var _ execinfra.RowReceiver = &rowDisposer{}
 
-// Push is part of the distsql.RowReceiver interface.
+// Push is part of the execinfra.RowReceiver interface.
 func (r *rowDisposer) Push(
 	row rowenc.EncDatumRow, meta *execinfrapb.ProducerMetadata,
 ) execinfra.ConsumerStatus {
@@ -167,10 +167,10 @@ func (r *rowDisposer) Push(
 	return execinfra.NeedMoreRows
 }
 
-// ProducerDone is part of the RowReceiver interface.
+// ProducerDone is part of the execinfra.RowReceiver interface.
 func (r *rowDisposer) ProducerDone() {}
 
-// Types is part of the RowReceiver interface.
+// Types is part of the execinfra.RowReceiver interface.
 func (r *rowDisposer) Types() []*types.T {
 	return nil
 }
@@ -181,10 +181,4 @@ func (r *rowDisposer) ResetNumRowsDisposed() {
 
 func (r *rowDisposer) NumRowsDisposed() int {
 	return r.numRowsDisposed
-}
-
-func (r *rowDisposer) DrainMeta(context.Context) []execinfrapb.ProducerMetadata {
-	meta := r.bufferedMeta
-	r.bufferedMeta = r.bufferedMeta[:0]
-	return meta
 }

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -260,7 +260,6 @@ var zigzagJoinerBatchSize = int64(util.ConstantWithMetamorphicTestValue(
 
 var _ execinfra.Processor = &zigzagJoiner{}
 var _ execinfra.RowSource = &zigzagJoiner{}
-var _ execinfrapb.MetadataSource = &zigzagJoiner{}
 var _ execinfra.OpNode = &zigzagJoiner{}
 
 const zigzagJoinerProcName = "zigzagJoiner"
@@ -1035,11 +1034,6 @@ func (z *zigzagJoiner) generateMeta(ctx context.Context) []execinfrapb.ProducerM
 		trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{LeafTxnFinalState: tfs})
 	}
 	return trailingMeta
-}
-
-// DrainMeta is part of the MetadataSource interface.
-func (z *zigzagJoiner) DrainMeta(ctx context.Context) []execinfrapb.ProducerMetadata {
-	return z.generateMeta(ctx)
 }
 
 // ChildCount is part of the execinfra.OpNode interface.


### PR DESCRIPTION
**colexec: wrap DrainMeta with panic-catcher and protect columnarizer**

Previously, in some edge cases (like when a panic is encountered during
`Operator.Init`) the metadata sources could have been uninitialized, so
when we tried to drain them, we'd encounter a crash. In order to avoid
that in the future, now all root components will wrap the draining with
the panic-catcher. Additionally, we now protect the columnarizer in this
case explicitly - if it wasn't initialized, it won't drain the wrapped
processor in `DrainMeta`.

Fixes: #62514.

Release note: None

**rowexec: remove redundant implementations of MetadataSource interface**

Previously, some row-by-row processors implemented
`execinfra.MetadataSource` interface. The idea behind that originally
was to allow for wrapped processors to return their metadata in the
vectorized flow, but nothing explicit is actually needed because every
wrapped processor has a columnarizer after it which will drain the
processor according to row-by-row model (by moving into draining state
and exhausting the trailing meta). This commit removes those redundant
implementations.

This allows us to move the interface into `colexecop` package where it
belongs.

Release note: None