### PR TITLE
opt: keep track of CTE-to-CTE references

### DIFF
--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -2460,6 +2460,9 @@ func deriveWithUses(r opt.Expr) props.WithUsesMap {
 	case *WithExpr:
 		excludedID = e.ID
 
+	case *RecursiveCTEExpr:
+		excludedID = e.WithID
+
 	default:
 		if opt.IsMutationOp(e) {
 			if p, ok := e.Private().(*MutationPrivate); ok {

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -91,8 +91,14 @@ type Builder struct {
 	catalog    cat.Catalog
 	scopeAlloc []scope
 
-	// ctes stores information about CTEs which are hoisted up.
-	ctes []cteSource
+	// ctes stores CTEs which may need to be built at the top-level.
+	ctes cteSources
+
+	// cteRefMap stores information about CTE-to-CTE references.
+	//
+	// For each WithID, the map stores a list of CTEs that refer to that WithID.
+	// Together, they form a directed acyclic graph.
+	cteRefMap map[opt.WithID]cteSources
 
 	// If set, the planner will skip checking for the SELECT privilege when
 	// resolving data sources (tables, views, etc). This is used when compiling

--- a/pkg/sql/opt/optbuilder/create_table.go
+++ b/pkg/sql/opt/optbuilder/create_table.go
@@ -62,9 +62,7 @@ func (b *Builder) buildCreateTable(ct *tree.CreateTable, inScope *scope) (outSco
 		}()
 
 		// Build the input query.
-		outScope = b.cteBoundary(func() *scope {
-			return b.buildStmt(ct.AsSource, nil /* desiredTypes */, inScope)
-		})
+		outScope = b.buildStmtAtRoot(ct.AsSource, nil /* desiredTypes */)
 
 		numColNames := 0
 		for i := 0; i < len(ct.Defs); i++ {

--- a/pkg/sql/opt/optbuilder/create_view.go
+++ b/pkg/sql/opt/optbuilder/create_view.go
@@ -39,9 +39,7 @@ func (b *Builder) buildCreateView(cv *tree.CreateView, inScope *scope) (outScope
 		b.qualifyDataSourceNamesInAST = false
 	}()
 
-	defScope := b.cteBoundary(func() *scope {
-		return b.buildStmtAtRoot(cv.AsSource, nil /* desiredTypes */, inScope)
-	})
+	defScope := b.buildStmtAtRoot(cv.AsSource, nil /* desiredTypes */)
 
 	p := defScope.makePhysicalProps().Presentation
 	if len(cv.ColumnNames) != 0 {

--- a/pkg/sql/opt/optbuilder/explain.go
+++ b/pkg/sql/opt/optbuilder/explain.go
@@ -20,12 +20,7 @@ import (
 )
 
 func (b *Builder) buildExplain(explain *tree.Explain, inScope *scope) (outScope *scope) {
-	stmtScope := b.cteBoundary(func() *scope {
-		// We don't allow the statement under Explain to reference outer columns, so we
-		// pass a "blank" scope rather than inScope.
-		emptyScope := b.allocScope()
-		return b.buildStmtAtRoot(explain.Statement, nil /* desiredTypes */, emptyScope)
-	})
+	stmtScope := b.buildStmtAtRoot(explain.Statement, nil /* desiredTypes */)
 
 	outScope = inScope.push()
 

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -168,7 +168,7 @@ func (b *Builder) buildDataSource(
 
 		id := b.factory.Memo().NextWithID()
 		b.factory.Metadata().AddWithBinding(id, innerScope.expr)
-		cte := cteSource{
+		cte := &cteSource{
 			name:         tree.AliasClause{},
 			cols:         innerScope.makePresentationWithHiddenCols(),
 			originalExpr: source.Statement,

--- a/pkg/sql/opt/optbuilder/sql_fn.go
+++ b/pkg/sql/opt/optbuilder/sql_fn.go
@@ -84,7 +84,7 @@ func (b *Builder) buildSQLFn(
 
 	id := b.factory.Memo().NextWithID()
 	b.factory.Metadata().AddWithBinding(id, innerScope.expr)
-	cte := cteSource{
+	cte := &cteSource{
 		name:         tree.AliasClause{},
 		cols:         innerScope.makePresentationWithHiddenCols(),
 		originalExpr: stmt.AST,

--- a/pkg/sql/opt/optbuilder/testdata/with
+++ b/pkg/sql/opt/optbuilder/testdata/with
@@ -1272,6 +1272,209 @@ with &3 (cte)
            ├──  a:3 => a:13
            └──  b:4 => b:14
 
+
+# Verify that we still hoist inner WITHs that don't refer to the recursive CTE.
+build
+WITH RECURSIVE cte(a, b) AS (
+    SELECT 1, 2
+  UNION ALL
+    (WITH foo AS (SELECT * FROM cte),
+          bar AS (SELECT 1 AS x, 2 AS y)
+    SELECT a+x, b+y FROM foo, bar)
+) SELECT * FROM cte;
+----
+with &3 (bar)
+ ├── columns: a:15 b:16
+ ├── project
+ │    ├── columns: x:7!null y:8!null
+ │    ├── values
+ │    │    └── ()
+ │    └── projections
+ │         ├── 1 [as=x:7]
+ │         └── 2 [as=y:8]
+ └── with &4 (cte)
+      ├── columns: a:15 b:16
+      ├── recursive-c-t-e
+      │    ├── columns: a:3 b:4
+      │    ├── working table binding: &1
+      │    ├── initial columns: "?column?":1 "?column?":2
+      │    ├── recursive columns: "?column?":13 "?column?":14
+      │    ├── fake-rel
+      │    │    └── columns: "?column?":1 "?column?":2
+      │    ├── project
+      │    │    ├── columns: "?column?":1!null "?column?":2!null
+      │    │    ├── values
+      │    │    │    └── ()
+      │    │    └── projections
+      │    │         ├── 1 [as="?column?":1]
+      │    │         └── 2 [as="?column?":2]
+      │    └── with &2 (foo)
+      │         ├── columns: "?column?":13 "?column?":14
+      │         ├── with-scan &1 (cte)
+      │         │    ├── columns: a:5 b:6
+      │         │    └── mapping:
+      │         │         ├──  a:3 => a:5
+      │         │         └──  b:4 => b:6
+      │         └── project
+      │              ├── columns: "?column?":13 "?column?":14
+      │              ├── inner-join (cross)
+      │              │    ├── columns: a:9 b:10 x:11!null y:12!null
+      │              │    ├── with-scan &2 (foo)
+      │              │    │    ├── columns: a:9 b:10
+      │              │    │    └── mapping:
+      │              │    │         ├──  a:5 => a:9
+      │              │    │         └──  b:6 => b:10
+      │              │    ├── with-scan &3 (bar)
+      │              │    │    ├── columns: x:11!null y:12!null
+      │              │    │    └── mapping:
+      │              │    │         ├──  x:7 => x:11
+      │              │    │         └──  y:8 => y:12
+      │              │    └── filters (true)
+      │              └── projections
+      │                   ├── a:9 + x:11 [as="?column?":13]
+      │                   └── b:10 + y:12 [as="?column?":14]
+      └── with-scan &4 (cte)
+           ├── columns: a:15 b:16
+           └── mapping:
+                ├──  a:3 => a:15
+                └──  b:4 => b:16
+
+# Verify that we don't hoist inner WITHs that indirecly refer to the recursive
+# CTE.
+build
+WITH RECURSIVE cte(a, b) AS (
+    SELECT 1, 2
+  UNION ALL
+    (WITH foo AS (SELECT * FROM cte),
+          bar AS (SELECT a+1 AS x, b+2 AS y FROM foo)
+    SELECT a+x, b+y FROM foo, bar)
+) SELECT * FROM cte;
+----
+with &4 (cte)
+ ├── columns: a:17 b:18
+ ├── recursive-c-t-e
+ │    ├── columns: a:3 b:4
+ │    ├── working table binding: &1
+ │    ├── initial columns: "?column?":1 "?column?":2
+ │    ├── recursive columns: "?column?":15 "?column?":16
+ │    ├── fake-rel
+ │    │    └── columns: "?column?":1 "?column?":2
+ │    ├── project
+ │    │    ├── columns: "?column?":1!null "?column?":2!null
+ │    │    ├── values
+ │    │    │    └── ()
+ │    │    └── projections
+ │    │         ├── 1 [as="?column?":1]
+ │    │         └── 2 [as="?column?":2]
+ │    └── with &2 (foo)
+ │         ├── columns: "?column?":15 "?column?":16
+ │         ├── with-scan &1 (cte)
+ │         │    ├── columns: a:5 b:6
+ │         │    └── mapping:
+ │         │         ├──  a:3 => a:5
+ │         │         └──  b:4 => b:6
+ │         └── with &3 (bar)
+ │              ├── columns: "?column?":15 "?column?":16
+ │              ├── project
+ │              │    ├── columns: x:9 y:10
+ │              │    ├── with-scan &2 (foo)
+ │              │    │    ├── columns: a:7 b:8
+ │              │    │    └── mapping:
+ │              │    │         ├──  a:5 => a:7
+ │              │    │         └──  b:6 => b:8
+ │              │    └── projections
+ │              │         ├── a:7 + 1 [as=x:9]
+ │              │         └── b:8 + 2 [as=y:10]
+ │              └── project
+ │                   ├── columns: "?column?":15 "?column?":16
+ │                   ├── inner-join (cross)
+ │                   │    ├── columns: a:11 b:12 x:13 y:14
+ │                   │    ├── with-scan &2 (foo)
+ │                   │    │    ├── columns: a:11 b:12
+ │                   │    │    └── mapping:
+ │                   │    │         ├──  a:5 => a:11
+ │                   │    │         └──  b:6 => b:12
+ │                   │    ├── with-scan &3 (bar)
+ │                   │    │    ├── columns: x:13 y:14
+ │                   │    │    └── mapping:
+ │                   │    │         ├──  x:9 => x:13
+ │                   │    │         └──  y:10 => y:14
+ │                   │    └── filters (true)
+ │                   └── projections
+ │                        ├── a:11 + x:13 [as="?column?":15]
+ │                        └── b:12 + y:14 [as="?column?":16]
+ └── with-scan &4 (cte)
+      ├── columns: a:17 b:18
+      └── mapping:
+           ├──  a:3 => a:17
+           └──  b:4 => b:18
+
+# Verify that [...] statements are hoisted to the top level.
+build
+WITH RECURSIVE cte(x, y) AS (
+    SELECT 1, 2
+  UNION ALL
+    SELECT a+x, b+y FROM cte, [INSERT INTO x VALUES (1,1),(2,2) RETURNING a, b] AS bar
+) SELECT * FROM cte;
+----
+with &2
+ ├── columns: x:18 y:19
+ ├── project
+ │    ├── columns: x.a:7!null x.b:8!null
+ │    └── insert x
+ │         ├── columns: x.a:7!null x.b:8!null rowid:9!null
+ │         ├── insert-mapping:
+ │         │    ├── column1:11 => x.a:7
+ │         │    ├── column2:12 => x.b:8
+ │         │    └── column13:13 => rowid:9
+ │         └── project
+ │              ├── columns: column13:13 column1:11!null column2:12!null
+ │              ├── values
+ │              │    ├── columns: column1:11!null column2:12!null
+ │              │    ├── (1, 1)
+ │              │    └── (2, 2)
+ │              └── projections
+ │                   └── unique_rowid() [as=column13:13]
+ └── with &3 (cte)
+      ├── columns: x:18 y:19
+      ├── recursive-c-t-e
+      │    ├── columns: x:3 y:4
+      │    ├── working table binding: &1
+      │    ├── initial columns: "?column?":1 "?column?":2
+      │    ├── recursive columns: "?column?":16 "?column?":17
+      │    ├── fake-rel
+      │    │    └── columns: "?column?":1 "?column?":2
+      │    ├── project
+      │    │    ├── columns: "?column?":1!null "?column?":2!null
+      │    │    ├── values
+      │    │    │    └── ()
+      │    │    └── projections
+      │    │         ├── 1 [as="?column?":1]
+      │    │         └── 2 [as="?column?":2]
+      │    └── project
+      │         ├── columns: "?column?":16 "?column?":17
+      │         ├── inner-join (cross)
+      │         │    ├── columns: x:5 y:6 a:14!null b:15!null
+      │         │    ├── with-scan &1 (cte)
+      │         │    │    ├── columns: x:5 y:6
+      │         │    │    └── mapping:
+      │         │    │         ├──  x:3 => x:5
+      │         │    │         └──  y:4 => y:6
+      │         │    ├── with-scan &2
+      │         │    │    ├── columns: a:14!null b:15!null
+      │         │    │    └── mapping:
+      │         │    │         ├──  x.a:7 => a:14
+      │         │    │         └──  x.b:8 => b:15
+      │         │    └── filters (true)
+      │         └── projections
+      │              ├── a:14 + x:5 [as="?column?":16]
+      │              └── b:15 + y:6 [as="?column?":17]
+      └── with-scan &3 (cte)
+           ├── columns: x:18 y:19
+           └── mapping:
+                ├──  x:3 => x:18
+                └──  y:4 => y:19
+
 # Veryify use of WITH inside the initial statement.
 build
 WITH RECURSIVE cte(a) AS (

--- a/pkg/sql/opt/optbuilder/with.go
+++ b/pkg/sql/opt/optbuilder/with.go
@@ -34,6 +34,19 @@ type cteSource struct {
 	// If set, this function is called when a CTE is referenced. It can throw an
 	// error.
 	onRef func()
+
+	// built is true if we have constructed a With operator for this CTE.
+	built bool
+}
+
+type cteSources []*cteSource
+
+// addCTERef adds a CTE-to-CTE reference to cteRefMap.
+func (b *Builder) addCTERef(referencedID opt.WithID, referencedBy *cteSource) {
+	if b.cteRefMap == nil {
+		b.cteRefMap = make(map[opt.WithID]cteSources)
+	}
+	b.cteRefMap[referencedID] = append(b.cteRefMap[referencedID], referencedBy)
 }
 
 // cteBoundary is used to build statements which impose a CTE boundary, like
@@ -49,15 +62,41 @@ func (b *Builder) cteBoundary(buildFn func() *scope) *scope {
 	return scope
 }
 
-func (b *Builder) addCTE(cte cteSource) {
+// addCTE adds a CTE to the list and adds its references to cteRefMap. If CTE
+// does not reference any other CTEs, it will be built at the top level (or more
+// generally, at the current CTE boundary). If it does, it will be built as a
+// pre-requisite to building the referenced CTEs.
+func (b *Builder) addCTE(cte *cteSource) {
+	withUses := memo.WithUses(cte.expr)
+	for refWithID := range withUses {
+		b.addCTERef(refWithID, cte)
+	}
+	// Note: if the CTE references other CTEs, we don't need to add it to the list
+	// (it will get built anyway). But that is fragile because withIDs are used
+	// for other purposes; in addition, adding it to the list helps ensure that we
+	// build the CTEs in the order in which they appear in the query, whenever
+	// possible.
 	b.ctes = append(b.ctes, cte)
 }
 
-// buildWiths adds With expressions on top of an expression.
-func (b *Builder) buildWiths(expr memo.RelExpr, ctes []cteSource) memo.RelExpr {
-	// Since later CTEs can refer to earlier ones, we want to add these in
-	// reverse order.
+// buildWiths adds With operators on top of an expression. Operators are built
+// for all given CTEs as well as any CTEs which refer to them (directly or
+// indirectly).
+func (b *Builder) buildWiths(expr memo.RelExpr, ctes cteSources) memo.RelExpr {
+	// Any order here would be correct, but we prefer to match the order in the
+	// query as much as possible. We are building the operators from the bottom
+	// up, so we start with the last CTE.
 	for i := len(ctes) - 1; i >= 0; i-- {
+		cte := ctes[i]
+		if cte.built {
+			continue
+		}
+		cte.built = true
+
+		// First, build all the CTEs that directly or indirectly reference this CTE.
+		// This is a depth-first search achieving a reverse topological sort.
+		expr = b.buildWiths(expr, b.cteRefMap[cte.id])
+
 		expr = b.factory.ConstructWith(
 			ctes[i].expr,
 			expr,
@@ -108,6 +147,15 @@ func (b *Builder) buildCTEs(with *tree.With, inScope *scope) (outScope *scope) {
 		hasRecursive = hasRecursive || with.Recursive
 		cteExpr, cteCols := b.buildCTE(cte, outScope, with.Recursive)
 
+		if cteExpr.Relational().CanMutate && !inScope.atRoot {
+			panic(
+				pgerror.Newf(
+					pgcode.FeatureNotSupported,
+					"WITH clause containing a data-modifying statement must be at the top level",
+				),
+			)
+		}
+
 		// TODO(justin): lift this restriction when possible. WITH should be hoistable.
 		if b.subquery != nil && !b.subquery.outerCols.Empty() {
 			panic(pgerror.Newf(pgcode.FeatureNotSupported, "CTEs may not be correlated"))
@@ -133,17 +181,7 @@ func (b *Builder) buildCTEs(with *tree.With, inScope *scope) (outScope *scope) {
 		}
 		cte := &addedCTEs[i]
 		outScope.ctes[cte.name.Alias.String()] = cte
-		b.addCTE(*cte)
-
-		if cteExpr.Relational().CanMutate && !inScope.atRoot {
-			panic(
-				pgerror.Newf(
-					pgcode.FeatureNotSupported,
-					"WITH clause containing a data-modifying statement must be at the top level",
-				),
-			)
-		}
-
+		b.addCTE(cte)
 	}
 
 	telemetry.Inc(sqltelemetry.CteUseCounter)
@@ -282,15 +320,7 @@ func (b *Builder) buildCTE(
 		numRefs++
 	}
 
-	// If the recursive statement contains CTEs, we don't want the Withs hoisted
-	// above the recursive CTE.
-	// TODO(radu): introducing a boundary here is a hack, and won't work well if
-	// the CTE contains [..] operators or SQLClass functions.
-
-	recursiveScope := b.cteBoundary(func() *scope {
-		return b.buildStmt(recursive, initialTypes /* desiredTypes */, cteScope)
-	})
-
+	recursiveScope := b.buildStmt(recursive, initialTypes /* desiredTypes */, cteScope)
 	if numRefs == 0 {
 		// Build this as a non-recursive CTE.
 		cteScope := b.buildSetOp(tree.UnionOp, false /* all */, inScope, initialScope, recursiveScope)
@@ -305,6 +335,11 @@ func (b *Builder) buildCTE(
 			cte.Name.Alias,
 		))
 	}
+
+	// Build the With operators for any CTEs that refer to this CTE recursively.
+	// They would become invalid if we let them get hoisted above the
+	// RecursiveCTE operator.
+	recursiveScope.expr = b.buildWiths(recursiveScope.expr, b.cteRefMap[cteSrc.id])
 
 	recursiveScope.removeHiddenCols()
 	b.dropOrderingAndExtraCols(recursiveScope)


### PR DESCRIPTION
#### opt: keep track of CTE-to-CTE references

This change adds a data structure that keeps track of CTE-to-CTE
references and reworks the way in which we build CTEs. We use a
depth-first search to make sure With operators are built in a legal
order. This will allow building correlated CTEs where they show up,
while still allowing other CTEs to be hoisted up (as long as they
don't reference the correlated CTE).

We have avoided keeping track of references thus far by always
building the CTEs in the same order as in the query. Even without
correlated CTEs, this was still problematic for recursive CTEs - any
new CTEs inside the recursive expression could have a recursive
reference; for that reason, we use a CTE boundary to force building
all CTEs inside the recursive expression - but this is not the
intended use of a boundary and it is not correct for the `[...]`
operator and SQLClass functions (which must be hoisted to the
top-level). This commit fixes this issue.

Note that a very different high level solution would have been to use
normalization rules to hoist With operators. That solution seems a lot
more complicated though (and a similar reference map would have had to
be built there anyway). We may revisit this later if it turns out that
we have to add a lot of normalization rules to hoist correlated CTEs
anyway.

Release note: None

#### opt: further cleanup of CTE boundary

This commit consolidates the CTE boundary logic into `buildStmtAtRoot`.

Release note: None

Informs #42540.