### PR TITLE
backupccl: clean up job state on errors

### DIFF
--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1891,17 +1891,29 @@ func doRestorePlan(
 	// the job record creation happens transactionally.
 	plannerTxn := p.ExtendedEvalContext().Txn
 
+	// Construct the job and commit the transaction. Perform this work in a
+	// closure to ensure that the job is cleaned up if an error occurs.
 	var sj *jobs.StartableJob
-	jobID := p.ExecCfg().JobRegistry.MakeJobID()
-	if err := p.ExecCfg().JobRegistry.CreateStartableJobWithTxn(ctx, &sj, jobID, plannerTxn, jr); err != nil {
-		return err
-	}
+	if err := func() (err error) {
+		defer func() {
+			if err == nil || sj == nil {
+				return
+			}
+			if cleanupErr := sj.CleanupOnRollback(ctx); cleanupErr != nil {
+				log.Errorf(ctx, "failed to cleanup job: %v", cleanupErr)
+			}
+		}()
+		jobID := p.ExecCfg().JobRegistry.MakeJobID()
+		if err := p.ExecCfg().JobRegistry.CreateStartableJobWithTxn(ctx, &sj, jobID, plannerTxn, jr); err != nil {
+			return err
+		}
 
-	// We commit the transaction here so that the job can be started. This is
-	// safe because we're in an implicit transaction. If we were in an explicit
-	// transaction the job would have to be created with the detached option and
-	// would have been handled above.
-	if err := plannerTxn.Commit(ctx); err != nil {
+		// We commit the transaction here so that the job can be started. This is
+		// safe because we're in an implicit transaction. If we were in an explicit
+		// transaction the job would have to be created with the detached option and
+		// would have been handled above.
+		return plannerTxn.Commit(ctx)
+	}(); err != nil {
 		return err
 	}
 

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -969,21 +969,33 @@ func importPlanHook(
 		// the job record creation happens transactionally.
 		plannerTxn := p.ExtendedEvalContext().Txn
 
+		// Construct the job and commit the transaction. Perform this work in a
+		// closure to ensure that the job is cleaned up if an error occurs.
 		var sj *jobs.StartableJob
-		jobID := p.ExecCfg().JobRegistry.MakeJobID()
-		if err := p.ExecCfg().JobRegistry.CreateStartableJobWithTxn(ctx, &sj, jobID, plannerTxn, jr); err != nil {
-			return err
-		}
+		if err := func() (err error) {
+			defer func() {
+				if err == nil || sj == nil {
+					return
+				}
+				if cleanupErr := sj.CleanupOnRollback(ctx); cleanupErr != nil {
+					log.Errorf(ctx, "failed to cleanup job: %v", cleanupErr)
+				}
+			}()
+			jobID := p.ExecCfg().JobRegistry.MakeJobID()
+			if err := p.ExecCfg().JobRegistry.CreateStartableJobWithTxn(ctx, &sj, jobID, plannerTxn, jr); err != nil {
+				return err
+			}
 
-		if err := protectTimestampForImport(ctx, p, plannerTxn, jobID, spansToProtect, walltime, importDetails); err != nil {
-			return err
-		}
+			if err := protectTimestampForImport(ctx, p, plannerTxn, jobID, spansToProtect, walltime, importDetails); err != nil {
+				return err
+			}
 
-		// We commit the transaction here so that the job can be started. This
-		// is safe because we're in an implicit transaction. If we were in an
-		// explicit transaction the job would have to be run with the detached
-		// option and would have been handled above.
-		if err := plannerTxn.Commit(ctx); err != nil {
+			// We commit the transaction here so that the job can be started. This
+			// is safe because we're in an implicit transaction. If we were in an
+			// explicit transaction the job would have to be run with the detached
+			// option and would have been handled above.
+			return plannerTxn.Commit(ctx)
+		}(); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
In #62379 we changed the logic for constructing jobs in backup and restore.
This change lost the code to cleanup the startable job in the case that the
planner transaction does not commit. This is problematic because it leaks a
bit of state in the registry and because it leaks a tracing span.

In the longer term we may be able to clean this up by associating the cleanup
with the transaction itself (#60671).

Fixes #63131

Release note: None