### PR TITLE
sqlsmith: fix tests under bazel

### DIFF
--- a/pkg/internal/sqlsmith/BUILD.bazel
+++ b/pkg/internal/sqlsmith/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
         "main_test.go",
         "sqlsmith_test.go",
     ],
+    data = ["@cockroach//c-deps:libgeos"],
     embed = [":sqlsmith"],
     deps = [
         "//pkg/base",


### PR DESCRIPTION
It was missing the GEOS data dependency.

Release note: None