### PR TITLE
roachtest: Don't connect workload to n1 in disk-full

### DIFF
--- a/pkg/cmd/roachtest/disk_full.go
+++ b/pkg/cmd/roachtest/disk_full.go
@@ -41,7 +41,7 @@ func registerDiskFull(r *testRegistry) {
 			m.Go(func(ctx context.Context) error {
 				cmd := fmt.Sprintf(
 					"./workload run kv --tolerate-errors --init --read-percent=0"+
-						" --concurrency=10 --duration=2m {pgurl:1-%d}",
+						" --concurrency=10 --duration=2m {pgurl:2-%d}",
 					nodes)
 				c.Run(ctx, c.Node(nodes+1), cmd)
 				return nil


### PR DESCRIPTION
Currently, the workload client connects to all 5 nodes
in the disk-full roachtest. If the connections to
n1 fail, such as due to a badly-timed node crash (which
is totally expected as it's the node being filled up),
the workload binary itself could crash and trip up the monitor
in a non-deterministic way, resulting in spurious test
failures.

This change updates the test to have the workload client
connect to nodes other than n1, as they're likely to remain
stable.

Fixes #63336.

Release note: None.