### PR TITLE
changefeedccl: disallow changfeeds on regional by row tables

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -123,6 +123,8 @@ go_test(
         "//pkg/ccl/changefeedccl/changefeedbase",
         "//pkg/ccl/changefeedccl/kvfeed",
         "//pkg/ccl/importccl",
+        "//pkg/ccl/multiregionccl",
+        "//pkg/ccl/partitionccl",
         "//pkg/ccl/storageccl",
         "//pkg/ccl/utilccl",
         "//pkg/clusterversion",

--- a/pkg/ccl/changefeedccl/changefeedbase/validate.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/validate.go
@@ -40,6 +40,9 @@ func ValidateTable(targets jobspb.ChangefeedTargets, tableDesc catalog.TableDesc
 	if tableDesc.IsSequence() {
 		return errors.Errorf(`CHANGEFEED cannot target sequences: %s`, tableDesc.GetName())
 	}
+	if tableDesc.IsLocalityRegionalByRow() {
+		return errors.Errorf(`CHANGEFEED cannot target REGIONAL BY ROW tables: %s`, tableDesc.GetName())
+	}
 	if len(tableDesc.GetFamilies()) != 1 {
 		return errors.Errorf(
 			`CHANGEFEEDs are currently supported on tables with exactly 1 column family: %s has %d`,

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -127,6 +127,15 @@ func (e schemaChangeDetectedError) Error() string {
 	return fmt.Sprintf("schema change detected at %v", e.ts)
 }
 
+type unsupportedSchemaChangeDetected struct {
+	desc string
+	ts   hlc.Timestamp
+}
+
+func (e unsupportedSchemaChangeDetected) Error() string {
+	return fmt.Sprintf("unsupported schema change %s detected at %s", e.desc, e.ts.AsOfSystemTime())
+}
+
 type schemaFeed interface {
 	Peek(ctx context.Context, atOrBefore hlc.Timestamp) (events []schemafeed.TableEvent, err error)
 	Pop(ctx context.Context, atOrBefore hlc.Timestamp) (events []schemafeed.TableEvent, err error)
@@ -214,7 +223,17 @@ func (f *kvFeed) run(ctx context.Context) (err error) {
 		boundaryType := jobspb.ResolvedSpan_BACKFILL
 		if f.schemaChangePolicy == changefeedbase.OptSchemaChangePolicyStop {
 			boundaryType = jobspb.ResolvedSpan_EXIT
-		} else if events, err := f.tableFeed.Peek(ctx, highWater.Next()); err == nil && isPrimaryKeyChange(events) {
+		} else if events, err := f.tableFeed.Peek(ctx, highWater.Next()); err == nil && isRegionalByRowChange(events) {
+			// NOTE(ssd): The user is unlikely to see this
+			// error. The schemafeed will fail with an
+			// non-retriable error, meaning we likely
+			// return right after runUntilTableEvent
+			// above.
+			return unsupportedSchemaChangeDetected{
+				desc: "SET REGIONAL BY ROW",
+				ts:   highWater.Next(),
+			}
+		} else if err == nil && isPrimaryKeyChange(events) {
 			boundaryType = jobspb.ResolvedSpan_RESTART
 		} else if err != nil {
 			return err
@@ -239,6 +258,15 @@ func (f *kvFeed) run(ctx context.Context) (err error) {
 func isPrimaryKeyChange(events []schemafeed.TableEvent) bool {
 	for _, ev := range events {
 		if schemafeed.IsPrimaryIndexChange(ev) {
+			return true
+		}
+	}
+	return false
+}
+
+func isRegionalByRowChange(events []schemafeed.TableEvent) bool {
+	for _, ev := range events {
+		if schemafeed.IsRegionalByRowChange(ev) {
 			return true
 		}
 	}

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -124,7 +124,7 @@ type schemaChangeDetectedError struct {
 }
 
 func (e schemaChangeDetectedError) Error() string {
-	return fmt.Sprintf("schema change deteceted at %v", e.ts)
+	return fmt.Sprintf("schema change detected at %v", e.ts)
 }
 
 type schemaFeed interface {

--- a/pkg/ccl/changefeedccl/schemafeed/schematestutils/schema_test_utils.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schematestutils/schema_test_utils.go
@@ -49,6 +49,17 @@ func MakeColumnDesc(id descpb.ColumnID) *descpb.ColumnDescriptor {
 	}
 }
 
+// SetLocalityRegionalByRow sets the LocalityConfig of the table
+// descriptor such that desc.IsLocalityRegionalByRow will return true.
+func SetLocalityRegionalByRow(desc catalog.TableDescriptor) catalog.TableDescriptor {
+	desc.TableDesc().LocalityConfig = &descpb.TableDescriptor_LocalityConfig{
+		Locality: &descpb.TableDescriptor_LocalityConfig_RegionalByRow_{
+			RegionalByRow: &descpb.TableDescriptor_LocalityConfig_RegionalByRow{},
+		},
+	}
+	return tabledesc.NewBuilder(desc.TableDesc()).BuildImmutableTable()
+}
+
 // AddColumnDropBackfillMutation adds a mutation to desc to drop a column.
 // Yes, this does modify an immutable.
 func AddColumnDropBackfillMutation(desc catalog.TableDescriptor) catalog.TableDescriptor {


### PR DESCRIPTION
To fully support changefeeds, we need to make a number of technical-
and product-level decisions and changes. Until those changes are made,
we want to disable changefeeds on regional by row tables.

This change ads a new check in the table validator that will prevent
new changefeeds from being started on a table where
IsLocalityRegionalByRow() is true.

Further, existing feeds will fails with a non-retriable error.

Fixes #63239

Release note (enterprise change): Changefeeds will now fail on any
regional by row table with an error such as:

    CHANGEFEED cannot target REGIONAL BY ROW tables: TABLE_NAME

This is to prevent unexpected changefeed behavior until we can offer
full support for regional by row tables.