### PR TITLE
lint: disable unused checks on 20.2

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1511,6 +1511,9 @@ func TestLint(t *testing.T) {
 		cmd, stderr, filter, err := dirCmd(
 			crdb.Dir,
 			"staticcheck",
+			// TODO(radu): we have started getting spurious "unused" (U1001) errors
+			// (#62753); disabling unused checks altogether.
+			"-checks=inherit,-U1001",
 			"-unused.whole-program",
 			pkgScope,
 		)


### PR DESCRIPTION
We have started getting spurious "unused" errors from TestStaticCheck
on release-20.2. It's not clear what is going on, and there isn't a
ton of benefit to these checks on an old release branch so this commit
disables the "unused" checker.

Informs #62753.

Release note: None