### PR TITLE
rsg_test: remove panic and fmt.Print

### DIFF
--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -121,7 +121,7 @@ func (c *nonCrasher) Error() string {
 	return c.err.Error()
 }
 
-func (db *verifyFormatDB) exec(ctx context.Context, sql string) error {
+func (db *verifyFormatDB) exec(t *testing.T, ctx context.Context, sql string) error {
 	if err := verifyFormat(sql); err != nil {
 		db.verifyFormatErr = err
 		return err
@@ -163,7 +163,7 @@ func (db *verifyFormatDB) exec(ctx context.Context, sql string) error {
 		defer db.mu.Unlock()
 		b := make([]byte, 1024*1024)
 		n := runtime.Stack(b, true)
-		fmt.Printf("%s\n", b[:n])
+		t.Logf("%s\n", b[:n])
 		// Now see if we can execute a SELECT 1. This is useful because sometimes an
 		// exec timeout is because of a slow-executing statement, and other times
 		// it's because the server is completely wedged. This is an automated way
@@ -178,16 +178,19 @@ func (db *verifyFormatDB) exec(ctx context.Context, sql string) error {
 		}()
 		select {
 		case <-time.After(5 * time.Second):
-			fmt.Println("SELECT 1 timeout: probably a wedged server")
+			t.Log("SELECT 1 timeout: probably a wedged server")
 		case err := <-errch:
 			if err != nil {
-				fmt.Println("SELECT 1 execute error:", err)
+				t.Log("SELECT 1 execute error:", err)
 			} else {
-				fmt.Println("SELECT 1 executed successfully: probably a slow statement")
+				t.Log("SELECT 1 executed successfully: probably a slow statement")
 			}
 		}
-		fmt.Printf("timeout: %q. currently executing: %v\n", sql, db.mu.active)
-		panic("statement exec timeout")
+		return &crasher{
+			sql:    sql,
+			err:    errors.Newf("statement exec timeout"),
+			detail: fmt.Sprintf("timeout: %q. currently executing: %v", sql, db.mu.active),
+		}
 	}
 }
 
@@ -221,10 +224,10 @@ func TestRandomSyntaxGeneration(t *testing.T) {
 		}
 		// Recreate the database on every run in case it was dropped or renamed in
 		// a previous run. Should always succeed.
-		if err := db.exec(ctx, `CREATE DATABASE IF NOT EXISTS ident`); err != nil {
+		if err := db.exec(t, ctx, `CREATE DATABASE IF NOT EXISTS ident`); err != nil {
 			return err
 		}
-		return db.exec(ctx, s)
+		return db.exec(t, ctx, s)
 	})
 }
 
@@ -235,7 +238,7 @@ func TestRandomSyntaxSelect(t *testing.T) {
 	const rootStmt = "target_list"
 
 	testRandomSyntax(t, false, "ident", func(ctx context.Context, db *verifyFormatDB, r *rsg.RSG) error {
-		return db.exec(ctx, `CREATE DATABASE IF NOT EXISTS ident; CREATE TABLE IF NOT EXISTS ident.ident (ident decimal);`)
+		return db.exec(t, ctx, `CREATE DATABASE IF NOT EXISTS ident; CREATE TABLE IF NOT EXISTS ident.ident (ident decimal);`)
 	}, func(ctx context.Context, db *verifyFormatDB, r *rsg.RSG) error {
 		targets := r.Generate(rootStmt, 300)
 		var where, from string
@@ -247,7 +250,7 @@ func TestRandomSyntaxSelect(t *testing.T) {
 			from = "FROM ident"
 		}
 		s := fmt.Sprintf("SELECT %s %s %s", targets, from, where)
-		return db.exec(ctx, s)
+		return db.exec(t, ctx, s)
 	})
 }
 
@@ -336,7 +339,7 @@ func TestRandomSyntaxFunctions(t *testing.T) {
 			limit = " LIMIT 100"
 		}
 		s := fmt.Sprintf("SELECT %s(%s) %s", nb.name, strings.Join(args, ", "), limit)
-		return db.exec(ctx, s)
+		return db.exec(t, ctx, s)
 	})
 }
 
@@ -349,7 +352,7 @@ func TestRandomSyntaxFuncCommon(t *testing.T) {
 	testRandomSyntax(t, false, "defaultdb", nil, func(ctx context.Context, db *verifyFormatDB, r *rsg.RSG) error {
 		expr := r.Generate(rootStmt, 30)
 		s := fmt.Sprintf("SELECT %s", expr)
-		return db.exec(ctx, s)
+		return db.exec(t, ctx, s)
 	})
 }
 
@@ -367,13 +370,13 @@ func TestRandomSyntaxSchemaChangeDatabase(t *testing.T) {
 	}
 
 	testRandomSyntax(t, true, "ident", func(ctx context.Context, db *verifyFormatDB, r *rsg.RSG) error {
-		return db.exec(ctx, `
+		return db.exec(t, ctx, `
 			CREATE DATABASE ident;
 		`)
 	}, func(ctx context.Context, db *verifyFormatDB, r *rsg.RSG) error {
 		n := r.Intn(len(roots))
 		s := r.Generate(roots[n], 30)
-		return db.exec(ctx, s)
+		return db.exec(t, ctx, s)
 	})
 }
 
@@ -386,14 +389,14 @@ func TestRandomSyntaxSchemaChangeColumn(t *testing.T) {
 	}
 
 	testRandomSyntax(t, true, "ident", func(ctx context.Context, db *verifyFormatDB, r *rsg.RSG) error {
-		return db.exec(ctx, `
+		return db.exec(t, ctx, `
 			CREATE DATABASE ident;
 			CREATE TABLE ident.ident (ident decimal);
 		`)
 	}, func(ctx context.Context, db *verifyFormatDB, r *rsg.RSG) error {
 		n := r.Intn(len(roots))
 		s := fmt.Sprintf("ALTER TABLE ident.ident %s", r.Generate(roots[n], 500))
-		return db.exec(ctx, s)
+		return db.exec(t, ctx, s)
 	})
 }
 
@@ -533,23 +536,23 @@ func TestRandomSyntaxSQLSmith(t *testing.T) {
 		setups := []string{"rand-tables", "seed"}
 		for _, s := range setups {
 			randTables := sqlsmith.Setups[s](r.Rnd)
-			if err := db.exec(ctx, randTables); err != nil {
+			if err := db.exec(t, ctx, randTables); err != nil {
 				return err
 			}
 			tableStmts = append(tableStmts, randTables)
-			fmt.Printf("%s;\n", randTables)
+			t.Logf("%s;", randTables)
 		}
 		var err error
 		smither, err = sqlsmith.NewSmither(db.db, r.Rnd, sqlsmith.DisableMutations())
 		return err
 	}, func(ctx context.Context, db *verifyFormatDB, r *rsg.RSG) error {
 		s := smither.Generate()
-		err := db.exec(ctx, s)
+		err := db.exec(t, ctx, s)
 		if c := (*crasher)(nil); errors.As(err, &c) {
-			if err := db.exec(ctx, "USE defaultdb"); err != nil {
+			if err := db.exec(t, ctx, "USE defaultdb"); err != nil {
 				t.Fatalf("couldn't reconnect to db after crasher: %v", c)
 			}
-			fmt.Printf("CRASHER:\ncaused by: %s\n\nSTATEMENT:\n%s;\n\nserver stacktrace:\n%s\n\n", c.Error(), s, c.detail)
+			t.Logf("CRASHER:\ncaused by: %s\n\nSTATEMENT:\n%s;\n\nserver stacktrace:\n%s\n", c.Error(), s, c.detail)
 			return c
 		}
 		if err == nil {
@@ -561,7 +564,7 @@ func TestRandomSyntaxSQLSmith(t *testing.T) {
 			shouldLogErr = false
 		}
 		if testing.Verbose() && shouldLogErr {
-			fmt.Printf("ERROR: %s\ncaused by:\n%s;\n\n", err, s)
+			t.Logf("ERROR: %s\ncaused by:\n%s;\n", err, s)
 		}
 		return err
 	})
@@ -569,11 +572,11 @@ func TestRandomSyntaxSQLSmith(t *testing.T) {
 		smither.Close()
 	}
 
-	fmt.Printf("To reproduce, use schema:\n\n")
+	t.Logf("To reproduce, use schema:\n")
 	for _, stmt := range tableStmts {
-		fmt.Printf("%s;", stmt)
+		t.Logf("%s;", stmt)
 	}
-	fmt.Printf("\n")
+	t.Log()
 }
 
 func TestRandomDatumRoundtrip(t *testing.T) {
@@ -725,7 +728,7 @@ func testRandomSyntax(
 			case <-time.After(5 * time.Second):
 			}
 			countsMu.Lock()
-			fmt.Printf("%v of %v: %d executions, %d successful\n",
+			t.Logf("%v of %v: %d executions, %d successful",
 				timeutil.Since(start).Round(time.Second),
 				*flagRSGTime,
 				countsMu.total,


### PR DESCRIPTION
Instead, use a handle-able error and t.Log. This should help with an
issue where the test fails but leaves behind no useful logs.

Release note: None