### PR TITLE
release-21.1: opt: fix UPSERT error with REGIONAL BY ROW tables

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -2242,3 +2242,15 @@ statement ok
 DROP TABLE regional_by_row;
 DROP TABLE regional_by_row_as;
 ALTER DATABASE drop_regions DROP REGION "ca-central-1";
+
+# Regression test for #63109. UPSERT should not cause the error
+# ERROR: missing "crdb_region" primary key column.
+statement ok
+CREATE DATABASE single_region_test_db PRIMARY REGION "ap-southeast-2";
+USE single_region_test_db;
+CREATE TABLE t63109 (a INT, b STRING);
+ALTER TABLE t63109 SET LOCALITY REGIONAL BY ROW;
+INSERT INTO t63109 VALUES (1, 'one');
+UPSERT INTO t63109 VALUES (1, 'two');
+UPSERT INTO t63109 (crdb_region, a, b) VALUES ('ap-southeast-2', 1, 'three');
+UPSERT INTO t63109 (a, b) VALUES (1, 'four');

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -345,10 +345,11 @@ func (b *Builder) buildInsert(ins *tree.Insert, inScope *scope) (outScope *scope
 //
 //   1. There are no secondary indexes. Existing values are needed to delete
 //      secondary index rows when the update causes them to move.
-//   2. All non-key columns (including mutation columns) have insert and update
+//   2. There are no implicit partitioning columns in the primary index.
+//   3. All non-key columns (including mutation columns) have insert and update
 //      values specified for them.
-//   3. Each update value is the same as the corresponding insert value.
-//   4. There are no inbound foreign keys containing non-key columns.
+//   4. Each update value is the same as the corresponding insert value.
+//   5. There are no inbound foreign keys containing non-key columns.
 //
 // TODO(andyk): The fast path is currently only enabled when the UPSERT alias
 // is explicitly selected by the user. It's possible to fast path some queries
@@ -357,6 +358,13 @@ func (b *Builder) buildInsert(ins *tree.Insert, inScope *scope) (outScope *scope
 // this support was removed and needs to re-enabled. See #14482.
 func (mb *mutationBuilder) needExistingRows() bool {
 	if mb.tab.DeletableIndexCount() > 1 {
+		return true
+	}
+
+	// If there are any implicit partitioning columns in the primary index,
+	// these columns will need to be fetched.
+	primaryIndex := mb.tab.Index(cat.PrimaryIndex)
+	if primaryIndex.ImplicitPartitioningColumnCount() > 0 {
 		return true
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #63194.

/cc @cockroachdb/release

---

This commit fixes a bug that could occur when performing an `UPSERT`
on a `REGIONAL BY ROW` table with no secondary indexes or foreign keys.
This bug occurred because the optimizer was not requesting the
`crdb_region` column as a fetch column, which resulted in an error at
execution time.

Fixes #63109

Release note (bug fix): Fixed an error that could occur when performing
an `UPSERT` on a `REGIONAL BY ROW` table with no secondary indexes or
foreign keys. The error, 'missing "crdb_region" primary key column',
has now been fixed.
