### PR TITLE
release-21.1: sql: collect exec stats for a statement if we see it for the first time

### DIFF
--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -480,18 +480,15 @@ func (a *appStats) recordTransaction(
 	}
 }
 
-// shouldSaveLogicalPlanDescription returns whether we should save this as a
-// sample logical plan for its corresponding fingerprint. We use
-// `logicalPlanCollectionPeriod` to assess how frequently to sample logical
-// plans.
-func (a *appStats) shouldSaveLogicalPlanDescription(anonymizedStmt string, implicitTxn bool) bool {
+// shouldSaveLogicalPlanDescription returns whether we should save the sample
+// logical plan for a fingerprint (represented implicitly by the corresponding
+// stmtStats object). stats is nil if it is the first time we see the
+// fingerprint. We use `logicalPlanCollectionPeriod` to assess how frequently to
+// sample logical plans.
+func (a *appStats) shouldSaveLogicalPlanDescription(stats *stmtStats) bool {
 	if !sampleLogicalPlans.Get(&a.st.SV) {
 		return false
 	}
-	// We don't know yet if we will hit an error, so we assume we don't. The worst
-	// that can happen is that for statements that always error out, we will
-	// always save the tree plan.
-	stats, _ := a.getStatsForStmt(anonymizedStmt, implicitTxn, nil /* error */, false /* createIfNonexistent */)
 	if stats == nil {
 		// Save logical plan the first time we see new statement fingerprint.
 		return true

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1080,9 +1080,9 @@ type connExecutor struct {
 
 		schemaChangerState SchemaChangerState
 
-		// shouldCollectExecutionStats specifies whether the statements in this
-		// transaction should collect execution stats.
-		shouldCollectExecutionStats bool
+		// shouldCollectTxnExecutionStats specifies whether the statements in
+		// this transaction should collect execution stats.
+		shouldCollectTxnExecutionStats bool
 		// accumulatedStats are the accumulated stats of all statements.
 		accumulatedStats execstats.QueryLevelStats
 		// rowsRead and bytesRead are separate from QueryLevelStats because they are


### PR DESCRIPTION
Backport 1/1 commits from #63012.

/cc @cockroachdb/release

---

Previously, we would decide whether we collect the execution stats for
a statement based on `sql.txn_stats.sample_rate` that will determine the
stats collection on a txn basis. This commit additionally begins
collecting the stats on a per stmt basis if it is the first time we see
the stmt. We are careful not to populate txn stats for explicit txns if
the exec stats collection wasn't enabled on a txn level so that we don't
provide an incomplete picture.

Release note (sql change): CockroachDB will now collect execution
stats for all statements when seen for the first time. In order to
disable this behavior, `sql.txn_stats.sample_rate` cluster setting needs
to be set to 0 (this will disable all execution stats collection).
