### PR TITLE
release-21.1: roachtest: wait for rebalancing to each region in follower-reads test

### DIFF
--- a/pkg/cmd/roachtest/follower_reads.go
+++ b/pkg/cmd/roachtest/follower_reads.go
@@ -281,6 +281,14 @@ func runFollowerReadsTest(
 		}
 	}
 
+	// Enable the slow query log so we have a shot at identifying why follower
+	// reads are not being served after the fact when this test fails. Use a
+	// latency threshold of 50ms, which should be well below the latency of a
+	// cross-region hop to read from the leaseholder but well above the latency
+	// of a follower read.
+	_, err = db.ExecContext(ctx, "SET CLUSTER SETTING sql.log.slow_query.latency_threshold = '50ms'")
+	require.NoError(t, err)
+
 	// Read the follower read counts before issuing the follower reads to observe
 	// the delta and protect from follower reads which might have happened due to
 	// system queries.

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -1804,6 +1804,8 @@ func (ds *DistSender) sendToReplicas(
 			// we created replicas.
 			log.Eventf(ctx, "leaseholder %s missing from replicas", leaseholder)
 		}
+	} else {
+		log.VEvent(ctx, 2, "routing to nearest replica")
 	}
 
 	opts := SendOptions{


### PR DESCRIPTION
Backport:
  * 1/1 commits from "roachtest: enable slow query log in follower-reads tests" (#63319)
  * 2/2 commits from "roachtest: wait for rebalancing to each region in follower-reads test" (#63353)

Please see individual PRs for details.

/cc @cockroachdb/release
