### PR TITLE
changefeed: correctly classify primary key swaps with column adds

### DIFF
--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -302,7 +302,7 @@ func (f *kvFeed) scanIfShould(
 			// and returns early. This is important because a change to a primary
 			// index may occur in the same transaction as a change requiring a
 			// backfill.
-			if schemafeed.IsPrimaryIndexChange(ev) {
+			if schemafeed.IsOnlyPrimaryIndexChange(ev) {
 				continue
 			}
 			tablePrefix := f.codec.TablePrefix(uint32(ev.After.GetID()))

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
@@ -194,8 +194,8 @@ func TestKVFeed(t *testing.T) {
 				ts(3),
 			},
 			descs: []catalog.TableDescriptor{
-				makeTableDesc(42, 1, ts(1), 2),
-				addColumnDropBackfillMutation(makeTableDesc(42, 2, ts(3), 1)),
+				makeTableDesc(42, 1, ts(1), 2, 1),
+				addColumnDropBackfillMutation(makeTableDesc(42, 2, ts(3), 1, 1)),
 			},
 			expEvents: 2,
 		},
@@ -218,8 +218,8 @@ func TestKVFeed(t *testing.T) {
 				ts(2),
 			},
 			descs: []catalog.TableDescriptor{
-				makeTableDesc(42, 1, ts(1), 2),
-				addColumnDropBackfillMutation(makeTableDesc(42, 2, ts(3), 1)),
+				makeTableDesc(42, 1, ts(1), 2, 1),
+				addColumnDropBackfillMutation(makeTableDesc(42, 2, ts(3), 1, 1)),
 			},
 			expEvents: 4,
 		},
@@ -243,8 +243,8 @@ func TestKVFeed(t *testing.T) {
 				ts(2),
 			},
 			descs: []catalog.TableDescriptor{
-				makeTableDesc(42, 1, ts(1), 2),
-				addColumnDropBackfillMutation(makeTableDesc(42, 2, ts(4), 1)),
+				makeTableDesc(42, 1, ts(1), 2, 1),
+				addColumnDropBackfillMutation(makeTableDesc(42, 2, ts(4), 1, 1)),
 			},
 			expEvents: 2,
 			expErrRE:  "schema change ...",

--- a/pkg/ccl/changefeedccl/schemafeed/schematestutils/schema_test_utils.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schematestutils/schema_test_utils.go
@@ -23,7 +23,11 @@ import (
 
 // MakeTableDesc makes a generic table descriptor with the provided properties.
 func MakeTableDesc(
-	tableID descpb.ID, version descpb.DescriptorVersion, modTime hlc.Timestamp, cols int,
+	tableID descpb.ID,
+	version descpb.DescriptorVersion,
+	modTime hlc.Timestamp,
+	cols int,
+	primaryKeyIndex int,
 ) catalog.TableDescriptor {
 	td := descpb.TableDescriptor{
 		Name:             "foo",
@@ -31,6 +35,9 @@ func MakeTableDesc(
 		Version:          version,
 		ModificationTime: modTime,
 		NextColumnID:     1,
+		PrimaryIndex: descpb.IndexDescriptor{
+			ID: descpb.IndexID(primaryKeyIndex),
+		},
 	}
 	for i := 0; i < cols; i++ {
 		td.Columns = append(td.Columns, *MakeColumnDesc(td.NextColumnID))
@@ -80,6 +87,39 @@ func AddNewColumnBackfillMutation(desc catalog.TableDescriptor) catalog.TableDes
 		Direction:   descpb.DescriptorMutation_ADD,
 		MutationID:  0,
 		Rollback:    false,
+	})
+	return tabledesc.NewBuilder(desc.TableDesc()).BuildImmutableTable()
+}
+
+// AddPrimaryKeySwapMutation adds a mutation to desc to do a primary key swap.
+// Yes, this does modify an immutable.
+func AddPrimaryKeySwapMutation(desc catalog.TableDescriptor) catalog.TableDescriptor {
+	desc.TableDesc().Mutations = append(desc.TableDesc().Mutations, descpb.DescriptorMutation{
+		State:       descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY,
+		Direction:   descpb.DescriptorMutation_ADD,
+		Descriptor_: &descpb.DescriptorMutation_PrimaryKeySwap{PrimaryKeySwap: &descpb.PrimaryKeySwap{}},
+	})
+	return tabledesc.NewBuilder(desc.TableDesc()).BuildImmutableTable()
+}
+
+// AddNewIndexMutation adds a mutation to desc to add an index.
+// Yes, this does modify an immutable.
+func AddNewIndexMutation(desc catalog.TableDescriptor) catalog.TableDescriptor {
+	desc.TableDesc().Mutations = append(desc.TableDesc().Mutations, descpb.DescriptorMutation{
+		State:       descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY,
+		Direction:   descpb.DescriptorMutation_ADD,
+		Descriptor_: &descpb.DescriptorMutation_Index{Index: &descpb.IndexDescriptor{}},
+	})
+	return tabledesc.NewBuilder(desc.TableDesc()).BuildImmutableTable()
+}
+
+// AddDropIndexMutation adds a mutation to desc to drop an index.
+// Yes, this does modify an immutable.
+func AddDropIndexMutation(desc catalog.TableDescriptor) catalog.TableDescriptor {
+	desc.TableDesc().Mutations = append(desc.TableDesc().Mutations, descpb.DescriptorMutation{
+		State:       descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY,
+		Direction:   descpb.DescriptorMutation_DROP,
+		Descriptor_: &descpb.DescriptorMutation_Index{Index: &descpb.IndexDescriptor{}},
 	})
 	return tabledesc.NewBuilder(desc.TableDesc()).BuildImmutableTable()
 }

--- a/pkg/ccl/changefeedccl/schemafeed/table_event_filter_test.go
+++ b/pkg/ccl/changefeedccl/schemafeed/table_event_filter_test.go
@@ -25,9 +25,11 @@ func TestTableEventIsRegionalByRowChange(t *testing.T) {
 	ts := func(seconds int) hlc.Timestamp {
 		return hlc.Timestamp{WallTime: (time.Duration(seconds) * time.Second).Nanoseconds()}
 	}
-	mkTableDesc := schematestutils.MakeTableDesc
-	addColBackfill := schematestutils.AddNewColumnBackfillMutation
-	setRBR := schematestutils.SetLocalityRegionalByRow
+	var (
+		mkTableDesc    = schematestutils.MakeTableDesc
+		addColBackfill = schematestutils.AddNewColumnBackfillMutation
+		setRBR         = schematestutils.SetLocalityRegionalByRow
+	)
 	for _, c := range []struct {
 		name string
 		e    TableEvent
@@ -36,25 +38,221 @@ func TestTableEventIsRegionalByRowChange(t *testing.T) {
 		{
 			name: "regional by row change",
 			e: TableEvent{
-				Before: mkTableDesc(42, 1, ts(2), 2),
-				After:  setRBR(mkTableDesc(42, 2, ts(3), 2)),
+				Before: mkTableDesc(42, 1, ts(2), 2, 1),
+				After:  setRBR(mkTableDesc(42, 2, ts(3), 2, 1)),
 			},
 			exp: true,
 		},
 		{
 			name: "add non-NULL column",
 			e: TableEvent{
-				Before: addColBackfill(mkTableDesc(42, 3, ts(2), 1)),
-				After:  mkTableDesc(42, 4, ts(4), 2),
+				Before: addColBackfill(mkTableDesc(42, 3, ts(2), 1, 1)),
+				After:  mkTableDesc(42, 4, ts(4), 2, 1),
+			},
+			exp: false,
+		},
+		{
+			name: "unknown table event",
+			e: TableEvent{
+				Before: mkTableDesc(42, 1, ts(2), 2, 1),
+				After:  mkTableDesc(42, 1, ts(2), 2, 1),
 			},
 			exp: false,
 		},
 	} {
 		t.Run(c.name, func(t *testing.T) {
-			require.Equal(t, c.exp, IsRegionalByRowChange(c.e))
+			require.Equalf(t, c.exp, IsRegionalByRowChange(c.e), "event %v", c.e)
 		})
 	}
+}
 
+func TestTableEventIsPrimaryIndexChange(t *testing.T) {
+	ts := func(seconds int) hlc.Timestamp {
+		return hlc.Timestamp{WallTime: (time.Duration(seconds) * time.Second).Nanoseconds()}
+	}
+	var (
+		mkTableDesc     = schematestutils.MakeTableDesc
+		addColBackfill  = schematestutils.AddNewColumnBackfillMutation
+		dropColBackfill = schematestutils.AddColumnDropBackfillMutation
+		addIdx          = schematestutils.AddNewIndexMutation
+		pkSwap          = schematestutils.AddPrimaryKeySwapMutation
+		dropIdx         = schematestutils.AddDropIndexMutation
+	)
+	for _, c := range []struct {
+		name string
+		e    TableEvent
+		exp  bool
+	}{
+		{
+			name: "primary index change",
+			e: TableEvent{
+				Before: pkSwap(addIdx(mkTableDesc(42, 1, ts(2), 2, 1))),
+				After:  dropIdx(mkTableDesc(42, 2, ts(3), 2, 2)),
+			},
+			exp: true,
+		},
+		{
+			name: "primary index change with column addition",
+			e: TableEvent{
+				Before: pkSwap(addIdx(addColBackfill(
+					mkTableDesc(42, 1, ts(2), 1, 1),
+				))),
+				After: dropIdx(mkTableDesc(42, 2, ts(3), 2, 2)),
+			},
+			exp: true,
+		},
+		{
+			name: "drop column",
+			e: TableEvent{
+				Before: mkTableDesc(42, 1, ts(2), 2, 1),
+				After:  dropColBackfill(mkTableDesc(42, 2, ts(3), 1, 1)),
+			},
+			exp: false,
+		},
+		{
+			name: "add non-NULL column",
+			e: TableEvent{
+				Before: addColBackfill(mkTableDesc(42, 3, ts(2), 1, 1)),
+				After:  mkTableDesc(42, 4, ts(4), 2, 1),
+			},
+			exp: false,
+		},
+		{
+			name: "add NULL-able computed column",
+			e: TableEvent{
+				Before: func() catalog.TableDescriptor {
+					td := addColBackfill(mkTableDesc(42, 4, ts(4), 1, 1))
+					col := td.TableDesc().Mutations[0].GetColumn()
+					col.Nullable = true
+					col.ComputeExpr = proto.String("1")
+					return tabledesc.NewBuilder(td.TableDesc()).BuildImmutableTable()
+				}(),
+				After: mkTableDesc(42, 4, ts(4), 2, 1),
+			},
+			exp: false,
+		},
+		{
+			name: "unknown table event",
+			e: TableEvent{
+				Before: mkTableDesc(42, 1, ts(2), 2, 1),
+				After:  mkTableDesc(42, 1, ts(2), 2, 1),
+			},
+			exp: false,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equalf(t, c.exp, IsPrimaryIndexChange(c.e), "event %v", c.e)
+		})
+	}
+}
+
+func TestTableEventIsOnlyPrimaryIndexChange(t *testing.T) {
+	ts := func(seconds int) hlc.Timestamp {
+		return hlc.Timestamp{WallTime: (time.Duration(seconds) * time.Second).Nanoseconds()}
+	}
+	var (
+		mkTableDesc     = schematestutils.MakeTableDesc
+		addColBackfill  = schematestutils.AddNewColumnBackfillMutation
+		dropColBackfill = schematestutils.AddColumnDropBackfillMutation
+		addIdx          = schematestutils.AddNewIndexMutation
+		pkSwap          = schematestutils.AddPrimaryKeySwapMutation
+		dropIdx         = schematestutils.AddDropIndexMutation
+	)
+	for _, c := range []struct {
+		name string
+		e    TableEvent
+		exp  bool
+	}{
+		{
+			name: "primary index change",
+			e: TableEvent{
+				Before: pkSwap(addIdx(mkTableDesc(42, 1, ts(2), 2, 1))),
+				After:  dropIdx(mkTableDesc(42, 2, ts(3), 2, 2)),
+			},
+			exp: true,
+		},
+		{
+			name: "primary index change with column addition",
+			e: TableEvent{
+				Before: pkSwap(addIdx(addColBackfill(
+					mkTableDesc(42, 1, ts(2), 1, 1),
+				))),
+				After: dropIdx(mkTableDesc(42, 2, ts(3), 2, 2)),
+			},
+			exp: false,
+		},
+		{
+			name: "drop column",
+			e: TableEvent{
+				Before: mkTableDesc(42, 1, ts(2), 2, 1),
+				After:  dropColBackfill(mkTableDesc(42, 2, ts(3), 1, 1)),
+			},
+			exp: false,
+		},
+		{
+			name: "add non-NULL column",
+			e: TableEvent{
+				Before: addColBackfill(mkTableDesc(42, 3, ts(2), 1, 1)),
+				After:  mkTableDesc(42, 4, ts(4), 2, 1),
+			},
+			exp: false,
+		},
+		{
+			name: "add NULL-able computed column",
+			e: TableEvent{
+				Before: func() catalog.TableDescriptor {
+					td := addColBackfill(mkTableDesc(42, 4, ts(4), 1, 1))
+					col := td.TableDesc().Mutations[0].GetColumn()
+					col.Nullable = true
+					col.ComputeExpr = proto.String("1")
+					return tabledesc.NewBuilder(td.TableDesc()).BuildImmutableTable()
+				}(),
+				After: mkTableDesc(42, 4, ts(4), 2, 1),
+			},
+			exp: false,
+		},
+		{
+			name: "unknown table event",
+			e: TableEvent{
+				Before: mkTableDesc(42, 1, ts(2), 2, 1),
+				After:  mkTableDesc(42, 1, ts(2), 2, 1),
+			},
+			exp: false,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equalf(t, c.exp, IsOnlyPrimaryIndexChange(c.e), "event %v", c.e)
+		})
+	}
+}
+
+func TestTableEventFilterErrorsWithIncompletePolicy(t *testing.T) {
+	ts := func(seconds int) hlc.Timestamp {
+		return hlc.Timestamp{WallTime: (time.Duration(seconds) * time.Second).Nanoseconds()}
+	}
+	mkTableDesc := schematestutils.MakeTableDesc
+	dropColBackfill := schematestutils.AddColumnDropBackfillMutation
+
+	incompleteFilter := tableEventFilter{
+		// tableEventTypeDropColumn:            false,
+		tableEventTypeAddColumnWithBackfill: false,
+		tableEventTypeAddColumnNoBackfill:   true,
+		// tableEventTypeUnknown:               true,
+		tableEventPrimaryKeyChange: false,
+	}
+	dropColEvent := TableEvent{
+		Before: mkTableDesc(42, 1, ts(2), 2, 1),
+		After:  dropColBackfill(mkTableDesc(42, 2, ts(3), 1, 1)),
+	}
+	_, err := incompleteFilter.shouldFilter(context.Background(), dropColEvent)
+	require.Error(t, err)
+
+	unknownEvent := TableEvent{
+		Before: mkTableDesc(42, 1, ts(2), 2, 1),
+		After:  mkTableDesc(42, 1, ts(2), 2, 1),
+	}
+	_, err = incompleteFilter.shouldFilter(context.Background(), unknownEvent)
+	require.Error(t, err)
 }
 
 func TestTableEventFilter(t *testing.T) {
@@ -75,8 +273,8 @@ func TestTableEventFilter(t *testing.T) {
 			name: "don't filter drop column",
 			p:    defaultTableEventFilter,
 			e: TableEvent{
-				Before: mkTableDesc(42, 1, ts(2), 2),
-				After:  dropColBackfill(mkTableDesc(42, 2, ts(3), 1)),
+				Before: mkTableDesc(42, 1, ts(2), 2, 1),
+				After:  dropColBackfill(mkTableDesc(42, 2, ts(3), 1, 1)),
 			},
 			exp: false,
 		},
@@ -84,8 +282,8 @@ func TestTableEventFilter(t *testing.T) {
 			name: "filter first step of add non-NULL column",
 			p:    defaultTableEventFilter,
 			e: TableEvent{
-				Before: mkTableDesc(42, 1, ts(2), 1),
-				After:  addColBackfill(mkTableDesc(42, 2, ts(4), 1)),
+				Before: mkTableDesc(42, 1, ts(2), 1, 1),
+				After:  addColBackfill(mkTableDesc(42, 2, ts(4), 1, 1)),
 			},
 			exp: true,
 		},
@@ -93,8 +291,8 @@ func TestTableEventFilter(t *testing.T) {
 			name: "filter rollback of add column",
 			p:    defaultTableEventFilter,
 			e: TableEvent{
-				Before: addColBackfill(mkTableDesc(42, 3, ts(2), 1)),
-				After:  mkTableDesc(42, 4, ts(4), 1),
+				Before: addColBackfill(mkTableDesc(42, 3, ts(2), 1, 1)),
+				After:  mkTableDesc(42, 4, ts(4), 1, 1),
 			},
 			exp: true,
 		},
@@ -102,8 +300,8 @@ func TestTableEventFilter(t *testing.T) {
 			name: "don't filter end of add non-NULL column",
 			p:    defaultTableEventFilter,
 			e: TableEvent{
-				Before: addColBackfill(mkTableDesc(42, 3, ts(2), 1)),
-				After:  mkTableDesc(42, 4, ts(4), 2),
+				Before: addColBackfill(mkTableDesc(42, 3, ts(2), 1, 1)),
+				After:  mkTableDesc(42, 4, ts(4), 2, 1),
 			},
 			exp: false,
 		},
@@ -112,13 +310,13 @@ func TestTableEventFilter(t *testing.T) {
 			p:    defaultTableEventFilter,
 			e: TableEvent{
 				Before: func() catalog.TableDescriptor {
-					td := addColBackfill(mkTableDesc(42, 4, ts(4), 1))
+					td := addColBackfill(mkTableDesc(42, 4, ts(4), 1, 1))
 					col := td.TableDesc().Mutations[0].GetColumn()
 					col.Nullable = true
 					col.ComputeExpr = proto.String("1")
 					return tabledesc.NewBuilder(td.TableDesc()).BuildImmutableTable()
 				}(),
-				After: mkTableDesc(42, 4, ts(4), 2),
+				After: mkTableDesc(42, 4, ts(4), 2, 1),
 			},
 			exp: false,
 		},
@@ -126,8 +324,17 @@ func TestTableEventFilter(t *testing.T) {
 			name: "filter end of add NULL column",
 			p:    defaultTableEventFilter,
 			e: TableEvent{
-				Before: mkTableDesc(42, 3, ts(2), 1),
-				After:  mkTableDesc(42, 4, ts(4), 2),
+				Before: mkTableDesc(42, 3, ts(2), 1, 1),
+				After:  mkTableDesc(42, 4, ts(4), 2, 1),
+			},
+			exp: true,
+		},
+		{
+			name: "filter unknown table event",
+			p:    defaultTableEventFilter,
+			e: TableEvent{
+				Before: mkTableDesc(42, 1, ts(2), 2, 1),
+				After:  mkTableDesc(42, 1, ts(2), 2, 1),
 			},
 			exp: true,
 		},
@@ -135,8 +342,8 @@ func TestTableEventFilter(t *testing.T) {
 			name: "don't filter regional by row change",
 			p:    defaultTableEventFilter,
 			e: TableEvent{
-				Before: mkTableDesc(42, 1, ts(2), 2),
-				After:  setRBR(mkTableDesc(42, 2, ts(3), 2)),
+				Before: mkTableDesc(42, 1, ts(2), 2, 1),
+				After:  setRBR(mkTableDesc(42, 2, ts(3), 2, 1)),
 			},
 			exp: false,
 		},
@@ -144,8 +351,8 @@ func TestTableEventFilter(t *testing.T) {
 			name: "columnChange - don't filter end of add NULL column",
 			p:    columnChangeTableEventFilter,
 			e: TableEvent{
-				Before: mkTableDesc(42, 3, ts(2), 1),
-				After:  mkTableDesc(42, 4, ts(4), 2),
+				Before: mkTableDesc(42, 3, ts(2), 1, 1),
+				After:  mkTableDesc(42, 4, ts(4), 2, 1),
 			},
 			exp: false,
 		},
@@ -153,10 +360,19 @@ func TestTableEventFilter(t *testing.T) {
 			name: "columnChange - don't filter regional by row change",
 			p:    columnChangeTableEventFilter,
 			e: TableEvent{
-				Before: mkTableDesc(42, 1, ts(2), 2),
-				After:  setRBR(mkTableDesc(42, 2, ts(3), 2)),
+				Before: mkTableDesc(42, 1, ts(2), 2, 1),
+				After:  setRBR(mkTableDesc(42, 2, ts(3), 2, 1)),
 			},
 			exp: false,
+		},
+		{
+			name: "columnChange - filter unknown table event",
+			p:    columnChangeTableEventFilter,
+			e: TableEvent{
+				Before: mkTableDesc(42, 1, ts(2), 2, 1),
+				After:  mkTableDesc(42, 1, ts(2), 2, 1),
+			},
+			exp: true,
 		},
 	} {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
In most cases, ALTER PRIMARY KEY will fail if other schema mutations
are in the same transaction.

The new `SET LOCALITY REGIONAL BY ROW` statement, however, can create
a transaction that contains both a column addition and a primary key
swap.

Before this change, the event classifier assigned every event a single
type. This, combined with the ordering of our classification
logic, meant that functions like schemafeed.IsPrimaryIndexChange would return
`false` for events that contained both a column addition and primary
key swap.

As a result, in such cases we would not restart the changefeed but we
_would_ attempt a backfill scan for the new column. This backfill scan
would be using the old index but the new table descriptor, leading to
unexepected encoding failures in the JSON encoder.

Now, the event classifier can assign multiple event types to a single
event. This allows the kvfeed to correctly determine that it both
needs to restart the changefeed and perform a backfill.

NOTE: This change alone does not complete support for `REGIONAL BY
ROW` tables for changefeeds.

Release note (bug fix): Schema changes that include both a column
addition and primary key change in the same transaction no longer
result in a failed changefeed.