### PR TITLE
README.md: fix indentation for Deployment section

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ CockroachDB supports the PostgreSQL wire protocol, so you can use any available 
 
 ## Deployment
 
-    - [CockroachCloud](https://www.cockroachlabs.com/docs/cockroachcloud/quickstart) - Steps to deploy a [free CockroachCloud cluster](https://cockroachlabs.cloud/signup?referralId=githubquickstart) on public Cloud platforms.
-    - [Manual](https://www.cockroachlabs.com/docs/stable/manual-deployment.html) - Steps to deploy a CockroachDB cluster manually on multiple machines.
-    - [Cloud](https://www.cockroachlabs.com/docs/stable/cloud-deployment.html) - Guides for deploying CockroachDB on various cloud platforms.
-    - [Orchestration](https://www.cockroachlabs.com/docs/stable/orchestration.html) - Guides for running CockroachDB with popular open-source orchestration systems.
+- [CockroachCloud](https://www.cockroachlabs.com/docs/cockroachcloud/quickstart) - Steps to deploy a [free CockroachCloud cluster](https://cockroachlabs.cloud/signup?referralId=githubquickstart) on public Cloud platforms.
+- [Manual](https://www.cockroachlabs.com/docs/stable/manual-deployment.html) - Steps to deploy a CockroachDB cluster manually on multiple machines.
+- [Cloud](https://www.cockroachlabs.com/docs/stable/cloud-deployment.html) - Guides for deploying CockroachDB on various cloud platforms.
+- [Orchestration](https://www.cockroachlabs.com/docs/stable/orchestration.html) - Guides for running CockroachDB with popular open-source orchestration systems.
 
 ## Need Help?
 


### PR DESCRIPTION
It was formatted as preformatted as opposed to the list it was trying to be.

Release note: None