### PR TITLE
opt: remove view deps user defined types used by dependent table

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -1527,3 +1527,17 @@ ALTER DATABASE db_enum_name_clash SET PRIMARY REGION "us-east-1"
 statement ok
 DROP TYPE db_enum_name_clash.crdb_internal_region;
 ALTER DATABASE db_enum_name_clash SET PRIMARY REGION "us-east-1"
+
+
+# Verify we can create a view off of a regional by row table.
+# Regression for #63191.
+subtest regional_by_row_view
+
+statement ok
+CREATE DATABASE db;
+USE db;
+ALTER DATABASE db PRIMARY REGION "us-east-1";
+CREATE TABLE kv (k INT PRIMARY KEY, v INT) LOCALITY REGIONAL BY ROW
+
+statement ok
+CREATE VIEW v AS SELECT v FROM kv

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -965,12 +965,20 @@ statement ok
 DROP VIEW v
 
 statement ok
-CREATE TABLE t (k STRING AS ('a'::typ::string) STORED)
+CREATE TABLE t (i INT, k STRING AS ('a'::typ::string) STORED)
 
 statement ok
-CREATE VIEW v AS SELECT k FROM t
+CREATE VIEW v AS (SELECT i FROM t)
 
-statement error cannot drop type "typ" because other objects \(\[db2.public.t db2.public.v\]\) still depend on it
+# Note that v does not depend on typ since it does not use column k.
+statement error cannot drop type "typ" because other objects \(\[db2.public.t\]\) still depend on it
+DROP TYPE typ
+
+statement ok
+CREATE VIEW v_dep AS (SELECT k FROM t)
+
+# Since v_dep depends on t.k which uses type typ, v_dep has a dependency to typ.
+statement error cannot drop type "typ" because other objects \(\[db2.public.t db2.public.v_dep\]\) still depend on it
 DROP TYPE typ
 
 statement ok
@@ -1002,3 +1010,91 @@ ALTER TYPE typ2 RENAME TO typ3
 
 statement error cannot drop type "typ3" because other objects \(\[db2.public.v3\]\) still depend on it
 DROP TYPE typ3
+
+statement ok
+CREATE TYPE typ4 AS ENUM('a')
+
+statement ok
+CREATE TABLE t4 (i INT, j typ4)
+
+statement ok
+CREATE VIEW v4 AS (SELECT i FROM t4)
+
+# Note that v4 does not depend on typ4.
+statement error cannot drop type "typ4" because other objects \(\[db2.public.t4\]\) still depend on it
+DROP TYPE typ4
+
+statement ok
+ALTER TABLE t4 DROP COLUMN j
+
+statement ok
+DROP TYPE typ4
+
+statement ok
+CREATE TYPE typ4 AS ENUM('a')
+
+statement ok
+ALTER TABLE t4 ADD COLUMN j typ4
+
+statement ok
+CREATE VIEW v4_dep AS (SELECT j FROM t4)
+
+# Since v4_dep depends on t4.j which is of type typ4, v4_dep has a dependency to typ4.
+statement error cannot drop type "typ4" because other objects \(\[db2.public.t4 db2.public.v4_dep\]\) still depend on it
+DROP type typ4
+
+statement ok
+CREATE TYPE typ5 AS ENUM('a')
+
+statement ok
+CREATE TABLE t5 (i INT, j STRING DEFAULT 'a'::typ5::string)
+
+# Note that v5 does not depend on typ5.
+statement ok
+CREATE VIEW v5 AS (SELECT i FROM t5)
+
+statement error cannot drop type "typ5" because other objects \(\[db2.public.t5\]\) still depend on it
+DROP TYPE typ5
+
+statement ok
+CREATE VIEW v5_dep AS (SELECT j FROM t5)
+
+# Since v5_dep depends on t5.j which uses type typ5, v5_dep has a dependency to typ5.
+statement error cannot drop type "typ5" because other objects \(\[db2.public.t5 db2.public.v5_dep\]\) still depend on it
+DROP TYPE typ5
+
+statement ok
+CREATE VIEW v6 AS (SELECT j FROM v4_dep)
+
+# v6 depends on v4_dep.j, which depends on t4.j, which depends on typ4, so v6 also depends on typ4.
+statement error cannot drop type "typ4" because other objects \(\[db2.public.t4 db2.public.v4_dep db2.public.v6\]\) still depend on it
+DROP TYPE typ4
+
+statement ok
+CREATE TYPE typ6 AS ENUM('a');
+CREATE TABLE t6 (i INT, k typ6);
+CREATE INDEX idx ON t6 (i) WHERE k < 'a'::typ6
+
+statement ok
+CREATE VIEW v7 AS (SELECT i FROM t6)
+
+# Note that v7 does not depend on t6.
+statement error cannot drop type "typ6" because other objects \(\[db2.public.t6\]\) still depend on it
+DROP TYPE typ6
+
+statement ok
+CREATE VIEW v7_dep AS (SELECT i FROM t6@idx WHERE k < 'a'::typ6)
+
+# v7_dep depends on typ6 now.
+statement error cannot drop type "typ6" because other objects \(\[db2.public.t6 db2.public.v7_dep\]\) still depend on it
+DROP TYPE typ6
+
+# Test we can create views from various data sources.
+statement ok
+CREATE SEQUENCE s
+
+statement ok
+CREATE VIEW v8 AS (SELECT last_value FROM s)
+
+statement ok
+CREATE VIEW v9 AS (SELECT sequence_name FROM information_schema.sequences)

--- a/pkg/sql/opt/cat/data_source.go
+++ b/pkg/sql/opt/cat/data_source.go
@@ -10,7 +10,10 @@
 
 package cat
 
-import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
 
 // DataSourceName is an alias for tree.TableName, and is used for views and
 // sequences as well as tables.
@@ -23,4 +26,9 @@ type DataSource interface {
 
 	// Name returns the unqualified name of the object.
 	Name() tree.Name
+
+	// CollectTypes returns all user defined types that the column uses.
+	// This includes types used in default expressions, computed columns,
+	// and the type of the column itself.
+	CollectTypes(ord int) (descpb.IDs, error)
 }

--- a/pkg/sql/opt/optbuilder/partial_index.go
+++ b/pkg/sql/opt/optbuilder/partial_index.go
@@ -33,6 +33,15 @@ import (
 // scan. A scan and its logical properties are required in order to fully
 // normalize the partial index predicates.
 func (b *Builder) addPartialIndexPredicatesForTable(tabMeta *opt.TableMeta, scan memo.RelExpr) {
+	// We do not want to track view deps here, otherwise a view depending
+	// on a table with a partial index predicate using an UDT will result in a
+	// type dependency being added between the view and the UDT.
+	if b.trackViewDeps {
+		b.trackViewDeps = false
+		defer func() {
+			b.trackViewDeps = true
+		}()
+	}
 	tab := tabMeta.Table
 	numIndexes := tab.DeletableIndexCount()
 

--- a/pkg/sql/opt/testutils/testcat/BUILD.bazel
+++ b/pkg/sql/opt/testutils/testcat/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/typedesc",
         "//pkg/sql/opt/cat",
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/63191.

Previously, when a view depended on a table that had
a user defined type column, we would create a
dependency between the view and the type, even if
the view did not directly reference that column.
This is because the table referencing the UDT 
has an implicit CHECK constraint on the type.

For example,
```
CREATE TYPE typ AS ENUM('a', 'b', 'c');
CREATE TABLE t (i INT, j typ); # Has check constraint (j IN (x'40':::@100053, x'80':::@100053, x'c0':::@100053))
CREATE VIEW v AS (SELECT i FROM t); # Has a dependency on typ.
```

When we create `v`, it calls `buildScalar` on `t`'s check constraint
and then `maybeTrackUserDefinedTypeDepsForViews`,  which
adds dependencies to the types even if the view does
not directly use them. 
 
This patch addresses this by not capturing this dependency
inside `maybeTrackUserDefinedTypeDepsForViews`.
Instead, it will only capture dependencies explicitly used in
the view. Then, in `ConstructCreateView`, we will look for
column dependencies, and see if any columns are a UDT.

Release note: None