### PR TITLE
cli: don't call (raftpb.Entry).String

### DIFF
--- a/pkg/kv/kvserver/debug_print.go
+++ b/pkg/kv/kvserver/debug_print.go
@@ -231,7 +231,10 @@ func tryRaftLogEntry(kv storage.MVCCKeyValue) (string, error) {
 	}
 	cmd.WriteBatch = nil
 
-	return fmt.Sprintf("%s by %s\n%s\nwrite batch:\n%s", &ent, leaseStr, &cmd, wbStr), nil
+	// Unfortunately `ent.String()` panics because of gogoproto/golangproto
+	// woes.
+	entStr := fmt.Sprintf("idx=%d term:%d type:%d", ent.Index, ent.Term, ent.Type)
+	return fmt.Sprintf("%s by %s\n%s\nwrite batch:\n%s", entStr, leaseStr, &cmd, wbStr), nil
 }
 
 func tryTxn(kv storage.MVCCKeyValue) (string, error) {

--- a/pkg/util/protoutil/BUILD.bazel
+++ b/pkg/util/protoutil/BUILD.bazel
@@ -25,7 +25,10 @@ go_library(
 go_test(
     name = "protoutil_test",
     size = "small",
-    srcs = ["clone_test.go"],
+    srcs = [
+        "clone_test.go",
+        "stringer_test.go",
+    ],
     deps = [
         ":protoutil",
         "//pkg/config/zonepb",
@@ -35,6 +38,8 @@ go_test(
         "//pkg/sql/catalog/descpb",
         "//pkg/storage/enginepb",
         "@com_github_gogo_protobuf//proto",
+        "@com_github_stretchr_testify//require",
+        "@io_etcd_go_etcd_raft_v3//raftpb",
     ],
 )
 

--- a/pkg/util/protoutil/stringer_test.go
+++ b/pkg/util/protoutil/stringer_test.go
@@ -1,0 +1,34 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package protoutil_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/raft/v3/raftpb"
+)
+
+// TestStringerGolangProto is an anti-test: it shows that
+// undesirable behavior is present.
+func TestStringerGolangProto(t *testing.T) {
+	ent := raftpb.Entry{
+		Term:  1,
+		Index: 2,
+		Type:  3,
+		Data:  []byte("foo"),
+	}
+	require.PanicsWithValue(
+		t,
+		"field raftpb.Entry.Term has invalid type: got uint64, want pointer",
+		func() { _ = ent.String() },
+	)
+}


### PR DESCRIPTION
Likely due to golang/gogo proto incompatibilities around our use of the
`(gogoproto.nullable)` option, calling `.String()` on a `raftpb.Entry`
panics.

However, upstream at our currently vendored commit
578ffd578362a8962194c4c0c68c1a9824cf9ea3,

```
func TestFoo(t *testing.T) {
        ent := pb.Entry{Term: 1, Index: 2}
        _ = ent.String()
}
```

does not panic.

This commit adds a test documenting the undesired behavior and working
around it in `./cockroach debug raft-log` (and the other debug commands
that stringify log entries).

Found while investigating #61990.

Release note: None
