### PR TITLE
sql: return a SQL Notice if "CREATE TYPE IF NOT EXISTS" command is used to create a type and the type's already existed.

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type
@@ -570,3 +570,13 @@ ALTER TYPE alphabets_60004 DROP VALUE 'a'
 
 statement ok
 ALTER TYPE alphabets_60004 DROP VALUE 'b'
+
+subtest if_not_exists
+
+statement ok
+CREATE TYPE ifNotExists AS ENUM()
+
+query T noticetrace
+CREATE TYPE IF NOT EXISTS ifNotExists AS ENUM();
+----
+NOTICE: type "ifnotexists" already exists, skipping


### PR DESCRIPTION
sql: return a SQL Notice if "CREATE TYPE IF NOT EXISTS" command is used to create a type and the type's already existed.

Previously, a command "CREATE TYPE IF NOT EXISTS" returned "CREATE TYPE" message
even if the type had already existed. This patch changes the message to a notice
"NOTICE: type already exists, skipping" to inform the user about a no-op and to
be compliant with PG CREATE TABLE command.

Fixes #62074 

Release note (sql change): return a SQL Notice if "CREATE TYPE IF NOT EXISTS"
command is used to create a type and the type's already existed.