### PR TITLE
workload/schemachange: fix issue creating unique columns, fix SET DAT…

### DIFF
--- a/pkg/workload/schemachange/BUILD.bazel
+++ b/pkg/workload/schemachange/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/rowenc",
+        "//pkg/sql/schemachange",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
         "//pkg/util/encoding",

--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -56,19 +56,6 @@ func columnExistsOnTable(tx *pgx.Tx, tableName *tree.TableName, columnName strin
    )`, tableName.Schema(), tableName.Object(), columnName)
 }
 
-func typeExists(tx *pgx.Tx, typ *tree.TypeName) (bool, error) {
-	if !strings.Contains(typ.Object(), "enum") {
-		return true, nil
-	}
-
-	return scanBool(tx, `SELECT EXISTS (
-	SELECT ns.nspname, t.typname
-  FROM pg_catalog.pg_namespace AS ns
-  JOIN pg_catalog.pg_type AS t ON t.typnamespace = ns.oid
- WHERE ns.nspname = $1 AND t.typname = $2
-	)`, typ.Schema(), typ.Object())
-}
-
 func tableHasRows(tx *pgx.Tx, tableName *tree.TableName) (bool, error) {
 	return scanBool(tx, fmt.Sprintf(`SELECT EXISTS (SELECT * FROM %s)`, tableName.String()))
 }


### PR DESCRIPTION
…A TYPE

Not all types can be indexed. A unique constraint implies an index. Add the
proper error code expectation for that case. Along the way, uncovered that
the typeFromTypeName method was bogus in some cases and was getting called.
This general refactor revealed some logic in the way that alter column type
worked. Namely, it pretty much never worked. We would get ErrNoRows and then
not really exercise the behaviors. I suspect ErrNoRows is causing other
trouble elsewhere. I made sure to properly deal with it in the type resolver.
This also revealed that the type resolver was not accounting for some logic
we add to deal with the width of char types.

Release note: None