### PR TITLE
catalog/descs: fix panic when type resolution finds a non-type descriptor

### DIFF
--- a/pkg/sql/catalog/descs/BUILD.bazel
+++ b/pkg/sql/catalog/descs/BUILD.bazel
@@ -64,6 +64,8 @@ go_test(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/lease",
         "//pkg/sql/catalog/tabledesc",
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sqlutil",
         "//pkg/sql/types",

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -2040,8 +2040,13 @@ func (dt DistSQLTypeResolver) GetTypeDescriptor(
 	if err != nil {
 		return tree.TypeName{}, nil, err
 	}
+	typeDesc, isType := desc.(catalog.TypeDescriptor)
+	if !isType {
+		return tree.TypeName{}, nil, pgerror.Newf(pgcode.WrongObjectType,
+			"descriptor %d is a %s not a %s", id, desc.DescriptorType(), catalog.Type)
+	}
 	name := tree.MakeUnqualifiedTypeName(tree.Name(desc.GetName()))
-	return name, desc.(catalog.TypeDescriptor), nil
+	return name, typeDesc, nil
 }
 
 // HydrateTypeSlice installs metadata into a slice of types.T's.


### PR DESCRIPTION
Prior to this change, the type resolution logic for resolving types by ID
would panic if the descriptor was not a type.

Touches #63378

Release note (bug fix): Fixed a panic which can occur in cases after a
RESTORE of a table using user defined types.