### PR TITLE
sql: fix dropping zone configs from REGIONAL BY ROW during failure

### DIFF
--- a/pkg/ccl/multiregionccl/regional_by_row_test.go
+++ b/pkg/ccl/multiregionccl/regional_by_row_test.go
@@ -466,6 +466,10 @@ USE t;
 									)
 								}
 
+								// Validate zone configs are still correct.
+								_, err = sqlDB.Exec(`SELECT crdb_internal.validate_multi_region_zone_configs()`)
+								require.NoError(t, err)
+
 								return nil
 							})
 

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -2436,9 +2436,10 @@ func (sc *SchemaChanger) applyZoneConfigChangeForMutation(
 ) error {
 	if pkSwap := mutation.GetPrimaryKeySwap(); pkSwap != nil {
 		if lcSwap := pkSwap.LocalityConfigSwap; lcSwap != nil {
-			// We will add up to two options - one for the table itself, and one
+			// We will add up to three options - one for the table itself,
+			// one for dropping any zone configs for old indexes and one
 			// for all the new indexes associated with the table.
-			opts := make([]applyZoneConfigForMultiRegionTableOption, 0, 2)
+			opts := make([]applyZoneConfigForMultiRegionTableOption, 0, 3)
 
 			// For locality configs, we need to update the zone configs to match
 			// the new multi-region locality configuration, instead of
@@ -2447,24 +2448,25 @@ func (sc *SchemaChanger) applyZoneConfigChangeForMutation(
 				// Only apply the zone configuration on the table when the mutation
 				// is complete.
 				if isDone {
+					// The table re-writing the LocalityConfig does most of the work for
+					// us here, but if we're coming from REGIONAL BY ROW, it's also
+					// necessary to drop the zone configurations on the index partitions.
+					if lcSwap.OldLocalityConfig.GetRegionalByRow() != nil {
+						opts = append(
+							opts,
+							dropZoneConfigsForMultiRegionIndexes(
+								append(
+									[]descpb.IndexID{pkSwap.OldPrimaryIndexId},
+									pkSwap.OldIndexes...,
+								)...,
+							),
+						)
+					}
+
 					opts = append(
 						opts,
 						applyZoneConfigForMultiRegionTableOptionTableNewConfig(
 							lcSwap.NewLocalityConfig,
-						),
-					)
-				}
-				// The table re-writing the LocalityConfig does most of the work for
-				// us here, but if we're coming from REGIONAL BY ROW, it's also
-				// necessary to drop the zone configurations on the index partitions.
-				if lcSwap.OldLocalityConfig.GetRegionalByRow() != nil {
-					opts = append(
-						opts,
-						dropZoneConfigsForMultiRegionIndexes(
-							append(
-								[]descpb.IndexID{pkSwap.OldPrimaryIndexId},
-								pkSwap.OldIndexes...,
-							)...,
 						),
 					)
 				}


### PR DESCRIPTION
Also added some more useful error messaging + fixed validation to use
NonDropIndexes as Active, which is in line with how the ApplyOption
function works.

Refs: #63201

Release note (bug fix): Fix a bug where REGIONAL BY ROW zone configs
were dropped before REGIONAL BY ROW changes are finalised. This causes a
bug when the REGIONAL BY ROW transformation fail.