### PR TITLE
sql: mark implicit partition columns in information_schema.pg_indexes

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -490,6 +490,38 @@ CREATE TABLE public.t (
 )
 -- Warning: Partitioned table with no zone configurations.
 
+query TTB
+SELECT index_name, column_name, implicit FROM [SHOW INDEXES FROM t]
+ORDER BY index_name, seq_in_index
+----
+created_idx           partition_by  true
+created_idx           c             false
+created_idx           pk            true
+primary               partition_by  true
+primary               pk            false
+t_a_idx               partition_by  true
+t_a_idx               a             false
+t_a_idx               pk            true
+t_b_key               partition_by  true
+t_b_key               b             false
+t_b_key               pk            true
+t_e_key               partition_by  true
+t_e_key               e             false
+t_e_key               pk            true
+t_j_idx               partition_by  true
+t_j_idx               j             false
+t_j_idx               pk            true
+t_partition_by_c_idx  partition_by  false
+t_partition_by_c_idx  c             false
+t_partition_by_c_idx  pk            true
+t_u_key               partition_by  true
+t_u_key               u             false
+t_u_key               pk            true
+unique_c_d            partition_by  true
+unique_c_d            c             false
+unique_c_d            d             false
+unique_c_d            pk            true
+
 query TTB colnames
 SELECT index_name, column_name, implicit FROM crdb_internal.index_columns
 WHERE descriptor_name = 't' AND column_type = 'key'

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -182,6 +182,22 @@ CREATE TABLE regional_by_row_table (
   FAMILY (pk, pk2, a, b)
 ) LOCALITY REGIONAL BY ROW
 
+query TTB
+SELECT index_name, column_name, implicit FROM [SHOW INDEXES FROM regional_by_row_table]
+ORDER BY index_name, seq_in_index
+----
+primary                      crdb_region  true
+primary                      pk           false
+regional_by_row_table_a_idx  crdb_region  true
+regional_by_row_table_a_idx  a            false
+regional_by_row_table_a_idx  pk           true
+regional_by_row_table_b_key  crdb_region  true
+regional_by_row_table_b_key  b            false
+regional_by_row_table_b_key  pk           true
+regional_by_row_table_j_idx  crdb_region  true
+regional_by_row_table_j_idx  j            false
+regional_by_row_table_j_idx  pk           true
+
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE regional_by_row_table]
 ----

--- a/pkg/sql/catalog/table_elements.go
+++ b/pkg/sql/catalog/table_elements.go
@@ -140,6 +140,8 @@ type Index interface {
 	FindPartitionByName(name string) descpb.PartitioningDescriptor
 	PartitionNames() []string
 
+	ExplicitColumnStartIdx() int
+
 	NumInterleaveAncestors() int
 	GetInterleaveAncestor(ancestorOrdinal int) descpb.InterleaveDescriptor_Ancestor
 

--- a/pkg/sql/catalog/tabledesc/index.go
+++ b/pkg/sql/catalog/tabledesc/index.go
@@ -128,6 +128,12 @@ func (w index) PartitionNames() []string {
 	return w.desc.Partitioning.PartitionNames()
 }
 
+// ExplicitColumnStartIdx returns the first index in which the column is
+// explicitly part of the index.
+func (w index) ExplicitColumnStartIdx() int {
+	return w.desc.ExplicitColumnStartIdx()
+}
+
 // IsValidOriginIndex returns whether the index can serve as an origin index for
 // a foreign key constraint with the provided set of originColIDs.
 func (w index) IsValidOriginIndex(originColIDs descpb.ColumnIDs) bool {

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1368,7 +1368,14 @@ CREATE TABLE information_schema.statistics (
 						col := index.GetColumnName(i)
 						// We add a row for each column of index.
 						dir := dStringForIndexDirection(index.GetColumnDirection(i))
-						if err := appendRow(index.IndexDesc(), col, sequence, dir, false, false); err != nil {
+						if err := appendRow(
+							index.IndexDesc(),
+							col,
+							sequence,
+							dir,
+							false,
+							i < index.ExplicitColumnStartIdx(),
+						); err != nil {
 							return err
 						}
 						sequence++

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -58,6 +58,13 @@ ORDER BY 1, 2, 3
 tablename        indexname  indexdef
 sharded_primary  primary    CREATE UNIQUE INDEX "primary" ON test.public.sharded_primary USING btree (a ASC)
 
+query TTB
+SELECT index_name, column_name, implicit FROM [SHOW INDEXES FROM sharded_primary]
+ORDER BY index_name, seq_in_index
+----
+primary  crdb_internal_a_shard_10  true
+primary  a                         false
+
 query TTB colnames
 SELECT index_name, column_name, implicit FROM crdb_internal.index_columns
 WHERE descriptor_name = 'sharded_primary' AND column_type = 'key'


### PR DESCRIPTION
Refs: #63203 

Release note (bug fix): Fix a case where implicitly partitioned columns
(e.g. from REGIONAL BY ROW tables and hash sharded indexes) previously
showed as implicit = false when using SHOW INDEXES /
information_schema.pg_indexes.