### PR TITLE
release-21.1: catalog/descs: fix panic when type resolution finds a non-type descriptor

### DIFF
--- a/pkg/sql/catalog/descs/BUILD.bazel
+++ b/pkg/sql/catalog/descs/BUILD.bazel
@@ -65,6 +65,8 @@ go_test(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/lease",
         "//pkg/sql/catalog/tabledesc",
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sqlutil",
         "//pkg/sql/types",

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -1998,8 +1998,13 @@ func (dt DistSQLTypeResolver) GetTypeDescriptor(
 	if err != nil {
 		return tree.TypeName{}, nil, err
 	}
+	typeDesc, isType := desc.(*typedesc.Immutable)
+	if !isType {
+		return tree.TypeName{}, nil, pgerror.Newf(pgcode.WrongObjectType,
+			"descriptor %d is a %s not a %s", id, desc.DescriptorType(), catalog.Type)
+	}
 	name := tree.MakeUnqualifiedTypeName(tree.Name(desc.GetName()))
-	return name, desc.(*typedesc.Immutable), nil
+	return name, typeDesc, nil
 }
 
 // HydrateTypeSlice installs metadata into a slice of types.T's.


### PR DESCRIPTION
Backport 1/1 commits from #63523.

/cc @cockroachdb/release

---

Prior to this change, the type resolution logic for resolving types by ID
would panic if the descriptor was not a type.

Touches #63378

Release note (bug fix): Fixed a panic which can occur in cases after a
RESTORE of a table using user defined types.
