### PR TITLE
release-21.1: sqlsmith: fix INSERTs for rand-tables

### DIFF
--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -836,8 +836,8 @@ func (s *Smither) makeUpdate(refs colRefs) (*tree.Update, *tableRef, bool) {
 		ref := upRefs[n]
 		upRefs = append(upRefs[:n], upRefs[n+1:]...)
 		col := cols[ref.item.ColumnName]
-		// Ignore computed columns.
-		if col == nil || col.Computed.Computed {
+		// Ignore computed and hidden columns.
+		if col == nil || col.Computed.Computed || col.Hidden {
 			continue
 		}
 		var expr tree.TypedExpr
@@ -954,7 +954,8 @@ func (s *Smither) makeInsert(refs colRefs) (*tree.Insert, *tableRef, bool) {
 		for _, c := range tableRef.Columns {
 			// We *must* write a column if it's writable and non-nullable.
 			// We *can* write a column if it's writable and nullable.
-			if c.Computed.Computed {
+			// We *cannot* write a column if it's computed or hidden.
+			if c.Computed.Computed || c.Hidden {
 				continue
 			}
 			if unnamed || c.Nullable.Nullability == tree.NotNull || s.coin() {

--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -316,8 +316,9 @@ ORDER BY
 				continue
 			}
 			currentCols = append(currentCols, &tree.ColumnTableDef{
-				Name: tree.Name(col.Name),
-				Type: col.Type,
+				Name:   tree.Name(col.Name),
+				Type:   col.Type,
+				Hidden: true,
 			})
 		}
 		tableName := tree.MakeTableNameWithSchema(lastCatalog, lastSchema, lastName)


### PR DESCRIPTION
Backport 1/1 commits from #63190.

/cc @cockroachdb/release

---

Starting in #51656, sqlsmith became aware of system columns, like
`crdb_internal_mvcc_timestamp`. With this new perspective, sqlsmith
could find bugs when running `SELECT` queries with these system columns.

However, a negative side effect was that sqlsmith always included these
columns in `INSERT` statements (except those of the form
`INSERT INTO t DEFAULT VALUES`). Writing to these columns is not
allowed, so the `INSERT`s would always fail (and fail silently due to
sqlsmith ignoring user errors). In sqlsmith setups where `INSERT`s with
`DEFAULT VALUES` are likely to fail due one or more `NOT NULL` columns
in the table, like `rand-tables`, tables would be empty for the duration
of a sqlsmith test run. This severely impaired the efficacy of
sqlsmith—any bugs that required non-empty tables to reproduce would not
be found.

This commit marks sqlsmith's representation of system columns as hidden,
and avoids including hidden columns in randomly generated `INSERT` and
`UPDATE` statements.

I attempted to write a test to catch regressions for this, because
there's little visibility into the validity of statements produced by
sqlsmith. However, given that statements generated by sqlsmith are not
guaranteed to run successfully (and in reality are quite prone to
resulting in errors) it would be very difficult to write a robust test.
Even a test which runs 1000 random `INSERT`s and passes with just 1
successful `INSERT` is likely to be flaky. In practice this type of test
fails after only a few hundred stress test runs.

Release note: None
