### PR TITLE
release-20.2: backupccl: only backup public indexes

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
@@ -6678,4 +6679,214 @@ table_name FROM [SHOW TABLES] ORDER BY schema_name, table_name`
 		require.Equal(t, commentCount, 0)
 		return nil
 	})
+}
+
+func TestBackupOnlyPublicIndexes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	skip.UnderRace(t, "likely slow under race")
+
+	numAccounts := 1000
+	chunkSize := int64(100)
+
+	// Create 2 blockers that block the backfill after 3 and 6 chunks have been
+	// processed respectively.
+	// Expect there to be 10 chunks in an index backfill:
+	//  numAccounts / chunkSize = 1000 / 100 = 10 chunks.
+	backfillBlockers := []thresholdBlocker{
+		makeThresholdBlocker(3),
+		makeThresholdBlocker(6),
+	}
+
+	// Separately, make a coule of blockers that block all schema change jobs.
+	blockBackfills := make(chan struct{})
+	// By default allow backfills to proceed.
+	close(blockBackfills)
+
+	var chunkCount int32
+	serverArgs := base.TestServerArgs{}
+	serverArgs.Knobs = base.TestingKnobs{
+		// Configure knobs to block the index backfills.
+		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+			BackfillChunkSize: chunkSize,
+		},
+		DistSQL: &execinfra.TestingKnobs{
+			RunBeforeBackfillChunk: func(sp roachpb.Span) error {
+				curChunk := int(atomic.LoadInt32(&chunkCount))
+				for _, blocker := range backfillBlockers {
+					blocker.maybeBlock(curChunk)
+				}
+				atomic.AddInt32(&chunkCount, 1)
+
+				// Separately, block backfills.
+				<-blockBackfills
+
+				return nil
+			},
+			// Flush every chunk during the backfills.
+			BulkAdderFlushesEveryBatch: true,
+		},
+	}
+	params := base.TestClusterArgs{ServerArgs: serverArgs}
+
+	ctx, tc, sqlDB, rawDir, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, numAccounts, InitNone, params)
+	defer cleanupFn()
+	kvDB := tc.Server(0).DB()
+
+	locationToDir := func(location string) string {
+		return strings.Replace(location, LocalFoo, filepath.Join(rawDir, "foo"), 1)
+	}
+
+	// Test timeline:
+	//  1. Full backup
+	//  2. Backfill started
+	//  3. Inc 1
+	//  4. Inc 2
+	//  5. Backfill completeed
+	//  6. Inc 3
+	//  7. Drop index
+	//  8. Inc 4
+
+	// First take a full backup.
+	fullBackup := LocalFoo + "/full"
+	sqlDB.Exec(t, `BACKUP DATABASE data TO $1 WITH revision_history`, fullBackup)
+
+	fullBackupSpans := getSpansFromManifest(t, locationToDir(fullBackup))
+	require.Equal(t, 1, len(fullBackupSpans))
+	require.Equal(t, "/Table/53/{1-2}", fullBackupSpans[0].String())
+
+	// Now we're going to add an index. We should only see the index
+	// appear in the backup once it is PUBLIC.
+	var g errgroup.Group
+	g.Go(func() error {
+		// We use the underlying DB since the goroutine should not call t.Fatal.
+		_, err := sqlDB.DB.ExecContext(ctx,
+			`CREATE INDEX new_balance_idx ON data.bank(balance)`)
+		return errors.Wrap(err, "creating index")
+	})
+
+	inc1Loc := LocalFoo + "/inc1"
+	inc2Loc := LocalFoo + "/inc2"
+
+	g.Go(func() error {
+		defer backfillBlockers[0].allowToProceed()
+		backfillBlockers[0].waitUntilBlocked()
+
+		// Take an incremental backup and assert that it doesn't contain any
+		// data. The only added data was from the backfill, which should not
+		// be included because they are historical writes.
+		_, err := sqlDB.DB.ExecContext(ctx, `BACKUP DATABASE data TO $1 INCREMENTAL FROM $2 WITH revision_history`,
+			inc1Loc, fullBackup)
+		return errors.Wrap(err, "running inc 1 backup")
+	})
+
+	g.Go(func() error {
+		defer backfillBlockers[1].allowToProceed()
+		backfillBlockers[1].waitUntilBlocked()
+
+		// Take an incremental backup and assert that it doesn't contain any
+		// data. The only added data was from the backfill, which should not be
+		// included because they are historical writes.
+		_, err := sqlDB.DB.ExecContext(ctx, `BACKUP DATABASE data TO $1 INCREMENTAL FROM $2, $3 WITH revision_history`,
+			inc2Loc, fullBackup, inc1Loc)
+		return errors.Wrap(err, "running inc 2 backup")
+	})
+
+	// Wait for the backfill and incremental backup to complete.
+	require.NoError(t, g.Wait())
+
+	inc1Spans := getSpansFromManifest(t, locationToDir(inc1Loc))
+	require.Equalf(t, 0, len(inc1Spans), "expected inc1 to not have any data, found %v", inc1Spans)
+
+	inc2Spans := getSpansFromManifest(t, locationToDir(inc2Loc))
+	require.Equalf(t, 0, len(inc2Spans), "expected inc2 to not have any data, found %v", inc2Spans)
+
+	// Take another incremental backup that should only contain the newly added
+	// index.
+	inc3Loc := LocalFoo + "/inc3"
+	sqlDB.Exec(t, `BACKUP DATABASE data TO $1 INCREMENTAL FROM $2, $3, $4 WITH revision_history`,
+		inc3Loc, fullBackup, inc1Loc, inc2Loc)
+	inc3Spans := getSpansFromManifest(t, locationToDir(inc3Loc))
+	require.Equal(t, 1, len(inc3Spans))
+	require.Equal(t, "/Table/53/{2-3}", inc3Spans[0].String())
+
+	// Drop the index.
+	sqlDB.Exec(t, `DROP INDEX new_balance_idx`)
+
+	// Take another incremental backup.
+	inc4Loc := LocalFoo + "/inc4"
+	sqlDB.Exec(t, `BACKUP DATABASE data TO $1 INCREMENTAL FROM $2, $3, $4, $5 WITH revision_history`,
+		inc4Loc, fullBackup, inc1Loc, inc2Loc, inc3Loc)
+
+	numAccountsStr := strconv.Itoa(numAccounts)
+
+	// Restore the entire chain and check that we got the full indexes.
+	{
+		sqlDB.Exec(t, `CREATE DATABASE restoredb;`)
+		sqlDB.Exec(t, `RESTORE data.bank FROM $1, $2, $3, $4 WITH into_db='restoredb'`,
+			fullBackup, inc1Loc, inc2Loc, inc3Loc)
+		sqlDB.CheckQueryResults(t, `SELECT count(*) FROM restoredb.bank@[1]`, [][]string{{numAccountsStr}})
+		sqlDB.CheckQueryResults(t, `SELECT count(*) FROM restoredb.bank@[2]`, [][]string{{numAccountsStr}})
+		kvCount, err := getKVCount(ctx, kvDB, "restoredb", "bank")
+		require.NoError(t, err)
+		require.Equal(t, 2*numAccounts, kvCount)
+
+		// Cleanup.
+		sqlDB.Exec(t, `DROP DATABASE restoredb CASCADE;`)
+	}
+
+	// Restore to a time where the index was being added and check that the
+	// second index was regenerated entirely.
+	{
+		blockBackfills = make(chan struct{}) // block the synthesized schema change job
+		sqlDB.Exec(t, `CREATE DATABASE restoredb;`)
+		sqlDB.Exec(t, `RESTORE data.bank FROM $1, $2, $3 WITH into_db='restoredb';`,
+			fullBackup, inc1Loc, inc2Loc)
+		sqlDB.CheckQueryResults(t, `SELECT count(*) FROM restoredb.bank@[1]`, [][]string{{numAccountsStr}})
+		sqlDB.ExpectErr(t, "index .* not found", `SELECT count(*) FROM restoredb.bank@[2]`)
+
+		// Allow backfills to proceed.
+		close(blockBackfills)
+
+		// Wait for the synthesized schema change to finish, and assert that it
+		// finishes correctly.
+		scQueryRes := sqlDB.QueryStr(t, `SELECT job_id FROM [SHOW JOBS]
+		WHERE job_type = 'SCHEMA CHANGE' AND description LIKE 'RESTORING:%'`)
+		require.Equal(t, 1, len(scQueryRes),
+			`expected only 1 schema change to be generated by the restore`)
+		require.Equal(t, 1, len(scQueryRes[0]),
+			`expected only 1 column to be returned from query`)
+		scJobID, err := strconv.Atoi(scQueryRes[0][0])
+		require.NoError(t, err)
+		waitForSuccessfulJob(t, tc, int64(scJobID))
+
+		// The synthesized index addition has completed.
+		sqlDB.CheckQueryResults(t, `SELECT count(*) FROM restoredb.bank@[2]`, [][]string{{numAccountsStr}})
+		kvCount, err := getKVCount(ctx, kvDB, "restoredb", "bank")
+		require.NoError(t, err)
+		require.Equal(t, 2*numAccounts, kvCount)
+
+		// Cleanup.
+		sqlDB.Exec(t, `DROP DATABASE restoredb CASCADE;`)
+	}
+
+	// Restore to a time aftere the index was dropped and double check that we
+	// didn't bring back any keys from the dropped index.
+	{
+		blockBackfills = make(chan struct{}) // block the synthesized schema change job
+		sqlDB.Exec(t, `CREATE DATABASE restoredb;`)
+		sqlDB.Exec(t, `RESTORE data.bank FROM $1, $2, $3, $4, $5 WITH into_db='restoredb';`,
+			fullBackup, inc1Loc, inc2Loc, inc3Loc, inc4Loc)
+		sqlDB.CheckQueryResults(t, `SELECT count(*) FROM restoredb.bank@[1]`, [][]string{{numAccountsStr}})
+		sqlDB.ExpectErr(t, "index .* not found", `SELECT count(*) FROM restoredb.bank@[2]`)
+
+		// Allow backfills to proceed.
+		close(blockBackfills)
+		kvCount, err := getKVCount(ctx, kvDB, "restoredb", "bank")
+		require.NoError(t, err)
+		require.Equal(t, numAccounts, kvCount)
+
+		// Cleanup.
+		sqlDB.Exec(t, `DROP DATABASE restoredb CASCADE;`)
+	}
 }

--- a/pkg/ccl/backupccl/restore_mid_schema_change_test.go
+++ b/pkg/ccl/backupccl/restore_mid_schema_change_test.go
@@ -19,6 +19,9 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
@@ -99,73 +102,91 @@ func TestRestoreMidSchemaChange(t *testing.T) {
 	}
 }
 
-func verifyMidSchemaChange(
-	t *testing.T, scName string, sqlDB *sqlutils.SQLRunner, isClusterRestore bool,
-) {
-	var expectedData [][]string
-	tableName := fmt.Sprintf("defaultdb.%s", scName)
-	// numJobsInCluster is the number of completed jobs that will be restored
-	// during a cluster restore.
-	var numJobsInCluster int
-	expNumSchemaChangeJobs := 1
-	// This enumerates the tests cases and specifies how each case should be
-	// handled.
+// expectedSCJobCount returns the expected number of schema change jobs
+// we expect to fin.d
+func expectedSCJobCount(scName string, isClusterRestore bool) int {
+	// The number of schema change under test. These will be the ones that are
+	// synthesized in database restore.
+	var expNumSCJobs int
+	var numBackgroundSCJobs int
+
+	// Some test cases may have more than 1 background schema change job.
 	switch scName {
-	case "midaddcol":
-		numJobsInCluster = 1 // the CREATE TABLE job
-		expectedData = [][]string{{"1", "1.3"}, {"2", "1.3"}, {"3", "1.3"}}
-	case "midaddconst":
-		numJobsInCluster = 1 // the CREATE TABLE job
-		expectedData = [][]string{{"1"}, {"2"}, {"3"}}
-		sqlDB.CheckQueryResults(t, "SELECT count(*) FROM [SHOW CONSTRAINTS FROM defaultdb.midaddconst] WHERE constraint_name = 'my_const'", [][]string{{"1"}})
-	case "midaddindex":
-		numJobsInCluster = 1 // the CREATE TABLE job
-		expectedData = [][]string{{"1"}, {"2"}, {"3"}}
-		sqlDB.CheckQueryResults(t, "SELECT count(*) FROM [SHOW INDEXES FROM defaultdb.midaddindex] WHERE column_name = 'a'", [][]string{{"1"}})
-	case "middropcol":
-		numJobsInCluster = 1 // the CREATE TABLE job
-		expectedData = [][]string{{"1"}, {"1"}, {"1"}, {"2"}, {"2"}, {"2"}, {"3"}, {"3"}, {"3"}}
 	case "midmany":
-		numJobsInCluster = 1 // the CREATE TABLE job
-		expNumSchemaChangeJobs = 3
-		expectedData = [][]string{{"1", "1.3"}, {"2", "1.3"}, {"3", "1.3"}}
-		sqlDB.CheckQueryResults(t, "SELECT count(*) FROM [SHOW CONSTRAINTS FROM defaultdb.midmany] WHERE constraint_name = 'my_const'", [][]string{{"1"}})
-		sqlDB.CheckQueryResults(t, "SELECT count(*) FROM [SHOW INDEXES FROM defaultdb.midmany] WHERE column_name = 'a'", [][]string{{"1"}})
-	case "midmultitxn":
-		numJobsInCluster = 1 // the CREATE TABLE job
-		expectedData = [][]string{{"1", "1.3"}, {"2", "1.3"}, {"3", "1.3"}}
-		sqlDB.CheckQueryResults(t, "SELECT count(*) FROM [SHOW CONSTRAINTS FROM defaultdb.midmultitxn] WHERE constraint_name = 'my_const'", [][]string{{"1"}})
-		sqlDB.CheckQueryResults(t, "SELECT count(*) FROM [SHOW INDEXES FROM defaultdb.midmultitxn] WHERE column_name = 'a'", [][]string{{"1"}})
+		numBackgroundSCJobs = 1 // the create table
+		// This test runs 3 schema changes on a single table.
+		expNumSCJobs = 3
 	case "midmultitable":
-		numJobsInCluster = 2 // the 2 CREATE TABLE jobs
-		expNumSchemaChangeJobs = 2
-		expectedData = [][]string{{"1", "1.3"}, {"2", "1.3"}, {"3", "1.3"}}
-		sqlDB.CheckQueryResults(t, fmt.Sprintf("SELECT * FROM %s1", tableName), expectedData)
-		expectedData = [][]string{{"1"}, {"2"}, {"3"}}
-		sqlDB.CheckQueryResults(t, fmt.Sprintf("SELECT * FROM %s2", tableName), expectedData)
-		tableName += "1"
+		numBackgroundSCJobs = 2 // this test creates 2 tables
+		expNumSCJobs = 2        // this test perform a schema change for each table
 	case "midprimarykeyswap":
-		numJobsInCluster = 2 // the CREATE TABLE job and the ALTER COLUMN
-		// The primary key swap will also create a cleanup job.
-		expNumSchemaChangeJobs = 2
-		expectedData = [][]string{{"1"}, {"2"}, {"3"}}
+		// Create table + alter column is done in the prep stage of this test.
+		numBackgroundSCJobs = 2
+		// PK change + PK cleanup
+		expNumSCJobs = 2
 	case "midprimarykeyswapcleanup":
-		// The CREATE TABLE job, the ALTER COLUMN, and the original ALTER PRIMARY
+		// This test performs an ALTER COLUMN, and the original ALTER PRIMARY
 		// KEY that is being cleaned up.
-		numJobsInCluster = 3
-		// This backup only contains the cleanup job mentioned above.
-		expectedData = [][]string{{"1"}, {"2"}, {"3"}}
+		numBackgroundSCJobs = 3
+		expNumSCJobs = 1
+	default:
+		// Most test cases only have 1 schema change under test.
+		expNumSCJobs = 1
+		// Most test cases have just a CREATE TABLE job that created the table
+		// under test.
+		numBackgroundSCJobs = 1
 	}
-	if scName != "midmultitable" {
-		sqlDB.CheckQueryResults(t, fmt.Sprintf("SELECT * FROM %s", tableName), expectedData)
-	}
+
+	// Since we're doing a cluster restore, we need to account for all of
+	// the schema change jobs that existed in the backup.
 	if isClusterRestore {
+		expNumSCJobs += numBackgroundSCJobs
+
 		// If we're performing a cluster restore, we also need to include the drop
 		// crdb_temp_system job.
-		expNumSchemaChangeJobs++
-		// And the create table jobs included from the backups.
-		expNumSchemaChangeJobs += numJobsInCluster
+		expNumSCJobs++
 	}
+
+	return expNumSCJobs
+}
+
+func validateTable(
+	t *testing.T, kvDB *kv.DB, sqlDB *sqlutils.SQLRunner, dbName string, tableName string,
+) {
+	desc := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, dbName, tableName)
+	// There should be no mutations on these table descriptors at this point.
+	require.Equal(t, 0, len(desc.TableDesc().Mutations))
+
+	var rowCount int
+	sqlDB.QueryRow(t, fmt.Sprintf(`SELECT count(*) FROM %s.%s`, dbName, tableName)).Scan(&rowCount)
+	// The number of entries in all indexes should be the same.
+	for _, index := range append(desc.GetPublicNonPrimaryIndexes(), *desc.GetPrimaryIndex()) {
+		var indexCount int
+		sqlDB.QueryRow(t, fmt.Sprintf(`SELECT count(*) FROM %s.%s@[%d]`, dbName, tableName, index.ID)).Scan(&indexCount)
+		require.Equal(t, rowCount, indexCount, `index should have the same number of rows as PK`)
+	}
+}
+
+func getTablesInTest(scName string) (tableNames []string) {
+	// Most of the backups name their table the test name.
+	tableNames = []string{scName}
+
+	// Some create multiple tables thouhg.
+	switch scName {
+	case "midmultitable":
+		tableNames = []string{"midmultitable1", "midmultitable2"}
+	}
+
+	return
+}
+
+func verifyMidSchemaChange(
+	t *testing.T, scName string, kvDB *kv.DB, sqlDB *sqlutils.SQLRunner, isClusterRestore bool,
+) {
+	tables := getTablesInTest(scName)
+
+	// Check that we are left with the expected number of schema change jobs.
+	expNumSchemaChangeJobs := expectedSCJobCount(scName, isClusterRestore)
 	schemaChangeJobs := sqlDB.QueryStr(t, "SELECT description FROM crdb_internal.jobs WHERE job_type = 'SCHEMA CHANGE'")
 	require.Equal(t, expNumSchemaChangeJobs, len(schemaChangeJobs),
 		"Expected %d schema change jobs but found %v", expNumSchemaChangeJobs, schemaChangeJobs)
@@ -185,9 +206,14 @@ func verifyMidSchemaChange(
 		require.Equal(t, expNumSchemaChangeJobs, len(schemaChangeJobs),
 			"Expected %d schema change jobs but found %v", expNumSchemaChangeJobs, schemaChangeJobs)
 	}
-	// Ensure that a schema change can complete on the restored table.
-	schemaChangeQuery := fmt.Sprintf("ALTER TABLE %s ADD CONSTRAINT post_restore_const CHECK (a > 0)", tableName)
-	sqlDB.Exec(t, schemaChangeQuery)
+
+	for _, tableName := range tables {
+		validateTable(t, kvDB, sqlDB, "defaultdb", tableName)
+		// Ensure that a schema change can complete on the restored table.
+		schemaChangeQuery := fmt.Sprintf("ALTER TABLE defaultdb.%s ADD CONSTRAINT post_restore_const CHECK (a > 0)", tableName)
+		sqlDB.Exec(t, schemaChangeQuery)
+	}
+
 }
 
 func restoreMidSchemaChange(
@@ -207,6 +233,7 @@ func restoreMidSchemaChange(
 			dirCleanupFn()
 		}()
 		sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+		kvDB := tc.Server(0).DB()
 
 		symlink := filepath.Join(dir, "foo")
 		err := os.Symlink(backupDir, symlink)
@@ -219,7 +246,9 @@ func restoreMidSchemaChange(
 		}
 		log.Infof(context.Background(), "%+v", sqlDB.QueryStr(t, "SHOW BACKUP $1", LocalFoo))
 		sqlDB.Exec(t, restoreQuery, LocalFoo)
-		sqlDB.CheckQueryResultsRetry(t, "SELECT * FROM crdb_internal.jobs WHERE job_type = 'SCHEMA CHANGE' AND status <> 'succeeded'", [][]string{})
-		verifyMidSchemaChange(t, schemaChangeName, sqlDB, isClusterRestore)
+		// Wait for all jobs to terminate. Some may fail since we don't restore
+		// adding spans.
+		sqlDB.CheckQueryResultsRetry(t, "SELECT * FROM crdb_internal.jobs WHERE job_type = 'SCHEMA CHANGE' AND NOT (status = 'succeeded' OR status = 'failed')", [][]string{})
+		verifyMidSchemaChange(t, schemaChangeName, kvDB, sqlDB, isClusterRestore)
 	}
 }


### PR DESCRIPTION
Backport 3/3 commits from #62572.

/cc @cockroachdb/release

---

This commit ensures that backup only backs up PUBLIC indexes. This means
that it will not back up ADDING indexes.

This is because AddSSTable requests may write in the past, so
incremental backups may miss writes when performing a time-based scan
from the previous incremental backup.

Imforms https://github.com/cockroachdb/cockroach/issues/62564.

Test test previously failed with:
```
--- FAIL: TestBackupOnlyPublicSpans (1.92s)
    backup_test.go:7802: 
                Error Trace:    backup_test.go:7802
                Error:          Received unexpected error:
                                expected incremental backup to not contain any data, found spans [/Table/53/{2-3}]
```

Release note (bug fix): Fixes a bug where index backfill data may have
been missed by BACKUP in incremental backups.
