### PR TITLE
sql: fix ADD COLUMN ... UNIQUE for PARTITION ALL BY tables

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -455,6 +455,9 @@ CREATE INDEX created_idx ON t(c)
 ----
 
 statement ok
+ALTER TABLE t ADD COLUMN e INT8 NOT NULL UNIQUE
+
+statement ok
 ALTER TABLE t ADD CONSTRAINT unique_c_d UNIQUE(c, d)
 
 query T
@@ -470,6 +473,7 @@ CREATE TABLE public.t (
   d INT8 NOT NULL,
   j JSONB NULL,
   u STRING NULL,
+  e INT8 NOT NULL,
   CONSTRAINT "primary" PRIMARY KEY (pk ASC),
   UNIQUE INDEX t_u_key (u ASC),
   INDEX t_a_idx (a ASC),
@@ -477,8 +481,9 @@ CREATE TABLE public.t (
   INDEX t_partition_by_c_idx (partition_by ASC, c ASC),
   INVERTED INDEX t_j_idx (j),
   INDEX created_idx (c ASC),
+  UNIQUE INDEX t_e_key (e ASC),
   UNIQUE INDEX unique_c_d (c ASC, d ASC),
-  FAMILY fam_0_pk_pk2_partition_by_a_b_c_d_j_u (pk, pk2, partition_by, a, b, c, d, j, u)
+  FAMILY fam_0_pk_pk2_partition_by_a_b_c_d_j_u (pk, pk2, partition_by, a, b, c, d, j, u, e)
 ) PARTITION ALL BY LIST (partition_by) (
   PARTITION one VALUES IN ((1)),
   PARTITION two VALUES IN ((2))
@@ -499,6 +504,8 @@ t_a_idx               a             false
 t_a_idx               partition_by  true
 t_b_key               b             false
 t_b_key               partition_by  true
+t_e_key               e             false
+t_e_key               partition_by  true
 t_j_idx               j             false
 t_j_idx               partition_by  true
 t_partition_by_c_idx  c             false
@@ -525,6 +532,7 @@ CREATE TABLE public.t (
   d INT8 NOT NULL,
   j JSONB NULL,
   u STRING NULL,
+  e INT8 NOT NULL,
   CONSTRAINT "primary" PRIMARY KEY (pk2 ASC),
   UNIQUE INDEX t_pk_key (pk ASC),
   UNIQUE INDEX t_u_key (u ASC),
@@ -533,8 +541,9 @@ CREATE TABLE public.t (
   INDEX t_partition_by_c_idx (partition_by ASC, c ASC),
   INVERTED INDEX t_j_idx (j),
   INDEX created_idx (c ASC),
+  UNIQUE INDEX t_e_key (e ASC),
   UNIQUE INDEX unique_c_d (c ASC, d ASC),
-  FAMILY fam_0_pk_pk2_partition_by_a_b_c_d_j_u (pk, pk2, partition_by, a, b, c, d, j, u)
+  FAMILY fam_0_pk_pk2_partition_by_a_b_c_d_j_u (pk, pk2, partition_by, a, b, c, d, j, u, e)
 ) PARTITION ALL BY LIST (partition_by) (
   PARTITION one VALUES IN ((1)),
   PARTITION two VALUES IN ((2))
@@ -555,6 +564,8 @@ t_a_idx               a             false
 t_a_idx               partition_by  true
 t_b_key               b             false
 t_b_key               partition_by  true
+t_e_key               e             false
+t_e_key               partition_by  true
 t_j_idx               j             false
 t_j_idx               partition_by  true
 t_partition_by_c_idx  c             false

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -513,6 +513,33 @@ ALTER TABLE regional_by_row_table ALTER PRIMARY KEY USING COLUMNS(pk2) USING HAS
 statement error interleaved tables are not compatible with REGIONAL BY ROW tables
 CREATE INDEX bad_idx ON regional_by_row_table(pk) INTERLEAVE IN PARENT parent_table(pk)
 
+# Try add a new unique column.
+statement ok
+ALTER TABLE regional_by_row_table ADD COLUMN unique_col INT8 NOT NULL UNIQUE
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE regional_by_row_table]
+----
+CREATE TABLE public.regional_by_row_table (
+  pk INT8 NOT NULL,
+  pk2 INT8 NOT NULL,
+  a INT8 NOT NULL,
+  b INT8 NOT NULL,
+  j JSONB NULL,
+  crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+  unique_col INT8 NOT NULL,
+  CONSTRAINT "primary" PRIMARY KEY (pk ASC),
+  INDEX regional_by_row_table_a_idx (a ASC),
+  UNIQUE INDEX regional_by_row_table_b_key (b ASC),
+  INVERTED INDEX regional_by_row_table_j_idx (j),
+  UNIQUE INDEX regional_by_row_table_unique_col_key (unique_col ASC),
+  FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region, unique_col)
+) LOCALITY REGIONAL BY ROW;
+ALTER PARTITION "us-east-1" OF INDEX multi_region_test_db.public.regional_by_row_table@regional_by_row_table_a_idx CONFIGURE ZONE USING "gc.ttlseconds" = 10
+
+statement ok
+ALTER TABLE regional_by_row_table DROP COLUMN unique_col
+
 # Insert some rows into the regional_by_row_table.
 query TI
 INSERT INTO regional_by_row_table (pk, pk2, a, b, j) VALUES

--- a/pkg/sql/add_column.go
+++ b/pkg/sql/add_column.go
@@ -81,6 +81,19 @@ func (p *planner) addColumnImpl(
 	}
 	incTelemetryForNewColumn(d, col)
 
+	// Ensure all new indexes are partitioned appropriately.
+	if idx != nil {
+		*idx, err = p.configureIndexDescForNewIndexPartitioning(
+			params.ctx,
+			desc,
+			*idx,
+			nil, /* PartitionByIndex */
+		)
+		if err != nil {
+			return err
+		}
+	}
+
 	// If the new column has a DEFAULT expression that uses a sequence, add references between
 	// its descriptor and this column descriptor.
 	if d.HasDefaultExpr() {


### PR DESCRIPTION
Refs: #63113

Release note (bug fix): Fixed a bug where doing ALTER TABLE ... ADD
COLUMN ... UNIQUE would error if the table had a PARTITION ALL BY /
REGIONAL BY ROW definition.
