### PR TITLE
sql: reduce roundtrips for grant/revoke

### DIFF
--- a/pkg/bench/ddl_analysis/testdata/benchmark_expectations
+++ b/pkg/bench/ddl_analysis/testdata/benchmark_expectations
@@ -47,9 +47,9 @@ exp,benchmark
 25,DropView/drop_1_view
 44,DropView/drop_2_views
 63,DropView/drop_3_views
-22,Grant/grant_all_on_1_table
-29,Grant/grant_all_on_2_tables
-36,Grant/grant_all_on_3_tables
+21,Grant/grant_all_on_1_table
+27,Grant/grant_all_on_2_tables
+33,Grant/grant_all_on_3_tables
 19,GrantRole/grant_1_role
 22,GrantRole/grant_2_roles
 2,ORMQueries/activerecord_type_introspection_query
@@ -60,9 +60,9 @@ exp,benchmark
 2,ORMQueries/pg_class
 2,ORMQueries/pg_namespace
 2,ORMQueries/pg_type
-22,Revoke/revoke_all_on_1_table
-29,Revoke/revoke_all_on_2_tables
-36,Revoke/revoke_all_on_3_tables
+21,Revoke/revoke_all_on_1_table
+27,Revoke/revoke_all_on_2_tables
+33,Revoke/revoke_all_on_3_tables
 18,RevokeRole/revoke_1_role
 20,RevokeRole/revoke_2_roles
 1,SystemDatabaseQueries/select_system.users_with_empty_database_name

--- a/pkg/sql/catalog/accessor.go
+++ b/pkg/sql/catalog/accessor.go
@@ -37,7 +37,7 @@ type Accessor interface {
 	// exists under the target database.
 	GetSchema(ctx context.Context, txn *kv.Txn, codec keys.SQLCodec, dbID descpb.ID, scName string, flags tree.SchemaLookupFlags) (bool, ResolvedSchema, error)
 
-	// GetObjectNames returns the list of all objects in the given
+	// GetObjectNamesAndIDs returns the list of all objects in the given
 	// database and schema.
 	// TODO(solon): when separate schemas are supported, this
 	// API should be extended to use schema descriptors.
@@ -46,9 +46,9 @@ type Accessor interface {
 	// are fundamentally sometimes ambiguous (see GRANT and the ambiguity between
 	// tables and types). Furthermore, the fact that this buffers everything
 	// in ram in unfortunate.
-	GetObjectNames(ctx context.Context, txn *kv.Txn, codec keys.SQLCodec,
+	GetObjectNamesAndIDs(ctx context.Context, txn *kv.Txn, codec keys.SQLCodec,
 		db DatabaseDescriptor, scName string, flags tree.DatabaseListFlags,
-	) (tree.TableNames, error)
+	) (tree.TableNames, descpb.IDs, error)
 
 	// GetObjectDesc looks up an object by name and returns both its
 	// descriptor and that of its parent database. If the object is not

--- a/pkg/sql/catalog/catalogkv/catalogkv.go
+++ b/pkg/sql/catalog/catalogkv/catalogkv.go
@@ -315,7 +315,7 @@ func GetAllDatabaseDescriptorIDs(
 		return nil, err
 	}
 	// See the comment in physical_schema_accessors.go,
-	// func (a UncachedPhysicalAccessor) GetObjectNames. Same concept
+	// func (a UncachedPhysicalAccessor) GetObjectNamesAndIDs. Same concept
 	// applies here.
 	// TODO(solon): This complexity can be removed in 20.2.
 	nameKey = catalogkeys.NewDeprecatedDatabaseKey("" /* name */).Key(codec)

--- a/pkg/sql/catalog/resolver/resolver.go
+++ b/pkg/sql/catalog/resolver/resolver.go
@@ -58,10 +58,10 @@ type SchemaResolver interface {
 var ErrNoPrimaryKey = pgerror.Newf(pgcode.NoPrimaryKey,
 	"requested table does not have a primary key")
 
-// GetObjectNames retrieves the names of all objects in the target database/
-// schema. If explicitPrefix is set, the returned table names will have an
-// explicit schema and catalog name.
-func GetObjectNames(
+// GetObjectNamesAndIDs retrieves the names and IDs of all objects in the
+// target database/schema. If explicitPrefix is set, the returned
+// table names will have an explicit schema and catalog name.
+func GetObjectNamesAndIDs(
 	ctx context.Context,
 	txn *kv.Txn,
 	sc SchemaResolver,
@@ -69,8 +69,8 @@ func GetObjectNames(
 	dbDesc catalog.DatabaseDescriptor,
 	scName string,
 	explicitPrefix bool,
-) (res tree.TableNames, err error) {
-	return sc.LogicalSchemaAccessor().GetObjectNames(ctx, txn, codec, dbDesc, scName,
+) (tree.TableNames, descpb.IDs, error) {
+	return sc.LogicalSchemaAccessor().GetObjectNamesAndIDs(ctx, txn, codec, dbDesc, scName,
 		tree.DatabaseListFlags{
 			CommonLookupFlags: sc.CommonLookupFlags(true /* required */),
 			ExplicitPrefix:    explicitPrefix,

--- a/pkg/sql/delegate/show_grants.go
+++ b/pkg/sql/delegate/show_grants.go
@@ -170,7 +170,7 @@ FROM "".information_schema.type_privileges`
 				}
 				// We avoid the cache so that we can observe the grants taking
 				// a lease, like other SHOW commands.
-				tables, err := cat.ExpandDataSourceGlob(
+				tables, _, err := cat.ExpandDataSourceGlob(
 					d.ctx, d.catalog, cat.Flags{AvoidDescriptorCaches: true}, tableGlob,
 				)
 				if err != nil {

--- a/pkg/sql/drop_cascade.go
+++ b/pkg/sql/drop_cascade.go
@@ -57,7 +57,7 @@ func newDropCascadeState() *dropCascadeState {
 func (d *dropCascadeState) collectObjectsInSchema(
 	ctx context.Context, p *planner, db *dbdesc.Mutable, schema *catalog.ResolvedSchema,
 ) error {
-	names, err := resolver.GetObjectNames(ctx, p.txn, p, p.ExecCfg().Codec, db, schema.Name, true /* explicitPrefix */)
+	names, _, err := resolver.GetObjectNamesAndIDs(ctx, p.txn, p, p.ExecCfg().Codec, db, schema.Name, true /* explicitPrefix */)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/opt/cat/BUILD.bazel
+++ b/pkg/sql/opt/cat/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
     srcs = ["utils_test.go"],
     deps = [
         ":cat",
+        "//pkg/sql/catalog/descpb",
         "//pkg/sql/opt/testutils/testcat",
         "//pkg/sql/sem/tree",
     ],

--- a/pkg/sql/opt/cat/schema.go
+++ b/pkg/sql/opt/cat/schema.go
@@ -10,7 +10,11 @@
 
 package cat
 
-import "context"
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+)
 
 // Schema is an interface to a database schema, which is a namespace that
 // contains other database objects, like tables and views. Examples of schema
@@ -24,7 +28,7 @@ type Schema interface {
 	// name are always specified.
 	Name() *SchemaName
 
-	// GetDataSourceNames returns the list of names for the data sources that the
-	// schema contains.
-	GetDataSourceNames(ctx context.Context) ([]DataSourceName, error)
+	// GetDataSourceNames returns the list of names and IDs for the data sources
+	// that the schema contains.
+	GetDataSourceNames(ctx context.Context) ([]DataSourceName, descpb.IDs, error)
 }

--- a/pkg/sql/opt/cat/utils_test.go
+++ b/pkg/sql/opt/cat/utils_test.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -34,49 +35,65 @@ func TestExpandDataSourceGlob(t *testing.T) {
 	exec("CREATE TABLE c (x INT)")
 
 	testCases := []struct {
-		pattern  tree.TablePattern
-		expected string
+		pattern       tree.TablePattern
+		expectedNames string
+		expectedIDs   string
+		expectedError string
 	}{
 		{
-			pattern:  tree.NewTableNameWithSchema("t", tree.PublicSchemaName, "a"),
-			expected: `[t.public.a]`,
+			pattern:       tree.NewTableNameWithSchema("t", tree.PublicSchemaName, "a"),
+			expectedNames: `[t.public.a]`,
+			expectedIDs:   `[53]`,
 		},
 		{
-			pattern:  tree.NewTableNameWithSchema("t", tree.PublicSchemaName, "z"),
-			expected: `error: no data source matches prefix: "t.public.z"`,
+			pattern:       tree.NewTableNameWithSchema("t", tree.PublicSchemaName, "z"),
+			expectedError: `error: no data source matches prefix: "t.public.z"`,
 		},
 		{
-			pattern:  &tree.AllTablesSelector{ObjectNamePrefix: tree.ObjectNamePrefix{}},
-			expected: `[t.public.a t.public.b t.public.c]`,
+			pattern:       &tree.AllTablesSelector{ObjectNamePrefix: tree.ObjectNamePrefix{}},
+			expectedNames: `[t.public.a t.public.b t.public.c]`,
+			expectedIDs:   `[53 54 55]`,
 		},
 		{
 			pattern: &tree.AllTablesSelector{ObjectNamePrefix: tree.ObjectNamePrefix{
 				SchemaName: "t", ExplicitSchema: true,
 			}},
-			expected: `[t.public.a t.public.b t.public.c]`,
+			expectedNames: `[t.public.a t.public.b t.public.c]`,
+			expectedIDs:   `[53 54 55]`,
 		},
 		{
 			pattern: &tree.AllTablesSelector{ObjectNamePrefix: tree.ObjectNamePrefix{
 				SchemaName: "z", ExplicitSchema: true,
 			}},
-			expected: `error: target database or schema does not exist`,
+			expectedError: `error: target database or schema does not exist`,
 		},
 	}
 
 	for _, tc := range testCases {
-		var res string
-		names, err := cat.ExpandDataSourceGlob(ctx, testcat, cat.Flags{}, tc.pattern)
+		var namesRes string
+		var errRes string
+		var IDsRes string
+		names, IDs, err := cat.ExpandDataSourceGlob(ctx, testcat, cat.Flags{}, tc.pattern)
 		if err != nil {
-			res = fmt.Sprintf("error: %v", err)
+			errRes = fmt.Sprintf("error: %v", err)
 		} else {
-			var r []string
-			for _, n := range names {
-				r = append(r, n.FQString())
+			var namesArr []string
+			var IDsArr []descpb.ID
+			for i := range names {
+				namesArr = append(namesArr, names[i].FQString())
+				IDsArr = append(IDsArr, IDs[i])
 			}
-			res = fmt.Sprintf("%v", r)
+			namesRes = fmt.Sprintf("%v", namesArr)
+			IDsRes = fmt.Sprintf("%v", IDsArr)
 		}
-		if res != tc.expected {
-			t.Errorf("pattern: %v  expected: %s  got: %s", tc.pattern, tc.expected, res)
+		if len(tc.expectedError) > 0 && errRes != tc.expectedError {
+			t.Errorf("pattern: %v  expectedError: %s  got: %s", tc.pattern, tc.expectedError, errRes)
+		}
+		if len(tc.expectedNames) > 0 && namesRes != tc.expectedNames {
+			t.Errorf("pattern: %v  expectedNames: %s  got: %s", tc.pattern, tc.expectedNames, namesRes)
+		}
+		if len(tc.expectedIDs) > 0 && IDsRes != tc.expectedIDs {
+			t.Errorf("pattern: %v  expectedIDs: %s  got: %s", tc.pattern, tc.expectedIDs, IDsRes)
 		}
 	}
 }

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -488,17 +488,19 @@ func (s *Schema) Name() *cat.SchemaName {
 }
 
 // GetDataSourceNames is part of the cat.Schema interface.
-func (s *Schema) GetDataSourceNames(ctx context.Context) ([]cat.DataSourceName, error) {
+func (s *Schema) GetDataSourceNames(ctx context.Context) ([]cat.DataSourceName, descpb.IDs, error) {
 	var keys []string
 	for k := range s.dataSources {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-	var res []cat.DataSourceName
+	names := make([]cat.DataSourceName, 0, len(keys))
+	IDs := make(descpb.IDs, 0, len(keys))
 	for _, k := range keys {
-		res = append(res, s.dataSources[k].fqName())
+		names = append(names, s.dataSources[k].fqName())
+		IDs = append(IDs, descpb.ID(s.dataSources[k].ID()))
 	}
-	return res, nil
+	return names, IDs, nil
 }
 
 // View implements the cat.View interface for testing purposes.

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -126,8 +126,10 @@ func (os *optSchema) Name() *cat.SchemaName {
 }
 
 // GetDataSourceNames is part of the cat.Schema interface.
-func (os *optSchema) GetDataSourceNames(ctx context.Context) ([]cat.DataSourceName, error) {
-	return resolver.GetObjectNames(
+func (os *optSchema) GetDataSourceNames(
+	ctx context.Context,
+) ([]cat.DataSourceName, descpb.IDs, error) {
+	return resolver.GetObjectNamesAndIDs(
 		ctx,
 		os.planner.Txn(),
 		os.planner,

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -131,7 +131,7 @@ func (n *renameDatabaseNode) startExec(params runParams) error {
 		return err
 	}
 	for _, schema := range schemas {
-		tbNames, err := p.Descriptors().GetObjectNames(
+		tbNames, _, err := p.Descriptors().GetObjectNamesAndIDs(
 			ctx,
 			p.txn,
 			dbDesc,

--- a/pkg/sql/reparent_database.go
+++ b/pkg/sql/reparent_database.go
@@ -144,7 +144,7 @@ func (n *reparentDatabaseNode) startExec(params runParams) error {
 	b := p.txn.NewBatch()
 
 	// Get all objects under the target database.
-	objNames, err := resolver.GetObjectNames(ctx, p.txn, p, codec, n.db, tree.PublicSchema, true /* explicitPrefix */)
+	objNames, _, err := resolver.GetObjectNamesAndIDs(ctx, p.txn, p, codec, n.db, tree.PublicSchema, true /* explicitPrefix */)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -171,7 +171,7 @@ func (n *scrubNode) startScrubDatabase(ctx context.Context, p *planner, name *tr
 
 	var tbNames tree.TableNames
 	for _, schema := range schemas {
-		toAppend, err := resolver.GetObjectNames(ctx, p.txn, p, p.ExecCfg().Codec, dbDesc, schema, true /*explicitPrefix*/)
+		toAppend, _, err := resolver.GetObjectNamesAndIDs(ctx, p.txn, p, p.ExecCfg().Codec, dbDesc, schema, true /*explicitPrefix*/)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/sem/tree/name_resolution.go
+++ b/pkg/sql/sem/tree/name_resolution.go
@@ -600,7 +600,7 @@ type SchemaLookupFlags = CommonLookupFlags
 // DatabaseLookupFlags is the flag struct suitable for GetDatabaseDesc().
 type DatabaseLookupFlags = CommonLookupFlags
 
-// DatabaseListFlags is the flag struct suitable for GetObjectNames().
+// DatabaseListFlags is the flag struct suitable for GetObjectNamesAndIDs().
 type DatabaseListFlags struct {
 	CommonLookupFlags
 	// ExplicitPrefix, when set, will cause the returned table names to

--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -218,7 +218,7 @@ func cleanupSchemaObjects(
 	if err != nil {
 		return err
 	}
-	tbNames, err := descsCol.GetObjectNames(
+	tbNames, _, err := descsCol.GetObjectNamesAndIDs(
 		ctx,
 		txn,
 		dbDesc,


### PR DESCRIPTION
Part of https://github.com/cockroachdb/cockroach/issues/41930.

This patch reduces the number of roundtrips that occur when
GRANT/REVOKE are called.

Previously, when resolving targets for privilege changes,
we would get the names of all of the tables in the database
and then resolve the corresponding descriptors via
`ResolveMutableExistingTableObject`, which results in a
roundtrip. This patch addresses this by return the IDs along
with the names, so that we can get the descriptors using
`p.Descriptors.GetMutableDescriptorByID` instead, saving
1 roundtrip per table.

More things can be done to reduce roundtrips further such as
batching jobs, which will be done in a separate PR.

Release note: None