### PR TITLE
util/quotapool: clean up some commentary, invert Update logic

### DIFF
--- a/pkg/util/quotapool/config.go
+++ b/pkg/util/quotapool/config.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
-// Option is used to configure a QuotaPool.
+// Option is used to configure a quotapool.
 type Option interface {
 	apply(*config)
 }
@@ -77,7 +77,7 @@ func WithTimeSource(ts timeutil.TimeSource) Option {
 }
 
 // WithCloser allows the client to provide a channel which will lead to the
-// QuotaPool being closed.
+// AbstractPool being closed.
 func WithCloser(closer <-chan struct{}) Option {
 	return optionFunc(func(cfg *config) {
 		cfg.closer = closer

--- a/pkg/util/quotapool/quotapool.go
+++ b/pkg/util/quotapool/quotapool.go
@@ -30,20 +30,9 @@ import (
 // TODO(ajwerner): provide mechanism to collect metrics.
 
 // Resource is an interface that represents a quantity which is being
-// pooled and allocated. It is any quantity that can be subdivided and
-// combined.
-//
-// This library does not provide any concrete implementations of Resource but
-// internally the *IntAlloc is used as a resource.
-type Resource interface {
-
-	// Merge combines val into the current resource.
-	// After val is passed to Merge, the QuotaPool will never use
-	// that Resource again. This behavior allows clients to pool instances of
-	// Resources by creating Resource during Acquisition and destroying them in
-	// Merge.
-	Merge(val interface{}) (shouldNotify bool)
-}
+// pooled and allocated. The Resource will be modified by a Request or
+// an a call to Update.
+type Resource interface{}
 
 // Request is an interface used to acquire quota from the pool.
 // Request is responsible for subdividing a resource into the portion which is
@@ -79,11 +68,11 @@ func (ec *ErrClosed) Error() string {
 	return fmt.Sprintf("%s pool closed: %s", ec.poolName, ec.reason)
 }
 
-// QuotaPool is an abstract implementation of a pool that stores some unit of
+// AbstractPool is an abstract implementation of a pool that stores some unit of
 // Resource. The basic idea is that it allows requests to acquire a quantity of
 // Resource from the pool in FIFO order in a way that interacts well with
 // context cancelation.
-type QuotaPool struct {
+type AbstractPool struct {
 	config
 
 	// name is used for logging purposes and is passed to functions used to report
@@ -91,7 +80,7 @@ type QuotaPool struct {
 	name string
 
 	// Ongoing acquisitions listen on done which is closed when the quota
-	// pool is closed (see QuotaPool.Close).
+	// pool is closed (see AbstractPool.Close).
 	done chan struct{}
 
 	// closeErr is populated with a non-nil error when Close is called.
@@ -120,7 +109,7 @@ type QuotaPool struct {
 		numCanceled int
 
 		// closed is set to true when the quota pool is closed (see
-		// QuotaPool.Close).
+		// AbstractPool.Close).
 		closed bool
 	}
 }
@@ -128,8 +117,8 @@ type QuotaPool struct {
 // New returns a new quota pool initialized with a given quota. The quota
 // is capped at this amount, meaning that callers may return more quota than they
 // acquired without ever making more than the quota capacity available.
-func New(name string, initialResource Resource, options ...Option) *QuotaPool {
-	qp := &QuotaPool{
+func New(name string, initialResource Resource, options ...Option) *AbstractPool {
+	qp := &AbstractPool{
 		name: name,
 		done: make(chan struct{}),
 	}
@@ -139,21 +128,13 @@ func New(name string, initialResource Resource, options ...Option) *QuotaPool {
 	return qp
 }
 
-// TimeSource returns the TimeSource associated with this QuotaPool.
-func (qp *QuotaPool) TimeSource() timeutil.TimeSource {
+// TimeSource returns the TimeSource associated with this AbstractPool.
+func (qp *AbstractPool) TimeSource() timeutil.TimeSource {
 	return qp.timeSource
 }
 
-// ApproximateQuota will report approximately the amount of quota available
-// in the pool to f. The provided Resource must not be mutated.
-func (qp *QuotaPool) ApproximateQuota(f func(Resource)) {
-	qp.mu.Lock()
-	defer qp.mu.Unlock()
-	f(qp.mu.quota)
-}
-
-// Len returns the current length of the queue for this QuotaPool.
-func (qp *QuotaPool) Len() int {
+// Len returns the current length of the queue for this AbstractPool.
+func (qp *AbstractPool) Len() int {
 	qp.mu.Lock()
 	defer qp.mu.Unlock()
 	return int(qp.mu.q.len) - qp.mu.numCanceled
@@ -164,7 +145,7 @@ func (qp *QuotaPool) Len() int {
 // contains this reason.
 //
 // Safe for concurrent use.
-func (qp *QuotaPool) Close(reason string) {
+func (qp *AbstractPool) Close(reason string) {
 	qp.mu.Lock()
 	defer qp.mu.Unlock()
 	if qp.mu.closed {
@@ -178,18 +159,21 @@ func (qp *QuotaPool) Close(reason string) {
 	close(qp.done)
 }
 
-// Add adds the provided Alloc back to the pool. The value will be merged with
-// the existing resources in the QuotaPool if there are any.
+// UpdateFunc is used to update a resource.
+type UpdateFunc func(resource Resource) (shouldNotify bool)
+
+// Update updates the underlying resource with the provided value, notifying the
+// head of the queue if the Resource indicates that it should.
 //
 // Safe for concurrent use.
-func (qp *QuotaPool) Add(val interface{}) {
+func (qp *AbstractPool) Update(f UpdateFunc) {
 	qp.mu.Lock()
 	defer qp.mu.Unlock()
-	qp.addLocked(val)
+	qp.updateLocked(f)
 }
 
-func (qp *QuotaPool) addLocked(val interface{}) {
-	if shouldNotify := qp.mu.quota.Merge(val); !shouldNotify {
+func (qp *AbstractPool) updateLocked(f UpdateFunc) {
+	if shouldNotify := f(qp.mu.quota); !shouldNotify {
 		return
 	}
 	// Notify the head of the queue if there is one waiting.
@@ -214,7 +198,7 @@ var chanSyncPool = sync.Pool{
 // canceled.
 //
 // Safe for concurrent use.
-func (qp *QuotaPool) Acquire(ctx context.Context, r Request) (err error) {
+func (qp *AbstractPool) Acquire(ctx context.Context, r Request) (err error) {
 
 	// Set up onAcquisition if we have one.
 	start := qp.timeSource.Now()
@@ -321,7 +305,7 @@ func (qp *QuotaPool) Acquire(ctx context.Context, r Request) (err error) {
 // tryAgainAfter will only be non-zero if the notifyee is at the front of the
 // queue. This property ensures that only one tryAgainTimer in acquire exists
 // at a time.
-func (qp *QuotaPool) acquireFastPath(
+func (qp *AbstractPool) acquireFastPath(
 	ctx context.Context, r Request,
 ) (fulfilled bool, _ *notifyee, tryAgainAfter time.Duration, _ error) {
 
@@ -342,7 +326,7 @@ func (qp *QuotaPool) acquireFastPath(
 	return false, qp.mu.q.enqueue(c), tryAgainAfter, nil
 }
 
-func (qp *QuotaPool) tryAcquireOnNotify(
+func (qp *AbstractPool) tryAcquireOnNotify(
 	ctx context.Context, r Request, n *notifyee,
 ) (fulfilled bool, tryAgainAfter time.Duration) {
 	// Release the notify channel back into the sync pool if we're fulfilled.
@@ -368,7 +352,7 @@ func (qp *QuotaPool) tryAcquireOnNotify(
 	return fulfilled, tryAgainAfter
 }
 
-func (qp *QuotaPool) cleanupOnCancel(n *notifyee) {
+func (qp *AbstractPool) cleanupOnCancel(n *notifyee) {
 	// No matter what, we're going to want to put our notify channel back in to
 	// the sync pool. Note that this defer call evaluates n.c here and is not
 	// affected by later code that sets n.c to nil.
@@ -395,7 +379,7 @@ func (qp *QuotaPool) cleanupOnCancel(n *notifyee) {
 
 // notifyNextLocked notifies the waiting acquisition goroutine next in line (if
 // any). It requires that qp.mu.Mutex is held.
-func (qp *QuotaPool) notifyNextLocked() {
+func (qp *AbstractPool) notifyNextLocked() {
 	// Pop ourselves off the front of the queue.
 	qp.mu.q.dequeue()
 	// We traverse until we find a goroutine waiting to be notified, notify the


### PR DESCRIPTION
The `Merge` method was clunky and required type switched. Instead, the
quantity being used to do the update should know the type of the resource.

Also, renames the `QuotaPool` to `AbstractPool`.

Release note: None