### PR TITLE
roachprod: shorten the connection timeout for ssh

### DIFF
--- a/pkg/cmd/roachprod/install/session.go
+++ b/pkg/cmd/roachprod/install/session.go
@@ -70,6 +70,9 @@ func newRemoteSession(user, host string, logdir string) (*remoteSession, error) 
 		//
 		// https://github.com/cockroachdb/cockroach/issues/35337
 		"-o", "ServerAliveInterval=60",
+		// Timeout long connections so failure information is not lost by the roachtest
+		// context cancellation killing hanging roachprod processes.
+		"-o", "ConnectTimeout=5",
 	}
 	args = append(args, sshAuthArgs()...)
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Based on #47567 we need to ensure that `roachprod` has timout for ssh connection after 5 seconds.

We are adding a timeout inside `newRemoteSession` function so the `roachtest` context cancellation does hide failure information by kill hanging processes before they fail.

This is the first part of the effort, in further changes we will modify/rename `ssh.go` to avoid confusion and ensure every dependency of this is not impacted.

Release note: None