### PR TITLE
sql:  Enable locality optimized scans in the row engine

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_import_export
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_import_export
@@ -1,4 +1,4 @@
-# LogicTest: multiregion-9node-3region-3azs
+# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off
 
 query TTTT colnames
 SHOW REGIONS

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -1,4 +1,4 @@
-# LogicTest: multiregion-9node-3region-3azs
+# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off
 
 statement ok
 CREATE DATABASE multi_region_test_db PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1" SURVIVE REGION FAILURE
@@ -674,10 +674,8 @@ SET locality_optimized_partitioned_index_scan = false
 
 # Query with locality optimized search disabled.
 query T
-EXPLAIN SELECT * FROM regional_by_row_table WHERE pk = 1
+SELECT * FROM [EXPLAIN SELECT * FROM regional_by_row_table WHERE pk = 1] OFFSET 2
 ----
-distribution: local
-vectorized: true
 ·
 • scan
   missing stats
@@ -703,10 +701,8 @@ SET locality_optimized_partitioned_index_scan = true
 
 # Same query with locality optimized search enabled.
 query T
-EXPLAIN (DISTSQL) SELECT * FROM regional_by_row_table WHERE pk = 1
+SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM regional_by_row_table WHERE pk = 1] OFFSET 2
 ----
-distribution: local
-vectorized: true
 ·
 • union all
 │ limit: 1
@@ -721,7 +717,7 @@ vectorized: true
       table: regional_by_row_table@primary
       spans: [/'ca-central-1'/1 - /'ca-central-1'/1] [/'us-east-1'/1 - /'us-east-1'/1]
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJykkVFr2zAUhd_3K8R92oaGLWeDIRh4bC41uElqB1qoTVCsS2rqSK4k04Tg_15iP6QpSSHp4z1X5-g70hbscw0covtp8jcek6__42yW3SbfSBYl0b8Z-U6u0skNMbistBL1fLGZG_0yd2JRI7m7jtKINE_kD2FAQWmJY7FCC_wBGBQUGqNLtFabnbTtD8RyDdynUKmmdTu5oFBqg8C34CpXI3CY7dJTFBKN5wMFiU5UdR97FCRsTLUSZgMUskYoy4mXQ56vf_s5eMzziVCSMKLdIxqgMGkdJyGjYUDDEQ1_0vAXFB0F3bo9k3ViicBZRy_jZpdyhwPzmZzBSc49Xqu0kWhQHqAV3ZEmY_1DN15w2CGpVpUj7CSDf85bpWgbrSy-YzmVXFBAucShkNWtKXFqdNlfM4yT3tcLEq0btsEwxKpf9Z_51sw-Yw4-NI8OzH5XdF9eAwAA__86rhxz
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJykkdGL1DAQxt_9K4Z5Uom06SlIQKhoFwt1e7YFhWtZcs2wFrtJTVK8Y-n_Lts-nJVb4dbH-Wa-md-XHNH97FFgmWTJhwpewqbIP8NN8u06e59u4fnHtKzKL9kLWA9Y2ndGy353e7-z5tfOy9ue4OunpEhg-AHvgDeQbzZlUkGEDLVRtJUHcihukGPDcLCmJeeMPUnHeSBVdyhChp0eRn-SG4atsYTiiL7zPaHA6nSnIKnIBiEyVORl189rH0WKB9sdpL1HhuUgtRMQ1FjXd2_DGgMehCC1Ag7GfyeLDPPRC4g5iyMWX7H4NYvfYDMxNKN_YHJe7gkFn9hl3PxS7nhhfiJndJbzAW_UxiqypFZozfRIkq15ZYYgWmfIukPngZ9lCJ_yVgW5wWhHf7Gc29wwJLWnJZAzo23p2pp2PrOU-eybBUXOL91oKVI9t-bP_NPM_8cc_dN8tTKHUzM9-x0AAP__wyAi4g==
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM regional_by_row_table WHERE pk = 1; SET tracing = off
@@ -757,10 +753,8 @@ output row: [10 10 11 12 NULL]
 # scanned in the first child of the limited union all.
 query T nodeidx=3
 USE multi_region_test_db; SET locality_optimized_partitioned_index_scan = true;
-EXPLAIN SELECT * FROM regional_by_row_table WHERE pk = 1
+SELECT * FROM [EXPLAIN SELECT * FROM regional_by_row_table WHERE pk = 1] OFFSET 2
 ----
-distribution: local
-vectorized: true
 ·
 • union all
 │ limit: 1
@@ -804,10 +798,8 @@ SET locality_optimized_partitioned_index_scan = false
 
 # Query with locality optimized search disabled.
 query T
-EXPLAIN SELECT * FROM child WHERE NOT EXISTS (SELECT * FROM parent WHERE p_id = c_p_id) AND c_id = 10
+SELECT * FROM [EXPLAIN SELECT * FROM child WHERE NOT EXISTS (SELECT * FROM parent WHERE p_id = c_p_id) AND c_id = 10] OFFSET 2
 ----
-distribution: full
-vectorized: true
 ·
 • lookup join (anti)
 │ table: parent@primary
@@ -839,10 +831,8 @@ SET locality_optimized_partitioned_index_scan = true
 
 # Same query with locality optimized search enabled.
 query T
-EXPLAIN (DISTSQL) SELECT * FROM child WHERE NOT EXISTS (SELECT * FROM parent WHERE p_id = c_p_id) AND c_id = 10
+SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM child WHERE NOT EXISTS (SELECT * FROM parent WHERE p_id = c_p_id) AND c_id = 10] OFFSET 2
 ----
-distribution: local
-vectorized: true
 ·
 • lookup join (anti)
 │ table: parent@primary
@@ -867,7 +857,7 @@ vectorized: true
               table: child@primary
               spans: [/'ca-central-1'/10 - /'ca-central-1'/10] [/'us-east-1'/10 - /'us-east-1'/10]
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJy0k2Fr2zwQx98_n-K4N0keNCI7LhRBwGF1mYvndIlhhcUUzzpab4nkyTKkhHz3ETvQOCwh7dg763R_3-9_uttg9WuJAoOH-2gSxtC_CefJ_Es0gHkQBR8T-B9uZ9PPkD8XSwlfPwWzAPrxNIHgYZcI_W5amRlSdp9XPhYSxpA_7j4GA5jEN9DP26DDB8hQaUlxtqIKxTd0MGVYGp1TVWmzC22ahFCuUXCGhSpruwunDHNtCMUGbWGXhAKT7PuSZpRJMkOODCXZrFg2v23I_dIUq8y8IMN5malKwHCBi8X6mi9w6PAhh0xJcEDbZzLIcFpbAb7DfBfTLUNd29falc2eCIWzZe_jcy7l8_dsl_G4J3leMWqljSRDsoOQbv9AHOsPuhy6XdaoWBUWnJMM_C09udOF2rdk1C2TvJQkIApuE5jESQh30zBGhu1wHbQq0vpnXcIPXSjQSkDfH8EYfHc_ar4HY1j3PN4TQvgO5_zKG1zWzNE7jXj_yshuNde960MrDNa9vOPtQnPeW8zNqCq1quhoYk69f8qQ5BO1Y1fp2uR0b3TelGmP00bXBCRVtr1120OomqtmtQ7Fzt-I3bPiUUfMj8Wjs2LvvNg7K746Eqfb_34HAAD__-igvDk=
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJy0k9GL2kAQxt_7VwzzopYtbmIOjgUh0os0R5pcNdCDMxxpMtyl1d10swEP8X8vJsIZqeJd6Zs7-33O75vMbrD6vUSBcy_wPsfwEaaz6Cs8ePd3wcQPoX_jz-P5t2AAXUH2XCxz-P7Fm3nQD6MYvPudEPpdWZlqkmavKx-LHMaQPe5-DAYwCW-gn7VFiw8SiKbTuReDjQylyilMV1SheEALE4alVhlVldK70qYR-PkaBWdYyLI2u3LCMFOaUGzQFGZJKDBOfyxpRmlOesiRYU4mLZbN3zYZ3FIXq1S_IMN5mcpKwHCBi8X6mi9waPEhh1TmYIEyz6SRYVQbAa7FXBuTLUNVm9felUmfCIW1Ze_jsy7lc_dsl_HYJ3leMWqpdE6a8g5Csv0Lcag-qXJod1mDYlUYsE4y8LfM5FYVcj-SUbdN_FKSgMCbxjAJYx9uIz9Ehu2aHYwqUOpXXcJPVUhQUkDfHcEYXHu_dK4DY1j3HN4TQrgW5_zKGVw2zNE7gzj_K8juka5714dRGKx7WSfbheGct4SbUVUqWdHRxpz6_glDyp-oXbtK1TqjO62ypk17jBpfU8ipMu2t3R582Vw1T-vQbP2L2T5rHnXM_Ng8Omt2zpuds-arI3Oy_fAnAAD__xkswqg=
 
 statement ok
 SET tracing = on,kv,results; SELECT * FROM child WHERE NOT EXISTS (SELECT * FROM parent WHERE p_id = c_p_id) AND c_id = 10; SET tracing = off
@@ -903,10 +893,8 @@ Scan /Table/74/1/"\x80"/20/0, /Table/74/1/"\xc0"/20/0
 fetched: /parent/primary/'ca-central-1'/20 -> NULL
 
 query T
-EXPLAIN INSERT INTO child VALUES (1, 1)
+SELECT * FROM [EXPLAIN INSERT INTO child VALUES (1, 1)] OFFSET 2
 ----
-distribution: local
-vectorized: true
 ·
 • root
 │
@@ -956,10 +944,8 @@ vectorized: true
                       label: buffer 1
 
 query T
-EXPLAIN UPSERT INTO child VALUES (1, 1)
+SELECT * FROM [EXPLAIN UPSERT INTO child VALUES (1, 1)] OFFSET 2
 ----
-distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1009,10 +995,8 @@ vectorized: true
 
 # We don't yet support locality optimized search for semi join.
 query T
-EXPLAIN DELETE FROM parent WHERE p_id = 1
+SELECT * FROM [EXPLAIN DELETE FROM parent WHERE p_id = 1] OFFSET 2
 ----
-distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1061,10 +1045,8 @@ ALTER TABLE regional_by_row_table ADD CONSTRAINT unique_b_a UNIQUE(b, a)
 # We should plan uniqueness checks for all unique indexes in
 # REGIONAL BY ROW tables.
 query T
-EXPLAIN INSERT INTO regional_by_row_table (pk, pk2, a, b) VALUES (1, 1, 1, 1)
+SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table (pk, pk2, a, b) VALUES (1, 1, 1, 1)] OFFSET 2
 ----
-distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1162,10 +1144,8 @@ INSERT INTO regional_by_row_table (crdb_region, pk, pk2, a, b) VALUES ('us-east-
 # The conflict columns in an upsert should only include the primary key,
 # not the region column.
 query T
-EXPLAIN UPSERT INTO regional_by_row_table (crdb_region, pk, pk2, a, b) VALUES ('us-east-1', 2, 3, 2, 3)
+SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table (crdb_region, pk, pk2, a, b) VALUES ('us-east-1', 2, 3, 2, 3)] OFFSET 2
 ----
-distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1253,11 +1233,9 @@ vectorized: true
                       label: buffer 1
 
 query T
-EXPLAIN UPSERT INTO regional_by_row_table (crdb_region, pk, pk2, a, b)
-VALUES ('us-east-1', 23, 24, 25, 26), ('ca-central-1', 30, 30, 31, 32)
+SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table (crdb_region, pk, pk2, a, b)
+VALUES ('us-east-1', 23, 24, 25, 26), ('ca-central-1', 30, 30, 31, 32)] OFFSET 2
 ----
-distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1600,10 +1578,8 @@ ALTER TABLE regional_by_row_table_as DROP COLUMN crdb_region_col
 # We do not need uniqueness checks on pk since uniqueness can be inferred
 # through the functional dependency between pk and the computed region column.
 query T
-EXPLAIN INSERT INTO regional_by_row_table_as (pk, a, b) VALUES (1, 1, 1)
+SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_as (pk, a, b) VALUES (1, 1, 1)] OFFSET 2
 ----
-distribution: local
-vectorized: true
 ·
 • root
 │
@@ -1646,10 +1622,8 @@ INSERT INTO regional_by_row_table_as (pk, a, b) VALUES (2, 1, 1)
 
 # Verify that we plan single-region scans for REGIONAL BY ROW tables with a computed region.
 query T
-EXPLAIN SELECT * FROM regional_by_row_table_as WHERE pk = 10
+SELECT * FROM [EXPLAIN SELECT * FROM regional_by_row_table_as WHERE pk = 10] OFFSET 2
 ----
-distribution: local
-vectorized: true
 ·
 • scan
   missing stats

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_rename_column
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_rename_column
@@ -1,4 +1,4 @@
-# LogicTest: multiregion-9node-3region-3azs
+# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off
 
 # This test seems to flake (#60717).
 # It seems to hit the codepath:

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -3408,9 +3408,6 @@ func (dsp *DistSQLPlanner) createPlanForSetOp(
 				// result, the plan will end up with a serial unordered synchronizer,
 				// which has exactly the behavior that we want (in particular, it won't
 				// execute the right child if the limit is reached by the left child).
-				// TODO(rytaft,yuzefovich): This currently only works with the
-				// vectorized engine. We should consider adding support for the serial
-				// unordered synchronizer in the row-based engine (see #61081).
 				p.EnsureSingleStreamPerNode(
 					false, /* forceSerialization */
 					execinfrapb.PostProcessSpec{Limit: n.hardLimit},

--- a/pkg/sql/execinfrapb/data.go
+++ b/pkg/sql/execinfrapb/data.go
@@ -25,7 +25,7 @@ import (
 )
 
 // ConvertToColumnOrdering converts an Ordering type (as defined in data.proto)
-// to a sqlbase.ColumnOrdering type.
+// to a colinfo.ColumnOrdering type.
 func ConvertToColumnOrdering(specOrdering Ordering) colinfo.ColumnOrdering {
 	ordering := make(colinfo.ColumnOrdering, len(specOrdering.Columns))
 	for i, c := range specOrdering.Columns {
@@ -39,13 +39,13 @@ func ConvertToColumnOrdering(specOrdering Ordering) colinfo.ColumnOrdering {
 	return ordering
 }
 
-// ConvertToSpecOrdering converts a sqlbase.ColumnOrdering type
+// ConvertToSpecOrdering converts a colinfo.ColumnOrdering type
 // to an Ordering type (as defined in data.proto).
 func ConvertToSpecOrdering(columnOrdering colinfo.ColumnOrdering) Ordering {
 	return ConvertToMappedSpecOrdering(columnOrdering, nil)
 }
 
-// ConvertToMappedSpecOrdering converts a sqlbase.ColumnOrdering type
+// ConvertToMappedSpecOrdering converts a colinfo.ColumnOrdering type
 // to an Ordering type (as defined in data.proto), using the column
 // indices contained in planToStreamColMap.
 func ConvertToMappedSpecOrdering(

--- a/pkg/sql/execinfrapb/data.pb.go
+++ b/pkg/sql/execinfrapb/data.pb.go
@@ -289,7 +289,7 @@ func (m *Expression) XXX_DiscardUnknown() {
 var xxx_messageInfo_Expression proto.InternalMessageInfo
 
 // Ordering defines an order - specifically a list of column indices and
-// directions. See sqlbase.ColumnOrdering.
+// directions. See colinfo.ColumnOrdering.
 type Ordering struct {
 	Columns []Ordering_Column `protobuf:"bytes,1,rep,name=columns" json:"columns"`
 }

--- a/pkg/sql/execinfrapb/data.proto
+++ b/pkg/sql/execinfrapb/data.proto
@@ -58,7 +58,7 @@ message Expression {
 }
 
 // Ordering defines an order - specifically a list of column indices and
-// directions. See sqlbase.ColumnOrdering.
+// directions. See colinfo.ColumnOrdering.
 message Ordering {
   option (gogoproto.equal) = true;
 

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -472,6 +472,63 @@ type testClusterConfig struct {
 
 const threeNodeTenantConfigName = "3node-tenant"
 
+var multiregion9node3region3azsLocalities = map[int]roachpb.Locality{
+	1: {
+		Tiers: []roachpb.Tier{
+			{Key: "region", Value: "ap-southeast-2"},
+			{Key: "availability-zone", Value: "ap-az1"},
+		},
+	},
+	2: {
+		Tiers: []roachpb.Tier{
+			{Key: "region", Value: "ap-southeast-2"},
+			{Key: "availability-zone", Value: "ap-az2"},
+		},
+	},
+	3: {
+		Tiers: []roachpb.Tier{
+			{Key: "region", Value: "ap-southeast-2"},
+			{Key: "availability-zone", Value: "ap-az3"},
+		},
+	},
+	4: {
+		Tiers: []roachpb.Tier{
+			{Key: "region", Value: "ca-central-1"},
+			{Key: "availability-zone", Value: "ca-az1"},
+		},
+	},
+	5: {
+		Tiers: []roachpb.Tier{
+			{Key: "region", Value: "ca-central-1"},
+			{Key: "availability-zone", Value: "ca-az2"},
+		},
+	},
+	6: {
+		Tiers: []roachpb.Tier{
+			{Key: "region", Value: "ca-central-1"},
+			{Key: "availability-zone", Value: "ca-az3"},
+		},
+	},
+	7: {
+		Tiers: []roachpb.Tier{
+			{Key: "region", Value: "us-east-1"},
+			{Key: "availability-zone", Value: "us-az1"},
+		},
+	},
+	8: {
+		Tiers: []roachpb.Tier{
+			{Key: "region", Value: "us-east-1"},
+			{Key: "availability-zone", Value: "us-az2"},
+		},
+	},
+	9: {
+		Tiers: []roachpb.Tier{
+			{Key: "region", Value: "us-east-1"},
+			{Key: "availability-zone", Value: "us-az3"},
+		},
+	},
+}
+
 // logicTestConfigs contains all possible cluster configs. A test file can
 // specify a list of configs they run on in a file-level comment like:
 //   # LogicTest: default distsql
@@ -632,62 +689,14 @@ var logicTestConfigs = []testClusterConfig{
 		name:              "multiregion-9node-3region-3azs",
 		numNodes:          9,
 		overrideAutoStats: "false",
-		localities: map[int]roachpb.Locality{
-			1: {
-				Tiers: []roachpb.Tier{
-					{Key: "region", Value: "ap-southeast-2"},
-					{Key: "availability-zone", Value: "ap-az1"},
-				},
-			},
-			2: {
-				Tiers: []roachpb.Tier{
-					{Key: "region", Value: "ap-southeast-2"},
-					{Key: "availability-zone", Value: "ap-az2"},
-				},
-			},
-			3: {
-				Tiers: []roachpb.Tier{
-					{Key: "region", Value: "ap-southeast-2"},
-					{Key: "availability-zone", Value: "ap-az3"},
-				},
-			},
-			4: {
-				Tiers: []roachpb.Tier{
-					{Key: "region", Value: "ca-central-1"},
-					{Key: "availability-zone", Value: "ca-az1"},
-				},
-			},
-			5: {
-				Tiers: []roachpb.Tier{
-					{Key: "region", Value: "ca-central-1"},
-					{Key: "availability-zone", Value: "ca-az2"},
-				},
-			},
-			6: {
-				Tiers: []roachpb.Tier{
-					{Key: "region", Value: "ca-central-1"},
-					{Key: "availability-zone", Value: "ca-az3"},
-				},
-			},
-			7: {
-				Tiers: []roachpb.Tier{
-					{Key: "region", Value: "us-east-1"},
-					{Key: "availability-zone", Value: "us-az1"},
-				},
-			},
-			8: {
-				Tiers: []roachpb.Tier{
-					{Key: "region", Value: "us-east-1"},
-					{Key: "availability-zone", Value: "us-az2"},
-				},
-			},
-			9: {
-				Tiers: []roachpb.Tier{
-					{Key: "region", Value: "us-east-1"},
-					{Key: "availability-zone", Value: "us-az3"},
-				},
-			},
-		},
+		localities:        multiregion9node3region3azsLocalities,
+	},
+	{
+		name:              "multiregion-9node-3region-3azs-vec-off",
+		numNodes:          9,
+		overrideAutoStats: "false",
+		localities:        multiregion9node3region3azsLocalities,
+		overrideVectorize: "off",
 	},
 }
 

--- a/pkg/sql/rowflow/input_sync.go
+++ b/pkg/sql/rowflow/input_sync.go
@@ -36,44 +36,69 @@ type srcInfo struct {
 // srcIdx refers to the index of a source inside a []srcInfo array.
 type srcIdx int
 
-type orderedSynchronizerState int
+type serialSynchronizerState int
 
 const (
 	// notInitialized means that the heap has not yet been constructed. A row
 	// needs to be read from each source to build the heap.
-	notInitialized orderedSynchronizerState = iota
-	// returningRows is the regular operation mode of the orderedSynchronizer.
+	notInitialized serialSynchronizerState = iota
+	// returningRows is the regular mode of operation.
 	// Rows and metadata records are returning to the consumer.
 	returningRows
-	// draining means the orderedSynchronizer will ignore everything but metadata
+	// draining means the synchronizer will ignore everything but metadata
 	// records. On the first call to NextRow() while in draining mode, all the
 	// sources are read until exhausted and metadata is accumulated. The state is
 	// then transitioned to drained.
 	draining
-	// In the drainBuffered mode, all the sources of the orderedSynchronizer have been
-	// exhausted, and we might have some buffered metadata. Metadata records are
-	// going to be returned, one by one.
+	// In the drainBuffered mode, all the sources of the serialOrderedSynchronizer
+	// have been exhausted, and we might have some buffered metadata. Metadata
+	// records are going to be returned, one by one.   serialUnorderedSynchronizer
+	// doesn't buffer metadata and doesn't use this.
 	drainBuffered
 )
 
-// orderedSynchronizer receives rows from multiple streams and produces a single
+// Let setupProcessors peek at sources w/o caring about type of synchronizer.
+type serialSynchronizer interface {
+	getSources() []srcInfo
+}
+
+type serialSynchronizerBase struct {
+	state serialSynchronizerState
+
+	types    []*types.T
+	sources  []srcInfo
+	rowAlloc rowenc.EncDatumRowAlloc
+}
+
+var _ serialSynchronizer = &serialSynchronizerBase{}
+
+func (s *serialSynchronizerBase) getSources() []srcInfo {
+	return s.sources
+}
+
+// Start is part of the RowSource interface.
+func (s *serialSynchronizerBase) Start(ctx context.Context) {
+	for _, src := range s.sources {
+		src.src.Start(ctx)
+	}
+}
+
+// OutputTypes is part of the RowSource interface.
+func (s *serialSynchronizerBase) OutputTypes() []*types.T {
+	return s.types
+}
+
+// serialOrderedSynchronizer receives rows from multiple streams and produces a single
 // stream of rows, ordered according to a set of columns. The rows in each input
 // stream are assumed to be ordered according to the same set of columns
 // (intra-stream ordering).
-type orderedSynchronizer struct {
-	// ordering dictates the way in which rows compare. If nil (i.e.
-	// sqlbase.NoOrdering), then rows are not compared and sources are consumed in
-	// index order.
+type serialOrderedSynchronizer struct {
+	serialSynchronizerBase
+
+	// ordering dictates the way in which rows compare. This can't be nil.
 	ordering colinfo.ColumnOrdering
-	evalCtx  *tree.EvalContext
 
-	sources []srcInfo
-
-	types []*types.T
-
-	// state dictates the operation mode.
-	state orderedSynchronizerState
-
+	evalCtx *tree.EvalContext
 	// heap of source indexes. In state notInitialized, heap holds all source
 	// indexes. Once initialized (initHeap is called), heap will be ordered by the
 	// current row from each source and will only contain source indexes of
@@ -89,34 +114,22 @@ type orderedSynchronizer struct {
 	// err can be set by the Less function (used by the heap implementation)
 	err error
 
-	alloc    rowenc.DatumAlloc
-	rowAlloc rowenc.EncDatumRowAlloc
+	alloc rowenc.DatumAlloc
 
 	// metadata is accumulated from all the sources and is passed on as soon as
 	// possible.
 	metadata []*execinfrapb.ProducerMetadata
 }
 
-var _ execinfra.RowSource = &orderedSynchronizer{}
-
-// OutputTypes is part of the RowSource interface.
-func (s *orderedSynchronizer) OutputTypes() []*types.T {
-	return s.types
-}
+var _ execinfra.RowSource = &serialOrderedSynchronizer{}
 
 // Len is part of heap.Interface and is only meant to be used internally.
-func (s *orderedSynchronizer) Len() int {
+func (s *serialOrderedSynchronizer) Len() int {
 	return len(s.heap)
 }
 
 // Less is part of heap.Interface and is only meant to be used internally.
-func (s *orderedSynchronizer) Less(i, j int) bool {
-	// If we're not enforcing any ordering between rows, let's consume sources in
-	// their index order.
-	if s.ordering == nil {
-		return s.heap[i] < s.heap[j]
-	}
-
+func (s *serialOrderedSynchronizer) Less(i, j int) bool {
 	si := &s.sources[s.heap[i]]
 	sj := &s.sources[s.heap[j]]
 	cmp, err := si.row.Compare(s.types, &s.alloc, s.ordering, s.evalCtx, sj.row)
@@ -128,16 +141,16 @@ func (s *orderedSynchronizer) Less(i, j int) bool {
 }
 
 // Swap is part of heap.Interface and is only meant to be used internally.
-func (s *orderedSynchronizer) Swap(i, j int) {
+func (s *serialOrderedSynchronizer) Swap(i, j int) {
 	s.heap[i], s.heap[j] = s.heap[j], s.heap[i]
 }
 
 // Push is part of heap.Interface; it's not used as we never insert elements to
 // the heap (we initialize it with all sources, see initHeap).
-func (s *orderedSynchronizer) Push(x interface{}) { panic("unimplemented") }
+func (s *serialOrderedSynchronizer) Push(x interface{}) { panic("unimplemented") }
 
 // Pop is part of heap.Interface and is only meant to be used internally.
-func (s *orderedSynchronizer) Pop() interface{} {
+func (s *serialOrderedSynchronizer) Pop() interface{} {
 	s.heap = s.heap[:len(s.heap)-1]
 	return nil
 }
@@ -147,7 +160,7 @@ func (s *orderedSynchronizer) Pop() interface{} {
 // from it) unless there are no more rows to read from it.
 // If an error is returned, heap.Init() has not been called, so s.heap is not
 // an actual heap. In this case, all members of the heap need to be drained.
-func (s *orderedSynchronizer) initHeap() error {
+func (s *serialOrderedSynchronizer) initHeap() error {
 	// consumeErr is the last error encountered while consuming metadata.
 	var consumeErr error
 
@@ -201,7 +214,9 @@ const (
 // not consumed and the error is returned. With the drain mode, metadata records
 // with error are accumulated like all the others and this method doesn't return
 // any errors.
-func (s *orderedSynchronizer) consumeMetadata(src *srcInfo, mode consumeMetadataOption) error {
+func (s *serialOrderedSynchronizer) consumeMetadata(
+	src *srcInfo, mode consumeMetadataOption,
+) error {
 	for {
 		row, meta := src.src.Next()
 		if meta != nil {
@@ -232,8 +247,8 @@ func (s *orderedSynchronizer) consumeMetadata(src *srcInfo, mode consumeMetadata
 // If an error is returned, then either the heap is in a bad state (s.err has
 // been set), or one of the sources is borked. In either case, advanceRoot()
 // should not be called again - the caller should update the
-// orderedSynchronizer.state accordingly.
-func (s *orderedSynchronizer) advanceRoot() error {
+// serialOrderedSynchronizer.state accordingly.
+func (s *serialOrderedSynchronizer) advanceRoot() error {
 	if s.state != returningRows {
 		return errors.Errorf("advanceRoot() called in unsupported state: %d", s.state)
 	}
@@ -270,7 +285,7 @@ func (s *orderedSynchronizer) advanceRoot() error {
 
 // drainSources consumes all the rows from the sources. All the data is
 // discarded, except the metadata records which are accumulated in s.metadata.
-func (s *orderedSynchronizer) drainSources() {
+func (s *serialOrderedSynchronizer) drainSources() {
 	for _, srcIdx := range s.heap {
 		if err := s.consumeMetadata(&s.sources[srcIdx], drain); err != nil {
 			log.Fatalf(context.TODO(), "unexpected draining error: %s", err)
@@ -278,15 +293,8 @@ func (s *orderedSynchronizer) drainSources() {
 	}
 }
 
-// Start is part of the RowSource interface.
-func (s *orderedSynchronizer) Start(ctx context.Context) {
-	for _, src := range s.sources {
-		src.src.Start(ctx)
-	}
-}
-
 // Next is part of the RowSource interface.
-func (s *orderedSynchronizer) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {
+func (s *serialOrderedSynchronizer) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {
 	if s.state == notInitialized {
 		if err := s.initHeap(); err != nil {
 			s.ConsumerDone()
@@ -328,7 +336,7 @@ func (s *orderedSynchronizer) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerM
 }
 
 // ConsumerDone is part of the RowSource interface.
-func (s *orderedSynchronizer) ConsumerDone() {
+func (s *serialOrderedSynchronizer) ConsumerDone() {
 	// We're entering draining mode. Only metadata will be forwarded from now on.
 	if s.state != draining {
 		s.consumerStatusChanged(draining, execinfra.RowSource.ConsumerDone)
@@ -336,7 +344,7 @@ func (s *orderedSynchronizer) ConsumerDone() {
 }
 
 // ConsumerClosed is part of the RowSource interface.
-func (s *orderedSynchronizer) ConsumerClosed() {
+func (s *serialOrderedSynchronizer) ConsumerClosed() {
 	// The state shouldn't matter, as no further methods should be called, but
 	// we'll set it to something other than the default.
 	s.consumerStatusChanged(drainBuffered, execinfra.RowSource.ConsumerClosed)
@@ -344,8 +352,8 @@ func (s *orderedSynchronizer) ConsumerClosed() {
 
 // consumerStatusChanged calls a RowSource method on all the non-exhausted
 // sources.
-func (s *orderedSynchronizer) consumerStatusChanged(
-	newState orderedSynchronizerState, f func(execinfra.RowSource),
+func (s *serialOrderedSynchronizer) consumerStatusChanged(
+	newState serialSynchronizerState, f func(execinfra.RowSource),
 ) {
 	if s.state == notInitialized {
 		for i := range s.sources {
@@ -363,28 +371,99 @@ func (s *orderedSynchronizer) consumerStatusChanged(
 	s.state = newState
 }
 
-// makeOrderedSync creates an orderedSynchronizer. ordering dictates how rows
-// are to be compared. Use sqlbase.NoOrdering to indicate that the row ordering
-// doesn't matter and sources should be consumed in index order (which is useful
-// when you intend to fuse the synchronizer and its inputs later; see
-// FuseAggresively).
-func makeOrderedSync(
+// serialUnorderedSynchronizer exhausts its sources one at a time until
+// each is drained.  It's necessary to have the row engine support locality
+// optimized scans.
+type serialUnorderedSynchronizer struct {
+	serialSynchronizerBase
+
+	srcIndex int
+}
+
+var _ execinfra.RowSource = &serialUnorderedSynchronizer{}
+
+func (u *serialUnorderedSynchronizer) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {
+	for u.srcIndex < len(u.sources) {
+		row, metadata := u.sources[u.srcIndex].src.Next()
+
+		// If we're draining only return metadata.
+		if u.state == draining && row != nil {
+			continue
+		}
+
+		// If we see nil,nil go to next source.
+		if row == nil && metadata == nil {
+			u.srcIndex++
+			continue
+		}
+
+		if row != nil {
+			row = u.rowAlloc.CopyRow(row)
+		}
+
+		return row, metadata
+	}
+
+	return nil, nil
+}
+
+// ConsumerDone is part of the RowSource interface.
+func (u *serialUnorderedSynchronizer) ConsumerDone() {
+	if u.state != draining {
+		for i := range u.sources {
+			u.sources[i].src.ConsumerDone()
+		}
+		u.state = draining
+	}
+}
+
+// ConsumerClosed is part of the RowSource interface.
+func (u *serialUnorderedSynchronizer) ConsumerClosed() {
+	for i := range u.sources {
+		u.sources[i].src.ConsumerClosed()
+	}
+}
+
+// makeSerialSync creates a serialOrderedSynchronizer or a
+// serialUnorderedSynchronizer. ordering dictates how rows are to be compared.
+// Use colinfo.NoOrdering to indicate that the row ordering doesn't matter and
+// sources should be consumed in index order (which is useful when you intend to
+// fuse the synchronizer and its inputs later; see FuseAggressively).
+func makeSerialSync(
 	ordering colinfo.ColumnOrdering, evalCtx *tree.EvalContext, sources []execinfra.RowSource,
 ) (execinfra.RowSource, error) {
 	if len(sources) < 2 {
-		return nil, errors.Errorf("only %d sources for ordered synchronizer", len(sources))
+		return nil, errors.Errorf("only %d sources for serial synchronizer", len(sources))
 	}
-	s := &orderedSynchronizer{
-		state:    notInitialized,
-		sources:  make([]srcInfo, len(sources)),
-		types:    sources[0].OutputTypes(),
-		heap:     make([]srcIdx, 0, len(sources)),
-		ordering: ordering,
-		evalCtx:  evalCtx,
+
+	base := serialSynchronizerBase{
+		state:   notInitialized,
+		sources: make([]srcInfo, len(sources)),
+		types:   sources[0].OutputTypes(),
 	}
-	for i := range s.sources {
-		s.sources[i].src = sources[i]
-		s.heap = append(s.heap, srcIdx(i))
+
+	for i := range base.sources {
+		base.sources[i].src = sources[i]
 	}
-	return s, nil
+
+	var sync execinfra.RowSource
+
+	if len(ordering) > 0 {
+		os := &serialOrderedSynchronizer{
+			serialSynchronizerBase: base,
+			heap:                   make([]srcIdx, 0, len(sources)),
+			ordering:               ordering,
+			evalCtx:                evalCtx,
+		}
+		for i := range os.sources {
+			os.heap = append(os.heap, srcIdx(i))
+		}
+		sync = os
+	} else {
+		sync = &serialUnorderedSynchronizer{
+			serialSynchronizerBase: base,
+		}
+	}
+
+	return sync, nil
 }

--- a/pkg/sql/rowflow/input_sync_test.go
+++ b/pkg/sql/rowflow/input_sync_test.go
@@ -115,7 +115,7 @@ func TestOrderedSync(t *testing.T) {
 		}
 		evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 		defer evalCtx.Stop(context.Background())
-		src, err := makeOrderedSync(c.ordering, evalCtx, sources)
+		src, err := makeSerialSync(c.ordering, evalCtx, sources)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -155,7 +155,7 @@ func TestOrderedSyncDrainBeforeNext(t *testing.T) {
 	ctx := context.Background()
 	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(ctx)
-	o, err := makeOrderedSync(colinfo.ColumnOrdering{}, evalCtx, sources)
+	o, err := makeSerialSync(colinfo.ColumnOrdering{}, evalCtx, sources)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
First attempt at addressing #61081.   Just implemented peer to orderedSynchronizer.   Lots of questions:

- is the input spec sort type all we need to drive this?
- should I do more to consolidate commonalities between orderedSynchronizer and unorderedSynchronizer?