### PR TITLE
scripts: add roachtest-gobench.sh to convert roachtests to Go benchmarks

### DIFF
--- a/scripts/roachtest-gobench.sh
+++ b/scripts/roachtest-gobench.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Converts roachtest benchmark results (for kv or ycsb workloads) into Go
+# benchmark format, suitable for use with e.g. benchstat.
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: $0 <artifacts-dir>"
+    exit 1
+fi
+
+for file in $(find $1 -name test.log -o -name '*_ycsb.log' -o -name '*_kv.log'); do
+    name=$(dirname $(dirname $(realpath --relative-to=$1 $file)))
+    grep -h -A1 __result $file \
+        | grep -v '^--$' | grep -v __result | \
+        awk "{printf \"Benchmark$name  1  %s ops/sec  %s p50  %s p95  %s p99\n\", \$4, \$6, \$7, \$8}"
+done


### PR DESCRIPTION
This commit adds a script `scripts/roachtest-gobench.sh` which converts
`roachtest` performance results for `kv` and `ycsb` workloads to Go
benchmark format, such that they can be used e.g. with `benchstat`.

Release note: None