### PR TITLE
sql, doctor: miscellaneous bug fixes

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1298,7 +1298,12 @@ func init() {
 	debugPebbleCmd.AddCommand(pebbleTool.Commands...)
 	DebugCmd.AddCommand(debugPebbleCmd)
 
-	debugDoctorCmd.AddCommand(debugDoctorCmds...)
+	for _, c := range debugDoctorCmds {
+		f := c.Flags()
+		f.BoolVarP(&doctorOptions.Verbose, "verbose", "v", doctorOptions.Verbose,
+			"verbose output")
+		debugDoctorCmd.AddCommand(c)
+	}
 	DebugCmd.AddCommand(debugDoctorCmd)
 
 	f := debugSyncBenchCmd.Flags()

--- a/pkg/cli/doctor.go
+++ b/pkg/cli/doctor.go
@@ -49,6 +49,10 @@ a live cluster or a unzipped debug zip.
 `,
 }
 
+var doctorOptions = struct {
+	Verbose bool
+}{}
+
 var debugDoctorCmds = []*cobra.Command{
 	doctorZipDirCmd,
 	doctorClusterCmd,
@@ -88,9 +92,8 @@ func wrapExamine(
 	jobsTable doctor.JobsTable,
 	out io.Writer,
 ) error {
-	// TODO(spaskob): add --verbose flag.
 	valid, err := doctor.Examine(
-		context.Background(), descTable, namespaceTable, jobsTable, false, out)
+		context.Background(), descTable, namespaceTable, jobsTable, doctorOptions.Verbose, out)
 	if err != nil {
 		return &cliError{
 			// Note: we are using "unspecified" here because the error

--- a/pkg/sql/catalog/descpb/descriptor.go
+++ b/pkg/sql/catalog/descpb/descriptor.go
@@ -23,89 +23,90 @@ import (
 // descriptor is unnecessary.
 func GetDescriptorMetadata(
 	desc *Descriptor,
-) (id ID, version DescriptorVersion, name string, state DescriptorState) {
-	return GetDescriptorID(desc), GetDescriptorVersion(desc), GetDescriptorName(desc),
-		GetDescriptorState(desc)
+) (
+	id ID,
+	version DescriptorVersion,
+	name string,
+	state DescriptorState,
+	modTime hlc.Timestamp,
+	err error,
+) {
+	switch t := desc.Union.(type) {
+	case *Descriptor_Table:
+		id = t.Table.ID
+		version = t.Table.Version
+		name = t.Table.Name
+		state = t.Table.State
+		modTime = t.Table.ModificationTime
+	case *Descriptor_Database:
+		id = t.Database.ID
+		version = t.Database.Version
+		name = t.Database.Name
+		state = t.Database.State
+		modTime = t.Database.ModificationTime
+	case *Descriptor_Type:
+		id = t.Type.ID
+		version = t.Type.Version
+		name = t.Type.Name
+		state = t.Type.State
+		modTime = t.Type.ModificationTime
+	case *Descriptor_Schema:
+		id = t.Schema.ID
+		version = t.Schema.Version
+		name = t.Schema.Name
+		state = t.Schema.State
+		modTime = t.Schema.ModificationTime
+	case nil:
+		err = errors.AssertionFailedf("Table/Database/Type/Schema not set in descpb.Descriptor")
+	default:
+		err = errors.AssertionFailedf("Unknown descpb.Descriptor type %T", t)
+	}
+	return id, version, name, state, modTime, err
 }
 
 // GetDescriptorID returns the ID of the descriptor.
 func GetDescriptorID(desc *Descriptor) ID {
-	switch t := desc.Union.(type) {
-	case *Descriptor_Table:
-		return t.Table.ID
-	case *Descriptor_Database:
-		return t.Database.ID
-	case *Descriptor_Type:
-		return t.Type.ID
-	case *Descriptor_Schema:
-		return t.Schema.ID
-	default:
-		panic(errors.AssertionFailedf("GetID: unknown Descriptor type %T", t))
+	id, _, _, _, _, err := GetDescriptorMetadata(desc)
+	if err != nil {
+		panic(errors.Wrap(err, "GetDescriptorID"))
 	}
+	return id
 }
 
 // GetDescriptorName returns the Name of the descriptor.
 func GetDescriptorName(desc *Descriptor) string {
-	switch t := desc.Union.(type) {
-	case *Descriptor_Table:
-		return t.Table.Name
-	case *Descriptor_Database:
-		return t.Database.Name
-	case *Descriptor_Type:
-		return t.Type.Name
-	case *Descriptor_Schema:
-		return t.Schema.Name
-	default:
-		panic(errors.AssertionFailedf("GetDescriptorName: unknown Descriptor type %T", t))
+	_, _, name, _, _, err := GetDescriptorMetadata(desc)
+	if err != nil {
+		panic(errors.Wrap(err, "GetDescriptorName"))
 	}
+	return name
 }
 
 // GetDescriptorVersion returns the Version of the descriptor.
 func GetDescriptorVersion(desc *Descriptor) DescriptorVersion {
-	switch t := desc.Union.(type) {
-	case *Descriptor_Table:
-		return t.Table.Version
-	case *Descriptor_Database:
-		return t.Database.Version
-	case *Descriptor_Type:
-		return t.Type.Version
-	case *Descriptor_Schema:
-		return t.Schema.Version
-	default:
-		panic(errors.AssertionFailedf("GetVersion: unknown Descriptor type %T", t))
+	_, version, _, _, _, err := GetDescriptorMetadata(desc)
+	if err != nil {
+		panic(errors.Wrap(err, "GetDescriptorVersion"))
 	}
+	return version
 }
 
 // GetDescriptorModificationTime returns the ModificationTime of the descriptor.
 func GetDescriptorModificationTime(desc *Descriptor) hlc.Timestamp {
-	switch t := desc.Union.(type) {
-	case *Descriptor_Table:
-		return t.Table.ModificationTime
-	case *Descriptor_Database:
-		return t.Database.ModificationTime
-	case *Descriptor_Type:
-		return t.Type.ModificationTime
-	case *Descriptor_Schema:
-		return t.Schema.ModificationTime
-	default:
-		panic(errors.AssertionFailedf("GetDescriptorModificationTime: unknown Descriptor type %T", t))
+	_, _, _, _, modTime, err := GetDescriptorMetadata(desc)
+	if err != nil {
+		panic(errors.Wrap(err, "GetDescriptorModificationTime"))
 	}
+	return modTime
 }
 
 // GetDescriptorState returns the DescriptorState of the Descriptor.
 func GetDescriptorState(desc *Descriptor) DescriptorState {
-	switch t := desc.Union.(type) {
-	case *Descriptor_Table:
-		return t.Table.State
-	case *Descriptor_Database:
-		return t.Database.State
-	case *Descriptor_Type:
-		return t.Type.State
-	case *Descriptor_Schema:
-		return t.Schema.State
-	default:
-		panic(errors.AssertionFailedf("GetDescriptorState: unknown Descriptor type %T", t))
+	_, _, _, state, _, err := GetDescriptorMetadata(desc)
+	if err != nil {
+		panic(errors.Wrap(err, "GetDescriptorState"))
 	}
+	return state
 }
 
 // setDescriptorModificationTime sets the ModificationTime of the descriptor.

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1719,7 +1719,10 @@ func (m *Manager) RefreshLeases(ctx context.Context, s *stop.Stopper, db *kv.DB)
 					}
 				}
 
-				id, version, name, state := descpb.GetDescriptorMetadata(desc)
+				id, version, name, state, _, err := descpb.GetDescriptorMetadata(desc)
+				if err != nil {
+					panic(err)
+				}
 				dropped := state == descpb.DescriptorState_DROP
 				// Try to refresh the lease to one >= this version.
 				log.VEventf(ctx, 2, "purging old version of descriptor %d@%d (dropped %v)",
@@ -1767,7 +1770,10 @@ func (m *Manager) watchForUpdates(ctx context.Context, descUpdateCh chan<- *desc
 			return
 		}
 		descpb.MaybeSetDescriptorModificationTimeFromMVCCTimestamp(&descriptor, ev.Value.Timestamp)
-		id, version, name, _ := descpb.GetDescriptorMetadata(&descriptor)
+		id, version, name, _, _, err := descpb.GetDescriptorMetadata(&descriptor)
+		if err != nil {
+			panic(err)
+		}
 		if log.V(2) {
 			log.Infof(ctx, "%s: refreshing lease on descriptor: %d (%s), version: %d",
 				ev.Key, id, name, version)

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -2624,7 +2624,10 @@ func TestDropDescriptorRacesWithAcquisition(t *testing.T) {
 	testingKnobs := base.TestingKnobs{
 		SQLLeaseManager: &lease.ManagerTestingKnobs{
 			TestingDescriptorUpdateEvent: func(descriptor *descpb.Descriptor) error {
-				_, version, name, _ := descpb.GetDescriptorMetadata(descriptor)
+				_, version, name, _, _, err := descpb.GetDescriptorMetadata(descriptor)
+				if err != nil {
+					t.Fatal(err)
+				}
 				if name != tableName {
 					return nil
 				}
@@ -2638,7 +2641,10 @@ func TestDropDescriptorRacesWithAcquisition(t *testing.T) {
 				return nil
 			},
 			TestingDescriptorRefreshedEvent: func(descriptor *descpb.Descriptor) {
-				_, version, name, _ := descpb.GetDescriptorMetadata(descriptor)
+				_, version, name, _, _, err := descpb.GetDescriptorMetadata(descriptor)
+				if err != nil {
+					t.Fatal(err)
+				}
 				if name != tableName || version != 2 {
 					return
 				}

--- a/pkg/sql/doctor/doctor.go
+++ b/pkg/sql/doctor/doctor.go
@@ -277,7 +277,7 @@ func descReport(stdout io.Writer, desc catalog.Descriptor, format string, args .
 	// Add descriptor-identifying prefix if it isn't there already.
 	// The prefix has the same format as the validation error wrapper.
 	msgPrefix := fmt.Sprintf("%s %q (%d): ", desc.DescriptorType(), desc.GetName(), desc.GetID())
-	if msg[:len(msgPrefix)] == msgPrefix {
+	if strings.HasPrefix(msg, msgPrefix) {
 		msgPrefix = ""
 	}
 	_, _ = fmt.Fprintf(stdout, "  ParentID %3d, ParentSchemaID %2d: %s%s\n",

--- a/pkg/sql/rename_test.go
+++ b/pkg/sql/rename_test.go
@@ -125,7 +125,10 @@ func TestTxnCanStillResolveOldName(t *testing.T) {
 		func(descriptor *descpb.Descriptor) {
 			mu.Lock()
 			defer mu.Unlock()
-			id, version, name, _ := descpb.GetDescriptorMetadata(descriptor)
+			id, version, name, _, _, err := descpb.GetDescriptorMetadata(descriptor)
+			if err != nil {
+				t.Fatal(err)
+			}
 			if waitTableID != id {
 				return
 			}

--- a/pkg/sql/repair.go
+++ b/pkg/sql/repair.go
@@ -72,12 +72,22 @@ func (p *planner) UnsafeUpsertDescriptor(
 	id := descpb.ID(descID)
 	var desc descpb.Descriptor
 	if err := protoutil.Unmarshal(encodedDesc, &desc); err != nil {
-		return pgerror.Wrapf(err, pgcode.InvalidTableDefinition, "failed to decode descriptor")
+		return pgerror.Wrapf(err, pgcode.InvalidObjectDefinition, "failed to decode descriptor")
+	}
+	newID, newVersion, _, _, newModTime, err := descpb.GetDescriptorMetadata(&desc)
+	if err != nil {
+		return pgerror.Wrapf(err, pgcode.InvalidObjectDefinition, "invalid descriptor")
+	}
+	if newID != id {
+		return pgerror.Newf(pgcode.InvalidObjectDefinition, "invalid descriptor ID %d, expected %d", newID, id)
+	}
+	if newVersion > 1 && newModTime.IsEmpty() {
+		return pgerror.Newf(pgcode.InvalidObjectDefinition, "missing descriptor modification time for version %d",
+			newVersion)
 	}
 
 	// Fetch the existing descriptor.
-
-	existing, err := p.Descriptors().GetMutableDescriptorByID(ctx, id, p.txn)
+	mut, err := p.Descriptors().GetMutableDescriptorByID(ctx, id, p.txn)
 	var forceNoticeString string // for the event
 	if !errors.Is(err, catalog.ErrDescriptorNotFound) && err != nil {
 		if force {
@@ -93,29 +103,31 @@ func (p *planner) UnsafeUpsertDescriptor(
 	// Validate that existing is sane and store its hex serialization into
 	// existingStr to be written to the event log.
 	var existingStr string
+	var existingVersion descpb.DescriptorVersion
 	var previousOwner string
 	var previousUserPrivileges []descpb.UserPrivileges
-	if existing != nil {
-		if existing.IsUncommittedVersion() {
+	if mut != nil {
+		if mut.IsUncommittedVersion() {
 			return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
 				"cannot modify a modified descriptor (%d) with UnsafeUpsertDescriptor", id)
 		}
-		version := descpb.GetDescriptorVersion(&desc)
-		if version != existing.GetVersion() && version != existing.GetVersion()+1 {
-			return pgerror.Newf(pgcode.InvalidTableDefinition, "mismatched descriptor version, expected %v or %v, got %v",
-				version, version+1, existing.GetVersion())
-		}
-		marshaled, err := protoutil.Marshal(existing.DescriptorProto())
+		existingVersion = mut.GetVersion()
+		marshaled, err := protoutil.Marshal(mut.DescriptorProto())
 		if err != nil {
-			return errors.AssertionFailedf("failed to marshal existing descriptor %v: %v", existing, err)
+			return errors.AssertionFailedf("failed to marshal existing descriptor %v: %v", mut, err)
 		}
 		existingStr = hex.EncodeToString(marshaled)
-		previousOwner = existing.GetPrivileges().Owner().Normalized()
-		previousUserPrivileges = existing.GetPrivileges().Users
+		previousOwner = mut.GetPrivileges().Owner().Normalized()
+		previousUserPrivileges = mut.GetPrivileges().Users
+	}
+
+	if newVersion != existingVersion && newVersion != existingVersion+1 {
+		return pgerror.Newf(pgcode.InvalidObjectDefinition, "mismatched descriptor version %d, expected %v or %v",
+			newVersion, existingVersion, existingVersion+1)
 	}
 
 	tbl, db, typ, schema := descpb.FromDescriptor(&desc)
-	switch md := existing.(type) {
+	switch md := mut.(type) {
 	case *tabledesc.Mutable:
 		md.TableDescriptor = *tbl
 	case *schemadesc.Mutable:
@@ -129,13 +141,13 @@ func (p *planner) UnsafeUpsertDescriptor(
 		if b == nil {
 			return pgerror.New(pgcode.InvalidTableDefinition, "invalid ")
 		}
-		existing = b.BuildCreatedMutable()
+		mut = b.BuildCreatedMutable()
 	default:
-		return errors.AssertionFailedf("unknown descriptor type %T for id %d", existing, id)
+		return errors.AssertionFailedf("unknown descriptor type %T for id %d", mut, id)
 	}
 
 	objectType := privilege.Any
-	switch existing.DescriptorType() {
+	switch mut.DescriptorType() {
 	case catalog.Database:
 		objectType = privilege.Database
 	case catalog.Table:
@@ -153,7 +165,7 @@ func (p *planner) UnsafeUpsertDescriptor(
 	{
 		b := p.txn.NewBatch()
 		if err := p.Descriptors().WriteDescToBatch(
-			ctx, p.extendedEvalCtx.Tracing.KVTracingEnabled(), existing, b,
+			ctx, p.extendedEvalCtx.Tracing.KVTracingEnabled(), mut, b,
 		); err != nil {
 			return err
 		}
@@ -163,16 +175,16 @@ func (p *planner) UnsafeUpsertDescriptor(
 	}
 
 	// Log any ownership changes.
-	newOwner := existing.GetPrivileges().Owner().Normalized()
+	newOwner := mut.GetPrivileges().Owner().Normalized()
 	if previousOwner != newOwner {
-		if err := logOwnerEvents(ctx, p, newOwner, existing); err != nil {
+		if err := logOwnerEvents(ctx, p, newOwner, mut); err != nil {
 			return err
 		}
 	}
 
 	// Log any privilege changes.
 	if err := comparePrivileges(
-		ctx, p, existing, previousUserPrivileges, objectType,
+		ctx, p, mut, previousUserPrivileges, objectType,
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
    doctor: add verbose flag
    
    This commit adds a --verbose flag to the debug doctor CLI command
    which increases output verbosity.
    
    Release note (cli change): added --verbose flag to debug doctor command.


    doctor: fix string comparison bug
    
    Previously, doctor could panic when outputting validation failures with
    error messages under a certain length. This commit fixes this by using
    the proper string prefix comparison function, strings.HasPrefix.
    
    Release note: None


    sql: add checks in unsafe_upsert_descriptor
    
    Previously, it was quite easy to cause a node to crash by passing an
    invalid descriptor argument to the crdb_internal.unsafe_upsert_descriptor
    repair function. This commit makes this function more resilient to
    invalid inputs by changing the descpb.GetDescriptorMetadata function to
    return errors instead of panicking.
    
    Release note: None
