### PR TITLE
kvserver: do not allow lease transfers to replicas in `StateSnapshot`

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -325,9 +325,9 @@ type RaftConfig struct {
 	// means always renew.
 	RangeLeaseRenewalFraction float64
 
-	// RaftLogTruncationThreshold controls how large a single Range's Raft log
-	// can grow. When a Range's Raft log grows above this size, the Range will
-	// begin performing log truncations.
+	// RaftLogTruncationThreshold controls (in terms of the number of bytes) how
+	// large a single Range's Raft log can grow. When a Range's Raft log grows
+	// above this size, the Range will begin performing log truncations.
 	RaftLogTruncationThreshold int64
 
 	// RaftProposalQuota controls the maximum aggregate size of Raft commands

--- a/pkg/kv/kvnemesis/validator.go
+++ b/pkg/kv/kvnemesis/validator.go
@@ -361,6 +361,9 @@ func (v *validator) processOp(txnID *string, op Operation) {
 		} else if resultIsErrorStr(t.Result, `cannot transfer lease while merge in progress`) {
 			// A lease transfer is not permitted while a range merge is in its
 			// critical phase.
+		} else if resultIsErrorStr(t.Result, `cannot transfer lease to replica in need of a snapshot`) {
+			// A lease transfer to a replica that is waiting for a raft snapshot is
+			// not permitted.
 		} else if resultIsError(t.Result, liveness.ErrRecordCacheMiss) {
 			// If the existing leaseholder has not yet heard about the transfer
 			// target's liveness record through gossip, it will return an error.

--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -84,6 +84,8 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_gogo_protobuf//types",
         "@com_github_kr_pretty//:pretty",
+        "@io_etcd_go_etcd_raft_v3//:raft",
+        "@io_etcd_go_etcd_raft_v3//tracker",
         "@org_golang_x_time//rate",
     ],
 )

--- a/pkg/kv/kvserver/batcheval/eval_context.go
+++ b/pkg/kv/kvserver/batcheval/eval_context.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/limit"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"go.etcd.io/etcd/raft/v3"
 	"golang.org/x/time/rate"
 )
 
@@ -101,6 +102,12 @@ type EvalContext interface {
 	GetLastReplicaGCTimestamp(context.Context) (hlc.Timestamp, error)
 	GetLease() (roachpb.Lease, roachpb.Lease)
 	GetRangeInfo(context.Context) roachpb.RangeInfo
+
+	// RaftStatus returns this replica's raft status tracker.
+	//
+	// NB: The `Progress` field in a `*raft.Status` is only populated on the raft
+	// leader.
+	RaftStatus() *raft.Status
 
 	// GetCurrentReadSummary returns a new ReadSummary reflecting all reads
 	// served by the range to this point. The method requires a write latch
@@ -242,6 +249,9 @@ func (m *mockEvalCtxImpl) GetLease() (roachpb.Lease, roachpb.Lease) {
 }
 func (m *mockEvalCtxImpl) GetRangeInfo(ctx context.Context) roachpb.RangeInfo {
 	return roachpb.RangeInfo{Desc: *m.Desc(), Lease: m.Lease}
+}
+func (m *mockEvalCtxImpl) RaftStatus() *raft.Status {
+	return nil
 }
 func (m *mockEvalCtxImpl) GetCurrentReadSummary(ctx context.Context) rspb.ReadSummary {
 	return m.CurrentReadSummary

--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -42,6 +42,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/raft/v3/tracker"
+	"golang.org/x/sync/errgroup"
 )
 
 // TestStoreRangeLease verifies that regular ranges (not some special ones at
@@ -267,6 +269,133 @@ func TestGossipNodeLivenessOnLeaseChange(t *testing.T) {
 		}
 		return nil
 	})
+}
+
+// TestCannotTransferLeaseToStateSnapshot ensures that the evaluation of
+// TransferLeaseRequests to replicas that are known by the leader to be in
+// `StateSnapshot` will fail.
+func TestCannotTransferLeaseToStateSnapshot(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	knobs, ltk := makeReplicationTestKnobs()
+	var skipSnaps int32
+
+	ltk.storeKnobs.ReplicaSkipInitialSnapshot = func() bool {
+		return atomic.LoadInt32(&skipSnaps) == 1
+	}
+	// Prevent the raft snapshot queue from upreplicating the uninitialized
+	// replica we'll be adding in this test, lest it will not stay in
+	// `StateSnapshot`.
+	var uninitializedReplID int32
+	ltk.storeKnobs.RaftSnapshotQueueSkipReplica = func(id roachpb.ReplicaID) bool {
+		if atomic.LoadInt32(&uninitializedReplID) == 0 {
+			// If we haven't learned the replica ID of the new replica yet,
+			// conservatively prevent all snapshots until we do.
+			return atomic.LoadInt32(&skipSnaps) == 1
+		}
+		return atomic.LoadInt32(&skipSnaps) == 1 && atomic.LoadInt32(&uninitializedReplID) == int32(id)
+	}
+	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+		ServerArgs: base.TestServerArgs{
+			Knobs: knobs,
+		},
+	})
+	defer tc.Stopper().Stop(ctx)
+	scratchKey := tc.ScratchRange(t)
+	tc.AddVotersOrFatal(t, scratchKey, tc.Target(1))
+
+	// Force a log truncation (if it wasn't already truncated by this point) to
+	// ensure that the third replica we're going to add below can only upreplicate
+	// via a snapshot.
+	leaseholderStore := tc.GetFirstStoreFromServer(t, 0)
+	leaseholderStore.MustForceRaftLogScanAndProcess()
+
+	// Add a third voter, but don't initialize it.
+	g, _ := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		// Skip the initial learner snapshot sent during `AdminChangeReplicas` so
+		// that the newly added follower stays uninitialized and in `StateSnapshot`.
+		atomic.StoreInt32(&skipSnaps, 1)
+		_, err := tc.AddVoters(scratchKey, tc.Target(2))
+		return err
+	})
+
+	var scratchDesc roachpb.RangeDescriptor
+	testutils.SucceedsSoon(t, func() error {
+		scratchDesc = tc.LookupRangeOrFatal(t, scratchKey)
+		voters := scratchDesc.Replicas().VoterDescriptors()
+		if len(voters) != 3 {
+			return errors.Errorf("expected 3 voters found: %+v", voters)
+		}
+		for _, repl := range voters {
+			if repl.NodeID == tc.Server(2).NodeID() {
+				atomic.StoreInt32(&uninitializedReplID, int32(repl.ReplicaID))
+				break
+			}
+		}
+		return nil
+	})
+
+	getReplicaRaftState := func(id roachpb.ReplicaID) (tracker.StateType, error) {
+		progress := leaseholderStore.RaftStatus(scratchDesc.RangeID).Progress
+		log.Infof(ctx, "Raft progress: %+v", progress)
+		if progress == nil {
+			return 0, errors.Errorf("leaseholder not yet collocated with the leader")
+		}
+		status, ok := progress[uint64(uninitializedReplID)]
+		if !ok {
+			return 0, errors.Errorf("newly added voter not found in the leaseholders progress tracker")
+		}
+		return status.State, nil
+	}
+
+	log.Infof(ctx, "ensuring that the newly added voter is in StateSnapshot")
+	testutils.SucceedsSoon(t, func() error {
+		state, err := getReplicaRaftState(roachpb.ReplicaID(atomic.LoadInt32(&uninitializedReplID)))
+		if err != nil {
+			return err
+		}
+		if state != tracker.StateSnapshot {
+			return errors.Errorf(
+				"expected uninitialized voter to be in StateSnapshot, but it is in %s", state,
+			)
+		}
+		return nil
+	})
+	log.Infof(
+		ctx, "newly added voter is in StateSnapshot, attempting to transfer the range lease to it",
+	)
+	// Attempt to transfer the lease to the uninitialized voter we just added.
+	// This should fail during the evaluation of the TransferLeaseRequest because
+	// the leaseholder (also the leader in this test) knows that the target of the
+	// lease transfer is in `StateSnapshot`.
+	err := tc.TransferRangeLease(scratchDesc, tc.Target(2))
+	require.Regexp(t, "cannot transfer lease to replica not in StateReplicate", err)
+
+	// Ensure that the replica transitions into `StateReplicate` after snapshots
+	// are re-enabled.
+	atomic.StoreInt32(&skipSnaps, 0)
+	testutils.SucceedsSoon(t, func() error {
+		if err := leaseholderStore.ForceRaftSnapshotQueueProcess(); err != nil {
+			return errors.Wrap(err, "error while forcing a raft snapshot queue processing cycle")
+		}
+		state, err := getReplicaRaftState(roachpb.ReplicaID(atomic.LoadInt32(&uninitializedReplID)))
+		if err != nil {
+			return err
+		}
+		if state != tracker.StateReplicate {
+			return errors.Errorf(
+				"expected uninitialized voter to be in StateReplicate, but it is in %s", state,
+			)
+		}
+		return nil
+	})
+	require.NoError(t, g.Wait())
+	// The same lease transfer that failed above should succeed now.
+	tc.TransferRangeLeaseOrFatal(t, scratchDesc, tc.Target(2))
 }
 
 // TestCannotTransferLeaseToVoterOutgoing ensures that the evaluation of lease

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -4575,7 +4575,9 @@ func TestMergeQueueSeesNonVoters(t *testing.T) {
 				Store: &kvserver.StoreTestingKnobs{
 					// Disable load-based splitting, so that the absence of sufficient QPS
 					// measurements do not prevent ranges from merging.
-					DisableLoadBasedSplitting: true,
+					DisableLoadBasedSplitting:        true,
+					DisableRaftLogQueue:              true,
+					DontIgnoreFailureToTransferLease: true,
 				},
 			},
 		},

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -3270,7 +3270,7 @@ func TestSplitTriggerMeetsUnexpectedReplicaID(t *testing.T) {
 		ReplicaSkipInitialSnapshot: func() bool {
 			return atomic.LoadInt32(&skipSnaps) != 0
 		},
-		RaftSnapshotQueueSkipReplica: func() bool {
+		RaftSnapshotQueueSkipReplica: func(_ roachpb.ReplicaID) bool {
 			return atomic.LoadInt32(&skipSnaps) != 0
 		},
 		VoterAddStopAfterLearnerSnapshot: func(targets []roachpb.ReplicationTarget) bool {

--- a/pkg/kv/kvserver/raft_snapshot_queue.go
+++ b/pkg/kv/kvserver/raft_snapshot_queue.go
@@ -108,12 +108,11 @@ func (rq *raftSnapshotQueue) processRaftSnapshot(
 	if !ok {
 		return errors.Errorf("%s: replica %d not present in %v", repl, id, desc.Replicas())
 	}
+	if fn := repl.store.cfg.TestingKnobs.RaftSnapshotQueueSkipReplica; fn != nil && fn() {
+		return nil
+	}
 	snapType := SnapshotRequest_VIA_SNAPSHOT_QUEUE
-
 	if typ := repDesc.GetType(); typ == roachpb.LEARNER || typ == roachpb.NON_VOTER {
-		if fn := repl.store.cfg.TestingKnobs.RaftSnapshotQueueSkipReplica; fn != nil && fn() {
-			return nil
-		}
 		if index := repl.getAndGCSnapshotLogTruncationConstraints(
 			timeutil.Now(), repDesc.StoreID,
 		); index > 0 {

--- a/pkg/kv/kvserver/raft_snapshot_queue.go
+++ b/pkg/kv/kvserver/raft_snapshot_queue.go
@@ -108,7 +108,7 @@ func (rq *raftSnapshotQueue) processRaftSnapshot(
 	if !ok {
 		return errors.Errorf("%s: replica %d not present in %v", repl, id, desc.Replicas())
 	}
-	if fn := repl.store.cfg.TestingKnobs.RaftSnapshotQueueSkipReplica; fn != nil && fn() {
+	if fn := repl.store.cfg.TestingKnobs.RaftSnapshotQueueSkipReplica; fn != nil && fn(id) {
 		return nil
 	}
 	snapType := SnapshotRequest_VIA_SNAPSHOT_QUEUE

--- a/pkg/kv/kvserver/replica_eval_context_span.go
+++ b/pkg/kv/kvserver/replica_eval_context_span.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"go.etcd.io/etcd/raft/v3"
 )
 
 // SpanSetReplicaEvalContext is a testing-only implementation of
@@ -205,6 +206,11 @@ func (rec SpanSetReplicaEvalContext) GetRangeInfo(ctx context.Context) roachpb.R
 	rec.GetLease()
 
 	return rec.i.GetRangeInfo(ctx)
+}
+
+// RaftStatus is part of the EvalContext interface.
+func (rec SpanSetReplicaEvalContext) RaftStatus() *raft.Status {
+	return rec.i.RaftStatus()
 }
 
 // GetCurrentReadSummary is part of the EvalContext interface.

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -269,7 +269,7 @@ type StoreTestingKnobs struct {
 	ReplicaSkipInitialSnapshot func() bool
 	// RaftSnapshotQueueSkipReplica causes the raft snapshot queue to skip sending
 	// a snapshot to a follower replica.
-	RaftSnapshotQueueSkipReplica func() bool
+	RaftSnapshotQueueSkipReplica func(id roachpb.ReplicaID) bool
 	// VoterAddStopAfterJointConfig causes voter addition to return early if
 	// the func returns true. This happens before transitioning out of a joint
 	// configuration, after the joint configuration has been entered by means

--- a/pkg/roachpb/metadata_replicas.go
+++ b/pkg/roachpb/metadata_replicas.go
@@ -507,6 +507,13 @@ func (c ReplicaChangeType) IsRemoval() bool {
 
 var errReplicaNotFound = errors.Errorf(`replica not found in RangeDescriptor`)
 var errReplicaCannotHoldLease = errors.Errorf("replica cannot hold lease")
+var ErrTransferLeaseToNonReadyFollower = errors.Errorf("cannot transfer lease to replica not in StateReplicate")
+
+// IsRetriableLeaseTransferError detects whether the lease transfer failed due
+// to a transient error that could possibly succeed when retried.
+func IsRetriableLeaseTransferError(err error) bool {
+	return errors.Is(err, ErrTransferLeaseToNonReadyFollower)
+}
 
 // CheckCanReceiveLease checks whether `wouldbeLeaseholder` can receive a lease.
 // Returns an error if the respective replica is not eligible.


### PR DESCRIPTION
In some roachtest failures(#61541, for example) we've seen disruptive
effects from a range's lease being cooperatively transferred to a
follower replica that was either uninitialized or in need of a snapshot.

As of the time of this change, our default cluster settings make it such
that a snapshot would take ~64 seconds to transfer. This means that, if
our lease rebalancing heuristics (via either the replicate queue or the
store rebalancer) happen to make a decision to transfer a range lease to
a lagging follower during an unfortunate window of time (i.e. when the
follower is in need of a snapshot), we would be wedging all traffic on
that range until this follower applies this snapshot and then applies
the lease.

This commit prevents this behavior by rejecting lease transfers to replicas
that the leader (usually the leaseholder) knows are in need of a snapshot.

Resolves #61604

Release note: None