### PR TITLE
uuid: fix parsing for different uuid formats

### DIFF
--- a/pkg/acceptance/testdata/java/src/main/java/MainTest.java
+++ b/pkg/acceptance/testdata/java/src/main/java/MainTest.java
@@ -287,7 +287,7 @@ public class MainTest extends CockroachDBTest {
         PreparedStatement stmt = conn.prepareStatement("SELECT * FROM x WHERE b = ?");
         stmt.setObject(1, "e81bb788-2291-4b6e-9cf3-b237fe6c2f3");
         exception.expectMessage("ERROR: could not parse \"e81bb788-2291-4b6e-9cf3-b237fe6c2f3\" as " +
-            "type uuid: uuid: incorrect UUID length: e81bb788-2291-4b6e-9cf3-b237fe6c2f3");
+            "type uuid: uuid: incorrect UUID format: e81bb788-2291-4b6e-9cf3-b237fe6c2f3");
         stmt.executeQuery();
     }
 

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1946,7 +1946,7 @@ cafef00ddeadbeef
 query error uuid: incorrect UUID length
 SELECT to_uuid('63616665-6630-3064-6465')
 
-query error uuid: incorrect UUID length
+query error uuid: incorrect UUID format
 SELECT to_uuid('63616665-6630-3064-6465-616462656566-123')
 
 query error uuid: incorrect UUID format

--- a/pkg/sql/logictest/testdata/logic_test/uuid
+++ b/pkg/sql/logictest/testdata/logic_test/uuid
@@ -40,10 +40,10 @@ INSERT INTO u VALUES (b'cafef00ddeadbee')
 statement error UUID must be exactly 16 bytes long, got 17 bytes
 INSERT INTO u VALUES (b'cafef00ddeadbeefs')
 
-statement error uuid: incorrect UUID length
+statement error uuid: incorrect UUID format
 INSERT INTO u VALUES ('63616665-6630-3064-6465-61646265656')
 
-statement error uuid: incorrect UUID length
+statement error uuid: incorrect UUID format
 INSERT INTO u VALUES ('63616665-6630-3064-6465-6164626565620')
 
 statement error unsupported comparison operator: <uuid> = <bytes>

--- a/pkg/util/uuid/codec_test.go
+++ b/pkg/util/uuid/codec_test.go
@@ -129,6 +129,18 @@ var fromStringTests = []fromStringTest{
 		input:   "urn:uuid:6ba7b8109dad11d180b400c04fd430c8",
 		variant: "URNHashlike",
 	},
+	{
+		input:   "{6ba7-b8109dad11d180b400c04fd4-30c8}",
+		variant: "BracedExtraHyphens",
+	},
+	{
+		input:   "6ba7-b810-9dad-11d1-80b4-00c0-4fd4-30c8",
+		variant: "ExtraHyphens",
+	},
+	{
+		input:   "urn:uuid:6ba7-b810-9dad-11d1-80b4-00c0-4fd4-30c8",
+		variant: "URNExtraHyphens",
+	},
 }
 
 var invalidFromStringInputs = []string{
@@ -159,10 +171,17 @@ var invalidFromStringInputs = []string{
 	"(6ba7b810-9dad-11d1-80b4-00c04fd430c8}",
 	"{6ba7b810-9dad-11d1-80b4-00c04fd430c8>",
 	"zba7b810-9dad-11d1-80b4-00c04fd430c8",
-	"6ba7b810-9dad11d180b400c04fd430c8",
-	"6ba7b8109dad-11d180b400c04fd430c8",
-	"6ba7b8109dad11d1-80b400c04fd430c8",
-	"6ba7b8109dad11d180b4-00c04fd430c8",
+	"6ba7b810-9dad11d180b400c04fd430-c8",
+	"6-ba7b810-9dad11d180b400c04fd430c8",
+	"6ba7b810-9dad11d180b400c04fd430c8-",
+	"-6ba7b810-9dad11d180b400c04fd430c8",
+	"uuid:urn:zba7b810-9dad-11d1-80b4-00c04fd430c8",
+	"{6ba7b810-9dad1-1d1-80b4-00c04fd430c8}",
+	"{-6ba7b810-9dad11d180b400c04fd430c8}",
+	"uuid:urn:6-ba7b810-9dad11d180b400c04fd430c8",
+	"6ba7-b810-9dad--11d1-80b4-00c0-4fd4-30c8",
+	"6ba7-b810-9dad-11d1-80b4-00c0-4fd4-30c8--",
+	"6ba7-b810--9dad-11d180b4-00c04fd4-30c8-",
 }
 
 func TestFromString(t *testing.T) {
@@ -219,13 +238,12 @@ func TestMarshalText(t *testing.T) {
 	}
 }
 
-func TestDecodePlainWithWrongLength(t *testing.T) {
+func TestDecodeHyphenatedWithWrongLength(t *testing.T) {
 	arg := []byte{'4', '2'}
-
 	u := UUID{}
 
-	if u.decodePlain(arg) == nil {
-		t.Errorf("%v.decodePlain(%q): should return error, but it did not", u, arg)
+	if u.decodeHyphenated(arg) == nil {
+		t.Errorf("%v.decodeHyphenated(%q): should return error, but it did not", u, arg)
 	}
 }
 
@@ -257,6 +275,11 @@ func BenchmarkFromString(b *testing.B) {
 	b.Run("braced", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			Must(FromString("{6ba7b810-9dad-11d1-80b4-00c04fd430c8}"))
+		}
+	})
+	b.Run("hyphenated", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			Must(FromString("6ba7-b810-9dad11d1-80b4-00c04fd430c8"))
 		}
 	})
 }

--- a/pkg/util/uuid/uuid.go
+++ b/pkg/util/uuid/uuid.go
@@ -79,10 +79,7 @@ func TimestampFromV1(u UUID) (Timestamp, error) {
 }
 
 // String parse helpers.
-var (
-	urnPrefix  = []byte("urn:uuid:")
-	byteGroups = []int{8, 4, 4, 4, 12}
-)
+var urnPrefix = []byte("urn:uuid:")
 
 // Nil is the nil UUID, as specified in RFC-4122, that has all 128 bits set to
 // zero.


### PR DESCRIPTION
Fixes: #60011 
More details about Postgres [UUID data type](https://www.postgresql.org/docs/9.6/datatype-uuid.html)

Release note (sql change): CockroachDB now accepts UUID inputs that
have a hyphen after any group of four digits. This aligns with the UUID
format used by Postgres. For example, `a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11`
is now considered a valid UUID.