### PR TITLE
raftentry: fix accidental no-op in truncateFrom

### DIFF
--- a/pkg/kv/kvserver/raftentry/BUILD.bazel
+++ b/pkg/kv/kvserver/raftentry/BUILD.bazel
@@ -22,7 +22,10 @@ go_library(
 go_test(
     name = "raftentry_test",
     size = "small",
-    srcs = ["cache_test.go"],
+    srcs = [
+        "cache_test.go",
+        "ring_buffer_test.go",
+    ],
     embed = [":raftentry"],
     deps = [
         "//pkg/roachpb",

--- a/pkg/kv/kvserver/raftentry/BUILD.bazel
+++ b/pkg/kv/kvserver/raftentry/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
     deps = [
         "//pkg/roachpb",
         "//pkg/util/leaktest",
+        "@com_github_stretchr_testify//require",
         "@io_etcd_go_etcd_raft_v3//raftpb",
     ],
 )

--- a/pkg/kv/kvserver/raftentry/BUILD.bazel
+++ b/pkg/kv/kvserver/raftentry/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/roachpb",
+        "//pkg/util",
         "//pkg/util/metric",
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/kv/kvserver/raftentry/cache.go
+++ b/pkg/kv/kvserver/raftentry/cache.go
@@ -180,19 +180,19 @@ func (c *Cache) Add(id roachpb.RangeID, ents []raftpb.Entry, truncate bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	var bytesAdded, entriesAdded, bytesRemoved, entriesRemoved int32
-	if add {
-		bytesAdded, entriesAdded = p.add(ents)
-	}
+	// We truncate (if requested) before adding. This can lead to "wasted"
+	// work where we're zeroing out entries we would repopulate anyway, but
+	// past experience shows that it's best to keep this code as simple as
+	// possible (see #61990).
 	if truncate {
-		// Note that if !add, ents[0].Index may not even be in the cache
+		// Note that ents[0].Index may not even be in the cache
 		// at this point. `truncateFrom` will still remove any entries
 		// it may have at indexes >= truncIdx, as instructed.
 		truncIdx := ents[0].Index
-		if add {
-			// Some entries were already overwritten.
-			truncIdx = ents[len(ents)-1].Index + 1
-		}
 		bytesRemoved, entriesRemoved = p.truncateFrom(truncIdx)
+	}
+	if add {
+		bytesAdded, entriesAdded = p.add(ents)
 	}
 	c.recordUpdate(p, bytesAdded-bytesRemoved, bytesGuessed, entriesAdded-entriesRemoved)
 }
@@ -375,10 +375,10 @@ func analyzeEntries(ents []raftpb.Entry) (size int32) {
 	var prevTerm uint64
 	for i, e := range ents {
 		if i != 0 && e.Index != prevIndex+1 {
-			panic(errors.Errorf("invalid non-contiguous set of entries %d and %d", prevIndex, e.Index))
+			panic(errors.AssertionFailedf("invalid non-contiguous set of entries %d and %d", prevIndex, e.Index))
 		}
 		if i != 0 && e.Term < prevTerm {
-			err := errors.Errorf("term regression idx %d: %d -> %d", prevIndex, e.Term, prevTerm)
+			err := errors.AssertionFailedf("term regression idx %d: %d -> %d", prevIndex, prevTerm, e.Term)
 			panic(err)
 		}
 		prevIndex = e.Index

--- a/pkg/kv/kvserver/raftentry/cache.go
+++ b/pkg/kv/kvserver/raftentry/cache.go
@@ -184,6 +184,9 @@ func (c *Cache) Add(id roachpb.RangeID, ents []raftpb.Entry, truncate bool) {
 		bytesAdded, entriesAdded = p.add(ents)
 	}
 	if truncate {
+		// Note that if !add, ents[0].Index may not even be in the cache
+		// at this point. `truncateFrom` will still remove any entries
+		// it may have at indexes >= truncIdx, as instructed.
 		truncIdx := ents[0].Index
 		if add {
 			// Some entries were already overwritten.

--- a/pkg/kv/kvserver/raftentry/cache.go
+++ b/pkg/kv/kvserver/raftentry/cache.go
@@ -372,11 +372,17 @@ func (p *partition) setSize(orig, new cacheSize) bool {
 // entries in ents have contiguous indices.
 func analyzeEntries(ents []raftpb.Entry) (size int32) {
 	var prevIndex uint64
+	var prevTerm uint64
 	for i, e := range ents {
 		if i != 0 && e.Index != prevIndex+1 {
 			panic(errors.Errorf("invalid non-contiguous set of entries %d and %d", prevIndex, e.Index))
 		}
+		if i != 0 && e.Term < prevTerm {
+			err := errors.Errorf("term regression idx %d: %d -> %d", prevIndex, e.Term, prevTerm)
+			panic(err)
+		}
 		prevIndex = e.Index
+		prevTerm = e.Term
 		size += int32(e.Size())
 	}
 	return

--- a/pkg/kv/kvserver/raftentry/cache_test.go
+++ b/pkg/kv/kvserver/raftentry/cache_test.go
@@ -27,13 +27,28 @@ import (
 const noLimit = math.MaxUint64
 
 func newEntry(index, size uint64) raftpb.Entry {
+	r := rand.New(rand.NewSource(int64(index * size)))
 	data := make([]byte, size)
-	if _, err := rand.Read(data); err != nil {
+	if _, err := r.Read(data); err != nil {
 		panic(err)
 	}
-	return raftpb.Entry{
+	ent := raftpb.Entry{
 		Index: index,
 		Data:  data,
+	}
+	for {
+		entSize := uint64(ent.Size())
+		if entSize == size {
+			return ent
+		}
+		if entSize < size {
+			panic("size undershot")
+		}
+		delta := entSize - size
+		if uint64(len(ent.Data)) < delta {
+			panic("can't shorten ent.Data to target size")
+		}
+		ent.Data = ent.Data[delta:]
 	}
 }
 
@@ -46,7 +61,7 @@ func newEntries(lo, hi, size uint64) []raftpb.Entry {
 }
 
 func addEntries(c *Cache, rangeID roachpb.RangeID, lo, hi uint64) []raftpb.Entry {
-	ents := newEntries(lo, hi, 1)
+	ents := newEntries(lo, hi, 9)
 	c.Add(rangeID, ents, false)
 	return ents
 }
@@ -83,6 +98,26 @@ func verifyGet(
 			t.Fatalf("expected entry %v, but got %v", e, found)
 		}
 	}
+}
+
+func requireEqual(t *testing.T, c *Cache, rangeID roachpb.RangeID, idxs ...uint64) {
+	t.Helper()
+	p := c.getPartLocked(rangeID, false /* create */, false /* recordUse */)
+	if p == nil {
+		if len(idxs) > 0 {
+			t.Fatalf("expected idxs=%v but got empty cache", idxs)
+		}
+		return
+	}
+	b := &p.ringBuf
+	it := first(b)
+	var act []uint64
+	ok := it.valid(b)
+	for ok {
+		act = append(act, it.index(b))
+		it, ok = it.next(b)
+	}
+	require.Equal(t, idxs, act)
 }
 
 func TestEntryCache(t *testing.T) {
@@ -172,32 +207,47 @@ func TestIgnoredAdd(t *testing.T) {
 		require.True(t, 42*ignoredEnts[0].Size() > int(c.maxBytes)) // sanity check
 	}
 	verifyGet(t, c, rangeID, 1, 41, nil, 1, false)
+	requireEqual(t, c, rangeID)
 	verifyMetrics(t, c, 0, 0)
 	// Add some entries so we can show that a non-overlapping add is ignored.
 	ents := addEntries(c, rangeID, 4, 7)
 	verifyGet(t, c, rangeID, 4, 7, ents, 7, false)
+	requireEqual(t, c, rangeID, 4, 5, 6)
 	verifyMetrics(t, c, 3, 27+int64(partitionSize))
-	addEntries(c, rangeID, 1, 3)
+	addEntries(c, rangeID, 1, 3) // no-op because [1,2] does not overlap [4,5,6]
+	requireEqual(t, c, rangeID, 4, 5, 6)
 	verifyMetrics(t, c, 3, 27+int64(partitionSize))
 
 	// Cache has entries 4, 5, 6. Offer an oversize entry at index 7 (which is
 	// notably after 6) and request truncation. This should be a no-op.
 	c.Add(rangeID, []raftpb.Entry{newEntry(7, uint64(c.maxBytes+1))}, true /* truncate */)
+	requireEqual(t, c, rangeID, 4, 5, 6)
 	verifyGet(t, c, rangeID, 4, 7, ents, 7, false)
 
 	// Cache has entries 4, 5, 6. Offer an oversize entry at index 6 and request
 	// truncation. This should remove index 6 (as requested due to the truncation)
 	// without replacing it with the input entry.
 	c.Add(rangeID, []raftpb.Entry{newEntry(6, uint64(c.maxBytes+1))}, true /* truncate */)
+	requireEqual(t, c, rangeID, 4, 5)
 	verifyGet(t, c, rangeID, 4, 7, ents[:len(ents)-1], 6, false)
 
 	// Cache has entries 4, 5. Offer an oversize entry at index 3 (which is
 	// notably before 4) and request truncation. This should clear all entries
-	//>= 3, i.e. everything.
+	// >= 3, i.e. everything.
 	c.Add(rangeID, []raftpb.Entry{newEntry(3, uint64(c.maxBytes+1))}, true /* truncate */)
 	// And it did.
+	requireEqual(t, c, rangeID)
 	verifyGet(t, c, rangeID, 0, 0, nil, 0, false)
 	verifyMetrics(t, c, 0, int64(partitionSize))
+
+	addEntries(c, rangeID, 10, 13)
+	// Now, cache = [10, 11, 12].
+	requireEqual(t, c, rangeID, 10, 11, 12)
+	verifyMetrics(t, c, 3, 3*9+int64(partitionSize))
+
+	c.Add(rangeID, newEntries(3, 4, 9), true /* truncate */)
+	requireEqual(t, c, rangeID, 3)
+	verifyMetrics(t, c, 1, 1*9+int64(partitionSize))
 }
 
 func TestRingBuffer_truncateFrom(t *testing.T) {
@@ -207,7 +257,7 @@ func TestRingBuffer_truncateFrom(t *testing.T) {
 	const maxBytes = 100
 	c := NewCache(maxBytes)
 	// Add one entry.
-	c.Add(rangeID, newEntries(100, 101, 0), false /* truncate */)
+	c.Add(rangeID, newEntries(100, 101, 9), false /* truncate */)
 	ents, _, _, _ := c.Scan(nil, rangeID, 100, 101, noLimit)
 	// Entry is actually there.
 	require.Len(t, ents, 1)
@@ -229,7 +279,7 @@ func TestRingBuffer_clearTo(t *testing.T) {
 	const maxBytes = 100
 	c := NewCache(maxBytes)
 	// Add one entry.
-	c.Add(rangeID, newEntries(100, 101, 0), false /* truncate */)
+	c.Add(rangeID, newEntries(100, 101, 9), false /* truncate */)
 	ents, _, _, _ := c.Scan(nil, rangeID, 100, 101, noLimit)
 	// Entry is actually there.
 	require.Len(t, ents, 1)
@@ -256,7 +306,7 @@ func TestAddAndTruncate(t *testing.T) {
 	verifyMetrics(t, c, 6, 54+int64(partitionSize))
 	// Show that even if the addition is ignored due to size, entries
 	// with an equal or larger index are truncated.
-	largeEnts := newEntries(5, 6, 300)
+	largeEnts := newEntries(5, 6, 900)
 	c.Add(rangeID, largeEnts, true /* truncate */)
 	verifyGet(t, c, rangeID, 1, 10, ents[:4], 5, false)
 	verifyMetrics(t, c, 4, 36+int64(partitionSize))
@@ -269,8 +319,8 @@ func TestDrop(t *testing.T) {
 		r2 roachpb.RangeID = 2
 
 		sizeOf9Entries = 81
-		partitionSize  = int64(sizeOf9Entries + partitionSize)
 	)
+	partitionSize := int64(sizeOf9Entries + partitionSize)
 	c := NewCache(1 << 10)
 	ents1 := addEntries(c, r1, 1, 10)
 	verifyGet(t, c, r1, 1, 10, ents1, 10, false)
@@ -314,7 +364,7 @@ func TestEntryCacheClearTo(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	rangeID := roachpb.RangeID(1)
 	c := NewCache(100)
-	c.Add(rangeID, []raftpb.Entry{newEntry(20, 1), newEntry(21, 1)}, true)
+	c.Add(rangeID, []raftpb.Entry{newEntry(20, 9), newEntry(21, 9)}, true)
 	c.Clear(rangeID, 21)
 	c.Clear(rangeID, 18)
 	if ents, _, _, _ := c.Scan(nil, rangeID, 2, 21, noLimit); len(ents) != 0 {
@@ -389,12 +439,12 @@ func TestConcurrentEvictions(t *testing.T) {
 		if offset >= 0 && offset < len(ents) {
 			lo := ents[offset].Index
 			hi := lo + uint64(length)
-			toAdd = newEntries(lo, hi, 1)
+			toAdd = newEntries(lo, hi, 9)
 			ents = append(ents[:offset], toAdd...)
 		} else {
 			lo := uint64(offset + 2)
 			hi := lo + uint64(length)
-			toAdd = newEntries(lo, hi, 1)
+			toAdd = newEntries(lo, hi, 9)
 			ents = toAdd
 		}
 		rangeData[r] = ents
@@ -483,7 +533,7 @@ func TestEntryCacheEviction(t *testing.T) {
 	}
 	// Add another entry to the same range. This will exceed the size limit and
 	// lead to eviction.
-	c.Add(rangeID, []raftpb.Entry{newEntry(3, 40)}, true)
+	c.Add(rangeID, []raftpb.Entry{newEntry(3, 80)}, true)
 	ents, _, hi, _ = c.Scan(nil, rangeID, 1, 4, noLimit)
 	if len(ents) != 0 || hi != 1 {
 		t.Errorf("expected no entries; got %+v, %d", ents, hi)
@@ -498,9 +548,9 @@ func TestEntryCacheEviction(t *testing.T) {
 	if len(ents) != 1 || hi != 4 {
 		t.Errorf("expected the new entry; got %+v, %d", ents, hi)
 	}
-	c.Add(rangeID, []raftpb.Entry{newEntry(3, 1)}, true)
+	c.Add(rangeID, []raftpb.Entry{newEntry(3, 9)}, true)
 	verifyMetrics(t, c, 1, c.Metrics().Bytes.Value())
-	c.Add(rangeID2, []raftpb.Entry{newEntry(20, 1), newEntry(21, 1)}, true)
+	c.Add(rangeID2, []raftpb.Entry{newEntry(20, 9), newEntry(21, 9)}, true)
 	ents, _, hi, _ = c.Scan(nil, rangeID2, 20, 22, noLimit)
 	if len(ents) != 2 || hi != 22 {
 		t.Errorf("expected both entries; got %+v, %d", ents, hi)
@@ -612,7 +662,7 @@ func BenchmarkEntryCache(b *testing.B) {
 	rangeID := roachpb.RangeID(1)
 	ents := make([]raftpb.Entry, 1000)
 	for i := range ents {
-		ents[i] = newEntry(uint64(i+1), 8)
+		ents[i] = newEntry(uint64(i+1), 9)
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -634,7 +684,7 @@ func BenchmarkEntryCacheClearTo(b *testing.B) {
 	rangeID := roachpb.RangeID(1)
 	ents := make([]raftpb.Entry, 1000)
 	for i := range ents {
-		ents[i] = newEntry(uint64(i+1), 8)
+		ents[i] = newEntry(uint64(i+1), 9)
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/pkg/kv/kvserver/raftentry/ring_buffer.go
+++ b/pkg/kv/kvserver/raftentry/ring_buffer.go
@@ -34,10 +34,10 @@ const (
 // given that ents may overlap with existing entries or may be rejected from
 // the buffer. ents must not be empty.
 func (b *ringBuf) add(ents []raftpb.Entry) (addedBytes, addedEntries int32) {
-	if afterCache := b.len > 0 && ents[0].Index > last(b).index(b)+1; afterCache {
+	if it := last(b); it.valid(b) && ents[0].Index > it.index(b)+1 {
 		// If ents is non-contiguous and later than the currently cached range then
 		// remove the current entries and add ents in their place.
-		removedBytes, removedEntries := b.clearTo(last(b).index(b) + 1)
+		removedBytes, removedEntries := b.clearTo(it.index(b) + 1)
 		addedBytes, addedEntries = -1*removedBytes, -1*removedEntries
 	}
 	before, after, ok := computeExtension(b, ents[0].Index, ents[len(ents)-1].Index)
@@ -66,15 +66,18 @@ func (b *ringBuf) add(ents []raftpb.Entry) (addedBytes, addedEntries int32) {
 // greater than lo. The method returns the aggregate size and count of entries
 // removed. Note that lo itself may or may not be in the cache.
 func (b *ringBuf) truncateFrom(lo uint64) (removedBytes, removedEntries int32) {
-	it, ok := iterateFrom(b, lo)
-	if !ok {
-		if first(b).index(b) > lo {
-			// If `lo` precedes the indexes in the buffer
-			// (say the buf is idx=[100, 101, 102] and `lo` is 99),
-			// we need to truncate everything.
-			it, ok = iterateFrom(b, first(b).index(b))
-		}
+	if b.len == 0 {
+		return
 	}
+	if idx := first(b).index(b); idx > lo {
+		// If `lo` precedes the indexes in the buffer
+		// (say the buf is idx=[100, 101, 102] and `lo` is 99),
+		// `iterateFrom` will return an invalid iter. But we
+		// need to truncate everything and so advance to the
+		// first index before constructing the iterator.
+		lo = idx
+	}
+	it, ok := iterateFrom(b, lo)
 	for ok {
 		removedBytes += int32(it.entry(b).Size())
 		removedEntries++
@@ -88,15 +91,14 @@ func (b *ringBuf) truncateFrom(lo uint64) (removedBytes, removedEntries int32) {
 	if util.RaceEnabled {
 		if b.len > 0 {
 			if lastIdx := last(b).index(b); lastIdx >= lo {
-				err := errors.Errorf(
+				panic(errors.AssertionFailedf(
 					"buffer truncated to [..., %d], but current last index is %d",
 					lo, lastIdx,
-				)
-				panic(err)
+				))
 			}
 		}
 	}
-	return
+	return removedBytes, removedEntries
 }
 
 // clearTo clears all entries from the ringBuf with index less than hi. The
@@ -105,7 +107,8 @@ func (b *ringBuf) clearTo(hi uint64) (removedBytes, removedEntries int32) {
 	if b.len == 0 || hi < first(b).index(b) {
 		return
 	}
-	it, ok := first(b), true
+	it := first(b)
+	ok := it.valid(b) // true
 	firstIndex := it.index(b)
 	for ok && it.index(b) < hi {
 		removedBytes += int32(it.entry(b).Size())
@@ -234,12 +237,18 @@ func iterateFrom(b *ringBuf, index uint64) (_ iterator, ok bool) {
 // first returns an iterator pointing to the first entry of the ringBuf.
 // If b is empty, the returned iterator is not valid.
 func first(b *ringBuf) iterator {
+	if b.len == 0 {
+		return iterator(-1)
+	}
 	return iterator(b.head)
 }
 
 // last returns an iterator pointing to the last element in b.
-// It is unsafe to call last if b has an empty buffer.
+// If b is empty, the returned iterator is not valid.
 func last(b *ringBuf) iterator {
+	if b.len == 0 {
+		return iterator(-1)
+	}
 	return iterator((b.head + b.len - 1) % len(b.buf))
 }
 

--- a/pkg/kv/kvserver/raftentry/ring_buffer_test.go
+++ b/pkg/kv/kvserver/raftentry/ring_buffer_test.go
@@ -1,0 +1,215 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package raftentry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRingBuffer_Add(t *testing.T) {
+	b := &ringBuf{}
+	const size = 12
+	b.add(newEntries(5, 8, size))
+	eq(t, b, 5, 6, 7)
+	b.add(newEntries(3, 5, size))
+	eq(t, b, 3, 4, 5, 6, 7)
+
+	{
+		// Overwrite 5 and 6 with entries twice as large.
+		ab, ae := b.add(newEntries(5, 7, 2*size))
+		eq(t, b, 3, 4, 5, 6, 7)
+		require.EqualValues(t, 2*size, ab) // `size` for idx=5 and 6
+		require.EqualValues(t, 0, ae)      // we overwrote, did not add
+	}
+
+	{
+		rb, re := b.truncateFrom(6) // reduce typing work below
+		eq(t, b, 3, 4, 5)
+		require.EqualValues(t, 3*size, rb) // idx=6,7 have double size
+		require.EqualValues(t, 2, re)
+	}
+
+	{
+		// Add one entry at the end.
+		ab, ae := b.add(newEntries(6, 7, size))
+		require.EqualValues(t, size, ab)
+		require.EqualValues(t, 1, ae)
+		eq(t, b, 3, 4, 5, 6)
+	}
+
+	{
+		// Addition at beginning which matches up is accepted.
+		ab, ae := b.add(newEntries(1, 3, size))
+		eq(t, b, 1, 2, 3, 4, 5, 6)
+		require.EqualValues(t, 2*size, ab)
+		require.EqualValues(t, 2, ae)
+	}
+
+	{
+		rb, re := b.clearTo(3)
+		eq(t, b, 3, 4, 5, 6)
+		require.EqualValues(t, rb, 2*size)
+		require.EqualValues(t, re, 2)
+	}
+
+	{
+		// Addition at beginning which does not line up is rejected.
+		ab, ae := b.add(newEntries(1, 2, size))
+		eq(t, b, 3, 4, 5, 6)
+		require.Zero(t, ab)
+		require.Zero(t, ae)
+	}
+
+	{
+		// Addition at the end but with a gap clears the existing entries
+		// before.
+		b.add(newEntries(10, 11, size))
+		eq(t, b, 10)
+	}
+}
+
+func TestRingBuffer_Scan(t *testing.T) {
+	for _, tc := range []struct {
+		desc       string
+		lo, hi, mb uint64
+
+		idxs             []uint64 // full range is 10,11,12,13,14, each of size 10
+		scanBytes        uint64
+		nextIdx          uint64
+		exceededMaxBytes bool
+	}{
+		{
+			desc: "before cached entries",
+			lo:   5, hi: 10, mb: 100,
+			nextIdx: 5,
+		},
+		{
+			desc: "before up to excluding first cached entry",
+			lo:   5, hi: 11, mb: 100,
+			nextIdx: 5,
+		},
+		{
+			desc: "starts at first cached entry, remains in cache",
+			lo:   10, hi: 12, mb: 100,
+			idxs: []uint64{10, 11}, scanBytes: 20, nextIdx: 12,
+		},
+		{
+			desc: "starts at first cached entry, remains in cache, limit almost hit",
+			lo:   10, hi: 12, mb: 20,
+			idxs: []uint64{10, 11}, scanBytes: 20, nextIdx: 12, exceededMaxBytes: false,
+		},
+		{
+			desc: "starts at first cached entry, remains in cache, limit hit",
+			lo:   10, hi: 12, mb: 19,
+			idxs: []uint64{10}, scanBytes: 10, nextIdx: 11, exceededMaxBytes: true,
+		},
+		{
+			desc: "starts at first cached entry, stops at cache end",
+			lo:   10, hi: 15, mb: 100,
+			idxs: []uint64{10, 11, 12, 13, 14}, scanBytes: 50, nextIdx: 15,
+		},
+		{
+			desc: "starts at first cached entry, runs past the cache",
+			lo:   10, hi: 16, mb: 100,
+			idxs: []uint64{10, 11, 12, 13, 14}, scanBytes: 50, nextIdx: 15,
+		},
+		{
+			desc: "starts in middle of cache, runs past the cache",
+			lo:   12, hi: 16, mb: 100,
+			idxs: []uint64{12, 13, 14}, scanBytes: 30, nextIdx: 15,
+		},
+		{
+			desc: "starts in middle of cache, runs past the cache but limit hits",
+			lo:   12, hi: 16, mb: 29,
+			idxs: []uint64{12, 13}, scanBytes: 20, nextIdx: 14, exceededMaxBytes: true,
+		},
+		{
+			desc: "starts past cache",
+			lo:   15, hi: 16, mb: 100,
+			nextIdx: 15,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			b := &ringBuf{}
+			ab, _ := b.add(newEntries(10, 15, 10 /* size */))
+			require.EqualValues(t, 5*10, ab)
+			ents, sb, next, excmb := b.scan(nil, tc.lo, tc.hi, tc.mb)
+			var sl []uint64
+			for _, ent := range ents {
+				sl = append(sl, ent.Index)
+			}
+			require.Equal(t, tc.idxs, sl)
+			require.Equal(t, tc.scanBytes, sb)
+			require.Equal(t, tc.nextIdx, next)
+			require.Equal(t, tc.exceededMaxBytes, excmb)
+		})
+	}
+}
+
+func TestRingBuffer_TruncateFrom(t *testing.T) {
+	b := &ringBuf{}
+	b.truncateFrom(20)
+	eq(t, b)
+	b.add(newEntries(10, 20, 9))
+	eq(t, b, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19)
+	b.truncateFrom(20)
+	eq(t, b, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19)
+	b.truncateFrom(19)
+	eq(t, b, 10, 11, 12, 13, 14, 15, 16, 17, 18)
+	b.truncateFrom(13)
+	eq(t, b, 10, 11, 12)
+	b.truncateFrom(1)
+	eq(t, b)
+	it := first(b)
+	require.False(t, it.valid(b)) // regression test
+}
+
+func TestRingBuffer_ClearTo(t *testing.T) {
+	b := &ringBuf{}
+	b.clearTo(100)
+	eq(t, b)
+	b.add(newEntries(10, 20, 9))
+	eq(t, b, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19)
+	b.clearTo(10)
+	eq(t, b, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19)
+	b.clearTo(11)
+	eq(t, b, 11, 12, 13, 14, 15, 16, 17, 18, 19)
+	b.clearTo(17)
+	eq(t, b, 17, 18, 19)
+	b.clearTo(100)
+	eq(t, b)
+}
+
+func eq(t *testing.T, b *ringBuf, idxs ...uint64) {
+	t.Helper()
+	var sl []uint64
+	it := first(b)
+	for it.valid(b) {
+		idx := it.index(b)
+		sl = append(sl, idx)
+		it, _ = it.next(b)
+		ent, ok := b.get(idx)
+		require.True(t, ok)
+		require.Equal(t, idx, ent.Index)
+	}
+	require.Equal(t, idxs, sl)
+	if len(sl) == 0 {
+		return
+	}
+	// NB: this sufficiently tests `Get`, so it doesn't have its own
+	// unit tests.
+	_, ok := b.get(sl[0] - 1)
+	require.False(t, ok)
+	_, ok = b.get(sl[len(sl)-1] + 1)
+	require.False(t, ok)
+}

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1131,8 +1131,33 @@ func (r *Replica) sendRaftMessages(ctx context.Context, messages []raftpb.Messag
 				// contain fat entries. Since these are the only two sources that
 				// raft.sendAppend gathers entries from to populate MsgApps, we
 				// should never see thin entries here.
+				//
+				// Also assert that the log term only ever increases (most of the
+				// time it stays constant, as term changes are rare), and that
+				// the index increases by exactly one with each entry.
+				//
+				// This assertion came out of #61990.
+				prevTerm := message.LogTerm // term of entry preceding the append
+				prevIndex := message.Index  // index of entry preceding the append
 				for j := range message.Entries {
-					assertSideloadedRaftCommandInlined(ctx, &message.Entries[j])
+					ent := &message.Entries[j]
+					assertSideloadedRaftCommandInlined(ctx, ent)
+
+					if prevIndex+1 != ent.Index {
+						log.Fatalf(ctx,
+							"index gap in outgoing MsgApp: idx %d followed by %d",
+							prevIndex, ent.Index,
+						)
+					}
+					prevIndex = ent.Index
+					if prevTerm > ent.Term {
+						log.Fatalf(ctx,
+							"term regression in outgoing MsgApp: idx %d at term=%d "+
+								"appended with logterm=%d",
+							ent.Index, ent.Term, message.LogTerm,
+						)
+					}
+					prevTerm = ent.Term
 				}
 			}
 


### PR DESCRIPTION
When entries are appended to the raft log, they are also added to the
raft entry cache. Appending indexes, say, `100, 101, 102` to the raft
log has the (absolutely crucial for correctness) effect of removing any
higher indexes in the raft log ( `103` and up) and for correctness, the
raft entry cache must follow the same semantics, so that it is always
a coherent subset of the raft log.

It turns out it didn't do that in one edge case, namely when appending
a slice of entries that didn't fit into the cache, but whose first
entry preceded the currently cached entries. For a concrete example,
imagine the cache contains

    [101, 102, 103, 104]

and we are attempting to add a slice of large entries at indexes `[50,
51, 52]` which can not fit the cache at all (i.e. their aggregate size
exceeds that of the cache).

What *should* be the result of this addition is an empty cache. This
is because the true raft log now ends at index 52. In reality though,
the cache accidentally turned this operation into a no-op, as it was
using an iterator that would be invalid when positioned to an index
not currently cached (in this example, index `50`, whereas the first
cached index would be `101`).

It took us a while to identify this bug, as it manifested itself to us
only through a very rare replica inconsistency failure (#61990) of the
`hotspotsplits/nodes=4` roachtest (which was only caught thanks to
 #36241) that would then take days to reproduce. When we finally
managed to get a reproduction that contain the entire history of disk
writes for the cluster, we found that the inconsistency had occured
due to entries from a past term being replicated to the divergent
follower. Concretely, where the leader had something like

| idx  | 101 | 102 | 103 | 104 | 105 | 106 | 107 | 108 |
|------|-----|-----|-----|-----|-----|-----|-----|-----|
| term | 9   | 9   | 9   | 9   | 9   | 9   | 9   | 9   |

the divergent follower would have this:

| idx  | 101 | 102 | 103 | 104 | 105 | 106 | 107 | 108 |
|------|-----|-----|-----|-----|-----|-----|-----|-----|
| term | 9   | 9   | *7* | *7* | *7* | 9   | 9   | 9   |

This made it likely that the issue was connected to a raft leadership
change in which the "old" leader for term 7 had proposed entries for
indexes up to and including at least index 105, which the term 8 and
9 leaders had then discarded and replaced by entries for term 9. Of
course, these entries should consequently never have been committed
and in particular, the term can never regress in the raft log, even
for uncommitted entries, at least when Raft is working correctly.

From the WAL writes, we were able to ascertain that the leader (who
itself had the correct writes in the log) had in fact replicated the
incorrect (term 7) entries to the follower. This meant that that we
were either looking at pebble flat-out serving stale reads (highly
unlikely) or a bug in the raft entry cache. Being unable to find
issues through direct inspection, we added invariants and tweaked the
test to exacerbate what we considered the triggering conditions
(relatively frequent term changes).

A crucial assertion that allowed identifying this bug was adding
invariant checks (which will be re-added in a future commit) that
verified that the truncation had indeed removed subsequent entries.
This highlighted that we were hitting this bug in at least ~5% of
hotspotsplits runs, but possibly more frequently (the assertion did not
catch all instances of the bug). `hotspotsplits` brings the crucial
ingredients here: it's doing concentrated 256KiB inserts which puts the
raft group into mild overload; many entries pile up and get processed in
aggregate, which leads to constantly taking the path in which
truncations are erroneously ignored. However, most of the time omitting
the eviction does not yield replica inconsistency. For this to happen,
the erroneously cached entries need to be picked up by raft for sending
to a follower; they need to be the "incorrect" (which necessitates a
discarded log and term change at the right moment), and finally they
must be in log positions at which the correct entries actually had an
effect (which is to be fair mostly the case).

The history of this bug is actually interesting. The code that has
the bug was introduced in #36360. However, that PR fixed a much more
egregious version of this bug - prior to that PR, the raft entry
cache simply didn't evict entries at higher positions at all, i.e.
it exhibited the bug in many more scenarios, and this consequently
lead to more frequent inconsistencies (as referenced in the issue).
So we went from bad, moderately rare bug to bad, very very rare bug
and, in this PR, hopefully, to no bug.

A rough calculation suggests that we spent around 800.000 minutes of
`n2-standard-4` instances minutes on reproductions related to this bug
in this instance alone, which I think boils down to around $39.000. I
like to think we got off cheap here.

Closes #61990.

Release note (bug fix): A rare issue that could cause replica divergence
was fixed. These issues would be reported by the replica consistency
checker, typically within 24 hours of occurrence, which would cause
nodes to terminate.
