### PR TITLE
roachprod: upgrade to a newer ubuntu image

### DIFF
--- a/pkg/cmd/roachprod/install/install.go
+++ b/pkg/cmd/roachprod/install/install.go
@@ -43,7 +43,7 @@ sudo service cassandra stop;
     sudo ./configure --prefix=/usr
     sudo make -j$(nproc)
     sudo make install
-    (cd "${thrift_dir}/lib/py" && sudo python setup.py install)
+    (cd "${thrift_dir}/lib/py" && sudo python2 setup.py install)
   fi
 
   charybde_dir="/opt/charybdefs"

--- a/pkg/cmd/roachprod/vm/gce/gcloud.go
+++ b/pkg/cmd/roachprod/vm/gce/gcloud.go
@@ -273,8 +273,9 @@ func (o *providerOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 		"Machine type (see https://cloud.google.com/compute/docs/machine-types)")
 	flags.StringVar(&o.MinCPUPlatform, ProviderName+"-min-cpu-platform", "",
 		"Minimum CPU platform (see https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform)")
-	flags.StringVar(&o.Image, ProviderName+"-image", "ubuntu-1604-xenial-v20200129",
-		"Image to use to create the vm, ubuntu-2004-focal-v20210119a is a more modern image")
+	flags.StringVar(&o.Image, ProviderName+"-image", "ubuntu-2004-focal-v20210325",
+		"Image to use to create the vm, "+
+			"use `gcloud compute images list --filter=\"family=ubuntu-2004-lts\"` to list available images")
 
 	flags.IntVar(&o.SSDCount, ProviderName+"-local-ssd-count", 1,
 		"Number of local SSDs to create, only used if local-ssd=true")

--- a/pkg/cmd/roachprod/vm/gce/utils.go
+++ b/pkg/cmd/roachprod/vm/gce/utils.go
@@ -48,6 +48,11 @@ var Subdomain = func() string {
 const gceLocalSSDStartupScriptTemplate = `#!/usr/bin/env bash
 # Script for setting up a GCE machine for roachprod use.
 
+if [ -e /mnt/data1/.roachprod-initialized ]; then
+  echo "Already initialized, exiting."
+  exit 0
+fi
+
 mount_opts="defaults"
 {{if .ExtraMountOpts}}mount_opts="${mount_opts},{{.ExtraMountOpts}}"{{end}}
 
@@ -75,7 +80,8 @@ if [ "${disknum}" -eq "0" ]; then
 fi
 
 # sshguard can prevent frequent ssh connections to the same host. Disable it.
-sudo service sshguard stop
+systemctl stop sshguard
+systemctl mask sshguard
 # increase the number of concurrent unauthenticated connections to the sshd
 # daemon. See https://en.wikibooks.org/wiki/OpenSSH/Cookbook/Load_Balancing.
 # By default, only 10 unauthenticated connections are permitted before sshd
@@ -120,6 +126,13 @@ sysctl --system  # reload sysctl settings
 sudo apt-get update -q
 sudo apt-get install -qy chrony
 
+# Uninstall some packages to prevent them running cronjobs and similar jobs in parallel
+systemctl stop unattended-upgrades
+apt-get purge -y unattended-upgrades
+
+systemctl stop cron
+systemctl mask cron
+
 # Override the chrony config. In particular,
 # log aggressively when clock is adjusted (0.01s)
 # and exclusively use google's time servers.
@@ -141,6 +154,15 @@ EOF
 
 sudo /etc/init.d/chrony restart
 sudo chronyc -a waitsync 30 0.01 | sudo tee -a /root/chrony.log
+
+for timer in apt-daily-upgrade.timer apt-daily.timer e2scrub_all.timer fstrim.timer man-db.timer e2scrub_all.timer ; do
+  systemctl mask $timer
+done
+
+for service in apport.service atd.service; do
+  systemctl stop $service
+  systemctl mask $service
+done
 
 sudo touch /mnt/data1/.roachprod-initialized
 `


### PR DESCRIPTION
Also stop and mask some services on the `roachprod` machines to reduce
pressure and minimize the impact of a pervasive clock sync bug.

Release note: None