### PR TITLE
release-21.1: sql: fix constraint name roundtripping

### DIFF
--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -201,7 +201,8 @@ func TestParse(t *testing.T) {
 		{`CREATE TABLE a (a INT8 CONSTRAINT one DEFAULT 1 CONSTRAINT positive CHECK (a > 0))`},
 		{`CREATE TABLE a (a INT8 CONSTRAINT one CHECK (a > 0) CONSTRAINT two CHECK (a < 10))`},
 		{`CREATE TABLE a (b INT8 NOT VISIBLE)`},
-		{`CREATE TABLE a (b INT8 NOT VISIBLE NULL)`},
+		{`CREATE TABLE a (b INT8 NULL NOT VISIBLE)`},
+		{`CREATE TABLE a (b INT8 CONSTRAINT c NOT NULL NOT VISIBLE)`},
 		// "0" lost quotes previously.
 		{`CREATE TABLE a (b INT8, c STRING, PRIMARY KEY (b, c, "0"))`},
 		{`CREATE TABLE a (b INT8, c STRING, FOREIGN KEY (b) REFERENCES other)`},
@@ -1757,6 +1758,7 @@ func TestParse(t *testing.T) {
 		{`IMPORT TABLE foo FROM PGDUMPCREATE 'nodelocal://0/foo/bar' WITH temp = 'path/to/temp'`},
 		{`IMPORT INTO foo(id, email) CSV DATA ('path/to/some/file', $1) WITH temp = 'path/to/temp'`},
 		{`IMPORT INTO foo CSV DATA ('path/to/some/file', $1) WITH temp = 'path/to/temp'`},
+		{`IMPORT TABLE a.foo (LIKE tab, col INT8 CONSTRAINT conname NULL NOT VISIBLE) CSV DATA ('placeholder')`},
 
 		{`IMPORT PGDUMP 'nodelocal://0/foo/bar' WITH temp = 'path/to/temp'`},
 		{`EXPLAIN IMPORT PGDUMP 'nodelocal://0/foo/bar' WITH temp = 'path/to/temp'`},

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -599,14 +599,14 @@ func (node *ColumnTableDef) Format(ctx *FmtCtx) {
 		ctx.WriteString(" CONSTRAINT ")
 		ctx.FormatNode(&node.Nullable.ConstraintName)
 	}
-	if node.Hidden {
-		ctx.WriteString(" NOT VISIBLE")
-	}
 	switch node.Nullable.Nullability {
 	case Null:
 		ctx.WriteString(" NULL")
 	case NotNull:
 		ctx.WriteString(" NOT NULL")
+	}
+	if node.Hidden {
+		ctx.WriteString(" NOT VISIBLE")
 	}
 	if node.PrimaryKey.IsPrimaryKey || node.Unique.IsUnique {
 		if node.Unique.ConstraintName != "" {


### PR DESCRIPTION
Backport 1/1 commits from #63132.

/cc @cockroachdb/release

---

The name of a NULL/NOT NULL constraint would not roundtrip when the
column was also NOT VISIBLE.

No release note as this probably wasn't user-visible.
This was discovered by random syntax tests.

Release note: None
