### PR TITLE
release-21.1: colfetcher,execinfra: use soft limit for sizing batches

### DIFF
--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -320,10 +320,12 @@ type cFetcher struct {
 func (rf *cFetcher) resetBatch(timestampOutputIdx, tableOidOutputIdx int) {
 	var reallocated bool
 	var minCapacity int
-	if rf.estimatedRowCount == 0 && rf.machine.limitHint > 0 {
-		// If we don't have an estimate but we have a limit hint, use the hint
-		// to size the batch. Note that if it exceeds coldata.BatchSize,
-		// ResetMaybeReallocate will chop it down.
+	if rf.machine.limitHint > 0 && (rf.estimatedRowCount == 0 || uint64(rf.machine.limitHint) < rf.estimatedRowCount) {
+		// If we have a limit hint, and either
+		//   1) we don't have an estimate, or
+		//   2) we have a soft limit,
+		// use the hint to size the batch. Note that if it exceeds
+		// coldata.BatchSize, ResetMaybeReallocate will chop it down.
 		minCapacity = rf.machine.limitHint
 	} else {
 		// Otherwise, use the estimate. Note that if the estimate is not

--- a/pkg/sql/opt/exec/execbuilder/testdata/stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/stats
@@ -317,20 +317,20 @@ limit
  ├── cardinality: [0 - 1]
  ├── immutable
  ├── stats: [rows=1]
- ├── cost: 217.049998
+ ├── cost: 111.049999
  ├── key: ()
  ├── fd: ()-->(1)
  ├── select
  │    ├── columns: j:1
  │    ├── immutable
  │    ├── stats: [rows=10.0000001, distinct(1)=1, null(1)=10]
- │    ├── cost: 217.029998
+ │    ├── cost: 111.029999
  │    ├── fd: ()-->(1)
  │    ├── limit hint: 1.00
  │    ├── scan tj
  │    │    ├── columns: j:1
  │    │    ├── stats: [rows=1000, distinct(1)=100, null(1)=10]
- │    │    ├── cost: 216.009998
+ │    │    ├── cost: 110.009999
  │    │    ├── limit hint: 100.00
  │    │    └── prune: (1)
  │    └── filters
@@ -348,20 +348,20 @@ limit
  ├── cardinality: [0 - 1]
  ├── immutable
  ├── stats: [rows=1]
- ├── cost: 14.7
+ ├── cost: 9.4
  ├── key: ()
  ├── fd: ()-->(1)
  ├── select
  │    ├── columns: j:1
  │    ├── immutable
  │    ├── stats: [rows=1, distinct(1)=1, null(1)=1]
- │    ├── cost: 14.68
+ │    ├── cost: 9.38
  │    ├── fd: ()-->(1)
  │    ├── limit hint: 1.00
  │    ├── scan tj
  │    │    ├── columns: j:1
  │    │    ├── stats: [rows=5, distinct(1)=4, null(1)=1]
- │    │    ├── cost: 14.61
+ │    │    ├── cost: 9.31
  │    │    ├── limit hint: 5.00
  │    │    └── prune: (1)
  │    └── filters

--- a/pkg/sql/opt/optgen/exprgen/testdata/limit
+++ b/pkg/sql/opt/optgen/exprgen/testdata/limit
@@ -14,13 +14,13 @@ limit
  ├── internal-ordering: +1
  ├── cardinality: [0 - 10]
  ├── stats: [rows=10]
- ├── cost: 25.12
+ ├── cost: 14.62
  ├── prune: (2)
  ├── interesting orderings: (+1,+2)
  ├── scan t.public.abc@ab
  │    ├── columns: t.public.abc.a:1(int) t.public.abc.b:2(int)
  │    ├── stats: [rows=1000]
- │    ├── cost: 25.01
+ │    ├── cost: 14.51
  │    ├── ordering: +1
  │    ├── limit hint: 10.00
  │    ├── prune: (1,2)

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -116,10 +116,6 @@ const (
 	// See joinreader.go.
 	joinReaderBatchSize = 100.0
 
-	// In the case of a limit hint, a scan will read this multiple of the expected
-	// number of rows. See scanNode.limitHint.
-	scanSoftLimitMultiplier = 2.0
-
 	// latencyCostFactor represents the throughput impact of doing scans on an
 	// index that may be remotely located in a different locality. If latencies
 	// are higher, then overall cluster throughput will suffer somewhat, as there
@@ -615,7 +611,7 @@ func (c *coster) computeScanCost(scan *memo.ScanExpr, required *physical.Require
 	}
 
 	if required.LimitHint != 0 {
-		rowCount = math.Min(rowCount, required.LimitHint*scanSoftLimitMultiplier)
+		rowCount = math.Min(rowCount, required.LimitHint)
 	}
 
 	if ordering.ScanIsReverse(scan, &required.Ordering) {

--- a/pkg/sql/opt/xform/testdata/coster/join
+++ b/pkg/sql/opt/xform/testdata/coster/join
@@ -235,25 +235,25 @@ limit
  ├── columns: k:1!null i:2 s:3 d:4!null x:6!null z:7!null
  ├── cardinality: [0 - 6000]
  ├── stats: [rows=6000]
- ├── cost: 47174.55
+ ├── cost: 42964.05
  ├── fd: (1)-->(2-4), (1)==(7), (7)==(1)
  ├── inner-join (lookup a)
  │    ├── columns: k:1!null i:2 s:3 d:4!null x:6!null z:7!null
  │    ├── key columns: [7] = [1]
  │    ├── lookup columns are key
  │    ├── stats: [rows=10000, distinct(1)=1000, null(1)=0, distinct(7)=1000, null(7)=0]
- │    ├── cost: 47114.54
+ │    ├── cost: 42904.04
  │    ├── fd: (1)-->(2-4), (1)==(7), (7)==(1)
  │    ├── limit hint: 6000.00
  │    ├── select
  │    │    ├── columns: x:6!null z:7!null
  │    │    ├── stats: [rows=10000, distinct(6)=1000, null(6)=0, distinct(7)=1000, null(7)=0]
- │    │    ├── cost: 10574.53
+ │    │    ├── cost: 6364.03
  │    │    ├── limit hint: 6000.00
  │    │    ├── scan b
  │    │    │    ├── columns: x:6 z:7!null
  │    │    │    ├── stats: [rows=10000, distinct(6)=1000, null(6)=0, distinct(7)=1000, null(7)=0]
- │    │    │    ├── cost: 10514.51
+ │    │    │    ├── cost: 6304.01
  │    │    │    └── limit hint: 6000.00
  │    │    └── filters
  │    │         └── (x:6 > 0) AND (x:6 <= 5000) [outer=(6), constraints=(/6: [/1 - /5000]; tight)]
@@ -270,25 +270,25 @@ limit
  ├── columns: k:1!null i:2 s:3 d:4!null x:6!null z:7!null
  ├── cardinality: [0 - 5950]
  ├── stats: [rows=5950]
- ├── cost: 47174.05
+ ├── cost: 42963.55
  ├── fd: (1)-->(2-4), (1)==(7), (7)==(1)
  ├── inner-join (lookup a)
  │    ├── columns: k:1!null i:2 s:3 d:4!null x:6!null z:7!null
  │    ├── key columns: [7] = [1]
  │    ├── lookup columns are key
  │    ├── stats: [rows=10000, distinct(1)=1000, null(1)=0, distinct(7)=1000, null(7)=0]
- │    ├── cost: 47114.54
+ │    ├── cost: 42904.04
  │    ├── fd: (1)-->(2-4), (1)==(7), (7)==(1)
  │    ├── limit hint: 5950.00
  │    ├── select
  │    │    ├── columns: x:6!null z:7!null
  │    │    ├── stats: [rows=10000, distinct(6)=1000, null(6)=0, distinct(7)=1000, null(7)=0]
- │    │    ├── cost: 10574.53
+ │    │    ├── cost: 6364.03
  │    │    ├── limit hint: 6000.00
  │    │    ├── scan b
  │    │    │    ├── columns: x:6 z:7!null
  │    │    │    ├── stats: [rows=10000, distinct(6)=1000, null(6)=0, distinct(7)=1000, null(7)=0]
- │    │    │    ├── cost: 10514.51
+ │    │    │    ├── cost: 6304.01
  │    │    │    └── limit hint: 6000.00
  │    │    └── filters
  │    │         └── (x:6 > 0) AND (x:6 <= 5000) [outer=(6), constraints=(/6: [/1 - /5000]; tight)]
@@ -347,7 +347,7 @@ limit
  ├── columns: id:1!null sender_id:2!null receiver_id:3!null amount:4!null creation_date:5!null last_update:6 schedule_date:7 status:8 comment:9 linked_trans_id:10 c1:11 c2:12 c3:13 id:15!null name:16!null gender:17 email:18 first_name:19 last_name:20 creation_date:21!null situation:22 balance:23!null is_blocked:24 id:26!null name:27!null gender:28 email:29 first_name:30 last_name:31 creation_date:32!null situation:33 balance:34!null is_blocked:35
  ├── cardinality: [0 - 10]
  ├── stats: [rows=10]
- ├── cost: 2364.51
+ ├── cost: 2112.51
  ├── key: (1)
  ├── fd: (1)-->(2-13), (15)-->(16-24), (2)==(15), (15)==(2), (26)-->(27-35), (3)==(26), (26)==(3)
  ├── inner-join (lookup wallet [as=r])
@@ -355,7 +355,7 @@ limit
  │    ├── key columns: [3] = [26]
  │    ├── lookup columns are key
  │    ├── stats: [rows=980.1, distinct(3)=98.9950071, null(3)=0, distinct(26)=98.9950071, null(26)=0]
- │    ├── cost: 2364.4
+ │    ├── cost: 2112.4
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-13), (15)-->(16-24), (2)==(15), (15)==(2), (26)-->(27-35), (3)==(26), (26)==(3)
  │    ├── limit hint: 10.00
@@ -364,14 +364,14 @@ limit
  │    │    ├── key columns: [2] = [15]
  │    │    ├── lookup columns are key
  │    │    ├── stats: [rows=990, distinct(1)=628.605476, null(1)=0, distinct(2)=99, null(2)=0, distinct(3)=99.9950071, null(3)=9.9, distinct(4)=99.9950071, null(4)=0, distinct(5)=99.9950071, null(5)=0, distinct(15)=99, null(15)=0, distinct(16)=99.9950071, null(16)=0, distinct(21)=99.9950071, null(21)=0, distinct(23)=99.9950071, null(23)=0]
- │    │    ├── cost: 1745.6
+ │    │    ├── cost: 1493.6
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-13), (15)-->(16-24), (2)==(15), (15)==(2)
  │    │    ├── limit hint: 100.00
  │    │    ├── scan transaction [as=t]
  │    │    │    ├── columns: t.id:1!null sender_id:2 receiver_id:3 amount:4!null t.creation_date:5!null last_update:6 schedule_date:7 status:8 comment:9 linked_trans_id:10 c1:11 c2:12 c3:13
  │    │    │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=100, null(2)=10, distinct(3)=100, null(3)=10, distinct(4)=100, null(4)=0, distinct(5)=100, null(5)=0]
- │    │    │    ├── cost: 508.01
+ │    │    │    ├── cost: 256.01
  │    │    │    ├── key: (1)
  │    │    │    ├── fd: (1)-->(2-13)
  │    │    │    └── limit hint: 200.00
@@ -725,7 +725,7 @@ project
  ├── columns: w:1!null x:2!null y:3!null z:4!null  [hidden: d:9!null]
  ├── cardinality: [0 - 10]
  ├── stats: [rows=10]
- ├── cost: 703.94172
+ ├── cost: 595.94172
  ├── key: (9)
  ├── fd: ()-->(1,2), (3)-->(4,9), (9)-->(3,4)
  ├── ordering: +9 opt(1,2) [actual: +9]
@@ -734,7 +734,7 @@ project
       ├── internal-ordering: +9 opt(1,2,6,7)
       ├── cardinality: [0 - 10]
       ├── stats: [rows=10]
-      ├── cost: 703.83172
+      ├── cost: 595.83172
       ├── key: (8)
       ├── fd: ()-->(1,2,6,7), (3)-->(4), (8)-->(9), (9)-->(8), (1)==(6), (6)==(1), (2)==(7), (7)==(2), (3)==(8), (8)==(3)
       ├── ordering: +9 opt(1,2,6,7) [actual: +9]
@@ -743,7 +743,7 @@ project
       │    ├── key columns: [6 7 8] = [1 2 3]
       │    ├── lookup columns are key
       │    ├── stats: [rows=50048.8759, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=2500, null(3)=0, distinct(6)=1, null(6)=0, distinct(7)=1, null(7)=0, distinct(8)=2500, null(8)=0]
-      │    ├── cost: 703.72172
+      │    ├── cost: 595.72172
       │    ├── key: (8)
       │    ├── fd: ()-->(1,2,6,7), (3)-->(4), (8)-->(9), (9)-->(8), (1)==(6), (6)==(1), (2)==(7), (7)==(2), (3)==(8), (8)==(3)
       │    ├── ordering: +9 opt(1,2,6,7) [actual: +9]
@@ -752,7 +752,7 @@ project
       │    │    ├── columns: a:6!null b:7!null c:8!null d:9!null
       │    │    ├── constraint: /6/7/9: [/'foo'/'2ab23800-06b1-4e19-a3bb-df3768b808d2' - /'foo'/'2ab23800-06b1-4e19-a3bb-df3768b808d2']
       │    │    ├── stats: [rows=125000, distinct(6)=1, null(6)=0, distinct(7)=1, null(7)=0, distinct(8)=24975.5859, null(8)=0, distinct(9)=93750, null(9)=0]
-      │    │    ├── cost: 220.01
+      │    │    ├── cost: 112.01
       │    │    ├── key: (8)
       │    │    ├── fd: ()-->(6,7), (8)-->(9), (9)-->(8)
       │    │    ├── ordering: +9 opt(6,7) [actual: +9]

--- a/pkg/sql/opt/xform/testdata/coster/scan
+++ b/pkg/sql/opt/xform/testdata/coster/scan
@@ -38,13 +38,13 @@ limit
  ├── columns: k:1!null i:2!null s:3 d:4!null
  ├── cardinality: [0 - 20]
  ├── stats: [rows=20]
- ├── cost: 317.097143
+ ├── cost: 162.811429
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  ├── select
  │    ├── columns: k:1!null i:2!null s:3 d:4!null
  │    ├── stats: [rows=4666.66667, distinct(1)=4666.66667, null(1)=0, distinct(2)=5, null(2)=0, distinct(1,2)=4666.66667, null(1,2)=0]
- │    ├── cost: 316.887143
+ │    ├── cost: 162.601429
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
  │    ├── limit hint: 20.00
@@ -52,7 +52,7 @@ limit
  │    │    ├── columns: k:1!null i:2 s:3 d:4!null
  │    │    ├── constraint: /1: [/6 - ]
  │    │    ├── stats: [rows=33333.3333, distinct(1)=33333.3333, null(1)=0]
- │    │    ├── cost: 312.581429
+ │    │    ├── cost: 158.295714
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-4)
  │    │    └── limit hint: 142.86
@@ -69,14 +69,14 @@ limit
  ├── columns: k:1!null i:2!null s:3 d:4!null
  ├── cardinality: [0 - 20]
  ├── stats: [rows=20]
- ├── cost: 56.4748066
+ ├── cost: 32.6074033
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  ├── select
  │    ├── columns: k:1!null i:2!null s:3 d:4!null
  │    ├── cardinality: [0 - 450]
  │    ├── stats: [rows=407.25, distinct(1)=407.25, null(1)=0, distinct(2)=5, null(2)=0, distinct(1,2)=407.25, null(1,2)=0]
- │    ├── cost: 56.2648066
+ │    ├── cost: 32.3974033
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
  │    ├── limit hint: 20.00
@@ -85,7 +85,7 @@ limit
  │    │    ├── constraint: /1: [/1 - /450]
  │    │    ├── cardinality: [0 - 450]
  │    │    ├── stats: [rows=450, distinct(1)=450, null(1)=0]
- │    │    ├── cost: 51.7448066
+ │    │    ├── cost: 27.8774033
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-4)
  │    │    └── limit hint: 22.10

--- a/pkg/sql/opt/xform/testdata/coster/select
+++ b/pkg/sql/opt/xform/testdata/coster/select
@@ -54,28 +54,28 @@ project
  ├── cardinality: [0 - 10]
  ├── immutable
  ├── stats: [rows=10]
- ├── cost: 285.159091
+ ├── cost: 190.613636
  ├── key: (1)
  └── limit
       ├── columns: id:1!null geog:2!null
       ├── cardinality: [0 - 10]
       ├── immutable
       ├── stats: [rows=10]
-      ├── cost: 285.049091
+      ├── cost: 190.503636
       ├── key: (1)
       ├── fd: (1)-->(2)
       ├── select
       │    ├── columns: id:1!null geog:2!null
       │    ├── immutable
       │    ├── stats: [rows=55000, distinct(2)=50000, null(2)=0]
-      │    ├── cost: 284.939091
+      │    ├── cost: 190.393636
       │    ├── key: (1)
       │    ├── fd: (1)-->(2)
       │    ├── limit hint: 10.00
       │    ├── scan g
       │    │    ├── columns: id:1!null geog:2
       │    │    ├── stats: [rows=500000, distinct(1)=500000, null(1)=0, distinct(2)=50000, null(2)=5000]
-      │    │    ├── cost: 193.100909
+      │    │    ├── cost: 98.5554545
       │    │    ├── key: (1)
       │    │    ├── fd: (1)-->(2)
       │    │    └── limit hint: 90.91

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -498,7 +498,7 @@ memo (optimized, ~5KB, required=[presentation: min:6])
  ├── G2: (scan abc,cols=(1))
  │    ├── [ordering: +1] [limit hint: 1.00]
  │    │    ├── best: (scan abc,cols=(1))
- │    │    └── cost: 6.11
+ │    │    └── cost: 5.06
  │    └── []
  │         ├── best: (scan abc,cols=(1))
  │         └── cost: 1064.51
@@ -560,7 +560,7 @@ memo (optimized, ~5KB, required=[presentation: max:6])
  ├── G2: (scan abc,cols=(1))
  │    ├── [ordering: -1] [limit hint: 1.00]
  │    │    ├── best: (scan abc,rev,cols=(1))
- │    │    └── cost: 6.13
+ │    │    └── cost: 5.06
  │    └── []
  │         ├── best: (scan abc,cols=(1))
  │         └── cost: 1064.51

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -247,12 +247,12 @@ memo (optimized, ~7KB, required=[presentation: s:4])
  ├── G2: (select G4 G5) (scan a@s_idx,cols=(4),constrained) (scan a@si_idx,cols=(4),constrained)
  │    └── [limit hint: 1.00]
  │         ├── best: (scan a@s_idx,cols=(4),constrained)
- │         └── cost: 6.11
+ │         └── cost: 5.06
  ├── G3: (const 1)
  ├── G4: (scan a,cols=(4)) (scan a@s_idx,cols=(4)) (scan a@si_idx,cols=(4))
  │    └── [limit hint: 100.00]
  │         ├── best: (scan a@s_idx,cols=(4))
- │         └── cost: 214.01
+ │         └── cost: 109.01
  ├── G5: (filters G6)
  ├── G6: (eq G7 G8)
  ├── G7: (variable s)
@@ -637,7 +637,7 @@ EliminateProject
               └── 5
 ================================================================================
 GenerateIndexScans
-  Cost: 4078.46
+  Cost: 3556.51
 ================================================================================
    explain
     ├── columns: info:6
@@ -709,7 +709,7 @@ GenerateZigzagJoins (no changes)
 --------------------------------------------------------------------------------
 ================================================================================
 Final best expression
-  Cost: 4078.46
+  Cost: 3556.51
 ================================================================================
   explain
    ├── columns: info:6

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -64,7 +64,7 @@ memo (optimized, ~3KB, required=[presentation: k:1,f:3] [ordering: -1])
  ├── G2: (scan a,cols=(1,3)) (scan a@s_idx,cols=(1,3))
  │    ├── [ordering: -1] [limit hint: 10.00]
  │    │    ├── best: (scan a,rev,cols=(1,3))
- │    │    └── cost: 26.27
+ │    │    └── cost: 15.04
  │    └── []
  │         ├── best: (scan a@s_idx,cols=(1,3))
  │         └── cost: 1074.61

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -195,17 +195,6 @@ func (n *scanNode) disableBatchLimit() {
 	n.softLimit = 0
 }
 
-func (n *scanNode) limitHint() int64 {
-	var limitHint int64
-	if n.hardLimit != 0 {
-		limitHint = n.hardLimit
-	} else {
-		// Read a multiple of the limit when the limit is "soft" to avoid needing a second batch.
-		limitHint = n.softLimit * 2
-	}
-	return limitHint
-}
-
 // Initializes a scanNode with a table descriptor.
 func (n *scanNode) initTable(
 	ctx context.Context,

--- a/pkg/sql/scan_test.go
+++ b/pkg/sql/scan_test.go
@@ -184,27 +184,3 @@ func TestScanBatches(t *testing.T) {
 		})
 	}
 }
-
-func TestKVLimitHint(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	testCases := []struct {
-		hardLimit int64
-		softLimit int64
-		expected  int64
-	}{
-		{hardLimit: 0, softLimit: 0, expected: 0},
-		{hardLimit: 0, softLimit: 1, expected: 2},
-		{hardLimit: 0, softLimit: 23, expected: 46},
-		{hardLimit: 1, softLimit: 0, expected: 1},
-		{hardLimit: 1, softLimit: 23, expected: 1},
-		{hardLimit: 5, softLimit: 23, expected: 5},
-	}
-	for _, tc := range testCases {
-		sn := scanNode{hardLimit: tc.hardLimit, softLimit: tc.softLimit}
-		if limitHint := sn.limitHint(); limitHint != tc.expected {
-			t.Errorf("%+v: got %d", tc, limitHint)
-		}
-	}
-}


### PR DESCRIPTION
Backport 2/2 commits from #63101.

/cc @cockroachdb/release

---

**colfetcher,execinfra: use soft limit for sizing batches**

Previously, we would use the limit hint for sizing batches only if the
estimated row count wasn't available. There is another scenario where
the hint should take precedence - when we have a soft limit: in such
scenario it is beneficial to size the original batch up to that soft
limit. The soft limit is present when it is smaller than the estimated
row count.

Additionally, this commit removes some ad-hoc logic when updating the
limit hint in the execution engine where we artificially increased the
hint so that in the row-by-row engine we blocked the reader in some
cases. That logic doesn't apply to the vectorized engine which is now
the default and only makes the hint imprecise, so it is now removed.

Release note: None

**sql,xform: remove no longer used scanNode.limitHint**

This function hasn't been used for a while now, so this commit removes
it. Accordingly, the 2.0 multiple is removed during the costing of scans
with soft limits.

Release note: None
