### PR TITLE
kvserver: use VoterConstraints when transferring leases

### DIFF
--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -440,6 +440,7 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 			}
 
 			filteredStoreList := storeList.filter(zone.Constraints)
+			filteredStoreList = storeList.filter(zone.VoterConstraints)
 			if sr.rq.allocator.followTheWorkloadPrefersLocal(
 				ctx,
 				filteredStoreList,


### PR DESCRIPTION
TransferLeaseTarget and ShouldTransferLease use Constraints
to filter down the list of available stores to calculate the
mean leases across all the potential stores that could hold
a replica. With addition of non-voter replicas, we should be
pairing that list down to only the replicas that could hold voters.
This commit adds filtering by VoterConstraints to the lease
transfer logic.

Release note: None