### PR TITLE
Updating syntax diagram for EXPLAIN ANALYZE (PLAN).

### DIFF
--- a/docs/generated/sql/bnf/explain_analyze_stmt.bnf
+++ b/docs/generated/sql/bnf/explain_analyze_stmt.bnf
@@ -1,7 +1,7 @@
 explain_stmt ::=
 	'EXPLAIN' preparable_stmt
-	| 'EXPLAIN' '(' ( 'DISTSQL' | 'DEBUG' ) ( ( ',' ( 'DISTSQL' | 'DEBUG' ) ) )* ')' preparable_stmt
+	| 'EXPLAIN' '(' ( 'PLAN' | 'DISTSQL' | 'DEBUG' ) ( ( ',' ( 'PLAN' | 'DISTSQL' | 'DEBUG' ) ) )* ')' preparable_stmt
 	| 'EXPLAIN' 'ANALYZE' preparable_stmt
 	| 'EXPLAIN' 'ANALYSE' preparable_stmt
-	| 'EXPLAIN' 'ANALYZE' '(' ( 'DISTSQL' | 'DEBUG' ) ( ( ',' ( 'DISTSQL' | 'DEBUG' ) ) )* ')' preparable_stmt
-	| 'EXPLAIN' 'ANALYSE' '(' ( 'DISTSQL' | 'DEBUG' ) ( ( ',' ( 'DISTSQL' | 'DEBUG' ) ) )* ')' preparable_stmt
+	| 'EXPLAIN' 'ANALYZE' '(' ( 'PLAN' | 'DISTSQL' | 'DEBUG' ) ( ( ',' ( 'PLAN' | 'DISTSQL' | 'DEBUG' ) ) )* ')' preparable_stmt
+	| 'EXPLAIN' 'ANALYSE' '(' ( 'PLAN' | 'DISTSQL' | 'DEBUG' ) ( ( ',' ( 'PLAN' | 'DISTSQL' | 'DEBUG' ) ) )* ')' preparable_stmt

--- a/pkg/cmd/docgen/diagrams.go
+++ b/pkg/cmd/docgen/diagrams.go
@@ -807,7 +807,7 @@ var specs = []stmtSpec{
 		stmt:   "explain_stmt",
 		inline: []string{"explain_option_list"},
 		replace: map[string]string{
-			"explain_option_name": "( 'DISTSQL' | 'DEBUG' )",
+			"explain_option_name": "( 'PLAN' | 'DISTSQL' | 'DEBUG' )",
 		},
 		unlink: []string{"'DISTSQL'"},
 	},


### PR DESCRIPTION
Related to #56524.

Updates the syntax diagram and BNF for `EXPLAIN ANALYZE (PLAN)`.

Release note: None