### PR TITLE
release-21.1: sql: add crdb_internal.get_vmodule

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2678,6 +2678,8 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.get_database_id"></a><code>crdb_internal.get_database_id(name: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td></td></tr>
 <tr><td><a name="crdb_internal.get_namespace_id"></a><code>crdb_internal.get_namespace_id(parent_id: <a href="int.html">int</a>, name: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td></td></tr>
+<tr><td><a name="crdb_internal.get_vmodule"></a><code>crdb_internal.get_vmodule() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the vmodule configuration on the gateway node processing this request.</p>
+</span></td></tr>
 <tr><td><a name="crdb_internal.get_zone_config"></a><code>crdb_internal.get_zone_config(namespace_id: <a href="int.html">int</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td></td></tr>
 <tr><td><a name="crdb_internal.has_role_option"></a><code>crdb_internal.has_role_option(option: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether the current user has the specified role option</p>
 </span></td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -480,6 +480,9 @@ select crdb_internal.force_log_fatal('foo')
 query error insufficient privilege
 select crdb_internal.set_vmodule('')
 
+query error insufficient privilege
+select crdb_internal.get_vmodule()
+
 query error pq: only users with the admin role are allowed to access the node runtime information
 select * from crdb_internal.node_runtime_info
 

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -337,10 +337,20 @@ select crdb_internal.set_vmodule('doesntexist=2,butitsok=4')
 ----
 0
 
+query T
+select crdb_internal.get_vmodule()
+----
+doesntexist=2,butitsok=4
+
 query I
 select crdb_internal.set_vmodule('')
 ----
 0
+
+query T
+select crdb_internal.get_vmodule()
+----
+·
 
 query T
 select regexp_replace(crdb_internal.node_executable_version()::string, '(-\d+)?$', '');

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
@@ -309,10 +309,20 @@ select crdb_internal.set_vmodule('doesntexist=2,butitsok=4')
 ----
 0
 
+query T
+select crdb_internal.get_vmodule()
+----
+doesntexist=2,butitsok=4
+
 query I
 select crdb_internal.set_vmodule('')
 ----
 0
+
+query T
+select crdb_internal.get_vmodule()
+----
+·
 
 query T
 select regexp_replace(crdb_internal.node_executable_version()::string, '(-\d+)?$', '');

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
@@ -384,6 +384,9 @@ select crdb_internal.force_log_fatal('foo')
 query error insufficient privilege
 select crdb_internal.set_vmodule('')
 
+query error insufficient privilege
+select crdb_internal.get_vmodule()
+
 query error pq: only users with the admin role are allowed to access the node runtime information
 select * from crdb_internal.node_runtime_info
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4322,6 +4322,25 @@ may increase either contention or retry errors, or both.`,
 			Volatility: tree.VolatilityVolatile,
 		},
 	),
+
+	"crdb_internal.get_vmodule": makeBuiltin(
+		tree.FunctionProperties{
+			Category: categorySystemInfo,
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(ctx *tree.EvalContext, _ tree.Datums) (tree.Datum, error) {
+				if err := checkPrivilegedUser(ctx); err != nil {
+					return nil, err
+				}
+				return tree.NewDString(log.GetVModule()), nil
+			},
+			Info:       "Returns the vmodule configuration on the gateway node processing this request.",
+			Volatility: tree.VolatilityVolatile,
+		},
+	),
+
 	// Returns the number of distinct inverted index entries that would be
 	// generated for a value.
 	"crdb_internal.num_geo_inverted_index_entries": makeBuiltin(

--- a/pkg/util/log/vmodule.go
+++ b/pkg/util/log/vmodule.go
@@ -65,6 +65,11 @@ func SetVModule(value string) error {
 	return logging.vmoduleConfig.mu.vmodule.Set(value)
 }
 
+// GetVModule returns the current vmodule configuration.
+func GetVModule() string {
+	return logging.vmoduleConfig.mu.vmodule.String()
+}
+
 // VDepth reports whether verbosity at the call site is at least the requested
 // level.
 func VDepth(l Level, depth int) bool {


### PR DESCRIPTION
Backport 2/2 commits from #61053.

/cc @cockroachdb/release

---

This new function lets the user see the current vmodule configuration
for the gateway node processing the request. This is useful for
checking whether the configuration previously set by
`crdb_internal.set_vmodule` is still in place.

Release note (sql change): The new function
`crdb_internal.get_vmodule` returns the current vmodule configuration
on the node processing the request.
