### PR TITLE
sql: add validation for partitions matching REGIONAL BY ROW

### DIFF
--- a/pkg/ccl/multiregionccl/region_test.go
+++ b/pkg/ccl/multiregionccl/region_test.go
@@ -141,7 +141,7 @@ func TestConcurrentAddDropRegions(t *testing.T) {
 			// Create a multi-region database with a REGIONAL BY ROW table inside of it
 			// which needs to be re-partitioned on add/drop operations.
 			_, err := sqlDB.Exec(`
-CREATE DATABASE db WITH PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3"; 
+CREATE DATABASE db WITH PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3";
 CREATE TABLE db.rbr () LOCALITY REGIONAL BY ROW`)
 			require.NoError(t, err)
 
@@ -157,12 +157,12 @@ CREATE TABLE db.rbr () LOCALITY REGIONAL BY ROW`)
 
 			// Start the second operation.
 			_, err = sqlDB.Exec(tc.secondOp)
+			close(secondOpFinished)
 			if tc.secondOpErr == "" {
 				require.NoError(t, err)
 			} else {
 				require.True(t, testutils.IsError(err, tc.secondOpErr))
 			}
-			close(secondOpFinished)
 
 			<-firstOpFinished
 

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -345,7 +345,7 @@ type TypeDescriptor interface {
 	PrimaryRegionName() (descpb.RegionName, error)
 	RegionNames() (descpb.RegionNames, error)
 	RegionNamesIncludingTransitioning() (descpb.RegionNames, error)
-	RegionNamesForZoneConfigValidation() (descpb.RegionNames, error)
+	RegionNamesForValidation() (descpb.RegionNames, error)
 	GetArrayTypeID() descpb.ID
 	GetKind() descpb.TypeDescriptor_Kind
 

--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -196,14 +196,14 @@ func (desc *immutable) RegionNames() (descpb.RegionNames, error) {
 	return regions, nil
 }
 
-// RegionNamesForZoneConfigValidation returns all regions on the multi-region
-// enum to make validation with the public zone configs possible. Since the zone
-// configs are only updated when a transaction commits, this must ignore all
-// regions being added (since they will not be reflected in the zone
-// configuration yet), but it must include all region being dropped (since they
-// will not be dropped from the zone configuration until they are fully removed
-// from the type descriptor, again, at the end of the transaction).
-func (desc *immutable) RegionNamesForZoneConfigValidation() (descpb.RegionNames, error) {
+// RegionNamesForValidation returns all regions on the multi-region
+// enum to make validation with zone configs and table descriptors possible.
+// Since the zone configs and table descriptor are only updated when a transaction
+// commits, this must ignore all regions being added (since they will not be
+// reflected in the zone configuration yet), but it must include all region being
+// dropped (since they will not be dropped from the zone configuration until they
+// are fully removed from the type descriptor, again, at the end of the transaction).
+func (desc *immutable) RegionNamesForValidation() (descpb.RegionNames, error) {
 	if desc.Kind != descpb.TypeDescriptor_MULTIREGION_ENUM {
 		return nil, errors.AssertionFailedf(
 			"can not get regions of a non multi-region enum %d", desc.ID,

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -1028,7 +1028,7 @@ func synthesizeRegionConfigImpl(
 	}
 	var regionNames descpb.RegionNames
 	if forZoneConfigValidate {
-		regionNames, err = regionEnum.RegionNamesForZoneConfigValidation()
+		regionNames, err = regionEnum.RegionNamesForValidation()
 	} else {
 		regionNames, err = regionEnum.RegionNames()
 	}


### PR DESCRIPTION
This commit adds validation that partitions for a REGIONAL BY ROW table
matches regions in the database descriptor.

This required some hacking - the type schema changer modifies the enum
and the table separately. If we modify the enum before the table, the
validation would fail on fetching the table descriptor as the partitions
are not there. If we modify the table before the enum or in the same
batch, the new region is still in the adding state and would hit an
assertion error. To remedy this, we have to fetch the tables before the
enum is changed, then re-hydrate the type in the columns so that the new
region value is not read only.

Release note: None