### PR TITLE
sqlsmith: improve INSERT validity

### DIFF
--- a/pkg/internal/sqlsmith/setup.go
+++ b/pkg/internal/sqlsmith/setup.go
@@ -73,7 +73,13 @@ func stringSetup(s string) Setup {
 	}
 }
 
+// randTables is a Setup function that creates 1-5 random tables.
 func randTables(r *rand.Rand) string {
+	return randTablesN(r, r.Intn(5)+1)
+}
+
+// randTablesN is a Setup function that creates n random tables.
+func randTablesN(r *rand.Rand, n int) string {
 	var sb strings.Builder
 	// Since we use the stats mutator, disable auto stats generation.
 	sb.WriteString(`
@@ -83,7 +89,7 @@ func randTables(r *rand.Rand) string {
 	`)
 
 	// Create the random tables.
-	stmts := rowenc.RandCreateTables(r, "table", r.Intn(5)+1,
+	stmts := rowenc.RandCreateTables(r, "table", n,
 		mutations.StatisticsMutator,
 		mutations.PartialIndexMutator,
 		mutations.ForeignKeyMutator,

--- a/pkg/internal/sqlsmith/sqlsmith_test.go
+++ b/pkg/internal/sqlsmith/sqlsmith_test.go
@@ -55,6 +55,85 @@ func TestSetups(t *testing.T) {
 	}
 }
 
+// TestRandTableInserts tests that valid INSERTS can be generated for the
+// rand-tables setup.
+//
+// There is little visibility into the validity of statements created by
+// sqlsmith. This makes it easy to unknowingly make a change to sqlsmith that
+// results in many or all generated statements being invalid, reducing the
+// efficacy of sqlsmith. sqlsmith is greatly hampered if all INSERTs fail,
+// because queries will only run on empty tables. See #63190 for additional
+// context.
+//
+// This test is meant to catch these types of regressions in sqlsmith or
+// rand-tables. It creates 10 random tables, and performs up to 1000 inserts.
+// The test fails if not a single row was inserted.
+//
+// If this test fails, there is likely a bug in:
+//
+//   1. sqlsmith that makes valid INSERTs impossible or very unlikely
+//   2. Or rand-tables that makes it impossible or very unlikely to ever
+//      generate a successful INSERT
+//
+// Note that there is a small but non-zero chance that this test produces a
+// false-negative.
+func TestRandTableInserts(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	rnd, _ := randutil.NewPseudoRand()
+
+	setup := randTablesN(rnd, 10)
+	if _, err := sqlDB.Exec(setup); err != nil {
+		t.Log(setup)
+		t.Fatal(err)
+	}
+
+	insertOnly := simpleOption("insert only", func(s *Smither) {
+		s.stmtWeights = []statementWeight{
+			{1, makeInsert},
+		}
+	})
+
+	smither, err := NewSmither(sqlDB, rnd, insertOnly())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer smither.Close()
+
+	// Run up to numInserts INSERT statements.
+	success := false
+	numErrors := 0
+	numZeroRowInserts := 0
+	numInserts := 1000
+	for i := 0; i < numInserts; i++ {
+		stmt := smither.Generate()
+		res, err := sqlDB.Exec(stmt)
+		if err != nil {
+			numErrors++
+			continue
+		}
+		rows, _ := res.RowsAffected()
+		if rows == 0 {
+			numZeroRowInserts++
+			continue
+		}
+		success = true
+		break
+	}
+
+	if !success {
+		t.Errorf(
+			"expected 1 success out of %v inserts, got %v errors and %v zero-row inserts",
+			numInserts, numErrors, numZeroRowInserts,
+		)
+		t.Log(setup)
+	}
+}
+
 // TestGenerateParse verifies that statements produced by Generate can be
 // parsed. This is useful because since we make AST nodes directly we can
 // sometimes put them into bad states that the parser would never do.


### PR DESCRIPTION
This commit makes several changes to sqlsmith and the random table
generator to make it more likely that a randomly generated `INSERT`
statement will successfully insert a row. This is important to maintain
the efficacy of sqlsmith. See #63190 for additional context.

  1. `Smither.makeInsert` now has a significant chance of generating a
     simple `INSERT ... VALUES` statement. This is more likely to insert
     a row than the previously common alternative `INSERT ... SELECT`
     which pulled values from existing, often empty tables and
     frequently applied filters resulting in an empty set of rows.
  2. `rowenc.randComputedColumnTableDef` now considers the nullability
     of dependent columns when building computed columns. Previously, it
     was common for this function to generate a `NOT NULL` computed
     column dependent on a `NULL` column, making many inserts fail. It
     was also possible to generate a `NOT NULL` computed column with an
     expression like `(a + NULL)`, making inserts impossible.

A regression test has been added to catch bugs in sqlsmith or the random
table generator that might cause many or all `INSERT` statements to
fail. I'm hesitant about this test because there is a non-zero chance it
will produce a false-negative. But I don't think there is another way to
catch these types of regressions. I stressed the test for 2500+ runs
over 4 minutes without a false-negative, which provides some assurance
that a false-negative is very unlikely. I also verified that this test
catches the issues fixed by (1) and (2) after a few hundred runs, and it
almost instantly catches the issue fixed in #63190.

Release note: None
