### PR TITLE
release-21.1: changefeedccl: Make it possible to configure kafka behavior.

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -84,6 +84,9 @@ const (
 	OptFormatAvro   FormatType = `experimental_avro`
 	OptFormatNative FormatType = `native`
 
+	// OptKafkaSinkConfig is a JSON configuration for kafka sink (kafkaSinkConfig).
+	OptKafkaSinkConfig = `kafka_sink_config`
+
 	SinkParamCACert           = `ca_cert`
 	SinkParamClientCert       = `client_cert`
 	SinkParamClientKey        = `client_key`


### PR DESCRIPTION
Backport 1/1 commits from #63039.

/cc @cockroachdb/release

---

Make it possible to configure kafka behavior, in particular Flushing,
via `kafka_sink_config` CHANGEFEED option.

This option can be used to configure underlying kafka library
(sarama) to balance latency vs throughput configuraitons.  The default
is to optimize for latency.  Clients can choose to configure for
throughput instead.

For example, the following will batch up to 1000 messages, or up to
1 second worth of messages.
```
CREATE CHANGEFEED ... WITH kafka_sink_config='{"Flush": {"MaxMessages": 1000, "Frequency": "1s"}}`'
```

Release Notes: Make kafka library used in changefeeds configurable via `kafka_sink_config`
option to enable latency vs throughput configurations.

