### PR TITLE
kv: don't commit-wait on each columnBackfiller chunk

### DIFF
--- a/pkg/ccl/multiregionccl/regional_by_row_test.go
+++ b/pkg/ccl/multiregionccl/regional_by_row_test.go
@@ -376,15 +376,6 @@ func TestAlterTableLocalityRegionalByRowError(t *testing.T) {
 							// TTL into the system with AddImmediateGCZoneConfig.
 							defer sqltestutils.DisableGCTTLStrictEnforcement(t, sqlDB)()
 
-							// Drop the closed timestamp target lead for GLOBAL tables.
-							// The test passes with it configured to its default, but it
-							// is very slow due to #61444 (2.5s vs. 35s).
-							// TODO(nvanbenschoten): We can remove this when that issue
-							// is addressed.
-							if _, err := sqlDB.Exec(`SET CLUSTER SETTING kv.closed_timestamp.lead_for_global_reads_override = '5ms'`); err != nil {
-								t.Fatal(err)
-							}
-
 							if _, err := sqlDB.Exec(fmt.Sprintf(`
 CREATE DATABASE t PRIMARY REGION "ajstorm-1";
 USE t;

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -119,6 +119,12 @@ type TxnCoordSender struct {
 		// userPriority is the txn's priority. Used when restarting the transaction.
 		// This field is only populated on rootTxns.
 		userPriority roachpb.UserPriority
+
+		// commitWaitDeferred is set to true when the transaction commit-wait
+		// state is deferred and should not be run automatically. Instead, the
+		// caller of DeferCommitWait has assumed responsibility for performing
+		// the commit-wait.
+		commitWaitDeferred bool
 	}
 
 	// A pointer member to the creating factory provides access to
@@ -444,7 +450,7 @@ func (tc *TxnCoordSender) finalizeNonLockingTxnLocked(
 	}
 	tc.finalizeAndCleanupTxnLocked(ctx)
 	if et.Commit {
-		tc.maybeCommitWait(ctx)
+		tc.maybeCommitWait(ctx, false /* deferred */)
 	}
 	return nil
 }
@@ -513,7 +519,7 @@ func (tc *TxnCoordSender) Send(
 		if (et.Commit && pErr == nil) || !et.Commit {
 			tc.finalizeAndCleanupTxnLocked(ctx)
 			if et.Commit {
-				tc.maybeCommitWait(ctx)
+				tc.maybeCommitWait(ctx, false /* deferred */)
 			}
 		}
 	}
@@ -581,9 +587,15 @@ func (tc *TxnCoordSender) Send(
 //
 // For more, see https://www.cockroachlabs.com/blog/consistency-model/ and
 // docs/RFCS/20200811_non_blocking_txns.md.
-func (tc *TxnCoordSender) maybeCommitWait(ctx context.Context) {
+func (tc *TxnCoordSender) maybeCommitWait(ctx context.Context, deferred bool) {
 	if tc.mu.txn.Status != roachpb.COMMITTED {
 		log.Fatalf(ctx, "maybeCommitWait called when not committed")
+	}
+	if tc.mu.commitWaitDeferred && !deferred {
+		// If this is an automatic commit-wait call and the user of this
+		// transaction has opted to defer the commit-wait and handle it
+		// externally, there's nothing to do yet.
+		return
 	}
 
 	commitTS := tc.mu.txn.WriteTimestamp
@@ -1244,4 +1256,20 @@ func (tc *TxnCoordSender) ManualRefresh(ctx context.Context) error {
 		pErr = tc.updateStateLocked(ctx, ba, &br, nil)
 	}
 	return pErr.GoError()
+}
+
+// DeferCommitWait is part of the TxnSender interface.
+func (tc *TxnCoordSender) DeferCommitWait(ctx context.Context) func(context.Context) {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	tc.mu.commitWaitDeferred = true
+	return func(ctx context.Context) {
+		tc.mu.Lock()
+		defer tc.mu.Unlock()
+		if tc.mu.txn.Status != roachpb.COMMITTED {
+			// If transaction has not committed, there's nothing to do.
+			return
+		}
+		tc.maybeCommitWait(ctx, true /* deferred */)
+	}
 }

--- a/pkg/kv/mock_transactional_sender.go
+++ b/pkg/kv/mock_transactional_sender.go
@@ -208,6 +208,11 @@ func (m *MockTransactionalSender) ManualRefresh(ctx context.Context) error {
 	panic("unimplemented")
 }
 
+// DeferCommitWait is part of the TxnSender interface.
+func (m *MockTransactionalSender) DeferCommitWait(ctx context.Context) func(context.Context) {
+	panic("unimplemented")
+}
+
 // MockTxnSenderFactory is a TxnSenderFactory producing MockTxnSenders.
 type MockTxnSenderFactory struct {
 	senderFunc func(context.Context, *roachpb.Transaction, roachpb.BatchRequest) (

--- a/pkg/kv/sender.go
+++ b/pkg/kv/sender.go
@@ -309,6 +309,17 @@ type TxnSender interface {
 	// refresh reads performed on the RHS after the RHS has been subsumed but
 	// before the merge transaction completed.
 	ManualRefresh(ctx context.Context) error
+
+	// DeferCommitWait defers the transaction's commit-wait operation, passing
+	// responsibility of commit-waiting from the TxnSender to the caller of this
+	// method. The method returns a function which the caller must eventually
+	// run if the transaction completes without error. This function is safe to
+	// call multiple times.
+	//
+	// WARNING: failure to call the returned function could lead to consistency
+	// violations where a future, causally dependent transaction may fail to
+	// observe the writes performed by this transaction.
+	DeferCommitWait(ctx context.Context) func(context.Context)
 }
 
 // SteppingMode is the argument type to ConfigureStepping.

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -1318,3 +1318,18 @@ func (txn *Txn) ManualRefresh(ctx context.Context) error {
 	txn.mu.Unlock()
 	return sender.ManualRefresh(ctx)
 }
+
+// DeferCommitWait defers the transaction's commit-wait operation, passing
+// responsibility of commit-waiting from the Txn to the caller of this
+// method. The method returns a function which the caller must eventually
+// run if the transaction completes without error. This function is safe to
+// call multiple times.
+//
+// WARNING: failure to run the returned function could lead to consistency
+// violations where a future, causally dependent transaction may fail to
+// observe the writes performed by this transaction.
+func (txn *Txn) DeferCommitWait(ctx context.Context) func(context.Context) {
+	txn.mu.Lock()
+	defer txn.mu.Unlock()
+	return txn.mu.sender.DeferCommitWait(ctx)
+}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -54,7 +54,7 @@ const (
 	// TODO(vivek): Replace these constants with a runtime budget for the
 	// operation chunk involved.
 
-	// columnTruncateAndBackfillChunkSize is the maximum number of columns
+	// columnTruncateAndBackfillChunkSize is the maximum number of rows
 	// processed per chunk during column truncate or backfill.
 	columnTruncateAndBackfillChunkSize = 200
 

--- a/pkg/sql/rowexec/columnbackfiller.go
+++ b/pkg/sql/rowexec/columnbackfiller.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/backfill"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -29,10 +30,27 @@ type columnBackfiller struct {
 	backfill.ColumnBackfiller
 
 	desc catalog.TableDescriptor
+
+	// commitWaitFns contains a set of functions, each of which was returned
+	// from a call to (*kv.Txn).DeferCommitWait when backfilling a single chunk
+	// of rows. The functions must be called to ensure consistency with any
+	// causally dependent readers.
+	commitWaitFns []func(context.Context)
 }
 
 var _ execinfra.Processor = &columnBackfiller{}
 var _ chunkBackfiller = &columnBackfiller{}
+
+// maxCommitWaitFns is the maximum number of commit-wait functions that the
+// columnBackfiller will accumulate before consuming them to reclaim memory.
+// Each function retains a reference to its corresponding TxnCoordSender, so we
+// need to be careful not to accumulate an unbounded number of these functions.
+var backfillerMaxCommitWaitFns = settings.RegisterIntSetting(
+	"schemachanger.backfiller.max_commit_wait_fns",
+	"the maximum number of commit-wait functions that the columnBackfiller will accumulate before consuming them to reclaim memory",
+	128,
+	settings.PositiveInt,
+)
 
 func newColumnBackfiller(
 	ctx context.Context,
@@ -73,6 +91,7 @@ func (cb *columnBackfiller) prepare(ctx context.Context) error {
 	return nil
 }
 func (cb *columnBackfiller) flush(ctx context.Context) error {
+	cb.runCommitWait(ctx)
 	return nil
 }
 func (cb *columnBackfiller) CurrentBufferFill() float32 {
@@ -84,6 +103,7 @@ func (cb *columnBackfiller) runChunk(
 	ctx context.Context, sp roachpb.Span, chunkSize int64, _ hlc.Timestamp,
 ) (roachpb.Key, error) {
 	var key roachpb.Key
+	var commitWaitFn func(context.Context)
 	err := cb.flowCtx.Cfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		if cb.flowCtx.Cfg.TestingKnobs.RunBeforeBackfillChunk != nil {
 			if err := cb.flowCtx.Cfg.TestingKnobs.RunBeforeBackfillChunk(sp); err != nil {
@@ -93,6 +113,11 @@ func (cb *columnBackfiller) runChunk(
 		if cb.flowCtx.Cfg.TestingKnobs.RunAfterBackfillChunk != nil {
 			defer cb.flowCtx.Cfg.TestingKnobs.RunAfterBackfillChunk()
 		}
+
+		// Defer the commit-wait operation so that we can coalesce this wait
+		// across all batches. This dramatically reduces the total time we spend
+		// waiting for consistency when backfilling a column on GLOBAL tables.
+		commitWaitFn = txn.DeferCommitWait(ctx)
 
 		// TODO(knz): do KV tracing in DistSQL processors.
 		var err error
@@ -107,5 +132,24 @@ func (cb *columnBackfiller) runChunk(
 		)
 		return err
 	})
+	if err == nil {
+		cb.commitWaitFns = append(cb.commitWaitFns, commitWaitFn)
+		maxCommitWaitFns := int(backfillerMaxCommitWaitFns.Get(&cb.flowCtx.Cfg.Settings.SV))
+		if len(cb.commitWaitFns) >= maxCommitWaitFns {
+			cb.runCommitWait(ctx)
+		}
+	}
 	return key, err
+}
+
+// runCommitWait consumes the commit-wait functions that the columnBackfiller
+// has accumulated across the chunks that it has backfilled. It calls each
+// commit-wait function to ensure that any dependent reads on the rows we just
+// backfilled observe the new column.
+func (cb *columnBackfiller) runCommitWait(ctx context.Context) {
+	for i, fn := range cb.commitWaitFns {
+		fn(ctx)
+		cb.commitWaitFns[i] = nil
+	}
+	cb.commitWaitFns = cb.commitWaitFns[:0]
 }


### PR DESCRIPTION
Fixes #61444.

Previously, each transaction issued by `columnBackfiller.runChunk` would perform a
commit-wait of about 800ms when writing to a GLOBAL table. This adds up,
as the `ColumnBackfiller` can issue many small transactions. The commit-wait step
is meant to ensure linearizability with future reads of the values written by
the column backfiller. However, there's no need to pay this cost on each chunk -
we only need reads after the backfiller is completely finished to be guaranteed
to observe its writes. So we only need to pay the commit-wait cost once.

This commit accomplishes this by exposing a new `(*kv.Txn).DeferCommitWait` API,
which allows well-informed callers to take responsibility for performing the
commit-wait for a committed transaction.

The commit then begins using this `DeferCommitWait` API in `columnBackfiller`.
The `columnBackfiller` defers the commit-wait stage for each chunk that it runs
and accumulates a collection of commit-wait handles to run before flushing. In
doing so, it can coalesce the wait across all chunks, which dramatically reduces
the total time we spend waiting for consistency when backfilling a column on
GLOBAL tables.

This speedup is reflected in `TestAlterTableLocalityRegionalByRowError`, which
drops from a runtime of 419s to 48s.

I'm mildly concerned about a potential memory blowup of holding references to
previously committed TxnCoordSender objects through these commit-wait handle
functions, so I've conservatively capped the number of functions that we'll
retain at any given time to 128. Is there a roachtest I can run to validate
that this isn't a problem?