### PR TITLE
release-21.1: cli: assorted backports about the command-line help texts

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1431,13 +1431,12 @@ Available Commands:
 Flags:
   -h, --help                 help for cockroach
       --log <string>         
-                                     Logging configuration, expressed using YAML syntax. For example, you
-                                     can change the default logging directory with: --log='file-defaults:
-                                     {dir: ...}'. See the documentation for more options and details.  To
-                                     preview how the log configuration is applied, or preview the default
-                                     configuration, you can use the 'cockroach debug check-log-config'
-                                     sub-command.
-                                    
+                              Logging configuration, expressed using YAML syntax. For example, you can
+                              change the default logging directory with: --log='file-defaults: {dir: ...}'.
+                              See the documentation for more options and details.  To preview how the log
+                              configuration is applied, or preview the default configuration, you can use
+                              the 'cockroach debug check-log-config' sub-command.
+                             
       --version              version for cockroach
 
 Use "cockroach [command] --help" for more information about a command.

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1431,7 +1431,12 @@ Available Commands:
 Flags:
   -h, --help                 help for cockroach
       --log <string>         
-                                     Logging configuration. See the documentation for details.
+                                     Logging configuration, expressed using YAML syntax. For example, you
+                                     can change the default logging directory with: --log='file-defaults:
+                                     {dir: ...}'. See the documentation for more options and details.  To
+                                     preview how the log configuration is applied, or preview the default
+                                     configuration, you can use the 'cockroach debug check-log-config'
+                                     sub-command.
                                     
       --version              version for cockroach
 

--- a/pkg/cli/client_url.go
+++ b/pkg/cli/client_url.go
@@ -75,7 +75,7 @@ type urlParser struct {
 func (u urlParser) String() string { return "" }
 
 func (u urlParser) Type() string {
-	return "postgresql://[user[:passwd]@]host[:port]/[db][?parameters...]"
+	return "<postgres://...>"
 }
 
 func (u urlParser) Set(v string) error {

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1338,8 +1338,15 @@ This can be used to check schema and data correctness without running the entire
 	}
 
 	Log = FlagInfo{
-		Name:        "log",
-		Description: `Logging configuration. See the documentation for details.`,
+		Name: "log",
+		Description: `Logging configuration, expressed using YAML syntax.
+For example, you can change the default logging directory with:
+--log='file-defaults: {dir: ...}'.
+See the documentation for more options and details.
+
+To preview how the log configuration is applied, or preview the
+default configuration, you can use the 'cockroach debug check-log-config' sub-command.
+`,
 	}
 
 	DeprecatedStderrThreshold = FlagInfo{

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -42,7 +42,7 @@ type FlagInfo struct {
 	Description string
 }
 
-const usageIndentation = 8
+const usageIndentation = 1
 const wrapWidth = 79 - usageIndentation
 
 // wrapDescription wraps the text in a FlagInfo.Description.
@@ -80,7 +80,7 @@ func wrapDescription(s string) string {
 // * indentation
 // * env variable name (if set)
 func (f FlagInfo) Usage() string {
-	s := "\n" + wrapDescription(f.Description) + "\n"
+	s := "\n" + wrapDescription(f.Description)
 	if f.EnvVar != "" {
 		// Check that the environment variable name matches the flag name. Note: we
 		// don't want to automatically generate the name so that grepping for a flag
@@ -90,12 +90,12 @@ func (f FlagInfo) Usage() string {
 			panic(fmt.Sprintf("incorrect EnvVar %s for flag %s (should be %s)",
 				f.EnvVar, f.Name, correctName))
 		}
-		s = s + "Environment variable: " + f.EnvVar + "\n"
+		s = s + "\nEnvironment variable: " + f.EnvVar
 	}
 	// github.com/spf13/pflag appends the default value after the usage text. Add
-	// the correct indentation (7 spaces) here. This is admittedly fragile.
-	return text.Indent(s, strings.Repeat(" ", usageIndentation)) +
-		strings.Repeat(" ", usageIndentation-1)
+	// an additional indentation so the default is well-aligned with the
+	// rest of the text. This is admittedly fragile.
+	return text.Indent(s, strings.Repeat(" ", usageIndentation)) + "\n"
 }
 
 // Attrs and others store the static information for CLI flags.

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -948,9 +948,16 @@ The value "disabled" will disable all local file I/O.
 		Name:   "url",
 		EnvVar: "COCKROACH_URL",
 		Description: `
-Connection URL, e.g. "postgresql://myuser@localhost:26257/mydb".
-If left empty, the connection flags are used (host, port, user,
-database, insecure, certs-dir).`,
+Connection URL, of the form:
+<PRE>
+   postgresql://[user[:passwd]@]host[:port]/[db][?parameters...]
+</PRE>
+For example, postgresql://myuser@localhost:26257/mydb.
+<PRE>
+
+</PRE>
+If left empty, the discrete connection flags are used: host, port,
+user, database, insecure, certs-dir.`,
 	}
 
 	User = FlagInfo{

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -299,37 +299,37 @@ func init() {
 		// TODO(knz): Remove this.
 		varFlag(pf, &cliCtx.deprecatedLogOverrides.stderrThreshold, cliflags.DeprecatedStderrThreshold)
 		_ = pf.MarkDeprecated(cliflags.DeprecatedStderrThreshold.Name,
-			"use --"+cliflags.Log.Name+" instead to specify sinks.stderr.filter.")
+			"use --"+cliflags.Log.Name+" instead to specify 'sinks: {stderr: {filter: ...}}'.")
 		// This flag can also be specified without an explicit argument.
 		pf.Lookup(cliflags.DeprecatedStderrThreshold.Name).NoOptDefVal = "DEFAULT"
 
 		varFlag(pf, &cliCtx.deprecatedLogOverrides.stderrNoColor, cliflags.DeprecatedStderrNoColor)
 		_ = pf.MarkDeprecated(cliflags.DeprecatedStderrNoColor.Name,
-			"use --"+cliflags.Log.Name+" instead to specify sinks.stderr.no-color.")
+			"use --"+cliflags.Log.Name+" instead to specify 'sinks: {stderr: {no-color: true}}'")
 
 		varFlag(pf, &cliCtx.deprecatedLogOverrides.logDir, cliflags.DeprecatedLogDir)
 		_ = pf.MarkDeprecated(cliflags.DeprecatedLogDir.Name,
-			"use --"+cliflags.Log.Name+" instead to specify file-defaults.dir.")
+			"use --"+cliflags.Log.Name+" instead to specify 'file-defaults: {dir: ...}'")
 
 		varFlag(pf, cliCtx.deprecatedLogOverrides.fileMaxSizeVal, cliflags.DeprecatedLogFileMaxSize)
 		_ = pf.MarkDeprecated(cliflags.DeprecatedLogFileMaxSize.Name,
-			"use --"+cliflags.Log.Name+" instead to specify file-defaults.max-file-size.")
+			"use --"+cliflags.Log.Name+" instead to specify 'file-defaults: {max-file-size: ...}'")
 
 		varFlag(pf, cliCtx.deprecatedLogOverrides.maxGroupSizeVal, cliflags.DeprecatedLogGroupMaxSize)
 		_ = pf.MarkDeprecated(cliflags.DeprecatedLogGroupMaxSize.Name,
-			"use --"+cliflags.Log.Name+" instead to specify file-defaults.max-group-size.")
+			"use --"+cliflags.Log.Name+" instead to specify 'file-defaults: {max-group-size: ...}'")
 
 		varFlag(pf, &cliCtx.deprecatedLogOverrides.fileThreshold, cliflags.DeprecatedFileThreshold)
 		_ = pf.MarkDeprecated(cliflags.DeprecatedFileThreshold.Name,
-			"use --"+cliflags.Log.Name+" instead to specify file-defaults.filter.")
+			"use --"+cliflags.Log.Name+" instead to specify 'file-defaults: {filter: ...}'")
 
 		varFlag(pf, &cliCtx.deprecatedLogOverrides.redactableLogs, cliflags.DeprecatedRedactableLogs)
 		_ = pf.MarkDeprecated(cliflags.DeprecatedRedactableLogs.Name,
-			"use --"+cliflags.Log.Name+" instead to specify file-defaults:redactable-logs.")
+			"use --"+cliflags.Log.Name+" instead to specify 'file-defaults: {redactable: ...}")
 
 		varFlag(pf, &cliCtx.deprecatedLogOverrides.sqlAuditLogDir, cliflags.DeprecatedSQLAuditLogDir)
 		_ = pf.MarkDeprecated(cliflags.DeprecatedSQLAuditLogDir.Name,
-			"use --"+cliflags.Log.Name+" instead to specify sinks:file-groups:sql-audit.")
+			"use --"+cliflags.Log.Name+" instead to specify 'sinks: {file-groups: {sql-audit: {channels: SENSITIVE_ACCESS, dir: ...}}}")
 	}
 
 	// Remember we are starting in the background as the `start` command will


### PR DESCRIPTION
Backport:
  * 1/1 commits from "cli: better document the logging flags" (#62068)
  * 2/2 commits from "cli/flags: make 'cockroach help' more narrow" (#62304)

Please see individual PRs for details.

/cc @cockroachdb/release
