### PR TITLE
sql,docs: hide UNIQUE WITHOUT INDEX from the docs

### DIFF
--- a/docs/generated/sql/bnf/col_qualification.bnf
+++ b/docs/generated/sql/bnf/col_qualification.bnf
@@ -2,7 +2,7 @@ col_qualification ::=
 	'CONSTRAINT' constraint_name 'NOT' 'NULL'
 	| 'CONSTRAINT' constraint_name 'NULL'
 	| 'CONSTRAINT' constraint_name 'NOT' 'VISIBLE'
-	| 'CONSTRAINT' constraint_name 'UNIQUE' opt_without_index
+	| 'CONSTRAINT' constraint_name 'UNIQUE'
 	| 'CONSTRAINT' constraint_name 'PRIMARY' 'KEY'
 	| 'CONSTRAINT' constraint_name 'PRIMARY' 'KEY' 'USING' 'HASH' 'WITH' 'BUCKET_COUNT' '=' n_buckets
 	| 'CONSTRAINT' constraint_name 'CHECK' '(' a_expr ')'
@@ -15,7 +15,7 @@ col_qualification ::=
 	| 'NOT' 'NULL'
 	| 'NULL'
 	| 'NOT' 'VISIBLE'
-	| 'UNIQUE' opt_without_index
+	| 'UNIQUE'
 	| 'PRIMARY' 'KEY'
 	| 'PRIMARY' 'KEY' 'USING' 'HASH' 'WITH' 'BUCKET_COUNT' '=' n_buckets
 	| 'CHECK' '(' a_expr ')'

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -2387,7 +2387,7 @@ constraint_name ::=
 
 constraint_elem ::=
 	'CHECK' '(' a_expr ')'
-	| 'UNIQUE' opt_without_index '(' index_params ')' opt_storing opt_interleave opt_partition_by_index opt_where_clause
+	| 'UNIQUE' '(' index_params ')' opt_storing opt_interleave opt_partition_by_index opt_where_clause
 	| 'PRIMARY' 'KEY' '(' index_params ')' opt_hash_sharded opt_interleave
 	| 'FOREIGN' 'KEY' '(' name_list ')' 'REFERENCES' table_name opt_column_list key_match reference_actions
 
@@ -2680,10 +2680,6 @@ col_qualification ::=
 	| 'CREATE' 'FAMILY'
 	| 'CREATE' 'IF' 'NOT' 'EXISTS' 'FAMILY' family_name
 
-opt_without_index ::=
-	'WITHOUT' 'INDEX'
-	| 
-
 key_match ::=
 	'MATCH' 'SIMPLE'
 	| 'MATCH' 'FULL'
@@ -2932,7 +2928,7 @@ col_qualification_elem ::=
 	'NOT' 'NULL'
 	| 'NULL'
 	| 'NOT' 'VISIBLE'
-	| 'UNIQUE' opt_without_index
+	| 'UNIQUE'
 	| 'PRIMARY' 'KEY'
 	| 'PRIMARY' 'KEY' 'USING' 'HASH' 'WITH' 'BUCKET_COUNT' '=' a_expr
 	| 'CHECK' '(' a_expr ')'

--- a/docs/generated/sql/bnf/table_constraint.bnf
+++ b/docs/generated/sql/bnf/table_constraint.bnf
@@ -1,17 +1,17 @@
 table_constraint ::=
 	'CONSTRAINT' constraint_name 'CHECK' '(' a_expr ')'
-	| 'CONSTRAINT' constraint_name 'UNIQUE' opt_without_index '(' index_params ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by_index opt_where_clause
-	| 'CONSTRAINT' constraint_name 'UNIQUE' opt_without_index '(' index_params ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by_index opt_where_clause
-	| 'CONSTRAINT' constraint_name 'UNIQUE' opt_without_index '(' index_params ')' 'INCLUDE' '(' name_list ')' opt_interleave opt_partition_by_index opt_where_clause
-	| 'CONSTRAINT' constraint_name 'UNIQUE' opt_without_index '(' index_params ')'  opt_interleave opt_partition_by_index opt_where_clause
+	| 'CONSTRAINT' constraint_name 'UNIQUE' '(' index_params ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by_index opt_where_clause
+	| 'CONSTRAINT' constraint_name 'UNIQUE' '(' index_params ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by_index opt_where_clause
+	| 'CONSTRAINT' constraint_name 'UNIQUE' '(' index_params ')' 'INCLUDE' '(' name_list ')' opt_interleave opt_partition_by_index opt_where_clause
+	| 'CONSTRAINT' constraint_name 'UNIQUE' '(' index_params ')'  opt_interleave opt_partition_by_index opt_where_clause
 	| 'CONSTRAINT' constraint_name 'PRIMARY' 'KEY' '(' index_params ')' 'USING' 'HASH' 'WITH' 'BUCKET_COUNT' '=' n_buckets opt_interleave
 	| 'CONSTRAINT' constraint_name 'PRIMARY' 'KEY' '(' index_params ')'  opt_interleave
 	| 'CONSTRAINT' constraint_name 'FOREIGN' 'KEY' '(' name_list ')' 'REFERENCES' table_name opt_column_list key_match reference_actions
 	| 'CHECK' '(' a_expr ')'
-	| 'UNIQUE' opt_without_index '(' index_params ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by_index opt_where_clause
-	| 'UNIQUE' opt_without_index '(' index_params ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by_index opt_where_clause
-	| 'UNIQUE' opt_without_index '(' index_params ')' 'INCLUDE' '(' name_list ')' opt_interleave opt_partition_by_index opt_where_clause
-	| 'UNIQUE' opt_without_index '(' index_params ')'  opt_interleave opt_partition_by_index opt_where_clause
+	| 'UNIQUE' '(' index_params ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by_index opt_where_clause
+	| 'UNIQUE' '(' index_params ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by_index opt_where_clause
+	| 'UNIQUE' '(' index_params ')' 'INCLUDE' '(' name_list ')' opt_interleave opt_partition_by_index opt_where_clause
+	| 'UNIQUE' '(' index_params ')'  opt_interleave opt_partition_by_index opt_where_clause
 	| 'PRIMARY' 'KEY' '(' index_params ')' 'USING' 'HASH' 'WITH' 'BUCKET_COUNT' '=' n_buckets opt_interleave
 	| 'PRIMARY' 'KEY' '(' index_params ')'  opt_interleave
 	| 'FOREIGN' 'KEY' '(' name_list ')' 'REFERENCES' table_name opt_column_list key_match reference_actions

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1383,7 +1383,7 @@ alter_ddl_stmt:
 //   ALTER TABLE ... SET LOCALITY [REGIONAL BY [TABLE IN <region> | ROW] | GLOBAL]
 //
 // Column qualifiers:
-//   [CONSTRAINT <constraintname>] {NULL | NOT NULL | UNIQUE [WITHOUT INDEX] | PRIMARY KEY | CHECK (<expr>) | DEFAULT <expr>}
+//   [CONSTRAINT <constraintname>] {NULL | NOT NULL | UNIQUE | PRIMARY KEY | CHECK (<expr>) | DEFAULT <expr>}
 //   FAMILY <familyname>, CREATE [IF NOT EXISTS] FAMILY [<familyname>]
 //   REFERENCES <tablename> [( <colnames...> )]
 //   COLLATE <collationname>
@@ -5869,11 +5869,11 @@ alter_schema_stmt:
 // Table constraints:
 //    PRIMARY KEY ( <colnames...> ) [USING HASH WITH BUCKET_COUNT = <shard_buckets>]
 //    FOREIGN KEY ( <colnames...> ) REFERENCES <tablename> [( <colnames...> )] [ON DELETE {NO ACTION | RESTRICT}] [ON UPDATE {NO ACTION | RESTRICT}]
-//    UNIQUE [WITHOUT INDEX] ( <colnames... ) [{STORING | INCLUDE | COVERING} ( <colnames...> )] [<interleave>]
+//    UNIQUE ( <colnames... ) [{STORING | INCLUDE | COVERING} ( <colnames...> )] [<interleave>]
 //    CHECK ( <expr> )
 //
 // Column qualifiers:
-//   [CONSTRAINT <constraintname>] {NULL | NOT NULL | NOT VISIBLE |UNIQUE [WITHOUT INDEX] | PRIMARY KEY | CHECK (<expr>) | DEFAULT <expr>}
+//   [CONSTRAINT <constraintname>] {NULL | NOT NULL | NOT VISIBLE | UNIQUE | PRIMARY KEY | CHECK (<expr>) | DEFAULT <expr>}
 //   FAMILY <familyname>, CREATE [IF NOT EXISTS] FAMILY [<familyname>]
 //   REFERENCES <tablename> [( <colnames...> )] [ON DELETE {NO ACTION | RESTRICT}] [ON UPDATE {NO ACTION | RESTRICT}]
 //   COLLATE <collationname>
@@ -6430,6 +6430,7 @@ col_qualification_elem:
 opt_without_index:
   WITHOUT INDEX
   {
+    /* SKIP DOC */
     $$.val = true
   }
 | /* EMPTY */


### PR DESCRIPTION
This commit hides `UNIQUE WITHOUT INDEX` from all documentation
since we do not want users to try to use this experimental feature.

Release note (general change): We hid `UNIQUE WITHOUT INDEX` from all
documentation since we do not want users to try to use this experimental
feature.