### PR TITLE
sql: add pgcode for DROP REGION on PRIMARY REGION

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -1015,7 +1015,7 @@ statement ok
 CREATE DATABASE drop_region_db PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1";
 USE drop_region_db
 
-statement error pq: cannot drop region "ca-central-1"\nHINT: You must designate another region as the primary region using ALTER DATABASE drop_region_db PRIMARY REGION <region name> or remove all other regions before attempting to drop region "ca-central-1"
+statement error pgcode 42P12 cannot drop region "ca-central-1"\nHINT: You must designate another region as the primary region using ALTER DATABASE drop_region_db PRIMARY REGION <region name> or remove all other regions before attempting to drop region "ca-central-1"
 ALTER DATABASE drop_region_db DROP REGION "ca-central-1"
 
 statement ok
@@ -1108,7 +1108,7 @@ CREATE TABLE start_off_non_multi_region.public.t(a INT);
 ALTER DATABASE start_off_non_multi_region PRIMARY REGION "ca-central-1";
 ALTER DATABASE start_off_non_multi_region ADD REGION "ap-southeast-2"
 
-statement error pq: cannot drop region "ca-central-1"\nHINT: You must designate another region as the primary region using ALTER DATABASE start_off_non_multi_region PRIMARY REGION <region name> or remove all other regions before attempting to drop region "ca-central-1"
+statement error pgcode 42P12 cannot drop region "ca-central-1"\nHINT: You must designate another region as the primary region using ALTER DATABASE start_off_non_multi_region PRIMARY REGION <region name> or remove all other regions before attempting to drop region "ca-central-1"
 ALTER DATABASE start_off_non_multi_region DROP REGION "ca-central-1"
 
 statement ok
@@ -1203,7 +1203,7 @@ statement ok
 ALTER DATABASE drop_primary_regions_db DROP REGION "ca-central-1"
 
 # Cannot drop the primary region yet, as there are other regions in the db.
-statement error pq: cannot drop region "us-east-1"\nHINT: You must designate another region as the primary region using ALTER DATABASE drop_primary_regions_db PRIMARY REGION <region name> or remove all other regions before attempting to drop region "us-east-1"
+statement error pgcode 42P12 cannot drop region "us-east-1"\nHINT: You must designate another region as the primary region using ALTER DATABASE drop_primary_regions_db PRIMARY REGION <region name> or remove all other regions before attempting to drop region "us-east-1"
 ALTER DATABASE drop_primary_regions_db DROP REGION "us-east-1"
 
 statement ok

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -332,7 +332,11 @@ func (p *planner) AlterDatabaseDropRegion(
 		}
 		if len(regions) != 1 {
 			return nil, errors.WithHintf(
-				errors.Newf("cannot drop region %q", dbDesc.RegionConfig.PrimaryRegion),
+				pgerror.Newf(
+					pgcode.InvalidDatabaseDefinition,
+					"cannot drop region %q",
+					dbDesc.RegionConfig.PrimaryRegion,
+				),
 				"You must designate another region as the primary region using "+
 					"ALTER DATABASE %s PRIMARY REGION <region name> or remove all other regions before "+
 					"attempting to drop region %q", dbDesc.GetName(), n.Region,


### PR DESCRIPTION
Release note (sql change): Introduce a pgcode when attempting to DROP
REGION when the the region being dropped is the PRIMARY REGION.