### PR TITLE
sql: block initial multi-region if zone configs have multi-region fields set

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
@@ -11,6 +11,16 @@ statement ok
 SELECT crdb_internal.validate_multi_region_zone_configs()
 
 statement ok
+CREATE DATABASE bad_db PRIMARY REGION "ca-central-1";
+USE bad_db;
+SET override_multi_region_zone_config = true;
+ALTER DATABASE bad_db CONFIGURE ZONE DISCARD;
+SET override_multi_region_zone_config = false
+
+statement error zone configuration for database bad_db contains incorrectly configured field "num_replicas"
+SELECT crdb_internal.validate_multi_region_zone_configs()
+
+statement ok
 CREATE DATABASE "mr-zone-configs" primary region "ca-central-1" regions "ap-southeast-2", "us-east-1"
 
 statement ok
@@ -274,12 +284,13 @@ DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USIN
 query TTTTT colnames
 SHOW DATABASES
 ----
-database_name    owner  primary_region  regions  survival_goal
-defaultdb        root   NULL            {}       NULL
-mr-zone-configs  root   NULL            {}       NULL
-postgres         root   NULL            {}       NULL
-system           node   NULL            {}       NULL
-test             root   NULL            {}       NULL
+database_name    owner  primary_region  regions         survival_goal
+bad_db           root   ca-central-1    {ca-central-1}  zone
+defaultdb        root   NULL            {}              NULL
+mr-zone-configs  root   NULL            {}              NULL
+postgres         root   NULL            {}              NULL
+system           node   NULL            {}              NULL
+test             root   NULL            {}              NULL
 
 statement ok
 ALTER DATABASE "mr-zone-configs" SET PRIMARY REGION "us-east-1"
@@ -294,6 +305,7 @@ query TTTTT colnames
 SHOW DATABASES
 ----
 database_name    owner  primary_region  regions                                  survival_goal
+bad_db           root   ca-central-1    {ca-central-1}                           zone
 defaultdb        root   NULL            {}                                       NULL
 mr-zone-configs  root   us-east-1       {ap-southeast-2,ca-central-1,us-east-1}  zone
 postgres         root   NULL            {}                                       NULL

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
@@ -11,16 +11,6 @@ statement ok
 SELECT crdb_internal.validate_multi_region_zone_configs()
 
 statement ok
-CREATE DATABASE bad_db PRIMARY REGION "ca-central-1";
-USE bad_db;
-SET override_multi_region_zone_config = true;
-ALTER DATABASE bad_db CONFIGURE ZONE DISCARD;
-SET override_multi_region_zone_config = false
-
-statement error zone configuration for database bad_db contains incorrectly configured field "num_replicas"
-SELECT crdb_internal.validate_multi_region_zone_configs()
-
-statement ok
 CREATE DATABASE "mr-zone-configs" primary region "ca-central-1" regions "ap-southeast-2", "us-east-1"
 
 statement ok
@@ -284,13 +274,12 @@ DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USIN
 query TTTTT colnames
 SHOW DATABASES
 ----
-database_name    owner  primary_region  regions         survival_goal
-bad_db           root   ca-central-1    {ca-central-1}  zone
-defaultdb        root   NULL            {}              NULL
-mr-zone-configs  root   NULL            {}              NULL
-postgres         root   NULL            {}              NULL
-system           node   NULL            {}              NULL
-test             root   NULL            {}              NULL
+database_name    owner  primary_region  regions  survival_goal
+defaultdb        root   NULL            {}       NULL
+mr-zone-configs  root   NULL            {}       NULL
+postgres         root   NULL            {}       NULL
+system           node   NULL            {}       NULL
+test             root   NULL            {}       NULL
 
 statement ok
 ALTER DATABASE "mr-zone-configs" SET PRIMARY REGION "us-east-1"
@@ -305,7 +294,6 @@ query TTTTT colnames
 SHOW DATABASES
 ----
 database_name    owner  primary_region  regions                                  survival_goal
-bad_db           root   ca-central-1    {ca-central-1}                           zone
 defaultdb        root   NULL            {}                                       NULL
 mr-zone-configs  root   us-east-1       {ap-southeast-2,ca-central-1,us-east-1}  zone
 postgres         root   NULL            {}                                       NULL
@@ -496,13 +484,13 @@ SET override_multi_region_zone_config = true;
 ALTER index regional_by_row@primary CONFIGURE ZONE USING num_replicas = 10;
 SET override_multi_region_zone_config = false
 
-statement error attempting to update zone config which contains an extra zone configuration for index regional_by_row@"primary"
+statement error attempting to update zone config which contains an extra zone configuration for index regional_by_row@"primary" with field num_replicas populated
 ALTER TABLE regional_by_row SET LOCALITY GLOBAL
 
-statement error extraneous zone configuration for index regional_by_row@"primary"
+statement error extraneous zone configuration for index regional_by_row@"primary" with field num_replicas populated
 SELECT crdb_internal.validate_multi_region_zone_configs()
 
-statement error attempting to update zone config which contains an extra zone configuration for index regional_by_row@"primary"
+statement error attempting to update zone config which contains an extra zone configuration for index regional_by_row@"primary" with field num_replicas populated
 ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY ROW
 
 statement ok
@@ -537,7 +525,7 @@ INDEX regional_by_row_as@primary  ALTER INDEX regional_by_row_as@primary CONFIGU
                                   voter_constraints = '[+region=us-east-1]',
                                   lease_preferences = '[[+region=us-east-1]]'
 
-statement error attempting to update zone config which contains an extra zone configuration for index regional_by_row_as@"primary"
+statement error attempting to update zone config which contains an extra zone configuration for index regional_by_row_as@"primary" with field num_replicas populated
 ALTER TABLE regional_by_row_as SET LOCALITY REGIONAL BY ROW
 
 statement ok
@@ -641,3 +629,79 @@ statement ok
 SET override_multi_region_zone_config = true;
 ALTER PARTITION "ca-central-1" OF INDEX regional_by_row@primary CONFIGURE ZONE DISCARD;
 SET override_multi_region_zone_config = false
+
+# Test validation for initial SET PRIMARY REGION
+statement ok
+CREATE DATABASE initial_multiregion_db;
+USE initial_multiregion_db;
+CREATE TABLE tbl (a INT PRIMARY KEY, INDEX a_idx (a));
+ALTER DATABASE initial_multiregion_db CONFIGURE ZONE USING gc.ttlseconds = 5;
+ALTER TABLE tbl CONFIGURE ZONE USING gc.ttlseconds = 5;
+ALTER INDEX tbl@a_idx CONFIGURE ZONE USING gc.ttlseconds = 5
+
+statement ok
+ALTER DATABASE initial_multiregion_db SET PRIMARY REGION "us-east-1"
+
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE initial_multiregion_db
+----
+DATABASE initial_multiregion_db  ALTER DATABASE initial_multiregion_db CONFIGURE ZONE USING
+                                 range_min_bytes = 134217728,
+                                 range_max_bytes = 536870912,
+                                 gc.ttlseconds = 5,
+                                 num_replicas = 3,
+                                 num_voters = 3,
+                                 constraints = '{+region=us-east-1: 1}',
+                                 voter_constraints = '[+region=us-east-1]',
+                                 lease_preferences = '[[+region=us-east-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE tbl
+----
+TABLE tbl  ALTER TABLE tbl CONFIGURE ZONE USING
+           range_min_bytes = 134217728,
+           range_max_bytes = 536870912,
+           gc.ttlseconds = 5,
+           num_replicas = 3,
+           num_voters = 3,
+           constraints = '{+region=us-east-1: 1}',
+           voter_constraints = '[+region=us-east-1]',
+           lease_preferences = '[[+region=us-east-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR INDEX tbl@a_idx
+----
+INDEX tbl@a_idx  ALTER INDEX tbl@a_idx CONFIGURE ZONE USING
+                 range_min_bytes = 134217728,
+                 range_max_bytes = 536870912,
+                 gc.ttlseconds = 5,
+                 num_replicas = 3,
+                 num_voters = 3,
+                 constraints = '{+region=us-east-1: 1}',
+                 voter_constraints = '[+region=us-east-1]',
+                 lease_preferences = '[[+region=us-east-1]]'
+
+statement ok
+ALTER DATABASE initial_multiregion_db DROP REGION "us-east-1";
+ALTER INDEX tbl@a_idx CONFIGURE ZONE USING num_replicas = 10
+
+statement error zone configuration for index tbl@a_idx has field "num_replicas" set which will be overwritten when setting the initial PRIMARY REGION\nHINT: discard the zone config using CONFIGURE ZONE DISCARD before continuing
+ALTER DATABASE initial_multiregion_db SET PRIMARY REGION "us-east-1"
+
+statement ok
+ALTER INDEX tbl@a_idx CONFIGURE ZONE DISCARD;
+ALTER TABLE tbl CONFIGURE ZONE USING num_replicas = 10
+
+statement error zone configuration for table tbl has field "num_replicas" set which will be overwritten when setting the the initial PRIMARY REGION\nHINT: discard the zone config using CONFIGURE ZONE DISCARD before continuing
+ALTER DATABASE initial_multiregion_db SET PRIMARY REGION "us-east-1"
+
+statement ok
+ALTER TABLE tbl CONFIGURE ZONE DISCARD;
+ALTER DATABASE initial_multiregion_db CONFIGURE ZONE USING num_replicas = 10;
+
+statement error zone configuration for database initial_multiregion_db has field "num_replicas" set which will be overwritten when setting the the initial PRIMARY REGION\nHINT: discard the zone config using CONFIGURE ZONE DISCARD before continuing
+ALTER DATABASE initial_multiregion_db SET PRIMARY REGION "us-east-1"
+
+statement ok
+ALTER DATABASE initial_multiregion_db CONFIGURE ZONE DISCARD;
+ALTER DATABASE initial_multiregion_db SET PRIMARY REGION "us-east-1"

--- a/pkg/config/zonepb/zone.go
+++ b/pkg/config/zonepb/zone.go
@@ -611,8 +611,6 @@ type DiffWithZoneMismatch struct {
 	// PartitionName represents a subzone with a mismatching partitionName.
 	PartitionName string
 
-	// NOTE: only one of the below fields is set.
-
 	// IsMissingSubzone indicates a subzone is missing.
 	IsMissingSubzone bool
 	// IsExtraSubzone indicates we have an extraneous subzone.
@@ -782,6 +780,7 @@ func (z *ZoneConfig) DiffWithZone(
 					IndexID:        s.IndexID,
 					PartitionName:  s.PartitionName,
 					IsExtraSubzone: true,
+					Field:          subzoneMismatch.Field,
 				}, nil
 			}
 			continue
@@ -822,6 +821,7 @@ func (z *ZoneConfig) DiffWithZone(
 				IndexID:          o.IndexID,
 				PartitionName:    o.PartitionName,
 				IsMissingSubzone: true,
+				Field:            subzoneMismatch.Field,
 			}, nil
 		}
 	}

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -425,7 +425,7 @@ func (p *planner) checkPrivilegesForMultiRegionOp(
 func (p *planner) checkPrivilegesForRepartitioningRegionalByRowTables(
 	ctx context.Context, dbDesc *dbdesc.Immutable,
 ) error {
-	return p.forEachTableInMultiRegionDatabase(ctx, dbDesc,
+	return p.forEachMutableTableInDatabase(ctx, dbDesc,
 		func(ctx context.Context, tbDesc *tabledesc.Mutable) error {
 			if tbDesc.IsLocalityRegionalByRow() {
 				err := p.checkPrivilegesForMultiRegionOp(ctx, tbDesc)
@@ -455,7 +455,7 @@ func removeLocalityConfigFromAllTablesInDB(
 		)
 	}
 	b := p.Txn().NewBatch()
-	if err := p.forEachTableInMultiRegionDatabase(ctx, desc, func(ctx context.Context, tbDesc *tabledesc.Mutable) error {
+	if err := p.forEachMutableTableInDatabase(ctx, desc, func(ctx context.Context, tbDesc *tabledesc.Mutable) error {
 		// The user must either be an admin or have the requisite privileges.
 		if err := p.checkPrivilegesForMultiRegionOp(ctx, tbDesc); err != nil {
 			return err
@@ -694,7 +694,7 @@ func addDefaultLocalityConfigToAllTables(
 		)
 	}
 	b := p.Txn().NewBatch()
-	if err := p.forEachTableInMultiRegionDatabase(ctx, dbDesc, func(ctx context.Context, tbDesc *tabledesc.Mutable) error {
+	if err := p.forEachMutableTableInDatabase(ctx, dbDesc, func(ctx context.Context, tbDesc *tabledesc.Mutable) error {
 		if err := p.checkPrivilegesForMultiRegionOp(ctx, tbDesc); err != nil {
 			return err
 		}

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -756,7 +756,6 @@ func checkCanConvertTableToMultiRegion(
 			)
 		}
 	}
-	// TODO(#57668): check zone configurations are not set here
 	return nil
 }
 
@@ -772,6 +771,15 @@ func (n *alterDatabasePrimaryRegionNode) setInitialPrimaryRegion(params runParam
 		[]tree.Name{n.n.PrimaryRegion},
 	)
 	if err != nil {
+		return err
+	}
+
+	// Check we are writing valid zone configurations.
+	if err := params.p.validateAllMultiRegionZoneConfigsInDatabase(
+		params.ctx,
+		&n.desc.Immutable,
+		&zoneConfigForMultiRegionValidatorSetInitialRegion{},
+	); err != nil {
 		return err
 	}
 

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -132,7 +132,7 @@ func makeRequiredConstraintForRegion(r descpb.RegionName) zonepb.Constraint {
 // are set the way they are.
 func zoneConfigForMultiRegionDatabase(
 	regionConfig multiregion.RegionConfig,
-) (*zonepb.ZoneConfig, error) {
+) (zonepb.ZoneConfig, error) {
 	numVoters, numReplicas := getNumVotersAndNumReplicas(regionConfig)
 	constraints := make([]zonepb.ConstraintsConjunction, len(regionConfig.Regions()))
 	for i, region := range regionConfig.Regions() {
@@ -145,10 +145,10 @@ func zoneConfigForMultiRegionDatabase(
 
 	voterConstraints, err := synthesizeVoterConstraints(regionConfig.PrimaryRegion(), regionConfig)
 	if err != nil {
-		return nil, err
+		return zonepb.ZoneConfig{}, err
 	}
 
-	return &zonepb.ZoneConfig{
+	return zonepb.ZoneConfig{
 		NumReplicas: &numReplicas,
 		NumVoters:   &numVoters,
 		LeasePreferences: []zonepb.LeasePreference{
@@ -669,7 +669,7 @@ func discardMultiRegionFieldsForDatabaseZoneConfig(
 	return applyZoneConfigForMultiRegionDatabase(
 		ctx,
 		dbID,
-		zonepb.NewZoneConfig(),
+		*zonepb.NewZoneConfig(),
 		txn,
 		execConfig,
 	)
@@ -678,7 +678,7 @@ func discardMultiRegionFieldsForDatabaseZoneConfig(
 func applyZoneConfigForMultiRegionDatabase(
 	ctx context.Context,
 	dbID descpb.ID,
-	mergeZoneConfig *zonepb.ZoneConfig,
+	mergeZoneConfig zonepb.ZoneConfig,
 	txn *kv.Txn,
 	execConfig *ExecutorConfig,
 ) error {
@@ -691,7 +691,7 @@ func applyZoneConfigForMultiRegionDatabase(
 		newZoneConfig = *currentZoneConfig
 	}
 	newZoneConfig.CopyFromZone(
-		*mergeZoneConfig,
+		mergeZoneConfig,
 		zonepb.MultiRegionZoneConfigFields,
 	)
 	// If the new zone config is the same as a blank zone config, delete it.
@@ -851,7 +851,26 @@ func (p *planner) ValidateAllMultiRegionZoneConfigsInCurrentDatabase(ctx context
 	if !dbDesc.IsMultiRegion() {
 		return nil
 	}
+	regionConfig, err := SynthesizeRegionConfigForZoneConfigValidation(ctx, p.txn, dbDesc.ID, p.Descriptors())
+	if err != nil {
+		return err
+	}
+	return p.validateAllMultiRegionZoneConfigsInDatabase(
+		ctx,
+		dbDesc,
+		&zoneConfigForMultiRegionValidatorValidation{
+			zoneConfigForMultiRegionValidatorExistingMultiRegionObject: zoneConfigForMultiRegionValidatorExistingMultiRegionObject{
+				regionConfig: regionConfig,
+			},
+		},
+	)
+}
 
+func (p *planner) validateAllMultiRegionZoneConfigsInDatabase(
+	ctx context.Context,
+	dbDesc *dbdesc.Immutable,
+	zoneConfigForMultiRegionValidator zoneConfigForMultiRegionValidator,
+) error {
 	var ids []descpb.ID
 	if err := p.forEachTableInMultiRegionDatabase(
 		ctx,
@@ -879,7 +898,7 @@ func (p *planner) ValidateAllMultiRegionZoneConfigsInCurrentDatabase(ctx context
 		ctx,
 		dbDesc,
 		zoneConfigs[dbDesc.GetID()],
-		&validateZoneConfigForMultiRegionErrorHandlerValidation{},
+		zoneConfigForMultiRegionValidator,
 	); err != nil {
 		return err
 	}
@@ -893,7 +912,7 @@ func (p *planner) ValidateAllMultiRegionZoneConfigsInCurrentDatabase(ctx context
 				dbDesc,
 				tbDesc,
 				zoneConfigs[tbDesc.GetID()],
-				&validateZoneConfigForMultiRegionErrorHandlerValidation{},
+				zoneConfigForMultiRegionValidator,
 			)
 		},
 	)
@@ -1145,22 +1164,54 @@ func (p *planner) CheckZoneConfigChangePermittedForMultiRegion(
 	return nil
 }
 
-// validateZoneConfigForMultiRegionErrorHandler is an interface representing
-// an error to generate if validating a zone config for multi-region
-// fails.
-type validateZoneConfigForMultiRegionErrorHandler interface {
+// zoneConfigForMultiRegionValidator is an interface representing
+// actions to take when validating a zone config for multi-region
+// purposes.
+type zoneConfigForMultiRegionValidator interface {
+	getExpectedDatabaseZoneConfig() (zonepb.ZoneConfig, error)
+	getExpectedTableZoneConfig(desc catalog.TableDescriptor) (zonepb.ZoneConfig, error)
+
 	newMismatchFieldError(descType string, descName string, field string) error
 	newMissingSubzoneError(descType string, descName string) error
 	newExtraSubzoneError(descType string, descName string) error
 }
 
-// validateZoneConfigForMultiRegionErrorHandlerModifiedByUser implements
-// interface validateZoneConfigForMultiRegionErrorHandler.
-type validateZoneConfigForMultiRegionErrorHandlerModifiedByUser struct{}
+// zoneConfigForMultiRegionValidatorExistingMultiRegionObject partially implements
+// the zoneConfigForMultiRegionValidator interface.
+type zoneConfigForMultiRegionValidatorExistingMultiRegionObject struct {
+	regionConfig multiregion.RegionConfig
+}
 
-var _ validateZoneConfigForMultiRegionErrorHandler = (*validateZoneConfigForMultiRegionErrorHandlerModifiedByUser)(nil)
+func (v *zoneConfigForMultiRegionValidatorExistingMultiRegionObject) getExpectedDatabaseZoneConfig() (
+	zonepb.ZoneConfig,
+	error,
+) {
+	return zoneConfigForMultiRegionDatabase(v.regionConfig)
+}
 
-func (v *validateZoneConfigForMultiRegionErrorHandlerModifiedByUser) newMismatchFieldError(
+func (v *zoneConfigForMultiRegionValidatorExistingMultiRegionObject) getExpectedTableZoneConfig(
+	desc catalog.TableDescriptor,
+) (zonepb.ZoneConfig, error) {
+	_, expectedZoneConfig, err := ApplyZoneConfigForMultiRegionTableOptionTableAndIndexes(
+		*zonepb.NewZoneConfig(),
+		v.regionConfig,
+		desc,
+	)
+	if err != nil {
+		return zonepb.ZoneConfig{}, err
+	}
+	return expectedZoneConfig, err
+}
+
+// zoneConfigForMultiRegionValidatorModifiedByUser implements
+// interface zoneConfigForMultiRegionValidator.
+type zoneConfigForMultiRegionValidatorModifiedByUser struct {
+	zoneConfigForMultiRegionValidatorExistingMultiRegionObject
+}
+
+var _ zoneConfigForMultiRegionValidator = (*zoneConfigForMultiRegionValidatorModifiedByUser)(nil)
+
+func (v *zoneConfigForMultiRegionValidatorModifiedByUser) newMismatchFieldError(
 	descType string, descName string, field string,
 ) error {
 	return v.wrapErr(
@@ -1174,7 +1225,7 @@ func (v *validateZoneConfigForMultiRegionErrorHandlerModifiedByUser) newMismatch
 	)
 }
 
-func (v *validateZoneConfigForMultiRegionErrorHandlerModifiedByUser) wrapErr(err error) error {
+func (v *zoneConfigForMultiRegionValidatorModifiedByUser) wrapErr(err error) error {
 	err = errors.WithDetail(
 		err,
 		"the attempted operation will overwrite a user modified field",
@@ -1186,7 +1237,7 @@ func (v *validateZoneConfigForMultiRegionErrorHandlerModifiedByUser) wrapErr(err
 	)
 }
 
-func (v *validateZoneConfigForMultiRegionErrorHandlerModifiedByUser) newMissingSubzoneError(
+func (v *zoneConfigForMultiRegionValidatorModifiedByUser) newMissingSubzoneError(
 	descType string, descName string,
 ) error {
 	return v.wrapErr(
@@ -1199,7 +1250,7 @@ func (v *validateZoneConfigForMultiRegionErrorHandlerModifiedByUser) newMissingS
 	)
 }
 
-func (v *validateZoneConfigForMultiRegionErrorHandlerModifiedByUser) newExtraSubzoneError(
+func (v *zoneConfigForMultiRegionValidatorModifiedByUser) newExtraSubzoneError(
 	descType string, descName string,
 ) error {
 	return v.wrapErr(
@@ -1212,13 +1263,15 @@ func (v *validateZoneConfigForMultiRegionErrorHandlerModifiedByUser) newExtraSub
 	)
 }
 
-// validateZoneConfigForMultiRegionErrorHandlerValidation implements
-// interface validateZoneConfigForMultiRegionErrorHandler.
-type validateZoneConfigForMultiRegionErrorHandlerValidation struct{}
+// zoneConfigForMultiRegionValidatorValidation implements
+// interface zoneConfigForMultiRegionValidator.
+type zoneConfigForMultiRegionValidatorValidation struct {
+	zoneConfigForMultiRegionValidatorExistingMultiRegionObject
+}
 
-var _ validateZoneConfigForMultiRegionErrorHandler = (*validateZoneConfigForMultiRegionErrorHandlerValidation)(nil)
+var _ zoneConfigForMultiRegionValidator = (*zoneConfigForMultiRegionValidatorValidation)(nil)
 
-func (v *validateZoneConfigForMultiRegionErrorHandlerValidation) newMismatchFieldError(
+func (v *zoneConfigForMultiRegionValidatorValidation) newMismatchFieldError(
 	descType string, descName string, field string,
 ) error {
 	return pgerror.Newf(
@@ -1230,7 +1283,7 @@ func (v *validateZoneConfigForMultiRegionErrorHandlerValidation) newMismatchFiel
 	)
 }
 
-func (v *validateZoneConfigForMultiRegionErrorHandlerValidation) newMissingSubzoneError(
+func (v *zoneConfigForMultiRegionValidatorValidation) newMissingSubzoneError(
 	descType string, descName string,
 ) error {
 	return pgerror.Newf(
@@ -1241,7 +1294,7 @@ func (v *validateZoneConfigForMultiRegionErrorHandlerValidation) newMissingSubzo
 	)
 }
 
-func (v *validateZoneConfigForMultiRegionErrorHandlerValidation) newExtraSubzoneError(
+func (v *zoneConfigForMultiRegionValidatorValidation) newExtraSubzoneError(
 	descType string, descName string,
 ) error {
 	return pgerror.Newf(
@@ -1268,11 +1321,19 @@ func (p *planner) validateZoneConfigForMultiRegionDatabaseWasNotModifiedByUser(
 	if err != nil {
 		return err
 	}
+	regionConfig, err := SynthesizeRegionConfigForZoneConfigValidation(ctx, p.txn, dbDesc.ID, p.Descriptors())
+	if err != nil {
+		return err
+	}
 	return p.validateZoneConfigForMultiRegionDatabase(
 		ctx,
 		dbDesc,
 		currentZoneConfig,
-		&validateZoneConfigForMultiRegionErrorHandlerModifiedByUser{},
+		&zoneConfigForMultiRegionValidatorModifiedByUser{
+			zoneConfigForMultiRegionValidatorExistingMultiRegionObject: zoneConfigForMultiRegionValidatorExistingMultiRegionObject{
+				regionConfig: regionConfig,
+			},
+		},
 	)
 }
 
@@ -1282,22 +1343,18 @@ func (p *planner) validateZoneConfigForMultiRegionDatabase(
 	ctx context.Context,
 	dbDesc *dbdesc.Immutable,
 	currentZoneConfig *zonepb.ZoneConfig,
-	validateZoneConfigForMultiRegionErrorHandler validateZoneConfigForMultiRegionErrorHandler,
+	zoneConfigForMultiRegionValidator zoneConfigForMultiRegionValidator,
 ) error {
 	if currentZoneConfig == nil {
 		currentZoneConfig = zonepb.NewZoneConfig()
 	}
-	regionConfig, err := SynthesizeRegionConfigForZoneConfigValidation(ctx, p.txn, dbDesc.ID, p.Descriptors())
-	if err != nil {
-		return err
-	}
-	expectedZoneConfig, err := zoneConfigForMultiRegionDatabase(regionConfig)
+	expectedZoneConfig, err := zoneConfigForMultiRegionValidator.getExpectedDatabaseZoneConfig()
 	if err != nil {
 		return err
 	}
 
 	same, mismatch, err := currentZoneConfig.DiffWithZone(
-		*expectedZoneConfig,
+		expectedZoneConfig,
 		zonepb.MultiRegionZoneConfigFields,
 	)
 	if err != nil {
@@ -1305,7 +1362,7 @@ func (p *planner) validateZoneConfigForMultiRegionDatabase(
 	}
 	if !same {
 		dbName := tree.Name(dbDesc.GetName())
-		return validateZoneConfigForMultiRegionErrorHandler.newMismatchFieldError(
+		return zoneConfigForMultiRegionValidator.newMismatchFieldError(
 			"database",
 			dbName.String(),
 			mismatch.Field,
@@ -1336,39 +1393,41 @@ func (p *planner) validateZoneConfigForMultiRegionTableWasNotModifiedByUser(
 	if err != nil {
 		return err
 	}
+	regionConfig, err := SynthesizeRegionConfig(ctx, p.txn, dbDesc.ID, p.Descriptors())
+	if err != nil {
+		return err
+	}
 
 	return p.validateZoneConfigForMultiRegionTable(
 		ctx,
 		dbDesc,
 		desc,
 		currentZoneConfig,
-		&validateZoneConfigForMultiRegionErrorHandlerModifiedByUser{},
+		&zoneConfigForMultiRegionValidatorModifiedByUser{
+			zoneConfigForMultiRegionValidatorExistingMultiRegionObject: zoneConfigForMultiRegionValidatorExistingMultiRegionObject{
+				regionConfig: regionConfig,
+			},
+		},
 	)
 }
 
 // validateZoneConfigForMultiRegionTableOptions validates that
-// the table's zone configuration matches exactly what is expected.
+// the multi-region fields of the table's zone configuration
+// matches what is expected for the given table.
 func (p *planner) validateZoneConfigForMultiRegionTable(
 	ctx context.Context,
 	dbDesc *dbdesc.Immutable,
 	desc catalog.TableDescriptor,
 	currentZoneConfig *zonepb.ZoneConfig,
-	validateZoneConfigForMultiRegionErrorHandler validateZoneConfigForMultiRegionErrorHandler,
+	zoneConfigForMultiRegionValidator zoneConfigForMultiRegionValidator,
 ) error {
 	if currentZoneConfig == nil {
 		currentZoneConfig = zonepb.NewZoneConfig()
 	}
 
-	regionConfig, err := SynthesizeRegionConfig(ctx, p.txn, dbDesc.ID, p.Descriptors())
-	if err != nil {
-		return err
-	}
-
 	tableName := tree.Name(desc.GetName())
 
-	_, expectedZoneConfig, err := ApplyZoneConfigForMultiRegionTableOptionTableAndIndexes(
-		*zonepb.NewZoneConfig(),
-		regionConfig,
+	expectedZoneConfig, err := zoneConfigForMultiRegionValidator.getExpectedTableZoneConfig(
 		desc,
 	)
 	if err != nil {
@@ -1446,18 +1505,18 @@ func (p *planner) validateZoneConfigForMultiRegionTable(
 		}
 
 		if mismatch.IsMissingSubzone {
-			return validateZoneConfigForMultiRegionErrorHandler.newMissingSubzoneError(
+			return zoneConfigForMultiRegionValidator.newMissingSubzoneError(
 				descType,
 				name,
 			)
 		}
 		if mismatch.IsExtraSubzone {
-			return validateZoneConfigForMultiRegionErrorHandler.newExtraSubzoneError(
+			return zoneConfigForMultiRegionValidator.newExtraSubzoneError(
 				descType,
 				name,
 			)
 		}
-		return validateZoneConfigForMultiRegionErrorHandler.newMismatchFieldError(
+		return zoneConfigForMultiRegionValidator.newMismatchFieldError(
 			descType,
 			name,
 			mismatch.Field,

--- a/pkg/sql/region_util_test.go
+++ b/pkg/sql/region_util_test.go
@@ -27,7 +27,7 @@ func TestZoneConfigForMultiRegionDatabase(t *testing.T) {
 	testCases := []struct {
 		desc         string
 		regionConfig multiregion.RegionConfig
-		expected     *zonepb.ZoneConfig
+		expected     zonepb.ZoneConfig
 	}{
 		{
 			desc: "one region, zone survival",
@@ -39,7 +39,7 @@ func TestZoneConfigForMultiRegionDatabase(t *testing.T) {
 				descpb.SurvivalGoal_ZONE_FAILURE,
 				descpb.InvalidID,
 			),
-			expected: &zonepb.ZoneConfig{
+			expected: zonepb.ZoneConfig{
 				NumReplicas: proto.Int32(3),
 				NumVoters:   proto.Int32(3),
 				LeasePreferences: []zonepb.LeasePreference{
@@ -77,7 +77,7 @@ func TestZoneConfigForMultiRegionDatabase(t *testing.T) {
 				descpb.SurvivalGoal_ZONE_FAILURE,
 				descpb.InvalidID,
 			),
-			expected: &zonepb.ZoneConfig{
+			expected: zonepb.ZoneConfig{
 				NumReplicas: proto.Int32(4),
 				NumVoters:   proto.Int32(3),
 				LeasePreferences: []zonepb.LeasePreference{
@@ -122,7 +122,7 @@ func TestZoneConfigForMultiRegionDatabase(t *testing.T) {
 				descpb.SurvivalGoal_ZONE_FAILURE,
 				descpb.InvalidID,
 			),
-			expected: &zonepb.ZoneConfig{
+			expected: zonepb.ZoneConfig{
 				NumReplicas: proto.Int32(5),
 				NumVoters:   proto.Int32(3),
 				LeasePreferences: []zonepb.LeasePreference{
@@ -173,7 +173,7 @@ func TestZoneConfigForMultiRegionDatabase(t *testing.T) {
 				descpb.SurvivalGoal_REGION_FAILURE,
 				descpb.InvalidID,
 			),
-			expected: &zonepb.ZoneConfig{
+			expected: zonepb.ZoneConfig{
 				NumReplicas: proto.Int32(5),
 				NumVoters:   proto.Int32(5),
 				LeasePreferences: []zonepb.LeasePreference{
@@ -225,7 +225,7 @@ func TestZoneConfigForMultiRegionDatabase(t *testing.T) {
 				descpb.SurvivalGoal_ZONE_FAILURE,
 				descpb.InvalidID,
 			),
-			expected: &zonepb.ZoneConfig{
+			expected: zonepb.ZoneConfig{
 				NumReplicas: proto.Int32(6),
 				NumVoters:   proto.Int32(3),
 				LeasePreferences: []zonepb.LeasePreference{
@@ -283,7 +283,7 @@ func TestZoneConfigForMultiRegionDatabase(t *testing.T) {
 				descpb.SurvivalGoal_REGION_FAILURE,
 				descpb.InvalidID,
 			),
-			expected: &zonepb.ZoneConfig{
+			expected: zonepb.ZoneConfig{
 				NumReplicas: proto.Int32(5),
 				NumVoters:   proto.Int32(5),
 				LeasePreferences: []zonepb.LeasePreference{

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -494,7 +494,7 @@ func repartitionRegionalByRowTables(
 	}
 
 	b := txn.NewBatch()
-	err = localPlanner.forEachTableInMultiRegionDatabase(ctx, dbDesc,
+	err = localPlanner.forEachMutableTableInDatabase(ctx, dbDesc,
 		func(ctx context.Context, tableDesc *tabledesc.Mutable) error {
 			if !tableDesc.IsLocalityRegionalByRow() || tableDesc.Dropped() {
 				// We only need to re-partition REGIONAL BY ROW tables. Even then, we


### PR DESCRIPTION
Refs: #63071

See individual commits for details.

Note I have not done overwriting. This is not going to be planned for 21.1 unless we deem it a GA-blocker.