### PR TITLE
release-20.2: tree: unwrap datum in AsJSON

### DIFF
--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -3119,6 +3119,7 @@ func MustBeDJSON(e Expr) DJSON {
 
 // AsJSON converts a datum into our standard json representation.
 func AsJSON(d Datum, loc *time.Location) (json.JSON, error) {
+	d = UnwrapDatum(nil /* evalCtx */, d)
 	switch t := d.(type) {
 	case *DBool:
 		return json.FromBool(bool(*t)), nil


### PR DESCRIPTION
We were missing unwrapping of a datum before doing a type switch. Note
that this change was added on master in 21.1 release cycle, so this
commit only exists on older branches. Also, I couldn't reproduce the
problem manually, that's why there is no regression test.

Fixes: #63164.

Release note (bug fix): Fix for a rare error "unexpected type
*tree.DOidWrapper for AsJSON".