### PR TITLE
release-20.2: release: publish to RedHat should use explicit tag

### DIFF
--- a/build/release/teamcity-publish-redhat-release.sh
+++ b/build/release/teamcity-publish-redhat-release.sh
@@ -6,9 +6,12 @@ source "$(dirname "${0}")/teamcity-support.sh"
 source "$(dirname "${0}")/../shlib.sh"
 
 tc_start_block "Sanity Check"
-# Make sure that the version is a substring of TC branch name (e.g. v20.2.4-57-abcd345)
-# The "-" suffix makes sure we differentiate v20.2.4-57 and v20.2.4-5
-if [[ $TC_BUILD_BRANCH != "${NAME}-"* ]]; then
+# Make sure that the version matches the TeamCity branch name. The TeamCity
+# branch name becomes available only after the new tag is pushed to GitHub by
+# the `teamcity-publish-release.sh` script.
+# In the future, when this script becomes a part of the automated process, we
+# may need to change this check to match the tag used by the process.
+if [[ $TC_BUILD_BRANCH != ${NAME} ]]; then
   echo "Release name \"$NAME\" cannot be built using \"$TC_BUILD_BRANCH\""
   exit 1
 fi


### PR DESCRIPTION
Backport 1/1 commits from #62752.

/cc @cockroachdb/release

---

Previously, the publish to RedHat script was trying to compare the
version passed via TeamCity deploy parameters and TC_BUILD_BRANCH to
prevent using wrong commits for the process.

Apparently, the `$VERSION-$BUILD_NUMBER-$SHORT_SHA` style builds only
appear after we create the tag and start building the next version.

Instead, we can use the branch created after the tag is pushed. The name
doesn't contain any suffixes.

Release note: None

This is a screenshot of how the v20.2.7 publish release looks like.

![image](https://user-images.githubusercontent.com/42865/112896483-72d0e700-90ac-11eb-8843-ce0861a928b7.png)

And this is Publish to RedHat:
![image](https://user-images.githubusercontent.com/42865/112897050-2508ae80-90ad-11eb-873b-aaacfcb97237.png)

