### PR TITLE
release-21.1: sql: fix dropping zone configs from REGIONAL BY ROW during failure

### DIFF
--- a/pkg/ccl/multiregionccl/regional_by_row_test.go
+++ b/pkg/ccl/multiregionccl/regional_by_row_test.go
@@ -466,6 +466,10 @@ USE t;
 									)
 								}
 
+								// Validate zone configs are still correct.
+								_, err = sqlDB.Exec(`SELECT crdb_internal.validate_multi_region_zone_configs()`)
+								require.NoError(t, err)
+
 								return nil
 							})
 


### PR DESCRIPTION
Backport 1/1 commits from #63200.

/cc @cockroachdb/release

---

Also added some more useful error messaging + fixed validation to use
NonDropIndexes as Active, which is in line with how the ApplyOption
function works.

Resolves: #63201

Release note (bug fix): Fix a bug where REGIONAL BY ROW zone configs
were dropped before REGIONAL BY ROW changes are finalised. This causes a
bug when the REGIONAL BY ROW transformation fail.
