### PR TITLE
bazel: bump timeout of `ring_test`

### DIFF
--- a/pkg/util/ring/BUILD.bazel
+++ b/pkg/util/ring/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
 
 go_test(
     name = "ring_test",
-    size = "small",
+    size = "medium",
     srcs = ["ring_buffer_test.go"],
     embed = [":ring"],
     deps = ["@com_github_stretchr_testify//require"],


### PR DESCRIPTION
This has timed out in CI.
Release note: None