### PR TITLE
colexec: fix usage of incorrect type schema for external hash agg

### DIFF
--- a/pkg/sql/colexec/external_hash_aggregator.go
+++ b/pkg/sql/colexec/external_hash_aggregator.go
@@ -100,7 +100,7 @@ func NewExternalHashAggregator(
 	// sort isn't accounted for when considering the number file descriptors to
 	// acquire. Not urgent, but it should be fixed.
 	maxNumberActivePartitions := calculateMaxNumberActivePartitions(flowCtx, args, ehaNumRequiredActivePartitions)
-	return createDiskBackedSorter(eha, args.Spec.ResultTypes, outputOrdering.Columns, maxNumberActivePartitions)
+	return createDiskBackedSorter(eha, newAggArgs.OutputTypes, outputOrdering.Columns, maxNumberActivePartitions)
 }
 
 // HashAggregationDiskSpillingEnabled is a cluster setting that allows to

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -3840,3 +3840,9 @@ SELECT a, b, count(*) FROM t63159 GROUP BY a,b ORDER BY a
 2  2  1
 3  3  1
 5  5  1
+
+# Regression test for the vectorized hash aggregator using incorrect type schema
+# when planning an external sort to maintain the required ordering.
+statement ok
+CREATE TABLE t63436 (a INT, b FLOAT, c DECIMAL, INDEX(a));
+SELECT count(*) FROM t63436@t63436_a_idx GROUP BY b, c ORDER BY c;


### PR DESCRIPTION
We recently merged a change to the external hash aggregator to maintain
ordering. This was done by planning an explicit sort after aggregation.
However, a bug was introduced in which we were using the incorrect type
schema for sort planning: namely, we used the "result types" for the
aggregator stage (after a projection is applied), but we should have
used the "output types" (the schema of what the aggregator outputs). Now
this is fixed.

Fixes: #63430.
Fixes: #63431.
Fixes: #63432.
Fixes: #63433.
Fixes: #63434.
Fixes: #63435.
Fixes: #63436.
Fixes: #63437.
Fixes: #63438.
Fixes: #63439.
Fixes: #63440.
Fixes: #63441.
Fixes: #63442.
Fixes: #63443.

Release note: None