### PR TITLE
sql: prevent REGIONAL BY ROW and ADD/DROP REGION concurrent transitions

### DIFF
--- a/pkg/ccl/multiregionccl/regional_by_row_test.go
+++ b/pkg/ccl/multiregionccl/regional_by_row_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -161,10 +162,19 @@ func TestAlterTableLocalityRegionalByRowCorrectZoneConfigBeforeBackfill(t *testi
 
 func TestRegionChangeDuringAlterTableRegionalByRow(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderRace(t, "too slow under race (>10min)")
 
 	interruptStartCh := make(chan struct{})
 	interruptEndCh := make(chan struct{})
-	performInterrupt := false
+
+	// The mutex protects against concurrent index backfill jobs from
+	// accessing the same RunBeforeBackfillChunk hook.
+	var mu struct {
+		m                syncutil.Mutex
+		performInterrupt bool
+	}
 
 	regionalByRowChanges := []struct {
 		setup    string
@@ -218,8 +228,11 @@ USE t;
 					base.TestingKnobs{
 						DistSQL: &execinfra.TestingKnobs{
 							RunBeforeBackfillChunk: func(sp roachpb.Span) error {
-								if performInterrupt {
-									performInterrupt = false
+								mu.m.Lock()
+								defer mu.m.Unlock()
+
+								if mu.performInterrupt {
+									mu.performInterrupt = false
 									interruptStartCh <- struct{}{}
 									<-interruptEndCh
 								}
@@ -231,7 +244,7 @@ USE t;
 				)
 				defer cleanup()
 				setupDB(sqlDB, rbrChange.setup)
-				performInterrupt = true
+				mu.performInterrupt = true
 
 				// Perform the alter table command asynchronously; this will be interrupted by the region change.
 				rbrErrCh := make(chan error)
@@ -245,12 +258,68 @@ USE t;
 
 				// Now run the alter command on the database.
 				_, err := sqlDB.Exec(regionChange)
+
+				// Now finish up and ensure no errors (we must do this before the error check to ensure the interrupt completes).
+				interruptEndCh <- struct{}{}
+				require.NoError(t, <-rbrErrCh)
+
+				// Ensure the region command errors.
 				require.Error(t, err)
 				require.EqualError(t, err, "pq: cannot perform database region changes whilst a REGIONAL BY ROW transition is underway")
 
-				// Now finish up and ensure no errors.
+				// Validate the zone configuration.
+				_, err = sqlDB.Exec(`SELECT crdb_internal.validate_multi_region_zone_configs()`)
+				require.NoError(t, err)
+			})
+		}
+	}
+
+	// Tests REGIONAL BY ROW during an ADD/DROP REGION transition.
+	for _, regionChange := range regionChanges {
+		for _, rbrChange := range regionalByRowChanges {
+			t.Run(fmt.Sprintf("%s with racing from %s to %s", regionChange, rbrChange.setup, rbrChange.alterCmd), func(t *testing.T) {
+				_, sqlDB, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
+					t,
+					3, /* numServers */
+					base.TestingKnobs{
+						SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
+							RunBeforeEnumMemberPromotion: func() {
+								mu.m.Lock()
+								defer mu.m.Unlock()
+
+								if mu.performInterrupt {
+									mu.performInterrupt = false
+									interruptStartCh <- struct{}{}
+									<-interruptEndCh
+								}
+							},
+						},
+					},
+					nil, /* baseDir */
+				)
+				defer cleanup()
+				setupDB(sqlDB, rbrChange.setup)
+				mu.performInterrupt = true
+
+				regionChangeErr := make(chan error)
+				go func() {
+					_, err := sqlDB.Exec(regionChange)
+					regionChangeErr <- err
+				}()
+
+				// Wait for the backfill to start.
+				<-interruptStartCh
+
+				// Perform the REGIONAL BY ROW transformation.
+				_, err := sqlDB.Exec(rbrChange.alterCmd)
+
+				// Now finish up and ensure no errors (we must do this before the error check to ensure the interrupt completes).
 				interruptEndCh <- struct{}{}
-				require.NoError(t, <-rbrErrCh)
+				require.NoError(t, <-regionChangeErr)
+
+				// Ensure the alter cmd errors.
+				require.Error(t, err)
+				require.EqualError(t, err, "pq: cannot transition to or from REGIONAL BY ROW whilst a region is being added or dropped")
 
 				// Validate the zone configuration.
 				_, err = sqlDB.Exec(`SELECT crdb_internal.validate_multi_region_zone_configs()`)

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -158,6 +158,14 @@ func (p *planner) AlterDatabaseAddRegion(
 		return nil, err
 	}
 
+	if err := checkRegionalByRowTransitionIsNotUnderway(
+		ctx,
+		p,
+		dbDesc,
+	); err != nil {
+		return nil, err
+	}
+
 	// Adding a region also involves repartitioning all REGIONAL BY ROW tables
 	// underneath the hood, so we must ensure the user has the requisite
 	// privileges.
@@ -290,6 +298,15 @@ func (p *planner) AlterDatabaseDropRegion(
 	if err := p.checkPrivilegesForMultiRegionOp(ctx, dbDesc); err != nil {
 		return nil, err
 	}
+
+	if err := checkRegionalByRowTransitionIsNotUnderway(
+		ctx,
+		p,
+		dbDesc,
+	); err != nil {
+		return nil, err
+	}
+
 	// Dropping a region also involves repartitioning all REGIONAL BY ROW tables
 	// underneath the hood, so we must ensure the user has the requisite
 	// privileges.
@@ -600,6 +617,14 @@ func (p *planner) AlterDatabasePrimaryRegion(
 	}
 
 	if err := p.checkPrivilegesForMultiRegionOp(ctx, dbDesc); err != nil {
+		return nil, err
+	}
+
+	if err := checkRegionalByRowTransitionIsNotUnderway(
+		ctx,
+		p,
+		dbDesc,
+	); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -345,6 +345,7 @@ type TypeDescriptor interface {
 	PrimaryRegionName() (descpb.RegionName, error)
 	RegionNames() (descpb.RegionNames, error)
 	RegionNamesIncludingTransitioning() (descpb.RegionNames, error)
+	TransitioningRegionNames() (descpb.RegionNames, error)
 	RegionNamesForZoneConfigValidation() (descpb.RegionNames, error)
 	GetArrayTypeID() descpb.ID
 	GetKind() descpb.TypeDescriptor_Kind

--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -235,6 +235,23 @@ func (desc *immutable) RegionNamesIncludingTransitioning() (descpb.RegionNames, 
 	return regions, nil
 }
 
+// TransitioningRegionNames returns all the regions which are in
+// the process of transitioning.
+func (desc *immutable) TransitioningRegionNames() (descpb.RegionNames, error) {
+	if desc.Kind != descpb.TypeDescriptor_MULTIREGION_ENUM {
+		return nil, errors.AssertionFailedf(
+			"can not get regions of a non multi-region enum %d", desc.ID,
+		)
+	}
+	var regions descpb.RegionNames
+	for _, member := range desc.EnumMembers {
+		if member.Direction != descpb.TypeDescriptor_EnumMember_NONE {
+			regions = append(regions, descpb.RegionName(member.LogicalRepresentation))
+		}
+	}
+	return regions, nil
+}
+
 // SetDrainingNames implements the MutableDescriptor interface.
 func (desc *Mutable) SetDrainingNames(names []descpb.NameInfo) {
 	desc.DrainingNames = names

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -1412,10 +1412,7 @@ func (p *planner) validateZoneConfigForMultiRegionDatabase(
 // the user about that before it occurs (and require the
 // override_multi_region_zone_config session variable to be set).
 func (p *planner) validateZoneConfigForMultiRegionTableWasNotModifiedByUser(
-	ctx context.Context,
-	dbDesc catalog.DatabaseDescriptor,
-	desc *tabledesc.Mutable,
-	checkIndexZoneConfigs bool,
+	ctx context.Context, dbDesc catalog.DatabaseDescriptor, desc *tabledesc.Mutable,
 ) error {
 	// If the user is overriding, or this is not a multi-region table our work here
 	// is done.
@@ -1426,7 +1423,7 @@ func (p *planner) validateZoneConfigForMultiRegionTableWasNotModifiedByUser(
 	if err != nil {
 		return err
 	}
-	regionConfig, err := SynthesizeRegionConfig(ctx, p.txn, dbDesc.GetID(), p.Descriptors())
+	regionConfig, err := SynthesizeRegionConfigForZoneConfigValidation(ctx, p.txn, dbDesc.GetID(), p.Descriptors())
 	if err != nil {
 		return err
 	}
@@ -1598,7 +1595,7 @@ func (p *planner) validateZoneConfigForMultiRegionTable(
 }
 
 // checkRegionalByRowTransitionIsNotUnderway checks no REGIONAL BY ROW activity
-// is occuring on any table on a given database.
+// is occurring on any table on a given database.
 func checkRegionalByRowTransitionIsNotUnderway(
 	ctx context.Context, p *planner, dbDesc catalog.DatabaseDescriptor,
 ) error {


### PR DESCRIPTION
See individual commits for details.

Refs: #63368 