### PR TITLE
roachtest/schemachange_random_load: use geo distributed regions

### DIFF
--- a/pkg/cmd/roachtest/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/schemachange_random_load.go
@@ -25,10 +25,19 @@ type randomLoadBenchSpec struct {
 }
 
 func registerSchemaChangeRandomLoad(r *testRegistry) {
+	geoZones := []string{"us-east1-b", "us-west1-b", "europe-west2-b"}
+	if cloud == aws {
+		geoZones = []string{"us-east-2b", "us-west-1a", "eu-west-1a"}
+	}
+	geoZonesStr := strings.Join(geoZones, ",")
 	r.Add(testSpec{
-		Name:       "schemachange/random-load",
-		Owner:      OwnerSQLSchema,
-		Cluster:    makeClusterSpec(3),
+		Name:  "schemachange/random-load",
+		Owner: OwnerSQLSchema,
+		Cluster: makeClusterSpec(
+			3,
+			geo(),
+			zones(geoZonesStr),
+		),
 		MinVersion: "v20.1.0",
 		// This is set while development is still happening on the workload and we
 		// fix (or bypass) minor schema change bugs that are discovered.


### PR DESCRIPTION
To enable testing with multiple regions, looks like the easiest way
to go about it is to distribute the roachprod machines across
different regions.

Release note: None