### PR TITLE
 tabledesc: MakeFirstMutationPublic should ignore PK swaps

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1769,7 +1769,7 @@ func ValidateForwardIndexes(
 			// added earlier in the same mutation. Make the mutations public in an
 			// in-memory copy of the descriptor and add it to the Collection's synthetic
 			// descriptors, so that we can use SQL below to perform the validation.
-			descI, err := tableDesc.MakeFirstMutationPublic(catalog.IgnoreConstraints)
+			descI, err := tableDesc.MakeFirstMutationPublic(catalog.IgnoreConstraintsAndPKSwaps)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -713,7 +713,7 @@ func (sc *SchemaChanger) validateConstraints(
 			// (the validation can take many minutes). So we pretend that the schema
 			// has been updated and actually update it in a separate transaction that
 			// follows this one.
-			descI, err := tableDesc.MakeFirstMutationPublic(tabledesc.IgnoreConstraints)
+			descI, err := tableDesc.MakeFirstMutationPublic(catalog.IgnoreConstraints)
 			if err != nil {
 				return err
 			}
@@ -1677,7 +1677,7 @@ func ValidateForwardIndexes(
 				// add it to the Collection's synthetic descriptors, so that we can use
 				// SQL below to perform the validation.
 				var err error
-				desc, err = tableDesc.MakeFirstMutationPublic(tabledesc.IgnoreConstraints)
+				desc, err = tableDesc.MakeFirstMutationPublic(catalog.IgnoreConstraints)
 				if err != nil {
 					return err
 				}
@@ -1769,7 +1769,7 @@ func ValidateForwardIndexes(
 			// added earlier in the same mutation. Make the mutations public in an
 			// in-memory copy of the descriptor and add it to the Collection's synthetic
 			// descriptors, so that we can use SQL below to perform the validation.
-			descI, err := tableDesc.MakeFirstMutationPublic(tabledesc.IgnoreConstraints)
+			descI, err := tableDesc.MakeFirstMutationPublic(catalog.IgnoreConstraints)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/backfill/BUILD.bazel
+++ b/pkg/sql/backfill/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/schemaexpr",
-        "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/catalog/typedesc",
         "//pkg/sql/execinfra",
         "//pkg/sql/row",

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
@@ -384,7 +383,7 @@ func ConvertBackfillError(
 	// information useful in printing a sensible error. However
 	// ConvertBatchError() will only work correctly if the schema elements
 	// are "live" in the tableDesc.
-	desc, err := tableDesc.MakeFirstMutationPublic(tabledesc.IncludeConstraints)
+	desc, err := tableDesc.MakeFirstMutationPublic(catalog.IncludeConstraints)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -45,6 +45,24 @@ const (
 	Schema = "schema"
 )
 
+// MutationPublicationFilter is used by MakeFirstMutationPublic to filter the
+// mutation types published.
+type MutationPublicationFilter int
+
+const (
+	// IgnoreConstraints is used in MakeFirstMutationPublic to indicate that the
+	// table descriptor returned should not include newly added constraints, which
+	// is useful when passing the returned table descriptor to be used in
+	// validating constraints to be added.
+	IgnoreConstraints MutationPublicationFilter = 1
+	// IgnoreConstraintsAndPKSwaps is used in MakeFirstMutationPublic to indicate that the
+	// table descriptor returned should include newly added constraints.
+	IgnoreConstraintsAndPKSwaps = 2
+	// IncludeConstraints is used in MakeFirstMutationPublic to indicate that the
+	// table descriptor returned should include newly added constraints.
+	IncludeConstraints = 0
+)
+
 // DescriptorBuilder interfaces are used to build catalog.Descriptor
 // objects.
 type DescriptorBuilder interface {
@@ -297,7 +315,7 @@ type TableDescriptor interface {
 	IsAs() bool
 
 	HasColumnBackfillMutation() bool
-	MakeFirstMutationPublic(includeConstraints bool) (TableDescriptor, error)
+	MakeFirstMutationPublic(includeConstraints MutationPublicationFilter) (TableDescriptor, error)
 	MakePublic() TableDescriptor
 	AllMutations() []Mutation
 	GetGCMutations() []descpb.TableDescriptor_GCDescriptorMutation

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/backfill"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
@@ -388,7 +387,7 @@ func (ib *indexBackfiller) wrapDupError(ctx context.Context, orig error) error {
 		return orig
 	}
 
-	desc, err := ib.desc.MakeFirstMutationPublic(tabledesc.IncludeConstraints)
+	desc, err := ib.desc.MakeFirstMutationPublic(catalog.IncludeConstraints)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When MakeFirstMutationPublic is called on a temp table desc used for index validation,
it is very important that it does _not_ make a PK swap to that new index public. Doing
so would mean the validation then validates teh new index against itself as the now
primary index, effectively disabling index validation entirely.

This change piggybacks on the existing flag passed as true in the validation paths
to not publish constraints (PK technically is a constraint after all).

Release note (bug fix): Use existing primary key to validate indexes built for ALTER PRIMARY KEY changes.