### PR TITLE
release-21.1: backupccl: re-backup spans that come online during incremental backups

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -121,6 +121,7 @@ go_test(
         "create_scheduled_backup_test.go",
         "full_cluster_backup_restore_test.go",
         "helpers_test.go",
+        "import_spans_test.go",
         "main_test.go",
         "partitioned_backup_test.go",
         "restore_mid_schema_change_test.go",

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -1055,9 +1055,8 @@ func backupPlanHook(
 			_, coveredTime, err := makeImportSpans(
 				spans,
 				prevBackups,
-				nil, /*backupLocalityInfo*/
-				keys.MinKey,
-				p.User(),
+				nil,         /*backupLocalityMaps*/
+				keys.MinKey, /* lowWatermark */
 				func(span covering.Range, start, end hlc.Timestamp) error {
 					if start.IsEmpty() {
 						newSpans = append(newSpans, roachpb.Span{Key: span.Start, EndKey: span.End})
@@ -1110,7 +1109,6 @@ func backupPlanHook(
 			append(prevBackups, backupManifest),
 			nil, /*backupLocalityInfo*/
 			keys.MinKey,
-			p.User(),
 			errOnMissingRange,
 		); err != nil {
 			return err

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -1068,6 +1068,13 @@ func backupPlanHook(
 			if err != nil {
 				return errors.Wrap(err, "invalid previous backups")
 			}
+
+			tableSpans, err := getReintroducedSpans(ctx, p, prevBackups, tables, revs, endTime)
+			if err != nil {
+				return err
+			}
+			newSpans = append(newSpans, tableSpans...)
+
 			if coveredTime != startTime {
 				return errors.Errorf("expected previous backups to cover until time %v, got %v", startTime, coveredTime)
 			}
@@ -1318,6 +1325,77 @@ func backupPlanHook(
 		return fn, utilccl.DetachedJobExecutionResultHeader, nil, false, nil
 	}
 	return fn, utilccl.BulkJobExecutionResultHeader, nil, false, nil
+}
+
+// getReintroducedSpans checks to see if any spans need to be re-backed up from
+// ts = 0. This may be the case if a span was OFFLINE in the previous backup and
+// has come back online since. The entire span needs to be re-backed up because
+// we may otherwise miss AddSSTable requests which write to a timestamp older
+// than the last incremental.
+func getReintroducedSpans(
+	ctx context.Context,
+	p sql.PlanHookState,
+	prevBackups []BackupManifest,
+	tables []catalog.TableDescriptor,
+	revs []BackupManifest_DescriptorRevision,
+	endTime hlc.Timestamp,
+) ([]roachpb.Span, error) {
+	reintroducedTables := make(map[descpb.ID]struct{})
+
+	offlineInLastBackup := make(map[descpb.ID]struct{})
+	lastBackup := prevBackups[len(prevBackups)-1]
+	for _, desc := range lastBackup.Descriptors {
+		// TODO(pbardea): Also check that lastWriteTime is set once those are
+		// populated on the table descriptor.
+		if table, _, _, _ := descpb.FromDescriptor(&desc); table != nil && table.Offline() {
+			offlineInLastBackup[table.GetID()] = struct{}{}
+		}
+	}
+
+	// If the table was offline in the last backup, but becomes PUBLIC, then it
+	// needs to be re-included since we may have missed non-transactional writes.
+	tablesToReinclude := make([]catalog.TableDescriptor, 0)
+	for _, desc := range tables {
+		if _, wasOffline := offlineInLastBackup[desc.GetID()]; wasOffline && desc.Public() {
+			tablesToReinclude = append(tablesToReinclude, desc)
+			reintroducedTables[desc.GetID()] = struct{}{}
+		}
+	}
+
+	// Tables should be re-introduced if any revision of the table was PUBLIC. A
+	// table may have been OFFLINE at the time of the last backup, and OFFLINE at
+	// the time of the current backup, but may have been PUBLIC at some time in
+	// between.
+	for _, rev := range revs {
+		rawTable, _, _, _ := descpb.FromDescriptor(rev.Desc)
+		if rawTable == nil {
+			continue
+		}
+		table := tabledesc.NewBuilder(rawTable).BuildImmutableTable()
+		if _, wasOffline := offlineInLastBackup[table.GetID()]; wasOffline && table.Public() {
+			tablesToReinclude = append(tablesToReinclude, table)
+			reintroducedTables[table.GetID()] = struct{}{}
+		}
+	}
+
+	// All revisions of the table that we're re-introducing must also be
+	// considered.
+	allRevs := make([]BackupManifest_DescriptorRevision, 0, len(revs))
+	for _, rev := range revs {
+		rawTable, _, _, _ := descpb.FromDescriptor(rev.Desc)
+		if rawTable == nil {
+			continue
+		}
+		if _, ok := reintroducedTables[rawTable.GetID()]; ok {
+			allRevs = append(allRevs, rev)
+		}
+	}
+
+	tableSpans, err := spansForAllTableIndexes(ctx, p.ExecCfg(), endTime, tablesToReinclude, allRevs)
+	if err != nil {
+		return nil, err
+	}
+	return tableSpans, nil
 }
 
 func makeNewEncryptionOptions(

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -7944,7 +7944,7 @@ func TestBackupOnlyPublicIndexes(t *testing.T) {
 		sqlDB.Exec(t, `DROP DATABASE restoredb CASCADE;`)
 	}
 
-	// Restore to a time aftere the index was dropped and double check that we
+	// Restore to a time after the index was dropped and double check that we
 	// didn't bring back any keys from the dropped index.
 	{
 		blockBackfills = make(chan struct{}) // block the synthesized schema change job

--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -9,6 +9,7 @@
 package backupccl
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -25,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -33,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 )
 
 // Large test to ensure that all of the system table data is being restored in
@@ -800,4 +803,97 @@ func TestClusterRevisionHistory(t *testing.T) {
 		})
 	}
 
+}
+
+// TestReintroduceOfflineSpans is a regression test for #62564, which tracks a
+// bug where AddSSTable requests to OFFLINE tables may be missed by cluster
+// incremental backups since they can write at a timestamp older than the last
+// backup.
+func TestReintroduceOfflineSpans(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderRace(t, "likely slow under race")
+
+	// Block restores on the source cluster.
+	blockDBRestore := make(chan struct{})
+	dbRestoreStarted := make(chan struct{})
+	// The data is split such that there will be 10 span entries to process.
+	restoreBlockEntiresThreshold := 4
+	entriesCount := 0
+	params := base.TestClusterArgs{}
+	knobs := base.TestingKnobs{
+		DistSQL: &execinfra.TestingKnobs{
+			BackupRestoreTestingKnobs: &sql.BackupRestoreTestingKnobs{
+				RunAfterProcessingRestoreSpanEntry: func(_ context.Context) {
+					if entriesCount == 0 {
+						close(dbRestoreStarted)
+					}
+					if entriesCount == restoreBlockEntiresThreshold {
+						<-blockDBRestore
+					}
+
+					entriesCount++
+				},
+			}},
+	}
+	params.ServerArgs.Knobs = knobs
+
+	const numAccounts = 1000
+	ctx, _, srcDB, tempDir, cleanupSrc := backupRestoreTestSetupWithParams(t, singleNode, numAccounts, InitManualReplication, params)
+	_, _, destDB, cleanupDst := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitManualReplication, base.TestClusterArgs{})
+	defer cleanupSrc()
+	defer cleanupDst()
+
+	dbBackupLoc := "nodelocal://0/my_db_backup"
+	clusterBackupLoc := "nodelocal://0/my_cluster_backup"
+
+	// Take a backup that we'll use to create an OFFLINE descriptor.
+	srcDB.Exec(t, `CREATE INDEX new_idx ON data.bank (balance)`)
+	srcDB.Exec(t, `BACKUP DATABASE data TO $1 WITH revision_history`, dbBackupLoc)
+
+	srcDB.Exec(t, `CREATE DATABASE restoredb;`)
+
+	// Take a base full backup.
+	srcDB.Exec(t, `BACKUP TO $1 WITH revision_history`, clusterBackupLoc)
+
+	var g errgroup.Group
+	g.Go(func() error {
+		_, err := srcDB.DB.ExecContext(ctx, `RESTORE data.bank FROM $1 WITH into_db='restoredb'`, dbBackupLoc)
+		return err
+	})
+
+	// Take an incremental backup after the database restore starts.
+	<-dbRestoreStarted
+	srcDB.Exec(t, `BACKUP TO $1 WITH revision_history`, clusterBackupLoc)
+
+	// All the restore to finish. This will issue AddSSTable requests at a
+	// timestamp that is before the last incremental we just took.
+	close(blockDBRestore)
+
+	// Wait for the database restore to finish, and take another incremental
+	// backup that will miss the AddSSTable writes.
+	require.NoError(t, g.Wait())
+
+	var tsBefore string
+	srcDB.QueryRow(t, "SELECT cluster_logical_timestamp()").Scan(&tsBefore)
+
+	// Drop an index on the restored table to ensure that the dropped index was
+	// also re-included.
+	srcDB.Exec(t, `DROP INDEX new_idx`)
+
+	srcDB.Exec(t, `BACKUP TO $1 WITH revision_history`, clusterBackupLoc)
+
+	// Restore the incremental backup chain that has missing writes.
+	destDB.Exec(t, `RESTORE FROM $1 AS OF SYSTEM TIME `+tsBefore, clusterBackupLoc)
+
+	// Assert that the restored database has the same number
+	// of rows in both the source and destination cluster.
+	checkQuery := `SELECT count(*) FROM restoredb.bank AS OF SYSTEM TIME ` + tsBefore
+	expectedCount := srcDB.QueryStr(t, checkQuery)
+	destDB.CheckQueryResults(t, `SELECT count(*) FROM restoredb.bank`, expectedCount)
+
+	checkQuery = `SELECT count(*) FROM restoredb.bank@new_idx AS OF SYSTEM TIME ` + tsBefore
+	expectedCount = srcDB.QueryStr(t, checkQuery)
+	destDB.CheckQueryResults(t, `SELECT count(*) FROM restoredb.bank@new_idx`, expectedCount)
 }

--- a/pkg/ccl/backupccl/import_spans_test.go
+++ b/pkg/ccl/backupccl/import_spans_test.go
@@ -1,0 +1,263 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package backupccl
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	roachpb "github.com/cockroachdb/cockroach/pkg/roachpb"
+	hlc "github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func makeTimestamps(n int) []hlc.Timestamp {
+	timestamps := make([]hlc.Timestamp, n)
+	for i := range timestamps {
+		timestamps[i] = hlc.Timestamp{WallTime: int64(i * 10)}
+	}
+
+	return timestamps
+}
+
+// MakeImportSpans looks for the following properties:
+//  - Start time
+//  - End time
+//  - Spans
+//  - Introduced spans
+//  - Files
+func makeBackupManifest(
+	startTime, endTime hlc.Timestamp, spans, introducedSpans []roachpb.Span,
+) BackupManifest {
+	// We only care about the files' span.
+	files := make([]BackupManifest_File, 0)
+	for _, span := range append(spans, introducedSpans...) {
+		files = append(files, BackupManifest_File{Span: span})
+	}
+
+	return BackupManifest{
+		StartTime:       startTime,
+		EndTime:         endTime,
+		Spans:           spans,
+		IntroducedSpans: introducedSpans,
+		Files:           files,
+	}
+}
+
+func makeTableSpan(tableID uint32) roachpb.Span {
+	k := keys.SystemSQLCodec.TablePrefix(tableID)
+	return roachpb.Span{Key: k, EndKey: k.PrefixEnd()}
+}
+
+func TestMakeImportSpans(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ts := makeTimestamps(10)
+
+	var backupLocalityMap map[int]storeByLocalityKV
+	lowWaterMark := roachpb.KeyMin
+
+	noIntroducedSpans := make([]roachpb.Span, 0)
+	onMissing := errOnMissingRange
+
+	tcs := []struct {
+		name            string
+		tablesToRestore []roachpb.Span
+		backups         []BackupManifest
+
+		// In the successful cases, expectedSpans and endTime should be
+		// specified.
+		expectedSpans      []roachpb.Span
+		expectedMaxEndTime hlc.Timestamp
+
+		// In the error case, only the error is checked.
+		expectedError string
+	}{
+		{
+			name:            "single-backup",
+			tablesToRestore: []roachpb.Span{makeTableSpan(52), makeTableSpan(53)},
+			backups: []BackupManifest{
+				makeBackupManifest(
+					ts[0], ts[1],
+					[]roachpb.Span{makeTableSpan(52), makeTableSpan(53)},
+					noIntroducedSpans,
+				),
+			},
+
+			expectedSpans:      []roachpb.Span{makeTableSpan(52), makeTableSpan(53)},
+			expectedMaxEndTime: ts[1],
+		},
+		{
+			name:            "incremental-backup",
+			tablesToRestore: []roachpb.Span{makeTableSpan(52), makeTableSpan(53)},
+			backups: []BackupManifest{
+				makeBackupManifest(
+					ts[0], ts[1],
+					[]roachpb.Span{makeTableSpan(52), makeTableSpan(53)},
+					noIntroducedSpans,
+				),
+				// Now add an incremental backup of the same tables.
+				makeBackupManifest(
+					ts[1], ts[2],
+					[]roachpb.Span{makeTableSpan(52), makeTableSpan(53)},
+					noIntroducedSpans,
+				),
+			},
+
+			expectedSpans:      []roachpb.Span{makeTableSpan(52), makeTableSpan(53)},
+			expectedMaxEndTime: ts[2],
+		},
+		{
+			name: "restore-subset",
+			// Restore only a sub-set of the spans that have been backed up.
+			tablesToRestore: []roachpb.Span{makeTableSpan(52)},
+			backups: []BackupManifest{
+				makeBackupManifest(
+					ts[0], ts[1],
+					[]roachpb.Span{makeTableSpan(52), makeTableSpan(53)},
+					noIntroducedSpans,
+				),
+				makeBackupManifest(
+					ts[1], ts[2],
+					[]roachpb.Span{makeTableSpan(52), makeTableSpan(53)},
+					noIntroducedSpans,
+				),
+			},
+
+			expectedSpans:      []roachpb.Span{makeTableSpan(52)},
+			expectedMaxEndTime: ts[2],
+		},
+		{
+			// Try backing up a non-new table in an incremental backup.
+			name:            "widen-backup",
+			tablesToRestore: []roachpb.Span{makeTableSpan(52), makeTableSpan(53)},
+			backups: []BackupManifest{
+				// The full backup only has table 52.
+				makeBackupManifest(
+					ts[0], ts[1],
+					[]roachpb.Span{makeTableSpan(52)},
+					noIntroducedSpans,
+				),
+				// This incremental claims to have backed up more.
+				makeBackupManifest(
+					ts[1], ts[2],
+					[]roachpb.Span{makeTableSpan(52), makeTableSpan(53)},
+					noIntroducedSpans,
+				),
+			},
+
+			expectedError: "no backup covers time [0,0,0.000000010,0) for range [/Table/53,/Table/54) or backups listed out of order (mismatched start time)",
+		},
+		{
+			name:            "narrow-backup",
+			tablesToRestore: []roachpb.Span{makeTableSpan(52)},
+			backups: []BackupManifest{
+				makeBackupManifest(
+					ts[0], ts[1],
+					// This full backup backs up both tables 52 and 53.
+					[]roachpb.Span{makeTableSpan(52), makeTableSpan(53)},
+					noIntroducedSpans,
+				),
+				makeBackupManifest(
+					ts[1], ts[2],
+					// This incremental decided to only backup table 52. That's ok.
+					[]roachpb.Span{makeTableSpan(52)},
+					noIntroducedSpans,
+				),
+			},
+
+			expectedSpans:      []roachpb.Span{makeTableSpan(52)},
+			expectedMaxEndTime: ts[2],
+		},
+		{
+			name:            "narrow-backup-rewident",
+			tablesToRestore: []roachpb.Span{makeTableSpan(52)},
+			backups: []BackupManifest{
+				makeBackupManifest(
+					ts[0], ts[1],
+					// This full backup backs up both tables 52 and 53.
+					[]roachpb.Span{makeTableSpan(52), makeTableSpan(53)},
+					noIntroducedSpans,
+				),
+				makeBackupManifest(
+					ts[1], ts[2],
+					// This incremental decided to only backup table 52. That's
+					// permitted.
+					[]roachpb.Span{makeTableSpan(52)},
+					noIntroducedSpans,
+				),
+				makeBackupManifest(
+					ts[2], ts[3],
+					// We can't start backing up table 53 again after an
+					// incremental missed it though.
+					[]roachpb.Span{makeTableSpan(52), makeTableSpan(53)},
+					noIntroducedSpans,
+				),
+			},
+
+			expectedError: "no backup covers time [0.000000010,0,0.000000020,0) for range [/Table/53,/Table/54) or backups listed out of order (mismatched start time)",
+		},
+		{
+			name:            "incremental-newly-created-table",
+			tablesToRestore: []roachpb.Span{makeTableSpan(52), makeTableSpan(53)},
+			backups: []BackupManifest{
+				makeBackupManifest(
+					ts[0], ts[1],
+					[]roachpb.Span{makeTableSpan(52)},
+					noIntroducedSpans,
+				),
+				makeBackupManifest(
+					ts[1], ts[2],
+					// We're now backing up a new table (53), but this is only
+					// allowed since this table didn't exist at the time of the
+					// full backup. It must appear in introduced spans.
+					[]roachpb.Span{makeTableSpan(52), makeTableSpan(53)},
+					// Table 53 was created between the full backup and this
+					// inc, so it appears as introduced spans.
+					[]roachpb.Span{makeTableSpan(53)}, // introduced spans
+				),
+				makeBackupManifest(
+					ts[2], ts[3],
+					// We should be able to backup table 53 incremenatally after
+					// it has been introduced.
+					[]roachpb.Span{makeTableSpan(52), makeTableSpan(53)},
+					noIntroducedSpans,
+				),
+			},
+
+			expectedSpans:      []roachpb.Span{makeTableSpan(52), makeTableSpan(53)},
+			expectedMaxEndTime: ts[3],
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			importSpans, maxEndTime, err := makeImportSpans(
+				tc.tablesToRestore, tc.backups, backupLocalityMap,
+				lowWaterMark, onMissing)
+
+			// Collect just the spans to import.
+			spansToImport := make([]roachpb.Span, len(importSpans))
+			for i, importSpan := range importSpans {
+				spansToImport[i] = importSpan.Span
+			}
+
+			if len(tc.expectedError) != 0 {
+				require.Equal(t, tc.expectedError, err.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedSpans, spansToImport)
+				require.Equal(t, tc.expectedMaxEndTime, maxEndTime)
+			}
+		})
+	}
+}

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -122,9 +122,8 @@ type importEntry struct {
 func makeImportSpans(
 	tableSpans []roachpb.Span,
 	backups []BackupManifest,
-	backupLocalityInfo []jobspb.RestoreDetails_BackupLocalityInfo,
+	backupLocalityMap map[int]storeByLocalityKV,
 	lowWaterMark roachpb.Key,
-	user security.SQLUsername,
 	onMissing func(span covering.Range, start, end hlc.Timestamp) error,
 ) ([]execinfrapb.RestoreSpanEntry, hlc.Timestamp, error) {
 	// Put the covering for the already-completed spans into the
@@ -190,16 +189,10 @@ func makeImportSpans(
 		var backupFileCovering covering.Covering
 
 		var storesByLocalityKV map[string]roachpb.ExternalStorage
-		if backupLocalityInfo != nil && backupLocalityInfo[i].URIsByOriginalLocalityKV != nil {
-			storesByLocalityKV = make(map[string]roachpb.ExternalStorage)
-			for kv, uri := range backupLocalityInfo[i].URIsByOriginalLocalityKV {
-				conf, err := cloudimpl.ExternalStorageConfFromURI(uri, user)
-				if err != nil {
-					return nil, hlc.Timestamp{}, err
-				}
-				storesByLocalityKV[kv] = conf
-			}
+		if storesByLocalityKVMap, ok := backupLocalityMap[i]; ok {
+			storesByLocalityKV = storesByLocalityKVMap
 		}
+
 		for _, f := range b.Files {
 			dir := b.Dir
 			if storesByLocalityKV != nil {
@@ -231,6 +224,7 @@ func makeImportSpans(
 rangeLoop:
 	for _, importRange := range importRanges {
 		needed := false
+		// ts keeps track of the latest time that we've backed up for this span.
 		var ts hlc.Timestamp
 		var files []roachpb.ImportRequest_File
 		payloads := importRange.Payload.([]interface{})
@@ -502,6 +496,31 @@ func rewriteBackupSpanKey(
 	return newKey, nil
 }
 
+type storeByLocalityKV map[string]roachpb.ExternalStorage
+
+func makeBackupLocalityMap(
+	backupLocalityInfos []jobspb.RestoreDetails_BackupLocalityInfo, user security.SQLUsername,
+) (map[int]storeByLocalityKV, error) {
+
+	backupLocalityMap := make(map[int]storeByLocalityKV)
+	for i, localityInfo := range backupLocalityInfos {
+		storesByLocalityKV := make(storeByLocalityKV)
+		if localityInfo.URIsByOriginalLocalityKV != nil {
+			for kv, uri := range localityInfo.URIsByOriginalLocalityKV {
+				conf, err := cloudimpl.ExternalStorageConfFromURI(uri, user)
+				if err != nil {
+					return nil, errors.Wrap(err,
+						"creating locality external storage configuration")
+				}
+				storesByLocalityKV[kv] = conf
+			}
+		}
+		backupLocalityMap[i] = storesByLocalityKV
+	}
+
+	return backupLocalityMap, nil
+}
+
 // restore imports a SQL table (or tables) from sets of non-overlapping sstable
 // files.
 func restore(
@@ -534,11 +553,16 @@ func restore(
 		highWaterMark: -1,
 	}
 
+	backupLocalityMap, err := makeBackupLocalityMap(backupLocalityInfo, user)
+	if err != nil {
+		return emptyRowCount, errors.Wrap(err, "resolving locality locations")
+	}
+
 	// Pivot the backups, which are grouped by time, into requests for import,
 	// which are grouped by keyrange.
 	highWaterMark := job.Progress().Details.(*jobspb.Progress_Restore).Restore.HighWater
-	importSpans, _, err := makeImportSpans(dataToRestore.getSpans(), backupManifests, backupLocalityInfo,
-		highWaterMark, user, errOnMissingRange)
+	importSpans, _, err := makeImportSpans(dataToRestore.getSpans(), backupManifests, backupLocalityMap,
+		highWaterMark, errOnMissingRange)
 	if err != nil {
 		return emptyRowCount, errors.Wrapf(err, "making import requests for %d backups", len(backupManifests))
 	}

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -224,8 +224,7 @@ func makeImportSpans(
 rangeLoop:
 	for _, importRange := range importRanges {
 		needed := false
-		// ts keeps track of the latest time that we've backed up for this span.
-		var ts hlc.Timestamp
+		var latestCoveredTime hlc.Timestamp
 		var files []roachpb.ImportRequest_File
 		payloads := importRange.Payload.([]interface{})
 		for _, p := range payloads {
@@ -237,26 +236,19 @@ rangeLoop:
 				needed = true
 			case backupSpan:
 				// The latest time we've backed up this span may be ahead of the start
-				// time of this entry. This is because some spans can be re-introduced.
-				// Spans are re-introduced when they were taken OFFLINE (and therefore
-				// processed non-transactional writes) and brought back online (PUBLIC).
-				// They need to be re-introduced so that BACKUP re-captures the
-				// non-transactional writes which may have a write timestamp at any
-				// timestamp as far back as when the descriptor was originally taken
-				// OFFLINE.
-				// In practice, it's expected that ts == ie.start here. When that is not
-				// the case ts should be greater than ie.start and ie.start should be 0.
-				// This is safe because the iterators used to read the data from this
-				// backup can support reading from files with duplicate data. For more
-				// information see #62564.
-				if ts.Less(ie.start) {
+				// time of this entry. This is because some spans can be
+				// "re-introduced", meaning that they were previously backed up but
+				// still appear in introducedSpans. Spans are re-introduced when they
+				// were taken OFFLINE (and therefore processed non-transactional writes)
+				// and brought back online (PUBLIC). For more information see #62564.
+				if latestCoveredTime.Less(ie.start) {
 					return nil, hlc.Timestamp{}, errors.Errorf(
 						"no backup covers time [%s,%s) for range [%s,%s) or backups listed out of order (mismatched start time)",
-						ts, ie.start,
+						latestCoveredTime, ie.start,
 						roachpb.Key(importRange.Start), roachpb.Key(importRange.End))
 				}
-				if !ie.end.Less(ts) {
-					ts = ie.end
+				if !ie.end.Less(latestCoveredTime) {
+					latestCoveredTime = ie.end
 				}
 			case backupFile:
 				if len(ie.file.Path) > 0 {
@@ -269,8 +261,8 @@ rangeLoop:
 			}
 		}
 		if needed {
-			if ts != maxEndTime {
-				if err := onMissing(importRange, ts, maxEndTime); err != nil {
+			if latestCoveredTime != maxEndTime {
+				if err := onMissing(importRange, latestCoveredTime, maxEndTime); err != nil {
 					return nil, hlc.Timestamp{}, err
 				}
 			}

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -236,13 +236,28 @@ rangeLoop:
 			case tableSpan:
 				needed = true
 			case backupSpan:
-				if ts != ie.start {
+				// The latest time we've backed up this span may be ahead of the start
+				// time of this entry. This is because some spans can be re-introduced.
+				// Spans are re-introduced when they were taken OFFLINE (and therefore
+				// processed non-transactional writes) and brought back online (PUBLIC).
+				// They need to be re-introduced so that BACKUP re-captures the
+				// non-transactional writes which may have a write timestamp at any
+				// timestamp as far back as when the descriptor was originally taken
+				// OFFLINE.
+				// In practice, it's expected that ts == ie.start here. When that is not
+				// the case ts should be greater than ie.start and ie.start should be 0.
+				// This is safe because the iterators used to read the data from this
+				// backup can support reading from files with duplicate data. For more
+				// information see #62564.
+				if ts.Less(ie.start) {
 					return nil, hlc.Timestamp{}, errors.Errorf(
 						"no backup covers time [%s,%s) for range [%s,%s) or backups listed out of order (mismatched start time)",
 						ts, ie.start,
 						roachpb.Key(importRange.Start), roachpb.Key(importRange.End))
 				}
-				ts = ie.end
+				if !ie.end.Less(ts) {
+					ts = ie.end
+				}
 			case backupFile:
 				if len(ie.file.Path) > 0 {
 					files = append(files, roachpb.ImportRequest_File{


### PR DESCRIPTION
Backport 3/3 commits from #63121.

/cc @cockroachdb/release

---

This commit fixes a bug where backup would miss non-transactional writes
(via AddSSTable) during incremental backups. These backups were missed
because AddSSTable can write to a timestamp that is before the previous
incremental backup. So, if a table was written to while OFFLINE (e.g. by
a RESTORE or an IMPORT), during a backup, the following incremental
backup may miss some data.

To resolve this, BACKUP now re-backs up all of the data of OFFLINE
tables on incremental backups that put this table back online. This
comes with the drawback of some incremental backups (when a restore or
import completes) will be much slower since it has to recapture all of
the data.

There is planned future work so that these incrementals only the new
data written by the RESTORE or IMPORT, rather than resorting to backing
up the entire table again. This will be addressed in a later PR.

Implements fix 1 as described in https://github.com/cockroachdb/cockroach/issues/62564, which addresses
the correctness concerns at the expense of incremental backup performance.

Release note (bug fix): Incremental cluster backups may have missed data
written to tables while they were OFFLINE. In practice this can happen
if a RESTORE or IMPORT was running across incremental backups.

