### PR TITLE
logictest: compare floating point values approximately on s390x

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -265,6 +265,7 @@ ALL_TESTS = [
     "//pkg/storage/enginepb:enginepb_test",
     "//pkg/storage/metamorphic:metamorphic_test",
     "//pkg/storage:storage_test",
+    "//pkg/testutils/floatcmp:floatcmp_test",
     "//pkg/testutils/keysutils:keysutils_test",
     "//pkg/testutils/lint/passes/fmtsafe:fmtsafe_test",
     "//pkg/testutils/lint/passes/forbiddenmethod:forbiddenmethod_test",

--- a/pkg/sql/logictest/BUILD.bazel
+++ b/pkg/sql/logictest/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/sql/sessiondata",
         "//pkg/sql/stats",
         "//pkg/testutils",
+        "//pkg/testutils/floatcmp",
         "//pkg/testutils/physicalplanutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",

--- a/pkg/sql/logictest/logic_test.go
+++ b/pkg/sql/logictest/logic_test.go
@@ -36,7 +36,8 @@ func TestSqlLiteLogic(t *testing.T) {
 	RunSQLLiteLogicTest(t, "" /* configOverride */)
 }
 
-// TestFloatsMatch is a unit test for floatsMatch() function.
+// TestFloatsMatch is a unit test for floatsMatch() and floatsMatchApprox()
+// functions.
 func TestFloatsMatch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	for _, tc := range []struct {
@@ -60,7 +61,15 @@ func TestFloatsMatch(t *testing.T) {
 			t.Fatal(err)
 		}
 		if match != tc.match {
-			t.Fatalf("wrong result on %v", tc)
+			t.Fatalf("floatsMatch: wrong result on %v", tc)
+		}
+
+		match, err = floatsMatchApprox(tc.f1, tc.f2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if match != tc.match {
+			t.Fatalf("floatsMatchApprox: wrong result on %v", tc)
 		}
 	}
 }

--- a/pkg/testutils/floatcmp/BUILD.bazel
+++ b/pkg/testutils/floatcmp/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "floatcmp",
+    srcs = ["floatcmp.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/testutils/floatcmp",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_google_go_cmp//cmp",
+        "@com_github_google_go_cmp//cmp/cmpopts",
+    ],
+)
+
+go_test(
+    name = "floatcmp_test",
+    size = "small",
+    srcs = ["floatcmp_test.go"],
+    embed = [":floatcmp"],
+)

--- a/pkg/testutils/floatcmp/floatcmp.go
+++ b/pkg/testutils/floatcmp/floatcmp.go
@@ -1,0 +1,77 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package floatcmp provides functions for determining float values to be equal
+// if they are within a tolerance. It is designed to be used in tests.
+package floatcmp
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+const (
+	// CloseFraction can be used to set a "close" tolerance for the fraction
+	// argument of functions in this package. It should typically be used with
+	// the CloseMargin constant for the margin argument. Its value is taken from
+	// the close tolerances in go's math package.
+	CloseFraction float64 = 1e-14
+
+	// CloseMargin can be used to set a "close" tolerance for the margin
+	// argument of functions in this package. It should typically be used with
+	// the CloseFraction constant for the fraction argument.
+	//
+	// It is set to the square of CloseFraction so it is only used when the
+	// smaller of the absolute expected and actual values is in the range:
+	//
+	//   -CloseFraction <= 0 <= CloseFraction
+	//
+	// CloseMargin is greater than 0 otherwise if either expected or actual were
+	// 0 the calculated tolerance from the fraction would be 0.
+	CloseMargin float64 = CloseFraction * CloseFraction
+)
+
+// EqualApprox reports whether expected and actual are deeply equal with the
+// following modifications for float64 and float32 types:
+//
+// • If both expected and actual are not NaN or infinate, they are equal within
+// the larger of the relative fraction or absolute margin calculated from the
+// fraction and margin arguments.
+//
+// • If both expected and actual are NaN, they are equal.
+//
+// Both fraction and margin must be non-negative.
+//
+// fraction is used to calculate the tolerance as a relative fraction of the
+// smaller of expected and actual:
+//
+//   tolerance_frac = (fraction * min(|expected|, |actual|))
+//
+// margin specifies the tolerance as an absolute value:
+//
+//   tolerance_marg = margin
+//
+// The tolerance used to determine approximate equality is:
+//
+//   tolerance = max(tolerance_frac, tolerance_marg)
+//
+// To use only one of fraction or margin, set the other to 0.
+//
+// For comparing expected and actual values in tests, typically the fraction
+// should be set to the smallest relative fraction to tolerate. The margin
+// should be set to a much smaller value so that it is only used when:
+//
+//   (fraction * min(|expected|, |actual|)) < margin
+//
+// which allows expected and actual to be approximately equal within margin when
+// either is 0.
+func EqualApprox(expected interface{}, actual interface{}, fraction float64, margin float64) bool {
+	return cmp.Equal(expected, actual, cmpopts.EquateApprox(fraction, margin), cmpopts.EquateNaNs())
+}

--- a/pkg/testutils/floatcmp/floatcmp_test.go
+++ b/pkg/testutils/floatcmp/floatcmp_test.go
@@ -1,0 +1,158 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package floatcmp
+
+import (
+	"math"
+	"testing"
+)
+
+// EqualApprox takes an interface, allowing it to compare equality of both
+// primitive data types and structs. We want to test both cases.
+type (
+	// floatArgs holds the expected and actual values of floating point equality tests.
+	floatArgs struct {
+		expected float64
+		actual   float64
+	}
+
+	// testStruct structs are the values compared in struct equality tests.
+	testStruct struct {
+		X, Y float64
+		I    int
+	}
+
+	// structArgs holds the expected and actual values of struct equality tests.
+	structArgs struct {
+		expected testStruct
+		actual   testStruct
+	}
+
+	// floatTestCase represents a test case for floating point values.
+	floatTestCase struct {
+		name string
+		args floatArgs
+		want bool
+	}
+
+	// structTestCase represents a test case for struct values.
+	structTestCase struct {
+		name string
+		args structArgs
+		want bool
+	}
+)
+
+var floatTests = []floatTestCase{
+	{
+		name: "zeros",
+		args: floatArgs{expected: 0, actual: 0},
+		want: true,
+	},
+	{
+		name: "NaNs",
+		args: floatArgs{expected: math.NaN(), actual: math.NaN()},
+		want: true,
+	},
+	{
+		name: "zero not close to NaN",
+		args: floatArgs{expected: 0, actual: math.NaN()},
+		want: false,
+	},
+	{
+		name: "positive infinities",
+		args: floatArgs{expected: math.Inf(+1), actual: math.Inf(+1)},
+		want: true,
+	},
+	{
+		name: "negative infinities",
+		args: floatArgs{expected: math.Inf(-1), actual: math.Inf(-1)},
+		want: true,
+	},
+	{
+		name: "ones",
+		args: floatArgs{expected: 1, actual: 1},
+		want: true,
+	},
+	{
+		name: "signs",
+		args: floatArgs{expected: 1, actual: -1},
+		want: false,
+	},
+	{
+		name: "different",
+		args: floatArgs{expected: 1, actual: 2},
+		want: false,
+	},
+	{
+		name: "close to zero",
+		args: floatArgs{expected: 0, actual: math.Nextafter(0+CloseMargin, math.Inf(-1))},
+		want: true,
+	},
+	{
+		name: "not close to zero",
+		args: floatArgs{expected: 0, actual: math.Nextafter(0+CloseMargin, math.Inf(+1))},
+		want: false,
+	},
+	{
+		name: "close to CloseFraction",
+		args: floatArgs{expected: CloseFraction, actual: math.Nextafter(CloseFraction+CloseMargin, math.Inf(-1))},
+		want: true,
+	},
+	{
+		name: "not close to CloseFraction",
+		args: floatArgs{expected: CloseFraction, actual: math.Nextafter(CloseFraction+CloseMargin, math.Inf(+1))},
+		want: false,
+	},
+	{
+		name: "close to one",
+		args: floatArgs{expected: 1, actual: math.Nextafter(1+1*CloseFraction, math.Inf(-1))},
+		want: true,
+	},
+	{
+		name: "not close to one",
+		args: floatArgs{expected: 1, actual: math.Nextafter(1+1*CloseFraction, math.Inf(+1))},
+		want: false,
+	},
+}
+
+// toStructTests transforms an array of floatTestCases into an array of structTestCases by
+// copying the expected and actual values of each floatTestCase into corresponding values
+// in each structTestCase.
+func toStructTests(floatTestCases []floatTestCase) []structTestCase {
+	structTestCases := make([]structTestCase, 0, len(floatTestCases))
+	for _, ft := range floatTestCases {
+		structTestCases = append(structTestCases,
+			structTestCase{
+				name: ft.name + " struct",
+				args: structArgs{expected: testStruct{X: ft.args.expected, Y: ft.args.expected, I: 0}, actual: testStruct{X: ft.args.actual, Y: ft.args.actual, I: 0}},
+				want: ft.want,
+			})
+	}
+	return structTestCases
+}
+
+func TestEqualClose(t *testing.T) {
+	for _, tt := range floatTests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EqualApprox(tt.args.expected, tt.args.actual, CloseFraction, CloseMargin); got != tt.want {
+				t.Errorf("Close(%.16e, %.16e) = %v, want %v", tt.args.expected, tt.args.actual, got, tt.want)
+			}
+		})
+	}
+	for _, tt := range toStructTests(floatTests) {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EqualApprox(tt.args.expected, tt.args.actual, CloseFraction, CloseMargin); got != tt.want {
+				t.Errorf("Close(%.v, %.v) = %v, want %v", tt.args.expected, tt.args.actual, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Overview
On s390x in the std math package and some c-deps, floating point calculations can produce results that differ from the values calculated on amd64. This patch adds a function to compare logictest floating point and decimal values within a small relative margin on s390x. The existing behavior on all other platforms remains the same.

On s390x, there are three main reasons that floating point calculations sometimes give different results:
* the go compiler generates the s390x "fused multiply and add" (FMA) instruction where possible,
* the go math package uses s390x optimized versions of some functions,
* some c libs eg. libgeos, libproj also have platform specific floating point calculation differences.

### Proposal
The motivation for this work is so that users building CRDB on s390x do not need to diagnose tests that fail because of platform dependent floating point differences.

This PR proposes one possible approach to dealing with platform dependent floating point differences. Since development, testing and CI are done on amd64 it keeps the current logic for determining float equality exactly the same. On s390x, it determines values of decimal and float column types (R and F) in query tests to be equal if they are within a tolerance. See the new pkg/testutils/floatcmp package for the implementation of the approximate equality logic and changes in logictest.go to see how it is applied to only s390x.

There are probably other approaches I haven't thought of that would also work. I'd like to use this proposal to start a conversation on how all tests in CRDB that currently fail due to expected floating point differences could eventually be made to pass.

Of course platforms other than s390x may also have differences but I haven't looked at any other platforms. The changes should be easily extendable to other platforms if needed.

### Future Work
The changes in this PR allow the following tests to pass on s390x:
* TestLogic/fakedist-disk/builtin_function/extra_float_digits_3
*  TestLogic/fakedist-metadata/builtin_function/extra_float_digits_3
*  TestLogic/fakedist-vec-off/builtin_function/extra_float_digits_3
*  TestLogic/fakedist/builtin_function/extra_float_digits_3
*  TestLogic/local-spec-planning/builtin_function/extra_float_digits_3
*  TestLogic/local-vec-off/builtin_function/extra_float_digits_3
*  TestLogic/local/builtin_function/extra_float_digits_3

There are about 70 more tests that currently fail due to platform floating point differences on s390x, many are tests of geospatial functions. Assuming we can come up with a good approach, I'd like to continue working on fixes to be submitted in future PRs.

Release note: None