### PR TITLE
release-21.1: sql: drop expired zone configs on REGIONAL BY ROW -> REGIONAL BY ROW

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -2459,23 +2459,23 @@ func (sc *SchemaChanger) applyZoneConfigChangeForMutation(
 						),
 					)
 				}
+				// The table re-writing the LocalityConfig does most of the work for
+				// us here, but if we're coming from REGIONAL BY ROW, it's also
+				// necessary to drop the zone configurations on the index partitions.
+				if lcSwap.OldLocalityConfig.GetRegionalByRow() != nil {
+					opts = append(
+						opts,
+						dropZoneConfigsForMultiRegionIndexes(
+							append(
+								[]descpb.IndexID{pkSwap.OldPrimaryIndexId},
+								pkSwap.OldIndexes...,
+							)...,
+						),
+					)
+				}
 				switch lcSwap.NewLocalityConfig.Locality.(type) {
 				case *descpb.TableDescriptor_LocalityConfig_Global_,
 					*descpb.TableDescriptor_LocalityConfig_RegionalByTable_:
-					// The table re-writing the LocalityConfig does most of the work for
-					// us here, but if we're coming from REGIONAL BY ROW, it's also
-					// necessary to drop the zone configurations on the index partitions.
-					if lcSwap.OldLocalityConfig.GetRegionalByRow() != nil {
-						opts = append(
-							opts,
-							dropZoneConfigsForMultiRegionIndexes(
-								append(
-									[]descpb.IndexID{pkSwap.OldPrimaryIndexId},
-									pkSwap.OldIndexes...,
-								)...,
-							),
-						)
-					}
 				case *descpb.TableDescriptor_LocalityConfig_RegionalByRow_:
 					// Apply new zone configurations for all newly partitioned indexes.
 					opts = append(


### PR DESCRIPTION
Backport 1/1 commits from #62908.

/cc @cockroachdb/release

---

Also drop zone configs which should no longer exist after a successful
schema change on indexes when transitioning between REGIONAL BY ROW to
REGIONAL BY ROW.

Release note: None
