### PR TITLE
release-21.1: sql: fix zone config validation during a REGIONAL BY ROW transition

### DIFF
--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
         "//pkg/ccl/utilccl",
         "//pkg/jobs",
         "//pkg/keys",
+        "//pkg/kv",
         "//pkg/roachpb",
         "//pkg/security",
         "//pkg/security/securitytest",


### PR DESCRIPTION
Backport 1/1 commits from #63273.

/cc @cockroachdb/release

**probably could wait til 21.1.1 to merge, not a strict blocker**

---

Involves peeping into the mutations and excluding the new indexes being
created -- these will not have the correct zone configs set on them.

Resolves: #63204

Release note (bug fix): Fix a bug where
crdb_internal.validate_multi_region_zone_configs() fails during a
REGIONAL BY ROW locality transition.
