### PR TITLE
bazel: introduce bazci to stage artifacts from the build in /artifacts

### DIFF
--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -59,3 +59,7 @@ RUN apt-get purge -y \
 RUN rm -rf /tmp/* /var/lib/apt/lists/*
 
 RUN ln -s /usr/bin/bazel-3.6.0 /usr/bin/bazel
+
+COPY entrypoint.sh /usr/bin
+ENTRYPOINT ["/usr/bin/entrypoint.sh"]
+CMD ["/usr/bin/bash"]

--- a/build/bazelbuilder/entrypoint.sh
+++ b/build/bazelbuilder/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/bash
+# Without this `umask`, the image will create build artifacts that the host
+# won't have permission to delete (which can pollute the workspace with files
+# that can't be cleaned up).
+umask 0000
+exec "$@"

--- a/build/bazelutil/bazelbuild.sh
+++ b/build/bazelutil/bazelbuild.sh
@@ -2,6 +2,5 @@
 
 set -xeuo pipefail
 
-bazel build //pkg/cmd/cockroach-short
-# Stage artifacts.
-cp $(bazel info bazel-bin)/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short /artifacts
+bazel build //pkg/cmd/bazci
+$(bazel info bazel-bin)/pkg/cmd/bazci/bazci_/bazci build //pkg/cmd/cockroach-short

--- a/build/bazelutil/bazeltest.sh
+++ b/build/bazelutil/bazeltest.sh
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 
-set -xuo pipefail
+set -xeuo pipefail
 
-bazel test //pkg:small_tests //pkg:medium_tests //pkg:large_tests //pkg:enormous_tests
-EXIT_CODE=$?
-# Stage artifacts.
-cp -r $(bazel info bazel-testlogs) /artifacts/bazel-testlogs
-find /artifacts/bazel-testlogs -type f -exec chmod 666 {} +
-find /artifacts/bazel-testlogs -type d -exec chmod 777 {} +
-exit $EXIT_CODE
+bazel build //pkg/cmd/bazci
+$(bazel info bazel-bin)/pkg/cmd/bazci/bazci_/bazci test //pkg:small_tests //pkg:medium_tests //pkg:large_tests //pkg:enormous_tests

--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -1,4 +1,4 @@
-BAZEL_IMAGE=cockroachdb/bazel:20210401-180049
+BAZEL_IMAGE=cockroachdb/bazel:20210408-113636
 
 # Call `run_bazel $NAME_OF_SCRIPT` to start an appropriately-configured Docker
 # container with the `cockroachdb/bazel` image running the given script.

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -41,6 +41,7 @@ ALL_TESTS = [
     "//pkg/cli/exit:exit_test",
     "//pkg/cli:cli_test",
     "//pkg/clusterversion:clusterversion_test",
+    "//pkg/cmd/bazci:bazci_test",
     "//pkg/cmd/cmpconn:cmpconn_test",
     "//pkg/cmd/cockroach-oss:cockroach-oss_test",
     "//pkg/cmd/docgen/extract:extract_test",

--- a/pkg/cmd/bazci/BUILD.bazel
+++ b/pkg/cmd/bazci/BUILD.bazel
@@ -1,0 +1,36 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "bazci_lib",
+    srcs = [
+        "bazci.go",
+        "main.go",
+        "watch.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/pkg/cmd/bazci",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_spf13_cobra//:cobra",
+    ],
+)
+
+go_binary(
+    name = "bazci",
+    embed = [":bazci_lib"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "bazci_test",
+    srcs = [
+        "bazci_test.go",
+        "watch_test.go",
+    ],
+    data = glob(["testdata/**"]),
+    embed = [":bazci_lib"],
+    deps = [
+        "//pkg/testutils",
+        "@com_github_stretchr_testify//assert",
+    ],
+)

--- a/pkg/cmd/bazci/bazci.go
+++ b/pkg/cmd/bazci/bazci.go
@@ -1,0 +1,204 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+package main
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"github.com/spf13/cobra"
+)
+
+const (
+	buildSubcmd = "build"
+	testSubcmd  = "test"
+)
+
+var (
+	artifactsDir string
+
+	rootCmd = &cobra.Command{
+		Use:   "bazci",
+		Short: "A glue binary for making Bazel usable in Teamcity",
+		Long: `bazci is glue code to make debugging Bazel builds and
+tests in Teamcity as painless as possible.`,
+		Args: func(cmd *cobra.Command, args []string) error {
+			_, err := parseArgs(args, cmd.ArgsLenAtDash())
+			return err
+		},
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE:          bazciImpl,
+	}
+)
+
+func init() {
+	rootCmd.Flags().StringVar(
+		&artifactsDir,
+		"artifacts_dir",
+		"/artifacts",
+		"path where artifacts should be staged")
+}
+
+// parsedArgs looks basically like the `args` slice that Cobra gives us, but
+// a little more tightly structured.
+// e.g. the args ["test", "//pkg:small_tests", "--" "--verbose_failures"]
+// get converted to parsedArgs {
+//   subcmd: "test",
+//   targets: ["//pkg:small_tests"],
+//   additional: ["--verbose_failures"]
+// }
+type parsedArgs struct {
+	// The subcommand: either "build" or "test".
+	subcmd string
+	// The list of targets being built or tested. May include test suites.
+	targets []string
+	// Additional arguments to pass along to Bazel.
+	additional []string
+}
+
+// Returned by parseArgs on some bad inputs.
+var errUsage = errors.New("At least 2 arguments required (e.g. `bazci build TARGET`)")
+
+// parseArgs converts a raw list of arguments from Cobra to a parsedArgs. The second argument,
+// `argsLenAtDash`, should be the value returned by `cobra.Command.ArgsLenAtDash()`.
+func parseArgs(args []string, argsLenAtDash int) (*parsedArgs, error) {
+	// The minimum number of arguments needed is 2: the first is the
+	// subcommand to run (`build` or `test`), and the second is the
+	// first label (e.g. `//pkg/cmd/cockroach-short`). An arbitrary
+	// number of additional labels can follow.
+	if len(args) < 2 {
+		return nil, errUsage
+	}
+	if args[0] != buildSubcmd && args[0] != testSubcmd {
+		return nil, errors.Newf("First argument must be `build` or `test`; got %v", args[0])
+	}
+	var splitLoc int
+	if argsLenAtDash < 0 {
+		// Cobra sets the value of `ArgsLenAtDash()` to -1 if there's no
+		// dash in the args.
+		splitLoc = len(args)
+	} else if argsLenAtDash < 2 {
+		return nil, errUsage
+	} else {
+		splitLoc = argsLenAtDash
+	}
+	return &parsedArgs{
+		subcmd:     args[0],
+		targets:    args[1:splitLoc],
+		additional: args[splitLoc:],
+	}, nil
+}
+
+// buildInfo captures more specific, granular data about the build or test
+// request. We query bazel for this data before running the build and use it to
+// find output artifacts.
+type buildInfo struct {
+	// Location of the bazel-bin directory.
+	binDir string
+	// Location of the bazel-testlogs directory.
+	testlogsDir string
+	// Expanded list of Go binary targets to be built.
+	goBinaries []string
+	// Expanded list of Go test targets to be run. Test suites are split up
+	// into their component tests and all put in this list, so this may be
+	// considerably longer than the argument list.
+	tests []string
+}
+
+func runBazelReturningStdout(arg ...string) (string, error) {
+	buf, err := exec.Command("bazel", arg...).Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(buf)), nil
+}
+
+func getBuildInfo(args parsedArgs) (buildInfo, error) {
+	binDir, err := runBazelReturningStdout("info", "bazel-bin")
+	if err != nil {
+		return buildInfo{}, err
+	}
+	testlogsDir, err := runBazelReturningStdout("info", "bazel-testlogs")
+	if err != nil {
+		return buildInfo{}, err
+	}
+
+	ret := buildInfo{
+		binDir:      binDir,
+		testlogsDir: testlogsDir,
+	}
+
+	for _, target := range args.targets {
+		output, err := runBazelReturningStdout("query", "--output=label_kind", target)
+		if err != nil {
+			return buildInfo{}, err
+		}
+		// The format of the output is `[kind] rule [full_target_name].
+		outputSplit := strings.Fields(output)
+		if len(outputSplit) != 3 {
+			return buildInfo{}, errors.Newf("Could not parse bazel query output: %v", output)
+		}
+		targetKind := outputSplit[0]
+		fullTarget := outputSplit[2]
+
+		switch targetKind {
+		case "go_binary":
+			ret.goBinaries = append(ret.goBinaries, fullTarget)
+		case "go_test":
+			ret.tests = append(ret.tests, fullTarget)
+		case "test_suite":
+			// Expand the list of tests from the test suite with another query.
+			allTests, err := runBazelReturningStdout("query", "tests("+fullTarget+")")
+			if err != nil {
+				return buildInfo{}, err
+			}
+			ret.tests = append(ret.tests, strings.Fields(allTests)...)
+		default:
+			return buildInfo{}, errors.Newf("Got unexpected target kind %v", targetKind)
+		}
+	}
+
+	return ret, nil
+}
+
+func bazciImpl(cmd *cobra.Command, args []string) error {
+	parsedArgs, err := parseArgs(args, cmd.ArgsLenAtDash())
+	if err != nil {
+		return err
+	}
+
+	info, err := getBuildInfo(*parsedArgs)
+	if err != nil {
+		return err
+	}
+
+	// Run the build in a background thread and ping the `completion`
+	// channel when done.
+	completion := make(chan error)
+	go func() {
+		processArgs := []string{parsedArgs.subcmd}
+		processArgs = append(processArgs, parsedArgs.targets...)
+		processArgs = append(processArgs, parsedArgs.additional...)
+		cmd := exec.Command("bazel", processArgs...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		err := cmd.Start()
+		if err != nil {
+			completion <- err
+			return
+		}
+		completion <- cmd.Wait()
+	}()
+
+	return makeWatcher(completion, info).Watch()
+}

--- a/pkg/cmd/bazci/bazci_test.go
+++ b/pkg/cmd/bazci/bazci_test.go
@@ -1,0 +1,46 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseArgs(t *testing.T) {
+	_, err := parseArgs([]string{}, -1)
+	assert.True(t, errors.Is(err, errUsage))
+	_, err = parseArgs([]string{"build"}, -1)
+	assert.True(t, errors.Is(err, errUsage))
+	_, err = parseArgs([]string{"typo", "target"}, -1)
+	assert.NotNil(t, err)
+	args, err := parseArgs([]string{"build", "target"}, -1)
+	assert.Nil(t, err)
+	assert.Equal(t, parsedArgs{
+		subcmd:     "build",
+		targets:    []string{"target"},
+		additional: []string{}}, *args)
+	args, err = parseArgs([]string{"test", "target1", "target2"}, -1)
+	assert.Nil(t, err)
+	assert.Equal(t, parsedArgs{
+		subcmd:     "test",
+		targets:    []string{"target1", "target2"},
+		additional: []string{}}, *args)
+	// Make sure additional arguments are captured correctly.
+	args, err = parseArgs([]string{"test", "target1", "target2", "--verbose_failures"}, 3)
+	assert.Nil(t, err)
+	assert.Equal(t, parsedArgs{
+		subcmd:     "test",
+		targets:    []string{"target1", "target2"},
+		additional: []string{"--verbose_failures"},
+	}, *args)
+}

--- a/pkg/cmd/bazci/main.go
+++ b/pkg/cmd/bazci/main.go
@@ -1,0 +1,42 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+//
+// bazci is glue code to make debugging Bazel builds and tests in Teamcity as
+// painless as possible.
+//
+// bazci [build|test] \
+//     --artifacts_dir=$ARTIFACTS_DIR targets... -- [command-line options]
+//
+// bazci will invoke a `bazel build` or `bazel test` of all the given targets
+// and stage the resultant build/test artifacts in the given `artifacts_dir`.
+// The build/test artifacts are munged slightly such that TC can easily parse
+// them.
+package main
+
+import (
+	"log"
+	"os"
+	"os/exec"
+)
+
+func main() {
+	log.SetFlags(0)
+	log.SetPrefix("")
+
+	if _, err := exec.LookPath("bazel"); err != nil {
+		log.Printf("ERROR: bazel not found in $PATH")
+		os.Exit(1)
+	}
+
+	if err := rootCmd.Execute(); err != nil {
+		log.Printf("ERROR: %v", err)
+		os.Exit(1)
+	}
+}

--- a/pkg/cmd/bazci/testdata/bazel-bin/pkg/cmd/fake_bin/fake_bin_/fake_bin
+++ b/pkg/cmd/bazci/testdata/bazel-bin/pkg/cmd/fake_bin/fake_bin_/fake_bin
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo hello

--- a/pkg/cmd/bazci/testdata/bazel-testlogs/pkg/rpc/rpc_test/test.log
+++ b/pkg/cmd/bazci/testdata/bazel-testlogs/pkg/rpc/rpc_test/test.log
@@ -1,0 +1,283 @@
+exec ${PAGER:-/usr/bin/less} "$0" || exit 1
+Executing tests from //pkg/rpc:rpc_test
+-----------------------------------------------------------------------------
+=== RUN   TestWrappedServerStream
+--- PASS: TestWrappedServerStream (0.00s)
+=== RUN   TestTenantFromCert
+=== RUN   TestTenantFromCert/10
+=== RUN   TestTenantFromCert/2
+=== RUN   TestTenantFromCert/18446744073709551615
+=== RUN   TestTenantFromCert/system
+=== RUN   TestTenantFromCert/-1
+=== RUN   TestTenantFromCert/0
+=== RUN   TestTenantFromCert/1
+=== RUN   TestTenantFromCert/root
+=== RUN   TestTenantFromCert/other
+=== RUN   TestTenantFromCert/other#01
+=== RUN   TestTenantFromCert/other#02
+=== RUN   TestTenantFromCert/other#03
+--- PASS: TestTenantFromCert (0.00s)
+    --- PASS: TestTenantFromCert/10 (0.00s)
+    --- PASS: TestTenantFromCert/2 (0.00s)
+    --- PASS: TestTenantFromCert/18446744073709551615 (0.00s)
+    --- PASS: TestTenantFromCert/system (0.00s)
+    --- PASS: TestTenantFromCert/-1 (0.00s)
+    --- PASS: TestTenantFromCert/0 (0.00s)
+    --- PASS: TestTenantFromCert/1 (0.00s)
+    --- PASS: TestTenantFromCert/root (0.00s)
+    --- PASS: TestTenantFromCert/other (0.00s)
+    --- PASS: TestTenantFromCert/other#01 (0.00s)
+    --- PASS: TestTenantFromCert/other#02 (0.00s)
+    --- PASS: TestTenantFromCert/other#03 (0.00s)
+=== RUN   TestTenantAuthRequest
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/Batch
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#00
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#01
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#02
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#03
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#04
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#05
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#06
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#07
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#08
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#09
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#10
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#11
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#12
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#13
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#14
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/RangeLookup
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/RangeLookup/#00
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/RangeLookup/#01
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/RangeLookup/#02
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/RangeLookup/#03
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/RangeLookup/#04
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/RangeFeed
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/RangeFeed/#00
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/RangeFeed/#01
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/RangeFeed/#02
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/RangeFeed/#03
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/RangeFeed/#04
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/RangeFeed/#05
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/RangeFeed/#06
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/GossipSubscription
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/GossipSubscription/#00
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/GossipSubscription/#01
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/GossipSubscription/#02
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/GossipSubscription/#03
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/GossipSubscription/#04
+=== RUN   TestTenantAuthRequest//cockroach.roachpb.Internal/GossipSubscription/#05
+=== RUN   TestTenantAuthRequest//cockroach.rpc.Heartbeat/Ping
+=== RUN   TestTenantAuthRequest//cockroach.rpc.Heartbeat/Ping/#00
+=== RUN   TestTenantAuthRequest//cockroach.rpc.Testing/Foo
+=== RUN   TestTenantAuthRequest//cockroach.rpc.Testing/Foo/#00
+--- PASS: TestTenantAuthRequest (0.00s)
+    --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/Batch (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#00 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#01 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#02 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#03 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#04 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#05 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#06 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#07 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#08 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#09 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#10 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#11 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#12 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#13 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/Batch/#14 (0.00s)
+    --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/RangeLookup (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/RangeLookup/#00 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/RangeLookup/#01 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/RangeLookup/#02 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/RangeLookup/#03 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/RangeLookup/#04 (0.00s)
+    --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/RangeFeed (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/RangeFeed/#00 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/RangeFeed/#01 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/RangeFeed/#02 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/RangeFeed/#03 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/RangeFeed/#04 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/RangeFeed/#05 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/RangeFeed/#06 (0.00s)
+    --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/GossipSubscription (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/GossipSubscription/#00 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/GossipSubscription/#01 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/GossipSubscription/#02 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/GossipSubscription/#03 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/GossipSubscription/#04 (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.roachpb.Internal/GossipSubscription/#05 (0.00s)
+    --- PASS: TestTenantAuthRequest//cockroach.rpc.Heartbeat/Ping (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.rpc.Heartbeat/Ping/#00 (0.00s)
+    --- PASS: TestTenantAuthRequest//cockroach.rpc.Testing/Foo (0.00s)
+        --- PASS: TestTenantAuthRequest//cockroach.rpc.Testing/Foo/#00 (0.00s)
+=== RUN   TestUpdateOffset
+--- PASS: TestUpdateOffset (0.00s)
+=== RUN   TestVerifyClockOffset
+--- PASS: TestVerifyClockOffset (0.00s)
+=== RUN   TestIsHealthyOffsetInterval
+--- PASS: TestIsHealthyOffsetInterval (0.00s)
+=== RUN   TestClockOffsetMetrics
+--- PASS: TestClockOffsetMetrics (0.00s)
+=== RUN   TestLatencies
+--- PASS: TestLatencies (0.00s)
+=== RUN   TestCodecMarshalUnmarshal
+=== RUN   TestCodecMarshalUnmarshal/rpc.PingRequest
+=== RUN   TestCodecMarshalUnmarshal/raftpb.Message
+=== RUN   TestCodecMarshalUnmarshal/grpc_health_v1.HealthCheckRequest
+=== RUN   TestCodecMarshalUnmarshal/roachpb.GetRequest
+--- PASS: TestCodecMarshalUnmarshal (0.00s)
+    --- PASS: TestCodecMarshalUnmarshal/rpc.PingRequest (0.00s)
+    --- PASS: TestCodecMarshalUnmarshal/raftpb.Message (0.00s)
+    --- PASS: TestCodecMarshalUnmarshal/grpc_health_v1.HealthCheckRequest (0.00s)
+    --- PASS: TestCodecMarshalUnmarshal/roachpb.GetRequest (0.00s)
+=== RUN   TestHeartbeatCB
+=== RUN   TestHeartbeatCB/compression=false
+=== RUN   TestHeartbeatCB/compression=true
+--- PASS: TestHeartbeatCB (0.03s)
+    --- PASS: TestHeartbeatCB/compression=false (0.01s)
+    --- PASS: TestHeartbeatCB/compression=true (0.01s)
+=== RUN   TestPingInterceptors
+E210407 21:13:13.394554 198 2@pkg/rpc/context.go:1063  [-] 1  removing connection to unused:1234 due to error: boom due to onSendPing
+--- PASS: TestPingInterceptors (1.10s)
+=== RUN   TestInternalServerAddress
+--- PASS: TestInternalServerAddress (0.01s)
+=== RUN   TestHeartbeatHealth
+--- PASS: TestHeartbeatHealth (0.04s)
+=== RUN   TestConnectionRemoveNodeIDZero
+--- PASS: TestConnectionRemoveNodeIDZero (1.11s)
+=== RUN   TestHeartbeatHealthTransport
+--- PASS: TestHeartbeatHealthTransport (0.09s)
+=== RUN   TestOffsetMeasurement
+--- PASS: TestOffsetMeasurement (0.02s)
+=== RUN   TestFailedOffsetMeasurement
+--- PASS: TestFailedOffsetMeasurement (0.02s)
+=== RUN   TestRemoteOffsetUnhealthy
+    context_test.go:985: max offset: 100ms - node 0 with acceptable clock offset of 0s did not return an error, as expected
+    context_test.go:985: max offset: 100ms - node 1 with acceptable clock offset of 0s did not return an error, as expected
+    context_test.go:985: max offset: 100ms - node 2 with acceptable clock offset of 0s did not return an error, as expected
+    context_test.go:977: max offset: 100ms - node 3 with excessive clock offset of 100.000001ms returned expected error: clock synchronization error: this node is more than 100ms away from at least half of the known nodes (0 of 3 are within the offset)
+--- PASS: TestRemoteOffsetUnhealthy (0.07s)
+=== RUN   TestGRPCKeepaliveFailureFailsInflightRPCs
+    context_test.go:1004: [https://github.com/cockroachdb/cockroach/issues/51800 Takes too long given https://github.com/grpc/grpc-go/pull/2642]
+--- SKIP: TestGRPCKeepaliveFailureFailsInflightRPCs (0.00s)
+=== RUN   TestClusterIDMismatch
+--- PASS: TestClusterIDMismatch (0.02s)
+=== RUN   TestClusterNameMismatch
+=== RUN   TestClusterNameMismatch/0
+=== RUN   TestClusterNameMismatch/1
+E210407 21:13:15.883762 614 1@pkg/rpc/heartbeat.go:78  [-] 2  peer node expects cluster name "a", use --cluster-name to configure
+E210407 21:13:15.883898 614 2@pkg/rpc/context.go:1063  [-] 3  removing connection to 127.0.0.1:56503 due to error: cluster name check failed on ping response: peer node expects cluster name "a", use --cluster-name to configure
+=== RUN   TestClusterNameMismatch/2
+E210407 21:13:15.899548 598 1@pkg/rpc/heartbeat.go:78  [-] 4  peer node does not have a cluster name configured, cannot use --cluster-name
+E210407 21:13:15.899669 598 2@pkg/rpc/context.go:1063  [-] 5  removing connection to 127.0.0.1:56505 due to error: cluster name check failed on ping response: peer node does not have a cluster name configured, cannot use --cluster-name
+=== RUN   TestClusterNameMismatch/3
+E210407 21:13:15.914534 709 1@pkg/rpc/heartbeat.go:78  [-] 6  local cluster name "b" does not match peer cluster name "a"
+E210407 21:13:15.914647 709 2@pkg/rpc/context.go:1063  [-] 7  removing connection to 127.0.0.1:56507 due to error: cluster name check failed on ping response: local cluster name "b" does not match peer cluster name "a"
+=== RUN   TestClusterNameMismatch/4
+=== RUN   TestClusterNameMismatch/5
+=== RUN   TestClusterNameMismatch/6
+=== RUN   TestClusterNameMismatch/7
+=== RUN   TestClusterNameMismatch/8
+=== RUN   TestClusterNameMismatch/9
+=== RUN   TestClusterNameMismatch/10
+=== RUN   TestClusterNameMismatch/11
+=== RUN   TestClusterNameMismatch/12
+--- PASS: TestClusterNameMismatch (0.19s)
+    --- PASS: TestClusterNameMismatch/0 (0.01s)
+    --- PASS: TestClusterNameMismatch/1 (0.01s)
+    --- PASS: TestClusterNameMismatch/2 (0.02s)
+    --- PASS: TestClusterNameMismatch/3 (0.02s)
+    --- PASS: TestClusterNameMismatch/4 (0.01s)
+    --- PASS: TestClusterNameMismatch/5 (0.01s)
+    --- PASS: TestClusterNameMismatch/6 (0.01s)
+    --- PASS: TestClusterNameMismatch/7 (0.01s)
+    --- PASS: TestClusterNameMismatch/8 (0.01s)
+    --- PASS: TestClusterNameMismatch/9 (0.02s)
+    --- PASS: TestClusterNameMismatch/10 (0.02s)
+    --- PASS: TestClusterNameMismatch/11 (0.01s)
+    --- PASS: TestClusterNameMismatch/12 (0.02s)
+=== RUN   TestNodeIDMismatch
+--- PASS: TestNodeIDMismatch (0.02s)
+=== RUN   TestVersionCheckBidirectional
+=== RUN   TestVersionCheckBidirectional/serverVersion_==_clientVersion
+=== RUN   TestVersionCheckBidirectional/serverVersion_<_clientVersion
+E210407 21:13:16.088439 1032 2@pkg/rpc/context.go:1063  [-] 8  removing connection to 127.0.0.1:56531 due to error: version compatibility check failed on ping response: cluster requires at least version 20.2-50, but peer has version 1.0
+=== RUN   TestVersionCheckBidirectional/serverVersion_>_clientVersion
+--- PASS: TestVersionCheckBidirectional (0.04s)
+    --- PASS: TestVersionCheckBidirectional/serverVersion_==_clientVersion (0.01s)
+    --- PASS: TestVersionCheckBidirectional/serverVersion_<_clientVersion (0.01s)
+    --- PASS: TestVersionCheckBidirectional/serverVersion_>_clientVersion (0.01s)
+=== RUN   TestGRPCDialClass
+--- PASS: TestGRPCDialClass (0.01s)
+=== RUN   TestTestingKnobs
+--- PASS: TestTestingKnobs (0.02s)
+=== RUN   TestRunHeartbeatSetsHeartbeatStateWhenExitingBeforeFirstHeartbeat
+--- PASS: TestRunHeartbeatSetsHeartbeatStateWhenExitingBeforeFirstHeartbeat (0.01s)
+=== RUN   TestRemoteOffsetString
+    heartbeat_test.go:32: something unusual happened
+--- FAIL: TestRemoteOffsetString (0.00s)
+=== RUN   TestHeartbeatReply
+--- PASS: TestHeartbeatReply (0.00s)
+=== RUN   TestManualHeartbeat
+--- PASS: TestManualHeartbeat (0.00s)
+=== RUN   TestClockOffsetMismatch
+locally configured maximum clock offset (250ms) does not match that of node test (500ms)
+--- PASS: TestClockOffsetMismatch (0.00s)
+=== RUN   TestClusterIDCompare
+=== RUN   TestClusterIDCompare/cluster_IDs_match
+=== RUN   TestClusterIDCompare/their_cluster_ID_missing
+=== RUN   TestClusterIDCompare/our_cluster_ID_missing
+=== RUN   TestClusterIDCompare/both_cluster_IDs_missing
+=== RUN   TestClusterIDCompare/cluster_ID_mismatch
+--- PASS: TestClusterIDCompare (0.00s)
+    --- PASS: TestClusterIDCompare/cluster_IDs_match (0.00s)
+    --- PASS: TestClusterIDCompare/their_cluster_ID_missing (0.00s)
+    --- PASS: TestClusterIDCompare/our_cluster_ID_missing (0.00s)
+    --- PASS: TestClusterIDCompare/both_cluster_IDs_missing (0.00s)
+    --- PASS: TestClusterIDCompare/cluster_ID_mismatch (0.00s)
+=== RUN   TestNodeIDCompare
+=== RUN   TestNodeIDCompare/node_IDs_match
+=== RUN   TestNodeIDCompare/their_node_ID_missing
+=== RUN   TestNodeIDCompare/our_node_ID_missing
+=== RUN   TestNodeIDCompare/both_node_IDs_missing
+=== RUN   TestNodeIDCompare/node_ID_mismatch
+--- PASS: TestNodeIDCompare (0.00s)
+    --- PASS: TestNodeIDCompare/node_IDs_match (0.00s)
+    --- PASS: TestNodeIDCompare/their_node_ID_missing (0.00s)
+    --- PASS: TestNodeIDCompare/our_node_ID_missing (0.00s)
+    --- PASS: TestNodeIDCompare/both_node_IDs_missing (0.00s)
+    --- PASS: TestNodeIDCompare/node_ID_mismatch (0.00s)
+=== RUN   TestStatsHandlerBasic
+--- PASS: TestStatsHandlerBasic (0.00s)
+=== RUN   TestStatsHandlerWithHeartbeats
+I210407 21:13:16.174706 1187 pkg/rpc/stats_handler_test.go:174  [-] 9  server incoming = 183, server outgoing = 41, client incoming = 97, client outgoing = 69
+--- PASS: TestStatsHandlerWithHeartbeats (0.02s)
+=== RUN   TestClientSSLSettings
+=== RUN   TestClientSSLSettings/#00
+=== RUN   TestClientSSLSettings/#01
+=== RUN   TestClientSSLSettings/#02
+=== RUN   TestClientSSLSettings/#03
+=== RUN   TestClientSSLSettings/#04
+=== RUN   TestClientSSLSettings/#05
+--- PASS: TestClientSSLSettings (0.04s)
+    --- PASS: TestClientSSLSettings/#00 (0.01s)
+    --- PASS: TestClientSSLSettings/#01 (0.01s)
+    --- PASS: TestClientSSLSettings/#02 (0.01s)
+    --- PASS: TestClientSSLSettings/#03 (0.01s)
+    --- PASS: TestClientSSLSettings/#04 (0.01s)
+    --- PASS: TestClientSSLSettings/#05 (0.01s)
+=== RUN   TestServerSSLSettings
+=== RUN   TestServerSSLSettings/#00
+=== RUN   TestServerSSLSettings/#01
+=== RUN   TestServerSSLSettings/#02
+=== RUN   TestServerSSLSettings/#03
+--- PASS: TestServerSSLSettings (0.03s)
+    --- PASS: TestServerSSLSettings/#00 (0.01s)
+    --- PASS: TestServerSSLSettings/#01 (0.01s)
+    --- PASS: TestServerSSLSettings/#02 (0.01s)
+    --- PASS: TestServerSSLSettings/#03 (0.01s)
+FAIL
+I210407 21:13:16.254783 1 (gostd) testmain.go:138  [-] 1  Test //pkg/rpc:rpc_test exited with error code 1

--- a/pkg/cmd/bazci/testdata/bazel-testlogs/pkg/rpc/rpc_test/test.xml
+++ b/pkg/cmd/bazci/testdata/bazel-testlogs/pkg/rpc/rpc_test/test.xml
@@ -1,0 +1,12 @@
+<testsuites>
+	<testsuite errors="0" failures="1" skipped="1" tests="131" time="2.949" name="github.com/cockroachdb/cockroach/pkg/rpc">
+		<testcase classname="rpc" name="TestGRPCDialClass" time="0.010"></testcase>
+		<testcase classname="rpc" name="TestGRPCKeepaliveFailureFailsInflightRPCs" time="0.000">
+			<skipped message="Skipped" type="">=== RUN   TestGRPCKeepaliveFailureFailsInflightRPCs&#xA;    context_test.go:1004: [https://github.com/cockroachdb/cockroach/issues/51800 Takes too long given https://github.com/grpc/grpc-go/pull/2642]&#xA;--- SKIP: TestGRPCKeepaliveFailureFailsInflightRPCs (0.00s)&#xA;</skipped>
+		</testcase>
+		<testcase classname="rpc" name="TestRemoteOffsetString" time="0.000">
+			<failure message="Failed" type="">=== RUN   TestRemoteOffsetString&#xA;    heartbeat_test.go:32: something unusual happened&#xA;--- FAIL: TestRemoteOffsetString (0.00s)&#xA;</failure>
+		</testcase>
+		<testcase classname="rpc" name="TestRemoteOffsetUnhealthy" time="0.070"></testcase>
+	</testsuite>
+</testsuites>

--- a/pkg/cmd/bazci/testdata/expected/test.xml
+++ b/pkg/cmd/bazci/testdata/expected/test.xml
@@ -1,0 +1,10 @@
+<testsuite errors="0" failures="1" skipped="1" tests="131" time="2.949" name="github.com/cockroachdb/cockroach/pkg/rpc">
+	<testcase name="TestGRPCDialClass" time="0.010"></testcase>
+	<testcase name="TestGRPCKeepaliveFailureFailsInflightRPCs" time="0.000">
+		<skipped message="Skipped" type="">=== RUN   TestGRPCKeepaliveFailureFailsInflightRPCs&#xA;    context_test.go:1004: [https://github.com/cockroachdb/cockroach/issues/51800 Takes too long given https://github.com/grpc/grpc-go/pull/2642]&#xA;--- SKIP: TestGRPCKeepaliveFailureFailsInflightRPCs (0.00s)&#xA;</skipped>
+	</testcase>
+	<testcase name="TestRemoteOffsetString" time="0.000">
+		<failure message="Failed" type="">=== RUN   TestRemoteOffsetString&#xA;    heartbeat_test.go:32: something unusual happened&#xA;--- FAIL: TestRemoteOffsetString (0.00s)&#xA;</failure>
+	</testcase>
+	<testcase name="TestRemoteOffsetUnhealthy" time="0.070"></testcase>
+</testsuite>

--- a/pkg/cmd/bazci/watch.go
+++ b/pkg/cmd/bazci/watch.go
@@ -1,0 +1,270 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+package main
+
+import (
+	"encoding/xml"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/errors"
+)
+
+// SourceDir is an enumeration of possible output locations.
+type SourceDir int
+
+const (
+	// Represents `bazel-testlogs`.
+	testlogsSourceDir SourceDir = iota
+	// Represents `bazel-bin`.
+	binSourceDir
+)
+
+// fileMetadata captures the relevant stats associated with a given file
+// on-disk. This is used for caching.
+type fileMetadata struct {
+	size    int64
+	modTime time.Time
+}
+
+// A watcher watches the status of a build and regularly copies over relevant
+// artifacts.
+type watcher struct {
+	// Channel to watch for completion of the build.
+	completion <-chan error
+	info       buildInfo
+	// Map of file path -> file metadata. Cache used to determine whether
+	// any given file is up-to-date. If the fileMetadata doesn't match the
+	// latest file `stat`, we assume the file's been updated and read it
+	// again.
+	files map[string]fileMetadata
+}
+
+// makeWatcher returns an appropriate watcher.
+func makeWatcher(completion <-chan error, info buildInfo) *watcher {
+	return &watcher{
+		completion: completion,
+		info:       info,
+		files:      make(map[string]fileMetadata),
+	}
+}
+
+// Watch performs most of the heavy lifting for bazci by monitoring the
+// progress of the ongoing Bazel build (represented by the `completion`
+// channel in the watcher), staging any test artifacts that are produced.
+func (w watcher) Watch() error {
+	for {
+		select {
+		case buildErr := <-w.completion:
+			// Note that even if the build failed, we still want to
+			// try to stage test artifacts.
+			testErr := w.stageTestArtifacts()
+			// Also stage binary artifacts this time.
+			binErr := w.stageBinaryArtifacts()
+			// Only check errors after we're done staging all
+			// artifacts.
+			if buildErr != nil {
+				return buildErr
+			}
+			if testErr != nil {
+				return testErr
+			}
+			if binErr != nil {
+				return binErr
+			}
+			return nil
+		case <-time.After(10 * time.Second):
+			// Otherwise, every 10 seconds, stage the latest test
+			// artifacts.
+			err := w.stageTestArtifacts()
+			if err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// stageTestArtifacts copies the latest test artifacts into the artifactsDir.
+// The "test artifacts" are the test.log (which is copied verbatim) and test.xml
+// (which we need to munge a little bit before copying).
+func (w watcher) stageTestArtifacts() error {
+	for _, test := range w.info.tests {
+		// relDir is the directory under bazel-testlogs where the test
+		// output files can be found.
+		relDir := strings.ReplaceAll(strings.TrimPrefix(test, "//"), ":", "/")
+		// First, copy the log file verbatim.
+		relLogFilePath := path.Join(relDir, "test.log")
+		err := w.maybeStageArtifact(testlogsSourceDir, relLogFilePath, 0666, copyContentTo)
+		if err != nil {
+			return err
+		}
+		// Munge and copy the xml file.
+		relXMLFilePath := path.Join(relDir, "test.xml")
+		err = w.maybeStageArtifact(testlogsSourceDir, relXMLFilePath, 0666,
+			func(srcContent []byte, outFile io.Writer) error {
+				// Parse the XML into a testSuites struct.
+				suites := testSuites{}
+				err := xml.Unmarshal(srcContent, &suites)
+				if err != nil {
+					switch {
+					// Syntax errors we can just ignore. (Maybe we read the file
+					// while it was in the process of being written?) Better to
+					// have something than nothing, so copy the raw content.
+					case errors.HasType(err, (*xml.SyntaxError)(nil)):
+						_, err = outFile.Write(srcContent)
+						return err
+					default:
+						return err
+					}
+				}
+				// We only want the first test suite in the list of suites.
+				munged, err := xml.MarshalIndent(&suites.Suites[0], "", "\t")
+				if err != nil {
+					return err
+				}
+				_, err = outFile.Write(munged)
+				if err != nil {
+					return err
+				}
+				// Insert a newline just to make our lives a little easier.
+				_, err = outFile.Write([]byte("\n"))
+				return err
+			})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Below are data structures representing the `test.xml` schema.
+// Ref: https://github.com/bazelbuild/rules_go/blob/master/go/tools/bzltestutil/xml.go
+type testSuites struct {
+	XMLName xml.Name    `xml:"testsuites"`
+	Suites  []testSuite `xml:"testsuite"`
+}
+
+type testSuite struct {
+	XMLName   xml.Name   `xml:"testsuite"`
+	TestCases []testCase `xml:"testcase"`
+	Attrs     []xml.Attr `xml:",any,attr"`
+}
+
+type testCase struct {
+	XMLName xml.Name `xml:"testcase"`
+	// Note that we deliberately exclude the `classname` attribute. It never
+	// contains useful information (always just the name of the package --
+	// this isn't Java so there isn't a classname) and excluding it causes
+	// the TeamCity UI to display the same data in a slightly more coherent
+	// and usable way.
+	Name    string      `xml:"name,attr"`
+	Time    string      `xml:"time,attr"`
+	Failure *xmlMessage `xml:"failure,omitempty"`
+	Error   *xmlMessage `xml:"error,omitempty"`
+	Skipped *xmlMessage `xml:"skipped,omitempty"`
+}
+
+type xmlMessage struct {
+	Message  string     `xml:"message,attr"`
+	Attrs    []xml.Attr `xml:",any,attr"`
+	Contents string     `xml:",chardata"`
+}
+
+// stageBinaryArtifacts stages the latest binary artifacts from the build.
+func (w watcher) stageBinaryArtifacts() error {
+	for _, bin := range w.info.goBinaries {
+		// Convert a target like `//pkg/cmd/cockroach-short` to the
+		// relative path atop bazel-bin where that file can be found --
+		// in this example, `pkg/cmd/cockroach-short/cockroach-short_/cockroach-short.
+		head := strings.ReplaceAll(strings.TrimPrefix(bin, "//"), ":", "/")
+		components := strings.Split(bin, ":")
+		relBinPath := path.Join(head+"_", components[len(components)-1])
+		err := w.maybeStageArtifact(binSourceDir, relBinPath, 0777, copyContentTo)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// copyContentTo writes the given srcContent to the output file. Helper function
+// meant to be used with maybeStageArtifact.
+func copyContentTo(srcContent []byte, outFile io.Writer) error {
+	_, err := outFile.Write(srcContent)
+	return err
+}
+
+// maybeStageArtifact stages a build or test artifact in the artifactsDir unless
+// the cache indicates the file is already up-to-date. maybeStageArtifact stages
+// the file from the given `root` (e.g. either `bazel-testlogs` or `bazel-bin`)
+// and at the given relative path. If maybeStageArtifact determines that a file
+// needs to be staged, it is created in the artifactsDir at the same `root` and
+// `relPath` with the given `perm`, and the `stagefn` is called to populate the
+// contents of the newly staged file. With the `stagefn`, callers can choose
+// whether to copy the file verbatim or edit it. If the source artifact does not
+// exist, then maybeStageArtifact does nothing.
+//
+// For example, one might stage a log file with a call like:
+// w.maybeStageArtifact(testlogsSourceDir, "pkg/server/server_test/test.log", 0666, copycontentTo)
+func (w watcher) maybeStageArtifact(
+	root SourceDir,
+	relPath string,
+	perm os.FileMode,
+	stagefn func(srcContent []byte, outFile io.Writer) error,
+) error {
+	var rootPath string
+	var artifactsSubdir string
+	switch root {
+	case testlogsSourceDir:
+		rootPath = w.info.testlogsDir
+		artifactsSubdir = "bazel-testlogs"
+	case binSourceDir:
+		rootPath = w.info.binDir
+		artifactsSubdir = "bazel-bin"
+	}
+	// Fully qualified source and destination paths.
+	srcPath := path.Join(rootPath, relPath)
+	destPath := path.Join(artifactsDir, artifactsSubdir, relPath)
+
+	stat, err := os.Stat(srcPath)
+	if err == nil {
+		meta := fileMetadata{size: stat.Size(), modTime: stat.ModTime()}
+		oldMeta, ok := w.files[srcPath]
+		// Stage if we haven't staged this file yet, or if the size or modTime has been
+		// updated since the last time we staged it.
+		if !ok || meta != oldMeta {
+			err := os.MkdirAll(path.Dir(destPath), 0777)
+			if err != nil {
+				return err
+			}
+			f, err := os.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			contents, err := ioutil.ReadFile(srcPath)
+			if err != nil {
+				return err
+			}
+			err = stagefn(contents, f)
+			if err != nil {
+				return err
+			}
+			w.files[srcPath] = meta
+		}
+	}
+	// stat errors can simply be ignored -- if the file doesn't exist, we
+	// skip it.
+	return nil
+}

--- a/pkg/cmd/bazci/watch_test.go
+++ b/pkg/cmd/bazci/watch_test.go
@@ -1,0 +1,56 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+package main
+
+import (
+	"io/ioutil"
+	"path"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func assertFileCopiedVerbatim(t *testing.T, relPath string) {
+	testdata := testutils.TestDataPath(t)
+	actual, err := ioutil.ReadFile(path.Join(artifactsDir, relPath))
+	assert.Nil(t, err)
+	expected, err := ioutil.ReadFile(path.Join(testdata, relPath))
+	assert.Nil(t, err)
+	assert.Equal(t, actual, expected)
+}
+
+func TestWatch(t *testing.T) {
+	dir, cleanup := testutils.TempDir(t)
+	defer cleanup()
+	artifactsDir = dir
+	testdata := testutils.TestDataPath(t)
+	info := buildInfo{
+		binDir:      path.Join(testdata, "bazel-bin"),
+		testlogsDir: path.Join(testdata, "bazel-testlogs"),
+		goBinaries:  []string{"//pkg/cmd/fake_bin:fake_bin"},
+		tests:       []string{"//pkg/rpc:rpc_test"},
+	}
+	completion := make(chan error, 1)
+	completion <- nil
+
+	err := makeWatcher(completion, info).Watch()
+
+	assert.Nil(t, err)
+	assertFileCopiedVerbatim(t, "bazel-testlogs/pkg/rpc/rpc_test/test.log")
+	assertFileCopiedVerbatim(t, "bazel-bin/pkg/cmd/fake_bin/fake_bin_/fake_bin")
+	// check the xml file was munged correctly.
+	actual, err := ioutil.ReadFile(
+		path.Join(artifactsDir, "bazel-testlogs/pkg/rpc/rpc_test/test.xml"))
+	assert.Nil(t, err)
+	expected, err := ioutil.ReadFile(path.Join(testdata, "expected/test.xml"))
+	assert.Nil(t, err)
+	assert.Equal(t, actual, expected)
+}


### PR DESCRIPTION
Before this commit, the Bazel jobs in CI would call directly into Bazel
to perform builds/tests, and then just do a straight-up `cp -r` into the
`/artifacts` directory. This has a few disadvantages:

1. Test results only appear in TeamCity after all of the tests finish.
   Obviously, we'd like them to stream such that successes and failures
   show up in the UI immediately.
2. The `test.xml` files that Bazel produces are almost, but not exactly,
   in the correct schema that TeamCity produces. The slight differences
   have a negative impact on usability -- for example, it makes it
   difficult to filter tests.
3. The `testlogs` directory can (and often will) contain artifacts that
   are not related to any of the tests you are currently running. The
   `cp -r` strategy has no way of addressing this, so TC can sometimes
   contain references to tests that aren't even in your pull request.

We address all of this in one fell swoop by introducing `bazci`, a
simple wrapper that calls into Bazel to perform builds/tests, but also
watches the build as it goes on and copies only the appropriate
artifacts into the `/artifacts` dir. It also intercepts the `test.xml`
files and munges them to be in the schema that TC expects.

Right now only Go binaries and tests are supported, but we can easily
update `bazci` in the future to support arbitrary new targets.

Also update build scripts to use `bazci` instead of `bazel` directly.

Resolves #63177.

Release note: None