### PR TITLE
release-21.1: changefeedccl: Use memory monitor for kafka and cloud sinks.

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -49,6 +49,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -319,7 +320,8 @@ func changefeedPlanHook(
 			var nilOracle timestampLowerBoundOracle
 			canarySink, err := getSink(
 				ctx, details.SinkURI, p.ExecCfg().NodeID.SQLInstanceID(), details.Opts, details.Targets,
-				settings, nilOracle, p.ExecCfg().DistSQLSrv.ExternalStorageFromURI, p.User(),
+				settings, nilOracle, p.ExecCfg().DistSQLSrv.ExternalStorageFromURI,
+				p.User(), mon.BoundAccount{},
 			)
 			if err != nil {
 				return MaybeStripRetryableErrorMarker(err)

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -87,6 +88,7 @@ func getSink(
 	timestampOracle timestampLowerBoundOracle,
 	makeExternalStorageFromURI cloud.ExternalStorageFromURIFactory,
 	user security.SQLUsername,
+	acc mon.BoundAccount,
 ) (Sink, error) {
 	u, err := url.Parse(sinkURI)
 	if err != nil {
@@ -207,7 +209,7 @@ func getSink(
 		}
 
 		makeSink = func() (Sink, error) {
-			return makeKafkaSink(cfg, u.Host, targets, opts)
+			return makeKafkaSink(ctx, cfg, u.Host, targets, opts, acc)
 		}
 	case isCloudStorageSink(u):
 		fileSizeParam := q.Get(changefeedbase.SinkParamFileSize)
@@ -226,7 +228,7 @@ func getSink(
 		makeSink = func() (Sink, error) {
 			return makeCloudStorageSink(
 				ctx, u.String(), srcID, fileSize, settings,
-				opts, timestampOracle, makeExternalStorageFromURI, user,
+				opts, timestampOracle, makeExternalStorageFromURI, user, acc,
 			)
 		}
 	case u.Scheme == changefeedbase.SinkSchemeExperimentalSQL:
@@ -341,6 +343,7 @@ type kafkaSinkConfig struct {
 // kafkaSink emits to Kafka asynchronously. It is not concurrency-safe; all
 // calls to Emit and Flush should be from the same goroutine.
 type kafkaSink struct {
+	ctx      context.Context
 	cfg      kafkaSinkConfig
 	client   sarama.Client
 	producer sarama.AsyncProducer
@@ -355,6 +358,7 @@ type kafkaSink struct {
 	// Only synchronized between the client goroutine and the worker goroutine.
 	mu struct {
 		syncutil.Mutex
+		mem      mon.BoundAccount
 		inflight int64
 		flushErr error
 		flushCh  chan struct{}
@@ -459,13 +463,19 @@ func getSaramaConfig(opts map[string]string) (config *saramaConfig, err error) {
 }
 
 func makeKafkaSink(
+	ctx context.Context,
 	cfg kafkaSinkConfig,
 	bootstrapServers string,
 	targets jobspb.ChangefeedTargets,
 	opts map[string]string,
+	acc mon.BoundAccount,
 ) (Sink, error) {
-	sink := &kafkaSink{cfg: cfg}
+	sink := &kafkaSink{
+		ctx: ctx,
+		cfg: cfg,
+	}
 	sink.setTargets(targets)
+	sink.mu.mem = acc
 
 	config := sarama.NewConfig()
 	config.ClientID = `CockroachDB`
@@ -554,9 +564,14 @@ func (s *kafkaSink) start() {
 
 // Close implements the Sink interface.
 func (s *kafkaSink) Close() error {
+	defer func() {
+		s.mu.Lock()
+		s.mu.mem.Close(s.ctx)
+		s.mu.Unlock()
+	}()
+
 	close(s.stopWorkerCh)
 	s.worker.Wait()
-
 	// If we're shutting down, we don't care what happens to the outstanding
 	// messages, so ignore this error.
 	_ = s.producer.Close()
@@ -670,11 +685,35 @@ func (s *kafkaSink) Flush(ctx context.Context) error {
 	}
 }
 
-func (s *kafkaSink) emitMessage(ctx context.Context, msg *sarama.ProducerMessage) error {
+func kafkaMessageBytes(m *sarama.ProducerMessage) (s int64) {
+	if m.Key != nil {
+		s += int64(m.Key.Length())
+	}
+	if m.Value != nil {
+		s += int64(m.Value.Length())
+	}
+	return
+}
+
+func (s *kafkaSink) startInflightMessage(ctx context.Context, msg *sarama.ProducerMessage) error {
 	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.mu.mem.Grow(ctx, kafkaMessageBytes(msg)); err != nil {
+		return err
+	}
+
 	s.mu.inflight++
-	inflight := s.mu.inflight
-	s.mu.Unlock()
+
+	if log.V(2) {
+		log.Infof(ctx, "emitting %d inflight records to kafka", s.mu.inflight)
+	}
+	return nil
+}
+
+func (s *kafkaSink) emitMessage(ctx context.Context, msg *sarama.ProducerMessage) error {
+	if err := s.startInflightMessage(ctx, msg); err != nil {
+		return err
+	}
 
 	select {
 	case <-ctx.Done():
@@ -682,9 +721,6 @@ func (s *kafkaSink) emitMessage(ctx context.Context, msg *sarama.ProducerMessage
 	case s.producer.Input() <- msg:
 	}
 
-	if log.V(2) {
-		log.Infof(ctx, "emitted %d inflight records to kafka", inflight)
-	}
 	return nil
 }
 
@@ -692,20 +728,25 @@ func (s *kafkaSink) workerLoop() {
 	defer s.worker.Done()
 
 	for {
+		var ackMsg *sarama.ProducerMessage
+		var ackError error
+
 		select {
 		case <-s.stopWorkerCh:
 			return
-		case <-s.producer.Successes():
+		case m := <-s.producer.Successes():
+			ackMsg = m
 		case err := <-s.producer.Errors():
-			s.mu.Lock()
-			if s.mu.flushErr == nil {
-				s.mu.flushErr = err
-			}
-			s.mu.Unlock()
+			ackMsg, ackError = err.Msg, err.Err
 		}
 
 		s.mu.Lock()
 		s.mu.inflight--
+		s.mu.mem.Shrink(s.ctx, kafkaMessageBytes(ackMsg))
+		if s.mu.flushErr == nil && ackError != nil {
+			s.mu.flushErr = ackError
+		}
+
 		if s.mu.inflight == 0 && s.mu.flushCh != nil {
 			s.mu.flushCh <- struct{}{}
 			s.mu.flushCh = nil

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -10,8 +10,10 @@ package changefeedccl
 
 import (
 	"context"
+	"math"
 	"net/url"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -20,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -28,6 +31,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -38,21 +44,127 @@ type asyncProducerMock struct {
 	inputCh     chan *sarama.ProducerMessage
 	successesCh chan *sarama.ProducerMessage
 	errorsCh    chan *sarama.ProducerError
+	mu          struct {
+		syncutil.Mutex
+		outstanding []*sarama.ProducerMessage
+	}
 }
 
-func (p asyncProducerMock) Input() chan<- *sarama.ProducerMessage     { return p.inputCh }
-func (p asyncProducerMock) Successes() <-chan *sarama.ProducerMessage { return p.successesCh }
-func (p asyncProducerMock) Errors() <-chan *sarama.ProducerError      { return p.errorsCh }
-func (p asyncProducerMock) AsyncClose()                               { panic(`unimplemented`) }
-func (p asyncProducerMock) Close() error {
+const unbuffered = 0
+
+func newAsyncProducerMock(bufSize int) *asyncProducerMock {
+	return &asyncProducerMock{
+		inputCh:     make(chan *sarama.ProducerMessage, bufSize),
+		successesCh: make(chan *sarama.ProducerMessage, bufSize),
+		errorsCh:    make(chan *sarama.ProducerError, bufSize),
+	}
+}
+
+func (p *asyncProducerMock) Input() chan<- *sarama.ProducerMessage     { return p.inputCh }
+func (p *asyncProducerMock) Successes() <-chan *sarama.ProducerMessage { return p.successesCh }
+func (p *asyncProducerMock) Errors() <-chan *sarama.ProducerError      { return p.errorsCh }
+func (p *asyncProducerMock) AsyncClose()                               { panic(`unimplemented`) }
+func (p *asyncProducerMock) Close() error {
 	close(p.inputCh)
 	close(p.successesCh)
 	close(p.errorsCh)
 	return nil
 }
 
+// consume consumes input messages but does not acknowledge neither successes, nor errors.
+// In essence, this simulates an unreachable kafka sink.
+// Use acknowledge methods to acknowledge successes or errors.
+// Returns a function that must be called to stop this consumer
+// to clean up. The cleanup function must be called before closing asyncProducerMock.
+func (p *asyncProducerMock) consume() (cleanup func()) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	done := make(chan struct{})
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			case m := <-p.inputCh:
+				p.mu.Lock()
+				p.mu.outstanding = append(p.mu.outstanding, m)
+				p.mu.Unlock()
+			}
+		}
+	}()
+	return func() {
+		close(done)
+		wg.Wait()
+	}
+}
+
+// acknowledge sends acknowledgements on the specified channel
+// for each of the outstanding messages.
+func (p *asyncProducerMock) acknowledge(n int, ch chan *sarama.ProducerMessage) {
+	for n > 0 {
+		var outstanding []*sarama.ProducerMessage
+		p.mu.Lock()
+		outstanding = append(outstanding, p.mu.outstanding...)
+		p.mu.outstanding = p.mu.outstanding[:0]
+		p.mu.Unlock()
+
+		for _, m := range outstanding {
+			ch <- m
+		}
+		n -= len(outstanding)
+	}
+}
+
+// outstanding returns the number of un-acknowledged messages.
+func (p *asyncProducerMock) outstanding() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.mu.outstanding)
+}
+
 func topic(name string) tableDescriptorTopic {
 	return tableDescriptorTopic{tabledesc.NewBuilder(&descpb.TableDescriptor{Name: name}).BuildImmutableTable()}
+}
+
+const memoryUnlimited int64 = math.MaxInt64
+
+func getBoundAccountWithBudget(budget int64) (account mon.BoundAccount, cleanup func()) {
+	mm := mon.NewMonitorWithLimit(
+		"test-mm", mon.MemoryResource, budget,
+		nil, nil, mon.DefaultPoolAllocationSize, 100,
+		cluster.MakeTestingClusterSettings())
+	mm.Start(context.Background(), nil, mon.MakeStandaloneBudget(budget))
+	return mm.MakeBoundAccount(), func() { mm.Stop(context.Background()) }
+}
+
+func makeTestKafkaSink(
+	t testing.TB, p sarama.AsyncProducer, budget int64, targetNames ...string,
+) (s *kafkaSink, cleanup func()) {
+	mem, release := getBoundAccountWithBudget(budget)
+
+	targets := makeChangefeedTargets(targetNames...)
+
+	s = &kafkaSink{
+		ctx:      context.Background(),
+		producer: p,
+	}
+	s.setTargets(targets)
+	s.mu.mem = mem
+	s.start()
+
+	return s, func() {
+		require.NoError(t, s.Close())
+		release()
+	}
+}
+
+func makeChangefeedTargets(targetNames ...string) jobspb.ChangefeedTargets {
+	targets := make(jobspb.ChangefeedTargets, len(targetNames))
+	for i, name := range targetNames {
+		targets[descpb.ID(i)] = jobspb.ChangefeedTarget{StatementTimeName: name}
+	}
+	return targets
 }
 
 func TestKafkaSink(t *testing.T) {
@@ -60,23 +172,9 @@ func TestKafkaSink(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	p := asyncProducerMock{
-		inputCh:     make(chan *sarama.ProducerMessage, 1),
-		successesCh: make(chan *sarama.ProducerMessage, 1),
-		errorsCh:    make(chan *sarama.ProducerError, 1),
-	}
-	sink := &kafkaSink{
-		producer: p,
-	}
-	targets := make(jobspb.ChangefeedTargets, 1)
-	targets[0] = jobspb.ChangefeedTarget{StatementTimeName: `t`}
-	sink.setTargets(targets)
-	sink.start()
-	defer func() {
-		if err := sink.Close(); err != nil {
-			t.Fatal(err)
-		}
-	}()
+	p := newAsyncProducerMock(1)
+	sink, cleanup := makeTestKafkaSink(t, p, memoryUnlimited, "t")
+	defer cleanup()
 
 	// No inflight
 	if err := sink.Flush(ctx); err != nil {
@@ -148,19 +246,12 @@ func TestKafkaSinkEscaping(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	p := asyncProducerMock{
-		inputCh:     make(chan *sarama.ProducerMessage, 1),
-		successesCh: make(chan *sarama.ProducerMessage, 1),
-		errorsCh:    make(chan *sarama.ProducerError, 1),
-	}
-	sink := &kafkaSink{
-		producer: p,
-	}
-	targets := make(jobspb.ChangefeedTargets, 1)
-	targets[0] = jobspb.ChangefeedTarget{StatementTimeName: `☃`}
-	sink.setTargets(targets)
-	sink.start()
-	defer func() { require.NoError(t, sink.Close()) }()
+
+	p := newAsyncProducerMock(1)
+	sink, cleanup := makeTestKafkaSink(
+		t, p, memoryUnlimited, `☃`)
+	defer cleanup()
+
 	if err := sink.EmitRow(ctx, topic(`☃`), []byte(`k☃`), []byte(`v☃`), zeroTS); err != nil {
 		t.Fatal(err)
 	}
@@ -184,7 +275,7 @@ func TestSQLSink(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	topic := func(name string) tableDescriptorTopic {
+	overrideTopic := func(name string) tableDescriptorTopic {
 		id, _ := strconv.ParseUint(name, 36, 64)
 		return tableDescriptorTopic{
 			tabledesc.NewBuilder(&descpb.TableDescriptor{Name: name, ID: descpb.ID(id)}).BuildImmutableTable()}
@@ -200,8 +291,8 @@ func TestSQLSink(t *testing.T) {
 	defer cleanup()
 	sinkURL.Path = `d`
 
-	fooTopic := topic(`foo`)
-	barTopic := topic(`bar`)
+	fooTopic := overrideTopic(`foo`)
+	barTopic := overrideTopic(`bar`)
 	targets := jobspb.ChangefeedTargets{
 		fooTopic.GetID(): jobspb.ChangefeedTarget{StatementTimeName: `foo`},
 		barTopic.GetID(): jobspb.ChangefeedTarget{StatementTimeName: `bar`},
@@ -215,7 +306,7 @@ func TestSQLSink(t *testing.T) {
 
 	// Undeclared topic
 	require.EqualError(t,
-		sink.EmitRow(ctx, topic(`nope`), nil, nil, zeroTS), `cannot emit to undeclared topic: `)
+		sink.EmitRow(ctx, overrideTopic(`nope`), nil, nil, zeroTS), `cannot emit to undeclared topic: `)
 
 	// With one row, nothing flushes until Flush is called.
 	require.NoError(t, sink.EmitRow(ctx, fooTopic, []byte(`k1`), []byte(`v0`), zeroTS))
@@ -318,4 +409,84 @@ func TestSaramaConfigOptionParsing(t *testing.T) {
 	cfg, err = getSaramaConfig(opts)
 	require.NoError(t, err)
 	require.Equal(t, expected, cfg)
+}
+
+func TestKafkaSinkTracksMemory(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	memCapacity := mon.DefaultPoolAllocationSize
+
+	// Use fake kafka sink which "consumes" all messages on its input channel,
+	// but does not acknowledge them automatically (i.e. slow sink)
+	p := newAsyncProducerMock(unbuffered)
+	stopConsume := p.consume()
+
+	sink, cleanup := makeTestKafkaSink(t, p, memCapacity, "t")
+	defer func() {
+		stopConsume()
+		cleanup()
+	}()
+
+	// No inflight
+	require.NoError(t, sink.Flush(ctx))
+
+	// Emit few messages
+	rnd, _ := randutil.NewTestPseudoRand()
+	key := randutil.RandBytes(rnd, 1+rnd.Intn(64))
+	val := randutil.RandBytes(rnd, 1+rnd.Intn(512))
+	kvLen := int64(len(key)) + int64(len(val))
+
+	testTopic := topic(`t`)
+	for i := 0; i < 10; i++ {
+		require.NoError(t, sink.EmitRow(ctx, testTopic, key, val, zeroTS))
+	}
+
+	memUsed := func() int64 {
+		sink.mu.Lock()
+		defer sink.mu.Unlock()
+		return sink.mu.mem.Used()
+	}
+	require.Equal(t, 10*kvLen, memUsed())
+
+	// Acknowledge outstanding messages, and flush.
+	p.acknowledge(10, p.successesCh)
+	require.NoError(t, sink.Flush(ctx))
+	require.EqualValues(t, 0, p.outstanding())
+
+	// Try emitting resolved timestamp.  This message type is different from the
+	// regular messages since it doesn't have Key set.
+	// We bypass majority of EmitResolvedTimestamp logic since we don't have
+	// a real kafka client instantiated.  Instead, we call emitMessage directly.
+	reg := makeTestSchemaRegistry()
+	defer reg.Close()
+	opts := map[string]string{
+		changefeedbase.OptEnvelope:                string(changefeedbase.OptEnvelopeWrapped),
+		changefeedbase.OptConfluentSchemaRegistry: reg.server.URL,
+	}
+	encoder, err := newConfluentAvroEncoder(opts, makeChangefeedTargets("t"))
+	require.NoError(t, err)
+	payload, err := encoder.EncodeResolvedTimestamp(ctx, "t", hlc.Timestamp{})
+	require.NoError(t, err)
+	msg := &sarama.ProducerMessage{
+		Topic: "t",
+		Key:   nil,
+		Value: sarama.ByteEncoder(payload),
+	}
+	require.NoError(t, sink.emitMessage(ctx, msg))
+	p.acknowledge(1, p.successesCh)
+	require.NoError(t, sink.Flush(ctx))
+	require.EqualValues(t, 0, p.outstanding())
+
+	// Try to emit more than we can handle.
+	expectOverflow := memCapacity / kvLen
+	for err == nil {
+		err = sink.EmitRow(ctx, testTopic, key, val, zeroTS)
+	}
+
+	require.Regexp(t, `memory budget exceeded`, err)
+	// We failed to allocate more memory, but we should have used
+	// memory for the expectOverflow key/values.
+	require.EqualValues(t, expectOverflow*kvLen, memUsed())
 }


### PR DESCRIPTION
Backport 1/1 commits from #63406.

/cc @cockroachdb/release

---

Kafka, as well as cloud sinks, use internal buffering when emitting
events.  Use memory monitor to account for memory used in internal buffers.
If the downstream sink is unavailable for extended periods of time,
memory monitor will ensure that the amount of buffered data does not
grow to cause OOM issues.

Informs #63186
Informs #60697

Release Notes: Kafka and cloud storage sinks use memory monitor
to limit the amount of memory that can be used in internal buffers.
