### PR TITLE
release-21.1: backupccl: disallow cluster restore between tenants

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -89,6 +89,7 @@ go_library(
         "//pkg/testutils",
         "//pkg/util/ctxgroup",
         "//pkg/util/encoding",
+        "//pkg/util/errorutil/unimplemented",
         "//pkg/util/hlc",
         "//pkg/util/interval",
         "//pkg/util/log",

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -6357,6 +6357,130 @@ func TestPaginatedBackupTenant(t *testing.T) {
 	// TODO(adityamaru): Add a RESTORE inside tenant once it is supported.
 }
 
+func TestBackupRestoreInsideTenant(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	makeTenant := func(srv serverutils.TestServerInterface, tenant uint64) (*sqlutils.SQLRunner, func()) {
+		// Prevent a logging assertion that the server ID is initialized multiple times.
+		log.TestingClearServerIdentifiers()
+
+		_, conn := serverutils.StartTenant(t, srv, base.TestTenantArgs{TenantID: roachpb.MakeTenantID(tenant)})
+		cleanup := func() { conn.Close() }
+		return sqlutils.MakeSQLRunner(conn), cleanup
+	}
+
+	const numAccounts = 1
+	_, tc, systemDB, dir, cleanupFn := BackupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
+	_, _ = tc, systemDB
+	defer cleanupFn()
+	srv := tc.Server(0)
+
+	// NB: tenant certs for 10, 11, and 20 are embedded. See:
+	_ = security.EmbeddedTenantIDs()
+
+	tenant10, cleanupT10 := makeTenant(srv, 10)
+	defer cleanupT10()
+	tenant10.Exec(t, `CREATE DATABASE foo; CREATE TABLE foo.bar(i int primary key); INSERT INTO foo.bar VALUES (110), (210)`)
+
+	tenant11, cleanupT11 := makeTenant(srv, 11)
+	defer cleanupT11()
+
+	// Create another server.
+	_, tc2, systemDB2, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, dir, InitManualReplication, base.TestClusterArgs{})
+	srv2 := tc2.Server(0)
+	defer cleanupEmptyCluster()
+
+	tenant10C2, cleanupT10C2 := makeTenant(srv2, 10)
+	defer cleanupT10C2()
+
+	tenant11C2, cleanupT11C2 := makeTenant(srv2, 11)
+	defer cleanupT11C2()
+
+	t.Run("tenant-backup", func(t *testing.T) {
+		// This test uses this mock HTTP server to pass the backup files between tenants.
+		httpAddr, httpServerCleanup := makeInsecureHTTPServer(t)
+		defer httpServerCleanup()
+
+		tenant10.Exec(t, `BACKUP TO $1`, httpAddr)
+
+		t.Run("cluster-restore", func(t *testing.T) {
+			t.Run("into-same-tenant-id", func(t *testing.T) {
+				tenant10C2.Exec(t, `RESTORE FROM $1`, httpAddr)
+				tenant10C2.CheckQueryResults(t, `SELECT * FROM foo.bar`, tenant10.QueryStr(t, `SELECT * FROM foo.bar`))
+			})
+			t.Run("into-different-tenant-id", func(t *testing.T) {
+				tenant11C2.ExpectErr(t, `cannot cluster RESTORE backups taken from different tenant: 10`,
+					`RESTORE FROM $1`, httpAddr)
+			})
+			t.Run("into-system-tenant-id", func(t *testing.T) {
+				systemDB2.ExpectErr(t, `cannot cluster RESTORE backups taken from different tenant: 10`,
+					`RESTORE FROM $1`, httpAddr)
+			})
+		})
+
+		t.Run("database-restore", func(t *testing.T) {
+			t.Run("into-same-tenant-id", func(t *testing.T) {
+				tenant10.Exec(t, `CREATE DATABASE foo2`)
+				tenant10.Exec(t, `RESTORE foo.bar FROM $1 WITH into_db='foo2'`, httpAddr)
+				tenant10.CheckQueryResults(t, `SELECT * FROM foo2.bar`, tenant10.QueryStr(t, `SELECT * FROM foo.bar`))
+			})
+			t.Run("into-different-tenant-id", func(t *testing.T) {
+				tenant11.Exec(t, `CREATE DATABASE foo`)
+				tenant11.Exec(t, `RESTORE foo.bar FROM $1`, httpAddr)
+				tenant11.CheckQueryResults(t, `SELECT * FROM foo.bar`, tenant10.QueryStr(t, `SELECT * FROM foo.bar`))
+			})
+			t.Run("into-system-tenant-id", func(t *testing.T) {
+				systemDB.Exec(t, `CREATE DATABASE foo2`)
+				systemDB.ExpectErr(t, `cannot restore tenant backups into system tenant`,
+					`RESTORE foo.bar FROM $1 WITH into_db='foo2'`, httpAddr)
+			})
+		})
+	})
+
+	t.Run("system-backup", func(t *testing.T) {
+		// This test uses this mock HTTP server to pass the backup files between tenants.
+		httpAddr, httpServerCleanup := makeInsecureHTTPServer(t)
+		defer httpServerCleanup()
+
+		systemDB.Exec(t, `BACKUP TO $1`, httpAddr)
+
+		tenant20C2, cleanupT20C2 := makeTenant(srv2, 20)
+		defer cleanupT20C2()
+
+		t.Run("cluster-restore", func(t *testing.T) {
+			t.Run("with-tenant", func(t *testing.T) {
+				// This is disallowed because the cluster restore includes other
+				// tenants, which can't be restored inside a tenant.
+				tenant20C2.ExpectErr(t, `only the system tenant can restore other tenants`,
+					`RESTORE FROM $1`, httpAddr)
+			})
+
+			t.Run("with-no-tenant", func(t *testing.T) {
+				// Now restore a cluster backup taken from a system tenant that
+				// hasn't created any tenants.
+				httpAddrEmpty, cleanupEmptyHTTPServer := makeInsecureHTTPServer(t)
+				defer cleanupEmptyHTTPServer()
+
+				_, _, emptySystemDB, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode,
+					dir, InitManualReplication, base.TestClusterArgs{})
+				defer cleanupEmptyCluster()
+
+				emptySystemDB.Exec(t, `BACKUP TO $1`, httpAddrEmpty)
+				tenant20C2.ExpectErr(t, `cannot cluster RESTORE backups taken from different tenant: system`,
+					`RESTORE FROM $1`, httpAddrEmpty)
+			})
+		})
+
+		t.Run("database-restore-into-tenant", func(t *testing.T) {
+			tenant10.Exec(t, `CREATE DATABASE data`)
+			tenant10.Exec(t, `RESTORE data.bank FROM $1`, httpAddr)
+			systemDB.CheckQueryResults(t, `SELECT * FROM data.bank`, tenant10.QueryStr(t, `SELECT * FROM data.bank`))
+		})
+
+	})
+}
+
 // Ensure that backing up and restoring tenants succeeds.
 func TestBackupRestoreTenant(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -6412,29 +6536,6 @@ func TestBackupRestoreTenant(t *testing.T) {
 
 	systemDB.Exec(t, `BACKUP TENANT 11 TO 'nodelocal://1/t11'`)
 	systemDB.Exec(t, `BACKUP TENANT 20 TO 'nodelocal://1/t20'`)
-
-	t.Run("inside-tenant", func(t *testing.T) {
-		// This test uses this mock HTTP server to pass the backup files between tenants.
-		httpServer, httpServerCleanup := makeInsecureHTTPServer(t)
-		defer httpServerCleanup()
-		httpAddr := httpServer.String() + "/test"
-
-		tenant10.Exec(t, `BACKUP DATABASE foo TO $1`, httpAddr)
-		t.Run("same-tenant", func(t *testing.T) {
-			tenant10.Exec(t, `CREATE DATABASE foo2`)
-			tenant10.Exec(t, `RESTORE foo.bar FROM $1 WITH into_db='foo2'`, httpAddr)
-			tenant10.CheckQueryResults(t, `SELECT * FROM foo2.bar`, tenant10.QueryStr(t, `SELECT * FROM foo.bar`))
-		})
-		t.Run("another-tenant", func(t *testing.T) {
-			tenant11.Exec(t, `RESTORE foo.bar FROM $1`, httpAddr)
-			tenant11.CheckQueryResults(t, `SELECT * FROM foo.bar`, tenant10.QueryStr(t, `SELECT * FROM foo.bar`))
-		})
-		t.Run("system-tenant", func(t *testing.T) {
-			systemDB.Exec(t, `CREATE DATABASE foo2`)
-			systemDB.ExpectErr(t, `cannot restore tenant backups into system tenant`,
-				`RESTORE foo.bar FROM $1 WITH into_db='foo2'`, httpAddr)
-		})
-	})
 
 	t.Run("non-existent", func(t *testing.T) {
 		systemDB.ExpectErr(t, "tenant 123 does not exist", `BACKUP TENANT 123 TO 'nodelocal://1/t1'`)

--- a/pkg/ccl/backupccl/helpers_test.go
+++ b/pkg/ccl/backupccl/helpers_test.go
@@ -302,7 +302,7 @@ func injectStatsWithRowCount(
 	return sqlDB.QueryStr(t, getStatsQuery(tableName))
 }
 
-func makeInsecureHTTPServer(t *testing.T) (*url.URL, func()) {
+func makeInsecureHTTPServer(t *testing.T) (string, func()) {
 	t.Helper()
 
 	const badHeadResponse = "bad-head-response"
@@ -352,5 +352,5 @@ func makeInsecureHTTPServer(t *testing.T) (*url.URL, func()) {
 		t.Fatal(err)
 	}
 	uri.Path = filepath.Join(uri.Path, "testing")
-	return uri, cleanup
+	return uri.String(), cleanup
 }

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -1382,6 +1383,14 @@ func (r *restoreResumer) Resume(ctx context.Context, execCtx interface{}) error 
 				return err
 			}
 			backupCodec = keys.MakeSQLCodec(backupTenantID)
+			// Disallow cluster restores, unless the tenant IDs match.
+			if details.DescriptorCoverage == tree.AllDescriptors {
+				if !backupCodec.TenantPrefix().Equal(p.ExecCfg().Codec.TenantPrefix()) {
+					return unimplemented.NewWithIssuef(62277,
+						"cannot cluster RESTORE backups taken from different tenant: %s",
+						backupTenantID.String())
+				}
+			}
 			if backupTenantID != roachpb.SystemTenantID && p.ExecCfg().Codec.ForSystemTenant() {
 				// TODO(pbardea): This is unsupported for now because the key-rewriter
 				// cannot distinguish between RESTORE TENANT and table restore from a


### PR DESCRIPTION
Backport 1/1 commits from #62279.

/cc @cockroachdb/release

---

Cluster RESTOREs of backups from a different tenant are not permitted
because rekeying of system tables is not yet implemented. This prevents
the RESTORE from being able to perform the necessary rekeying of the
backup data from one tenant space to the other.

Instead, we return an error.

Release note (bug fix): Return an error when trying to perform a cluster
of a backup that was taken on another tenant.
