### PR TITLE
release-20.2: catalog/descs: fix panic when type resolution finds a non-type descriptor

### DIFF
--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -1817,8 +1817,13 @@ func (dt *DistSQLTypeResolver) GetTypeDescriptor(
 	if err != nil {
 		return tree.TypeName{}, nil, err
 	}
+	typeDesc, isType := desc.(*typedesc.Immutable)
+	if !isType {
+		return tree.TypeName{}, nil, pgerror.Newf(pgcode.WrongObjectType,
+			"descriptor %d is a %s not a %s", id, desc.TypeName(), "type")
+	}
 	name := tree.MakeUnqualifiedTypeName(tree.Name(desc.GetName()))
-	return name, desc.(*typedesc.Immutable), nil
+	return name, typeDesc, nil
 }
 
 // HydrateTypeSlice installs metadata into a slice of types.T's.

--- a/pkg/sql/catalog/descs/collection_test.go
+++ b/pkg/sql/catalog/descs/collection_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -157,4 +159,36 @@ func TestTxnClearsCollectionOnRetry(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
+}
+
+// Regression test to ensure that resolving a type descriptor which is not a
+// type using the DistSQLTypeResolver is properly handled.
+func TestDistSQLTypeResolver_GetTypeDescriptor_WrongType(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	s := tc.Server(0)
+
+	tdb := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	tdb.Exec(t, `CREATE TABLE t()`)
+	var id descpb.ID
+	tdb.QueryRow(t, "SELECT ($1)::regclass::int", "t").Scan(&id)
+
+	err := descs.Txn(
+		ctx,
+		s.ClusterSettings(),
+		s.LeaseManager().(*lease.Manager),
+		s.InternalExecutor().(sqlutil.InternalExecutor),
+		s.DB(),
+		func(ctx context.Context, txn *kv.Txn, descriptors *descs.Collection) error {
+			tr := descs.NewDistSQLTypeResolver(descriptors, txn)
+			_, _, err := tr.GetTypeDescriptor(ctx, id)
+			return err
+		})
+	require.Regexp(t, `descriptor \d+ is a relation not a type`, err)
+	require.Equal(t, pgcode.WrongObjectType, pgerror.GetPGCode(err))
 }


### PR DESCRIPTION
Backport 1/1 commits from #63523.

/cc @cockroachdb/release

---

Prior to this change, the type resolution logic for resolving types by ID
would panic if the descriptor was not a type.

Closes #63378

Release note (bug fix): Fixed a panic which can occur in cases after a
RESTORE of a table using user defined types.
