### PR TITLE
ccl: call rows.Err() when rows.Next() returns false

### DIFF
--- a/pkg/ccl/backupccl/create_scheduled_backup_test.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup_test.go
@@ -152,6 +152,9 @@ func (h *testHelper) createBackupSchedule(
 		require.NoError(t, s.InitFromDatums(datums, cols))
 		schedules = append(schedules, s)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
 	return schedules, nil
 }
@@ -635,6 +638,7 @@ func TestCreateBackupScheduleInExplicitTxnRollback(t *testing.T) {
 
 	res := th.sqlDB.Query(t, "SELECT id FROM [SHOW SCHEDULES];")
 	require.False(t, res.Next())
+	require.NoError(t, res.Err())
 
 	th.sqlDB.Exec(t, "BEGIN;")
 	th.sqlDB.Exec(t, "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://1/collection' RECURRING '@daily';")
@@ -642,6 +646,7 @@ func TestCreateBackupScheduleInExplicitTxnRollback(t *testing.T) {
 
 	res = th.sqlDB.Query(t, "SELECT id FROM [SHOW SCHEDULES];")
 	require.False(t, res.Next())
+	require.NoError(t, res.Err())
 }
 
 // Normally, we issue backups with AOST set to be the scheduled nextRun.

--- a/pkg/ccl/backupccl/helpers_test.go
+++ b/pkg/ccl/backupccl/helpers_test.go
@@ -144,6 +144,9 @@ func verifyBackupRestoreStatementResult(
 	var unused int64
 
 	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return err
+		}
 		return errors.New("zero rows in result")
 	}
 	if err := rows.Scan(

--- a/pkg/ccl/changefeedccl/cdctest/nemeses.go
+++ b/pkg/ccl/changefeedccl/cdctest/nemeses.go
@@ -524,6 +524,9 @@ func openTxn(a fsm.Args) error {
 				return err
 			}
 		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
 		// If there aren't any rows, skip the DELETE this time.
 	}
 

--- a/pkg/ccl/changefeedccl/cdctest/validator.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator.go
@@ -368,7 +368,7 @@ func NewFingerprintValidator(
 			}
 			fmt.Fprintf(&addColumnStmt, `ADD COLUMN test%d STRING`, i)
 		}
-		if _, err := sqlDB.Query(addColumnStmt.String()); err != nil {
+		if _, err := sqlDB.Exec(addColumnStmt.String()); err != nil {
 			return nil, err
 		}
 	}
@@ -707,6 +707,9 @@ func fetchPrimaryKeyCols(sqlDB *gosql.DB, tableStr string) ([]string, error) {
 			return nil, err
 		}
 		primaryKeyCols = append(primaryKeyCols, primaryKeyCol)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	if len(primaryKeyCols) == 0 {
 		return nil, errors.Errorf("no primary key information found for %s", tableStr)

--- a/pkg/ccl/cliccl/load_test.go
+++ b/pkg/ccl/cliccl/load_test.go
@@ -98,7 +98,10 @@ func TestLoadShowSummary(t *testing.T) {
 		var sstFile string
 		rows := sqlDB.Query(t, `select path from [show backup files $1]`, backupPath)
 		defer rows.Close()
-		rows.Next()
+		if !rows.Next() {
+			require.NoError(t, rows.Err())
+			t.Fatal("expected at least 1 row")
+		}
 		err = rows.Scan(&sstFile)
 		require.NoError(t, err)
 

--- a/pkg/ccl/importccl/exportcsv_test.go
+++ b/pkg/ccl/importccl/exportcsv_test.go
@@ -192,8 +192,11 @@ func TestMultiNodeExportStmt(t *testing.T) {
 			totalBytes += bytes
 			nodesSeen[strings.SplitN(filename, ".", 2)[0]] = true
 		}
+		if err := rows.Err(); err != nil {
+			t.Fatalf("unexpected error during export: %s", err.Error())
+		}
 		if totalRows != exportRows {
-			t.Fatalf("Expected %d rows, got %d", exportRows, totalRows)
+			t.Fatalf("expected %d rows, got %d", exportRows, totalRows)
 		}
 		if expected := exportRows / chunkSize; files < expected {
 			t.Fatalf("expected at least %d files, got %d", expected, files)

--- a/pkg/ccl/multiregionccl/regional_by_row_test.go
+++ b/pkg/ccl/multiregionccl/regional_by_row_test.go
@@ -654,6 +654,10 @@ CREATE TABLE regional_by_row (
 					require.NoError(t, err)
 					rows = append(rows, r)
 				}
+				if err := res.Err(); err != nil {
+					return errors.Wrap(err, "unexepected error querying schema change GC jobs")
+				}
+
 				actualCount := len(rows)
 				if actualCount != expectedCount {
 					return errors.Newf("expected %d jobs with status %q, found %d. Jobs found: %v",

--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -1116,6 +1116,9 @@ func verifyScansOnNode(
 			}
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return errors.Wrap(err, "unexpected error querying traces")
+	}
 	if len(scansWrongNode) > 0 {
 		err := errors.Newf("expected to scan on %s: %s", node, query)
 		err = errors.WithDetailf(err, "scans:\n%s", strings.Join(scansWrongNode, "\n"))

--- a/pkg/ccl/streamingccl/streamclient/cockroach_sinkless_replication_client.go
+++ b/pkg/ccl/streamingccl/streamclient/cockroach_sinkless_replication_client.go
@@ -73,7 +73,7 @@ func (m *sinklessReplicationClient) ConsumePartition(
 		return nil, nil, err
 	}
 
-	_, err = conn.QueryContext(ctx, `SET enable_experimental_stream_replication = true`)
+	_, err = conn.ExecContext(ctx, `SET enable_experimental_stream_replication = true`)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -122,6 +122,10 @@ func (m *sinklessReplicationClient) ConsumePartition(
 				errCh <- ctx.Err()
 				return
 			}
+		}
+		if err := rows.Err(); err != nil {
+			errCh <- err
+			return
 		}
 	}()
 

--- a/pkg/ccl/testccl/sqlccl/run_control_test.go
+++ b/pkg/ccl/testccl/sqlccl/run_control_test.go
@@ -183,7 +183,11 @@ func testCancelSession(t *testing.T, hasActiveSession bool) {
 
 			var id string
 			if !rows.Next() {
-				t.Fatal("no sessions on node 1")
+				if err := rows.Err(); err != nil {
+					t.Fatalf("unexpected error querying sessions: %s", err.Error())
+				} else {
+					t.Fatal("no sessions on node 1")
+				}
 			}
 			if err := rows.Scan(&id); err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
This change fixes instances where we failed to rows.Err() after
rows.Next() returned false.

All of the changes are in test code, so it is likely that there wasn't
much user-impact here.

These were found with the rowserrcheck linter.

Informs #61059

Release note: None