### PR TITLE
bazel: tweak xml test report schema for better exposure in teamcity

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,7 +12,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 # Load go bazel tools. This gives us access to the go bazel SDK/toolchains.
 git_repository(
     name = "io_bazel_rules_go",
-    commit = "2fe8a6256c818840cc9a10cf3f366d8410437245",
+    commit = "4a7bcd47e30a8e87ad062b7ecf1b3a46c22f5b09",
     remote = "https://github.com/cockroachdb/rules_go",
 )
 


### PR DESCRIPTION
Pull in https://github.com/cockroachdb/rules_go/commit/4a7bcd47e30a8e87ad062b7ecf1b3a46c22f5b09
for better teamcity test support.
    
The XML report that `rules_go` generates begins with a `<test_suites>`
stanza that Teamcity is apparently not expecting -- removing it allows
TC to properly recognize the test suite. Additionally, we remove the
unnecessary `classname` attribute that was clogging up the test results
with unnecessary information.
    
All of this results in the Bazel test job exposing test results that are
very close to what we see in the actual unit test job.

Release note: None