### PR TITLE
release-20.2:  tabledesc: MakeFirstMutationPublic should ignore PK swaps

### DIFF
--- a/pkg/ccl/backupccl/restore_mid_schema_change_test.go
+++ b/pkg/ccl/backupccl/restore_mid_schema_change_test.go
@@ -92,7 +92,7 @@ func TestRestoreMidSchemaChange(t *testing.T) {
 							for _, backupDir := range backupDirs {
 								fullBackupDir, err := filepath.Abs(filepath.Join(fullClusterVersionDir, backupDir.Name()))
 								require.NoError(t, err)
-								t.Run(backupDir.Name(), restoreMidSchemaChange(fullBackupDir, backupDir.Name(), isClusterRestore))
+								t.Run(backupDir.Name(), restoreMidSchemaChange(fullBackupDir, backupDir.Name(), isClusterRestore, blockLocation == "after"))
 							}
 						})
 					}
@@ -103,8 +103,8 @@ func TestRestoreMidSchemaChange(t *testing.T) {
 }
 
 // expectedSCJobCount returns the expected number of schema change jobs
-// we expect to fin.d
-func expectedSCJobCount(scName string, isClusterRestore bool) int {
+// we expect to find.
+func expectedSCJobCount(scName string, isClusterRestore, after bool) int {
 	// The number of schema change under test. These will be the ones that are
 	// synthesized in database restore.
 	var expNumSCJobs int
@@ -124,6 +124,9 @@ func expectedSCJobCount(scName string, isClusterRestore bool) int {
 		numBackgroundSCJobs = 2
 		// PK change + PK cleanup
 		expNumSCJobs = 2
+		if isClusterRestore && after {
+			expNumSCJobs = 1
+		}
 	case "midprimarykeyswapcleanup":
 		// This test performs an ALTER COLUMN, and the original ALTER PRIMARY
 		// KEY that is being cleaned up.
@@ -159,6 +162,7 @@ func validateTable(
 
 	var rowCount int
 	sqlDB.QueryRow(t, fmt.Sprintf(`SELECT count(*) FROM %s.%s`, dbName, tableName)).Scan(&rowCount)
+	require.Greater(t, rowCount, 0, "expected table to have some rows")
 	// The number of entries in all indexes should be the same.
 	for _, index := range append(desc.GetPublicNonPrimaryIndexes(), *desc.GetPrimaryIndex()) {
 		var indexCount int
@@ -181,12 +185,12 @@ func getTablesInTest(scName string) (tableNames []string) {
 }
 
 func verifyMidSchemaChange(
-	t *testing.T, scName string, kvDB *kv.DB, sqlDB *sqlutils.SQLRunner, isClusterRestore bool,
+	t *testing.T, scName string, kvDB *kv.DB, sqlDB *sqlutils.SQLRunner, isClusterRestore, after bool,
 ) {
 	tables := getTablesInTest(scName)
 
 	// Check that we are left with the expected number of schema change jobs.
-	expNumSchemaChangeJobs := expectedSCJobCount(scName, isClusterRestore)
+	expNumSchemaChangeJobs := expectedSCJobCount(scName, isClusterRestore, after)
 	schemaChangeJobs := sqlDB.QueryStr(t, "SELECT description FROM crdb_internal.jobs WHERE job_type = 'SCHEMA CHANGE'")
 	require.Equal(t, expNumSchemaChangeJobs, len(schemaChangeJobs),
 		"Expected %d schema change jobs but found %v", expNumSchemaChangeJobs, schemaChangeJobs)
@@ -217,7 +221,7 @@ func verifyMidSchemaChange(
 }
 
 func restoreMidSchemaChange(
-	backupDir, schemaChangeName string, isClusterRestore bool,
+	backupDir, schemaChangeName string, isClusterRestore bool, after bool,
 ) func(t *testing.T) {
 	return func(t *testing.T) {
 		ctx := context.Background()
@@ -249,6 +253,6 @@ func restoreMidSchemaChange(
 		// Wait for all jobs to terminate. Some may fail since we don't restore
 		// adding spans.
 		sqlDB.CheckQueryResultsRetry(t, "SELECT * FROM crdb_internal.jobs WHERE job_type = 'SCHEMA CHANGE' AND NOT (status = 'succeeded' OR status = 'failed')", [][]string{})
-		verifyMidSchemaChange(t, schemaChangeName, kvDB, sqlDB, isClusterRestore)
+		verifyMidSchemaChange(t, schemaChangeName, kvDB, sqlDB, isClusterRestore, after)
 	}
 }

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -669,7 +669,7 @@ func (sc *SchemaChanger) validateConstraints(
 			// (the validation can take many minutes). So we pretend that the schema
 			// has been updated and actually update it in a separate transaction that
 			// follows this one.
-			desc, err := tableDesc.MakeFirstMutationPublic(tabledesc.IgnoreConstraints)
+			desc, err := tableDesc.MakeFirstMutationPublic(catalog.IgnoreConstraints)
 			if err != nil {
 				return err
 			}
@@ -1432,7 +1432,7 @@ func ValidateForwardIndexes(
 				// has been updated and actually update it in a separate transaction that
 				// follows this one.
 				var err error
-				desc, err = tableDesc.MakeFirstMutationPublic(tabledesc.IgnoreConstraints)
+				desc, err = tableDesc.MakeFirstMutationPublic(catalog.IgnoreConstraints)
 				if err != nil {
 					return err
 				}
@@ -1521,7 +1521,7 @@ func ValidateForwardIndexes(
 			// added earlier in the same mutation. Here we make those mutations
 			// pubic so that the query can reference those columns.
 			var err error
-			desc, err = tableDesc.MakeFirstMutationPublic(tabledesc.IgnoreConstraints)
+			desc, err = tableDesc.MakeFirstMutationPublic(catalog.IgnoreConstraints)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1521,7 +1521,7 @@ func ValidateForwardIndexes(
 			// added earlier in the same mutation. Here we make those mutations
 			// pubic so that the query can reference those columns.
 			var err error
-			desc, err = tableDesc.MakeFirstMutationPublic(catalog.IgnoreConstraints)
+			desc, err = tableDesc.MakeFirstMutationPublic(catalog.IgnoreConstraintsAndPKSwaps)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/backfill/BUILD.bazel
+++ b/pkg/sql/backfill/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "backfill",
+    srcs = ["backfill.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/backfill",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/kv",
+        "//pkg/roachpb",
+        "//pkg/sql/catalog",
+        "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/schemaexpr",
+        "//pkg/sql/catalog/typedesc",
+        "//pkg/sql/execinfra",
+        "//pkg/sql/row",
+        "//pkg/sql/rowenc",
+        "//pkg/sql/sem/transform",
+        "//pkg/sql/sem/tree",
+        "//pkg/sql/sqlerrors",
+        "//pkg/sql/types",
+        "//pkg/util",
+        "//pkg/util/log",
+        "//pkg/util/mon",
+        "//pkg/util/syncutil",
+        "@com_github_cockroachdb_errors//:errors",
+    ],
+)

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
@@ -370,7 +371,7 @@ func ConvertBackfillError(ctx context.Context, tableDesc *tabledesc.Immutable, b
 	// information useful in printing a sensible error. However
 	// ConvertBatchError() will only work correctly if the schema elements
 	// are "live" in the tableDesc.
-	desc, err := tableDesc.MakeFirstMutationPublic(tabledesc.IncludeConstraints)
+	desc, err := tableDesc.MakeFirstMutationPublic(catalog.IncludeConstraints)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -34,6 +34,24 @@ type IndexOpts struct {
 	AddMutations bool
 }
 
+// MutationPublicationFilter is used by MakeFirstMutationPublic to filter the
+// mutation types published.
+type MutationPublicationFilter int
+
+const (
+	// IgnoreConstraints is used in MakeFirstMutationPublic to indicate that the
+	// table descriptor returned should not include newly added constraints, which
+	// is useful when passing the returned table descriptor to be used in
+	// validating constraints to be added.
+	IgnoreConstraints MutationPublicationFilter = 1
+	// IgnoreConstraintsAndPKSwaps is used in MakeFirstMutationPublic to indicate that the
+	// table descriptor returned should include newly added constraints.
+	IgnoreConstraintsAndPKSwaps = 2
+	// IncludeConstraints is used in MakeFirstMutationPublic to indicate that the
+	// table descriptor returned should include newly added constraints.
+	IncludeConstraints = 0
+)
+
 // Descriptor is an interface to be shared by individual descriptor
 // types.
 type Descriptor interface {

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/backfill"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -134,7 +135,7 @@ func (ib *indexBackfiller) wrapDupError(ctx context.Context, orig error) error {
 		return orig
 	}
 
-	desc, err := ib.desc.MakeFirstMutationPublic(tabledesc.IncludeConstraints)
+	desc, err := ib.desc.MakeFirstMutationPublic(catalog.IncludeConstraints)
 	immutable := tabledesc.NewImmutable(*desc.TableDesc())
 	if err != nil {
 		return err


### PR DESCRIPTION
Backport 2/2 commits from #63513.

/cc @cockroachdb/release

---

When MakeFirstMutationPublic is called on a temp table desc used for index validation,
it is very important that it does _not_ make a PK swap to that new index public. Doing
so would mean the validation then validates teh new index against itself as the now
primary index, effectively disabling index validation entirely.

This change piggybacks on the existing flag passed as true in the validation paths
to not publish constraints (PK technically is a constraint after all).

Release note (bug fix): Use existing primary key to validate indexes built for ALTER PRIMARY KEY changes.
