### PR TITLE
release-21.1: roachtest: fix ORM tests after upgrading them

### DIFF
--- a/pkg/cmd/roachtest/django.go
+++ b/pkg/cmd/roachtest/django.go
@@ -251,6 +251,7 @@ PASSWORD_HASHERS = [
     'django.contrib.auth.hashers.MD5PasswordHasher',
 ]
 TEST_RUNNER = '.cockroach_settings.NonDescribingDiscoverRunner'
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 class NonDescribingDiscoverRunner(DiscoverRunner):
     def get_test_runner_kwargs(self):

--- a/pkg/cmd/roachtest/go_helpers.go
+++ b/pkg/cmd/roachtest/go_helpers.go
@@ -14,22 +14,28 @@ import "context"
 
 const goPath = `/mnt/data1/go`
 
-// installLatestGolang installs the latest version of Go on all nodes in
+// installGolang installs a specific version of Go on all nodes in
 // "node".
-func installLatestGolang(ctx context.Context, t *test, c *cluster, node nodeListOption) {
+func installGolang(ctx context.Context, t *test, c *cluster, node nodeListOption) {
 	if err := repeatRunE(
-		ctx, c, node, "add recent go version repository", "sudo add-apt-repository -y ppa:longsleep/golang-backports",
+		ctx, c, node, "download go", `curl -fsSL https://dl.google.com/go/go1.15.10.linux-amd64.tar.gz > /tmp/go.tgz`,
 	); err != nil {
 		t.Fatal(err)
 	}
 	if err := repeatRunE(
-		ctx, c, node, "update apt-get", `sudo apt-get -qq update`,
+		ctx, c, node, "verify tarball", `sha256sum -c - <<EOF
+4aa1267517df32f2bf1cc3d55dfc27d0c6b2c2b0989449c96dd19273ccca051d /tmp/go.tgz
+EOF`,
 	); err != nil {
 		t.Fatal(err)
 	}
-
 	if err := repeatRunE(
-		ctx, c, node, "install go", "sudo apt-get install -y golang-go",
+		ctx, c, node, "extract go", `sudo tar -C /usr/local -zxf /tmp/go.tgz && rm /tmp/go.tgz`,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := repeatRunE(
+		ctx, c, node, "force symlink go", "sudo ln -sf /usr/local/go/bin/go /usr/bin",
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cmd/roachtest/gopg.go
+++ b/pkg/cmd/roachtest/gopg.go
@@ -63,7 +63,7 @@ func registerGopg(r *testRegistry) {
 		c.l.Printf("Latest gopg release is %s.", gopgLatestTag)
 		c.l.Printf("Supported gopg release is %s.", gopgSupportedTag)
 
-		installLatestGolang(ctx, t, c, node)
+		installGolang(ctx, t, c, node)
 
 		if err := repeatRunE(
 			ctx,

--- a/pkg/cmd/roachtest/hibernate.go
+++ b/pkg/cmd/roachtest/hibernate.go
@@ -60,6 +60,7 @@ func registerHibernate(r *testRegistry) {
 			t.Fatal(err)
 		}
 
+		// TODO(rafi): use openjdk-11-jdk-headless once we are off of Ubuntu 16.
 		if err := repeatRunE(
 			ctx,
 			c,

--- a/pkg/cmd/roachtest/libpq.go
+++ b/pkg/cmd/roachtest/libpq.go
@@ -45,7 +45,7 @@ func registerLibPQ(r *testRegistry) {
 		c.l.Printf("Latest lib/pq release is %s.", latestTag)
 		c.l.Printf("Supported lib/pq release is %s.", libPQSupportedTag)
 
-		installLatestGolang(ctx, t, c, node)
+		installGolang(ctx, t, c, node)
 
 		const (
 			libPQRepo   = "github.com/lib/pq"

--- a/pkg/cmd/roachtest/pgjdbc.go
+++ b/pkg/cmd/roachtest/pgjdbc.go
@@ -62,12 +62,13 @@ func registerPgjdbc(r *testRegistry) {
 			t.Fatal(err)
 		}
 
+		// TODO(rafi): use openjdk-11-jdk-headless once we are off of Ubuntu 16.
 		if err := repeatRunE(
 			ctx,
 			c,
 			node,
 			"install dependencies",
-			`sudo apt-get -qq install default-jre openjdk-11-jdk-headless maven`,
+			`sudo apt-get -qq install default-jre openjdk-8-jdk-headless gradle`,
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/pgx.go
+++ b/pkg/cmd/roachtest/pgx.go
@@ -45,7 +45,7 @@ func registerPgx(r *testRegistry) {
 		}
 
 		t.Status("setting up go")
-		installLatestGolang(ctx, t, c, node)
+		installGolang(ctx, t, c, node)
 
 		t.Status("getting pgx")
 		if err := repeatGitCloneE(

--- a/pkg/cmd/roachtest/pgx_blocklist.go
+++ b/pkg/cmd/roachtest/pgx_blocklist.go
@@ -20,42 +20,7 @@ var pgxBlocklists = blocklistsForVersion{
 // Please keep these lists alphabetized for easy diffing.
 // After a failed run, an updated version of this blocklist should be available
 // in the test log.
-var pgxBlocklist21_1 = blocklist{
-	"v4.Example_CustomType":                                        "27796",
-	"v4.TestConnBeginBatchDeferredError":                           "31632",
-	"v4.TestConnCopyFromLarge":                                     "52722",
-	"v4.TestConnQueryDeferredError":                                "31632",
-	"v4.TestConnQueryErrorWhileReturningRows":                      "26925",
-	"v4.TestConnQueryReadRowMultipleTimes":                         "26925",
-	"v4.TestConnQueryValues":                                       "26925",
-	"v4.TestConnSendBatch":                                         "44712",
-	"v4.TestConnSimpleProtocol":                                    "21286",
-	"v4.TestConnSimpleProtocolRefusesNonStandardConformingStrings": "36215",
-	"v4.TestConnSimpleProtocolRefusesNonUTF8ClientEncoding":        "37129",
-	"v4.TestDomainType":                                            "27796",
-	"v4.TestFatalRxError":                                          "35897",
-	"v4.TestFatalTxError":                                          "35897",
-	"v4.TestInetCIDRArrayTranscodeIP":                              "18846",
-	"v4.TestInetCIDRArrayTranscodeIPNet":                           "18846",
-	"v4.TestInetCIDRTranscodeIP":                                   "18846",
-	"v4.TestInetCIDRTranscodeIPNet":                                "18846",
-	"v4.TestInetCIDRTranscodeWithJustIP":                           "18846",
-	"v4.TestLargeObjects":                                          "26725",
-	"v4.TestLargeObjectsMultipleTransactions":                      "26725",
-	"v4.TestLargeObjectsPreferSimpleProtocol":                      "26725",
-	"v4.TestListenNotify":                                          "41522",
-	"v4.TestListenNotifySelfNotification":                          "41522",
-	"v4.TestListenNotifyWhileBusyIsSafe":                           "41522",
-	"v4.TestQueryContextErrorWhileReceivingRows":                   "26925",
-	"v4.TestRowDecode":                                             "26925",
-	"v4.TestTransactionSuccessfulCommit":                           "31632",
-	"v4.TestTransactionSuccessfulRollback":                         "31632",
-	"v4.TestTxCommitSerializationFailure":                          "12701",
-	"v4.TestTxCommitWhenTxBroken":                                  "31632",
-	"v4.TestTxNestedTransactionCommit":                             "31632",
-	"v4.TestTxNestedTransactionRollback":                           "31632",
-	"v4.TestUnregisteredTypeUsableAsStringArgumentAndBaseResult":   "27796",
-}
+var pgxBlocklist21_1 = blocklist{}
 
 var pgxBlocklist20_2 = blocklist{
 	"v4.Example_CustomType":                                        "27796",

--- a/pkg/cmd/roachtest/sqlalchemy.go
+++ b/pkg/cmd/roachtest/sqlalchemy.go
@@ -22,7 +22,7 @@ import (
 var sqlAlchemyResultRegex = regexp.MustCompile(`^(?P<test>test.*::.*::[^ \[\]]*(?:\[.*])?) (?P<result>\w+)\s+\[.+]$`)
 var sqlAlchemyReleaseTagRegex = regexp.MustCompile(`^rel_(?P<major>\d+)_(?P<minor>\d+)_(?P<point>\d+)$`)
 
-var supportedSQLAlchemyTag = "rel_1_4_5"
+var supportedSQLAlchemyTag = "rel_1_3_24"
 
 // This test runs the SQLAlchemy dialect test suite against a single Cockroach
 // node.


### PR DESCRIPTION
Backport 1/1 commits from #63584.

/cc @cockroachdb/release

---

- django had a missing option
- go tests need go1.15
- pgjdbc goes back to using java 8 until we update the roachprod OS
- sqlalchemy is tested with 1.3, which is a maintained branch of
  sqlalchemy. 1.4 has too many other changes.

Release note: None
