### PR TITLE
sql: copy VIRTUAL columns in CREATE TABLE LIKE

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -2520,6 +2520,7 @@ func replaceLikeTableOpts(n *tree.CreateTable, params runParams) (tree.TableDefs
 			if c.ComputeExpr != nil {
 				if opts.Has(tree.LikeTableOptGenerated) {
 					def.Computed.Computed = true
+					def.Computed.Virtual = c.Virtual
 					def.Computed.Expr, err = parser.ParseExpr(*c.ComputeExpr)
 					if err != nil {
 						return nil, err

--- a/pkg/sql/logictest/testdata/logic_test/virtual_columns
+++ b/pkg/sql/logictest/testdata/logic_test/virtual_columns
@@ -1092,3 +1092,20 @@ COMMIT;
 
 statement ok
 DROP TABLE t_ref;
+
+# Regression test for #63167. CREATE TABLE LIKE should copy VIRTUAL columns as
+# VIRTUAL, not STORED.
+statement ok
+CREATE TABLE t63167_a (a INT, v INT AS (a + 1) VIRTUAL);
+CREATE TABLE t63167_b (LIKE t63167_a INCLUDING ALL);
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t63167_b]
+----
+CREATE TABLE public.t63167_b (
+   a INT8 NULL,
+   v INT8 NULL AS (a + 1:::INT8) VIRTUAL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
+   FAMILY "primary" (a, rowid)
+)


### PR DESCRIPTION
This commit fixes a bug where a `VIRTUAL` column in a source table would
be copied as a `STORED` column in the destination table in a
`CREATE TABLE LIKE` expression.

Fixes #63167

Release note (bug fix): Previously, CREATE TABLE LIKE would copy a
VIRTUAL column from the source table as a STORED colum in the
destination table. This bug, which is only present in pre-release 21.1
versions, has been fixed.