### PR TITLE
kvserver: remove same node check from TransferLeaseTarget

### DIFF
--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -1247,29 +1247,6 @@ func (a *Allocator) TransferLeaseTarget(
 	sl, _, _ := a.storePool.getStoreList(storeFilterNone)
 	sl = sl.filter(zone.Constraints)
 
-	// Filter stores that are on nodes containing existing replicas, but leave
-	// the stores containing the existing replicas in place. This excludes stores
-	// that we can't rebalance to, avoiding an issue in a 3-node cluster where
-	// there are multiple stores per node.
-	//
-	// TODO(peter,bram): This will need adjustment with the new allocator. `sl`
-	// needs to contain only the possible rebalance candidates + the existing
-	// stores the replicas are on.
-	filteredDescs := make([]roachpb.StoreDescriptor, 0, len(sl.stores))
-	for _, s := range sl.stores {
-		var exclude bool
-		for _, r := range existing {
-			if r.NodeID == s.Node.NodeID && r.StoreID != s.StoreID {
-				exclude = true
-				break
-			}
-		}
-		if !exclude {
-			filteredDescs = append(filteredDescs, s)
-		}
-	}
-	sl = makeStoreList(filteredDescs)
-
 	source, ok := a.storePool.getStoreDescriptor(leaseStoreID)
 	if !ok {
 		return roachpb.ReplicaDescriptor{}


### PR DESCRIPTION
In #51567 we added the ability to rebalance replicas between
stores on the same node. This PR reverts the changes
introduced in #12565, since we no longer need to special case
multiple stores per node.

Release note: None