### PR TITLE
kvserver: downgrade a Fatal

### DIFF
--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -599,10 +599,5 @@ func (ba BatchRequest) ValidateForEvaluation() error {
 	if _, ok := ba.GetArg(EndTxn); ok && ba.Txn == nil {
 		return errors.AssertionFailedf("EndTxn request without transaction")
 	}
-	if ba.Txn != nil {
-		if ba.Txn.WriteTooOld && (ba.Txn.ReadTimestamp.Equal(ba.Txn.WriteTimestamp)) {
-			return errors.AssertionFailedf("WriteTooOld set but no offset in timestamps. txn: %s", ba.Txn)
-		}
-	}
 	return nil
 }


### PR DESCRIPTION
This is original work on the 20.1 branch.
We have an assertion checking that, if a client sends a request with the
WriteTooOld flag set, then the WriteTimestamp is different from the
ReadTimestamp. This assertion fires for someone upgrading from 19.2 to
20. The assertion is new in 20.1. I don't know why it fires; the wto
handling has changed a bunch since, and we're now more disciplined.

This patch downgrades the assertion to just a request error. It might
be OK to remove the assertion completely, but I'm not sure - so I'm
doing the safe thing.

Release note: None