### PR TITLE
release-21.1: sqlsmith: fix RESTORE generation

### DIFF
--- a/pkg/internal/sqlsmith/bulkio.go
+++ b/pkg/internal/sqlsmith/bulkio.go
@@ -144,7 +144,7 @@ func makeRestore(s *Smither) (tree.Statement, bool) {
 		From:    []tree.StringOrPlaceholderOptList{{tree.NewStrVal(name)}},
 		AsOf:    makeAsOf(s),
 		Options: tree.RestoreOptions{
-			IntoDB: tree.NewDString("into_db"),
+			IntoDB: tree.NewStrVal("into_db"),
 		},
 	}, true
 }


### PR DESCRIPTION
Backport 1/1 commits from #63318.

/cc @cockroachdb/release

---

The IntoDB option can only be a literal string constant or a
placeholder. The generating code incorrectly uses a DString. Recent
changes to AST formatting caused this to be formatted with a
`:::STRING` type hint which does not parse.

Release note: None

Fixes #63316.
