### PR TITLE
release-21.1: backupccl: require explicit option to backup interleaved tables

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -898,6 +898,7 @@ unreserved_keyword ::=
 	| 'IMMEDIATE'
 	| 'IMPORT'
 	| 'INCLUDE'
+	| 'INCLUDE_DEPRECATED_INTERLEAVES'
 	| 'INCLUDING'
 	| 'INCREMENT'
 	| 'INCREMENTAL'
@@ -1773,6 +1774,7 @@ backup_options ::=
 	| 'REVISION_HISTORY'
 	| 'DETACHED'
 	| 'KMS' '=' string_or_placeholder_opt_list
+	| 'INCLUDE_DEPRECATED_INTERLEAVES'
 
 c_expr ::=
 	d_expr

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -2830,7 +2830,7 @@ func TestBackupRestoreInterleaved(t *testing.T) {
 
 	var unused string
 	var exportedRows int
-	sqlDB.QueryRow(t, `BACKUP DATABASE data TO $1`, LocalFoo).Scan(
+	sqlDB.QueryRow(t, `BACKUP DATABASE data TO $1 WITH include_deprecated_interleaves`, LocalFoo).Scan(
 		&unused, &unused, &unused, &exportedRows, &unused, &unused,
 	)
 	if exportedRows != totalRows {
@@ -2875,7 +2875,7 @@ func TestBackupRestoreInterleaved(t *testing.T) {
 	})
 
 	t.Run("interleaved table without parent", func(t *testing.T) {
-		sqlDB.ExpectErr(t, "without interleave parent", `BACKUP data.i0 TO $1`, LocalFoo)
+		sqlDB.ExpectErr(t, "without interleave parent", `BACKUP data.i0 TO $1 WITH include_deprecated_interleaves`, LocalFoo)
 
 		tcRestore := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{ServerArgs: args})
 		defer tcRestore.Stopper().Stop(context.Background())
@@ -2888,7 +2888,7 @@ func TestBackupRestoreInterleaved(t *testing.T) {
 	})
 
 	t.Run("interleaved table without child", func(t *testing.T) {
-		sqlDB.ExpectErr(t, "without interleave child", `BACKUP data.bank TO $1`, LocalFoo)
+		sqlDB.ExpectErr(t, "without interleave child", `BACKUP data.bank TO $1 WITH include_deprecated_interleaves`, LocalFoo)
 
 		tcRestore := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{ServerArgs: args})
 		defer tcRestore.Stopper().Stop(context.Background())
@@ -5962,7 +5962,7 @@ func TestProtectedTimestampSpanSelectionDuringBackup(t *testing.T) {
 		runner.Exec(t, "CREATE TABLE child (a INT, b INT, c INT, v BYTES, "+
 			"PRIMARY KEY(a, b, c), INDEX childindex(c)) INTERLEAVE IN PARENT parent(a, b)")
 
-		runner.Exec(t, fmt.Sprintf(`BACKUP DATABASE test INTO '%s'`, baseBackupURI+t.Name()))
+		runner.Exec(t, fmt.Sprintf(`BACKUP DATABASE test INTO '%s' WITH include_deprecated_interleaves`, baseBackupURI+t.Name()))
 		// /Table/59/{1-2} encompasses the pk of grandparent, and the interleaved
 		// tables parent and child.
 		// /Table/59/2 - /Table/59/3 is for the gpindex
@@ -6999,7 +6999,7 @@ func TestRestoreTypeDescriptorsRollBack(t *testing.T) {
 	}
 
 	sqlDB.Exec(t, `
-CREATE DATABASE db; 
+CREATE DATABASE db;
 CREATE TYPE db.typ AS ENUM();
 CREATE TABLE db.table (k INT PRIMARY KEY, v db.typ);
 `)

--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -344,7 +344,7 @@ func TestFullClusterBackupDroppedTables(t *testing.T) {
 
 	_, tablesToCheck := generateInterleavedData(sqlDB, t, numAccounts)
 
-	sqlDB.Exec(t, `BACKUP TO $1`, LocalFoo)
+	sqlDB.Exec(t, `BACKUP TO $1 WITH include_deprecated_interleaves`, LocalFoo)
 	sqlDBRestore.Exec(t, `RESTORE FROM $1`, LocalFoo)
 
 	for _, table := range tablesToCheck {

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -644,7 +644,7 @@ func (u *sqlSymUnion) objectNamePrefixList() tree.ObjectNamePrefixList {
 %token <str> HAVING HASH HIGH HISTOGRAM HOUR
 
 %token <str> IDENTITY
-%token <str> IF IFERROR IFNULL IGNORE_FOREIGN_KEYS ILIKE IMMEDIATE IMPORT IN INCLUDE INCLUDING INCREMENT INCREMENTAL
+%token <str> IF IFERROR IFNULL IGNORE_FOREIGN_KEYS ILIKE IMMEDIATE IMPORT IN INCLUDE INCLUDE_DEPRECATED_INTERLEAVES INCLUDING INCREMENT INCREMENTAL
 %token <str> INET INET_CONTAINED_BY_OR_EQUALS
 %token <str> INET_CONTAINS_OR_EQUALS INDEX INDEXES INHERITS INJECT INTERLEAVE INITIALLY
 %token <str> INNER INSERT INT INTEGER
@@ -2344,6 +2344,7 @@ opt_clear_data:
 //    encryption_passphrase="secret": encrypt backups
 //    kms="[kms_provider]://[kms_host]/[master_key_identifier]?[parameters]" : encrypt backups using KMS
 //    detached: execute backup job asynchronously, without waiting for its completion
+//    include_deprecated_interleaves: allow backing up interleaved tables, even if future versions will be unable to restore.
 //
 // %SeeAlso: RESTORE, WEBDOCS/backup.html
 backup_stmt:
@@ -2449,6 +2450,11 @@ backup_options:
   {
     $$.val = &tree.BackupOptions{EncryptionKMSURI: $3.stringOrPlaceholderOptList()}
   }
+| INCLUDE_DEPRECATED_INTERLEAVES
+  {
+    $$.val = &tree.BackupOptions{IncludeDeprecatedInterleaves: true}
+  }
+
 
 // %Help: CREATE SCHEDULE FOR BACKUP - backup data periodically
 // %Category: CCL
@@ -12410,6 +12416,7 @@ unreserved_keyword:
 | IMMEDIATE
 | IMPORT
 | INCLUDE
+| INCLUDE_DEPRECATED_INTERLEAVES
 | INCLUDING
 | INCREMENT
 | INCREMENTAL

--- a/pkg/sql/parser/testdata/parse/backup_restore
+++ b/pkg/sql/parser/testdata/parse/backup_restore
@@ -313,13 +313,13 @@ BACKUP TABLE _ TO 'bar' WITH revision_history, encryption_passphrase = '*****' -
 BACKUP TABLE foo TO 'bar' WITH revision_history, encryption_passphrase = 'secret' -- passwords exposed
 
 parse
-BACKUP foo TO 'bar' WITH KMS = 'foo', revision_history
+BACKUP foo TO 'bar' WITH KMS = 'foo', revision_history, include_deprecated_interleaves
 ----
-BACKUP TABLE foo TO 'bar' WITH revision_history, kms = 'foo' -- normalized!
-BACKUP TABLE (foo) TO ('bar') WITH revision_history, kms = ('foo') -- fully parenthetized
-BACKUP TABLE foo TO _ WITH revision_history, kms = _ -- literals removed
-BACKUP TABLE foo TO '_' WITH revision_history, kms = '_' -- UNEXPECTED REPARSED AST WITHOUT LITERALS
-BACKUP TABLE _ TO 'bar' WITH revision_history, kms = 'foo' -- identifiers removed
+BACKUP TABLE foo TO 'bar' WITH revision_history, kms = 'foo', include_deprecated_interleaves -- normalized!
+BACKUP TABLE (foo) TO ('bar') WITH revision_history, kms = ('foo'), include_deprecated_interleaves -- fully parenthetized
+BACKUP TABLE foo TO _ WITH revision_history, kms = _, include_deprecated_interleaves -- literals removed
+BACKUP TABLE foo TO '_' WITH revision_history, kms = '_', include_deprecated_interleaves -- UNEXPECTED REPARSED AST WITHOUT LITERALS
+BACKUP TABLE _ TO 'bar' WITH revision_history, kms = 'foo', include_deprecated_interleaves -- identifiers removed
 
 parse
 BACKUP foo TO 'bar' WITH KMS = ('foo', 'bar'), revision_history

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -36,10 +36,11 @@ const (
 
 // BackupOptions describes options for the BACKUP execution.
 type BackupOptions struct {
-	CaptureRevisionHistory bool
-	EncryptionPassphrase   Expr
-	Detached               bool
-	EncryptionKMSURI       StringOrPlaceholderOptList
+	CaptureRevisionHistory       bool
+	EncryptionPassphrase         Expr
+	Detached                     bool
+	EncryptionKMSURI             StringOrPlaceholderOptList
+	IncludeDeprecatedInterleaves bool
 }
 
 var _ NodeFormatter = &BackupOptions{}
@@ -230,6 +231,11 @@ func (o *BackupOptions) Format(ctx *FmtCtx) {
 		ctx.WriteString("kms = ")
 		ctx.FormatNode(&o.EncryptionKMSURI)
 	}
+
+	if o.IncludeDeprecatedInterleaves {
+		maybeAddSep()
+		ctx.WriteString("include_deprecated_interleaves")
+	}
 }
 
 // CombineWith merges other backup options into this backup options struct.
@@ -261,6 +267,14 @@ func (o *BackupOptions) CombineWith(other *BackupOptions) error {
 		o.EncryptionKMSURI = other.EncryptionKMSURI
 	} else if other.EncryptionKMSURI != nil {
 		return errors.New("kms specified multiple times")
+	}
+
+	if o.IncludeDeprecatedInterleaves {
+		if other.IncludeDeprecatedInterleaves {
+			return errors.New("include_deprecated_interleaves option specified multiple times")
+		}
+	} else {
+		o.IncludeDeprecatedInterleaves = other.IncludeDeprecatedInterleaves
 	}
 
 	return nil


### PR DESCRIPTION
Backport 1/1 commits from #63356.

/cc @cockroachdb/release

---

Currently creation of interleaved tables emits a simple warning, but continues. 
This change enforces a much more strict deprecation warning, asking users
to explicitly pass a flag, when *backing up* interleaved tables. 

This is motivated by the fact that BACKUPs of interleaved data will not be able to
be read or restored by v21.2. Backups are often retained or a month or more
so it is important that a user _planning_ to upgrade to 21.2 de-interleave
their tables and start backing up forward-compatible backups well before
their planned upgrade. Since backups are often run by a cron-job or schedule
simply emitting a warning may not draw enough attention to the need to make
this switch.

This change adds a flag that must be passed to include an interleaved table
in a backup. Existing users of interleaved tables will get errors when they
upgrade and try to backup, highlighting the coming incompatibility, but can
simply append the option to their backups until they're ready to actually
migrate to de-interleaved tables.

Release note (sql change): BACKUP of interleaved tables requires passing the 'include_deprecated_interleaves' option as these backups will not be able to be restored by future versions.
