### PR TITLE
server, security: Fix one-way connectivity with connect cmd

### DIFF
--- a/pkg/security/certificate_manager.go
+++ b/pkg/security/certificate_manager.go
@@ -304,6 +304,18 @@ func (cl CertsLocator) ClientCAKeyPath() string {
 	return filepath.Join(cl.certsDir, "ca-client"+keyExtension)
 }
 
+// ClientNodeCertPath returns the expected file path for the certificate used
+// by other nodes to verify outgoing RPCs from this node.
+func (cl CertsLocator) ClientNodeCertPath() string {
+	return filepath.Join(cl.certsDir, "client.node"+certExtension)
+}
+
+// ClientNodeKeyPath returns the expected file path for the key used
+// to sign outgoing RPCs.
+func (cl CertsLocator) ClientNodeKeyPath() string {
+	return filepath.Join(cl.certsDir, "client.node"+keyExtension)
+}
+
 // UICACertPath returns the expected file path for the CA certificate
 // used to verify Admin UI certificates.
 func (cl CertsLocator) UICACertPath() string {


### PR DESCRIPTION
Informs #60632.

Previously, non-trust-leader nodes couldn't connect back
to the trust leader due to the presence of the wrong
`ca-client.crt` on their disk; the main CA cert/key was
being written in four places.

This change fixes that bug,
and also creates a new `client.node.crt` certificate to prevent
other subsequent errors from being thrown.

Fixes #61624.

Release note: None.