### PR TITLE
release-21.1: sql: add pg_get_partkeydef builtin for compatibility

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -152,3 +152,9 @@ query B
 SELECT pg_type_is_visible(NULL)
 ----
 NULL
+
+
+query TT
+SELECT pg_get_partkeydef(1), pg_get_partkeydef(NULL)
+----
+NULL  NULL

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -679,6 +679,21 @@ var pgBuiltins = map[string]builtinDefinition{
 		makePGGetConstraintDef(tree.ArgTypes{{"constraint_oid", types.Oid}}),
 	),
 
+	// pg_get_partkeydef is only provided for compatibility and always returns
+	// NULL. It is supposed to return the PARTITION BY clause of a table's
+	// CREATE statement.
+	"pg_get_partkeydef": makeBuiltin(defProps(),
+		tree.Overload{
+			Types:      tree.ArgTypes{{"oid", types.Oid}},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				return tree.DNull, nil
+			},
+			Info:       notUsableInfo,
+			Volatility: tree.VolatilityStable,
+		},
+	),
+
 	// pg_get_function_result returns the types of the result of an builtin
 	// function. Multi-return builtins currently are returned as anyelement, which
 	// is a known incompatibility with Postgres.


### PR DESCRIPTION
Backport 1/1 commits from #63107.

/cc @cockroachdb/release

---

We can't implement this Postgres builtin, but we can return NULL for now so
that tools that rely on it don't get errors.

refer to #63068 

Release note (sql change): The pg_get_partkeydef builtin function is now
implemented by always returning NULL.
