### PR TITLE
roachtest: wait for rebalancing to each region in follower-reads test

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -1804,6 +1804,8 @@ func (ds *DistSender) sendToReplicas(
 			// we created replicas.
 			log.Eventf(ctx, "leaseholder %s missing from replicas", leaseholder)
 		}
+	} else {
+		log.VEvent(ctx, 2, "routing to nearest replica")
 	}
 
 	opts := SendOptions{


### PR DESCRIPTION
Fixes #62855.

This commit adds a stage to the follower-reads suite of tests to wait
for replicas to be in the correct regions before starting to apply and
measure load. Previously, the test was waiting for the correct count and
type of replicas to be present, but not for them to be in the correct
locations.

This also replaces the slow query logging added in #63319 with slow
query tracing, which was the original intention.