### PR TITLE
sql: fix multi-region test knob

### DIFF
--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -370,7 +370,9 @@ func (t *typeSchemaChanger) exec(ctx context.Context) error {
 					return err
 				}
 				if fn := t.execCfg.TypeSchemaChangerTestingKnobs.RunBeforeMultiRegionUpdates; fn != nil {
-					return fn()
+					if err := fn(); err != nil {
+						return err
+					}
 				}
 				repartitionedTables, err = performMultiRegionFinalization(
 					ctx,


### PR DESCRIPTION
There was an error in the `RunBeforeMultiRegionUpdates` knob such that
if it were set, we would short circuit. The intention, instead, was to
only short circuit in the error case.

Release note: None