### PR TITLE
roachprod: disable some cron jobs for GCE workers

### DIFF
--- a/pkg/cmd/roachprod/vm/gce/utils.go
+++ b/pkg/cmd/roachprod/vm/gce/utils.go
@@ -120,6 +120,16 @@ sysctl --system  # reload sysctl settings
 sudo apt-get update -q
 sudo apt-get install -qy chrony
 
+# Remove unattended-upgrades. We don't want to upgraded while running a cluster
+systemctl stop unattended-upgrades
+apt-get purge -y unattended-upgrades
+
+# Disable some cronjobs to reduce CPU usage
+systemctl stop cron
+systemctl mask cron
+systemctl mask apt-daily-upgrade.timer
+systemctl mask apt-daily.timer
+
 # Override the chrony config. In particular,
 # log aggressively when clock is adjusted (0.01s)
 # and exclusively use google's time servers.


### PR DESCRIPTION
In issue #62946 we see a lot of clock skew issues between 6am and 7am
UTC. There are some cron jobs running around that time, that may cause a
spikes in CPU/IO usage, what may affect the hypervisor scheduling and
the system clock.

This patch disables the cron daemon completely and some systemd timers
that may cause heavy CPU/IO usage.

Release note: None