### PR TITLE
release-21.1: sql: block initial multi-region if zone configs have multi-region fields set

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -1015,7 +1015,7 @@ statement ok
 CREATE DATABASE drop_region_db PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1";
 USE drop_region_db
 
-statement error pq: cannot drop region "ca-central-1"\nHINT: You must designate another region as the primary region using ALTER DATABASE drop_region_db PRIMARY REGION <region name> or remove all other regions before attempting to drop region "ca-central-1"
+statement error pgcode 42P12 cannot drop region "ca-central-1"\nHINT: You must designate another region as the primary region using ALTER DATABASE drop_region_db PRIMARY REGION <region name> or remove all other regions before attempting to drop region "ca-central-1"
 ALTER DATABASE drop_region_db DROP REGION "ca-central-1"
 
 statement ok
@@ -1108,7 +1108,7 @@ CREATE TABLE start_off_non_multi_region.public.t(a INT);
 ALTER DATABASE start_off_non_multi_region PRIMARY REGION "ca-central-1";
 ALTER DATABASE start_off_non_multi_region ADD REGION "ap-southeast-2"
 
-statement error pq: cannot drop region "ca-central-1"\nHINT: You must designate another region as the primary region using ALTER DATABASE start_off_non_multi_region PRIMARY REGION <region name> or remove all other regions before attempting to drop region "ca-central-1"
+statement error pgcode 42P12 cannot drop region "ca-central-1"\nHINT: You must designate another region as the primary region using ALTER DATABASE start_off_non_multi_region PRIMARY REGION <region name> or remove all other regions before attempting to drop region "ca-central-1"
 ALTER DATABASE start_off_non_multi_region DROP REGION "ca-central-1"
 
 statement ok
@@ -1203,7 +1203,7 @@ statement ok
 ALTER DATABASE drop_primary_regions_db DROP REGION "ca-central-1"
 
 # Cannot drop the primary region yet, as there are other regions in the db.
-statement error pq: cannot drop region "us-east-1"\nHINT: You must designate another region as the primary region using ALTER DATABASE drop_primary_regions_db PRIMARY REGION <region name> or remove all other regions before attempting to drop region "us-east-1"
+statement error pgcode 42P12 cannot drop region "us-east-1"\nHINT: You must designate another region as the primary region using ALTER DATABASE drop_primary_regions_db PRIMARY REGION <region name> or remove all other regions before attempting to drop region "us-east-1"
 ALTER DATABASE drop_primary_regions_db DROP REGION "us-east-1"
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
@@ -11,6 +11,16 @@ statement ok
 SELECT crdb_internal.validate_multi_region_zone_configs()
 
 statement ok
+CREATE DATABASE bad_db PRIMARY REGION "ca-central-1";
+USE bad_db;
+SET override_multi_region_zone_config = true;
+ALTER DATABASE bad_db CONFIGURE ZONE DISCARD;
+SET override_multi_region_zone_config = false
+
+statement error zone configuration for database bad_db contains incorrectly configured field "num_replicas"
+SELECT crdb_internal.validate_multi_region_zone_configs()
+
+statement ok
 CREATE DATABASE "mr-zone-configs" primary region "ca-central-1" regions "ap-southeast-2", "us-east-1"
 
 statement ok
@@ -274,12 +284,13 @@ DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USIN
 query TTTTT colnames
 SHOW DATABASES
 ----
-database_name    owner  primary_region  regions  survival_goal
-defaultdb        root   NULL            {}       NULL
-mr-zone-configs  root   NULL            {}       NULL
-postgres         root   NULL            {}       NULL
-system           node   NULL            {}       NULL
-test             root   NULL            {}       NULL
+database_name    owner  primary_region  regions         survival_goal
+bad_db           root   ca-central-1    {ca-central-1}  zone
+defaultdb        root   NULL            {}              NULL
+mr-zone-configs  root   NULL            {}              NULL
+postgres         root   NULL            {}              NULL
+system           node   NULL            {}              NULL
+test             root   NULL            {}              NULL
 
 statement ok
 ALTER DATABASE "mr-zone-configs" SET PRIMARY REGION "us-east-1"
@@ -294,6 +305,7 @@ query TTTTT colnames
 SHOW DATABASES
 ----
 database_name    owner  primary_region  regions                                  survival_goal
+bad_db           root   ca-central-1    {ca-central-1}                           zone
 defaultdb        root   NULL            {}                                       NULL
 mr-zone-configs  root   us-east-1       {ap-southeast-2,ca-central-1,us-east-1}  zone
 postgres         root   NULL            {}                                       NULL

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
@@ -11,16 +11,6 @@ statement ok
 SELECT crdb_internal.validate_multi_region_zone_configs()
 
 statement ok
-CREATE DATABASE bad_db PRIMARY REGION "ca-central-1";
-USE bad_db;
-SET override_multi_region_zone_config = true;
-ALTER DATABASE bad_db CONFIGURE ZONE DISCARD;
-SET override_multi_region_zone_config = false
-
-statement error zone configuration for database bad_db contains incorrectly configured field "num_replicas"
-SELECT crdb_internal.validate_multi_region_zone_configs()
-
-statement ok
 CREATE DATABASE "mr-zone-configs" primary region "ca-central-1" regions "ap-southeast-2", "us-east-1"
 
 statement ok
@@ -284,13 +274,12 @@ DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USIN
 query TTTTT colnames
 SHOW DATABASES
 ----
-database_name    owner  primary_region  regions         survival_goal
-bad_db           root   ca-central-1    {ca-central-1}  zone
-defaultdb        root   NULL            {}              NULL
-mr-zone-configs  root   NULL            {}              NULL
-postgres         root   NULL            {}              NULL
-system           node   NULL            {}              NULL
-test             root   NULL            {}              NULL
+database_name    owner  primary_region  regions  survival_goal
+defaultdb        root   NULL            {}       NULL
+mr-zone-configs  root   NULL            {}       NULL
+postgres         root   NULL            {}       NULL
+system           node   NULL            {}       NULL
+test             root   NULL            {}       NULL
 
 statement ok
 ALTER DATABASE "mr-zone-configs" SET PRIMARY REGION "us-east-1"
@@ -305,7 +294,6 @@ query TTTTT colnames
 SHOW DATABASES
 ----
 database_name    owner  primary_region  regions                                  survival_goal
-bad_db           root   ca-central-1    {ca-central-1}                           zone
 defaultdb        root   NULL            {}                                       NULL
 mr-zone-configs  root   us-east-1       {ap-southeast-2,ca-central-1,us-east-1}  zone
 postgres         root   NULL            {}                                       NULL
@@ -496,13 +484,13 @@ SET override_multi_region_zone_config = true;
 ALTER index regional_by_row@primary CONFIGURE ZONE USING num_replicas = 10;
 SET override_multi_region_zone_config = false
 
-statement error attempting to update zone config which contains an extra zone configuration for index regional_by_row@"primary"
+statement error attempting to update zone config which contains an extra zone configuration for index regional_by_row@"primary" with field num_replicas populated
 ALTER TABLE regional_by_row SET LOCALITY GLOBAL
 
-statement error extraneous zone configuration for index regional_by_row@"primary"
+statement error extraneous zone configuration for index regional_by_row@"primary" with field num_replicas populated
 SELECT crdb_internal.validate_multi_region_zone_configs()
 
-statement error attempting to update zone config which contains an extra zone configuration for index regional_by_row@"primary"
+statement error attempting to update zone config which contains an extra zone configuration for index regional_by_row@"primary" with field num_replicas populated
 ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY ROW
 
 statement ok
@@ -537,7 +525,7 @@ INDEX regional_by_row_as@primary  ALTER INDEX regional_by_row_as@primary CONFIGU
                                   voter_constraints = '[+region=us-east-1]',
                                   lease_preferences = '[[+region=us-east-1]]'
 
-statement error attempting to update zone config which contains an extra zone configuration for index regional_by_row_as@"primary"
+statement error attempting to update zone config which contains an extra zone configuration for index regional_by_row_as@"primary" with field num_replicas populated
 ALTER TABLE regional_by_row_as SET LOCALITY REGIONAL BY ROW
 
 statement ok
@@ -641,3 +629,79 @@ statement ok
 SET override_multi_region_zone_config = true;
 ALTER PARTITION "ca-central-1" OF INDEX regional_by_row@primary CONFIGURE ZONE DISCARD;
 SET override_multi_region_zone_config = false
+
+# Test validation for initial SET PRIMARY REGION
+statement ok
+CREATE DATABASE initial_multiregion_db;
+USE initial_multiregion_db;
+CREATE TABLE tbl (a INT PRIMARY KEY, INDEX a_idx (a));
+ALTER DATABASE initial_multiregion_db CONFIGURE ZONE USING gc.ttlseconds = 5;
+ALTER TABLE tbl CONFIGURE ZONE USING gc.ttlseconds = 5;
+ALTER INDEX tbl@a_idx CONFIGURE ZONE USING gc.ttlseconds = 5
+
+statement ok
+ALTER DATABASE initial_multiregion_db SET PRIMARY REGION "us-east-1"
+
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE initial_multiregion_db
+----
+DATABASE initial_multiregion_db  ALTER DATABASE initial_multiregion_db CONFIGURE ZONE USING
+                                 range_min_bytes = 134217728,
+                                 range_max_bytes = 536870912,
+                                 gc.ttlseconds = 5,
+                                 num_replicas = 3,
+                                 num_voters = 3,
+                                 constraints = '{+region=us-east-1: 1}',
+                                 voter_constraints = '[+region=us-east-1]',
+                                 lease_preferences = '[[+region=us-east-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE tbl
+----
+TABLE tbl  ALTER TABLE tbl CONFIGURE ZONE USING
+           range_min_bytes = 134217728,
+           range_max_bytes = 536870912,
+           gc.ttlseconds = 5,
+           num_replicas = 3,
+           num_voters = 3,
+           constraints = '{+region=us-east-1: 1}',
+           voter_constraints = '[+region=us-east-1]',
+           lease_preferences = '[[+region=us-east-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR INDEX tbl@a_idx
+----
+INDEX tbl@a_idx  ALTER INDEX tbl@a_idx CONFIGURE ZONE USING
+                 range_min_bytes = 134217728,
+                 range_max_bytes = 536870912,
+                 gc.ttlseconds = 5,
+                 num_replicas = 3,
+                 num_voters = 3,
+                 constraints = '{+region=us-east-1: 1}',
+                 voter_constraints = '[+region=us-east-1]',
+                 lease_preferences = '[[+region=us-east-1]]'
+
+statement ok
+ALTER DATABASE initial_multiregion_db DROP REGION "us-east-1";
+ALTER INDEX tbl@a_idx CONFIGURE ZONE USING num_replicas = 10
+
+statement error zone configuration for index tbl@a_idx has field "num_replicas" set which will be overwritten when setting the initial PRIMARY REGION\nHINT: discard the zone config using CONFIGURE ZONE DISCARD before continuing
+ALTER DATABASE initial_multiregion_db SET PRIMARY REGION "us-east-1"
+
+statement ok
+ALTER INDEX tbl@a_idx CONFIGURE ZONE DISCARD;
+ALTER TABLE tbl CONFIGURE ZONE USING num_replicas = 10
+
+statement error zone configuration for table tbl has field "num_replicas" set which will be overwritten when setting the the initial PRIMARY REGION\nHINT: discard the zone config using CONFIGURE ZONE DISCARD before continuing
+ALTER DATABASE initial_multiregion_db SET PRIMARY REGION "us-east-1"
+
+statement ok
+ALTER TABLE tbl CONFIGURE ZONE DISCARD;
+ALTER DATABASE initial_multiregion_db CONFIGURE ZONE USING num_replicas = 10;
+
+statement error zone configuration for database initial_multiregion_db has field "num_replicas" set which will be overwritten when setting the the initial PRIMARY REGION\nHINT: discard the zone config using CONFIGURE ZONE DISCARD before continuing
+ALTER DATABASE initial_multiregion_db SET PRIMARY REGION "us-east-1"
+
+statement ok
+ALTER DATABASE initial_multiregion_db CONFIGURE ZONE DISCARD;
+ALTER DATABASE initial_multiregion_db SET PRIMARY REGION "us-east-1"

--- a/pkg/config/zonepb/zone.go
+++ b/pkg/config/zonepb/zone.go
@@ -611,8 +611,6 @@ type DiffWithZoneMismatch struct {
 	// PartitionName represents a subzone with a mismatching partitionName.
 	PartitionName string
 
-	// NOTE: only one of the below fields is set.
-
 	// IsMissingSubzone indicates a subzone is missing.
 	IsMissingSubzone bool
 	// IsExtraSubzone indicates we have an extraneous subzone.
@@ -782,6 +780,7 @@ func (z *ZoneConfig) DiffWithZone(
 					IndexID:        s.IndexID,
 					PartitionName:  s.PartitionName,
 					IsExtraSubzone: true,
+					Field:          subzoneMismatch.Field,
 				}, nil
 			}
 			continue
@@ -822,6 +821,7 @@ func (z *ZoneConfig) DiffWithZone(
 				IndexID:          o.IndexID,
 				PartitionName:    o.PartitionName,
 				IsMissingSubzone: true,
+				Field:            subzoneMismatch.Field,
 			}, nil
 		}
 	}

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -425,7 +425,7 @@ func (p *planner) checkPrivilegesForMultiRegionOp(
 func (p *planner) checkPrivilegesForRepartitioningRegionalByRowTables(
 	ctx context.Context, dbDesc *dbdesc.Immutable,
 ) error {
-	return p.forEachTableInMultiRegionDatabase(ctx, dbDesc,
+	return p.forEachMutableTableInDatabase(ctx, dbDesc,
 		func(ctx context.Context, tbDesc *tabledesc.Mutable) error {
 			if tbDesc.IsLocalityRegionalByRow() {
 				err := p.checkPrivilegesForMultiRegionOp(ctx, tbDesc)
@@ -455,7 +455,7 @@ func removeLocalityConfigFromAllTablesInDB(
 		)
 	}
 	b := p.Txn().NewBatch()
-	if err := p.forEachTableInMultiRegionDatabase(ctx, desc, func(ctx context.Context, tbDesc *tabledesc.Mutable) error {
+	if err := p.forEachMutableTableInDatabase(ctx, desc, func(ctx context.Context, tbDesc *tabledesc.Mutable) error {
 		// The user must either be an admin or have the requisite privileges.
 		if err := p.checkPrivilegesForMultiRegionOp(ctx, tbDesc); err != nil {
 			return err
@@ -694,7 +694,7 @@ func addDefaultLocalityConfigToAllTables(
 		)
 	}
 	b := p.Txn().NewBatch()
-	if err := p.forEachTableInMultiRegionDatabase(ctx, dbDesc, func(ctx context.Context, tbDesc *tabledesc.Mutable) error {
+	if err := p.forEachMutableTableInDatabase(ctx, dbDesc, func(ctx context.Context, tbDesc *tabledesc.Mutable) error {
 		if err := p.checkPrivilegesForMultiRegionOp(ctx, tbDesc); err != nil {
 			return err
 		}

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -332,7 +332,11 @@ func (p *planner) AlterDatabaseDropRegion(
 		}
 		if len(regions) != 1 {
 			return nil, errors.WithHintf(
-				errors.Newf("cannot drop region %q", dbDesc.RegionConfig.PrimaryRegion),
+				pgerror.Newf(
+					pgcode.InvalidDatabaseDefinition,
+					"cannot drop region %q",
+					dbDesc.RegionConfig.PrimaryRegion,
+				),
 				"You must designate another region as the primary region using "+
 					"ALTER DATABASE %s PRIMARY REGION <region name> or remove all other regions before "+
 					"attempting to drop region %q", dbDesc.GetName(), n.Region,

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -756,7 +756,6 @@ func checkCanConvertTableToMultiRegion(
 			)
 		}
 	}
-	// TODO(#57668): check zone configurations are not set here
 	return nil
 }
 
@@ -772,6 +771,15 @@ func (n *alterDatabasePrimaryRegionNode) setInitialPrimaryRegion(params runParam
 		[]tree.Name{n.n.PrimaryRegion},
 	)
 	if err != nil {
+		return err
+	}
+
+	// Check we are writing valid zone configurations.
+	if err := params.p.validateAllMultiRegionZoneConfigsInDatabase(
+		params.ctx,
+		&n.desc.Immutable,
+		&zoneConfigForMultiRegionValidatorSetInitialRegion{},
+	); err != nil {
 		return err
 	}
 

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -845,13 +845,38 @@ func (p *planner) ValidateAllMultiRegionZoneConfigsInCurrentDatabase(ctx context
 		return nil
 	}
 
+	var ids []descpb.ID
+	if err := p.forEachTableInMultiRegionDatabase(
+		ctx,
+		dbDesc,
+		func(ctx context.Context, tbDesc *tabledesc.Mutable) error {
+			ids = append(ids, tbDesc.GetID())
+			return nil
+		},
+	); err != nil {
+		return err
+	}
+	ids = append(ids, dbDesc.GetID())
+
+	zoneConfigs, err := getZoneConfigRawBatch(
+		ctx,
+		p.txn,
+		p.ExecCfg().Codec,
+		ids,
+	)
+	if err != nil {
+		return err
+	}
+
 	if err := p.validateZoneConfigForMultiRegionDatabase(
 		ctx,
 		dbDesc,
+		zoneConfigs[dbDesc.GetID()],
 		&validateZoneConfigForMultiRegionErrorHandlerValidation{},
 	); err != nil {
 		return err
 	}
+
 	return p.forEachTableInMultiRegionDatabase(
 		ctx,
 		dbDesc,
@@ -860,6 +885,7 @@ func (p *planner) ValidateAllMultiRegionZoneConfigsInCurrentDatabase(ctx context
 				ctx,
 				dbDesc,
 				tbDesc,
+				zoneConfigs[tbDesc.GetID()],
 				&validateZoneConfigForMultiRegionErrorHandlerValidation{},
 			)
 		},
@@ -1125,6 +1151,8 @@ type validateZoneConfigForMultiRegionErrorHandler interface {
 // interface validateZoneConfigForMultiRegionErrorHandler.
 type validateZoneConfigForMultiRegionErrorHandlerModifiedByUser struct{}
 
+var _ validateZoneConfigForMultiRegionErrorHandler = (*validateZoneConfigForMultiRegionErrorHandlerModifiedByUser)(nil)
+
 func (v *validateZoneConfigForMultiRegionErrorHandlerModifiedByUser) newMismatchFieldError(
 	descType string, descName string, field string,
 ) error {
@@ -1181,6 +1209,8 @@ func (v *validateZoneConfigForMultiRegionErrorHandlerModifiedByUser) newExtraSub
 // interface validateZoneConfigForMultiRegionErrorHandler.
 type validateZoneConfigForMultiRegionErrorHandlerValidation struct{}
 
+var _ validateZoneConfigForMultiRegionErrorHandler = (*validateZoneConfigForMultiRegionErrorHandlerValidation)(nil)
+
 func (v *validateZoneConfigForMultiRegionErrorHandlerValidation) newMismatchFieldError(
 	descType string, descName string, field string,
 ) error {
@@ -1227,9 +1257,14 @@ func (p *planner) validateZoneConfigForMultiRegionDatabaseWasNotModifiedByUser(
 	if p.SessionData().OverrideMultiRegionZoneConfigEnabled {
 		return nil
 	}
+	currentZoneConfig, err := getZoneConfigRaw(ctx, p.txn, p.ExecCfg().Codec, dbDesc.ID)
+	if err != nil {
+		return err
+	}
 	return p.validateZoneConfigForMultiRegionDatabase(
 		ctx,
 		dbDesc,
+		currentZoneConfig,
 		&validateZoneConfigForMultiRegionErrorHandlerModifiedByUser{},
 	)
 }
@@ -1239,18 +1274,17 @@ func (p *planner) validateZoneConfigForMultiRegionDatabaseWasNotModifiedByUser(
 func (p *planner) validateZoneConfigForMultiRegionDatabase(
 	ctx context.Context,
 	dbDesc *dbdesc.Immutable,
+	currentZoneConfig *zonepb.ZoneConfig,
 	validateZoneConfigForMultiRegionErrorHandler validateZoneConfigForMultiRegionErrorHandler,
 ) error {
+	if currentZoneConfig == nil {
+		currentZoneConfig = zonepb.NewZoneConfig()
+	}
 	regionConfig, err := SynthesizeRegionConfigForZoneConfigValidation(ctx, p.txn, dbDesc.ID, p.Descriptors())
 	if err != nil {
 		return err
 	}
 	expectedZoneConfig, err := zoneConfigForMultiRegionDatabase(regionConfig)
-	if err != nil {
-		return err
-	}
-
-	currentZoneConfig, err := getZoneConfigRaw(ctx, p.txn, p.ExecCfg().Codec, dbDesc.ID)
 	if err != nil {
 		return err
 	}
@@ -1291,11 +1325,16 @@ func (p *planner) validateZoneConfigForMultiRegionTableWasNotModifiedByUser(
 	if p.SessionData().OverrideMultiRegionZoneConfigEnabled || desc.GetLocalityConfig() == nil {
 		return nil
 	}
+	currentZoneConfig, err := getZoneConfigRaw(ctx, p.txn, p.ExecCfg().Codec, desc.GetID())
+	if err != nil {
+		return err
+	}
 
 	return p.validateZoneConfigForMultiRegionTable(
 		ctx,
 		dbDesc,
 		desc,
+		currentZoneConfig,
 		&validateZoneConfigForMultiRegionErrorHandlerModifiedByUser{},
 	)
 }
@@ -1306,12 +1345,9 @@ func (p *planner) validateZoneConfigForMultiRegionTable(
 	ctx context.Context,
 	dbDesc *dbdesc.Immutable,
 	desc catalog.TableDescriptor,
+	currentZoneConfig *zonepb.ZoneConfig,
 	validateZoneConfigForMultiRegionErrorHandler validateZoneConfigForMultiRegionErrorHandler,
 ) error {
-	currentZoneConfig, err := getZoneConfigRaw(ctx, p.txn, p.ExecCfg().Codec, desc.GetID())
-	if err != nil {
-		return err
-	}
 	if currentZoneConfig == nil {
 		currentZoneConfig = zonepb.NewZoneConfig()
 	}

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -712,40 +712,10 @@ func applyZoneConfigForMultiRegionDatabase(
 	return nil
 }
 
-// forEachTableInMultiRegionDatabase calls the given function on every table
-// descriptor inside the given multi-region database. Tables that have been
-// dropped are skipped.
-func (p *planner) forEachTableInMultiRegionDatabase(
-	ctx context.Context,
-	dbDesc *dbdesc.Immutable,
-	fn func(ctx context.Context, tbDesc *tabledesc.Mutable) error,
-) error {
-	if !dbDesc.IsMultiRegion() {
-		return errors.AssertionFailedf("db %q is not multi-region", dbDesc.Name)
-	}
-	allDescs, err := p.Descriptors().GetAllDescriptors(ctx, p.txn)
-	if err != nil {
-		return err
-	}
-
-	lCtx := newInternalLookupCtx(ctx, allDescs, dbDesc, nil /* fallback */)
-	for _, tbID := range lCtx.tbIDs {
-		desc := lCtx.tbDescs[tbID]
-		if desc.Dropped() {
-			continue
-		}
-		mutable := tabledesc.NewBuilder(desc.TableDesc()).BuildExistingMutableTable()
-		if err := fn(ctx, mutable); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // updateZoneConfigsForAllTables loops through all of the tables in the
 // specified database and refreshes the zone configs for all tables.
 func (p *planner) updateZoneConfigsForAllTables(ctx context.Context, desc *dbdesc.Mutable) error {
-	return p.forEachTableInMultiRegionDatabase(
+	return p.forEachMutableTableInDatabase(
 		ctx,
 		&desc.Immutable,
 		func(ctx context.Context, tbDesc *tabledesc.Mutable) error {
@@ -865,7 +835,7 @@ func (p *planner) validateAllMultiRegionZoneConfigsInDatabase(
 	zoneConfigForMultiRegionValidator zoneConfigForMultiRegionValidator,
 ) error {
 	var ids []descpb.ID
-	if err := p.forEachTableInMultiRegionDatabase(
+	if err := p.forEachMutableTableInDatabase(
 		ctx,
 		dbDesc,
 		func(ctx context.Context, tbDesc *tabledesc.Mutable) error {
@@ -896,7 +866,7 @@ func (p *planner) validateAllMultiRegionZoneConfigsInDatabase(
 		return err
 	}
 
-	return p.forEachTableInMultiRegionDatabase(
+	return p.forEachMutableTableInDatabase(
 		ctx,
 		dbDesc,
 		func(ctx context.Context, tbDesc *tabledesc.Mutable) error {

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -858,7 +858,6 @@ func (p *planner) validateAllMultiRegionZoneConfigsInDatabase(
 	}
 
 	if err := p.validateZoneConfigForMultiRegionDatabase(
-		ctx,
 		dbDesc,
 		zoneConfigs[dbDesc.GetID()],
 		zoneConfigForMultiRegionValidator,
@@ -871,8 +870,6 @@ func (p *planner) validateAllMultiRegionZoneConfigsInDatabase(
 		dbDesc,
 		func(ctx context.Context, tbDesc *tabledesc.Mutable) error {
 			return p.validateZoneConfigForMultiRegionTable(
-				ctx,
-				dbDesc,
 				tbDesc,
 				zoneConfigs[tbDesc.GetID()],
 				zoneConfigForMultiRegionValidator,
@@ -1135,8 +1132,81 @@ type zoneConfigForMultiRegionValidator interface {
 	getExpectedTableZoneConfig(desc catalog.TableDescriptor) (zonepb.ZoneConfig, error)
 
 	newMismatchFieldError(descType string, descName string, field string) error
-	newMissingSubzoneError(descType string, descName string) error
-	newExtraSubzoneError(descType string, descName string) error
+	newMissingSubzoneError(descType string, descName string, field string) error
+	newExtraSubzoneError(descType string, descName string, field string) error
+}
+
+// zoneConfigForMultiRegionValidatorSetInitialRegion implements
+// interface zoneConfigForMultiRegionValidator.
+type zoneConfigForMultiRegionValidatorSetInitialRegion struct{}
+
+var _ zoneConfigForMultiRegionValidator = (*zoneConfigForMultiRegionValidatorSetInitialRegion)(nil)
+
+func (v *zoneConfigForMultiRegionValidatorSetInitialRegion) getExpectedDatabaseZoneConfig() (
+	zonepb.ZoneConfig,
+	error,
+) {
+	// For set initial region, we want no multi-region fields to be set.
+	return *zonepb.NewZoneConfig(), nil
+}
+
+func (v *zoneConfigForMultiRegionValidatorSetInitialRegion) getExpectedTableZoneConfig(
+	desc catalog.TableDescriptor,
+) (zonepb.ZoneConfig, error) {
+	// For set initial region, we want no multi-region fields to be set.
+	return *zonepb.NewZoneConfig(), nil
+}
+
+func (v *zoneConfigForMultiRegionValidatorSetInitialRegion) wrapErr(err error) error {
+	// We currently do not allow "inherit from parent" behavior, so one must
+	// discard the zone config before continuing.
+	// COPY FROM PARENT copies the value but does not inherit.
+	// This can be replaced with the override session variable hint when it is
+	// available.
+	return errors.WithHintf(
+		err,
+		"discard the zone config using CONFIGURE ZONE DISCARD before continuing",
+	)
+}
+
+func (v *zoneConfigForMultiRegionValidatorSetInitialRegion) newMismatchFieldError(
+	descType string, descName string, field string,
+) error {
+	return v.wrapErr(
+		pgerror.Newf(
+			pgcode.InvalidObjectDefinition,
+			"zone configuration for %s %s has field %q set which will be overwritten when setting the the initial PRIMARY REGION",
+			descType,
+			descName,
+			field,
+		),
+	)
+}
+
+func (v *zoneConfigForMultiRegionValidatorSetInitialRegion) newMissingSubzoneError(
+	descType string, descName string, field string,
+) error {
+	// There can never be a missing subzone as we only compare against
+	// blank zone configs.
+	return errors.AssertionFailedf(
+		"unexpected missing subzone for %s %s",
+		descType,
+		descName,
+	)
+}
+
+func (v *zoneConfigForMultiRegionValidatorSetInitialRegion) newExtraSubzoneError(
+	descType string, descName string, field string,
+) error {
+	return v.wrapErr(
+		pgerror.Newf(
+			pgcode.InvalidObjectDefinition,
+			"zone configuration for %s %s has field %q set which will be overwritten when setting the initial PRIMARY REGION",
+			descType,
+			descName,
+			field,
+		),
+	)
 }
 
 // zoneConfigForMultiRegionValidatorExistingMultiRegionObject partially implements
@@ -1201,7 +1271,7 @@ func (v *zoneConfigForMultiRegionValidatorModifiedByUser) wrapErr(err error) err
 }
 
 func (v *zoneConfigForMultiRegionValidatorModifiedByUser) newMissingSubzoneError(
-	descType string, descName string,
+	descType string, descName string, field string,
 ) error {
 	return v.wrapErr(
 		pgerror.Newf(
@@ -1214,14 +1284,15 @@ func (v *zoneConfigForMultiRegionValidatorModifiedByUser) newMissingSubzoneError
 }
 
 func (v *zoneConfigForMultiRegionValidatorModifiedByUser) newExtraSubzoneError(
-	descType string, descName string,
+	descType string, descName string, field string,
 ) error {
 	return v.wrapErr(
 		pgerror.Newf(
 			pgcode.InvalidObjectDefinition,
-			"attempting to update zone config which contains an extra zone configuration for %s %s",
+			"attempting to update zone config which contains an extra zone configuration for %s %s with field %s populated",
 			descType,
 			descName,
+			field,
 		),
 	)
 }
@@ -1247,7 +1318,7 @@ func (v *zoneConfigForMultiRegionValidatorValidation) newMismatchFieldError(
 }
 
 func (v *zoneConfigForMultiRegionValidatorValidation) newMissingSubzoneError(
-	descType string, descName string,
+	descType string, descName string, field string,
 ) error {
 	return pgerror.Newf(
 		pgcode.InvalidObjectDefinition,
@@ -1258,13 +1329,14 @@ func (v *zoneConfigForMultiRegionValidatorValidation) newMissingSubzoneError(
 }
 
 func (v *zoneConfigForMultiRegionValidatorValidation) newExtraSubzoneError(
-	descType string, descName string,
+	descType string, descName string, field string,
 ) error {
 	return pgerror.Newf(
 		pgcode.InvalidObjectDefinition,
-		"extraneous zone configuration for %s %s",
+		"extraneous zone configuration for %s %s with field %s populated",
 		descType,
 		descName,
+		field,
 	)
 }
 
@@ -1289,7 +1361,6 @@ func (p *planner) validateZoneConfigForMultiRegionDatabaseWasNotModifiedByUser(
 		return err
 	}
 	return p.validateZoneConfigForMultiRegionDatabase(
-		ctx,
 		dbDesc,
 		currentZoneConfig,
 		&zoneConfigForMultiRegionValidatorModifiedByUser{
@@ -1303,7 +1374,6 @@ func (p *planner) validateZoneConfigForMultiRegionDatabaseWasNotModifiedByUser(
 // validateZoneConfigForMultiRegionDatabase validates that the zone config
 // for the databases matches as the multi-region database definition.
 func (p *planner) validateZoneConfigForMultiRegionDatabase(
-	ctx context.Context,
 	dbDesc *dbdesc.Immutable,
 	currentZoneConfig *zonepb.ZoneConfig,
 	zoneConfigForMultiRegionValidator zoneConfigForMultiRegionValidator,
@@ -1362,8 +1432,6 @@ func (p *planner) validateZoneConfigForMultiRegionTableWasNotModifiedByUser(
 	}
 
 	return p.validateZoneConfigForMultiRegionTable(
-		ctx,
-		dbDesc,
 		desc,
 		currentZoneConfig,
 		&zoneConfigForMultiRegionValidatorModifiedByUser{
@@ -1378,8 +1446,6 @@ func (p *planner) validateZoneConfigForMultiRegionTableWasNotModifiedByUser(
 // the multi-region fields of the table's zone configuration
 // matches what is expected for the given table.
 func (p *planner) validateZoneConfigForMultiRegionTable(
-	ctx context.Context,
-	dbDesc *dbdesc.Immutable,
 	desc catalog.TableDescriptor,
 	currentZoneConfig *zonepb.ZoneConfig,
 	zoneConfigForMultiRegionValidator zoneConfigForMultiRegionValidator,
@@ -1472,12 +1538,14 @@ func (p *planner) validateZoneConfigForMultiRegionTable(
 			return zoneConfigForMultiRegionValidator.newMissingSubzoneError(
 				descType,
 				name,
+				mismatch.Field,
 			)
 		}
 		if mismatch.IsExtraSubzone {
 			return zoneConfigForMultiRegionValidator.newExtraSubzoneError(
 				descType,
 				name,
+				mismatch.Field,
 			)
 		}
 		return zoneConfigForMultiRegionValidator.newMismatchFieldError(

--- a/pkg/sql/region_util_test.go
+++ b/pkg/sql/region_util_test.go
@@ -27,7 +27,7 @@ func TestZoneConfigForMultiRegionDatabase(t *testing.T) {
 	testCases := []struct {
 		desc         string
 		regionConfig multiregion.RegionConfig
-		expected     *zonepb.ZoneConfig
+		expected     zonepb.ZoneConfig
 	}{
 		{
 			desc: "one region, zone survival",
@@ -39,7 +39,7 @@ func TestZoneConfigForMultiRegionDatabase(t *testing.T) {
 				descpb.SurvivalGoal_ZONE_FAILURE,
 				descpb.InvalidID,
 			),
-			expected: &zonepb.ZoneConfig{
+			expected: zonepb.ZoneConfig{
 				NumReplicas: proto.Int32(3),
 				NumVoters:   proto.Int32(3),
 				LeasePreferences: []zonepb.LeasePreference{
@@ -77,7 +77,7 @@ func TestZoneConfigForMultiRegionDatabase(t *testing.T) {
 				descpb.SurvivalGoal_ZONE_FAILURE,
 				descpb.InvalidID,
 			),
-			expected: &zonepb.ZoneConfig{
+			expected: zonepb.ZoneConfig{
 				NumReplicas: proto.Int32(4),
 				NumVoters:   proto.Int32(3),
 				LeasePreferences: []zonepb.LeasePreference{
@@ -122,7 +122,7 @@ func TestZoneConfigForMultiRegionDatabase(t *testing.T) {
 				descpb.SurvivalGoal_ZONE_FAILURE,
 				descpb.InvalidID,
 			),
-			expected: &zonepb.ZoneConfig{
+			expected: zonepb.ZoneConfig{
 				NumReplicas: proto.Int32(5),
 				NumVoters:   proto.Int32(3),
 				LeasePreferences: []zonepb.LeasePreference{
@@ -173,7 +173,7 @@ func TestZoneConfigForMultiRegionDatabase(t *testing.T) {
 				descpb.SurvivalGoal_REGION_FAILURE,
 				descpb.InvalidID,
 			),
-			expected: &zonepb.ZoneConfig{
+			expected: zonepb.ZoneConfig{
 				NumReplicas: proto.Int32(5),
 				NumVoters:   proto.Int32(5),
 				LeasePreferences: []zonepb.LeasePreference{
@@ -225,7 +225,7 @@ func TestZoneConfigForMultiRegionDatabase(t *testing.T) {
 				descpb.SurvivalGoal_ZONE_FAILURE,
 				descpb.InvalidID,
 			),
-			expected: &zonepb.ZoneConfig{
+			expected: zonepb.ZoneConfig{
 				NumReplicas: proto.Int32(6),
 				NumVoters:   proto.Int32(3),
 				LeasePreferences: []zonepb.LeasePreference{
@@ -283,7 +283,7 @@ func TestZoneConfigForMultiRegionDatabase(t *testing.T) {
 				descpb.SurvivalGoal_REGION_FAILURE,
 				descpb.InvalidID,
 			),
-			expected: &zonepb.ZoneConfig{
+			expected: zonepb.ZoneConfig{
 				NumReplicas: proto.Int32(5),
 				NumVoters:   proto.Int32(5),
 				LeasePreferences: []zonepb.LeasePreference{

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -1008,6 +1008,41 @@ func getZoneConfigRaw(
 	return &zone, nil
 }
 
+// getZoneConfigRawBatch looks up the zone config with the given IDs.
+// Unlike getZoneConfig, it does not attempt to ascend the zone config hierarchy.
+// If no zone config exists for the given ID, the map entry is not provided.
+func getZoneConfigRawBatch(
+	ctx context.Context, txn *kv.Txn, codec keys.SQLCodec, ids []descpb.ID,
+) (map[descpb.ID]*zonepb.ZoneConfig, error) {
+	if !codec.ForSystemTenant() {
+		// Secondary tenants do not have zone configs for individual objects.
+		return nil, nil
+	}
+	b := txn.NewBatch()
+	for _, id := range ids {
+		b.Get(config.MakeZoneKey(config.SystemTenantObjectID(id)))
+	}
+	if err := txn.Run(ctx, b); err != nil {
+		return nil, err
+	}
+	ret := make(map[descpb.ID]*zonepb.ZoneConfig, len(b.Results))
+	for idx, r := range b.Results {
+		if r.Err != nil {
+			return nil, r.Err
+		}
+		var zone zonepb.ZoneConfig
+		row := r.Rows[0]
+		if row.Value == nil {
+			continue
+		}
+		if err := row.ValueProto(&zone); err != nil {
+			return nil, err
+		}
+		ret[ids[idx]] = &zone
+	}
+	return ret, nil
+}
+
 // RemoveIndexZoneConfigs removes the zone configurations for some
 // indexes being dropped. It is a no-op if there is no zone
 // configuration, there's no index zone configs to be dropped,

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -494,7 +494,7 @@ func repartitionRegionalByRowTables(
 	}
 
 	b := txn.NewBatch()
-	err = localPlanner.forEachTableInMultiRegionDatabase(ctx, dbDesc,
+	err = localPlanner.forEachMutableTableInDatabase(ctx, dbDesc,
 		func(ctx context.Context, tableDesc *tabledesc.Mutable) error {
 			if !tableDesc.IsLocalityRegionalByRow() || tableDesc.Dropped() {
 				// We only need to re-partition REGIONAL BY ROW tables. Even then, we


### PR DESCRIPTION
Backport:
  * 4/4 commits from "sql: block initial multi-region if zone configs have multi-region fields set" (#63129)
  * 1/1 commits from "sql: add pgcode for DROP REGION on PRIMARY REGION" (#63259)

Resolves #63071 

Please see individual PRs for details.

/cc @cockroachdb/release
