### PR TITLE
release-21.1: sql: wrap CastExpr within IndirectionExpr in a ParenExpr

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1324,3 +1324,42 @@ query T
 SELECT _enum FROM t58889 WHERE _enum::greeting58889 IN (NULL, 'hi':::greeting58889);
 ----
 hi
+
+
+subtest enum_array_cast
+
+statement ok
+CREATE TYPE typ AS ENUM('a', 'b', 'c')
+
+statement ok
+CREATE TABLE arr_t (i STRING DEFAULT ('{a}'::_typ)[1]::STRING)
+
+statement ok
+INSERT INTO arr_t VALUES (default)
+
+query T
+SELECT * FROM arr_t
+----
+a
+
+statement ok
+CREATE TABLE arr_t2 (i typ DEFAULT ('{a, b, c}'::typ[])[2])
+
+statement ok
+INSERT INTO arr_t2 VALUES (default)
+
+query T
+SELECT * FROM arr_t2
+----
+b
+
+statement ok
+CREATE TABLE arr_t3 (i STRING DEFAULT ('{c}'::_typ:::_typ)[1]::STRING)
+
+statement ok
+INSERT INTO arr_t3 VALUES (default)
+
+query T
+SELECT * FROM arr_t3
+----
+c

--- a/pkg/sql/parser/testdata/parse/create_table
+++ b/pkg/sql/parser/testdata/parse/create_table
@@ -2134,3 +2134,19 @@ CREATE TABLE a (b INT8) -- normalized!
 CREATE TABLE a (b INT8) -- fully parenthetized
 CREATE TABLE a (b INT8) -- literals removed
 CREATE TABLE _ (_ INT8) -- identifiers removed
+
+parse
+CREATE TABLE arr_t (i STRING DEFAULT (('{' || 'a' || '}')::STRING[])[1]::STRING)
+----
+CREATE TABLE arr_t (i STRING DEFAULT ((('{' || 'a') || '}')::STRING[])[1]::STRING) -- normalized!
+CREATE TABLE arr_t (i STRING DEFAULT ((((((((((('{') || ('a'))) || ('}'))))::STRING[])))[(1)])::STRING)) -- fully parenthetized
+CREATE TABLE arr_t (i STRING DEFAULT (((_ || _) || _)::STRING[])[_]::STRING) -- literals removed
+CREATE TABLE _ (_ STRING DEFAULT ((('{' || 'a') || '}')::STRING[])[1]::STRING) -- identifiers removed
+
+parse
+CREATE TABLE arr_t (i INT8 DEFAULT (('{' || '1' || '}')::INT8[])[1])
+----
+CREATE TABLE arr_t (i INT8 DEFAULT ((('{' || '1') || '}')::INT8[])[1]) -- normalized!
+CREATE TABLE arr_t (i INT8 DEFAULT (((((((((('{') || ('1'))) || ('}'))))::INT8[])))[(1)])) -- fully parenthetized
+CREATE TABLE arr_t (i INT8 DEFAULT (((_ || _) || _)::INT8[])[_]) -- literals removed
+CREATE TABLE _ (_ INT8 DEFAULT ((('{' || '1') || '}')::INT8[])[1]) -- identifiers removed

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -196,6 +196,9 @@ func TestTypeCheck(t *testing.T) {
 		{`1:::d.s.t3 + 1.4`, `1:::DECIMAL + 1.4:::DECIMAL`},
 		{`1 IS OF (d.t1, t2)`, `1:::INT8 IS OF (INT8, STRING)`},
 		{`1::d.t1`, `1:::INT8`},
+
+		{`(('{' || 'a' ||'}')::STRING[])[1]::STRING`, `((('{':::STRING || 'a':::STRING) || '}':::STRING)::STRING[])[1:::INT8]`},
+		{`(('{' || '1' ||'}')::INT[])[1]`, `((('{':::STRING || '1':::STRING) || '}':::STRING)::INT8[])[1:::INT8]`},
 	}
 	ctx := context.Background()
 	for _, d := range testData {


### PR DESCRIPTION
Backport 1/1 commits from #63103.

/cc @cockroachdb/release

---

Fixes https://github.com/cockroachdb/cockroach/issues/63097.

When we type check ParenExpr, we remove the parentheses.
This can cause issues for IndirectionExprs.

For example, something like `('{a}'::_typ)[1]` would
turn into `'{a}'::_typ[1]` after type checking, resulting
in the `[1]` being interpreted as part of the type.
This would result in errors when trying to use these
expressions in default expressions.
This patch checks for this specific case, and if
it finds that there is a CastExpr within an IndirecionExpr,
it will wrap it in a ParenExpr.

Release note: None
