### PR TITLE
release-20.2: sql: drain instead of hard shutdown in DistSQLReceiver.Push

### DIFF
--- a/pkg/ccl/backupccl/backup_processor_planning.go
+++ b/pkg/ccl/backupccl/backup_processor_planning.go
@@ -113,6 +113,7 @@ func distBackup(
 		noTxn, /* txn - the flow does not read or write the database */
 		func(ts hlc.Timestamp) {},
 		evalCtx.Tracing,
+		nil, /* testingPushCallback */
 	)
 	defer recv.Release()
 

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -218,6 +218,7 @@ func distRestore(
 		noTxn, /* txn - the flow does not read or write the database */
 		func(ts hlc.Timestamp) {},
 		evalCtx.Tracing,
+		nil, /* testingPushCallback */
 	)
 	defer recv.Release()
 

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -178,6 +178,7 @@ func distChangefeedFlow(
 		noTxn,
 		func(ts hlc.Timestamp) {},
 		evalCtx.Tracing,
+		nil, /* testingPushCallback */
 	)
 	defer recv.Release()
 

--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -240,6 +240,7 @@ func runPlanInsidePlan(
 			params.extendedEvalCtx.ExecCfg.Clock.Update(ts)
 		},
 		params.p.extendedEvalCtx.Tracing,
+		nil, /* testingPushCallback */
 	)
 	defer recv.Release()
 

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1014,6 +1014,7 @@ func (sc *SchemaChanger) distBackfill(
 					sc.clock.Update(ts)
 				},
 				evalCtx.Tracing,
+				nil, /* testingPushCallback */
 			)
 			defer recv.Release()
 

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -272,8 +272,15 @@ func TestDistSQLReceiverUpdatesCaches(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	rangeCache := kvcoord.NewRangeDescriptorCache(st, nil /* db */, size, stop.NewStopper())
 	r := MakeDistSQLReceiver(
-		ctx, nil /* resultWriter */, tree.Rows,
-		rangeCache, nil /* txn */, nil /* updateClock */, &SessionTracing{})
+		ctx,
+		&errOnlyResultWriter{}, /* resultWriter */
+		tree.Rows,
+		rangeCache,
+		nil, /* txn */
+		nil, /* clockUpdater */
+		&SessionTracing{},
+		nil, /* testingPushCallback */
+	)
 
 	replicas := []roachpb.ReplicaDescriptor{{ReplicaID: 1}, {ReplicaID: 2}, {ReplicaID: 3}}
 

--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -294,6 +294,7 @@ func DistIngest(
 		nil, /* txn - the flow does not read or write the database */
 		func(ts hlc.Timestamp) {},
 		evalCtx.Tracing,
+		nil, /* testingPushCallback */
 	)
 	defer recv.Release()
 

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -282,6 +282,7 @@ func (dsp *DistSQLPlanner) planAndRunCreateStats(
 			evalCtx.ExecCfg.Clock.Update(ts)
 		},
 		evalCtx.Tracing,
+		nil, /* testingPushCallback */
 	)
 	defer recv.Release()
 

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -13,6 +13,7 @@ package sql
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -21,15 +22,22 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/pgtest"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
 )
 
 // Test that we don't attempt to create flows in an aborted transaction.
@@ -144,6 +152,7 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 				execCfg.Clock.Update(ts)
 			},
 			p.ExtendedEvalContext().Tracing,
+			nil, /* testingPushCallback */
 		)
 
 		// We need to re-plan every time, since close() below makes
@@ -204,6 +213,7 @@ func TestDistSQLReceiverErrorRanking(t *testing.T) {
 		txn,
 		func(hlc.Timestamp) {}, /* updateClock */
 		&SessionTracing{},
+		nil, /* testingPushCallback */
 	)
 
 	retryErr := roachpb.NewErrorWithTxn(
@@ -257,4 +267,115 @@ func TestDistSQLReceiverErrorRanking(t *testing.T) {
 			t.Fatalf("%d: expected %s, got %s", i, tc.expErr, rw.Err())
 		}
 	}
+}
+
+// TestDistSQLReceiverDrainsOnError is a simple unit test that asserts that the
+// DistSQLReceiver transitions to execinfra.DrainRequested status if an error is
+// pushed into it.
+func TestDistSQLReceiverDrainsOnError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	recv := MakeDistSQLReceiver(
+		context.Background(),
+		&errOnlyResultWriter{},
+		tree.Rows,
+		nil, /* rangeCache */
+		nil, /* txn */
+		nil, /* clockUpdater */
+		&SessionTracing{},
+		nil, /* testingPushCallback */
+	)
+	status := recv.Push(nil /* row */, &execinfrapb.ProducerMetadata{Err: errors.New("some error")})
+	require.Equal(t, execinfra.DrainRequested, status)
+}
+
+// TestDistSQLReceiverDrainsMeta verifies that the DistSQLReceiver drains the
+// execution flow in order to retrieve the required metadata. In particular, it
+// sets up a 3 node cluster which is then accessed via PGWire protocol in order
+// to take advantage of the LIMIT feature of portals (pausing the execution once
+// the desired number of rows have been returned to the client). The crux of the
+// test is, once the portal is closed and the execution flow is shutdown, making
+// sure that the receiver collects LeafTxnFinalState metadata from each of the
+// nodes which is required for correctness.
+func TestDistSQLReceiverDrainsMeta(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	var accumulatedMeta []execinfrapb.ProducerMetadata
+	// Set up a 3 node cluster and inject a callback to accumulate all metadata
+	// for the test query.
+	const numNodes = 3
+	const testQuery = "SELECT * FROM foo"
+	ctx := context.Background()
+	tc := serverutils.StartNewTestCluster(t, numNodes, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+		ServerArgs: base.TestServerArgs{
+			UseDatabase: "test",
+			Knobs: base.TestingKnobs{
+				SQLExecutor: &ExecutorTestingKnobs{
+					DistSQLReceiverPushCallbackFactory: func(query string) func(rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {
+						if query != testQuery {
+							return nil
+						}
+						return func(row rowenc.EncDatumRow, meta *execinfrapb.ProducerMetadata) {
+							if meta != nil {
+								accumulatedMeta = append(accumulatedMeta, *meta)
+							}
+						}
+					},
+				},
+			},
+			Insecure: true,
+		}})
+	defer tc.Stopper().Stop(ctx)
+
+	// Create a table with 30 rows, split them into 3 ranges with each node
+	// having one.
+	db := tc.ServerConn(0 /* idx */)
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlutils.CreateTable(
+		t, db, "foo",
+		"k INT PRIMARY KEY, v INT",
+		30,
+		sqlutils.ToRowFn(sqlutils.RowIdxFn, sqlutils.RowModuloFn(2)),
+	)
+	sqlDB.Exec(t, "ALTER TABLE test.foo SPLIT AT VALUES (10), (20)")
+	sqlDB.Exec(
+		t,
+		fmt.Sprintf("ALTER TABLE test.foo EXPERIMENTAL_RELOCATE VALUES (ARRAY[%d], 0), (ARRAY[%d], 10), (ARRAY[%d], 20)",
+			tc.Server(0).GetFirstStoreID(),
+			tc.Server(1).GetFirstStoreID(),
+			tc.Server(2).GetFirstStoreID(),
+		),
+	)
+
+	// Connect to the cluster via the PGWire client.
+	p, err := pgtest.NewPGTest(ctx, tc.Server(0).ServingSQLAddr(), security.RootUser)
+	require.NoError(t, err)
+
+	// Execute the test query asking for at most 25 rows.
+	require.NoError(t, p.SendOneLine(`Query {"String": "USE test"}`))
+	require.NoError(t, p.SendOneLine(fmt.Sprintf(`Parse {"Query": "%s"}`, testQuery)))
+	require.NoError(t, p.SendOneLine(`Bind`))
+	require.NoError(t, p.SendOneLine(`Execute {"MaxRows": 25}`))
+	require.NoError(t, p.SendOneLine(`Sync`))
+
+	// Retrieve all of the results. We need to receive until two 'ReadyForQuery'
+	// messages are returned (the first one for "USE test" query and the second
+	// one is for the limited portal execution).
+	until := pgtest.ParseMessages("ReadyForQuery\nReadyForQuery")
+	msgs, err := p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+	received := pgtest.MsgsToJSONWithIgnore(msgs, &datadriven.TestData{})
+
+	// Confirm that we did retrieve 25 rows as well as 3 metadata objects.
+	require.Equal(t, 25, strings.Count(received, `"Type":"DataRow"`))
+	numLeafTxnFinalMeta := 0
+	for _, meta := range accumulatedMeta {
+		if meta.LeafTxnFinalState != nil {
+			numLeafTxnFinalMeta++
+		}
+	}
+	require.Equal(t, numNodes, numLeafTxnFinalMeta)
 }

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -49,6 +49,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/gcjob/gcjobnotifier"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
@@ -58,6 +59,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/querycache"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
@@ -863,6 +865,12 @@ type ExecutorTestingKnobs struct {
 	// RunAfterSCJobsCacheLookup is called after the SchemaChangeJobCache is checked for
 	// a given table id.
 	RunAfterSCJobsCacheLookup func(*jobs.Job)
+
+	// DistSQLReceiverPushCallbackFactory, if set, will be called every time a
+	// DistSQLReceiver is created for a new query execution, and it should
+	// return, possibly nil, a callback that will be called every time
+	// DistSQLReceiver.Push is called.
+	DistSQLReceiverPushCallbackFactory func(query string) func(rowenc.EncDatumRow, *execinfrapb.ProducerMetadata)
 }
 
 // PGWireTestingKnobs contains knobs for the pgwire module.

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -132,6 +132,7 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 				execCfg.Clock.Update(ts)
 			},
 			params.extendedEvalCtx.Tracing,
+			nil, /* testingPushCallback */
 		)
 		if !distSQLPlanner.PlanAndRunSubqueries(
 			planCtx.ctx,
@@ -204,6 +205,7 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 				execCfg.Clock.Update(ts)
 			},
 			newParams.extendedEvalCtx.Tracing,
+			nil, /* testingPushCallback */
 		)
 		defer recv.Release()
 
@@ -256,6 +258,7 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 				execCfg.Clock.Update(ts)
 			},
 			params.extendedEvalCtx.Tracing,
+			nil, /* testingPushCallback */
 		)
 		if !distSQLPlanner.PlanAndRunCascadesAndChecks(
 			planCtx.ctx,

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -285,6 +285,7 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 			// because it sets "enabled: false" and thus none of the
 			// other fields are used.
 			&SessionTracing{},
+			nil, /* testingPushCallback */
 		)
 		defer recv.Release()
 

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -483,6 +483,7 @@ func scrubRunDistSQL(
 			p.ExecCfg().Clock.Update(ts)
 		},
 		p.extendedEvalCtx.Tracing,
+		nil, /* testingPushCallback */
 	)
 	defer recv.Release()
 

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -131,6 +131,7 @@ func (dsp *DistSQLPlanner) Exec(
 			execCfg.Clock.Update(ts)
 		},
 		p.ExtendedEvalContext().Tracing,
+		nil, /* testingPushCallback */
 	)
 	defer recv.Release()
 

--- a/pkg/testutils/pgtest/pgtest.go
+++ b/pkg/testutils/pgtest/pgtest.go
@@ -14,9 +14,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/gob"
+	"encoding/json"
 	"fmt"
 	"net"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/errors"
@@ -80,7 +82,30 @@ func (p *PGTest) Close() error {
 	return p.fe.Send(&pgproto3.Terminate{})
 }
 
-// Send sends msg to the serrver.
+// SendOneLine sends a single msg to the server represented as a single string
+// in the format `<msg type> <msg body in JSON>`. See testdata for examples.
+func (p *PGTest) SendOneLine(line string) error {
+	sp := strings.SplitN(line, " ", 2)
+	msg := toMessage(sp[0])
+	if len(sp) == 2 {
+		msgBytes := []byte(sp[1])
+		switch msg := msg.(type) {
+		case *pgproto3.CopyData:
+			var data struct{ Data string }
+			if err := json.Unmarshal(msgBytes, &data); err != nil {
+				return err
+			}
+			msg.Data = []byte(data.Data)
+		default:
+			if err := json.Unmarshal(msgBytes, msg); err != nil {
+				return err
+			}
+		}
+	}
+	return p.Send(msg.(pgproto3.FrontendMessage))
+}
+
+// Send sends msg to the server.
 func (p *PGTest) Send(msg pgproto3.FrontendMessage) error {
 	if testing.Verbose() {
 		fmt.Printf("SEND %T: %+[1]v\n", msg)


### PR DESCRIPTION
Backport 1/2 commits from #63032.

/cc @cockroachdb/release

---

**sql: drain instead of hard shutdown in DistSQLReceiver.Push**

Previously, when the DistSQLReceiver encountered an error or received
enough rows to satisfy its consumer, it would transition to
`ConsumerClosed` status. I believe this is an incorrect behavior, and in
almost all cases we actually must transition to draining (we already had
several TODOs to do that), the only exception is if we're canceled
(indicated by an error on the context).

My reasoning is that there are certain types of metadata (like
LeafTxnFinalState) that must be received by the gateway to achieve the
correctness, yet that metadata is only collected in the draining state,
so if we go from `NeedMoreRows` to `ConsumerClosed`, we don't get
a chance to collect that meta.

As a concrete example, consider the way we implemented portals with
limits - some SELECT query reads some rows, once the portal limit is
satisfied, an error is returned from `AddRow`, this will currently cause
us to perform a hard shutdown of the flow, and we end up not collecting
spans to refresh. I believe it is a no bueno, and it is confirmed by
a unit test (that we don't drain the required metadata).

This commit fixes this problem by transitioning to draining in all cases
except when the context has an error.

Release note: None
