### PR TITLE
release-21.1: kv: deflake multi-node kvnemesis

### DIFF
--- a/pkg/kv/kvnemesis/validator.go
+++ b/pkg/kv/kvnemesis/validator.go
@@ -326,6 +326,8 @@ func (v *validator) processOp(txnID *string, op Operation) {
 			// Probably should be transparently retried.
 		} else if resultIsErrorStr(t.Result, `merge failed: range missing intent on its local descriptor`) {
 			// Probably should be transparently retried.
+		} else if resultIsErrorStr(t.Result, `merge failed: RHS range bounds do not match`) {
+			// Probably should be transparently retried.
 		} else {
 			v.failIfError(op, t.Result)
 		}

--- a/pkg/kv/kvnemesis/validator.go
+++ b/pkg/kv/kvnemesis/validator.go
@@ -345,6 +345,10 @@ func (v *validator) processOp(txnID *string, op Operation) {
 			// Only VOTER_FULL replicas can currently hold a range lease.
 			// Attempts to transfer to lease to any other replica type are
 			// rejected.
+		} else if resultIsErrorStr(t.Result, `replica not found in RangeDescriptor`) {
+			// Only replicas that are part of the range can be given
+			// the lease. This case is hit if a TransferLease op races
+			// with a ChangeReplicas op.
 		} else if resultIsErrorStr(t.Result, `unable to find store \d+ in range`) {
 			// A lease transfer that races with a replica removal may find that
 			// the store it was targeting is no longer part of the range.
@@ -354,6 +358,10 @@ func (v *validator) processOp(txnID *string, op Operation) {
 		} else if resultIsError(t.Result, liveness.ErrRecordCacheMiss) {
 			// If the existing leaseholder has not yet heard about the transfer
 			// target's liveness record through gossip, it will return an error.
+		} else if resultIsErrorStr(t.Result, liveness.ErrRecordCacheMiss.Error()) {
+			// Same as above, but matches cases where ErrRecordCacheMiss is
+			// passed through a LeaseRejectedError. This is necessary until
+			// LeaseRejectedErrors works with errors.Cause.
 		} else {
 			v.failIfError(op, t.Result)
 		}

--- a/pkg/kv/kvserver/batcheval/cmd_subsume.go
+++ b/pkg/kv/kvserver/batcheval/cmd_subsume.go
@@ -79,7 +79,7 @@ func Subsume(
 	desc := cArgs.EvalCtx.Desc()
 	if !bytes.Equal(desc.StartKey, args.RightDesc.StartKey) ||
 		!bytes.Equal(desc.EndKey, args.RightDesc.EndKey) {
-		return result.Result{}, errors.AssertionFailedf("RHS range bounds do not match: %s != %s",
+		return result.Result{}, errors.Errorf("RHS range bounds do not match: %s != %s",
 			args.RightDesc, desc)
 	}
 
@@ -87,7 +87,7 @@ func Subsume(
 	// of operations in the AdminMerge transaction should make it impossible for
 	// these ranges to be nonadjacent, but double check.
 	if !bytes.Equal(args.LeftDesc.EndKey, desc.StartKey) {
-		return result.Result{}, errors.AssertionFailedf("ranges are not adjacent: %s != %s",
+		return result.Result{}, errors.Errorf("ranges are not adjacent: %s != %s",
 			args.LeftDesc.EndKey, desc.StartKey)
 	}
 
@@ -101,13 +101,13 @@ func Subsume(
 	if err != nil {
 		return result.Result{}, errors.Errorf("fetching local range descriptor: %s", err)
 	} else if intent == nil {
-		return result.Result{}, errors.AssertionFailedf("range missing intent on its local descriptor")
+		return result.Result{}, errors.Errorf("range missing intent on its local descriptor")
 	}
 	val, _, err := storage.MVCCGetAsTxn(ctx, readWriter, descKey, intent.Txn.WriteTimestamp, intent.Txn)
 	if err != nil {
 		return result.Result{}, errors.Errorf("fetching local range descriptor as txn: %s", err)
 	} else if val != nil {
-		return result.Result{}, errors.AssertionFailedf("non-deletion intent on local range descriptor")
+		return result.Result{}, errors.Errorf("non-deletion intent on local range descriptor")
 	}
 
 	// NOTE: the deletion intent on the range's meta2 descriptor is just as

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -2405,7 +2405,8 @@ func (r *Replica) sendSnapshot(
 
 	snap, err := r.GetSnapshot(ctx, snapType, recipient.StoreID)
 	if err != nil {
-		return errors.Wrapf(err, "%s: failed to generate %s snapshot", r, snapType)
+		err = errors.Wrapf(err, "%s: failed to generate %s snapshot", r, snapType)
+		return errors.Mark(err, errMarkSnapshotError)
 	}
 	defer snap.Close()
 	log.Event(ctx, "generated snapshot")


### PR DESCRIPTION
Backport 3/3 commits from #62580.

/cc @cockroachdb/release

---

Fixes #61322.
Prep to address #59062.

#### kv: don't consider Subsume error as assertion failures

These were added in b15e3dd, but that was incorrect. It is valid for a merge that races with another merge or split to hit these case, as the Subsume request is non-transactional.

Also, allow `RHS range bounds do not match` errors in kvnemesis. This is a valid error for the reasons mentioned above.

#### kv: mark error from Replica.GetSnapshot with errMarkSnapshotError

Without it, we see the following errors in kvnemesis:
```
Wraps: (2) error applying x.AdminChangeReplicas(ctx, /Table/50/"244956da", [{ADD_VOTER n2,s2}]) // [n1,s1,r36/1:/Table/{40-50/"ba86b…}]: failed to generate LEARNER_INITIAL snapshot: couldn't find range descriptor
```

#### kv: allow two more errors with TransferLeaseOperation

This deflakes TestKVNemesisMultiNode. The test had recently gotten flakier, which I bisected back to 3fe1992. It appears that the changes in that commit made it more likely to hit this `replica not found in RangeDescriptor`, which is returned after a TransferLease request has acquired latches, in addition to the existing `unable to find store \d+ in range` error, which is returned before a TransferLease request has acquired latches.
