### PR TITLE
optbuilder: add scopeColumnName struct

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -915,7 +915,7 @@ SELECT * FROM [EXPLAIN INSERT INTO child VALUES (1, 1)] OFFSET 2
 │           │ table: child@primary
 │           │ equality: (lookup_join_const_col_@12, column1) = (crdb_region,c_id)
 │           │ equality cols are key
-│           │ pred: column8 != crdb_region
+│           │ pred: crdb_region_default != crdb_region
 │           │
 │           └── • cross join
 │               │ estimated row count: 3
@@ -1067,7 +1067,7 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table (pk, pk2, a, b) VALUES 
 │           │ table: regional_by_row_table@primary
 │           │ equality: (lookup_join_const_col_@23, column1) = (crdb_region,pk)
 │           │ equality cols are key
-│           │ pred: column15 != crdb_region
+│           │ pred: crdb_region_default != crdb_region
 │           │
 │           └── • cross join
 │               │ estimated row count: 3
@@ -1086,7 +1086,7 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table (pk, pk2, a, b) VALUES 
 │           │ table: regional_by_row_table@regional_by_row_table_b_key
 │           │ equality: (lookup_join_const_col_@38, column4) = (crdb_region,b)
 │           │ equality cols are key
-│           │ pred: (column1 != pk) OR (column15 != crdb_region)
+│           │ pred: (column1 != pk) OR (crdb_region_default != crdb_region)
 │           │
 │           └── • cross join
 │               │ estimated row count: 3
@@ -1104,7 +1104,7 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table (pk, pk2, a, b) VALUES 
 │       └── • lookup join (semi)
 │           │ table: regional_by_row_table@uniq_idx (partial index)
 │           │ equality: (lookup_join_const_col_@53, column3) = (crdb_region,a)
-│           │ pred: (column1 != pk) OR (column15 != crdb_region)
+│           │ pred: (column1 != pk) OR (crdb_region_default != crdb_region)
 │           │
 │           └── • cross join
 │               │ estimated row count: 3
@@ -1127,7 +1127,7 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table (pk, pk2, a, b) VALUES 
             │ table: regional_by_row_table@new_idx
             │ equality: (lookup_join_const_col_@68, column3, column4) = (crdb_region,a,b)
             │ equality cols are key
-            │ pred: (column1 != pk) OR (column15 != crdb_region)
+            │ pred: (column1 != pk) OR (crdb_region_default != crdb_region)
             │
             └── • cross join
                 │ estimated row count: 3
@@ -1600,7 +1600,7 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_as (pk, a, b) VALUES (1
             │ table: regional_by_row_table_as@regional_by_row_table_as_b_key
             │ equality: (lookup_join_const_col_@21, column3) = (crdb_region_col,b)
             │ equality cols are key
-            │ pred: (column1 != pk) OR (column10 != crdb_region_col)
+            │ pred: (column1 != pk) OR (crdb_region_col_comp != crdb_region_col)
             │
             └── • cross join
                 │ estimated row count: 3

--- a/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
@@ -19,16 +19,16 @@ vectorized: true
 │ auto commit
 │
 └── • render
-    │ columns: (column6, column1, check1)
+    │ columns: (crdb_internal_a_shard_11_comp, column1, check1)
     │ estimated row count: 2
-    │ render check1: column6 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+    │ render check1: crdb_internal_a_shard_11_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
     │ render column1: column1
-    │ render column6: column6
+    │ render crdb_internal_a_shard_11_comp: crdb_internal_a_shard_11_comp
     │
     └── • render
-        │ columns: (column6, column1)
+        │ columns: (crdb_internal_a_shard_11_comp, column1)
         │ estimated row count: 2
-        │ render column6: mod(fnv32(COALESCE(column1::STRING, '')), 11)
+        │ render crdb_internal_a_shard_11_comp: mod(fnv32(COALESCE(column1::STRING, '')), 11)
         │ render column1: column1
         │
         └── • values
@@ -53,18 +53,18 @@ vectorized: true
 │ auto commit
 │
 └── • render
-    │ columns: (column1, column8, column7, check1)
+    │ columns: (column1, crdb_internal_a_shard_12_comp, rowid_default, check1)
     │ estimated row count: 2
-    │ render check1: column8 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
+    │ render check1: crdb_internal_a_shard_12_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
     │ render column1: column1
-    │ render column7: column7
-    │ render column8: column8
+    │ render rowid_default: rowid_default
+    │ render crdb_internal_a_shard_12_comp: crdb_internal_a_shard_12_comp
     │
     └── • render
-        │ columns: (column8, column7, column1)
+        │ columns: (crdb_internal_a_shard_12_comp, rowid_default, column1)
         │ estimated row count: 2
-        │ render column8: mod(fnv32(COALESCE(column1::STRING, '')), 12)
-        │ render column7: unique_rowid()
+        │ render crdb_internal_a_shard_12_comp: mod(fnv32(COALESCE(column1::STRING, '')), 12)
+        │ render rowid_default: unique_rowid()
         │ render column1: column1
         │
         └── • values

--- a/pkg/sql/opt/exec/execbuilder/testdata/insert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/insert
@@ -315,9 +315,9 @@ vectorized: true
 │ auto commit
 │
 └── • render
-    │ columns: (x, v, column11)
+    │ columns: (x, v, rowid_default)
     │ estimated row count: 10 (missing stats)
-    │ render column11: unique_rowid()
+    │ render rowid_default: unique_rowid()
     │ render x: x
     │ render v: v
     │
@@ -352,9 +352,9 @@ vectorized: true
 │ auto commit
 │
 └── • render
-    │ columns: (x, v, column11)
+    │ columns: (x, v, rowid_default)
     │ estimated row count: 1 (missing stats)
-    │ render column11: unique_rowid()
+    │ render rowid_default: unique_rowid()
     │ render x: x
     │ render v: v
     │
@@ -477,9 +477,9 @@ vectorized: true
     │ into: insert_t(x, v, rowid)
     │
     └── • render
-        │ columns: (length, "?column?", column13)
+        │ columns: (length, "?column?", rowid_default)
         │ estimated row count: 10 (missing stats)
-        │ render column13: unique_rowid()
+        │ render rowid_default: unique_rowid()
         │ render length: length
         │ render ?column?: "?column?"
         │
@@ -610,9 +610,9 @@ vectorized: true
                 │ into: xyz(x, y, z, rowid)
                 │
                 └── • render
-                    │ columns: (a, b, c, column13)
+                    │ columns: (a, b, c, rowid_default)
                     │ estimated row count: 1,000 (missing stats)
-                    │ render column13: unique_rowid()
+                    │ render rowid_default: unique_rowid()
                     │ render a: a
                     │ render b: b
                     │ render c: c

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -535,7 +535,7 @@ vectorized: true
 │       │
 │       └── • hash join (semi)
 │           │ equality: (v, x) = (b, c)
-│           │ pred: column17 != rowid
+│           │ pred: rowid_default != rowid
 │           │
 │           ├── • scan buffer
 │           │     label: buffer 1
@@ -551,7 +551,7 @@ vectorized: true
 │       │
 │       └── • hash join (semi)
 │           │ equality: (k, v, y) = (a, b, d)
-│           │ pred: column17 != rowid
+│           │ pred: rowid_default != rowid
 │           │
 │           ├── • scan buffer
 │           │     label: buffer 1
@@ -567,7 +567,7 @@ vectorized: true
         │
         └── • hash join (semi)
             │ equality: (k) = (a)
-            │ pred: column17 != rowid
+            │ pred: rowid_default != rowid
             │
             ├── • scan buffer
             │     label: buffer 1
@@ -604,7 +604,7 @@ vectorized: true
 │       │
 │       └── • hash join (right semi)
 │           │ equality: (a) = (column1)
-│           │ pred: column10 != rowid
+│           │ pred: rowid_default != rowid
 │           │
 │           ├── • scan
 │           │     missing stats
@@ -620,7 +620,7 @@ vectorized: true
         │
         └── • hash join (right semi)
             │ equality: (b, c) = (column2, column3)
-            │ pred: column10 != rowid
+            │ pred: rowid_default != rowid
             │
             ├── • scan
             │     missing stats
@@ -658,7 +658,7 @@ vectorized: true
 │       │
 │       └── • hash join (right semi)
 │           │ equality: (c) = (column3)
-│           │ pred: column10 != rowid
+│           │ pred: rowid_default != rowid
 │           │
 │           ├── • scan
 │           │     missing stats
@@ -833,23 +833,23 @@ vectorized: true
 │   │ into: uniq_enum(r, s, i, j)
 │   │
 │   └── • buffer
-│       │ columns: (column9, column1, column2, column10, check1)
+│       │ columns: (r_default, column1, column2, j_default, check1)
 │       │ label: buffer 1
 │       │
 │       └── • render
-│           │ columns: (column9, column1, column2, column10, check1)
+│           │ columns: (r_default, column1, column2, j_default, check1)
 │           │ estimated row count: 2
-│           │ render check1: column9 IN ('us-east', 'us-west', 'eu-west')
+│           │ render check1: r_default IN ('us-east', 'us-west', 'eu-west')
 │           │ render column1: column1
 │           │ render column2: column2
-│           │ render column9: column9
-│           │ render column10: column10
+│           │ render r_default: r_default
+│           │ render j_default: j_default
 │           │
 │           └── • render
-│               │ columns: (column9, column10, column1, column2)
+│               │ columns: (r_default, j_default, column1, column2)
 │               │ estimated row count: 2
-│               │ render column9: CASE (random() * 3.0)::INT8 WHEN 0 THEN 'us-east' WHEN 1 THEN 'us-west' ELSE 'eu-west' END
-│               │ render column10: CAST(NULL AS INT8)
+│               │ render r_default: CASE (random() * 3.0)::INT8 WHEN 0 THEN 'us-east' WHEN 1 THEN 'us-west' ELSE 'eu-west' END
+│               │ render j_default: CAST(NULL AS INT8)
 │               │ render column1: column1
 │               │ render column2: column2
 │               │
@@ -871,18 +871,18 @@ vectorized: true
             │ estimated row count: 1 (missing stats)
             │
             └── • project
-                │ columns: (column9, column2)
+                │ columns: (r_default, column2)
                 │ estimated row count: 1 (missing stats)
                 │
                 └── • lookup join (semi)
-                    │ columns: ("lookup_join_const_col_@12", column9, column2)
+                    │ columns: ("lookup_join_const_col_@12", r_default, column2)
                     │ table: uniq_enum@primary
                     │ equality: (lookup_join_const_col_@12, column2) = (r,i)
                     │ equality cols are key
-                    │ pred: column9 != r
+                    │ pred: r_default != r
                     │
                     └── • cross join (inner)
-                        │ columns: ("lookup_join_const_col_@12", column9, column2)
+                        │ columns: ("lookup_join_const_col_@12", r_default, column2)
                         │ estimated row count: 6
                         │
                         ├── • values
@@ -893,11 +893,11 @@ vectorized: true
                         │     row 2, expr 0: 'eu-west'
                         │
                         └── • project
-                            │ columns: (column9, column2)
+                            │ columns: (r_default, column2)
                             │ estimated row count: 2
                             │
                             └── • scan buffer
-                                  columns: (column9, column1, column2, column10, check1)
+                                  columns: (r_default, column1, column2, j_default, check1)
                                   label: buffer 1
 
 # Test that we use the index when available for de-duplicating INSERT ON
@@ -1278,7 +1278,7 @@ vectorized: true
         │
         └── • hash join (semi)
             │ equality: (v) = (b)
-            │ pred: column16 != rowid
+            │ pred: rowid_default != rowid
             │
             ├── • filter
             │   │ filter: x > 0
@@ -1475,7 +1475,7 @@ vectorized: true
         │
         └── • hash join (right semi)
             │ equality: (d) = (column3)
-            │ pred: (column1 != i) OR (column13 != c_i_expr)
+            │ pred: (column1 != i) OR (c_i_expr_comp != c_i_expr)
             │
             ├── • scan
             │     missing stats
@@ -1511,7 +1511,7 @@ vectorized: true
         └── • hash join (right semi)
             │ equality: (id2) = (column2)
             │ right cols are key
-            │ pred: column8 != rowid
+            │ pred: rowid_default != rowid
             │
             ├── • scan
             │     missing stats
@@ -1548,7 +1548,7 @@ vectorized: true
         └── • hash join (right semi)
             │ equality: (id2) = (column2)
             │ right cols are key
-            │ pred: column8 != rowid
+            │ pred: rowid_default != rowid
             │
             ├── • scan
             │     missing stats
@@ -1586,7 +1586,7 @@ vectorized: true
         │
         └── • hash join (semi)
             │ equality: (u) = (id2)
-            │ pred: column16 != rowid
+            │ pred: rowid_default != rowid
             │
             ├── • scan buffer
             │     label: buffer 1
@@ -1624,7 +1624,7 @@ vectorized: true
 │       └── • hash join (right semi)
 │           │ equality: (id1) = (column1)
 │           │ right cols are key
-│           │ pred: column8 != rowid
+│           │ pred: rowid_default != rowid
 │           │
 │           ├── • scan
 │           │     missing stats
@@ -1641,7 +1641,7 @@ vectorized: true
         └── • hash join (right semi)
             │ equality: (id2) = (column2)
             │ right cols are key
-            │ pred: column8 != rowid
+            │ pred: rowid_default != rowid
             │
             ├── • scan
             │     missing stats
@@ -3133,7 +3133,7 @@ vectorized: true
 │       │
 │       └── • hash join (semi)
 │           │ equality: (v, x) = (b, c)
-│           │ pred: column17 != rowid
+│           │ pred: rowid_default != rowid
 │           │
 │           ├── • scan buffer
 │           │     label: buffer 1
@@ -3149,7 +3149,7 @@ vectorized: true
 │       │
 │       └── • hash join (semi)
 │           │ equality: (k, v, y) = (a, b, d)
-│           │ pred: column17 != rowid
+│           │ pred: rowid_default != rowid
 │           │
 │           ├── • scan buffer
 │           │     label: buffer 1
@@ -3165,7 +3165,7 @@ vectorized: true
         │
         └── • hash join (semi)
             │ equality: (k) = (a)
-            │ pred: column17 != rowid
+            │ pred: rowid_default != rowid
             │
             ├── • scan buffer
             │     label: buffer 1
@@ -3196,12 +3196,12 @@ vectorized: true
 │           │
 │           └── • lookup join (left outer)
 │               │ table: uniq_fk_parent@primary
-│               │ equality: (column10) = (rowid)
+│               │ equality: (rowid_default) = (rowid)
 │               │ equality cols are key
 │               │
 │               └── • distinct
 │                   │ estimated row count: 2
-│                   │ distinct on: column10
+│                   │ distinct on: rowid_default
 │                   │ nulls are distinct
 │                   │ error on duplicate
 │                   │
@@ -3295,7 +3295,7 @@ vectorized: true
 │       │
 │       └── • hash join (right semi)
 │           │ equality: (c) = (column3)
-│           │ pred: column10 != rowid
+│           │ pred: rowid_default != rowid
 │           │
 │           ├── • scan
 │           │     missing stats
@@ -3797,7 +3797,7 @@ vectorized: true
 │           │
 │           └── • hash join (right outer)
 │               │ equality: (a) = (column2)
-│               │ pred: column8 > 0
+│               │ pred: b_default > 0
 │               │
 │               ├── • filter
 │               │   │ filter: b > 0
@@ -3885,7 +3885,7 @@ vectorized: true
 │           │
 │           └── • hash join (left outer)
 │               │ equality: (v) = (a)
-│               │ pred: column15 > 0
+│               │ pred: b_default > 0
 │               │
 │               ├── • distinct
 │               │   │ distinct on: arbiter_unique_a_distinct, v
@@ -3995,7 +3995,7 @@ vectorized: true
         │
         └── • hash join (semi)
             │ equality: (v) = (b)
-            │ pred: column16 != rowid
+            │ pred: rowid_default != rowid
             │
             ├── • filter
             │   │ filter: x > 0
@@ -4230,7 +4230,7 @@ vectorized: true
         └── • hash join (right semi)
             │ equality: (id2) = (column2)
             │ right cols are key
-            │ pred: column8 != rowid
+            │ pred: rowid_default != rowid
             │
             ├── • scan
             │     missing stats
@@ -4268,7 +4268,7 @@ vectorized: true
 │       └── • hash join (right semi)
 │           │ equality: (id1) = (column1)
 │           │ right cols are key
-│           │ pred: column8 != rowid
+│           │ pred: rowid_default != rowid
 │           │
 │           ├── • scan
 │           │     missing stats
@@ -4285,7 +4285,7 @@ vectorized: true
         └── • hash join (right semi)
             │ equality: (id2) = (column2)
             │ right cols are key
-            │ pred: column8 != rowid
+            │ pred: rowid_default != rowid
             │
             ├── • scan
             │     missing stats

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -120,23 +120,23 @@ vectorized: true
 │ arbiter indexes: primary
 │
 └── • lookup join (inner)
-    │ columns: (k, column9, k)
+    │ columns: (k, v_default, k)
     │ estimated row count: 2 (missing stats)
     │ table: kv@primary
     │ equality: (k) = (k)
     │ equality cols are key
     │
     └── • distinct
-        │ columns: (column9, k)
+        │ columns: (v_default, k)
         │ estimated row count: 2 (missing stats)
         │ distinct on: k
         │ nulls are distinct
         │ error on duplicate
         │
         └── • render
-            │ columns: (column9, k)
+            │ columns: (v_default, k)
             │ estimated row count: 2 (missing stats)
-            │ render column9: CAST(NULL AS INT8)
+            │ render v_default: CAST(NULL AS INT8)
             │ render k: k
             │
             └── • limit
@@ -184,27 +184,27 @@ vectorized: true
 │ arbiter indexes: primary
 │
 └── • project
-    │ columns: (column1, column8, column9, column10, a, b, c, d, column8, column9, column10, a, check1)
+    │ columns: (column1, b_default, c_default, d_comp, a, b, c, d, b_default, c_default, d_comp, a, check1)
     │
     └── • render
-        │ columns: (check1, column1, column8, column9, column10, a, b, c, d)
+        │ columns: (check1, column1, b_default, c_default, d_comp, a, b, c, d)
         │ estimated row count: 1 (missing stats)
-        │ render check1: column9 > 0
+        │ render check1: c_default > 0
         │ render column1: column1
-        │ render column8: column8
-        │ render column9: column9
-        │ render column10: column10
+        │ render b_default: b_default
+        │ render c_default: c_default
+        │ render d_comp: d_comp
         │ render a: a
         │ render b: b
         │ render c: c
         │ render d: d
         │
         └── • cross join (left outer)
-            │ columns: (column1, column8, column9, column10, a, b, c, d)
+            │ columns: (column1, b_default, c_default, d_comp, a, b, c, d)
             │ estimated row count: 1 (missing stats)
             │
             ├── • values
-            │     columns: (column1, column8, column9, column10)
+            │     columns: (column1, b_default, c_default, d_comp)
             │     size: 4 columns, 1 row
             │     row 0, expr 0: 1
             │     row 0, expr 1: CAST(NULL AS INT8)
@@ -232,23 +232,23 @@ vectorized: true
 │ arbiter indexes: primary
 │
 └── • project
-    │ columns: (column1, column8, column9, column10, a, b, c, d, column8, column9, column10, a, check1)
+    │ columns: (column1, b_default, c_default, d_comp, a, b, c, d, b_default, c_default, d_comp, a, check1)
     │
     └── • render
-        │ columns: (check1, column1, column8, column9, column10, a, b, c, d)
+        │ columns: (check1, column1, b_default, c_default, d_comp, a, b, c, d)
         │ estimated row count: 4 (missing stats)
-        │ render check1: column9 > 0
+        │ render check1: c_default > 0
         │ render column1: column1
-        │ render column8: column8
-        │ render column9: column9
-        │ render column10: column10
+        │ render b_default: b_default
+        │ render c_default: c_default
+        │ render d_comp: d_comp
         │ render a: a
         │ render b: b
         │ render c: c
         │ render d: d
         │
         └── • lookup join (left outer)
-            │ columns: (column10, column8, column9, column1, a, b, c, d)
+            │ columns: (d_comp, b_default, c_default, column1, a, b, c, d)
             │ estimated row count: 4 (missing stats)
             │ table: indexed@primary
             │ equality: (column1) = (a)
@@ -256,11 +256,11 @@ vectorized: true
             │ locking strength: for update
             │
             └── • render
-                │ columns: (column10, column8, column9, column1)
+                │ columns: (d_comp, b_default, c_default, column1)
                 │ estimated row count: 4
-                │ render column10: column1 + 10
-                │ render column8: CAST(NULL AS INT8)
-                │ render column9: 10
+                │ render d_comp: column1 + 10
+                │ render b_default: CAST(NULL AS INT8)
+                │ render c_default: 10
                 │ render column1: column1
                 │
                 └── • values
@@ -288,10 +288,10 @@ vectorized: true
 │ auto commit
 │
 └── • project
-    │ columns: (column1, column8, column9, column10, column8, column9, column10, check1)
+    │ columns: (column1, b_default, c_default, d_comp, b_default, c_default, d_comp, check1)
     │
     └── • values
-          columns: (column1, column8, column9, column10, check1)
+          columns: (column1, b_default, c_default, d_comp, check1)
           size: 5 columns, 1 row
           row 0, expr 0: 1
           row 0, expr 1: CAST(NULL AS INT8)
@@ -394,12 +394,12 @@ vectorized: true
                 │ into: xyz(x, y, z, rowid)
                 │
                 └── • project
-                    │ columns: (a, b, c, column13, a, b, c)
+                    │ columns: (a, b, c, rowid_default, a, b, c)
                     │
                     └── • render
-                        │ columns: (column13, a, b, c)
+                        │ columns: (rowid_default, a, b, c)
                         │ estimated row count: 1,000 (missing stats)
-                        │ render column13: unique_rowid()
+                        │ render rowid_default: unique_rowid()
                         │ render a: a
                         │ render b: b
                         │ render c: c

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
@@ -402,9 +402,9 @@ vectorized: true
 │ auto commit
 │
 └── • render
-    │ columns: (a, b, v, a_new, column12)
+    │ columns: (a, b, v, a_new, v_comp)
     │ estimated row count: 1,000 (missing stats)
-    │ render column12: a_new + b
+    │ render v_comp: a_new + b
     │ render a: a
     │ render b: b
     │ render v: v
@@ -438,9 +438,9 @@ vectorized: true
 │ auto commit
 │
 └── • render
-    │ columns: (a, b, v, b_new, column12)
+    │ columns: (a, b, v, b_new, v_comp)
     │ estimated row count: 333 (missing stats)
-    │ render column12: a + b_new
+    │ render v_comp: a + b_new
     │ render a: a
     │ render b: b
     │ render v: v
@@ -479,9 +479,9 @@ vectorized: true
 │ auto commit
 │
 └── • render
-    │ columns: (a, b, c, v, w, a_new, column16)
+    │ columns: (a, b, c, v, w, a_new, v_comp)
     │ estimated row count: 1,000 (missing stats)
-    │ render column16: a_new + b
+    │ render v_comp: a_new + b
     │ render a: a
     │ render b: b
     │ render c: c
@@ -523,9 +523,9 @@ vectorized: true
     │ auto commit
     │
     └── • render
-        │ columns: (a, b, v, w, b_new, column16)
+        │ columns: (a, b, v, w, b_new, v_comp)
         │ estimated row count: 1,000 (missing stats)
-        │ render column16: a + b_new
+        │ render v_comp: a + b_new
         │ render a: a
         │ render b: b
         │ render v: v
@@ -565,9 +565,9 @@ vectorized: true
     │ auto commit
     │
     └── • render
-        │ columns: (a, b, v, w, b_new, column16)
+        │ columns: (a, b, v, w, b_new, v_comp)
         │ estimated row count: 333 (missing stats)
-        │ render column16: a + b_new
+        │ render v_comp: a + b_new
         │ render a: a
         │ render b: b
         │ render v: v
@@ -609,9 +609,9 @@ vectorized: true
 │ auto commit
 │
 └── • render
-    │ columns: (a, c, w, c_new, column17)
+    │ columns: (a, c, w, c_new, w_comp)
     │ estimated row count: 1 (missing stats)
-    │ render column17: 7
+    │ render w_comp: 7
     │ render c_new: 6
     │ render w: c + 1
     │ render a: a
@@ -638,9 +638,9 @@ vectorized: true
 │ auto commit
 │
 └── • render
-    │ columns: (a, b, c, v, w, a_new, column16)
+    │ columns: (a, b, c, v, w, a_new, v_comp)
     │ estimated row count: 1,000 (missing stats)
-    │ render column16: a_new + b
+    │ render v_comp: a_new + b
     │ render a: a
     │ render b: b
     │ render c: c
@@ -682,9 +682,9 @@ vectorized: true
     │ auto commit
     │
     └── • render
-        │ columns: (a, b, v, w, b_new, column16)
+        │ columns: (a, b, v, w, b_new, v_comp)
         │ estimated row count: 1,000 (missing stats)
-        │ render column16: a + b_new
+        │ render v_comp: a + b_new
         │ render a: a
         │ render b: b
         │ render v: v
@@ -721,12 +721,12 @@ vectorized: true
 │ auto commit
 │
 └── • project
-    │ columns: (column1, column2, column8, column2, column8)
+    │ columns: (column1, column2, v_comp, column2, v_comp)
     │
     └── • render
-        │ columns: (column8, column1, column2)
+        │ columns: (v_comp, column1, column2)
         │ estimated row count: 4
-        │ render column8: column1 + column2
+        │ render v_comp: column1 + column2
         │ render column1: column1
         │ render column2: column2
         │
@@ -760,16 +760,16 @@ vectorized: true
     │ arbiter indexes: primary
     │
     └── • lookup join (anti)
-        │ columns: (column1, column2, column8)
+        │ columns: (column1, column2, v_comp)
         │ estimated row count: 0 (missing stats)
         │ table: t@primary
         │ equality: (column1) = (a)
         │ equality cols are key
         │
         └── • render
-            │ columns: (column8, column1, column2)
+            │ columns: (v_comp, column1, column2)
             │ estimated row count: 2
-            │ render column8: column1 + column2
+            │ render v_comp: column1 + column2
             │ render column1: column1
             │ render column2: column2
             │
@@ -795,41 +795,41 @@ vectorized: true
 │ arbiter indexes: primary
 │
 └── • project
-    │ columns: (column1, column2, column8, a, b, v, upsert_b, upsert_v, a)
+    │ columns: (column1, column2, v_comp, a, b, v, upsert_b, upsert_v, a)
     │
     └── • render
-        │ columns: (upsert_b, upsert_v, column1, column2, column8, a, b, v)
+        │ columns: (upsert_b, upsert_v, column1, column2, v_comp, a, b, v)
         │ estimated row count: 3 (missing stats)
         │ render upsert_b: CASE WHEN a IS NULL THEN column2 ELSE v END
-        │ render upsert_v: CASE WHEN a IS NULL THEN column8 ELSE a + v END
+        │ render upsert_v: CASE WHEN a IS NULL THEN v_comp ELSE a + v END
         │ render column1: column1
         │ render column2: column2
-        │ render column8: column8
+        │ render v_comp: v_comp
         │ render a: a
         │ render b: b
         │ render v: v
         │
         └── • render
-            │ columns: (v, column1, column2, column8, a, b)
+            │ columns: (v, column1, column2, v_comp, a, b)
             │ estimated row count: 3 (missing stats)
             │ render v: CASE a IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE a + b END
             │ render column1: column1
             │ render column2: column2
-            │ render column8: column8
+            │ render v_comp: v_comp
             │ render a: a
             │ render b: b
             │
             └── • lookup join (left outer)
-                │ columns: (column8, column1, column2, a, b)
+                │ columns: (v_comp, column1, column2, a, b)
                 │ estimated row count: 3 (missing stats)
                 │ table: t@primary
                 │ equality: (column1) = (a)
                 │ equality cols are key
                 │
                 └── • render
-                    │ columns: (column8, column1, column2)
+                    │ columns: (v_comp, column1, column2)
                     │ estimated row count: 3
-                    │ render column8: column1 + column2
+                    │ render v_comp: column1 + column2
                     │ render column1: column1
                     │ render column2: column2
                     │
@@ -857,41 +857,41 @@ vectorized: true
 │ arbiter indexes: primary
 │
 └── • project
-    │ columns: (column1, column2, column8, a, b, v, upsert_b, upsert_v, a)
+    │ columns: (column1, column2, v_comp, a, b, v, upsert_b, upsert_v, a)
     │
     └── • render
-        │ columns: (upsert_b, upsert_v, column1, column2, column8, a, b, v)
+        │ columns: (upsert_b, upsert_v, column1, column2, v_comp, a, b, v)
         │ estimated row count: 3 (missing stats)
-        │ render upsert_b: CASE WHEN a IS NULL THEN column2 ELSE column8 END
-        │ render upsert_v: CASE WHEN a IS NULL THEN column8 ELSE a + column8 END
+        │ render upsert_b: CASE WHEN a IS NULL THEN column2 ELSE v_comp END
+        │ render upsert_v: CASE WHEN a IS NULL THEN v_comp ELSE a + v_comp END
         │ render column1: column1
         │ render column2: column2
-        │ render column8: column8
+        │ render v_comp: v_comp
         │ render a: a
         │ render b: b
         │ render v: v
         │
         └── • render
-            │ columns: (v, column1, column2, column8, a, b)
+            │ columns: (v, column1, column2, v_comp, a, b)
             │ estimated row count: 3 (missing stats)
             │ render v: CASE a IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE a + b END
             │ render column1: column1
             │ render column2: column2
-            │ render column8: column8
+            │ render v_comp: v_comp
             │ render a: a
             │ render b: b
             │
             └── • lookup join (left outer)
-                │ columns: (column8, column1, column2, a, b)
+                │ columns: (v_comp, column1, column2, a, b)
                 │ estimated row count: 3 (missing stats)
                 │ table: t@primary
                 │ equality: (column1) = (a)
                 │ equality cols are key
                 │
                 └── • render
-                    │ columns: (column8, column1, column2)
+                    │ columns: (v_comp, column1, column2)
                     │ estimated row count: 3
-                    │ render column8: column1 + column2
+                    │ render v_comp: column1 + column2
                     │ render column1: column1
                     │ render column2: column2
                     │
@@ -919,24 +919,24 @@ vectorized: true
 │ arbiter indexes: primary
 │
 └── • project
-    │ columns: (column1, column2, column3, column11, column12, a, b, c, v, w, column2, column3, column11, column12, a)
+    │ columns: (column1, column2, column3, v_comp, w_comp, a, b, c, v, w, column2, column3, v_comp, w_comp, a)
     │
     └── • render
-        │ columns: (v, w, column1, column2, column3, column11, column12, a, b, c)
+        │ columns: (v, w, column1, column2, column3, v_comp, w_comp, a, b, c)
         │ estimated row count: 4 (missing stats)
         │ render v: CASE a IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE a + b END
         │ render w: CASE a IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE c + 1 END
         │ render column1: column1
         │ render column2: column2
         │ render column3: column3
-        │ render column11: column11
-        │ render column12: column12
+        │ render v_comp: v_comp
+        │ render w_comp: w_comp
         │ render a: a
         │ render b: b
         │ render c: c
         │
         └── • lookup join (left outer)
-            │ columns: (column11, column12, column1, column2, column3, a, b, c)
+            │ columns: (v_comp, w_comp, column1, column2, column3, a, b, c)
             │ estimated row count: 4 (missing stats)
             │ table: t_idx@primary
             │ equality: (column1) = (a)
@@ -944,10 +944,10 @@ vectorized: true
             │ locking strength: for update
             │
             └── • render
-                │ columns: (column11, column12, column1, column2, column3)
+                │ columns: (v_comp, w_comp, column1, column2, column3)
                 │ estimated row count: 4
-                │ render column11: column1 + column2
-                │ render column12: column3 + 1
+                │ render v_comp: column1 + column2
+                │ render w_comp: column3 + 1
                 │ render column1: column1
                 │ render column2: column2
                 │ render column3: column3
@@ -982,17 +982,17 @@ vectorized: true
 │ arbiter indexes: primary
 │
 └── • project
-    │ columns: (column1, column2, column3, column11, column12, a, b, c, v, w, column2, column3, column11, column12, a)
+    │ columns: (column1, column2, column3, v_comp, w_comp, a, b, c, v, w, column2, column3, v_comp, w_comp, a)
     │
     └── • render
-        │ columns: (upsert_a, column1, column2, column3, column11, column12, a, b, c, v, w)
+        │ columns: (upsert_a, column1, column2, column3, v_comp, w_comp, a, b, c, v, w)
         │ estimated row count: 2 (missing stats)
         │ render upsert_a: CASE WHEN a IS NULL THEN column1 ELSE a END
         │ render column1: column1
         │ render column2: column2
         │ render column3: column3
-        │ render column11: column11
-        │ render column12: column12
+        │ render v_comp: v_comp
+        │ render w_comp: w_comp
         │ render a: a
         │ render b: b
         │ render c: c
@@ -1000,31 +1000,31 @@ vectorized: true
         │ render w: w
         │
         └── • render
-            │ columns: (v, w, column1, column2, column3, column11, column12, a, b, c)
+            │ columns: (v, w, column1, column2, column3, v_comp, w_comp, a, b, c)
             │ estimated row count: 2 (missing stats)
             │ render v: CASE a IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE a + b END
             │ render w: CASE a IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE c + 1 END
             │ render column1: column1
             │ render column2: column2
             │ render column3: column3
-            │ render column11: column11
-            │ render column12: column12
+            │ render v_comp: v_comp
+            │ render w_comp: w_comp
             │ render a: a
             │ render b: b
             │ render c: c
             │
             └── • lookup join (left outer)
-                │ columns: (column11, column12, column1, column2, column3, a, b, c)
+                │ columns: (v_comp, w_comp, column1, column2, column3, a, b, c)
                 │ estimated row count: 2 (missing stats)
                 │ table: t_idx@primary
                 │ equality: (column1) = (a)
                 │ equality cols are key
                 │
                 └── • render
-                    │ columns: (column11, column12, column1, column2, column3)
+                    │ columns: (v_comp, w_comp, column1, column2, column3)
                     │ estimated row count: 2
-                    │ render column11: column1 + column2
-                    │ render column12: column3 + 1
+                    │ render v_comp: column1 + column2
+                    │ render w_comp: column3 + 1
                     │ render column1: column1
                     │ render column2: column2
                     │ render column3: column3
@@ -1057,22 +1057,22 @@ vectorized: true
     │ arbiter indexes: primary, t_idx_w_key
     │
     └── • distinct
-        │ columns: (column1, column2, column3, column11, column12)
+        │ columns: (column1, column2, column3, v_comp, w_comp)
         │ estimated row count: 0 (missing stats)
-        │ distinct on: column12
+        │ distinct on: w_comp
         │ nulls are distinct
         │
         └── • lookup join (anti)
-            │ columns: (column11, column12, column1, column2, column3)
+            │ columns: (v_comp, w_comp, column1, column2, column3)
             │ estimated row count: 0 (missing stats)
             │ table: t_idx@primary
             │ equality: (column1) = (a)
             │ equality cols are key
             │
             └── • hash join (right anti)
-                │ columns: (column11, column12, column1, column2, column3)
+                │ columns: (v_comp, w_comp, column1, column2, column3)
                 │ estimated row count: 0 (missing stats)
-                │ equality: (w) = (column12)
+                │ equality: (w) = (w_comp)
                 │
                 ├── • render
                 │   │ columns: (w)
@@ -1086,10 +1086,10 @@ vectorized: true
                 │         spans: FULL SCAN
                 │
                 └── • render
-                    │ columns: (column11, column12, column1, column2, column3)
+                    │ columns: (v_comp, w_comp, column1, column2, column3)
                     │ estimated row count: 3
-                    │ render column11: column1 + column2
-                    │ render column12: column3 + 1
+                    │ render v_comp: column1 + column2
+                    │ render w_comp: column3 + 1
                     │ render column1: column1
                     │ render column2: column2
                     │ render column3: column3
@@ -1121,46 +1121,46 @@ vectorized: true
 │ arbiter indexes: primary
 │
 └── • project
-    │ columns: (column1, column2, column3, column11, column12, a, c, w, upsert_c, upsert_w, a)
+    │ columns: (column1, column2, column3, v_comp, w_comp, a, c, w, upsert_c, upsert_w, a)
     │
     └── • render
-        │ columns: (upsert_c, upsert_w, column1, column2, column3, column11, column12, a, c, w)
+        │ columns: (upsert_c, upsert_w, column1, column2, column3, v_comp, w_comp, a, c, w)
         │ estimated row count: 3 (missing stats)
         │ render upsert_c: CASE WHEN a IS NULL THEN column3 ELSE 0 END
-        │ render upsert_w: CASE WHEN a IS NULL THEN column12 ELSE 1 END
+        │ render upsert_w: CASE WHEN a IS NULL THEN w_comp ELSE 1 END
         │ render column1: column1
         │ render column2: column2
         │ render column3: column3
-        │ render column11: column11
-        │ render column12: column12
+        │ render v_comp: v_comp
+        │ render w_comp: w_comp
         │ render a: a
         │ render c: c
         │ render w: w
         │
         └── • render
-            │ columns: (w, column1, column2, column3, column11, column12, a, c)
+            │ columns: (w, column1, column2, column3, v_comp, w_comp, a, c)
             │ estimated row count: 3 (missing stats)
             │ render w: CASE a IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE c + 1 END
             │ render column1: column1
             │ render column2: column2
             │ render column3: column3
-            │ render column11: column11
-            │ render column12: column12
+            │ render v_comp: v_comp
+            │ render w_comp: w_comp
             │ render a: a
             │ render c: c
             │
             └── • lookup join (left outer)
-                │ columns: (column11, column12, column1, column2, column3, a, c)
+                │ columns: (v_comp, w_comp, column1, column2, column3, a, c)
                 │ estimated row count: 3 (missing stats)
                 │ table: t_idx@primary
                 │ equality: (column1) = (a)
                 │ equality cols are key
                 │
                 └── • render
-                    │ columns: (column11, column12, column1, column2, column3)
+                    │ columns: (v_comp, w_comp, column1, column2, column3)
                     │ estimated row count: 3
-                    │ render column11: column1 + column2
-                    │ render column12: column3 + 1
+                    │ render v_comp: column1 + column2
+                    │ render w_comp: column3 + 1
                     │ render column1: column1
                     │ render column2: column2
                     │ render column3: column3
@@ -1192,21 +1192,21 @@ vectorized: true
 │ arbiter indexes: primary
 │
 └── • project
-    │ columns: (column1, column2, column3, column11, column12, a, b, c, v, w, upsert_c, upsert_w, a)
+    │ columns: (column1, column2, column3, v_comp, w_comp, a, b, c, v, w, upsert_c, upsert_w, a)
     │
     └── • render
-        │ columns: (upsert_a, upsert_b, upsert_c, upsert_v, upsert_w, column1, column2, column3, column11, column12, a, b, c, v, w)
+        │ columns: (upsert_a, upsert_b, upsert_c, upsert_v, upsert_w, column1, column2, column3, v_comp, w_comp, a, b, c, v, w)
         │ estimated row count: 3 (missing stats)
         │ render upsert_a: CASE WHEN a IS NULL THEN column1 ELSE a END
         │ render upsert_b: CASE WHEN a IS NULL THEN column2 ELSE b END
         │ render upsert_c: CASE WHEN a IS NULL THEN column3 ELSE w END
-        │ render upsert_v: CASE WHEN a IS NULL THEN column11 ELSE v END
-        │ render upsert_w: CASE WHEN a IS NULL THEN column12 ELSE w + 1 END
+        │ render upsert_v: CASE WHEN a IS NULL THEN v_comp ELSE v END
+        │ render upsert_w: CASE WHEN a IS NULL THEN w_comp ELSE w + 1 END
         │ render column1: column1
         │ render column2: column2
         │ render column3: column3
-        │ render column11: column11
-        │ render column12: column12
+        │ render v_comp: v_comp
+        │ render w_comp: w_comp
         │ render a: a
         │ render b: b
         │ render c: c
@@ -1214,31 +1214,31 @@ vectorized: true
         │ render w: w
         │
         └── • render
-            │ columns: (v, w, column1, column2, column3, column11, column12, a, b, c)
+            │ columns: (v, w, column1, column2, column3, v_comp, w_comp, a, b, c)
             │ estimated row count: 3 (missing stats)
             │ render v: CASE a IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE a + b END
             │ render w: CASE a IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE c + 1 END
             │ render column1: column1
             │ render column2: column2
             │ render column3: column3
-            │ render column11: column11
-            │ render column12: column12
+            │ render v_comp: v_comp
+            │ render w_comp: w_comp
             │ render a: a
             │ render b: b
             │ render c: c
             │
             └── • lookup join (left outer)
-                │ columns: (column11, column12, column1, column2, column3, a, b, c)
+                │ columns: (v_comp, w_comp, column1, column2, column3, a, b, c)
                 │ estimated row count: 3 (missing stats)
                 │ table: t_idx@primary
                 │ equality: (column1) = (a)
                 │ equality cols are key
                 │
                 └── • render
-                    │ columns: (column11, column12, column1, column2, column3)
+                    │ columns: (v_comp, w_comp, column1, column2, column3)
                     │ estimated row count: 3
-                    │ render column11: column1 + column2
-                    │ render column12: column3 + 1
+                    │ render v_comp: column1 + column2
+                    │ render w_comp: column3 + 1
                     │ render column1: column1
                     │ render column2: column2
                     │ render column3: column3
@@ -1270,19 +1270,19 @@ vectorized: true
 │ arbiter indexes: t_idx_w_key
 │
 └── • project
-    │ columns: (column1, column2, column3, column11, column12, a, b, c, v, w, column1, upsert_c, upsert_v, upsert_w, a)
+    │ columns: (column1, column2, column3, v_comp, w_comp, a, b, c, v, w, column1, upsert_c, upsert_v, upsert_w, a)
     │
     └── • render
-        │ columns: (upsert_c, upsert_v, upsert_w, column1, column2, column3, column11, column12, a, b, c, v, w)
+        │ columns: (upsert_c, upsert_v, upsert_w, column1, column2, column3, v_comp, w_comp, a, b, c, v, w)
         │ estimated row count: 20 (missing stats)
-        │ render upsert_c: CASE WHEN a IS NULL THEN column3 ELSE column11 END
-        │ render upsert_v: CASE WHEN a IS NULL THEN column11 ELSE column1 + b END
-        │ render upsert_w: CASE WHEN a IS NULL THEN column12 ELSE column11 + 1 END
+        │ render upsert_c: CASE WHEN a IS NULL THEN column3 ELSE v_comp END
+        │ render upsert_v: CASE WHEN a IS NULL THEN v_comp ELSE column1 + b END
+        │ render upsert_w: CASE WHEN a IS NULL THEN w_comp ELSE v_comp + 1 END
         │ render column1: column1
         │ render column2: column2
         │ render column3: column3
-        │ render column11: column11
-        │ render column12: column12
+        │ render v_comp: v_comp
+        │ render w_comp: w_comp
         │ render a: a
         │ render b: b
         │ render c: c
@@ -1290,9 +1290,9 @@ vectorized: true
         │ render w: w
         │
         └── • hash join (right outer)
-            │ columns: (v, w, a, b, c, column11, column12, column1, column2, column3)
+            │ columns: (v, w, a, b, c, v_comp, w_comp, column1, column2, column3)
             │ estimated row count: 20 (missing stats)
-            │ equality: (w) = (column12)
+            │ equality: (w) = (w_comp)
             │ right cols are key
             │
             ├── • render
@@ -1311,17 +1311,17 @@ vectorized: true
             │         spans: FULL SCAN
             │
             └── • distinct
-                │ columns: (column11, column12, column1, column2, column3)
+                │ columns: (v_comp, w_comp, column1, column2, column3)
                 │ estimated row count: 2
-                │ distinct on: column12
+                │ distinct on: w_comp
                 │ nulls are distinct
                 │ error on duplicate
                 │
                 └── • render
-                    │ columns: (column11, column12, column1, column2, column3)
+                    │ columns: (v_comp, w_comp, column1, column2, column3)
                     │ estimated row count: 2
-                    │ render column11: column1 + column2
-                    │ render column12: column3 + 1
+                    │ render v_comp: column1 + column2
+                    │ render w_comp: column3 + 1
                     │ render column1: column1
                     │ render column2: column2
                     │ render column3: column3

--- a/pkg/sql/opt/exec/execbuilder/testdata/with
+++ b/pkg/sql/opt/exec/execbuilder/testdata/with
@@ -97,7 +97,7 @@ vectorized: true
                 │ into: x(a, rowid)
                 │
                 └── • values
-                      columns: (column1, column6)
+                      columns: (column1, rowid_default)
                       size: 2 columns, 1 row
                       row 0, expr 0: 1
                       row 0, expr 1: unique_rowid()

--- a/pkg/sql/opt/memo/testdata/logprops/insert
+++ b/pkg/sql/opt/memo/testdata/logprops/insert
@@ -25,21 +25,21 @@ insert abcde
  ├── insert-mapping:
  │    ├── y:9 => a:1
  │    ├── y:9 => b:2
- │    ├── column12:12 => c:3
- │    ├── column15:15 => d:4
- │    ├── column13:13 => rowid:5
- │    └── column14:14 => e:6
+ │    ├── c_default:12 => c:3
+ │    ├── d_comp:15 => d:4
+ │    ├── rowid_default:13 => rowid:5
+ │    └── e_default:14 => e:6
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: column15:15(int!null) y:9(int!null) column12:12(int!null) column13:13(int) column14:14(int)
+      ├── columns: d_comp:15(int!null) y:9(int!null) c_default:12(int!null) rowid_default:13(int) e_default:14(int)
       ├── cardinality: [0 - 10]
       ├── volatile
       ├── fd: ()-->(12,14), (9)-->(15)
       ├── prune: (9,12-15)
       ├── interesting orderings: (+9 opt(12,14))
       ├── project
-      │    ├── columns: column12:12(int!null) column13:13(int) column14:14(int) y:9(int!null)
+      │    ├── columns: c_default:12(int!null) rowid_default:13(int) e_default:14(int) y:9(int!null)
       │    ├── cardinality: [0 - 10]
       │    ├── volatile
       │    ├── fd: ()-->(12,14)
@@ -66,15 +66,15 @@ insert abcde
       │    │    │              └── interesting orderings: (+8)
       │    │    └── const: 10 [type=int]
       │    └── projections
-      │         ├── const: 10 [as=column12:12, type=int]
-      │         ├── function: unique_rowid [as=column13:13, type=int, volatile]
-      │         └── cast: INT8 [as=column14:14, type=int, immutable]
+      │         ├── const: 10 [as=c_default:12, type=int]
+      │         ├── function: unique_rowid [as=rowid_default:13, type=int, volatile]
+      │         └── cast: INT8 [as=e_default:14, type=int, immutable]
       │              └── null [type=unknown]
       └── projections
-           └── plus [as=column15:15, type=int, outer=(9,12), immutable]
+           └── plus [as=d_comp:15, type=int, outer=(9,12), immutable]
                 ├── plus [type=int]
                 │    ├── variable: y:9 [type=int]
-                │    └── variable: column12:12 [type=int]
+                │    └── variable: c_default:12 [type=int]
                 └── const: 1 [type=int]
 
 # Properties with RETURNING clause.
@@ -92,22 +92,22 @@ project
       ├── insert-mapping:
       │    ├── y:9 => a:1
       │    ├── y:9 => b:2
-      │    ├── column12:12 => c:3
-      │    ├── column15:15 => d:4
-      │    ├── column13:13 => rowid:5
-      │    └── column14:14 => e:6
+      │    ├── c_default:12 => c:3
+      │    ├── d_comp:15 => d:4
+      │    ├── rowid_default:13 => rowid:5
+      │    └── e_default:14 => e:6
       ├── cardinality: [0 - 10]
       ├── volatile, mutations
       ├── fd: ()-->(3), (1)==(2), (2)==(1), (1)-->(4)
       └── project
-           ├── columns: column15:15(int!null) y:9(int!null) column12:12(int!null) column13:13(int) column14:14(int)
+           ├── columns: d_comp:15(int!null) y:9(int!null) c_default:12(int!null) rowid_default:13(int) e_default:14(int)
            ├── cardinality: [0 - 10]
            ├── volatile
            ├── fd: ()-->(12,14), (9)-->(15)
            ├── prune: (9,12-15)
            ├── interesting orderings: (+9 opt(12,14))
            ├── project
-           │    ├── columns: column12:12(int!null) column13:13(int) column14:14(int) y:9(int!null)
+           │    ├── columns: c_default:12(int!null) rowid_default:13(int) e_default:14(int) y:9(int!null)
            │    ├── cardinality: [0 - 10]
            │    ├── volatile
            │    ├── fd: ()-->(12,14)
@@ -134,15 +134,15 @@ project
            │    │    │              └── interesting orderings: (+8)
            │    │    └── const: 10 [type=int]
            │    └── projections
-           │         ├── const: 10 [as=column12:12, type=int]
-           │         ├── function: unique_rowid [as=column13:13, type=int, volatile]
-           │         └── cast: INT8 [as=column14:14, type=int, immutable]
+           │         ├── const: 10 [as=c_default:12, type=int]
+           │         ├── function: unique_rowid [as=rowid_default:13, type=int, volatile]
+           │         └── cast: INT8 [as=e_default:14, type=int, immutable]
            │              └── null [type=unknown]
            └── projections
-                └── plus [as=column15:15, type=int, outer=(9,12), immutable]
+                └── plus [as=d_comp:15, type=int, outer=(9,12), immutable]
                      ├── plus [type=int]
                      │    ├── variable: y:9 [type=int]
-                     │    └── variable: column12:12 [type=int]
+                     │    └── variable: c_default:12 [type=int]
                      └── const: 1 [type=int]
 
 # Properties with RETURNING clause.
@@ -159,19 +159,19 @@ project
       ├── insert-mapping:
       │    ├── y:9 => a:1
       │    ├── y:9 => b:2
-      │    ├── column12:12 => c:3
-      │    ├── column15:15 => d:4
-      │    ├── column13:13 => rowid:5
-      │    └── column14:14 => e:6
+      │    ├── c_default:12 => c:3
+      │    ├── d_comp:15 => d:4
+      │    ├── rowid_default:13 => rowid:5
+      │    └── e_default:14 => e:6
       ├── volatile, mutations
       ├── fd: ()-->(3), (1)==(2), (2)==(1), (1)-->(4)
       └── project
-           ├── columns: column15:15(int!null) y:9(int!null) column12:12(int!null) column13:13(int) column14:14(int)
+           ├── columns: d_comp:15(int!null) y:9(int!null) c_default:12(int!null) rowid_default:13(int) e_default:14(int)
            ├── volatile
            ├── fd: ()-->(12,14), (9)-->(15)
            ├── prune: (9,12-15)
            ├── project
-           │    ├── columns: column12:12(int!null) column13:13(int) column14:14(int) y:9(int!null)
+           │    ├── columns: c_default:12(int!null) rowid_default:13(int) e_default:14(int) y:9(int!null)
            │    ├── volatile
            │    ├── fd: ()-->(12,14)
            │    ├── prune: (9,12-14)
@@ -185,15 +185,15 @@ project
            │    │         ├── prune: (8-11)
            │    │         └── interesting orderings: (+8)
            │    └── projections
-           │         ├── const: 10 [as=column12:12, type=int]
-           │         ├── function: unique_rowid [as=column13:13, type=int, volatile]
-           │         └── cast: INT8 [as=column14:14, type=int, immutable]
+           │         ├── const: 10 [as=c_default:12, type=int]
+           │         ├── function: unique_rowid [as=rowid_default:13, type=int, volatile]
+           │         └── cast: INT8 [as=e_default:14, type=int, immutable]
            │              └── null [type=unknown]
            └── projections
-                └── plus [as=column15:15, type=int, outer=(9,12), immutable]
+                └── plus [as=d_comp:15, type=int, outer=(9,12), immutable]
                      ├── plus [type=int]
                      │    ├── variable: y:9 [type=int]
-                     │    └── variable: column12:12 [type=int]
+                     │    └── variable: c_default:12 [type=int]
                      └── const: 1 [type=int]
 
 # Input is cardinality 1 VALUES expression.
@@ -205,23 +205,23 @@ insert abcde
  ├── insert-mapping:
  │    ├── column1:8 => a:1
  │    ├── column2:9 => b:2
- │    ├── column10:10 => c:3
- │    ├── column13:13 => d:4
- │    ├── column11:11 => rowid:5
- │    └── column12:12 => e:6
+ │    ├── c_default:10 => c:3
+ │    ├── d_comp:13 => d:4
+ │    ├── rowid_default:11 => rowid:5
+ │    └── e_default:12 => e:6
  ├── cardinality: [1 - 1]
  ├── volatile, mutations
  ├── key: ()
  ├── fd: ()-->(1-5)
  └── project
-      ├── columns: column13:13(int!null) column1:8(int!null) column2:9(int!null) column10:10(int!null) column11:11(int) column12:12(int)
+      ├── columns: d_comp:13(int!null) column1:8(int!null) column2:9(int!null) c_default:10(int!null) rowid_default:11(int) e_default:12(int)
       ├── cardinality: [1 - 1]
       ├── volatile
       ├── key: ()
       ├── fd: ()-->(8-13)
       ├── prune: (8-13)
       ├── project
-      │    ├── columns: column10:10(int!null) column11:11(int) column12:12(int) column1:8(int!null) column2:9(int!null)
+      │    ├── columns: c_default:10(int!null) rowid_default:11(int) e_default:12(int) column1:8(int!null) column2:9(int!null)
       │    ├── cardinality: [1 - 1]
       │    ├── volatile
       │    ├── key: ()
@@ -237,15 +237,15 @@ insert abcde
       │    │         ├── const: 1 [type=int]
       │    │         └── const: 2 [type=int]
       │    └── projections
-      │         ├── const: 10 [as=column10:10, type=int]
-      │         ├── function: unique_rowid [as=column11:11, type=int, volatile]
-      │         └── cast: INT8 [as=column12:12, type=int, immutable]
+      │         ├── const: 10 [as=c_default:10, type=int]
+      │         ├── function: unique_rowid [as=rowid_default:11, type=int, volatile]
+      │         └── cast: INT8 [as=e_default:12, type=int, immutable]
       │              └── null [type=unknown]
       └── projections
-           └── plus [as=column13:13, type=int, outer=(9,10), immutable]
+           └── plus [as=d_comp:13, type=int, outer=(9,10), immutable]
                 ├── plus [type=int]
                 │    ├── variable: column2:9 [type=int]
-                │    └── variable: column10:10 [type=int]
+                │    └── variable: c_default:10 [type=int]
                 └── const: 1 [type=int]
 
 # Filter FD set.
@@ -262,19 +262,19 @@ project
       ├── insert-mapping:
       │    ├── y:9 => a:1
       │    ├── int8:12 => b:2
-      │    ├── column13:13 => c:3
-      │    ├── column16:16 => d:4
-      │    ├── column14:14 => rowid:5
-      │    └── column15:15 => e:6
+      │    ├── c_default:13 => c:3
+      │    ├── d_comp:16 => d:4
+      │    ├── rowid_default:14 => rowid:5
+      │    └── e_default:15 => e:6
       ├── volatile, mutations
       ├── fd: ()-->(1,3), (2)-->(4)
       └── project
-           ├── columns: column16:16(int) y:9(int!null) int8:12(int) column13:13(int!null) column14:14(int) column15:15(int)
+           ├── columns: d_comp:16(int) y:9(int!null) int8:12(int) c_default:13(int!null) rowid_default:14(int) e_default:15(int)
            ├── volatile
            ├── fd: ()-->(9,13,15), (12)-->(16)
            ├── prune: (9,12-16)
            ├── project
-           │    ├── columns: column13:13(int!null) column14:14(int) column15:15(int) y:9(int!null) int8:12(int)
+           │    ├── columns: c_default:13(int!null) rowid_default:14(int) e_default:15(int) y:9(int!null) int8:12(int)
            │    ├── volatile
            │    ├── fd: ()-->(9,13,15)
            │    ├── prune: (9,12-15)
@@ -305,13 +305,13 @@ project
            │    │                   ├── variable: z:10 [type=float]
            │    │                   └── const: 1.0 [type=float]
            │    └── projections
-           │         ├── const: 10 [as=column13:13, type=int]
-           │         ├── function: unique_rowid [as=column14:14, type=int, volatile]
-           │         └── cast: INT8 [as=column15:15, type=int, immutable]
+           │         ├── const: 10 [as=c_default:13, type=int]
+           │         ├── function: unique_rowid [as=rowid_default:14, type=int, volatile]
+           │         └── cast: INT8 [as=e_default:15, type=int, immutable]
            │              └── null [type=unknown]
            └── projections
-                └── plus [as=column16:16, type=int, outer=(12,13), immutable]
+                └── plus [as=d_comp:16, type=int, outer=(12,13), immutable]
                      ├── plus [type=int]
                      │    ├── variable: int8:12 [type=int]
-                     │    └── variable: column13:13 [type=int]
+                     │    └── variable: c_default:13 [type=int]
                      └── const: 1 [type=int]

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -1578,13 +1578,13 @@ with &1
  │         ├── insert-mapping:
  │         │    ├── column1:9 => uv.u:5
  │         │    ├── column2:10 => uv.v:6
- │         │    └── column11:11 => rowid:7
+ │         │    └── rowid_default:11 => rowid:7
  │         ├── cardinality: [1 - 1]
  │         ├── volatile, mutations
  │         ├── key: ()
  │         ├── fd: ()-->(5-7)
  │         └── values
- │              ├── columns: column1:9(int!null) column2:10(int!null) column11:11(int)
+ │              ├── columns: column1:9(int!null) column2:10(int!null) rowid_default:11(int)
  │              ├── cardinality: [1 - 1]
  │              ├── volatile
  │              ├── key: ()

--- a/pkg/sql/opt/memo/testdata/logprops/update
+++ b/pkg/sql/opt/memo/testdata/logprops/update
@@ -25,19 +25,19 @@ update abcde
  ├── fetch columns: a:8(int) b:9(int) c:10(int) d:11(int) rowid:12(int) e:13(int)
  ├── update-mapping:
  │    ├── b_new:15 => b:2
- │    ├── column17:17 => d:4
- │    └── column16:16 => e:6
+ │    ├── d_comp:17 => d:4
+ │    └── e_default:16 => e:6
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: column17:17(int!null) a:8(int!null) b:9(int) c:10(int!null) d:11(int) rowid:12(int!null) e:13(int) crdb_internal_mvcc_timestamp:14(decimal) b_new:15(int!null) column16:16(int!null)
+      ├── columns: d_comp:17(int!null) a:8(int!null) b:9(int) c:10(int!null) d:11(int) rowid:12(int!null) e:13(int) crdb_internal_mvcc_timestamp:14(decimal) b_new:15(int!null) e_default:16(int!null)
       ├── immutable
       ├── key: (12)
       ├── fd: ()-->(8,15,16), (12)-->(9-11,13,14), (9,10)-->(11), (10)-->(17)
       ├── prune: (8-17)
       ├── interesting orderings: (+12 opt(8,15,16))
       ├── project
-      │    ├── columns: column16:16(int!null) a:8(int!null) b:9(int) c:10(int!null) d:11(int) rowid:12(int!null) e:13(int) crdb_internal_mvcc_timestamp:14(decimal) b_new:15(int!null)
+      │    ├── columns: e_default:16(int!null) a:8(int!null) b:9(int) c:10(int!null) d:11(int) rowid:12(int!null) e:13(int) crdb_internal_mvcc_timestamp:14(decimal) b_new:15(int!null)
       │    ├── key: (12)
       │    ├── fd: ()-->(8,15,16), (12)-->(9-11,13,14), (9,10)-->(11)
       │    ├── prune: (8-16)
@@ -74,9 +74,9 @@ update abcde
       │    │    └── projections
       │    │         └── const: 10 [as=b_new:15, type=int]
       │    └── projections
-      │         └── const: 0 [as=column16:16, type=int]
+      │         └── const: 0 [as=e_default:16, type=int]
       └── projections
-           └── plus [as=column17:17, type=int, outer=(10,15), immutable]
+           └── plus [as=d_comp:17, type=int, outer=(10,15), immutable]
                 ├── plus [type=int]
                 │    ├── variable: b_new:15 [type=int]
                 │    └── variable: c:10 [type=int]
@@ -96,20 +96,20 @@ project
       ├── fetch columns: a:8(int) b:9(int) c:10(int) d:11(int) rowid:12(int) e:13(int)
       ├── update-mapping:
       │    ├── b_new:15 => b:2
-      │    ├── column17:17 => d:4
-      │    └── column16:16 => e:6
+      │    ├── d_comp:17 => d:4
+      │    └── e_default:16 => e:6
       ├── volatile, mutations
       ├── key: (5)
       ├── fd: ()-->(1,2), (5)-->(3,4), (3)-->(4)
       └── project
-           ├── columns: column17:17(int!null) a:8(int!null) b:9(int) c:10(int!null) d:11(int) rowid:12(int!null) e:13(int) crdb_internal_mvcc_timestamp:14(decimal) b_new:15(int!null) column16:16(int!null)
+           ├── columns: d_comp:17(int!null) a:8(int!null) b:9(int) c:10(int!null) d:11(int) rowid:12(int!null) e:13(int) crdb_internal_mvcc_timestamp:14(decimal) b_new:15(int!null) e_default:16(int!null)
            ├── immutable
            ├── key: (12)
            ├── fd: ()-->(8,15,16), (12)-->(9-11,13,14), (9,10)-->(11), (10)-->(17)
            ├── prune: (8-17)
            ├── interesting orderings: (+12 opt(8,15,16))
            ├── project
-           │    ├── columns: column16:16(int!null) a:8(int!null) b:9(int) c:10(int!null) d:11(int) rowid:12(int!null) e:13(int) crdb_internal_mvcc_timestamp:14(decimal) b_new:15(int!null)
+           │    ├── columns: e_default:16(int!null) a:8(int!null) b:9(int) c:10(int!null) d:11(int) rowid:12(int!null) e:13(int) crdb_internal_mvcc_timestamp:14(decimal) b_new:15(int!null)
            │    ├── key: (12)
            │    ├── fd: ()-->(8,15,16), (12)-->(9-11,13,14), (9,10)-->(11)
            │    ├── prune: (8-16)
@@ -146,9 +146,9 @@ project
            │    │    └── projections
            │    │         └── const: 10 [as=b_new:15, type=int]
            │    └── projections
-           │         └── const: 0 [as=column16:16, type=int]
+           │         └── const: 0 [as=e_default:16, type=int]
            └── projections
-                └── plus [as=column17:17, type=int, outer=(10,15), immutable]
+                └── plus [as=d_comp:17, type=int, outer=(10,15), immutable]
                      ├── plus [type=int]
                      │    ├── variable: b_new:15 [type=int]
                      │    └── variable: c:10 [type=int]
@@ -170,21 +170,21 @@ project
       ├── fetch columns: a:8(int) b:9(int) c:10(int) d:11(int) rowid:12(int) e:13(int)
       ├── update-mapping:
       │    ├── b_new:15 => b:2
-      │    ├── column17:17 => d:4
-      │    └── column16:16 => e:6
+      │    ├── d_comp:17 => d:4
+      │    └── e_default:16 => e:6
       ├── cardinality: [0 - 1]
       ├── volatile, mutations
       ├── key: ()
       ├── fd: ()-->(1-5)
       └── project
-           ├── columns: column17:17(int!null) a:8(int!null) b:9(int) c:10(int!null) d:11(int) rowid:12(int!null) e:13(int) crdb_internal_mvcc_timestamp:14(decimal) b_new:15(int!null) column16:16(int!null)
+           ├── columns: d_comp:17(int!null) a:8(int!null) b:9(int) c:10(int!null) d:11(int) rowid:12(int!null) e:13(int) crdb_internal_mvcc_timestamp:14(decimal) b_new:15(int!null) e_default:16(int!null)
            ├── cardinality: [0 - 1]
            ├── immutable
            ├── key: ()
            ├── fd: ()-->(8-17)
            ├── prune: (8-17)
            ├── project
-           │    ├── columns: column16:16(int!null) a:8(int!null) b:9(int) c:10(int!null) d:11(int) rowid:12(int!null) e:13(int) crdb_internal_mvcc_timestamp:14(decimal) b_new:15(int!null)
+           │    ├── columns: e_default:16(int!null) a:8(int!null) b:9(int) c:10(int!null) d:11(int) rowid:12(int!null) e:13(int) crdb_internal_mvcc_timestamp:14(decimal) b_new:15(int!null)
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
            │    ├── fd: ()-->(8-16)
@@ -221,9 +221,9 @@ project
            │    │    └── projections
            │    │         └── const: 10 [as=b_new:15, type=int]
            │    └── projections
-           │         └── const: 0 [as=column16:16, type=int]
+           │         └── const: 0 [as=e_default:16, type=int]
            └── projections
-                └── plus [as=column17:17, type=int, outer=(10,15), immutable]
+                └── plus [as=d_comp:17, type=int, outer=(10,15), immutable]
                      ├── plus [type=int]
                      │    ├── variable: b_new:15 [type=int]
                      │    └── variable: c:10 [type=int]
@@ -243,19 +243,19 @@ project
       ├── fetch columns: a:8(int) b:9(int) c:10(int) d:11(int) rowid:12(int) e:13(int)
       ├── update-mapping:
       │    ├── a_new:15 => a:1
-      │    └── column16:16 => e:6
+      │    └── e_default:16 => e:6
       ├── volatile, mutations
       ├── key: (5)
       ├── fd: ()-->(1), (2)==(3), (3)==(2), (5)-->(2-4), (2)-->(4)
       └── project
-           ├── columns: column17:17(int!null) a:8(int!null) b:9(int!null) c:10(int!null) d:11(int) rowid:12(int!null) e:13(int) crdb_internal_mvcc_timestamp:14(decimal) a_new:15(int!null) column16:16(int!null)
+           ├── columns: d_comp:17(int!null) a:8(int!null) b:9(int!null) c:10(int!null) d:11(int) rowid:12(int!null) e:13(int) crdb_internal_mvcc_timestamp:14(decimal) a_new:15(int!null) e_default:16(int!null)
            ├── immutable
            ├── key: (12)
            ├── fd: ()-->(15,16), (12)-->(8-11,13,14), (9,10)-->(11), (9)==(10), (10)==(9), (10)-->(17)
            ├── prune: (8-17)
            ├── interesting orderings: (+12 opt(15,16))
            ├── project
-           │    ├── columns: column16:16(int!null) a:8(int!null) b:9(int!null) c:10(int!null) d:11(int) rowid:12(int!null) e:13(int) crdb_internal_mvcc_timestamp:14(decimal) a_new:15(int!null)
+           │    ├── columns: e_default:16(int!null) a:8(int!null) b:9(int!null) c:10(int!null) d:11(int) rowid:12(int!null) e:13(int) crdb_internal_mvcc_timestamp:14(decimal) a_new:15(int!null)
            │    ├── key: (12)
            │    ├── fd: ()-->(15,16), (12)-->(8-11,13,14), (9,10)-->(11), (9)==(10), (10)==(9)
            │    ├── prune: (8-16)
@@ -292,9 +292,9 @@ project
            │    │    └── projections
            │    │         └── const: 1 [as=a_new:15, type=int]
            │    └── projections
-           │         └── const: 0 [as=column16:16, type=int]
+           │         └── const: 0 [as=e_default:16, type=int]
            └── projections
-                └── plus [as=column17:17, type=int, outer=(9,10), immutable]
+                └── plus [as=d_comp:17, type=int, outer=(9,10), immutable]
                      ├── plus [type=int]
                      │    ├── variable: b:9 [type=int]
                      │    └── variable: c:10 [type=int]

--- a/pkg/sql/opt/memo/testdata/logprops/upsert
+++ b/pkg/sql/opt/memo/testdata/logprops/upsert
@@ -39,8 +39,8 @@ project
       ├── insert-mapping:
       │    ├── x:6 => a:1
       │    ├── y:7 => b:2
-      │    ├── column11:11 => c:3
-      │    └── column10:10 => rowid:4
+      │    ├── c_comp:11 => c:3
+      │    └── rowid_default:10 => rowid:4
       ├── update-mapping:
       │    ├── upsert_a:20 => a:1
       │    ├── upsert_b:21 => b:2
@@ -53,7 +53,7 @@ project
       ├── cardinality: [0 - 1]
       ├── volatile, mutations
       └── project
-           ├── columns: upsert_a:20(int!null) upsert_b:21(int) upsert_c:22(int) upsert_rowid:23(int) x:6(int!null) y:7(int!null) column10:10(int) column11:11(int!null) a:12(int) b:13(int) c:14(int) rowid:15(int) abc.crdb_internal_mvcc_timestamp:16(decimal) a_new:17(int!null) b_new:18(int) column19:19(int)
+           ├── columns: upsert_a:20(int!null) upsert_b:21(int) upsert_c:22(int) upsert_rowid:23(int) x:6(int!null) y:7(int!null) rowid_default:10(int) c_comp:11(int!null) a:12(int) b:13(int) c:14(int) rowid:15(int) abc.crdb_internal_mvcc_timestamp:16(decimal) a_new:17(int!null) b_new:18(int) c_comp:19(int)
            ├── cardinality: [0 - 1]
            ├── volatile
            ├── key: (15)
@@ -62,7 +62,7 @@ project
            ├── reject-nulls: (12-16,18,19)
            ├── interesting orderings: (+15 opt(6,7,10,11,17)) (+12 opt(6,7,10,11,17)) (+13,+15 opt(6,7,10,11,17))
            ├── project
-           │    ├── columns: column19:19(int) x:6(int!null) y:7(int!null) column10:10(int) column11:11(int!null) a:12(int) b:13(int) c:14(int) rowid:15(int) abc.crdb_internal_mvcc_timestamp:16(decimal) a_new:17(int!null) b_new:18(int)
+           │    ├── columns: c_comp:19(int) x:6(int!null) y:7(int!null) rowid_default:10(int) c_comp:11(int!null) a:12(int) b:13(int) c:14(int) rowid:15(int) abc.crdb_internal_mvcc_timestamp:16(decimal) a_new:17(int!null) b_new:18(int)
            │    ├── cardinality: [0 - 1]
            │    ├── volatile
            │    ├── key: (15)
@@ -71,7 +71,7 @@ project
            │    ├── reject-nulls: (12-16,18,19)
            │    ├── interesting orderings: (+15 opt(6,7,10,11,17)) (+12 opt(6,7,10,11,17)) (+13,+15 opt(6,7,10,11,17))
            │    ├── project
-           │    │    ├── columns: a_new:17(int!null) b_new:18(int) x:6(int!null) y:7(int!null) column10:10(int) column11:11(int!null) a:12(int) b:13(int) c:14(int) rowid:15(int) abc.crdb_internal_mvcc_timestamp:16(decimal)
+           │    │    ├── columns: a_new:17(int!null) b_new:18(int) x:6(int!null) y:7(int!null) rowid_default:10(int) c_comp:11(int!null) a:12(int) b:13(int) c:14(int) rowid:15(int) abc.crdb_internal_mvcc_timestamp:16(decimal)
            │    │    ├── cardinality: [0 - 1]
            │    │    ├── volatile
            │    │    ├── key: (15)
@@ -80,7 +80,7 @@ project
            │    │    ├── reject-nulls: (12-16,18)
            │    │    ├── interesting orderings: (+15 opt(6,7,10,11,17)) (+12 opt(6,7,10,11,17)) (+13,+15 opt(6,7,10,11,17))
            │    │    ├── left-join (hash)
-           │    │    │    ├── columns: x:6(int!null) y:7(int!null) column10:10(int) column11:11(int!null) a:12(int) b:13(int) c:14(int) rowid:15(int) abc.crdb_internal_mvcc_timestamp:16(decimal)
+           │    │    │    ├── columns: x:6(int!null) y:7(int!null) rowid_default:10(int) c_comp:11(int!null) a:12(int) b:13(int) c:14(int) rowid:15(int) abc.crdb_internal_mvcc_timestamp:16(decimal)
            │    │    │    ├── cardinality: [0 - 1]
            │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
            │    │    │    ├── volatile
@@ -90,22 +90,22 @@ project
            │    │    │    ├── reject-nulls: (12-16)
            │    │    │    ├── interesting orderings: (+15) (+12) (+13,+15)
            │    │    │    ├── ensure-upsert-distinct-on
-           │    │    │    │    ├── columns: x:6(int!null) y:7(int!null) column10:10(int) column11:11(int!null)
-           │    │    │    │    ├── grouping columns: y:7(int!null) column11:11(int!null)
+           │    │    │    │    ├── columns: x:6(int!null) y:7(int!null) rowid_default:10(int) c_comp:11(int!null)
+           │    │    │    │    ├── grouping columns: y:7(int!null) c_comp:11(int!null)
            │    │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
            │    │    │    │    ├── cardinality: [0 - 1]
            │    │    │    │    ├── volatile
            │    │    │    │    ├── key: ()
            │    │    │    │    ├── fd: ()-->(6,7,10,11)
            │    │    │    │    ├── project
-           │    │    │    │    │    ├── columns: column11:11(int!null) x:6(int!null) y:7(int!null) column10:10(int)
+           │    │    │    │    │    ├── columns: c_comp:11(int!null) x:6(int!null) y:7(int!null) rowid_default:10(int)
            │    │    │    │    │    ├── volatile
            │    │    │    │    │    ├── key: (6)
            │    │    │    │    │    ├── fd: ()-->(7,11), (6)-->(10)
            │    │    │    │    │    ├── prune: (6,7,10,11)
            │    │    │    │    │    ├── interesting orderings: (+6 opt(7,11))
            │    │    │    │    │    ├── project
-           │    │    │    │    │    │    ├── columns: column10:10(int) x:6(int!null) y:7(int!null)
+           │    │    │    │    │    │    ├── columns: rowid_default:10(int) x:6(int!null) y:7(int!null)
            │    │    │    │    │    │    ├── volatile
            │    │    │    │    │    │    ├── key: (6)
            │    │    │    │    │    │    ├── fd: ()-->(7), (6)-->(10)
@@ -134,16 +134,16 @@ project
            │    │    │    │    │    │    │                   ├── variable: y:7 [type=int]
            │    │    │    │    │    │    │                   └── const: 1 [type=int]
            │    │    │    │    │    │    └── projections
-           │    │    │    │    │    │         └── function: unique_rowid [as=column10:10, type=int, volatile]
+           │    │    │    │    │    │         └── function: unique_rowid [as=rowid_default:10, type=int, volatile]
            │    │    │    │    │    └── projections
-           │    │    │    │    │         └── plus [as=column11:11, type=int, outer=(7), immutable]
+           │    │    │    │    │         └── plus [as=c_comp:11, type=int, outer=(7), immutable]
            │    │    │    │    │              ├── variable: y:7 [type=int]
            │    │    │    │    │              └── const: 1 [type=int]
            │    │    │    │    └── aggregations
            │    │    │    │         ├── first-agg [as=x:6, type=int, outer=(6)]
            │    │    │    │         │    └── variable: x:6 [type=int]
-           │    │    │    │         └── first-agg [as=column10:10, type=int, outer=(10)]
-           │    │    │    │              └── variable: column10:10 [type=int]
+           │    │    │    │         └── first-agg [as=rowid_default:10, type=int, outer=(10)]
+           │    │    │    │              └── variable: rowid_default:10 [type=int]
            │    │    │    ├── scan abc
            │    │    │    │    ├── columns: a:12(int!null) b:13(int) c:14(int) rowid:15(int!null) abc.crdb_internal_mvcc_timestamp:16(decimal)
            │    │    │    │    ├── computed column expressions
@@ -161,7 +161,7 @@ project
            │    │    │         │    ├── variable: y:7 [type=int]
            │    │    │         │    └── variable: b:13 [type=int]
            │    │    │         └── eq [type=bool, outer=(11,14), constraints=(/11: (/NULL - ]; /14: (/NULL - ]), fd=(11)==(14), (14)==(11)]
-           │    │    │              ├── variable: column11:11 [type=int]
+           │    │    │              ├── variable: c_comp:11 [type=int]
            │    │    │              └── variable: c:14 [type=int]
            │    │    └── projections
            │    │         ├── const: 1 [as=a_new:17, type=int]
@@ -169,7 +169,7 @@ project
            │    │              ├── variable: y:7 [type=int]
            │    │              └── variable: c:14 [type=int]
            │    └── projections
-           │         └── plus [as=column19:19, type=int, outer=(18), immutable]
+           │         └── plus [as=c_comp:19, type=int, outer=(18), immutable]
            │              ├── variable: b_new:18 [type=int]
            │              └── const: 1 [type=int]
            └── projections
@@ -195,15 +195,15 @@ project
                 │    │    ├── is [type=bool]
                 │    │    │    ├── variable: rowid:15 [type=int]
                 │    │    │    └── null [type=unknown]
-                │    │    └── variable: column11:11 [type=int]
-                │    └── variable: column19:19 [type=int]
+                │    │    └── variable: c_comp:11 [type=int]
+                │    └── variable: c_comp:19 [type=int]
                 └── case [as=upsert_rowid:23, type=int, outer=(10,15)]
                      ├── true [type=bool]
                      ├── when [type=int]
                      │    ├── is [type=bool]
                      │    │    ├── variable: rowid:15 [type=int]
                      │    │    └── null [type=unknown]
-                     │    └── variable: column10:10 [type=int]
+                     │    └── variable: rowid_default:10 [type=int]
                      └── variable: rowid:15 [type=int]
 
 # DO NOTHING case.
@@ -225,51 +225,51 @@ project
       ├── insert-mapping:
       │    ├── x:6 => a:1
       │    ├── y:7 => b:2
-      │    ├── column11:11 => c:3
-      │    └── column10:10 => rowid:4
+      │    ├── c_comp:11 => c:3
+      │    └── rowid_default:10 => rowid:4
       ├── volatile, mutations
       ├── key: (1)
       ├── fd: (1)-->(2-4), (2)-->(3), (4)~~>(1-3), (2,3)~~>(1,4)
       └── upsert-distinct-on
-           ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int)
-           ├── grouping columns: y:7(int) column11:11(int)
+           ├── columns: x:6(int!null) y:7(int) rowid_default:10(int) c_comp:11(int)
+           ├── grouping columns: y:7(int) c_comp:11(int)
            ├── volatile
            ├── key: (6)
            ├── fd: (6)-->(7,10,11), (7)-->(11), (10)~~>(6,7,11), (7,11)~~>(6,10)
            ├── upsert-distinct-on
-           │    ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int)
+           │    ├── columns: x:6(int!null) y:7(int) rowid_default:10(int) c_comp:11(int)
            │    ├── grouping columns: x:6(int!null)
            │    ├── volatile
            │    ├── key: (6)
            │    ├── fd: (6)-->(7,10,11), (7)-->(11), (10)~~>(6,7,11)
            │    ├── upsert-distinct-on
-           │    │    ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int)
-           │    │    ├── grouping columns: column10:10(int)
+           │    │    ├── columns: x:6(int!null) y:7(int) rowid_default:10(int) c_comp:11(int)
+           │    │    ├── grouping columns: rowid_default:10(int)
            │    │    ├── volatile
            │    │    ├── key: (6)
            │    │    ├── fd: (6)-->(7,10), (7)-->(11), (10)~~>(6,7,11)
            │    │    ├── anti-join (hash)
-           │    │    │    ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int)
+           │    │    │    ├── columns: x:6(int!null) y:7(int) rowid_default:10(int) c_comp:11(int)
            │    │    │    ├── volatile
            │    │    │    ├── key: (6)
            │    │    │    ├── fd: (6)-->(7,10), (7)-->(11)
            │    │    │    ├── interesting orderings: (+6) (+7)
            │    │    │    ├── anti-join (hash)
-           │    │    │    │    ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int)
+           │    │    │    │    ├── columns: x:6(int!null) y:7(int) rowid_default:10(int) c_comp:11(int)
            │    │    │    │    ├── volatile
            │    │    │    │    ├── key: (6)
            │    │    │    │    ├── fd: (6)-->(7,10), (7)-->(11)
            │    │    │    │    ├── prune: (7,11)
            │    │    │    │    ├── interesting orderings: (+6) (+7)
            │    │    │    │    ├── anti-join (hash)
-           │    │    │    │    │    ├── columns: x:6(int!null) y:7(int) column10:10(int) column11:11(int)
+           │    │    │    │    │    ├── columns: x:6(int!null) y:7(int) rowid_default:10(int) c_comp:11(int)
            │    │    │    │    │    ├── volatile
            │    │    │    │    │    ├── key: (6)
            │    │    │    │    │    ├── fd: (6)-->(7,10), (7)-->(11)
            │    │    │    │    │    ├── prune: (6,7,11)
            │    │    │    │    │    ├── interesting orderings: (+6) (+7)
            │    │    │    │    │    ├── project
-           │    │    │    │    │    │    ├── columns: column11:11(int) x:6(int!null) y:7(int) column10:10(int)
+           │    │    │    │    │    │    ├── columns: c_comp:11(int) x:6(int!null) y:7(int) rowid_default:10(int)
            │    │    │    │    │    │    ├── volatile
            │    │    │    │    │    │    ├── key: (6)
            │    │    │    │    │    │    ├── fd: (6)-->(7,10), (7)-->(11)
@@ -277,7 +277,7 @@ project
            │    │    │    │    │    │    ├── interesting orderings: (+6) (+7)
            │    │    │    │    │    │    ├── unfiltered-cols: (6-9)
            │    │    │    │    │    │    ├── project
-           │    │    │    │    │    │    │    ├── columns: column10:10(int) x:6(int!null) y:7(int)
+           │    │    │    │    │    │    │    ├── columns: rowid_default:10(int) x:6(int!null) y:7(int)
            │    │    │    │    │    │    │    ├── volatile
            │    │    │    │    │    │    │    ├── key: (6)
            │    │    │    │    │    │    │    ├── fd: (6)-->(7,10)
@@ -299,9 +299,9 @@ project
            │    │    │    │    │    │    │    │         ├── interesting orderings: (+6) (+7,+8,+6) (+8,+7,+6)
            │    │    │    │    │    │    │    │         └── unfiltered-cols: (6-9)
            │    │    │    │    │    │    │    └── projections
-           │    │    │    │    │    │    │         └── function: unique_rowid [as=column10:10, type=int, volatile]
+           │    │    │    │    │    │    │         └── function: unique_rowid [as=rowid_default:10, type=int, volatile]
            │    │    │    │    │    │    └── projections
-           │    │    │    │    │    │         └── plus [as=column11:11, type=int, outer=(7), immutable]
+           │    │    │    │    │    │         └── plus [as=c_comp:11, type=int, outer=(7), immutable]
            │    │    │    │    │    │              ├── variable: y:7 [type=int]
            │    │    │    │    │    │              └── const: 1 [type=int]
            │    │    │    │    │    ├── scan abc
@@ -318,7 +318,7 @@ project
            │    │    │    │    │    │    └── unfiltered-cols: (12-16)
            │    │    │    │    │    └── filters
            │    │    │    │    │         └── eq [type=bool, outer=(10,15), constraints=(/10: (/NULL - ]; /15: (/NULL - ]), fd=(10)==(15), (15)==(10)]
-           │    │    │    │    │              ├── variable: column10:10 [type=int]
+           │    │    │    │    │              ├── variable: rowid_default:10 [type=int]
            │    │    │    │    │              └── variable: rowid:15 [type=int]
            │    │    │    │    ├── scan abc
            │    │    │    │    │    ├── columns: a:17(int!null) b:18(int) c:19(int) rowid:20(int!null)
@@ -353,27 +353,27 @@ project
            │    │    │         │    ├── variable: y:7 [type=int]
            │    │    │         │    └── variable: b:23 [type=int]
            │    │    │         └── eq [type=bool, outer=(11,24), constraints=(/11: (/NULL - ]; /24: (/NULL - ]), fd=(11)==(24), (24)==(11)]
-           │    │    │              ├── variable: column11:11 [type=int]
+           │    │    │              ├── variable: c_comp:11 [type=int]
            │    │    │              └── variable: c:24 [type=int]
            │    │    └── aggregations
            │    │         ├── first-agg [as=x:6, type=int, outer=(6)]
            │    │         │    └── variable: x:6 [type=int]
            │    │         ├── first-agg [as=y:7, type=int, outer=(7)]
            │    │         │    └── variable: y:7 [type=int]
-           │    │         └── first-agg [as=column11:11, type=int, outer=(11)]
-           │    │              └── variable: column11:11 [type=int]
+           │    │         └── first-agg [as=c_comp:11, type=int, outer=(11)]
+           │    │              └── variable: c_comp:11 [type=int]
            │    └── aggregations
            │         ├── first-agg [as=y:7, type=int, outer=(7)]
            │         │    └── variable: y:7 [type=int]
-           │         ├── first-agg [as=column10:10, type=int, outer=(10)]
-           │         │    └── variable: column10:10 [type=int]
-           │         └── first-agg [as=column11:11, type=int, outer=(11)]
-           │              └── variable: column11:11 [type=int]
+           │         ├── first-agg [as=rowid_default:10, type=int, outer=(10)]
+           │         │    └── variable: rowid_default:10 [type=int]
+           │         └── first-agg [as=c_comp:11, type=int, outer=(11)]
+           │              └── variable: c_comp:11 [type=int]
            └── aggregations
                 ├── first-agg [as=x:6, type=int, outer=(6)]
                 │    └── variable: x:6 [type=int]
-                └── first-agg [as=column10:10, type=int, outer=(10)]
-                     └── variable: column10:10 [type=int]
+                └── first-agg [as=rowid_default:10, type=int, outer=(10)]
+                     └── variable: rowid_default:10 [type=int]
 
 # UPSERT case.
 build
@@ -391,9 +391,9 @@ project
  │    ├── fetch columns: a:10(int) b:11(int) c:12(int) rowid:13(int)
  │    ├── insert-mapping:
  │    │    ├── column1:6 => a:1
- │    │    ├── column7:7 => b:2
- │    │    ├── column9:9 => c:3
- │    │    └── column8:8 => rowid:4
+ │    │    ├── b_default:7 => b:2
+ │    │    ├── c_comp:9 => c:3
+ │    │    └── rowid_default:8 => rowid:4
  │    ├── update-mapping:
  │    │    └── column1:6 => a:1
  │    ├── return-mapping:
@@ -404,7 +404,7 @@ project
  │    ├── cardinality: [1 - 2]
  │    ├── volatile, mutations
  │    └── project
- │         ├── columns: upsert_b:16(int) upsert_c:17(int) upsert_rowid:18(int) column1:6(int!null) column7:7(int!null) column8:8(int) column9:9(int!null) a:10(int) b:11(int) c:12(int) rowid:13(int) crdb_internal_mvcc_timestamp:14(decimal) column15:15(int)
+ │         ├── columns: upsert_b:16(int) upsert_c:17(int) upsert_rowid:18(int) column1:6(int!null) b_default:7(int!null) rowid_default:8(int) c_comp:9(int!null) a:10(int) b:11(int) c:12(int) rowid:13(int) crdb_internal_mvcc_timestamp:14(decimal) c_comp:15(int)
  │         ├── cardinality: [1 - 2]
  │         ├── volatile
  │         ├── lax-key: (8,13)
@@ -413,7 +413,7 @@ project
  │         ├── reject-nulls: (10-15)
  │         ├── interesting orderings: (+13 opt(7,9)) (+10 opt(7,9)) (+11,+13 opt(7,9))
  │         ├── project
- │         │    ├── columns: column15:15(int) column1:6(int!null) column7:7(int!null) column8:8(int) column9:9(int!null) a:10(int) b:11(int) c:12(int) rowid:13(int) crdb_internal_mvcc_timestamp:14(decimal)
+ │         │    ├── columns: c_comp:15(int) column1:6(int!null) b_default:7(int!null) rowid_default:8(int) c_comp:9(int!null) a:10(int) b:11(int) c:12(int) rowid:13(int) crdb_internal_mvcc_timestamp:14(decimal)
  │         │    ├── cardinality: [1 - 2]
  │         │    ├── volatile
  │         │    ├── lax-key: (8,13)
@@ -422,7 +422,7 @@ project
  │         │    ├── reject-nulls: (10-15)
  │         │    ├── interesting orderings: (+13 opt(7,9)) (+10 opt(7,9)) (+11,+13 opt(7,9))
  │         │    ├── left-join (hash)
- │         │    │    ├── columns: column1:6(int!null) column7:7(int!null) column8:8(int) column9:9(int!null) a:10(int) b:11(int) c:12(int) rowid:13(int) crdb_internal_mvcc_timestamp:14(decimal)
+ │         │    │    ├── columns: column1:6(int!null) b_default:7(int!null) rowid_default:8(int) c_comp:9(int!null) a:10(int) b:11(int) c:12(int) rowid:13(int) crdb_internal_mvcc_timestamp:14(decimal)
  │         │    │    ├── cardinality: [1 - 2]
  │         │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
  │         │    │    ├── volatile
@@ -432,21 +432,21 @@ project
  │         │    │    ├── reject-nulls: (10-14)
  │         │    │    ├── interesting orderings: (+13) (+10) (+11,+13)
  │         │    │    ├── ensure-upsert-distinct-on
- │         │    │    │    ├── columns: column1:6(int!null) column7:7(int!null) column8:8(int) column9:9(int!null)
- │         │    │    │    ├── grouping columns: column8:8(int)
+ │         │    │    │    ├── columns: column1:6(int!null) b_default:7(int!null) rowid_default:8(int) c_comp:9(int!null)
+ │         │    │    │    ├── grouping columns: rowid_default:8(int)
  │         │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
  │         │    │    │    ├── cardinality: [1 - 2]
  │         │    │    │    ├── volatile
  │         │    │    │    ├── lax-key: (8)
  │         │    │    │    ├── fd: ()-->(7,9), (8)~~>(6,7,9)
  │         │    │    │    ├── project
- │         │    │    │    │    ├── columns: column9:9(int!null) column1:6(int!null) column7:7(int!null) column8:8(int)
+ │         │    │    │    │    ├── columns: c_comp:9(int!null) column1:6(int!null) b_default:7(int!null) rowid_default:8(int)
  │         │    │    │    │    ├── cardinality: [2 - 2]
  │         │    │    │    │    ├── volatile
  │         │    │    │    │    ├── fd: ()-->(7,9)
  │         │    │    │    │    ├── prune: (6-9)
  │         │    │    │    │    ├── project
- │         │    │    │    │    │    ├── columns: column7:7(int!null) column8:8(int) column1:6(int!null)
+ │         │    │    │    │    │    ├── columns: b_default:7(int!null) rowid_default:8(int) column1:6(int!null)
  │         │    │    │    │    │    ├── cardinality: [2 - 2]
  │         │    │    │    │    │    ├── volatile
  │         │    │    │    │    │    ├── fd: ()-->(7)
@@ -460,19 +460,19 @@ project
  │         │    │    │    │    │    │    └── tuple [type=tuple{int}]
  │         │    │    │    │    │    │         └── const: 2 [type=int]
  │         │    │    │    │    │    └── projections
- │         │    │    │    │    │         ├── const: 10 [as=column7:7, type=int]
- │         │    │    │    │    │         └── function: unique_rowid [as=column8:8, type=int, volatile]
+ │         │    │    │    │    │         ├── const: 10 [as=b_default:7, type=int]
+ │         │    │    │    │    │         └── function: unique_rowid [as=rowid_default:8, type=int, volatile]
  │         │    │    │    │    └── projections
- │         │    │    │    │         └── plus [as=column9:9, type=int, outer=(7), immutable]
- │         │    │    │    │              ├── variable: column7:7 [type=int]
+ │         │    │    │    │         └── plus [as=c_comp:9, type=int, outer=(7), immutable]
+ │         │    │    │    │              ├── variable: b_default:7 [type=int]
  │         │    │    │    │              └── const: 1 [type=int]
  │         │    │    │    └── aggregations
  │         │    │    │         ├── first-agg [as=column1:6, type=int, outer=(6)]
  │         │    │    │         │    └── variable: column1:6 [type=int]
- │         │    │    │         ├── first-agg [as=column7:7, type=int, outer=(7)]
- │         │    │    │         │    └── variable: column7:7 [type=int]
- │         │    │    │         └── first-agg [as=column9:9, type=int, outer=(9)]
- │         │    │    │              └── variable: column9:9 [type=int]
+ │         │    │    │         ├── first-agg [as=b_default:7, type=int, outer=(7)]
+ │         │    │    │         │    └── variable: b_default:7 [type=int]
+ │         │    │    │         └── first-agg [as=c_comp:9, type=int, outer=(9)]
+ │         │    │    │              └── variable: c_comp:9 [type=int]
  │         │    │    ├── scan abc
  │         │    │    │    ├── columns: a:10(int!null) b:11(int) c:12(int) rowid:13(int!null) crdb_internal_mvcc_timestamp:14(decimal)
  │         │    │    │    ├── computed column expressions
@@ -487,10 +487,10 @@ project
  │         │    │    │    └── unfiltered-cols: (10-14)
  │         │    │    └── filters
  │         │    │         └── eq [type=bool, outer=(8,13), constraints=(/8: (/NULL - ]; /13: (/NULL - ]), fd=(8)==(13), (13)==(8)]
- │         │    │              ├── variable: column8:8 [type=int]
+ │         │    │              ├── variable: rowid_default:8 [type=int]
  │         │    │              └── variable: rowid:13 [type=int]
  │         │    └── projections
- │         │         └── plus [as=column15:15, type=int, outer=(11), immutable]
+ │         │         └── plus [as=c_comp:15, type=int, outer=(11), immutable]
  │         │              ├── variable: b:11 [type=int]
  │         │              └── const: 1 [type=int]
  │         └── projections
@@ -500,7 +500,7 @@ project
  │              │    │    ├── is [type=bool]
  │              │    │    │    ├── variable: rowid:13 [type=int]
  │              │    │    │    └── null [type=unknown]
- │              │    │    └── variable: column7:7 [type=int]
+ │              │    │    └── variable: b_default:7 [type=int]
  │              │    └── variable: b:11 [type=int]
  │              ├── case [as=upsert_c:17, type=int, outer=(9,12,13)]
  │              │    ├── true [type=bool]
@@ -508,7 +508,7 @@ project
  │              │    │    ├── is [type=bool]
  │              │    │    │    ├── variable: rowid:13 [type=int]
  │              │    │    │    └── null [type=unknown]
- │              │    │    └── variable: column9:9 [type=int]
+ │              │    │    └── variable: c_comp:9 [type=int]
  │              │    └── variable: c:12 [type=int]
  │              └── case [as=upsert_rowid:18, type=int, outer=(8,13)]
  │                   ├── true [type=bool]
@@ -516,7 +516,7 @@ project
  │                   │    ├── is [type=bool]
  │                   │    │    ├── variable: rowid:13 [type=int]
  │                   │    │    └── null [type=unknown]
- │                   │    └── variable: column8:8 [type=int]
+ │                   │    └── variable: rowid_default:8 [type=int]
  │                   └── variable: rowid:13 [type=int]
  └── projections
       └── plus [as="?column?":19, type=int, outer=(2,3), immutable]
@@ -538,16 +538,16 @@ upsert abc
  ├── fetch columns: a:13(int) b:14(int) c:15(int) rowid:16(int)
  ├── insert-mapping:
  │    ├── y:7 => a:1
- │    ├── column10:10 => b:2
- │    ├── column12:12 => c:3
- │    └── column11:11 => rowid:4
+ │    ├── b_default:10 => b:2
+ │    ├── c_comp:12 => c:3
+ │    └── rowid_default:11 => rowid:4
  ├── update-mapping:
  │    ├── upsert_b:21 => b:2
  │    └── upsert_c:22 => c:3
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: upsert_a:20(int) upsert_b:21(int!null) upsert_c:22(int!null) upsert_rowid:23(int) y:7(int!null) column10:10(int!null) column11:11(int) column12:12(int!null) a:13(int) b:14(int) c:15(int) rowid:16(int) abc.crdb_internal_mvcc_timestamp:17(decimal) b_new:18(int!null) column19:19(int!null)
+      ├── columns: upsert_a:20(int) upsert_b:21(int!null) upsert_c:22(int!null) upsert_rowid:23(int) y:7(int!null) b_default:10(int!null) rowid_default:11(int) c_comp:12(int!null) a:13(int) b:14(int) c:15(int) rowid:16(int) abc.crdb_internal_mvcc_timestamp:17(decimal) b_new:18(int!null) c_comp:19(int!null)
       ├── volatile
       ├── key: (7)
       ├── fd: ()-->(10,12,18,19), (7)-->(11,13-17,20), (16)-->(13-15,17), (13)-->(14-17,21,22), (14,15)~~>(13,16,17), (14)~~>(15), (11,16)-->(23)
@@ -555,7 +555,7 @@ upsert abc
       ├── reject-nulls: (13-17)
       ├── interesting orderings: (+16 opt(10,12,18,19)) (+13 opt(10,12,18,19)) (+14,+16 opt(10,12,18,19))
       ├── project
-      │    ├── columns: column19:19(int!null) y:7(int!null) column10:10(int!null) column11:11(int) column12:12(int!null) a:13(int) b:14(int) c:15(int) rowid:16(int) abc.crdb_internal_mvcc_timestamp:17(decimal) b_new:18(int!null)
+      │    ├── columns: c_comp:19(int!null) y:7(int!null) b_default:10(int!null) rowid_default:11(int) c_comp:12(int!null) a:13(int) b:14(int) c:15(int) rowid:16(int) abc.crdb_internal_mvcc_timestamp:17(decimal) b_new:18(int!null)
       │    ├── volatile
       │    ├── key: (7)
       │    ├── fd: ()-->(10,12,18,19), (7)-->(11,13-17), (16)-->(13-15,17), (13)-->(14-17), (14,15)~~>(13,16,17), (14)~~>(15)
@@ -563,7 +563,7 @@ upsert abc
       │    ├── reject-nulls: (13-17)
       │    ├── interesting orderings: (+16 opt(10,12,18,19)) (+13 opt(10,12,18,19)) (+14,+16 opt(10,12,18,19))
       │    ├── project
-      │    │    ├── columns: b_new:18(int!null) y:7(int!null) column10:10(int!null) column11:11(int) column12:12(int!null) a:13(int) b:14(int) c:15(int) rowid:16(int) abc.crdb_internal_mvcc_timestamp:17(decimal)
+      │    │    ├── columns: b_new:18(int!null) y:7(int!null) b_default:10(int!null) rowid_default:11(int) c_comp:12(int!null) a:13(int) b:14(int) c:15(int) rowid:16(int) abc.crdb_internal_mvcc_timestamp:17(decimal)
       │    │    ├── volatile
       │    │    ├── key: (7)
       │    │    ├── fd: ()-->(10,12,18), (7)-->(11,13-17), (16)-->(13-15,17), (13)-->(14-17), (14,15)~~>(13,16,17), (14)~~>(15)
@@ -571,7 +571,7 @@ upsert abc
       │    │    ├── reject-nulls: (13-17)
       │    │    ├── interesting orderings: (+16 opt(10,12,18)) (+13 opt(10,12,18)) (+14,+16 opt(10,12,18))
       │    │    ├── left-join (hash)
-      │    │    │    ├── columns: y:7(int!null) column10:10(int!null) column11:11(int) column12:12(int!null) a:13(int) b:14(int) c:15(int) rowid:16(int) abc.crdb_internal_mvcc_timestamp:17(decimal)
+      │    │    │    ├── columns: y:7(int!null) b_default:10(int!null) rowid_default:11(int) c_comp:12(int!null) a:13(int) b:14(int) c:15(int) rowid:16(int) abc.crdb_internal_mvcc_timestamp:17(decimal)
       │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
       │    │    │    ├── volatile
       │    │    │    ├── key: (7)
@@ -580,20 +580,20 @@ upsert abc
       │    │    │    ├── reject-nulls: (13-17)
       │    │    │    ├── interesting orderings: (+16) (+13) (+14,+16)
       │    │    │    ├── ensure-upsert-distinct-on
-      │    │    │    │    ├── columns: y:7(int!null) column10:10(int!null) column11:11(int) column12:12(int!null)
+      │    │    │    │    ├── columns: y:7(int!null) b_default:10(int!null) rowid_default:11(int) c_comp:12(int!null)
       │    │    │    │    ├── grouping columns: y:7(int!null)
       │    │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
       │    │    │    │    ├── volatile
       │    │    │    │    ├── key: (7)
       │    │    │    │    ├── fd: ()-->(10,12), (7)-->(10-12)
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: column12:12(int!null) y:7(int!null) column10:10(int!null) column11:11(int)
+      │    │    │    │    │    ├── columns: c_comp:12(int!null) y:7(int!null) b_default:10(int!null) rowid_default:11(int)
       │    │    │    │    │    ├── volatile
       │    │    │    │    │    ├── fd: ()-->(10,12)
       │    │    │    │    │    ├── prune: (7,10-12)
       │    │    │    │    │    ├── interesting orderings: (+7 opt(10,12))
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: column10:10(int!null) column11:11(int) y:7(int!null)
+      │    │    │    │    │    │    ├── columns: b_default:10(int!null) rowid_default:11(int) y:7(int!null)
       │    │    │    │    │    │    ├── volatile
       │    │    │    │    │    │    ├── fd: ()-->(10)
       │    │    │    │    │    │    ├── prune: (7,10,11)
@@ -619,19 +619,19 @@ upsert abc
       │    │    │    │    │    │    │                   ├── variable: y:7 [type=int]
       │    │    │    │    │    │    │                   └── null [type=unknown]
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         ├── const: 10 [as=column10:10, type=int]
-      │    │    │    │    │    │         └── function: unique_rowid [as=column11:11, type=int, volatile]
+      │    │    │    │    │    │         ├── const: 10 [as=b_default:10, type=int]
+      │    │    │    │    │    │         └── function: unique_rowid [as=rowid_default:11, type=int, volatile]
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── plus [as=column12:12, type=int, outer=(10), immutable]
-      │    │    │    │    │              ├── variable: column10:10 [type=int]
+      │    │    │    │    │         └── plus [as=c_comp:12, type=int, outer=(10), immutable]
+      │    │    │    │    │              ├── variable: b_default:10 [type=int]
       │    │    │    │    │              └── const: 1 [type=int]
       │    │    │    │    └── aggregations
-      │    │    │    │         ├── first-agg [as=column10:10, type=int, outer=(10)]
-      │    │    │    │         │    └── variable: column10:10 [type=int]
-      │    │    │    │         ├── first-agg [as=column11:11, type=int, outer=(11)]
-      │    │    │    │         │    └── variable: column11:11 [type=int]
-      │    │    │    │         └── first-agg [as=column12:12, type=int, outer=(12)]
-      │    │    │    │              └── variable: column12:12 [type=int]
+      │    │    │    │         ├── first-agg [as=b_default:10, type=int, outer=(10)]
+      │    │    │    │         │    └── variable: b_default:10 [type=int]
+      │    │    │    │         ├── first-agg [as=rowid_default:11, type=int, outer=(11)]
+      │    │    │    │         │    └── variable: rowid_default:11 [type=int]
+      │    │    │    │         └── first-agg [as=c_comp:12, type=int, outer=(12)]
+      │    │    │    │              └── variable: c_comp:12 [type=int]
       │    │    │    ├── scan abc
       │    │    │    │    ├── columns: a:13(int!null) b:14(int) c:15(int) rowid:16(int!null) abc.crdb_internal_mvcc_timestamp:17(decimal)
       │    │    │    │    ├── computed column expressions
@@ -651,7 +651,7 @@ upsert abc
       │    │    └── projections
       │    │         └── const: 2 [as=b_new:18, type=int]
       │    └── projections
-      │         └── plus [as=column19:19, type=int, outer=(18), immutable]
+      │         └── plus [as=c_comp:19, type=int, outer=(18), immutable]
       │              ├── variable: b_new:18 [type=int]
       │              └── const: 1 [type=int]
       └── projections
@@ -669,7 +669,7 @@ upsert abc
            │    │    ├── is [type=bool]
            │    │    │    ├── variable: a:13 [type=int]
            │    │    │    └── null [type=unknown]
-           │    │    └── variable: column10:10 [type=int]
+           │    │    └── variable: b_default:10 [type=int]
            │    └── variable: b_new:18 [type=int]
            ├── case [as=upsert_c:22, type=int, outer=(12,13,19)]
            │    ├── true [type=bool]
@@ -677,13 +677,13 @@ upsert abc
            │    │    ├── is [type=bool]
            │    │    │    ├── variable: a:13 [type=int]
            │    │    │    └── null [type=unknown]
-           │    │    └── variable: column12:12 [type=int]
-           │    └── variable: column19:19 [type=int]
+           │    │    └── variable: c_comp:12 [type=int]
+           │    └── variable: c_comp:19 [type=int]
            └── case [as=upsert_rowid:23, type=int, outer=(11,13,16)]
                 ├── true [type=bool]
                 ├── when [type=int]
                 │    ├── is [type=bool]
                 │    │    ├── variable: a:13 [type=int]
                 │    │    └── null [type=unknown]
-                │    └── variable: column11:11 [type=int]
+                │    └── variable: rowid_default:11 [type=int]
                 └── variable: rowid:16 [type=int]

--- a/pkg/sql/opt/memo/testdata/stats/upsert
+++ b/pkg/sql/opt/memo/testdata/stats/upsert
@@ -101,7 +101,7 @@ with &1
  │    ├── insert-mapping:
  │    │    ├── b:6 => xyz.x:1
  │    │    ├── a:5 => xyz.y:2
- │    │    └── column10:10 => xyz.z:3
+ │    │    └── z_default:10 => xyz.z:3
  │    ├── update-mapping:
  │    │    └── upsert_y:17 => xyz.y:2
  │    ├── return-mapping:
@@ -111,26 +111,26 @@ with &1
  │    ├── volatile, mutations
  │    ├── stats: [rows=9.94974875, distinct(1)=9.94974875, null(1)=0, distinct(2)=9.94974875, null(2)=0]
  │    └── project
- │         ├── columns: upsert_x:16(string) upsert_y:17(int!null) upsert_z:18(float) a:5(int!null) b:6(string) column10:10(float) xyz.x:11(string) xyz.y:12(int) xyz.z:13(float) xyz.crdb_internal_mvcc_timestamp:14(decimal) y_new:15(int!null)
+ │         ├── columns: upsert_x:16(string) upsert_y:17(int!null) upsert_z:18(float) a:5(int!null) b:6(string) z_default:10(float) xyz.x:11(string) xyz.y:12(int) xyz.z:13(float) xyz.crdb_internal_mvcc_timestamp:14(decimal) y_new:15(int!null)
  │         ├── immutable
  │         ├── stats: [rows=9.94974875, distinct(16)=9.94974875, null(16)=0, distinct(17)=9.94974875, null(17)=0]
  │         ├── lax-key: (6,11)
  │         ├── fd: ()-->(10,15), (6)~~>(5), (11)-->(12-14), (6,11)-->(16), (5,11)-->(17), (6,11)~~>(5,17,18)
  │         ├── project
- │         │    ├── columns: y_new:15(int!null) a:5(int!null) b:6(string) column10:10(float) xyz.x:11(string) xyz.y:12(int) xyz.z:13(float) xyz.crdb_internal_mvcc_timestamp:14(decimal)
+ │         │    ├── columns: y_new:15(int!null) a:5(int!null) b:6(string) z_default:10(float) xyz.x:11(string) xyz.y:12(int) xyz.z:13(float) xyz.crdb_internal_mvcc_timestamp:14(decimal)
  │         │    ├── immutable
  │         │    ├── stats: [rows=9.94974875, distinct(6,11)=9.94974875, null(6,11)=0, distinct(5,11,15)=9.94974875, null(5,11,15)=0]
  │         │    ├── lax-key: (6,11)
  │         │    ├── fd: ()-->(10,15), (6)~~>(5), (11)-->(12-14)
  │         │    ├── left-join (hash)
- │         │    │    ├── columns: a:5(int!null) b:6(string) column10:10(float) xyz.x:11(string) xyz.y:12(int) xyz.z:13(float) xyz.crdb_internal_mvcc_timestamp:14(decimal)
+ │         │    │    ├── columns: a:5(int!null) b:6(string) z_default:10(float) xyz.x:11(string) xyz.y:12(int) xyz.z:13(float) xyz.crdb_internal_mvcc_timestamp:14(decimal)
  │         │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
  │         │    │    ├── immutable
  │         │    │    ├── stats: [rows=9.94974875, distinct(11)=9.94974875, null(11)=0, distinct(5,11)=9.94974875, null(5,11)=0, distinct(6,11)=9.94974875, null(6,11)=0]
  │         │    │    ├── lax-key: (6,11)
  │         │    │    ├── fd: ()-->(10), (6)~~>(5), (11)-->(12-14)
  │         │    │    ├── ensure-upsert-distinct-on
- │         │    │    │    ├── columns: a:5(int!null) b:6(string) column10:10(float)
+ │         │    │    │    ├── columns: a:5(int!null) b:6(string) z_default:10(float)
  │         │    │    │    ├── grouping columns: b:6(string)
  │         │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
  │         │    │    │    ├── immutable
@@ -138,7 +138,7 @@ with &1
  │         │    │    │    ├── lax-key: (6)
  │         │    │    │    ├── fd: ()-->(10), (6)~~>(5,10)
  │         │    │    │    ├── project
- │         │    │    │    │    ├── columns: column10:10(float) a:5(int!null) b:6(string)
+ │         │    │    │    │    ├── columns: z_default:10(float) a:5(int!null) b:6(string)
  │         │    │    │    │    ├── immutable
  │         │    │    │    │    ├── stats: [rows=9.94974875, distinct(6)=6.31184239, null(6)=0]
  │         │    │    │    │    ├── fd: ()-->(10)
@@ -161,12 +161,12 @@ with &1
  │         │    │    │    │    │         └── filters
  │         │    │    │    │    │              └── c:7 = 1.0 [type=bool, outer=(7), constraints=(/7: [/1.0 - /1.0]; tight), fd=()-->(7)]
  │         │    │    │    │    └── projections
- │         │    │    │    │         └── NULL::FLOAT8 [as=column10:10, type=float, immutable]
+ │         │    │    │    │         └── NULL::FLOAT8 [as=z_default:10, type=float, immutable]
  │         │    │    │    └── aggregations
  │         │    │    │         ├── first-agg [as=a:5, type=int, outer=(5)]
  │         │    │    │         │    └── a:5 [type=int]
- │         │    │    │         └── first-agg [as=column10:10, type=float, outer=(10)]
- │         │    │    │              └── column10:10 [type=float]
+ │         │    │    │         └── first-agg [as=z_default:10, type=float, outer=(10)]
+ │         │    │    │              └── z_default:10 [type=float]
  │         │    │    ├── scan xyz
  │         │    │    │    ├── columns: xyz.x:11(string!null) xyz.y:12(int!null) xyz.z:13(float) xyz.crdb_internal_mvcc_timestamp:14(decimal)
  │         │    │    │    ├── stats: [rows=1000, distinct(11)=1000, null(11)=0]
@@ -179,7 +179,7 @@ with &1
  │         └── projections
  │              ├── CASE WHEN xyz.x:11 IS NULL THEN b:6 ELSE xyz.x:11 END [as=upsert_x:16, type=string, outer=(6,11)]
  │              ├── CASE WHEN xyz.x:11 IS NULL THEN a:5 ELSE y_new:15 END [as=upsert_y:17, type=int, outer=(5,11,15)]
- │              └── CASE WHEN xyz.x:11 IS NULL THEN column10:10 ELSE xyz.z:13 END [as=upsert_z:18, type=float, outer=(10,11,13)]
+ │              └── CASE WHEN xyz.x:11 IS NULL THEN z_default:10 ELSE xyz.z:13 END [as=upsert_z:18, type=float, outer=(10,11,13)]
  └── select
       ├── columns: x:19(string!null) y:20(int!null) z:21(float)
       ├── stats: [rows=1, distinct(20)=1, null(20)=0]
@@ -203,13 +203,13 @@ upsert xyz
  ├── upsert-mapping:
  │    ├── b:6 => x:1
  │    ├── a:5 => y:2
- │    └── column10:10 => z:3
+ │    └── z_default:10 => z:3
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── stats: [rows=0]
  ├── fd: ()-->(3)
  └── project
-      ├── columns: column10:10(float) a:5(int!null) b:6(string)
+      ├── columns: z_default:10(float) a:5(int!null) b:6(string)
       ├── cardinality: [0 - 0]
       ├── immutable
       ├── stats: [rows=0]
@@ -235,7 +235,7 @@ upsert xyz
       │         └── filters
       │              └── false [type=bool, constraints=(contradiction; tight)]
       └── projections
-           └── NULL::FLOAT8 [as=column10:10, type=float, immutable]
+           └── NULL::FLOAT8 [as=z_default:10, type=float, immutable]
 
 # Nullable conflict column. Ensure that ensure-upsert-distinct-on passes through
 # the input's null count.
@@ -250,7 +250,7 @@ upsert uv
  ├── canary column: u:10(int)
  ├── fetch columns: u:10(int) v:11(int)
  ├── insert-mapping:
- │    ├── column9:9 => u:1
+ │    ├── u_default:9 => u:1
  │    └── z:8 => v:2
  ├── update-mapping:
  │    └── upsert_v:15 => v:2
@@ -258,26 +258,26 @@ upsert uv
  ├── volatile, mutations
  ├── stats: [rows=0]
  └── project
-      ├── columns: upsert_u:14(int) upsert_v:15(int) z:8(int) column9:9(int) u:10(int) v:11(int) uv.crdb_internal_mvcc_timestamp:12(decimal) v_new:13(int!null)
+      ├── columns: upsert_u:14(int) upsert_v:15(int) z:8(int) u_default:9(int) u:10(int) v:11(int) uv.crdb_internal_mvcc_timestamp:12(decimal) v_new:13(int!null)
       ├── volatile
       ├── stats: [rows=1000]
       ├── lax-key: (8,10)
       ├── fd: ()-->(13), (8)~~>(9), (10)-->(11,12), (11)~~>(10,12), (9,10)-->(14), (8,10)-->(15), (8,10)~~>(9,14)
       ├── project
-      │    ├── columns: v_new:13(int!null) z:8(int) column9:9(int) u:10(int) v:11(int) uv.crdb_internal_mvcc_timestamp:12(decimal)
+      │    ├── columns: v_new:13(int!null) z:8(int) u_default:9(int) u:10(int) v:11(int) uv.crdb_internal_mvcc_timestamp:12(decimal)
       │    ├── volatile
       │    ├── stats: [rows=1000]
       │    ├── lax-key: (8,10)
       │    ├── fd: ()-->(13), (8)~~>(9), (10)-->(11,12), (11)~~>(10,12)
       │    ├── left-join (hash)
-      │    │    ├── columns: z:8(int) column9:9(int) u:10(int) v:11(int) uv.crdb_internal_mvcc_timestamp:12(decimal)
+      │    │    ├── columns: z:8(int) u_default:9(int) u:10(int) v:11(int) uv.crdb_internal_mvcc_timestamp:12(decimal)
       │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
       │    │    ├── volatile
       │    │    ├── stats: [rows=1000, distinct(11)=991, null(11)=0]
       │    │    ├── lax-key: (8,10)
       │    │    ├── fd: (8)~~>(9), (10)-->(11,12), (11)~~>(10,12)
       │    │    ├── ensure-upsert-distinct-on
-      │    │    │    ├── columns: z:8(int) column9:9(int)
+      │    │    │    ├── columns: z:8(int) u_default:9(int)
       │    │    │    ├── grouping columns: z:8(int)
       │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
       │    │    │    ├── volatile
@@ -285,7 +285,7 @@ upsert uv
       │    │    │    ├── lax-key: (8)
       │    │    │    ├── fd: (8)~~>(9)
       │    │    │    ├── project
-      │    │    │    │    ├── columns: column9:9(int) z:8(int)
+      │    │    │    │    ├── columns: u_default:9(int) z:8(int)
       │    │    │    │    ├── volatile
       │    │    │    │    ├── stats: [rows=1000, distinct(8)=100, null(8)=0]
       │    │    │    │    ├── project
@@ -300,10 +300,10 @@ upsert uv
       │    │    │    │    │    └── projections
       │    │    │    │    │         └── xyz.z:6::INT8 [as=z:8, type=int, outer=(6), immutable]
       │    │    │    │    └── projections
-      │    │    │    │         └── unique_rowid() [as=column9:9, type=int, volatile]
+      │    │    │    │         └── unique_rowid() [as=u_default:9, type=int, volatile]
       │    │    │    └── aggregations
-      │    │    │         └── first-agg [as=column9:9, type=int, outer=(9)]
-      │    │    │              └── column9:9 [type=int]
+      │    │    │         └── first-agg [as=u_default:9, type=int, outer=(9)]
+      │    │    │              └── u_default:9 [type=int]
       │    │    ├── scan uv
       │    │    │    ├── columns: u:10(int!null) v:11(int) uv.crdb_internal_mvcc_timestamp:12(decimal)
       │    │    │    ├── stats: [rows=1000, distinct(11)=991, null(11)=10]
@@ -314,7 +314,7 @@ upsert uv
       │    └── projections
       │         └── 1 [as=v_new:13, type=int]
       └── projections
-           ├── CASE WHEN u:10 IS NULL THEN column9:9 ELSE u:10 END [as=upsert_u:14, type=int, outer=(9,10)]
+           ├── CASE WHEN u:10 IS NULL THEN u_default:9 ELSE u:10 END [as=upsert_u:14, type=int, outer=(9,10)]
            └── CASE WHEN u:10 IS NULL THEN z:8 ELSE v_new:13 END [as=upsert_v:15, type=int, outer=(8,10,13)]
 
 # Multiple conflict columns.

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -947,20 +947,20 @@ insert xy
  ├── arbiter indexes: primary
  ├── insert-mapping:
  │    ├── y:5 => x:1
- │    └── column7:7 => y:2
+ │    └── y_default:7 => y:2
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── limit
-      ├── columns: y:5!null column7:7
+      ├── columns: y:5!null y_default:7
       ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(5,7)
       ├── anti-join (hash)
-      │    ├── columns: y:5!null column7:7
+      │    ├── columns: y:5!null y_default:7
       │    ├── fd: ()-->(5,7)
       │    ├── limit hint: 1.00
       │    ├── project
-      │    │    ├── columns: column7:7 y:5!null
+      │    │    ├── columns: y_default:7 y:5!null
       │    │    ├── fd: ()-->(5,7)
       │    │    ├── select
       │    │    │    ├── columns: y:5!null
@@ -970,7 +970,7 @@ insert xy
       │    │    │    └── filters
       │    │    │         └── y:5 = 0 [outer=(5), constraints=(/5: [/0 - /0]; tight), fd=()-->(5)]
       │    │    └── projections
-      │    │         └── CAST(NULL AS INT8) [as=column7:7]
+      │    │         └── CAST(NULL AS INT8) [as=y_default:7]
       │    ├── scan xy
       │    │    ├── columns: x:8!null
       │    │    └── key: (8)
@@ -991,30 +991,30 @@ upsert xy
  ├── fetch columns: x:8 y:9
  ├── insert-mapping:
  │    ├── y:5 => x:1
- │    └── column7:7 => y:2
+ │    └── y_default:7 => y:2
  ├── update-mapping:
  │    └── upsert_y:13 => y:2
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: upsert_y:13 y:5!null column7:7 x:8 y:9
+      ├── columns: upsert_y:13 y:5!null y_default:7 x:8 y:9
       ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(5,7-9,13)
       ├── left-join (hash)
-      │    ├── columns: y:5!null column7:7 x:8 y:9
+      │    ├── columns: y:5!null y_default:7 x:8 y:9
       │    ├── cardinality: [0 - 1]
       │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
       │    ├── key: ()
       │    ├── fd: ()-->(5,7-9)
       │    ├── max1-row
-      │    │    ├── columns: y:5!null column7:7
+      │    │    ├── columns: y:5!null y_default:7
       │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(5,7)
       │    │    └── project
-      │    │         ├── columns: column7:7 y:5!null
+      │    │         ├── columns: y_default:7 y:5!null
       │    │         ├── fd: ()-->(5,7)
       │    │         ├── select
       │    │         │    ├── columns: y:5!null
@@ -1024,7 +1024,7 @@ upsert xy
       │    │         │    └── filters
       │    │         │         └── y:5 = 0 [outer=(5), constraints=(/5: [/0 - /0]; tight), fd=()-->(5)]
       │    │         └── projections
-      │    │              └── CAST(NULL AS INT8) [as=column7:7]
+      │    │              └── CAST(NULL AS INT8) [as=y_default:7]
       │    ├── scan xy
       │    │    ├── columns: x:8!null y:9
       │    │    ├── key: (8)
@@ -1032,7 +1032,7 @@ upsert xy
       │    └── filters
       │         └── y:5 = x:8 [outer=(5,8), constraints=(/5: (/NULL - ]; /8: (/NULL - ]), fd=(5)==(8), (8)==(5)]
       └── projections
-           └── CASE WHEN x:8 IS NULL THEN column7:7 ELSE 1 END [as=upsert_y:13, outer=(7,8)]
+           └── CASE WHEN x:8 IS NULL THEN y_default:7 ELSE 1 END [as=upsert_y:13, outer=(7,8)]
 
 # UpsertDistinctOn should not reduce nullable constant grouping column.
 norm expect-not=ReduceNotNullGroupingCols
@@ -1045,19 +1045,19 @@ insert xy
  ├── arbiter indexes: primary
  ├── insert-mapping:
  │    ├── y:5 => x:1
- │    └── column7:7 => y:2
+ │    └── y_default:7 => y:2
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── upsert-distinct-on
-      ├── columns: y:5 column7:7
+      ├── columns: y:5 y_default:7
       ├── grouping columns: y:5
       ├── lax-key: (5)
       ├── fd: ()-->(5,7)
       ├── anti-join (hash)
-      │    ├── columns: y:5 column7:7
+      │    ├── columns: y:5 y_default:7
       │    ├── fd: ()-->(5,7)
       │    ├── project
-      │    │    ├── columns: column7:7 y:5
+      │    │    ├── columns: y_default:7 y:5
       │    │    ├── fd: ()-->(5,7)
       │    │    ├── select
       │    │    │    ├── columns: y:5
@@ -1067,15 +1067,15 @@ insert xy
       │    │    │    └── filters
       │    │    │         └── y:5 IS NULL [outer=(5), constraints=(/5: [/NULL - /NULL]; tight), fd=()-->(5)]
       │    │    └── projections
-      │    │         └── CAST(NULL AS INT8) [as=column7:7]
+      │    │         └── CAST(NULL AS INT8) [as=y_default:7]
       │    ├── scan xy
       │    │    ├── columns: x:8!null
       │    │    └── key: (8)
       │    └── filters
       │         └── y:5 = x:8 [outer=(5,8), constraints=(/5: (/NULL - ]; /8: (/NULL - ]), fd=(5)==(8), (8)==(5)]
       └── aggregations
-           └── first-agg [as=column7:7, outer=(7)]
-                └── column7:7
+           └── first-agg [as=y_default:7, outer=(7)]
+                └── y_default:7
 
 # EnsureUpsertDistinctOn should not reduce nullable constant grouping column.
 norm expect-not=ReduceNotNullGroupingCols
@@ -1090,28 +1090,28 @@ upsert xy
  ├── fetch columns: x:8 y:9
  ├── insert-mapping:
  │    ├── y:5 => x:1
- │    └── column7:7 => y:2
+ │    └── y_default:7 => y:2
  ├── update-mapping:
  │    └── upsert_y:13 => y:2
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: upsert_y:13 y:5 column7:7 x:8 y:9
+      ├── columns: upsert_y:13 y:5 y_default:7 x:8 y:9
       ├── lax-key: (5,8)
       ├── fd: ()-->(5,7), (8)-->(9,13)
       ├── left-join (hash)
-      │    ├── columns: y:5 column7:7 x:8 y:9
+      │    ├── columns: y:5 y_default:7 x:8 y:9
       │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
       │    ├── lax-key: (5,8)
       │    ├── fd: ()-->(5,7), (8)-->(9)
       │    ├── ensure-upsert-distinct-on
-      │    │    ├── columns: y:5 column7:7
+      │    │    ├── columns: y:5 y_default:7
       │    │    ├── grouping columns: y:5
       │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
       │    │    ├── lax-key: (5)
       │    │    ├── fd: ()-->(5,7)
       │    │    ├── project
-      │    │    │    ├── columns: column7:7 y:5
+      │    │    │    ├── columns: y_default:7 y:5
       │    │    │    ├── fd: ()-->(5,7)
       │    │    │    ├── select
       │    │    │    │    ├── columns: y:5
@@ -1121,10 +1121,10 @@ upsert xy
       │    │    │    │    └── filters
       │    │    │    │         └── y:5 IS NULL [outer=(5), constraints=(/5: [/NULL - /NULL]; tight), fd=()-->(5)]
       │    │    │    └── projections
-      │    │    │         └── CAST(NULL AS INT8) [as=column7:7]
+      │    │    │         └── CAST(NULL AS INT8) [as=y_default:7]
       │    │    └── aggregations
-      │    │         └── first-agg [as=column7:7, outer=(7)]
-      │    │              └── column7:7
+      │    │         └── first-agg [as=y_default:7, outer=(7)]
+      │    │              └── y_default:7
       │    ├── scan xy
       │    │    ├── columns: x:8!null y:9
       │    │    ├── key: (8)
@@ -1132,7 +1132,7 @@ upsert xy
       │    └── filters
       │         └── y:5 = x:8 [outer=(5,8), constraints=(/5: (/NULL - ]; /8: (/NULL - ]), fd=(5)==(8), (8)==(5)]
       └── projections
-           └── CASE WHEN x:8 IS NULL THEN column7:7 ELSE 1 END [as=upsert_y:13, outer=(7,8)]
+           └── CASE WHEN x:8 IS NULL THEN y_default:7 ELSE 1 END [as=upsert_y:13, outer=(7,8)]
 
 # Test removal of 2/3 grouping columns.
 norm expect=ReduceNotNullGroupingCols
@@ -1669,22 +1669,22 @@ insert a
  ├── insert-mapping:
  │    ├── "?column?":13 => k:1
  │    ├── i:8 => i:2
- │    ├── column15:15 => f:3
+ │    ├── f_default:15 => f:3
  │    ├── "?column?":14 => s:4
- │    └── column16:16 => j:5
+ │    └── j_default:16 => j:5
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── limit
-      ├── columns: i:8!null "?column?":13!null "?column?":14!null column15:15 column16:16
+      ├── columns: i:8!null "?column?":13!null "?column?":14!null f_default:15 j_default:16
       ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(8,13-16)
       ├── anti-join (hash)
-      │    ├── columns: i:8!null "?column?":13!null "?column?":14!null column15:15 column16:16
+      │    ├── columns: i:8!null "?column?":13!null "?column?":14!null f_default:15 j_default:16
       │    ├── fd: ()-->(8,13-16)
       │    ├── limit hint: 1.00
       │    ├── project
-      │    │    ├── columns: column15:15 column16:16 "?column?":13!null "?column?":14!null i:8!null
+      │    │    ├── columns: f_default:15 j_default:16 "?column?":13!null "?column?":14!null i:8!null
       │    │    ├── fd: ()-->(8,13-16)
       │    │    ├── select
       │    │    │    ├── columns: i:8!null
@@ -1694,8 +1694,8 @@ insert a
       │    │    │    └── filters
       │    │    │         └── i:8 = 1 [outer=(8), constraints=(/8: [/1 - /1]; tight), fd=()-->(8)]
       │    │    └── projections
-      │    │         ├── CAST(NULL AS FLOAT8) [as=column15:15]
-      │    │         ├── CAST(NULL AS JSONB) [as=column16:16]
+      │    │         ├── CAST(NULL AS FLOAT8) [as=f_default:15]
+      │    │         ├── CAST(NULL AS JSONB) [as=j_default:16]
       │    │         ├── 1 [as="?column?":13]
       │    │         └── 'foo' [as="?column?":14]
       │    ├── select
@@ -1768,32 +1768,32 @@ upsert a
  ├── insert-mapping:
  │    ├── "?column?":13 => k:1
  │    ├── i:8 => i:2
- │    ├── column15:15 => f:3
+ │    ├── f_default:15 => f:3
  │    ├── "?column?":14 => s:4
- │    └── column16:16 => j:5
+ │    └── j_default:16 => j:5
  ├── update-mapping:
  │    └── upsert_f:26 => f:3
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: upsert_f:26 i:8!null "?column?":13!null "?column?":14!null column15:15 column16:16 k:17 i:18 f:19 s:20 j:21
+      ├── columns: upsert_f:26 i:8!null "?column?":13!null "?column?":14!null f_default:15 j_default:16 k:17 i:18 f:19 s:20 j:21
       ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(8,13-21,26)
       ├── left-join (hash)
-      │    ├── columns: i:8!null "?column?":13!null "?column?":14!null column15:15 column16:16 k:17 i:18 f:19 s:20 j:21
+      │    ├── columns: i:8!null "?column?":13!null "?column?":14!null f_default:15 j_default:16 k:17 i:18 f:19 s:20 j:21
       │    ├── cardinality: [0 - 1]
       │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
       │    ├── key: ()
       │    ├── fd: ()-->(8,13-21)
       │    ├── max1-row
-      │    │    ├── columns: i:8!null "?column?":13!null "?column?":14!null column15:15 column16:16
+      │    │    ├── columns: i:8!null "?column?":13!null "?column?":14!null f_default:15 j_default:16
       │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(8,13-16)
       │    │    └── project
-      │    │         ├── columns: column15:15 column16:16 "?column?":13!null "?column?":14!null i:8!null
+      │    │         ├── columns: f_default:15 j_default:16 "?column?":13!null "?column?":14!null i:8!null
       │    │         ├── fd: ()-->(8,13-16)
       │    │         ├── select
       │    │         │    ├── columns: i:8!null
@@ -1803,8 +1803,8 @@ upsert a
       │    │         │    └── filters
       │    │         │         └── i:8 = 1 [outer=(8), constraints=(/8: [/1 - /1]; tight), fd=()-->(8)]
       │    │         └── projections
-      │    │              ├── CAST(NULL AS FLOAT8) [as=column15:15]
-      │    │              ├── CAST(NULL AS JSONB) [as=column16:16]
+      │    │              ├── CAST(NULL AS FLOAT8) [as=f_default:15]
+      │    │              ├── CAST(NULL AS JSONB) [as=j_default:16]
       │    │              ├── 1 [as="?column?":13]
       │    │              └── 'foo' [as="?column?":14]
       │    ├── scan a
@@ -1815,7 +1815,7 @@ upsert a
       │         ├── i:8 = i:18 [outer=(8,18), constraints=(/8: (/NULL - ]; /18: (/NULL - ]), fd=(8)==(18), (18)==(8)]
       │         └── "?column?":14 = s:20 [outer=(14,20), constraints=(/14: (/NULL - ]; /20: (/NULL - ]), fd=(14)==(20), (20)==(14)]
       └── projections
-           └── CASE WHEN s:20 IS NULL THEN column15:15 ELSE 1.1 END [as=upsert_f:26, outer=(15,20)]
+           └── CASE WHEN s:20 IS NULL THEN f_default:15 ELSE 1.1 END [as=upsert_f:26, outer=(15,20)]
 
 # --------------------------------------------------
 # EliminateDistinctOnValues
@@ -2110,17 +2110,17 @@ insert a
  ├── insert-mapping:
  │    ├── column1:7 => k:1
  │    ├── column3:9 => i:2
- │    ├── column10:10 => f:3
+ │    ├── f_default:10 => f:3
  │    ├── column2:8 => s:4
- │    └── column11:11 => j:5
+ │    └── j_default:11 => j:5
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── anti-join (hash)
-      ├── columns: column1:7!null column2:8 column3:9 column10:10 column11:11
+      ├── columns: column1:7!null column2:8 column3:9 f_default:10 j_default:11
       ├── cardinality: [0 - 2]
       ├── fd: ()-->(10,11)
       ├── project
-      │    ├── columns: column10:10 column11:11 column1:7!null column2:8 column3:9
+      │    ├── columns: f_default:10 j_default:11 column1:7!null column2:8 column3:9
       │    ├── cardinality: [2 - 2]
       │    ├── fd: ()-->(10,11)
       │    ├── values
@@ -2129,8 +2129,8 @@ insert a
       │    │    ├── (1, NULL, NULL)
       │    │    └── (1, NULL, NULL)
       │    └── projections
-      │         ├── CAST(NULL AS FLOAT8) [as=column10:10]
-      │         └── CAST(NULL AS JSONB) [as=column11:11]
+      │         ├── CAST(NULL AS FLOAT8) [as=f_default:10]
+      │         └── CAST(NULL AS JSONB) [as=j_default:11]
       ├── scan a
       │    ├── columns: i:13!null s:15!null
       │    └── key: (13,15)
@@ -2151,24 +2151,24 @@ upsert a
  ├── insert-mapping:
  │    ├── column1:7 => k:1
  │    ├── column3:9 => i:2
- │    ├── column10:10 => f:3
+ │    ├── f_default:10 => f:3
  │    ├── column2:8 => s:4
- │    └── column11:11 => j:5
+ │    └── j_default:11 => j:5
  ├── update-mapping:
  │    └── upsert_f:21 => f:3
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: upsert_f:21 column1:7!null column2:8 column3:9 column10:10 column11:11 k:12 i:13 f:14 s:15 j:16
+      ├── columns: upsert_f:21 column1:7!null column2:8 column3:9 f_default:10 j_default:11 k:12 i:13 f:14 s:15 j:16
       ├── cardinality: [2 - 2]
       ├── fd: ()-->(10,11), (12)-->(13-16), (13,15)-->(12,14,16), (13,14)~~>(12,15,16)
       ├── left-join (hash)
-      │    ├── columns: column1:7!null column2:8 column3:9 column10:10 column11:11 k:12 i:13 f:14 s:15 j:16
+      │    ├── columns: column1:7!null column2:8 column3:9 f_default:10 j_default:11 k:12 i:13 f:14 s:15 j:16
       │    ├── cardinality: [2 - 2]
       │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
       │    ├── fd: ()-->(10,11), (12)-->(13-16), (13,15)-->(12,14,16), (13,14)~~>(12,15,16)
       │    ├── project
-      │    │    ├── columns: column10:10 column11:11 column1:7!null column2:8 column3:9
+      │    │    ├── columns: f_default:10 j_default:11 column1:7!null column2:8 column3:9
       │    │    ├── cardinality: [2 - 2]
       │    │    ├── fd: ()-->(10,11)
       │    │    ├── values
@@ -2177,8 +2177,8 @@ upsert a
       │    │    │    ├── (1, NULL, NULL)
       │    │    │    └── (1, NULL, NULL)
       │    │    └── projections
-      │    │         ├── CAST(NULL AS FLOAT8) [as=column10:10]
-      │    │         └── CAST(NULL AS JSONB) [as=column11:11]
+      │    │         ├── CAST(NULL AS FLOAT8) [as=f_default:10]
+      │    │         └── CAST(NULL AS JSONB) [as=j_default:11]
       │    ├── scan a
       │    │    ├── columns: k:12!null i:13!null f:14 s:15!null j:16
       │    │    ├── key: (12)
@@ -2187,7 +2187,7 @@ upsert a
       │         ├── column3:9 = i:13 [outer=(9,13), constraints=(/9: (/NULL - ]; /13: (/NULL - ]), fd=(9)==(13), (13)==(9)]
       │         └── column2:8 = s:15 [outer=(8,15), constraints=(/8: (/NULL - ]; /15: (/NULL - ]), fd=(8)==(15), (15)==(8)]
       └── projections
-           └── CASE WHEN s:15 IS NULL THEN column10:10 ELSE 1.0 END [as=upsert_f:21, outer=(10,15)]
+           └── CASE WHEN s:15 IS NULL THEN f_default:10 ELSE 1.0 END [as=upsert_f:21, outer=(10,15)]
 
 # EnsureUpsertDistinctOn is not removed when there are duplicates.
 norm expect-not=EliminateDistinctOnValues
@@ -2202,33 +2202,33 @@ upsert a
  ├── insert-mapping:
  │    ├── column1:7 => k:1
  │    ├── column3:9 => i:2
- │    ├── column10:10 => f:3
+ │    ├── f_default:10 => f:3
  │    ├── column2:8 => s:4
- │    └── column11:11 => j:5
+ │    └── j_default:11 => j:5
  ├── update-mapping:
  │    └── upsert_f:21 => f:3
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: upsert_f:21 column1:7!null column2:8!null column3:9!null column10:10 column11:11 k:12 i:13 f:14 s:15 j:16
+      ├── columns: upsert_f:21 column1:7!null column2:8!null column3:9!null f_default:10 j_default:11 k:12 i:13 f:14 s:15 j:16
       ├── cardinality: [1 - 3]
       ├── key: (8,9)
       ├── fd: ()-->(10,11), (8,9)-->(7,12-16,21), (12)-->(13-16), (13,15)-->(12,14,16), (13,14)~~>(12,15,16)
       ├── left-join (hash)
-      │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11 k:12 i:13 f:14 s:15 j:16
+      │    ├── columns: column1:7!null column2:8!null column3:9!null f_default:10 j_default:11 k:12 i:13 f:14 s:15 j:16
       │    ├── cardinality: [1 - 3]
       │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
       │    ├── key: (8,9)
       │    ├── fd: ()-->(10,11), (8,9)-->(7,12-16), (12)-->(13-16), (13,15)-->(12,14,16), (13,14)~~>(12,15,16)
       │    ├── ensure-upsert-distinct-on
-      │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      │    │    ├── columns: column1:7!null column2:8!null column3:9!null f_default:10 j_default:11
       │    │    ├── grouping columns: column2:8!null column3:9!null
       │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
       │    │    ├── cardinality: [1 - 3]
       │    │    ├── key: (8,9)
       │    │    ├── fd: ()-->(10,11), (8,9)-->(7,10,11)
       │    │    ├── project
-      │    │    │    ├── columns: column10:10 column11:11 column1:7!null column2:8!null column3:9!null
+      │    │    │    ├── columns: f_default:10 j_default:11 column1:7!null column2:8!null column3:9!null
       │    │    │    ├── cardinality: [3 - 3]
       │    │    │    ├── fd: ()-->(10,11)
       │    │    │    ├── values
@@ -2238,15 +2238,15 @@ upsert a
       │    │    │    │    ├── (2, 'bar', 2)
       │    │    │    │    └── (3, 'foo', 1)
       │    │    │    └── projections
-      │    │    │         ├── CAST(NULL AS FLOAT8) [as=column10:10]
-      │    │    │         └── CAST(NULL AS JSONB) [as=column11:11]
+      │    │    │         ├── CAST(NULL AS FLOAT8) [as=f_default:10]
+      │    │    │         └── CAST(NULL AS JSONB) [as=j_default:11]
       │    │    └── aggregations
       │    │         ├── first-agg [as=column1:7, outer=(7)]
       │    │         │    └── column1:7
-      │    │         ├── first-agg [as=column10:10, outer=(10)]
-      │    │         │    └── column10:10
-      │    │         └── first-agg [as=column11:11, outer=(11)]
-      │    │              └── column11:11
+      │    │         ├── first-agg [as=f_default:10, outer=(10)]
+      │    │         │    └── f_default:10
+      │    │         └── first-agg [as=j_default:11, outer=(11)]
+      │    │              └── j_default:11
       │    ├── scan a
       │    │    ├── columns: k:12!null i:13!null f:14 s:15!null j:16
       │    │    ├── key: (12)
@@ -2255,7 +2255,7 @@ upsert a
       │         ├── column3:9 = i:13 [outer=(9,13), constraints=(/9: (/NULL - ]; /13: (/NULL - ]), fd=(9)==(13), (13)==(9)]
       │         └── column2:8 = s:15 [outer=(8,15), constraints=(/8: (/NULL - ]; /15: (/NULL - ]), fd=(8)==(15), (15)==(8)]
       └── projections
-           └── CASE WHEN s:15 IS NULL THEN column10:10 ELSE 1.0 END [as=upsert_f:21, outer=(10,15)]
+           └── CASE WHEN s:15 IS NULL THEN f_default:10 ELSE 1.0 END [as=upsert_f:21, outer=(10,15)]
 
 # DO NOTHING case where all distinct ops can be removed.
 norm expect=EliminateDistinctOnValues
@@ -2270,23 +2270,23 @@ insert a
  │    ├── column3:9 => i:2
  │    ├── column4:10 => f:3
  │    ├── column2:8 => s:4
- │    └── column11:11 => j:5
+ │    └── j_default:11 => j:5
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── anti-join (hash)
-      ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column11:11
+      ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null j_default:11
       ├── cardinality: [0 - 3]
       ├── fd: ()-->(11)
       ├── anti-join (hash)
-      │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column11:11
+      │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null j_default:11
       │    ├── cardinality: [0 - 3]
       │    ├── fd: ()-->(11)
       │    ├── anti-join (hash)
-      │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column11:11
+      │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null j_default:11
       │    │    ├── cardinality: [0 - 3]
       │    │    ├── fd: ()-->(11)
       │    │    ├── project
-      │    │    │    ├── columns: column11:11 column1:7!null column2:8!null column3:9!null column4:10!null
+      │    │    │    ├── columns: j_default:11 column1:7!null column2:8!null column3:9!null column4:10!null
       │    │    │    ├── cardinality: [3 - 3]
       │    │    │    ├── fd: ()-->(11)
       │    │    │    ├── values
@@ -2296,7 +2296,7 @@ insert a
       │    │    │    │    ├── (2, 'bar', 2, 2.0)
       │    │    │    │    └── (3, 'foo', 2, 1.0)
       │    │    │    └── projections
-      │    │    │         └── CAST(NULL AS JSONB) [as=column11:11]
+      │    │    │         └── CAST(NULL AS JSONB) [as=j_default:11]
       │    │    ├── scan a
       │    │    │    ├── columns: k:12!null
       │    │    │    └── key: (12)
@@ -2326,38 +2326,38 @@ insert a
  ├── arbiter indexes: primary si_idx fi_idx
  ├── insert-mapping:
  │    ├── column1:7 => k:1
- │    ├── column10:10 => i:2
+ │    ├── i_default:10 => i:2
  │    ├── column3:9 => f:3
  │    ├── column2:8 => s:4
- │    └── column11:11 => j:5
+ │    └── j_default:11 => j:5
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── upsert-distinct-on
-      ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
-      ├── grouping columns: column3:9!null column10:10
+      ├── columns: column1:7!null column2:8!null column3:9!null i_default:10 j_default:11
+      ├── grouping columns: column3:9!null i_default:10
       ├── cardinality: [0 - 3]
       ├── lax-key: (8,10)
       ├── fd: ()-->(10,11), (8,10)~~>(7,9), (9,10)~~>(7,8,11)
       ├── upsert-distinct-on
-      │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
-      │    ├── grouping columns: column2:8!null column10:10
+      │    ├── columns: column1:7!null column2:8!null column3:9!null i_default:10 j_default:11
+      │    ├── grouping columns: column2:8!null i_default:10
       │    ├── cardinality: [0 - 3]
       │    ├── lax-key: (8,10)
       │    ├── fd: ()-->(10,11), (8,10)~~>(7,9,11)
       │    ├── anti-join (hash)
-      │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      │    │    ├── columns: column1:7!null column2:8!null column3:9!null i_default:10 j_default:11
       │    │    ├── cardinality: [0 - 3]
       │    │    ├── fd: ()-->(10,11)
       │    │    ├── anti-join (hash)
-      │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null i_default:10 j_default:11
       │    │    │    ├── cardinality: [0 - 3]
       │    │    │    ├── fd: ()-->(10,11)
       │    │    │    ├── anti-join (hash)
-      │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null i_default:10 j_default:11
       │    │    │    │    ├── cardinality: [0 - 3]
       │    │    │    │    ├── fd: ()-->(10,11)
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: column10:10 column11:11 column1:7!null column2:8!null column3:9!null
+      │    │    │    │    │    ├── columns: i_default:10 j_default:11 column1:7!null column2:8!null column3:9!null
       │    │    │    │    │    ├── cardinality: [3 - 3]
       │    │    │    │    │    ├── fd: ()-->(10,11)
       │    │    │    │    │    ├── values
@@ -2367,8 +2367,8 @@ insert a
       │    │    │    │    │    │    ├── (2, 'bar', 2.0)
       │    │    │    │    │    │    └── (3, 'foo', 1.0)
       │    │    │    │    │    └── projections
-      │    │    │    │    │         ├── CAST(NULL AS INT8) [as=column10:10]
-      │    │    │    │    │         └── CAST(NULL AS JSONB) [as=column11:11]
+      │    │    │    │    │         ├── CAST(NULL AS INT8) [as=i_default:10]
+      │    │    │    │    │         └── CAST(NULL AS JSONB) [as=j_default:11]
       │    │    │    │    ├── scan a
       │    │    │    │    │    ├── columns: k:12!null
       │    │    │    │    │    └── key: (12)
@@ -2378,28 +2378,28 @@ insert a
       │    │    │    │    ├── columns: i:19!null s:21!null
       │    │    │    │    └── key: (19,21)
       │    │    │    └── filters
-      │    │    │         ├── column10:10 = i:19 [outer=(10,19), constraints=(/10: (/NULL - ]; /19: (/NULL - ]), fd=(10)==(19), (19)==(10)]
+      │    │    │         ├── i_default:10 = i:19 [outer=(10,19), constraints=(/10: (/NULL - ]; /19: (/NULL - ]), fd=(10)==(19), (19)==(10)]
       │    │    │         └── column2:8 = s:21 [outer=(8,21), constraints=(/8: (/NULL - ]; /21: (/NULL - ]), fd=(8)==(21), (21)==(8)]
       │    │    ├── scan a
       │    │    │    ├── columns: i:25!null f:26
       │    │    │    └── lax-key: (25,26)
       │    │    └── filters
-      │    │         ├── column10:10 = i:25 [outer=(10,25), constraints=(/10: (/NULL - ]; /25: (/NULL - ]), fd=(10)==(25), (25)==(10)]
+      │    │         ├── i_default:10 = i:25 [outer=(10,25), constraints=(/10: (/NULL - ]; /25: (/NULL - ]), fd=(10)==(25), (25)==(10)]
       │    │         └── column3:9 = f:26 [outer=(9,26), constraints=(/9: (/NULL - ]; /26: (/NULL - ]), fd=(9)==(26), (26)==(9)]
       │    └── aggregations
       │         ├── first-agg [as=column1:7, outer=(7)]
       │         │    └── column1:7
       │         ├── first-agg [as=column3:9, outer=(9)]
       │         │    └── column3:9
-      │         └── first-agg [as=column11:11, outer=(11)]
-      │              └── column11:11
+      │         └── first-agg [as=j_default:11, outer=(11)]
+      │              └── j_default:11
       └── aggregations
            ├── first-agg [as=column1:7, outer=(7)]
            │    └── column1:7
            ├── first-agg [as=column2:8, outer=(8)]
            │    └── column2:8
-           └── first-agg [as=column11:11, outer=(11)]
-                └── column11:11
+           └── first-agg [as=j_default:11, outer=(11)]
+                └── j_default:11
 
 # DO NOTHING case where innermost distinct op cannot be removed (because it
 # groups on a non-constant column). Ensure that outer distinct ops can still be
@@ -2416,33 +2416,33 @@ insert a
  │    ├── column3:9 => i:2
  │    ├── column4:10 => f:3
  │    ├── column2:8 => s:4
- │    └── column11:11 => j:5
+ │    └── j_default:11 => j:5
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── upsert-distinct-on
-      ├── columns: column1:7 column2:8!null column3:9!null column4:10!null column11:11
+      ├── columns: column1:7 column2:8!null column3:9!null column4:10!null j_default:11
       ├── grouping columns: column1:7
       ├── cardinality: [0 - 2]
       ├── volatile
       ├── lax-key: (7)
       ├── fd: ()-->(11), (7)~~>(8-11)
       ├── anti-join (hash)
-      │    ├── columns: column1:7 column2:8!null column3:9!null column4:10!null column11:11
+      │    ├── columns: column1:7 column2:8!null column3:9!null column4:10!null j_default:11
       │    ├── cardinality: [0 - 2]
       │    ├── volatile
       │    ├── fd: ()-->(11)
       │    ├── anti-join (hash)
-      │    │    ├── columns: column1:7 column2:8!null column3:9!null column4:10!null column11:11
+      │    │    ├── columns: column1:7 column2:8!null column3:9!null column4:10!null j_default:11
       │    │    ├── cardinality: [0 - 2]
       │    │    ├── volatile
       │    │    ├── fd: ()-->(11)
       │    │    ├── anti-join (hash)
-      │    │    │    ├── columns: column1:7 column2:8!null column3:9!null column4:10!null column11:11
+      │    │    │    ├── columns: column1:7 column2:8!null column3:9!null column4:10!null j_default:11
       │    │    │    ├── cardinality: [0 - 2]
       │    │    │    ├── volatile
       │    │    │    ├── fd: ()-->(11)
       │    │    │    ├── project
-      │    │    │    │    ├── columns: column11:11 column1:7 column2:8!null column3:9!null column4:10!null
+      │    │    │    │    ├── columns: j_default:11 column1:7 column2:8!null column3:9!null column4:10!null
       │    │    │    │    ├── cardinality: [2 - 2]
       │    │    │    │    ├── volatile
       │    │    │    │    ├── fd: ()-->(11)
@@ -2453,7 +2453,7 @@ insert a
       │    │    │    │    │    ├── (unique_rowid(), 'foo', 1, 1.0)
       │    │    │    │    │    └── (unique_rowid(), 'bar', 2, 2.0)
       │    │    │    │    └── projections
-      │    │    │    │         └── CAST(NULL AS JSONB) [as=column11:11]
+      │    │    │    │         └── CAST(NULL AS JSONB) [as=j_default:11]
       │    │    │    ├── scan a
       │    │    │    │    ├── columns: k:12!null
       │    │    │    │    └── key: (12)
@@ -2478,8 +2478,8 @@ insert a
            │    └── column3:9
            ├── first-agg [as=column4:10, outer=(10)]
            │    └── column4:10
-           └── first-agg [as=column11:11, outer=(11)]
-                └── column11:11
+           └── first-agg [as=j_default:11, outer=(11)]
+                └── j_default:11
 
 # DO NOTHING case with explicit conflict columns (only add upsert-distinct-on
 # for one index).
@@ -2493,27 +2493,27 @@ insert a
  ├── insert-mapping:
  │    ├── i:8 => k:1
  │    ├── i:8 => i:2
- │    ├── column14:14 => f:3
+ │    ├── f_default:14 => f:3
  │    ├── "?column?":13 => s:4
- │    └── column15:15 => j:5
+ │    └── j_default:15 => j:5
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── upsert-distinct-on
-      ├── columns: i:8!null "?column?":13!null column14:14 column15:15
+      ├── columns: i:8!null "?column?":13!null f_default:14 j_default:15
       ├── grouping columns: i:8!null
       ├── key: (8)
       ├── fd: ()-->(13-15)
       ├── anti-join (hash)
-      │    ├── columns: i:8!null "?column?":13!null column14:14 column15:15
+      │    ├── columns: i:8!null "?column?":13!null f_default:14 j_default:15
       │    ├── fd: ()-->(13-15)
       │    ├── project
-      │    │    ├── columns: column14:14 column15:15 "?column?":13!null i:8!null
+      │    │    ├── columns: f_default:14 j_default:15 "?column?":13!null i:8!null
       │    │    ├── fd: ()-->(13-15)
       │    │    ├── scan a
       │    │    │    └── columns: i:8!null
       │    │    └── projections
-      │    │         ├── CAST(NULL AS FLOAT8) [as=column14:14]
-      │    │         ├── CAST(NULL AS JSONB) [as=column15:15]
+      │    │         ├── CAST(NULL AS FLOAT8) [as=f_default:14]
+      │    │         ├── CAST(NULL AS JSONB) [as=j_default:15]
       │    │         └── 'foo' [as="?column?":13]
       │    ├── select
       │    │    ├── columns: i:17!null s:19!null
@@ -2527,10 +2527,10 @@ insert a
       │    └── filters
       │         └── i:8 = i:17 [outer=(8,17), constraints=(/8: (/NULL - ]; /17: (/NULL - ]), fd=(8)==(17), (17)==(8)]
       └── aggregations
-           ├── first-agg [as=column14:14, outer=(14)]
-           │    └── column14:14
-           ├── first-agg [as=column15:15, outer=(15)]
-           │    └── column15:15
+           ├── first-agg [as=f_default:14, outer=(14)]
+           │    └── f_default:14
+           ├── first-agg [as=j_default:15, outer=(15)]
+           │    └── j_default:15
            └── const-agg [as="?column?":13, outer=(13)]
                 └── "?column?":13
 

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -183,11 +183,11 @@ update computed
  ├── update-mapping:
  │    ├── a_new:9 => a:1
  │    ├── b_new:10 => b:2
- │    └── column11:11 => c:3
+ │    └── c_comp:11 => c:3
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: column11:11!null a_new:9!null b_new:10!null a:5!null b:6 c:7
+      ├── columns: c_comp:11!null a_new:9!null b_new:10!null a:5!null b:6 c:7
       ├── key: (5)
       ├── fd: ()-->(9-11), (5)-->(6,7)
       ├── scan computed
@@ -198,7 +198,7 @@ update computed
       │    ├── key: (5)
       │    └── fd: (5)-->(6,7)
       └── projections
-           ├── 4 [as=column11:11]
+           ├── 4 [as=c_comp:11]
            ├── 1 [as=a_new:9]
            └── 2 [as=b_new:10]
 

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -2090,11 +2090,11 @@ update computed
  ├── fetch columns: a:7 b:8 x:11
  ├── update-mapping:
  │    ├── b_new:13 => b:2
- │    └── column15:15 => x:5
+ │    └── x_comp:15 => x:5
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: column15:15 b_new:13!null a:7!null b:8!null x:11
+      ├── columns: x_comp:15 b_new:13!null a:7!null b:8!null x:11
       ├── immutable
       ├── key: (7)
       ├── fd: ()-->(8,13), (7)-->(11,15)
@@ -2112,7 +2112,7 @@ update computed
       │    └── filters
       │         └── b:8 = 1 [outer=(8), constraints=(/8: [/1 - /1]; tight), fd=()-->(8)]
       └── projections
-           ├── c:9 + 10 [as=column15:15, outer=(9), immutable]
+           ├── c:9 + 10 [as=x_comp:15, outer=(9), immutable]
            └── b:8 * 2 [as=b_new:13, outer=(8), immutable]
 
 # We should produce a value for the computed column d.
@@ -2124,12 +2124,12 @@ update computed
  ├── fetch columns: a:7 c:9 d:10 x:11
  ├── update-mapping:
  │    ├── c_new:13 => c:3
- │    ├── column14:14 => d:4
- │    └── column15:15 => x:5
+ │    ├── d_comp:14 => d:4
+ │    └── x_comp:15 => x:5
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: column14:14 column15:15 a:7!null c:9 d:10 x:11 c_new:13
+      ├── columns: d_comp:14 x_comp:15 a:7!null c:9 d:10 x:11 c_new:13
       ├── immutable
       ├── key: (7)
       ├── fd: (7)-->(9-11), (9)-->(10,13), (13)-->(14,15)
@@ -2154,8 +2154,8 @@ update computed
       │    └── projections
       │         └── c:9 * 2 [as=c_new:13, outer=(9), immutable]
       └── projections
-           ├── c_new:13 + 1 [as=column14:14, outer=(13), immutable]
-           └── c_new:13 + 10 [as=column15:15, outer=(13), immutable]
+           ├── c_new:13 + 1 [as=d_comp:14, outer=(13), immutable]
+           └── c_new:13 + 10 [as=x_comp:15, outer=(13), immutable]
 
 # Prune UPDATE fetch columns when the partial index indexes the column but
 # neither the column nor the columns referenced in the partial index predicate
@@ -2250,8 +2250,8 @@ upsert partial_indexes
  ├── fetch columns: a:10 d:13
  ├── insert-mapping:
  │    ├── column1:6 => a:1
- │    ├── column8:8 => b:2
- │    ├── column9:9 => c:3
+ │    ├── b_default:8 => b:2
+ │    ├── c_default:9 => c:3
  │    └── column2:7 => d:4
  ├── update-mapping:
  │    └── column2:7 => d:4
@@ -2260,18 +2260,18 @@ upsert partial_indexes
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: partial_index_put1:18 partial_index_del1:19 column1:6!null column2:7!null column8:8 column9:9 a:10 d:13
+      ├── columns: partial_index_put1:18 partial_index_del1:19 column1:6!null column2:7!null b_default:8 c_default:9 a:10 d:13
       ├── cardinality: [1 - 1]
       ├── key: ()
       ├── fd: ()-->(6-10,13,18,19)
       ├── left-join (cross)
-      │    ├── columns: column1:6!null column2:7!null column8:8 column9:9 a:10 b:11 d:13
+      │    ├── columns: column1:6!null column2:7!null b_default:8 c_default:9 a:10 b:11 d:13
       │    ├── cardinality: [1 - 1]
       │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
       │    ├── key: ()
       │    ├── fd: ()-->(6-11,13)
       │    ├── values
-      │    │    ├── columns: column1:6!null column2:7!null column8:8 column9:9
+      │    │    ├── columns: column1:6!null column2:7!null b_default:8 c_default:9
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(6-9)
@@ -2292,7 +2292,7 @@ upsert partial_indexes
       │    │         └── a:10 = 1 [outer=(10), constraints=(/10: [/1 - /1]; tight), fd=()-->(10)]
       │    └── filters (true)
       └── projections
-           ├── CASE WHEN a:10 IS NULL THEN column8:8 ELSE b:11 END > 1 [as=partial_index_put1:18, outer=(8,10,11)]
+           ├── CASE WHEN a:10 IS NULL THEN b_default:8 ELSE b:11 END > 1 [as=partial_index_put1:18, outer=(8,10,11)]
            └── b:11 > 1 [as=partial_index_del1:19, outer=(11)]
 
 # Do not prune the indexed column c when a column in the partial index
@@ -2308,7 +2308,7 @@ upsert partial_indexes
  ├── insert-mapping:
  │    ├── column1:6 => a:1
  │    ├── column2:7 => b:2
- │    ├── column9:9 => c:3
+ │    ├── c_default:9 => c:3
  │    └── column3:8 => d:4
  ├── update-mapping:
  │    ├── column2:7 => b:2
@@ -2318,18 +2318,18 @@ upsert partial_indexes
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: partial_index_put1:17!null partial_index_del1:18 column1:6!null column2:7!null column3:8!null column9:9 a:10 b:11 c:12 d:13
+      ├── columns: partial_index_put1:17!null partial_index_del1:18 column1:6!null column2:7!null column3:8!null c_default:9 a:10 b:11 c:12 d:13
       ├── cardinality: [1 - 1]
       ├── key: ()
       ├── fd: ()-->(6-13,17,18)
       ├── left-join (cross)
-      │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9 a:10 b:11 c:12 d:13
+      │    ├── columns: column1:6!null column2:7!null column3:8!null c_default:9 a:10 b:11 c:12 d:13
       │    ├── cardinality: [1 - 1]
       │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
       │    ├── key: ()
       │    ├── fd: ()-->(6-13)
       │    ├── values
-      │    │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9
+      │    │    ├── columns: column1:6!null column2:7!null column3:8!null c_default:9
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(6-9)
@@ -2366,8 +2366,8 @@ upsert partial_indexes
  ├── fetch columns: a:10 d:13
  ├── insert-mapping:
  │    ├── column1:6 => a:1
- │    ├── column8:8 => b:2
- │    ├── column9:9 => c:3
+ │    ├── b_default:8 => b:2
+ │    ├── c_default:9 => c:3
  │    └── column2:7 => d:4
  ├── update-mapping:
  │    └── upsert_d:19 => d:4
@@ -2376,18 +2376,18 @@ upsert partial_indexes
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: partial_index_put1:20 partial_index_del1:21 upsert_d:19!null column1:6!null column2:7!null column8:8 column9:9 a:10 d:13
+      ├── columns: partial_index_put1:20 partial_index_del1:21 upsert_d:19!null column1:6!null column2:7!null b_default:8 c_default:9 a:10 d:13
       ├── cardinality: [1 - 1]
       ├── key: ()
       ├── fd: ()-->(6-10,13,19-21)
       ├── left-join (cross)
-      │    ├── columns: column1:6!null column2:7!null column8:8 column9:9 a:10 b:11 d:13
+      │    ├── columns: column1:6!null column2:7!null b_default:8 c_default:9 a:10 b:11 d:13
       │    ├── cardinality: [1 - 1]
       │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
       │    ├── key: ()
       │    ├── fd: ()-->(6-11,13)
       │    ├── values
-      │    │    ├── columns: column1:6!null column2:7!null column8:8 column9:9
+      │    │    ├── columns: column1:6!null column2:7!null b_default:8 c_default:9
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(6-9)
@@ -2408,7 +2408,7 @@ upsert partial_indexes
       │    │         └── a:10 = 1 [outer=(10), constraints=(/10: [/1 - /1]; tight), fd=()-->(10)]
       │    └── filters (true)
       └── projections
-           ├── CASE WHEN a:10 IS NULL THEN column8:8 ELSE b:11 END > 1 [as=partial_index_put1:20, outer=(8,10,11)]
+           ├── CASE WHEN a:10 IS NULL THEN b_default:8 ELSE b:11 END > 1 [as=partial_index_put1:20, outer=(8,10,11)]
            ├── b:11 > 1 [as=partial_index_del1:21, outer=(11)]
            └── CASE WHEN a:10 IS NULL THEN column2:7 ELSE 3 END [as=upsert_d:19, outer=(7,10)]
 
@@ -2424,8 +2424,8 @@ upsert partial_indexes
  ├── fetch columns: a:10 b:11 c:12 d:13
  ├── insert-mapping:
  │    ├── column1:6 => a:1
- │    ├── column8:8 => b:2
- │    ├── column9:9 => c:3
+ │    ├── b_default:8 => b:2
+ │    ├── c_default:9 => c:3
  │    └── column2:7 => d:4
  ├── update-mapping:
  │    ├── upsert_b:18 => b:2
@@ -2435,23 +2435,23 @@ upsert partial_indexes
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: partial_index_put1:21 partial_index_del1:22 column1:6!null column2:7!null column8:8 column9:9 a:10 b:11 c:12 d:13 upsert_b:18 upsert_d:20!null
+      ├── columns: partial_index_put1:21 partial_index_del1:22 column1:6!null column2:7!null b_default:8 c_default:9 a:10 b:11 c:12 d:13 upsert_b:18 upsert_d:20!null
       ├── cardinality: [1 - 1]
       ├── key: ()
       ├── fd: ()-->(6-13,18,20-22)
       ├── project
-      │    ├── columns: upsert_b:18 upsert_d:20!null column1:6!null column2:7!null column8:8 column9:9 a:10 b:11 c:12 d:13
+      │    ├── columns: upsert_b:18 upsert_d:20!null column1:6!null column2:7!null b_default:8 c_default:9 a:10 b:11 c:12 d:13
       │    ├── cardinality: [1 - 1]
       │    ├── key: ()
       │    ├── fd: ()-->(6-13,18,20)
       │    ├── left-join (cross)
-      │    │    ├── columns: column1:6!null column2:7!null column8:8 column9:9 a:10 b:11 c:12 d:13
+      │    │    ├── columns: column1:6!null column2:7!null b_default:8 c_default:9 a:10 b:11 c:12 d:13
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(6-13)
       │    │    ├── values
-      │    │    │    ├── columns: column1:6!null column2:7!null column8:8 column9:9
+      │    │    │    ├── columns: column1:6!null column2:7!null b_default:8 c_default:9
       │    │    │    ├── cardinality: [1 - 1]
       │    │    │    ├── key: ()
       │    │    │    ├── fd: ()-->(6-9)
@@ -2472,7 +2472,7 @@ upsert partial_indexes
       │    │    │         └── a:10 = 1 [outer=(10), constraints=(/10: [/1 - /1]; tight), fd=()-->(10)]
       │    │    └── filters (true)
       │    └── projections
-      │         ├── CASE WHEN a:10 IS NULL THEN column8:8 ELSE 3 END [as=upsert_b:18, outer=(8,10)]
+      │         ├── CASE WHEN a:10 IS NULL THEN b_default:8 ELSE 3 END [as=upsert_b:18, outer=(8,10)]
       │         └── CASE WHEN a:10 IS NULL THEN column2:7 ELSE 4 END [as=upsert_d:20, outer=(7,10)]
       └── projections
            ├── upsert_b:18 > 1 [as=partial_index_put1:21, outer=(18)]
@@ -2562,20 +2562,20 @@ update virt_partial_idx
  ├── fetch columns: a:7 b:8 v:9 c:10 d:11
  ├── update-mapping:
  │    ├── b_new:14 => b:2
- │    ├── column15:15 => v:3
+ │    ├── v_comp:15 => v:3
  │    └── d_new:13 => d:5
  ├── partial index put columns: partial_index_put1:16
  ├── partial index del columns: partial_index_del1:17
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: partial_index_put1:16!null partial_index_del1:17 a:7!null b:8 v:9 c:10 d:11 d_new:13 b_new:14!null column15:15!null
+      ├── columns: partial_index_put1:16!null partial_index_del1:17 a:7!null b:8 v:9 c:10 d:11 d_new:13 b_new:14!null v_comp:15!null
       ├── cardinality: [0 - 1]
       ├── immutable
       ├── key: ()
       ├── fd: ()-->(7-11,13-17)
       ├── project
-      │    ├── columns: column15:15!null d_new:13 b_new:14!null v:9 a:7!null b:8 c:10 d:11
+      │    ├── columns: v_comp:15!null d_new:13 b_new:14!null v:9 a:7!null b:8 c:10 d:11
       │    ├── cardinality: [0 - 1]
       │    ├── immutable
       │    ├── key: ()
@@ -2598,7 +2598,7 @@ update virt_partial_idx
       │    │    └── filters
       │    │         └── a:7 = 1 [outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
       │    └── projections
-      │         ├── 3 [as=column15:15]
+      │         ├── 3 [as=v_comp:15]
       │         ├── d:11 + 1 [as=d_new:13, outer=(11), immutable]
       │         ├── 2 [as=b_new:14]
       │         └── b:8 + 1 [as=v:9, outer=(8), immutable]
@@ -2619,9 +2619,9 @@ upsert virt_partial_idx
  ├── fetch columns: a:11 d:15
  ├── insert-mapping:
  │    ├── column1:7 => a:1
- │    ├── column9:9 => b:2
- │    ├── column10:10 => v:3
- │    ├── column9:9 => c:4
+ │    ├── b_default:9 => b:2
+ │    ├── v_comp:10 => v:3
+ │    ├── b_default:9 => c:4
  │    └── column2:8 => d:5
  ├── update-mapping:
  │    └── column2:8 => d:5
@@ -2630,20 +2630,20 @@ upsert virt_partial_idx
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: partial_index_put1:22 partial_index_del1:23 column1:7!null column2:8!null column9:9 column10:10 a:11 d:15
+      ├── columns: partial_index_put1:22 partial_index_del1:23 column1:7!null column2:8!null b_default:9 v_comp:10 a:11 d:15
       ├── cardinality: [1 - 1]
       ├── immutable
       ├── key: ()
       ├── fd: ()-->(7-11,15,22,23)
       ├── left-join (cross)
-      │    ├── columns: column1:7!null column2:8!null column9:9 column10:10 a:11 v:13 d:15
+      │    ├── columns: column1:7!null column2:8!null b_default:9 v_comp:10 a:11 v:13 d:15
       │    ├── cardinality: [1 - 1]
       │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
       │    ├── immutable
       │    ├── key: ()
       │    ├── fd: ()-->(7-11,13,15)
       │    ├── values
-      │    │    ├── columns: column1:7!null column2:8!null column9:9 column10:10
+      │    │    ├── columns: column1:7!null column2:8!null b_default:9 v_comp:10
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(7-10)
@@ -2675,7 +2675,7 @@ upsert virt_partial_idx
       │    │         └── b:12 + 1 [as=v:13, outer=(12), immutable]
       │    └── filters (true)
       └── projections
-           ├── CASE WHEN a:11 IS NULL THEN column10:10 ELSE v:13 END > 1 [as=partial_index_put1:22, outer=(10,11,13)]
+           ├── CASE WHEN a:11 IS NULL THEN v_comp:10 ELSE v:13 END > 1 [as=partial_index_put1:22, outer=(10,11,13)]
            └── v:13 > 1 [as=partial_index_del1:23, outer=(13)]
 
 # Do not prune the indexed column c because a column referenced in the partial
@@ -2691,32 +2691,32 @@ upsert virt_partial_idx
  ├── insert-mapping:
  │    ├── column1:7 => a:1
  │    ├── column2:8 => b:2
- │    ├── column11:11 => v:3
- │    ├── column10:10 => c:4
+ │    ├── v_comp:11 => v:3
+ │    ├── c_default:10 => c:4
  │    └── column3:9 => d:5
  ├── update-mapping:
  │    ├── column2:8 => b:2
- │    ├── column11:11 => v:3
+ │    ├── v_comp:11 => v:3
  │    └── column3:9 => d:5
  ├── partial index put columns: partial_index_put1:20
  ├── partial index del columns: partial_index_del1:21
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: partial_index_put1:20!null partial_index_del1:21 column1:7!null column2:8!null column3:9!null column10:10 column11:11!null a:12 b:13 v:14 c:15 d:16
+      ├── columns: partial_index_put1:20!null partial_index_del1:21 column1:7!null column2:8!null column3:9!null c_default:10 v_comp:11!null a:12 b:13 v:14 c:15 d:16
       ├── cardinality: [1 - 1]
       ├── immutable
       ├── key: ()
       ├── fd: ()-->(7-16,20,21)
       ├── left-join (cross)
-      │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11!null a:12 b:13 v:14 c:15 d:16
+      │    ├── columns: column1:7!null column2:8!null column3:9!null c_default:10 v_comp:11!null a:12 b:13 v:14 c:15 d:16
       │    ├── cardinality: [1 - 1]
       │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
       │    ├── immutable
       │    ├── key: ()
       │    ├── fd: ()-->(7-16)
       │    ├── values
-      │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11!null
+      │    │    ├── columns: column1:7!null column2:8!null column3:9!null c_default:10 v_comp:11!null
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(7-11)
@@ -2748,7 +2748,7 @@ upsert virt_partial_idx
       │    │         └── b:13 + 1 [as=v:14, outer=(13), immutable]
       │    └── filters (true)
       └── projections
-           ├── column11:11 > 1 [as=partial_index_put1:20, outer=(11)]
+           ├── v_comp:11 > 1 [as=partial_index_put1:20, outer=(11)]
            └── v:14 > 1 [as=partial_index_del1:21, outer=(14)]
 
 # Prune INSERT ON CONFLICT DO UPDATE fetch columns when neither the column
@@ -2764,9 +2764,9 @@ upsert virt_partial_idx
  ├── fetch columns: a:11 d:15
  ├── insert-mapping:
  │    ├── column1:7 => a:1
- │    ├── column9:9 => b:2
- │    ├── column10:10 => v:3
- │    ├── column9:9 => c:4
+ │    ├── b_default:9 => b:2
+ │    ├── v_comp:10 => v:3
+ │    ├── b_default:9 => c:4
  │    └── column2:8 => d:5
  ├── update-mapping:
  │    └── upsert_d:23 => d:5
@@ -2775,20 +2775,20 @@ upsert virt_partial_idx
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: partial_index_put1:24 partial_index_del1:25 upsert_d:23!null column1:7!null column2:8!null column9:9 column10:10 a:11 d:15
+      ├── columns: partial_index_put1:24 partial_index_del1:25 upsert_d:23!null column1:7!null column2:8!null b_default:9 v_comp:10 a:11 d:15
       ├── cardinality: [1 - 1]
       ├── immutable
       ├── key: ()
       ├── fd: ()-->(7-11,15,23-25)
       ├── left-join (cross)
-      │    ├── columns: column1:7!null column2:8!null column9:9 column10:10 a:11 v:13 d:15
+      │    ├── columns: column1:7!null column2:8!null b_default:9 v_comp:10 a:11 v:13 d:15
       │    ├── cardinality: [1 - 1]
       │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
       │    ├── immutable
       │    ├── key: ()
       │    ├── fd: ()-->(7-11,13,15)
       │    ├── values
-      │    │    ├── columns: column1:7!null column2:8!null column9:9 column10:10
+      │    │    ├── columns: column1:7!null column2:8!null b_default:9 v_comp:10
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(7-10)
@@ -2820,7 +2820,7 @@ upsert virt_partial_idx
       │    │         └── b:12 + 1 [as=v:13, outer=(12), immutable]
       │    └── filters (true)
       └── projections
-           ├── CASE WHEN a:11 IS NULL THEN column10:10 ELSE v:13 END > 1 [as=partial_index_put1:24, outer=(10,11,13)]
+           ├── CASE WHEN a:11 IS NULL THEN v_comp:10 ELSE v:13 END > 1 [as=partial_index_put1:24, outer=(10,11,13)]
            ├── v:13 > 1 [as=partial_index_del1:25, outer=(13)]
            └── CASE WHEN a:11 IS NULL THEN column2:8 ELSE 3 END [as=upsert_d:23, outer=(8,11)]
 
@@ -2836,9 +2836,9 @@ upsert virt_partial_idx
  ├── fetch columns: a:11 b:12 v:13 c:14 d:15
  ├── insert-mapping:
  │    ├── column1:7 => a:1
- │    ├── column9:9 => b:2
- │    ├── column10:10 => v:3
- │    ├── column9:9 => c:4
+ │    ├── b_default:9 => b:2
+ │    ├── v_comp:10 => v:3
+ │    ├── b_default:9 => c:4
  │    └── column2:8 => d:5
  ├── update-mapping:
  │    ├── upsert_b:21 => b:2
@@ -2849,26 +2849,26 @@ upsert virt_partial_idx
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: partial_index_put1:25 partial_index_del1:26 column1:7!null column2:8!null column9:9 column10:10 a:11 b:12 v:13 c:14 d:15 upsert_b:21 upsert_v:22 upsert_d:24!null
+      ├── columns: partial_index_put1:25 partial_index_del1:26 column1:7!null column2:8!null b_default:9 v_comp:10 a:11 b:12 v:13 c:14 d:15 upsert_b:21 upsert_v:22 upsert_d:24!null
       ├── cardinality: [1 - 1]
       ├── immutable
       ├── key: ()
       ├── fd: ()-->(7-15,21,22,24-26)
       ├── project
-      │    ├── columns: upsert_b:21 upsert_v:22 upsert_d:24!null column1:7!null column2:8!null column9:9 column10:10 a:11 b:12 v:13 c:14 d:15
+      │    ├── columns: upsert_b:21 upsert_v:22 upsert_d:24!null column1:7!null column2:8!null b_default:9 v_comp:10 a:11 b:12 v:13 c:14 d:15
       │    ├── cardinality: [1 - 1]
       │    ├── immutable
       │    ├── key: ()
       │    ├── fd: ()-->(7-15,21,22,24)
       │    ├── left-join (cross)
-      │    │    ├── columns: column1:7!null column2:8!null column9:9 column10:10 a:11 b:12 v:13 c:14 d:15
+      │    │    ├── columns: column1:7!null column2:8!null b_default:9 v_comp:10 a:11 b:12 v:13 c:14 d:15
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
       │    │    ├── immutable
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(7-15)
       │    │    ├── values
-      │    │    │    ├── columns: column1:7!null column2:8!null column9:9 column10:10
+      │    │    │    ├── columns: column1:7!null column2:8!null b_default:9 v_comp:10
       │    │    │    ├── cardinality: [1 - 1]
       │    │    │    ├── key: ()
       │    │    │    ├── fd: ()-->(7-10)
@@ -2900,8 +2900,8 @@ upsert virt_partial_idx
       │    │    │         └── b:12 + 1 [as=v:13, outer=(12), immutable]
       │    │    └── filters (true)
       │    └── projections
-      │         ├── CASE WHEN a:11 IS NULL THEN column9:9 ELSE 3 END [as=upsert_b:21, outer=(9,11)]
-      │         ├── CASE WHEN a:11 IS NULL THEN column10:10 ELSE 4 END [as=upsert_v:22, outer=(10,11)]
+      │         ├── CASE WHEN a:11 IS NULL THEN b_default:9 ELSE 3 END [as=upsert_b:21, outer=(9,11)]
+      │         ├── CASE WHEN a:11 IS NULL THEN v_comp:10 ELSE 4 END [as=upsert_v:22, outer=(10,11)]
       │         └── CASE WHEN a:11 IS NULL THEN column2:8 ELSE 4 END [as=upsert_d:24, outer=(8,11)]
       └── projections
            ├── upsert_v:22 > 1 [as=partial_index_put1:25, outer=(22)]
@@ -3109,27 +3109,27 @@ upsert a
  ├── fetch columns: k:10 i:11 f:12 s:13
  ├── insert-mapping:
  │    ├── column1:6 => k:1
- │    ├── column8:8 => i:2
- │    ├── column9:9 => f:3
+ │    ├── i_default:8 => i:2
+ │    ├── f_default:9 => f:3
  │    └── column2:7 => s:4
  ├── update-mapping:
  │    └── upsert_i:17 => i:2
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: upsert_i:17 column1:6!null column2:7!null column8:8 column9:9 k:10 i:11 f:12 s:13
+      ├── columns: upsert_i:17 column1:6!null column2:7!null i_default:8 f_default:9 k:10 i:11 f:12 s:13
       ├── cardinality: [1 - 1]
       ├── immutable
       ├── key: ()
       ├── fd: ()-->(6-13,17)
       ├── left-join (cross)
-      │    ├── columns: column1:6!null column2:7!null column8:8 column9:9 k:10 i:11 f:12 s:13
+      │    ├── columns: column1:6!null column2:7!null i_default:8 f_default:9 k:10 i:11 f:12 s:13
       │    ├── cardinality: [1 - 1]
       │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
       │    ├── key: ()
       │    ├── fd: ()-->(6-13)
       │    ├── values
-      │    │    ├── columns: column1:6!null column2:7!null column8:8 column9:9
+      │    │    ├── columns: column1:6!null column2:7!null i_default:8 f_default:9
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(6-9)
@@ -3147,7 +3147,7 @@ upsert a
       │    │         └── k:10 = 1 [outer=(10), constraints=(/10: [/1 - /1]; tight), fd=()-->(10)]
       │    └── filters (true)
       └── projections
-           └── CASE WHEN k:10 IS NULL THEN column8:8 ELSE i:11 + 1 END [as=upsert_i:17, outer=(8,10,11), immutable]
+           └── CASE WHEN k:10 IS NULL THEN i_default:8 ELSE i:11 + 1 END [as=upsert_i:17, outer=(8,10,11), immutable]
 
 # Prune update columns replaced by upsert columns.
 # TODO(andyk): Need to also prune output columns.
@@ -3161,8 +3161,8 @@ upsert a
  ├── fetch columns: k:10 i:11 f:12 s:13
  ├── insert-mapping:
  │    ├── column1:6 => k:1
- │    ├── column8:8 => i:2
- │    ├── column9:9 => f:3
+ │    ├── i_default:8 => i:2
+ │    ├── f_default:9 => f:3
  │    └── column2:7 => s:4
  ├── update-mapping:
  │    └── upsert_i:17 => i:2
@@ -3176,19 +3176,19 @@ upsert a
  ├── key: ()
  ├── fd: ()-->(1-4)
  └── project
-      ├── columns: upsert_k:16 upsert_i:17 upsert_f:18 upsert_s:19 column1:6!null column2:7!null column8:8 column9:9 k:10 i:11 f:12 s:13
+      ├── columns: upsert_k:16 upsert_i:17 upsert_f:18 upsert_s:19 column1:6!null column2:7!null i_default:8 f_default:9 k:10 i:11 f:12 s:13
       ├── cardinality: [1 - 1]
       ├── immutable
       ├── key: ()
       ├── fd: ()-->(6-13,16-19)
       ├── left-join (cross)
-      │    ├── columns: column1:6!null column2:7!null column8:8 column9:9 k:10 i:11 f:12 s:13
+      │    ├── columns: column1:6!null column2:7!null i_default:8 f_default:9 k:10 i:11 f:12 s:13
       │    ├── cardinality: [1 - 1]
       │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
       │    ├── key: ()
       │    ├── fd: ()-->(6-13)
       │    ├── values
-      │    │    ├── columns: column1:6!null column2:7!null column8:8 column9:9
+      │    │    ├── columns: column1:6!null column2:7!null i_default:8 f_default:9
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(6-9)
@@ -3207,8 +3207,8 @@ upsert a
       │    └── filters (true)
       └── projections
            ├── CASE WHEN k:10 IS NULL THEN column1:6 ELSE k:10 END [as=upsert_k:16, outer=(6,10)]
-           ├── CASE WHEN k:10 IS NULL THEN column8:8 ELSE i:11 + 1 END [as=upsert_i:17, outer=(8,10,11), immutable]
-           ├── CASE WHEN k:10 IS NULL THEN column9:9 ELSE f:12 END [as=upsert_f:18, outer=(9,10,12)]
+           ├── CASE WHEN k:10 IS NULL THEN i_default:8 ELSE i:11 + 1 END [as=upsert_i:17, outer=(8,10,11), immutable]
+           ├── CASE WHEN k:10 IS NULL THEN f_default:9 ELSE f:12 END [as=upsert_f:18, outer=(9,10,12)]
            └── CASE WHEN k:10 IS NULL THEN column2:7 ELSE s:13 END [as=upsert_s:19, outer=(7,10,13)]
 
 # Prune column in column family that is not updated.
@@ -3223,21 +3223,21 @@ upsert family
  ├── insert-mapping:
  │    ├── column1:7 => a:1
  │    ├── column2:8 => b:2
- │    ├── column9:9 => c:3
- │    ├── column9:9 => d:4
- │    └── column9:9 => e:5
+ │    ├── c_default:9 => c:3
+ │    ├── c_default:9 => d:4
+ │    └── c_default:9 => e:5
  ├── update-mapping:
  │    └── column2:8 => b:2
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── left-join (cross)
-      ├── columns: column1:7!null column2:8!null column9:9 a:10 b:11
+      ├── columns: column1:7!null column2:8!null c_default:9 a:10 b:11
       ├── cardinality: [1 - 1]
       ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
       ├── key: ()
       ├── fd: ()-->(7-11)
       ├── values
-      │    ├── columns: column1:7!null column2:8!null column9:9
+      │    ├── columns: column1:7!null column2:8!null c_default:9
       │    ├── cardinality: [1 - 1]
       │    ├── key: ()
       │    ├── fd: ()-->(7-9)
@@ -3333,24 +3333,24 @@ upsert family
  │    ├── column2:8 => b:2
  │    ├── column3:9 => c:3
  │    ├── column4:10 => d:4
- │    └── column11:11 => e:5
+ │    └── e_default:11 => e:5
  ├── update-mapping:
  │    └── upsert_d:22 => d:4
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: upsert_d:22!null column1:7!null column2:8!null column3:9!null column4:10!null column11:11 a:12 c:14 d:15
+      ├── columns: upsert_d:22!null column1:7!null column2:8!null column3:9!null column4:10!null e_default:11 a:12 c:14 d:15
       ├── cardinality: [1 - 1]
       ├── key: ()
       ├── fd: ()-->(7-12,14,15,22)
       ├── left-join (cross)
-      │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column11:11 a:12 c:14 d:15
+      │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null e_default:11 a:12 c:14 d:15
       │    ├── cardinality: [1 - 1]
       │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
       │    ├── key: ()
       │    ├── fd: ()-->(7-12,14,15)
       │    ├── values
-      │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column11:11
+      │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null e_default:11
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(7-11)
@@ -3383,25 +3383,25 @@ upsert mutation
  │    ├── column1:7 => a:1
  │    ├── column2:8 => b:2
  │    ├── column3:9 => c:3
- │    └── column10:10 => d:4
+ │    └── d_default:10 => d:4
  ├── update-mapping:
  │    ├── upsert_b:19 => b:2
- │    └── column10:10 => d:4
+ │    └── d_default:10 => d:4
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: upsert_b:19!null column1:7!null column2:8!null column3:9!null column10:10 a:11 b:12 c:13 d:14 e:15
+      ├── columns: upsert_b:19!null column1:7!null column2:8!null column3:9!null d_default:10 a:11 b:12 c:13 d:14 e:15
       ├── cardinality: [1 - 1]
       ├── key: ()
       ├── fd: ()-->(7-15,19)
       ├── left-join (cross)
-      │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 a:11 b:12 c:13 d:14 e:15
+      │    ├── columns: column1:7!null column2:8!null column3:9!null d_default:10 a:11 b:12 c:13 d:14 e:15
       │    ├── cardinality: [1 - 1]
       │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
       │    ├── key: ()
       │    ├── fd: ()-->(7-15)
       │    ├── values
-      │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10
+      │    │    ├── columns: column1:7!null column2:8!null column3:9!null d_default:10
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(7-10)
@@ -3493,14 +3493,14 @@ insert checks
  ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:6 => a:1
- │    ├── column9:9 => b:2
+ │    ├── b_default:9 => b:2
  │    ├── column2:7 => c:3
  │    └── column3:8 => d:4
  ├── check columns: check1:10 check2:11 check3:12
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── values
-      ├── columns: column1:6!null column2:7!null column3:8!null column9:9!null check1:10!null check2:11!null check3:12!null
+      ├── columns: column1:6!null column2:7!null column3:8!null b_default:9!null check1:10!null check2:11!null check3:12!null
       ├── cardinality: [1 - 1]
       ├── key: ()
       ├── fd: ()-->(6-12)
@@ -3538,7 +3538,7 @@ upsert checks
  ├── fetch columns: a:10 b:11 c:12 d:13
  ├── insert-mapping:
  │    ├── column1:6 => a:1
- │    ├── column9:9 => b:2
+ │    ├── b_default:9 => b:2
  │    ├── column2:7 => c:3
  │    └── column3:8 => d:4
  ├── update-mapping:
@@ -3548,23 +3548,23 @@ upsert checks
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: check1:17 check2:18 check3:19 column1:6!null column2:7!null column3:8!null column9:9!null a:10 b:11 c:12 d:13
+      ├── columns: check1:17 check2:18 check3:19 column1:6!null column2:7!null column3:8!null b_default:9!null a:10 b:11 c:12 d:13
       ├── cardinality: [1 - 1]
       ├── key: ()
       ├── fd: ()-->(6-13,17-19)
       ├── project
-      │    ├── columns: upsert_a:15 upsert_b:16 column1:6!null column2:7!null column3:8!null column9:9!null a:10 b:11 c:12 d:13
+      │    ├── columns: upsert_a:15 upsert_b:16 column1:6!null column2:7!null column3:8!null b_default:9!null a:10 b:11 c:12 d:13
       │    ├── cardinality: [1 - 1]
       │    ├── key: ()
       │    ├── fd: ()-->(6-13,15,16)
       │    ├── left-join (cross)
-      │    │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9!null a:10 b:11 c:12 d:13
+      │    │    ├── columns: column1:6!null column2:7!null column3:8!null b_default:9!null a:10 b:11 c:12 d:13
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
       │    │    ├── key: ()
       │    │    ├── fd: ()-->(6-13)
       │    │    ├── values
-      │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9!null
+      │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null b_default:9!null
       │    │    │    ├── cardinality: [1 - 1]
       │    │    │    ├── key: ()
       │    │    │    ├── fd: ()-->(6-9)
@@ -3585,7 +3585,7 @@ upsert checks
       │    │    └── filters (true)
       │    └── projections
       │         ├── CASE WHEN a:10 IS NULL THEN column1:6 ELSE a:10 END [as=upsert_a:15, outer=(6,10)]
-      │         └── CASE WHEN a:10 IS NULL THEN column9:9 ELSE b:11 END [as=upsert_b:16, outer=(9-11)]
+      │         └── CASE WHEN a:10 IS NULL THEN b_default:9 ELSE b:11 END [as=upsert_b:16, outer=(9-11)]
       └── projections
            ├── upsert_a:15 > 0 [as=check1:17, outer=(15)]
            ├── upsert_b:16 > 10 [as=check2:18, outer=(16)]
@@ -3763,9 +3763,9 @@ upsert uniq_fk_parent
  ├── insert-mapping:
  │    ├── column1:7 => uniq_fk_parent.k:1
  │    ├── column2:8 => uniq_fk_parent.a:2
- │    ├── column9:9 => uniq_fk_parent.b:3
- │    ├── column9:9 => uniq_fk_parent.c:4
- │    └── column9:9 => uniq_fk_parent.d:5
+ │    ├── b_default:9 => uniq_fk_parent.b:3
+ │    ├── b_default:9 => uniq_fk_parent.c:4
+ │    └── b_default:9 => uniq_fk_parent.d:5
  ├── update-mapping:
  │    └── upsert_c:20 => uniq_fk_parent.c:4
  ├── input binding: &1
@@ -3774,18 +3774,18 @@ upsert uniq_fk_parent
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── project
- │    ├── columns: upsert_k:17 upsert_a:18 upsert_b:19 upsert_c:20 column1:7!null column2:8!null column9:9 uniq_fk_parent.k:10 uniq_fk_parent.b:12 uniq_fk_parent.c:13
+ │    ├── columns: upsert_k:17 upsert_a:18 upsert_b:19 upsert_c:20 column1:7!null column2:8!null b_default:9 uniq_fk_parent.k:10 uniq_fk_parent.b:12 uniq_fk_parent.c:13
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(7-10,12,13,17-20)
  │    ├── left-join (cross)
- │    │    ├── columns: column1:7!null column2:8!null column9:9 uniq_fk_parent.k:10 uniq_fk_parent.a:11 uniq_fk_parent.b:12 uniq_fk_parent.c:13
+ │    │    ├── columns: column1:7!null column2:8!null b_default:9 uniq_fk_parent.k:10 uniq_fk_parent.a:11 uniq_fk_parent.b:12 uniq_fk_parent.c:13
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(7-13)
  │    │    ├── values
- │    │    │    ├── columns: column1:7!null column2:8!null column9:9
+ │    │    │    ├── columns: column1:7!null column2:8!null b_default:9
  │    │    │    ├── cardinality: [1 - 1]
  │    │    │    ├── key: ()
  │    │    │    ├── fd: ()-->(7-9)
@@ -3805,8 +3805,8 @@ upsert uniq_fk_parent
  │    └── projections
  │         ├── CASE WHEN uniq_fk_parent.k:10 IS NULL THEN column1:7 ELSE uniq_fk_parent.k:10 END [as=upsert_k:17, outer=(7,10)]
  │         ├── CASE WHEN uniq_fk_parent.k:10 IS NULL THEN column2:8 ELSE uniq_fk_parent.a:11 END [as=upsert_a:18, outer=(8,10,11)]
- │         ├── CASE WHEN uniq_fk_parent.k:10 IS NULL THEN column9:9 ELSE uniq_fk_parent.b:12 END [as=upsert_b:19, outer=(9,10,12)]
- │         └── CASE WHEN uniq_fk_parent.k:10 IS NULL THEN column9:9 ELSE 1 END [as=upsert_c:20, outer=(9,10)]
+ │         ├── CASE WHEN uniq_fk_parent.k:10 IS NULL THEN b_default:9 ELSE uniq_fk_parent.b:12 END [as=upsert_b:19, outer=(9,10,12)]
+ │         └── CASE WHEN uniq_fk_parent.k:10 IS NULL THEN b_default:9 ELSE 1 END [as=upsert_c:20, outer=(9,10)]
  └── unique-checks
       ├── unique-checks-item: uniq_fk_parent(a)
       │    └── project
@@ -3874,28 +3874,28 @@ upsert uniq_fk_parent
  ├── fetch columns: uniq_fk_parent.k:9 uniq_fk_parent.d:13
  ├── insert-mapping:
  │    ├── column1:7 => uniq_fk_parent.k:1
- │    ├── column8:8 => uniq_fk_parent.a:2
- │    ├── column8:8 => uniq_fk_parent.b:3
- │    ├── column8:8 => uniq_fk_parent.c:4
- │    └── column8:8 => uniq_fk_parent.d:5
+ │    ├── a_default:8 => uniq_fk_parent.a:2
+ │    ├── a_default:8 => uniq_fk_parent.b:3
+ │    ├── a_default:8 => uniq_fk_parent.c:4
+ │    └── a_default:8 => uniq_fk_parent.d:5
  ├── update-mapping:
  │    └── upsert_d:20 => uniq_fk_parent.d:5
  ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── project
- │    ├── columns: upsert_k:16 upsert_a:17 upsert_b:18 upsert_c:19 upsert_d:20 column1:7!null column8:8 uniq_fk_parent.k:9 uniq_fk_parent.d:13
+ │    ├── columns: upsert_k:16 upsert_a:17 upsert_b:18 upsert_c:19 upsert_d:20 column1:7!null a_default:8 uniq_fk_parent.k:9 uniq_fk_parent.d:13
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(7-9,13,16-20)
  │    ├── left-join (cross)
- │    │    ├── columns: column1:7!null column8:8 uniq_fk_parent.k:9 uniq_fk_parent.a:10 uniq_fk_parent.b:11 uniq_fk_parent.c:12 uniq_fk_parent.d:13
+ │    │    ├── columns: column1:7!null a_default:8 uniq_fk_parent.k:9 uniq_fk_parent.a:10 uniq_fk_parent.b:11 uniq_fk_parent.c:12 uniq_fk_parent.d:13
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(7-13)
  │    │    ├── values
- │    │    │    ├── columns: column1:7!null column8:8
+ │    │    │    ├── columns: column1:7!null a_default:8
  │    │    │    ├── cardinality: [1 - 1]
  │    │    │    ├── key: ()
  │    │    │    ├── fd: ()-->(7,8)
@@ -3914,10 +3914,10 @@ upsert uniq_fk_parent
  │    │    └── filters (true)
  │    └── projections
  │         ├── CASE WHEN uniq_fk_parent.k:9 IS NULL THEN column1:7 ELSE uniq_fk_parent.k:9 END [as=upsert_k:16, outer=(7,9)]
- │         ├── CASE WHEN uniq_fk_parent.k:9 IS NULL THEN column8:8 ELSE uniq_fk_parent.a:10 END [as=upsert_a:17, outer=(8-10)]
- │         ├── CASE WHEN uniq_fk_parent.k:9 IS NULL THEN column8:8 ELSE uniq_fk_parent.b:11 END [as=upsert_b:18, outer=(8,9,11)]
- │         ├── CASE WHEN uniq_fk_parent.k:9 IS NULL THEN column8:8 ELSE uniq_fk_parent.c:12 END [as=upsert_c:19, outer=(8,9,12)]
- │         └── CASE WHEN uniq_fk_parent.k:9 IS NULL THEN column8:8 ELSE 1 END [as=upsert_d:20, outer=(8,9)]
+ │         ├── CASE WHEN uniq_fk_parent.k:9 IS NULL THEN a_default:8 ELSE uniq_fk_parent.a:10 END [as=upsert_a:17, outer=(8-10)]
+ │         ├── CASE WHEN uniq_fk_parent.k:9 IS NULL THEN a_default:8 ELSE uniq_fk_parent.b:11 END [as=upsert_b:18, outer=(8,9,11)]
+ │         ├── CASE WHEN uniq_fk_parent.k:9 IS NULL THEN a_default:8 ELSE uniq_fk_parent.c:12 END [as=upsert_c:19, outer=(8,9,12)]
+ │         └── CASE WHEN uniq_fk_parent.k:9 IS NULL THEN a_default:8 ELSE 1 END [as=upsert_d:20, outer=(8,9)]
  └── unique-checks
       ├── unique-checks-item: uniq_fk_parent(a)
       │    └── project
@@ -4129,11 +4129,11 @@ update virt_idx
  ├── fetch columns: a:6 b:7 c:8 v:9
  ├── update-mapping:
  │    ├── a_new:11 => a:1
- │    └── column12:12 => v:4
+ │    └── v_comp:12 => v:4
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: column12:12 a:6!null b:7 c:8 v:9 a_new:11!null
+      ├── columns: v_comp:12 a:6!null b:7 c:8 v:9 a_new:11!null
       ├── immutable
       ├── key: (6)
       ├── fd: (6)-->(7-9,11), (7,11)-->(12)
@@ -4153,7 +4153,7 @@ update virt_idx
       │         ├── a:6 + 1 [as=a_new:11, outer=(6), immutable]
       │         └── a:6 + b:7 [as=v:9, outer=(6,7), immutable]
       └── projections
-           └── a_new:11 + b:7 [as=column12:12, outer=(7,11), immutable]
+           └── a_new:11 + b:7 [as=v_comp:12, outer=(7,11), immutable]
 
 # We cannot prune column v because it is affected by the change.
 norm
@@ -4164,11 +4164,11 @@ update virt_idx
  ├── fetch columns: a:6 b:7 v:9
  ├── update-mapping:
  │    ├── b_new:11 => b:2
- │    └── column12:12 => v:4
+ │    └── v_comp:12 => v:4
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: column12:12 a:6!null b:7 v:9 b_new:11
+      ├── columns: v_comp:12 a:6!null b:7 v:9 b_new:11
       ├── immutable
       ├── key: (6)
       ├── fd: (6)-->(7,9,12), (7)-->(11)
@@ -4188,7 +4188,7 @@ update virt_idx
       │         ├── b:7 + 1 [as=b_new:11, outer=(7), immutable]
       │         └── a:6 + b:7 [as=v:9, outer=(6,7), immutable]
       └── projections
-           └── a:6 + b_new:11 [as=column12:12, outer=(6,11), immutable]
+           └── a:6 + b_new:11 [as=v_comp:12, outer=(6,11), immutable]
 
 # We should prune columns b and v because they are unaffected by the update.
 norm expect=(PruneMutationFetchCols,PruneMutationInputCols)
@@ -4577,11 +4577,11 @@ project
       │    ├── column1:10 => a:1
       │    ├── column2:11 => b:2
       │    ├── column3:12 => c:3
-      │    ├── column13:13 => d:4
-      │    ├── column13:13 => e:5
-      │    ├── column13:13 => f:6
-      │    ├── column13:13 => g:7
-      │    └── column14:14 => rowid:8
+      │    ├── d_default:13 => d:4
+      │    ├── d_default:13 => e:5
+      │    ├── d_default:13 => f:6
+      │    ├── d_default:13 => g:7
+      │    └── rowid_default:14 => rowid:8
       ├── update-mapping:
       │    └── upsert_a:25 => a:1
       ├── return-mapping:
@@ -4594,20 +4594,20 @@ project
       ├── key: ()
       ├── fd: ()-->(1-3,8)
       └── project
-           ├── columns: upsert_a:25 upsert_b:26 upsert_c:27 upsert_rowid:32 column1:10!null column2:11!null column3:12!null column13:13 column14:14 a:15 b:16 c:17 rowid:22
+           ├── columns: upsert_a:25 upsert_b:26 upsert_c:27 upsert_rowid:32 column1:10!null column2:11!null column3:12!null d_default:13 rowid_default:14 a:15 b:16 c:17 rowid:22
            ├── cardinality: [1 - 1]
            ├── volatile
            ├── key: ()
            ├── fd: ()-->(10-17,22,25-27,32)
            ├── left-join (cross)
-           │    ├── columns: column1:10!null column2:11!null column3:12!null column13:13 column14:14 a:15 b:16 c:17 rowid:22
+           │    ├── columns: column1:10!null column2:11!null column3:12!null d_default:13 rowid_default:14 a:15 b:16 c:17 rowid:22
            │    ├── cardinality: [1 - 1]
            │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
            │    ├── volatile
            │    ├── key: ()
            │    ├── fd: ()-->(10-17,22)
            │    ├── values
-           │    │    ├── columns: column1:10!null column2:11!null column3:12!null column13:13 column14:14
+           │    │    ├── columns: column1:10!null column2:11!null column3:12!null d_default:13 rowid_default:14
            │    │    ├── cardinality: [1 - 1]
            │    │    ├── volatile
            │    │    ├── key: ()
@@ -4629,7 +4629,7 @@ project
                 ├── CASE WHEN rowid:22 IS NULL THEN column1:10 ELSE column1:10 + a:15 END [as=upsert_a:25, outer=(10,15,22), immutable]
                 ├── CASE WHEN rowid:22 IS NULL THEN column2:11 ELSE b:16 END [as=upsert_b:26, outer=(11,16,22)]
                 ├── CASE WHEN rowid:22 IS NULL THEN column3:12 ELSE c:17 END [as=upsert_c:27, outer=(12,17,22)]
-                └── CASE WHEN rowid:22 IS NULL THEN column14:14 ELSE rowid:22 END [as=upsert_rowid:32, outer=(14,22)]
+                └── CASE WHEN rowid:22 IS NULL THEN rowid_default:14 ELSE rowid:22 END [as=upsert_rowid:32, outer=(14,22)]
 
 norm
 DELETE FROM returning_test WHERE a < b + d RETURNING a, b, d
@@ -4675,11 +4675,11 @@ project
       │    ├── column1:10 => a:1
       │    ├── column2:11 => b:2
       │    ├── column3:12 => c:3
-      │    ├── column13:13 => d:4
-      │    ├── column13:13 => e:5
-      │    ├── column13:13 => f:6
-      │    ├── column13:13 => g:7
-      │    └── column14:14 => rowid:8
+      │    ├── d_default:13 => d:4
+      │    ├── d_default:13 => e:5
+      │    ├── d_default:13 => f:6
+      │    ├── d_default:13 => g:7
+      │    └── rowid_default:14 => rowid:8
       ├── update-mapping:
       │    ├── column1:10 => a:1
       │    ├── column2:11 => b:2
@@ -4695,28 +4695,28 @@ project
       ├── key: ()
       ├── fd: ()-->(1-4,8)
       └── project
-           ├── columns: upsert_d:24 upsert_rowid:28 column1:10!null column2:11!null column3:12!null column13:13 column14:14 a:15 b:16 c:17 d:18 rowid:22
+           ├── columns: upsert_d:24 upsert_rowid:28 column1:10!null column2:11!null column3:12!null d_default:13 rowid_default:14 a:15 b:16 c:17 d:18 rowid:22
            ├── cardinality: [1 - 1]
            ├── volatile
            ├── key: ()
            ├── fd: ()-->(10-18,22,24,28)
            ├── left-join (hash)
-           │    ├── columns: column1:10!null column2:11!null column3:12!null column13:13 column14:14 a:15 b:16 c:17 d:18 rowid:22
+           │    ├── columns: column1:10!null column2:11!null column3:12!null d_default:13 rowid_default:14 a:15 b:16 c:17 d:18 rowid:22
            │    ├── cardinality: [1 - 1]
            │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
            │    ├── volatile
            │    ├── key: ()
            │    ├── fd: ()-->(10-18,22)
            │    ├── ensure-upsert-distinct-on
-           │    │    ├── columns: column1:10!null column2:11!null column3:12!null column13:13 column14:14
-           │    │    ├── grouping columns: column14:14
+           │    │    ├── columns: column1:10!null column2:11!null column3:12!null d_default:13 rowid_default:14
+           │    │    ├── grouping columns: rowid_default:14
            │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
            │    │    ├── cardinality: [1 - 1]
            │    │    ├── volatile
            │    │    ├── key: ()
            │    │    ├── fd: ()-->(10-14)
            │    │    ├── values
-           │    │    │    ├── columns: column1:10!null column2:11!null column3:12!null column13:13 column14:14
+           │    │    │    ├── columns: column1:10!null column2:11!null column3:12!null d_default:13 rowid_default:14
            │    │    │    ├── cardinality: [1 - 1]
            │    │    │    ├── volatile
            │    │    │    ├── key: ()
@@ -4729,17 +4729,17 @@ project
            │    │         │    └── column2:11
            │    │         ├── first-agg [as=column3:12, outer=(12)]
            │    │         │    └── column3:12
-           │    │         └── first-agg [as=column13:13, outer=(13)]
-           │    │              └── column13:13
+           │    │         └── first-agg [as=d_default:13, outer=(13)]
+           │    │              └── d_default:13
            │    ├── scan returning_test
            │    │    ├── columns: a:15 b:16 c:17 d:18 rowid:22!null
            │    │    ├── key: (22)
            │    │    └── fd: (22)-->(15-18), (15)~~>(16-18,22)
            │    └── filters
-           │         └── column14:14 = rowid:22 [outer=(14,22), constraints=(/14: (/NULL - ]; /22: (/NULL - ]), fd=(14)==(22), (22)==(14)]
+           │         └── rowid_default:14 = rowid:22 [outer=(14,22), constraints=(/14: (/NULL - ]; /22: (/NULL - ]), fd=(14)==(22), (22)==(14)]
            └── projections
-                ├── CASE WHEN rowid:22 IS NULL THEN column13:13 ELSE d:18 END [as=upsert_d:24, outer=(13,18,22)]
-                └── CASE WHEN rowid:22 IS NULL THEN column14:14 ELSE rowid:22 END [as=upsert_rowid:28, outer=(14,22)]
+                ├── CASE WHEN rowid:22 IS NULL THEN d_default:13 ELSE d:18 END [as=upsert_d:24, outer=(13,18,22)]
+                └── CASE WHEN rowid:22 IS NULL THEN rowid_default:14 ELSE rowid:22 END [as=upsert_rowid:28, outer=(14,22)]
 
 # Make sure the passthrough columns of an UPDATE ... FROM query are pruned.
 norm

--- a/pkg/sql/opt/norm/testdata/rules/with
+++ b/pkg/sql/opt/norm/testdata/rules/with
@@ -403,16 +403,16 @@ with &1 (foo)
  │    ├── columns: a.k:1!null a.i:2 a.f:3 a.s:4 a.j:5
  │    ├── insert-mapping:
  │    │    ├── column1:7 => a.k:1
- │    │    ├── column8:8 => a.i:2
- │    │    ├── column9:9 => a.f:3
- │    │    ├── column10:10 => a.s:4
- │    │    └── column11:11 => a.j:5
+ │    │    ├── i_default:8 => a.i:2
+ │    │    ├── f_default:9 => a.f:3
+ │    │    ├── s_default:10 => a.s:4
+ │    │    └── j_default:11 => a.j:5
  │    ├── cardinality: [1 - 1]
  │    ├── volatile, mutations
  │    ├── key: ()
  │    ├── fd: ()-->(1-5)
  │    └── values
- │         ├── columns: column1:7!null column8:8 column9:9 column10:10 column11:11
+ │         ├── columns: column1:7!null i_default:8 f_default:9 s_default:10 j_default:11
  │         ├── cardinality: [1 - 1]
  │         ├── key: ()
  │         ├── fd: ()-->(7-11)

--- a/pkg/sql/opt/optbuilder/create_table.go
+++ b/pkg/sql/opt/optbuilder/create_table.go
@@ -89,7 +89,7 @@ func (b *Builder) buildCreateTable(ct *tree.CreateTable, inScope *scope) (outSco
 				Overload:   &overloads[0],
 			}
 			fn := b.factory.ConstructFunction(memo.EmptyScalarListExpr, private)
-			scopeCol := b.synthesizeColumn(outScope, "rowid", types.Int, nil /* expr */, fn)
+			scopeCol := b.synthesizeColumn(outScope, scopeColName("rowid"), types.Int, nil /* expr */, fn)
 			input = b.factory.CustomFuncs().ProjectExtraCol(outScope.expr, fn, scopeCol.id)
 		}
 		inputCols = outScope.makePhysicalProps().Presentation

--- a/pkg/sql/opt/optbuilder/fk_cascade.go
+++ b/pkg/sql/opt/optbuilder/fk_cascade.go
@@ -861,10 +861,12 @@ func (b *Builder) buildUpdateCascadeMutationInput(
 		outScope.expr, mutationInput, on, memo.EmptyJoinPrivate,
 	)
 	// Append the columns from the right-hand side to the scope.
-	for _, col := range outCols {
+	for i, col := range outCols {
 		colMeta := md.ColumnMeta(col)
+		ord := fk.OriginColumnOrdinal(childTable, i%numFKCols)
+		c := childTable.Column(ord)
 		outScope.cols = append(outScope.cols, scopeColumn{
-			name: tree.Name(colMeta.Alias),
+			name: scopeColName(c.ColName()),
 			id:   col,
 			typ:  colMeta.Type,
 		})

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -581,19 +581,19 @@ func (b *Builder) buildGrouping(
 				return
 			}
 			// Case 1 above.
-			targetName := name.Parts[0]
+			targetName := tree.Name(name.Parts[0])
 
 			// We must prefer a match against a FROM-clause column (but ignore upper
 			// scopes); in this case we let the general case below handle the reference.
 			for i := range fromScope.cols {
-				if string(fromScope.cols[i].name) == targetName {
+				if fromScope.cols[i].name.MatchesReferenceName(targetName) {
 					return
 				}
 			}
 			// See if it matches exactly one of the target lists.
 			var match *scopeColumn
 			for i := range projectionsScope.cols {
-				if col := &projectionsScope.cols[i]; string(col.name) == targetName {
+				if col := &projectionsScope.cols[i]; col.name.MatchesReferenceName(targetName) {
 					if match != nil {
 						// Multiple matches are only allowed if they refer to identical
 						// expressions.
@@ -605,7 +605,7 @@ func (b *Builder) buildGrouping(
 				}
 			}
 			if match != nil {
-				groupBy, alias = match.expr, targetName
+				groupBy, alias = match.expr, string(targetName)
 			}
 		}
 	}()
@@ -634,7 +634,7 @@ func (b *Builder) buildGrouping(
 		// Save a representation of the GROUP BY expression for validation of the
 		// SELECT and HAVING expressions. This enables queries such as:
 		//   SELECT x+y FROM t GROUP BY x+y
-		col := aggInScope.addColumn(alias, e)
+		col := aggInScope.addColumn(scopeColName(tree.Name(alias)), e)
 		b.buildScalar(e, fromScope, aggInScope, col, nil)
 		fromScope.groupby.groupStrs[exprStr] = col
 	}
@@ -648,7 +648,7 @@ func (b *Builder) buildAggArg(
 ) opt.ScalarExpr {
 	// This synthesizes a new tempScope column, unless the argument is a
 	// simple VariableOp.
-	col := tempScope.addColumn("" /* alias */, e)
+	col := tempScope.addColumn(scopeColName(""), e)
 	b.buildScalar(e, fromScope, tempScope, col, &info.colRefs)
 	if col.scalar != nil {
 		return col.scalar
@@ -735,7 +735,7 @@ func (b *Builder) buildAggregateFunction(
 
 		// Use 0 as the group for now; it will be filled in later by the
 		// buildAggregation method.
-		info.col = b.synthesizeColumn(g.aggOutScope, funcName, f.ResolvedType(), f, nil /* scalar */)
+		info.col = b.synthesizeColumn(g.aggOutScope, scopeColName(tree.Name(funcName)), f.ResolvedType(), f, nil /* scalar */)
 
 		// Move the columns for the aggregate input expressions to the correct scope.
 		if g.aggInScope != tempScope {
@@ -891,10 +891,10 @@ func isSQLFn(def *tree.FunctionDefinition) bool {
 	return def.Class == tree.SQLClass
 }
 
-func newGroupingError(name *tree.Name) error {
+func newGroupingError(name tree.Name) error {
 	return pgerror.Newf(pgcode.Grouping,
 		"column \"%s\" must appear in the GROUP BY clause or be used in an aggregate function",
-		tree.ErrString(name),
+		tree.ErrString(&name),
 	)
 }
 

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -615,7 +615,7 @@ func (mb *mutationBuilder) buildInputForInsert(inScope *scope, inputRows *tree.S
 		checkDatumTypeFitsColumnType(mb.tab.Column(ord), inCol.typ)
 
 		// Assign name of input column.
-		inCol.name = tree.Name(mb.md.ColumnMeta(mb.targetColList[i]).Alias)
+		inCol.name = scopeColName(tree.Name(mb.md.ColumnMeta(mb.targetColList[i]).Alias))
 
 		// Record the ID of the column that contains the value to be inserted
 		// into the corresponding target table column.
@@ -960,12 +960,11 @@ func (mb *mutationBuilder) projectUpsertColumns() {
 			mb.b.factory.ConstructVariable(updateColID),
 		)
 
-		alias := fmt.Sprintf("upsert_%s", mb.tab.Column(i).ColName())
+		name := scopeColName(col.ColName()).WithMetadataName(
+			fmt.Sprintf("upsert_%s", mb.tab.Column(i).ColName()),
+		)
 		typ := mb.md.ColumnMeta(insertColID).Type
-		scopeCol := mb.b.synthesizeColumn(projectionsScope, alias, typ, nil /* expr */, caseExpr)
-
-		// Assign name to synthesized column.
-		scopeCol.name = col.ColName()
+		scopeCol := mb.b.synthesizeColumn(projectionsScope, name, typ, nil /* expr */, caseExpr)
 
 		// Update the scope ordinals for the update columns that are involved in
 		// the Upsert. The new columns will be used by the Upsert operator in place

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -610,7 +610,7 @@ func (mb *mutationBuilder) addSynthesizedDefaultCols(
 
 		// Add synthesized column. It is important to use the real column name, as
 		// this column may later be referred to by a computed column.
-		newCol, _ := pb.Add(tabCol.ColName(), expr, tabCol.DatumType())
+		newCol, _ := pb.Add(scopeColName(tabCol.ColName()), expr, tabCol.DatumType())
 
 		// Remember id of newly synthesized column.
 		colIDs[i] = newCol
@@ -662,7 +662,7 @@ func (mb *mutationBuilder) addSynthesizedComputedCols(colIDs opt.OptionalColList
 		expr := mb.parseDefaultOrComputedExpr(tabColID)
 
 		// Add synthesized column.
-		newCol, scalar := pb.Add(tabCol.ColName(), expr, tabCol.DatumType())
+		newCol, scalar := pb.Add(scopeColName(tabCol.ColName()), expr, tabCol.DatumType())
 
 		if restrict && kind != cat.WriteOnly {
 			// Check if any of the columns referred to in the computed column
@@ -794,7 +794,7 @@ func (mb *mutationBuilder) roundDecimalValues(colIDs opt.OptionalColList, roundC
 		// addUpdateColumns would not include columns in the FROM clause. Those
 		// columns are only in-scope in the RETURNING clause via
 		// mb.extraAccessibleCols.
-		scopeCol.name = mb.tab.Column(i).ColName()
+		scopeCol.name = scopeColName(mb.tab.Column(i).ColName())
 	}
 
 	if projectionsScope != nil {
@@ -851,17 +851,17 @@ func (mb *mutationBuilder) addCheckConstraintCols() {
 				panic(err)
 			}
 
-			alias := fmt.Sprintf("check%d", i+1)
 			texpr := mb.outScope.resolveAndRequireType(expr, types.Bool)
-			scopeCol := projectionsScope.addColumn(alias, texpr)
+
+			// Use an anonymous name because the column cannot be referenced
+			// in other expressions.
+			colName := scopeColName("").WithMetadataName(fmt.Sprintf("check%d", i+1))
+			scopeCol := projectionsScope.addColumn(colName, texpr)
 
 			// TODO(ridwanmsharif): Maybe we can avoid building constraints here
 			// and instead use the constraints stored in the table metadata.
 			referencedCols := &opt.ColSet{}
 			mb.b.buildScalar(texpr, mb.outScope, projectionsScope, scopeCol, referencedCols)
-
-			// Clear the column name so that it cannot be referenced.
-			scopeCol.clearName()
 
 			// Synthesized check columns are only necessary if the columns
 			// referenced in the check expression are being mutated. If they are
@@ -941,27 +941,27 @@ func (mb *mutationBuilder) projectPartialIndexColsImpl(putScope, delScope *scope
 			// Build synthesized PUT columns.
 			if putScope != nil {
 				texpr := putScope.resolveAndRequireType(expr, types.Bool)
-				alias := fmt.Sprintf("partial_index_put%d", ord+1)
-				scopeCol := projectionScope.addColumn(alias, texpr)
+
+				// Use an anonymous name because the column cannot be referenced
+				// in other expressions.
+				colName := scopeColName("").WithMetadataName(fmt.Sprintf("partial_index_put%d", ord+1))
+				scopeCol := projectionScope.addColumn(colName, texpr)
 
 				mb.b.buildScalar(texpr, putScope, projectionScope, scopeCol, nil)
 				mb.partialIndexPutColIDs[ord] = scopeCol.id
-
-				// Clear the column name so that it cannot be referenced.
-				scopeCol.clearName()
 			}
 
 			// Build synthesized DEL columns.
 			if delScope != nil {
 				texpr := delScope.resolveAndRequireType(expr, types.Bool)
-				alias := fmt.Sprintf("partial_index_del%d", ord+1)
-				scopeCol := projectionScope.addColumn(alias, texpr)
+
+				// Use an anonymous name because the column cannot be referenced
+				// in other expressions.
+				colName := scopeColName("").WithMetadataName(fmt.Sprintf("partial_index_del%d", ord+1))
+				scopeCol := projectionScope.addColumn(colName, texpr)
 
 				mb.b.buildScalar(texpr, delScope, projectionScope, scopeCol, nil)
 				mb.partialIndexDelColIDs[ord] = scopeCol.id
-
-				// Clear the column name so that it cannot be referenced.
-				scopeCol.clearName()
 			}
 
 			ord++
@@ -1372,7 +1372,7 @@ func (mb *mutationBuilder) buildCheckInputScan(
 		outCol := mb.md.AddColumn(string(tableCol.ColName()), tableCol.DatumType())
 		withScanScope.cols[i] = scopeColumn{
 			id:   outCol,
-			name: tableCol.ColName(),
+			name: scopeColName(tableCol.ColName()),
 			typ:  tableCol.DatumType(),
 		}
 

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -608,9 +608,13 @@ func (mb *mutationBuilder) addSynthesizedDefaultCols(
 		tabColID := mb.tabID.ColumnID(i)
 		expr := mb.parseDefaultOrComputedExpr(tabColID)
 
-		// Add synthesized column. It is important to use the real column name, as
-		// this column may later be referred to by a computed column.
-		newCol, _ := pb.Add(scopeColName(tabCol.ColName()), expr, tabCol.DatumType())
+		// Add synthesized column. It is important to use the real column
+		// reference name, as this column may later be referred to by a computed
+		// column.
+		colName := scopeColName(tabCol.ColName()).WithMetadataName(
+			string(tabCol.ColName()) + "_default",
+		)
+		newCol, _ := pb.Add(colName, expr, tabCol.DatumType())
 
 		// Remember id of newly synthesized column.
 		colIDs[i] = newCol
@@ -662,7 +666,10 @@ func (mb *mutationBuilder) addSynthesizedComputedCols(colIDs opt.OptionalColList
 		expr := mb.parseDefaultOrComputedExpr(tabColID)
 
 		// Add synthesized column.
-		newCol, scalar := pb.Add(scopeColName(tabCol.ColName()), expr, tabCol.DatumType())
+		colName := scopeColName(tabCol.ColName()).WithMetadataName(
+			string(tabCol.ColName()) + "_comp",
+		)
+		newCol, scalar := pb.Add(colName, expr, tabCol.DatumType())
 
 		if restrict && kind != cat.WriteOnly {
 			// Check if any of the columns referred to in the computed column

--- a/pkg/sql/opt/optbuilder/mutation_builder_arbiter.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_arbiter.go
@@ -446,8 +446,10 @@ func (mb *mutationBuilder) projectPartialArbiterDistinctColumn(
 	}
 	texpr := insertScope.resolveAndRequireType(expr, types.Bool)
 
-	alias := fmt.Sprintf("arbiter_%s_distinct", arbiterName)
-	scopeCol := projectionScope.addColumn(alias, texpr)
+	// Use an anonymous name because the column cannot be referenced
+	// in other expressions.
+	colName := scopeColName("").WithMetadataName(fmt.Sprintf("arbiter_%s_distinct", arbiterName))
+	scopeCol := projectionScope.addColumn(colName, texpr)
 	mb.b.buildScalar(texpr, mb.outScope, projectionScope, scopeCol, nil)
 
 	mb.b.constructProjectForScope(mb.outScope, projectionScope)

--- a/pkg/sql/opt/optbuilder/name_resolution_test.go
+++ b/pkg/sql/opt/optbuilder/name_resolution_test.go
@@ -30,7 +30,7 @@ func (s *scope) GetColumnItemResolver() tree.ColumnItemResolver {
 // AddTable is part of the sqlutils.ColumnItemResolverTester interface.
 func (s *scope) AddTable(tabName tree.TableName, colNames []tree.Name) {
 	for _, col := range colNames {
-		s.cols = append(s.cols, scopeColumn{name: col, table: tabName})
+		s.cols = append(s.cols, scopeColumn{name: scopeColName(col), table: tabName})
 	}
 }
 
@@ -47,7 +47,7 @@ func (s *scope) ResolveQualifiedStarTestResults(
 	for i := range s.cols {
 		col := s.cols[i]
 		if col.table == *srcName && col.visibility == cat.Visible {
-			nl = append(nl, col.name)
+			nl = append(nl, col.name.ReferenceName())
 		}
 	}
 	return srcName.String(), nl.String(), nil
@@ -60,7 +60,7 @@ func (s *scope) ResolveColumnItemTestResults(colRes tree.ColumnResolutionResult)
 	if !ok {
 		return "", fmt.Errorf("resolver did not return *scopeColumn, found %T instead", colRes)
 	}
-	return fmt.Sprintf("%s.%s", col.table.String(), col.name), nil
+	return fmt.Sprintf("%s.%s", col.table.String(), col.name.ReferenceName()), nil
 }
 
 func TestResolveQualifiedStar(t *testing.T) {

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -142,7 +142,7 @@ func (b *Builder) analyzeOrderByIndex(
 
 		colItem := tree.NewColumnItem(&tn, col.ColName())
 		expr := inScope.resolveType(colItem, types.Any)
-		outCol := orderByScope.addColumn("" /* alias */, expr)
+		outCol := orderByScope.addColumn(scopeColName(""), expr)
 		outCol.descending = desc
 	}
 }
@@ -248,7 +248,7 @@ func (b *Builder) analyzeExtraArgument(
 	for _, e := range exprs {
 		// Ensure we can order on the given column(s).
 		ensureColumnOrderable(e)
-		extraColsScope.addColumn("" /* alias */, e)
+		extraColsScope.addColumn(scopeColName(""), e)
 	}
 }
 

--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -141,7 +141,7 @@ func (b *Builder) analyzeSelectList(
 						outScope.cols = make([]scopeColumn, 0, len(selects)+len(exprs)-1)
 					}
 					for j, e := range exprs {
-						outScope.addColumn(aliases[j], e)
+						outScope.addColumn(scopeColName(tree.Name(aliases[j])), e)
 					}
 					continue
 				}
@@ -162,7 +162,7 @@ func (b *Builder) analyzeSelectList(
 			outScope.cols = make([]scopeColumn, 0, len(selects))
 		}
 		alias := b.getColName(e)
-		outScope.addColumn(alias, texpr)
+		outScope.addColumn(scopeColName(tree.Name(alias)), texpr)
 	}
 }
 
@@ -296,7 +296,7 @@ func (b *Builder) finishBuildScalarRef(
 		// Avoid synthesizing a new column if possible.
 		existing := outScope.findExistingCol(col, false /* allowSideEffects */)
 		if existing == nil || existing == outCol {
-			if outCol.name == "" {
+			if outCol.name.IsAnonymous() {
 				outCol.name = col.name
 			}
 			group := b.factory.ConstructVariable(col.id)
@@ -339,7 +339,7 @@ func makeProjectionBuilder(b *Builder, inScope *scope) projectionBuilder {
 // given expression is a just bare column reference, it returns that column's ID
 // and a nil scalar expression.
 func (pb *projectionBuilder) Add(
-	name tree.Name, expr tree.Expr, desiredType *types.T,
+	name scopeColumnName, expr tree.Expr, desiredType *types.T,
 ) (opt.ColumnID, opt.ScalarExpr) {
 	if pb.outScope == nil {
 		pb.outScope = pb.inScope.replace()
@@ -350,7 +350,7 @@ func (pb *projectionBuilder) Add(
 	// auto-generated name in the metadata. We then override it below. This
 	// reduces clashes between column names in the metadata.
 	// TODO(radu): is this really better than using the real column name?
-	scopeCol := pb.outScope.addColumn("" /* alias */, typedExpr)
+	scopeCol := pb.outScope.addColumn(scopeColName(""), typedExpr)
 	scalar := pb.b.buildScalar(typedExpr, pb.inScope, pb.outScope, scopeCol, nil)
 	scopeCol.name = name
 

--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -346,13 +346,8 @@ func (pb *projectionBuilder) Add(
 		pb.outScope.appendColumnsFromScope(pb.inScope)
 	}
 	typedExpr := pb.inScope.resolveAndRequireType(expr, desiredType)
-	// Instead of passing the column name here, we let the column get an
-	// auto-generated name in the metadata. We then override it below. This
-	// reduces clashes between column names in the metadata.
-	// TODO(radu): is this really better than using the real column name?
-	scopeCol := pb.outScope.addColumn(scopeColName(""), typedExpr)
+	scopeCol := pb.outScope.addColumn(name, typedExpr)
 	scalar := pb.b.buildScalar(typedExpr, pb.inScope, pb.outScope, scopeCol, nil)
-	scopeCol.name = name
 
 	return scopeCol.id, scalar
 }

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -83,7 +83,7 @@ func (b *Builder) buildScalar(
 			// grouping on the entire PK of that table.
 			g := inScope.groupby
 			if !inScope.isOuterColumn(t.id) && !b.allowImplicitGroupingColumn(t.id, g) {
-				panic(newGroupingError(&t.name))
+				panic(newGroupingError(t.name.ReferenceName()))
 			}
 
 			// We add a new grouping column; these show up both in aggInScope and
@@ -92,7 +92,7 @@ func (b *Builder) buildScalar(
 			// Note that normalization rules will trim down the list of grouping
 			// columns based on FDs, so this is only for the purposes of building a
 			// valid operator.
-			aggInCol := g.aggInScope.addColumn("" /* alias */, t)
+			aggInCol := g.aggInScope.addColumn(scopeColName(""), t)
 			b.finishBuildScalarRef(t, inScope, g.aggInScope, aggInCol, nil)
 			g.groupStrs[symbolicExprStr(t)] = aggInCol
 
@@ -383,7 +383,7 @@ func (b *Builder) buildScalar(
 				// Non-grouping column was referenced. Note that a column that is part
 				// of a larger grouping expression would have been detected by the
 				// groupStrs checking code above.
-				panic(newGroupingError(&t.cols[0].name))
+				panic(newGroupingError(t.cols[0].name.ReferenceName()))
 			}
 			return b.finishBuildScalarRef(&t.cols[0], inScope, outScope, outCol, colRefs)
 		}
@@ -637,10 +637,11 @@ func (b *Builder) checkSubqueryOuterCols(
 			subqueryOuterCols.DifferenceWith(inScope.groupby.aggOutScope.colSet())
 			colID, _ := subqueryOuterCols.Next(0)
 			col := inScope.getColumn(colID)
+			name := col.name.ReferenceName()
 			panic(pgerror.Newf(
 				pgcode.Grouping,
 				"subquery uses ungrouped column \"%s\" from outer query",
-				tree.ErrString(&col.name)))
+				tree.ErrString(&name)))
 		}
 	}
 }
@@ -810,7 +811,7 @@ func NewScalar(
 	for colID := opt.ColumnID(1); int(colID) <= md.NumColumns(); colID++ {
 		colMeta := md.ColumnMeta(colID)
 		sb.scope.cols = append(sb.scope.cols, scopeColumn{
-			name: tree.Name(colMeta.Alias),
+			name: scopeColName(tree.Name(colMeta.Alias)),
 			typ:  colMeta.Type,
 			id:   colID,
 		})

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -219,7 +219,7 @@ func (s *scope) appendOrdinaryColumnsFromTable(tabMeta *opt.TableMeta, alias *tr
 			continue
 		}
 		s.cols = append(s.cols, scopeColumn{
-			name:       tabCol.ColName(),
+			name:       scopeColName(tabCol.ColName()),
 			table:      *alias,
 			typ:        tabCol.DatumType(),
 			id:         tabMeta.MetaID.ColumnID(i),
@@ -260,11 +260,10 @@ func (s *scope) addExtraColumns(cols []scopeColumn) {
 	}
 }
 
-// addColumn adds a column to scope with the given alias and typed expression.
+// addColumn adds a column to scope with the given name and typed expression.
 // It returns a pointer to the new column. The column ID and group are left
 // empty so they can be filled in later.
-func (s *scope) addColumn(alias string, expr tree.TypedExpr) *scopeColumn {
-	name := tree.Name(alias)
+func (s *scope) addColumn(name scopeColumnName, expr tree.TypedExpr) *scopeColumn {
 	s.cols = append(s.cols, scopeColumn{
 		name: name,
 		typ:  expr.ResolvedType(),
@@ -361,7 +360,7 @@ func (s *scope) makePresentation() physical.Presentation {
 		col := &s.cols[i]
 		if col.visibility == cat.Visible {
 			presentation = append(presentation, opt.AliasedColumn{
-				Alias: string(col.name),
+				Alias: string(col.name.ReferenceName()),
 				ID:    col.id,
 			})
 		}
@@ -379,7 +378,7 @@ func (s *scope) makePresentationWithHiddenCols() physical.Presentation {
 	for i := range s.cols {
 		col := &s.cols[i]
 		presentation = append(presentation, opt.AliasedColumn{
-			Alias: string(col.name),
+			Alias: string(col.name.ReferenceName()),
 			ID:    col.id,
 		})
 	}
@@ -720,7 +719,7 @@ func (s *scope) FindSourceProvidingColumn(
 	for ; s != nil; s, allowHidden = s.parent, false {
 		for i := range s.cols {
 			col := &s.cols[i]
-			if col.name != colName {
+			if !col.name.MatchesReferenceName(colName) {
 				continue
 			}
 
@@ -876,7 +875,7 @@ func (s *scope) Resolve(
 	inScope := srcMeta.(*scope)
 	for i := range inScope.cols {
 		col := &inScope.cols[i]
-		if col.name == colName && sourceNameMatches(*prefix, col.table) {
+		if col.name.MatchesReferenceName(colName) && sourceNameMatches(*prefix, col.table) {
 			return col, nil
 		}
 	}
@@ -1037,7 +1036,7 @@ func (s *scope) replaceSRF(f *tree.FuncExpr, def *tree.FunctionDefinition) *srf 
 
 	var typedFuncExpr = typedFunc.(*tree.FuncExpr)
 	if s.builder.shouldCreateDefaultColumn(typedFuncExpr) {
-		outCol = srfScope.addColumn(def.Name, typedFunc)
+		outCol = srfScope.addColumn(scopeColName(tree.Name(def.Name)), typedFunc)
 	}
 	out := s.builder.buildFunction(typedFuncExpr, s, srfScope, outCol, nil)
 	srf := &srf{
@@ -1274,7 +1273,7 @@ func (s *scope) replaceWindowFn(f *tree.FuncExpr, def *tree.FunctionDefinition) 
 	}
 
 	info.col = &scopeColumn{
-		name: tree.Name(def.Name),
+		name: scopeColName(tree.Name(def.Name)),
 		typ:  f.ResolvedType(),
 		id:   s.builder.factory.Metadata().AddColumn(def.Name, f.ResolvedType()),
 		expr: &info,
@@ -1539,7 +1538,7 @@ func (s *scope) newAmbiguousColumnError(
 	}
 	for i := range s.cols {
 		col := &s.cols[i]
-		if col.name == n && (col.visibility == cat.Visible || (col.visibility == cat.Hidden && allowHidden)) {
+		if col.name.MatchesReferenceName(n) && (col.visibility == cat.Visible || (col.visibility == cat.Hidden && allowHidden)) {
 			if col.table.ObjectName == "" && col.visibility == cat.Visible {
 				if moreThanOneCandidateFromAnonSource {
 					// Only print first anonymous source, since other(s) are identical.
@@ -1589,13 +1588,13 @@ func (s *scope) String() string {
 		if i > 0 {
 			buf.WriteByte(',')
 		}
-		fmt.Fprintf(&buf, "%s:%d", c.name.String(), c.id)
+		fmt.Fprintf(&buf, "%s:%d", c.name.ReferenceName(), c.id)
 	}
 	for i, c := range s.extraCols {
 		if i > 0 || len(s.cols) > 0 {
 			buf.WriteByte(',')
 		}
-		fmt.Fprintf(&buf, "%s:%d!extra", c.name.String(), c.id)
+		fmt.Fprintf(&buf, "%s:%d!extra", c.name.ReferenceName(), c.id)
 	}
 	buf.WriteByte(')')
 

--- a/pkg/sql/opt/optbuilder/scope_column.go
+++ b/pkg/sql/opt/optbuilder/scope_column.go
@@ -25,9 +25,11 @@ import (
 // interface. During name resolution, unresolved column names in the AST are
 // replaced with a scopeColumn.
 type scopeColumn struct {
-	// name is the current name of this column. It is usually the same as
-	// the original name, unless this column was renamed with an AS expression.
-	name  tree.Name
+	// name is the current name of this column in the scope. It is used to
+	// resolve column references when building expressions and to populate the
+	// metadata with a descriptive name.
+	name scopeColumnName
+
 	table tree.TableName
 	typ   *types.T
 
@@ -68,8 +70,9 @@ type scopeColumn struct {
 // clearName sets the empty table and column name. This is used to make the
 // column anonymous so that it cannot be referenced, but will still be
 // projected.
+// TODO(mgartner): Do we still need this?
 func (c *scopeColumn) clearName() {
-	c.name = ""
+	c.name.Anonymize()
 	c.table = tree.TableName{}
 }
 
@@ -123,7 +126,8 @@ func (c *scopeColumn) Format(ctx *tree.FmtCtx) {
 		ctx.FormatNode(&c.table.ObjectName)
 		ctx.WriteByte('.')
 	}
-	ctx.FormatNode(&c.name)
+	colName := c.name.ReferenceName()
+	ctx.FormatNode(&colName)
 }
 
 // Walk is part of the tree.Expr interface.
@@ -151,3 +155,87 @@ func (*scopeColumn) Eval(_ *tree.EvalContext) (tree.Datum, error) {
 // Variable is part of the tree.VariableExpr interface. This prevents the
 // column from being evaluated during normalization.
 func (*scopeColumn) Variable() {}
+
+// scopeColumnName represents the name of a scopeColumn. The struct tracks two
+// names: refName represents the name that can reference the scopeColumn, while
+// metadataName is the name used when adding the scopeColumn to the metadata.
+//
+// Separating these names allows a column to be referenced by one name while
+// optbuilder builds expressions, but added to the metadata and displayed in opt
+// trees with another. This is useful for:
+//
+//   1. Creating more descriptive metadata names, while having refNames that are
+//      required for column resolution while building expressions. This is
+//      particularly useful in mutations where there are multiple versions of
+//      target table columns for fetching, inserting, and updating that must be
+//      referenced by the same name.
+//
+//   2. Creating descriptive metadata names for anonymous columns that
+//      cannot be referenced. This is useful for columns like synthesized
+//      check constraint columns and partial index columns which cannot be
+//      referenced by other expressions. Prior to the creation of
+//      scopeColumnName, the same descriptive name added to the metadata
+//      could be referenced, making optbuilder vulnerable to "ambiguous
+//      column" bugs when a user table had a column with the same name.
+//
+type scopeColumnName struct {
+	// refName is the name used when resolving columns while building an
+	// expression. If it is empty, the column is anonymous and cannot be
+	// referenced. It is usually the same as the original column name, unless
+	// this column was renamed with an AS expression.
+	refName tree.Name
+
+	// metadataName is the name used when adding the column to the metadata. It
+	// is inconsequential while building expressions; it only makes plans more
+	// readable.
+	metadataName string
+}
+
+// scopeColName creates a scopeColumnName that can be referenced by the given
+// name and will be added to the metadata with the given name. If name is an
+// empty string, the returned scopeColumnName is anonymous; it cannot be
+// referenced in expressions and it will be added to the metadata with a name of
+// the form "column<ID>".
+func scopeColName(name tree.Name) scopeColumnName {
+	return scopeColumnName{
+		refName:      name,
+		metadataName: string(name),
+	}
+}
+
+// WithMetadataName returns a copy of s with the metadata name set to the given
+// name. This only affects the name of the column in the metadata. It does not
+// change the name by which the column can be referenced.
+func (s scopeColumnName) WithMetadataName(name string) scopeColumnName {
+	s.metadataName = name
+	return s
+}
+
+// Anonymize makes the scopeColumnName unable to be referenced.
+func (s *scopeColumnName) Anonymize() {
+	s.refName = ""
+}
+
+// IsAnonymous returns true if the scopeColumnName is a name that cannot be
+// referenced.
+func (s *scopeColumnName) IsAnonymous() bool {
+	return s.refName == ""
+}
+
+// MatchesReferenceName returns true if the given name references the
+// scopeColumn with this scopeColumnName.
+func (s *scopeColumnName) MatchesReferenceName(ref tree.Name) bool {
+	return s.refName == ref
+}
+
+// ReferenceName returns the name that the scopeColumn with this scopeColumnName
+// can be referenced by.
+func (s *scopeColumnName) ReferenceName() tree.Name {
+	return s.refName
+}
+
+// MetadataName returns the string to use when adding the scopeColumn with this
+// scopeColumnName to metadata.
+func (s *scopeColumnName) MetadataName() string {
+	return s.metadataName
+}

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -59,7 +59,7 @@ func (b *Builder) buildDataSource(
 		outScope = b.buildDataSource(source.Expr, indexFlags, locking, inScope)
 
 		if source.Ordinality {
-			outScope = b.buildWithOrdinality("ordinality", outScope)
+			outScope = b.buildWithOrdinality(outScope)
 		}
 
 		// Overwrite output properties with any alias information.
@@ -83,7 +83,7 @@ func (b *Builder) buildDataSource(
 			for i, col := range cte.cols {
 				id := col.ID
 				c := b.factory.Metadata().ColumnMeta(id)
-				newCol := b.synthesizeColumn(outScope, col.Alias, c.Type, nil, nil)
+				newCol := b.synthesizeColumn(outScope, scopeColName(tree.Name(col.Alias)), c.Type, nil, nil)
 				newCol.table = *tn
 				inCols[i] = id
 				outCols[i] = newCol.id
@@ -303,7 +303,7 @@ func (b *Builder) buildView(
 	for i := range outScope.cols {
 		outScope.cols[i].table = *viewName
 		if hasCols {
-			outScope.cols[i].name = view.ColumnName(i)
+			outScope.cols[i].name = scopeColName(view.ColumnName(i))
 		}
 	}
 
@@ -360,7 +360,7 @@ func (b *Builder) renameSource(as tree.AliasClause, scope *scope) {
 				if col.visibility != cat.Visible {
 					continue
 				}
-				col.name = colAlias[aliasIdx]
+				col.name = scopeColName(colAlias[aliasIdx])
 				if isScan {
 					// Override column metadata alias.
 					colMeta := b.factory.Metadata().ColumnMeta(col.id)
@@ -481,7 +481,7 @@ func (b *Builder) buildScan(
 		kind := col.Kind()
 		outScope.cols[i] = scopeColumn{
 			id:           colID,
-			name:         name,
+			name:         scopeColName(name),
 			table:        tabMeta.Alias,
 			typ:          col.DatumType(),
 			visibility:   col.Visibility(),
@@ -734,7 +734,7 @@ func (b *Builder) buildSequenceSelect(
 		col := md.ColumnMeta(c)
 		outScope.cols[i] = scopeColumn{
 			id:    c,
-			name:  tree.Name(col.Alias),
+			name:  scopeColName(tree.Name(col.Alias)),
 			table: *seqName,
 			typ:   col.Type,
 		}
@@ -752,14 +752,13 @@ func (b *Builder) buildSequenceSelect(
 	return outScope
 }
 
-// buildWithOrdinality builds a group which appends an increasing integer column to
-// the output. colName optionally denotes the name this column is given, or can
-// be blank for none.
+// buildWithOrdinality builds a group which appends an increasing integer column
+// to the output.
 //
-// See Builder.buildStmt for a description of the remaining input and
-// return values.
-func (b *Builder) buildWithOrdinality(colName string, inScope *scope) (outScope *scope) {
-	col := b.synthesizeColumn(inScope, colName, types.Int, nil, nil /* scalar */)
+// See Builder.buildStmt for a description of the remaining input and return
+// values.
+func (b *Builder) buildWithOrdinality(inScope *scope) (outScope *scope) {
+	col := b.synthesizeColumn(inScope, scopeColName("ordinality"), types.Int, nil, nil /* scalar */)
 
 	// See https://www.cockroachlabs.com/docs/stable/query-order.html#order-preservation
 	// for the semantics around WITH ORDINALITY and ordering.
@@ -897,7 +896,7 @@ func (b *Builder) buildSelectStmtWithoutParens(
 		projectionsScope.cols = make([]scopeColumn, 0, len(outScope.cols))
 		for i := range outScope.cols {
 			expr := &outScope.cols[i]
-			col := projectionsScope.addColumn("" /* alias */, expr)
+			col := projectionsScope.addColumn(scopeColName(""), expr)
 			b.buildScalar(expr, outScope, projectionsScope, col, nil)
 		}
 		orderByScope := b.analyzeOrderBy(orderBy, outScope, projectionsScope, tree.RejectGenerators|tree.RejectAggregates|tree.RejectWindowApplications)

--- a/pkg/sql/opt/optbuilder/srfs.go
+++ b/pkg/sql/opt/optbuilder/srfs.go
@@ -113,7 +113,7 @@ func (b *Builder) buildZip(exprs tree.Exprs, inScope *scope) (outScope *scope) {
 				// when used in a from clause.
 				alias = def.ReturnLabels[0]
 			}
-			outCol = outScope.addColumn(alias, texpr)
+			outCol = outScope.addColumn(scopeColName(tree.Name(alias)), texpr)
 		}
 
 		scalar := b.buildScalar(texpr, inScope, outScope, outCol, nil)
@@ -151,7 +151,7 @@ func (b *Builder) finishBuildGeneratorFunction(
 		// as column aliases.
 		typ := f.ResolvedType()
 		for i := range typ.TupleContents() {
-			b.synthesizeColumn(outScope, typ.TupleLabels()[i], typ.TupleContents()[i], nil, fn)
+			b.synthesizeColumn(outScope, scopeColName(tree.Name(typ.TupleLabels()[i])), typ.TupleContents()[i], nil, fn)
 		}
 	}
 

--- a/pkg/sql/opt/optbuilder/subquery.go
+++ b/pkg/sql/opt/optbuilder/subquery.go
@@ -165,7 +165,7 @@ func (s *subquery) TypeCheck(
 		labels := make([]string, len(s.cols))
 		for i := range s.cols {
 			contents[i] = s.cols[i].typ
-			labels[i] = string(s.cols[i].name)
+			labels[i] = string(s.cols[i].name.ReferenceName())
 		}
 		s.typ = types.MakeLabeledTuple(contents, labels)
 	}
@@ -287,7 +287,7 @@ func (b *Builder) buildSubqueryProjection(
 
 		texpr := tree.NewTypedTuple(typ, cols)
 		tup := b.factory.ConstructTuple(els, typ)
-		col := b.synthesizeColumn(outScope, "", texpr.ResolvedType(), texpr, tup)
+		col := b.synthesizeColumn(outScope, scopeColName(""), texpr.ResolvedType(), texpr, tup)
 		out = b.constructProject(out, []scopeColumn{*col})
 	}
 

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
@@ -189,15 +189,15 @@ insert child_nullable
  ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:4 => c:1
- │    └── column5:5 => p:2
+ │    └── p_default:5 => p:2
  └── project
-      ├── columns: column5:5 column1:4!null
+      ├── columns: p_default:5 column1:4!null
       ├── values
       │    ├── columns: column1:4!null
       │    ├── (100,)
       │    └── (200,)
       └── projections
-           └── NULL::INT8 [as=column5:5]
+           └── NULL::INT8 [as=p_default:5]
 
 # Check planning of filter with FULL match (which should be the same on a
 # single column).
@@ -243,15 +243,15 @@ insert child_nullable_full
  ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:4 => c:1
- │    └── column5:5 => p:2
+ │    └── p_default:5 => p:2
  └── project
-      ├── columns: column5:5 column1:4!null
+      ├── columns: p_default:5 column1:4!null
       ├── values
       │    ├── columns: column1:4!null
       │    ├── (100,)
       │    └── (200,)
       └── projections
-           └── NULL::INT8 [as=column5:5]
+           └── NULL::INT8 [as=p_default:5]
 
 # Tests with multicolumn FKs.
 exec-ddl

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-upsert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-upsert
@@ -38,16 +38,16 @@ upsert c1
  ├── upsert-mapping:
  │    ├── column1:5 => c:1
  │    ├── column2:6 => c1.p:2
- │    └── column7:7 => i:3
+ │    └── i_default:7 => i:3
  ├── input binding: &1
  ├── project
- │    ├── columns: column7:7 column1:5!null column2:6!null
+ │    ├── columns: i_default:7 column1:5!null column2:6!null
  │    ├── values
  │    │    ├── columns: column1:5!null column2:6!null
  │    │    ├── (100, 1)
  │    │    └── (200, 1)
  │    └── projections
- │         └── NULL::INT8 [as=column7:7]
+ │         └── NULL::INT8 [as=i_default:7]
  └── f-k-checks
       └── f-k-checks-item: c1(p) -> p(p)
            └── anti-join (hash)
@@ -71,38 +71,38 @@ upsert c1
  ├── fetch columns: c:8 c1.p:9 i:10
  ├── insert-mapping:
  │    ├── column1:5 => c:1
- │    ├── column6:6 => c1.p:2
- │    └── column7:7 => i:3
+ │    ├── p_default:6 => c1.p:2
+ │    └── i_default:7 => i:3
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_c:12 upsert_p:13 upsert_i:14 column1:5!null column6:6!null column7:7 c:8 c1.p:9 i:10 c1.crdb_internal_mvcc_timestamp:11
+ │    ├── columns: upsert_c:12 upsert_p:13 upsert_i:14 column1:5!null p_default:6!null i_default:7 c:8 c1.p:9 i:10 c1.crdb_internal_mvcc_timestamp:11
  │    ├── left-join (hash)
- │    │    ├── columns: column1:5!null column6:6!null column7:7 c:8 c1.p:9 i:10 c1.crdb_internal_mvcc_timestamp:11
+ │    │    ├── columns: column1:5!null p_default:6!null i_default:7 c:8 c1.p:9 i:10 c1.crdb_internal_mvcc_timestamp:11
  │    │    ├── ensure-upsert-distinct-on
- │    │    │    ├── columns: column1:5!null column6:6!null column7:7
+ │    │    │    ├── columns: column1:5!null p_default:6!null i_default:7
  │    │    │    ├── grouping columns: column1:5!null
  │    │    │    ├── project
- │    │    │    │    ├── columns: column6:6!null column7:7 column1:5!null
+ │    │    │    │    ├── columns: p_default:6!null i_default:7 column1:5!null
  │    │    │    │    ├── values
  │    │    │    │    │    ├── columns: column1:5!null
  │    │    │    │    │    ├── (100,)
  │    │    │    │    │    └── (200,)
  │    │    │    │    └── projections
- │    │    │    │         ├── 5 [as=column6:6]
- │    │    │    │         └── NULL::INT8 [as=column7:7]
+ │    │    │    │         ├── 5 [as=p_default:6]
+ │    │    │    │         └── NULL::INT8 [as=i_default:7]
  │    │    │    └── aggregations
- │    │    │         ├── first-agg [as=column6:6]
- │    │    │         │    └── column6:6
- │    │    │         └── first-agg [as=column7:7]
- │    │    │              └── column7:7
+ │    │    │         ├── first-agg [as=p_default:6]
+ │    │    │         │    └── p_default:6
+ │    │    │         └── first-agg [as=i_default:7]
+ │    │    │              └── i_default:7
  │    │    ├── scan c1
  │    │    │    └── columns: c:8!null c1.p:9!null i:10 c1.crdb_internal_mvcc_timestamp:11
  │    │    └── filters
  │    │         └── column1:5 = c:8
  │    └── projections
  │         ├── CASE WHEN c:8 IS NULL THEN column1:5 ELSE c:8 END [as=upsert_c:12]
- │         ├── CASE WHEN c:8 IS NULL THEN column6:6 ELSE c1.p:9 END [as=upsert_p:13]
- │         └── CASE WHEN c:8 IS NULL THEN column7:7 ELSE i:10 END [as=upsert_i:14]
+ │         ├── CASE WHEN c:8 IS NULL THEN p_default:6 ELSE c1.p:9 END [as=upsert_p:13]
+ │         └── CASE WHEN c:8 IS NULL THEN i_default:7 ELSE i:10 END [as=upsert_i:14]
  └── f-k-checks
       └── f-k-checks-item: c1(p) -> p(p)
            └── anti-join (hash)
@@ -125,16 +125,16 @@ upsert c1
  ├── upsert-mapping:
  │    ├── x:5 => c:1
  │    ├── y:6 => c1.p:2
- │    └── column11:11 => i:3
+ │    └── i_default:11 => i:3
  ├── input binding: &1
  ├── project
- │    ├── columns: column11:11 x:5 y:6
+ │    ├── columns: i_default:11 x:5 y:6
  │    ├── project
  │    │    ├── columns: x:5 y:6
  │    │    └── scan xyzw
  │    │         └── columns: x:5 y:6 z:7 w:8 rowid:9!null xyzw.crdb_internal_mvcc_timestamp:10
  │    └── projections
- │         └── NULL::INT8 [as=column11:11]
+ │         └── NULL::INT8 [as=i_default:11]
  └── f-k-checks
       └── f-k-checks-item: c1(p) -> p(p)
            └── anti-join (hash)
@@ -159,32 +159,32 @@ upsert c1
  ├── insert-mapping:
  │    ├── column1:5 => c:1
  │    ├── column2:6 => c1.p:2
- │    └── column7:7 => i:3
+ │    └── i_default:7 => i:3
  ├── update-mapping:
  │    └── upsert_p:14 => c1.p:2
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_c:13 upsert_p:14!null upsert_i:15 column1:5!null column2:6!null column7:7 c:8 c1.p:9 i:10 c1.crdb_internal_mvcc_timestamp:11 p_new:12!null
+ │    ├── columns: upsert_c:13 upsert_p:14!null upsert_i:15 column1:5!null column2:6!null i_default:7 c:8 c1.p:9 i:10 c1.crdb_internal_mvcc_timestamp:11 p_new:12!null
  │    ├── project
- │    │    ├── columns: p_new:12!null column1:5!null column2:6!null column7:7 c:8 c1.p:9 i:10 c1.crdb_internal_mvcc_timestamp:11
+ │    │    ├── columns: p_new:12!null column1:5!null column2:6!null i_default:7 c:8 c1.p:9 i:10 c1.crdb_internal_mvcc_timestamp:11
  │    │    ├── left-join (hash)
- │    │    │    ├── columns: column1:5!null column2:6!null column7:7 c:8 c1.p:9 i:10 c1.crdb_internal_mvcc_timestamp:11
+ │    │    │    ├── columns: column1:5!null column2:6!null i_default:7 c:8 c1.p:9 i:10 c1.crdb_internal_mvcc_timestamp:11
  │    │    │    ├── ensure-upsert-distinct-on
- │    │    │    │    ├── columns: column1:5!null column2:6!null column7:7
+ │    │    │    │    ├── columns: column1:5!null column2:6!null i_default:7
  │    │    │    │    ├── grouping columns: column1:5!null
  │    │    │    │    ├── project
- │    │    │    │    │    ├── columns: column7:7 column1:5!null column2:6!null
+ │    │    │    │    │    ├── columns: i_default:7 column1:5!null column2:6!null
  │    │    │    │    │    ├── values
  │    │    │    │    │    │    ├── columns: column1:5!null column2:6!null
  │    │    │    │    │    │    ├── (100, 1)
  │    │    │    │    │    │    └── (200, 1)
  │    │    │    │    │    └── projections
- │    │    │    │    │         └── NULL::INT8 [as=column7:7]
+ │    │    │    │    │         └── NULL::INT8 [as=i_default:7]
  │    │    │    │    └── aggregations
  │    │    │    │         ├── first-agg [as=column2:6]
  │    │    │    │         │    └── column2:6
- │    │    │    │         └── first-agg [as=column7:7]
- │    │    │    │              └── column7:7
+ │    │    │    │         └── first-agg [as=i_default:7]
+ │    │    │    │              └── i_default:7
  │    │    │    ├── scan c1
  │    │    │    │    └── columns: c:8!null c1.p:9!null i:10 c1.crdb_internal_mvcc_timestamp:11
  │    │    │    └── filters
@@ -194,7 +194,7 @@ upsert c1
  │    └── projections
  │         ├── CASE WHEN c:8 IS NULL THEN column1:5 ELSE c:8 END [as=upsert_c:13]
  │         ├── CASE WHEN c:8 IS NULL THEN column2:6 ELSE p_new:12 END [as=upsert_p:14]
- │         └── CASE WHEN c:8 IS NULL THEN column7:7 ELSE i:10 END [as=upsert_i:15]
+ │         └── CASE WHEN c:8 IS NULL THEN i_default:7 ELSE i:10 END [as=upsert_i:15]
  └── f-k-checks
       └── f-k-checks-item: c1(p) -> p(p)
            └── anti-join (hash)
@@ -219,32 +219,32 @@ upsert c1
  ├── insert-mapping:
  │    ├── u:5 => c:1
  │    ├── v:6 => c1.p:2
- │    └── column9:9 => i:3
+ │    └── i_default:9 => i:3
  ├── update-mapping:
  │    └── upsert_i:17 => i:3
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_c:15 upsert_p:16 upsert_i:17 u:5!null v:6!null column9:9 c:10 c1.p:11 i:12 c1.crdb_internal_mvcc_timestamp:13 i_new:14
+ │    ├── columns: upsert_c:15 upsert_p:16 upsert_i:17 u:5!null v:6!null i_default:9 c:10 c1.p:11 i:12 c1.crdb_internal_mvcc_timestamp:13 i_new:14
  │    ├── project
- │    │    ├── columns: i_new:14 u:5!null v:6!null column9:9 c:10 c1.p:11 i:12 c1.crdb_internal_mvcc_timestamp:13
+ │    │    ├── columns: i_new:14 u:5!null v:6!null i_default:9 c:10 c1.p:11 i:12 c1.crdb_internal_mvcc_timestamp:13
  │    │    ├── left-join (hash)
- │    │    │    ├── columns: u:5!null v:6!null column9:9 c:10 c1.p:11 i:12 c1.crdb_internal_mvcc_timestamp:13
+ │    │    │    ├── columns: u:5!null v:6!null i_default:9 c:10 c1.p:11 i:12 c1.crdb_internal_mvcc_timestamp:13
  │    │    │    ├── ensure-upsert-distinct-on
- │    │    │    │    ├── columns: u:5!null v:6!null column9:9
+ │    │    │    │    ├── columns: u:5!null v:6!null i_default:9
  │    │    │    │    ├── grouping columns: u:5!null
  │    │    │    │    ├── project
- │    │    │    │    │    ├── columns: column9:9 u:5!null v:6!null
+ │    │    │    │    │    ├── columns: i_default:9 u:5!null v:6!null
  │    │    │    │    │    ├── project
  │    │    │    │    │    │    ├── columns: u:5!null v:6!null
  │    │    │    │    │    │    └── scan uv
  │    │    │    │    │    │         └── columns: u:5!null v:6!null rowid:7!null uv.crdb_internal_mvcc_timestamp:8
  │    │    │    │    │    └── projections
- │    │    │    │    │         └── NULL::INT8 [as=column9:9]
+ │    │    │    │    │         └── NULL::INT8 [as=i_default:9]
  │    │    │    │    └── aggregations
  │    │    │    │         ├── first-agg [as=v:6]
  │    │    │    │         │    └── v:6
- │    │    │    │         └── first-agg [as=column9:9]
- │    │    │    │              └── column9:9
+ │    │    │    │         └── first-agg [as=i_default:9]
+ │    │    │    │              └── i_default:9
  │    │    │    ├── scan c1
  │    │    │    │    └── columns: c:10!null c1.p:11!null i:12 c1.crdb_internal_mvcc_timestamp:13
  │    │    │    └── filters
@@ -254,7 +254,7 @@ upsert c1
  │    └── projections
  │         ├── CASE WHEN c:10 IS NULL THEN u:5 ELSE c:10 END [as=upsert_c:15]
  │         ├── CASE WHEN c:10 IS NULL THEN v:6 ELSE c1.p:11 END [as=upsert_p:16]
- │         └── CASE WHEN c:10 IS NULL THEN column9:9 ELSE i_new:14 END [as=upsert_i:17]
+ │         └── CASE WHEN c:10 IS NULL THEN i_default:9 ELSE i_new:14 END [as=upsert_i:17]
  └── f-k-checks
       └── f-k-checks-item: c1(p) -> p(p)
            └── anti-join (hash)
@@ -365,33 +365,33 @@ upsert c3
  ├── fetch columns: c:6 c3.p:7
  ├── insert-mapping:
  │    ├── column1:4 => c:1
- │    └── column5:5 => c3.p:2
+ │    └── p_default:5 => c3.p:2
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_c:9 upsert_p:10 column1:4!null column5:5 c:6 c3.p:7 c3.crdb_internal_mvcc_timestamp:8
+ │    ├── columns: upsert_c:9 upsert_p:10 column1:4!null p_default:5 c:6 c3.p:7 c3.crdb_internal_mvcc_timestamp:8
  │    ├── left-join (hash)
- │    │    ├── columns: column1:4!null column5:5 c:6 c3.p:7 c3.crdb_internal_mvcc_timestamp:8
+ │    │    ├── columns: column1:4!null p_default:5 c:6 c3.p:7 c3.crdb_internal_mvcc_timestamp:8
  │    │    ├── ensure-upsert-distinct-on
- │    │    │    ├── columns: column1:4!null column5:5
+ │    │    │    ├── columns: column1:4!null p_default:5
  │    │    │    ├── grouping columns: column1:4!null
  │    │    │    ├── project
- │    │    │    │    ├── columns: column5:5 column1:4!null
+ │    │    │    │    ├── columns: p_default:5 column1:4!null
  │    │    │    │    ├── values
  │    │    │    │    │    ├── columns: column1:4!null
  │    │    │    │    │    ├── (100,)
  │    │    │    │    │    └── (200,)
  │    │    │    │    └── projections
- │    │    │    │         └── NULL::INT8 [as=column5:5]
+ │    │    │    │         └── NULL::INT8 [as=p_default:5]
  │    │    │    └── aggregations
- │    │    │         └── first-agg [as=column5:5]
- │    │    │              └── column5:5
+ │    │    │         └── first-agg [as=p_default:5]
+ │    │    │              └── p_default:5
  │    │    ├── scan c3
  │    │    │    └── columns: c:6!null c3.p:7 c3.crdb_internal_mvcc_timestamp:8
  │    │    └── filters
  │    │         └── column1:4 = c:6
  │    └── projections
  │         ├── CASE WHEN c:6 IS NULL THEN column1:4 ELSE c:6 END [as=upsert_c:9]
- │         └── CASE WHEN c:6 IS NULL THEN column5:5 ELSE c3.p:7 END [as=upsert_p:10]
+ │         └── CASE WHEN c:6 IS NULL THEN p_default:5 ELSE c3.p:7 END [as=upsert_p:10]
  └── f-k-checks
       └── f-k-checks-item: c3(p) -> p(p)
            └── anti-join (hash)
@@ -636,42 +636,42 @@ upsert cpq
  ├── insert-mapping:
  │    ├── x:6 => c:1
  │    ├── y:7 => cpq.p:2
- │    ├── column12:12 => cpq.q:3
- │    └── column13:13 => cpq.other:4
+ │    ├── q_default:12 => cpq.q:3
+ │    └── other_default:13 => cpq.other:4
  ├── update-mapping:
  │    └── y:7 => cpq.p:2
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_c:19 upsert_q:20 upsert_other:21 x:6 y:7 column12:12!null column13:13 c:14 cpq.p:15 cpq.q:16 cpq.other:17 cpq.crdb_internal_mvcc_timestamp:18
+ │    ├── columns: upsert_c:19 upsert_q:20 upsert_other:21 x:6 y:7 q_default:12!null other_default:13 c:14 cpq.p:15 cpq.q:16 cpq.other:17 cpq.crdb_internal_mvcc_timestamp:18
  │    ├── left-join (hash)
- │    │    ├── columns: x:6 y:7 column12:12!null column13:13 c:14 cpq.p:15 cpq.q:16 cpq.other:17 cpq.crdb_internal_mvcc_timestamp:18
+ │    │    ├── columns: x:6 y:7 q_default:12!null other_default:13 c:14 cpq.p:15 cpq.q:16 cpq.other:17 cpq.crdb_internal_mvcc_timestamp:18
  │    │    ├── ensure-upsert-distinct-on
- │    │    │    ├── columns: x:6 y:7 column12:12!null column13:13
+ │    │    │    ├── columns: x:6 y:7 q_default:12!null other_default:13
  │    │    │    ├── grouping columns: x:6
  │    │    │    ├── project
- │    │    │    │    ├── columns: column12:12!null column13:13 x:6 y:7
+ │    │    │    │    ├── columns: q_default:12!null other_default:13 x:6 y:7
  │    │    │    │    ├── project
  │    │    │    │    │    ├── columns: x:6 y:7
  │    │    │    │    │    └── scan xyzw
  │    │    │    │    │         └── columns: x:6 y:7 z:8 w:9 rowid:10!null xyzw.crdb_internal_mvcc_timestamp:11
  │    │    │    │    └── projections
- │    │    │    │         ├── 8 [as=column12:12]
- │    │    │    │         └── NULL::INT8 [as=column13:13]
+ │    │    │    │         ├── 8 [as=q_default:12]
+ │    │    │    │         └── NULL::INT8 [as=other_default:13]
  │    │    │    └── aggregations
  │    │    │         ├── first-agg [as=y:7]
  │    │    │         │    └── y:7
- │    │    │         ├── first-agg [as=column12:12]
- │    │    │         │    └── column12:12
- │    │    │         └── first-agg [as=column13:13]
- │    │    │              └── column13:13
+ │    │    │         ├── first-agg [as=q_default:12]
+ │    │    │         │    └── q_default:12
+ │    │    │         └── first-agg [as=other_default:13]
+ │    │    │              └── other_default:13
  │    │    ├── scan cpq
  │    │    │    └── columns: c:14!null cpq.p:15 cpq.q:16 cpq.other:17 cpq.crdb_internal_mvcc_timestamp:18
  │    │    └── filters
  │    │         └── x:6 = c:14
  │    └── projections
  │         ├── CASE WHEN c:14 IS NULL THEN x:6 ELSE c:14 END [as=upsert_c:19]
- │         ├── CASE WHEN c:14 IS NULL THEN column12:12 ELSE cpq.q:16 END [as=upsert_q:20]
- │         └── CASE WHEN c:14 IS NULL THEN column13:13 ELSE cpq.other:17 END [as=upsert_other:21]
+ │         ├── CASE WHEN c:14 IS NULL THEN q_default:12 ELSE cpq.q:16 END [as=upsert_q:20]
+ │         └── CASE WHEN c:14 IS NULL THEN other_default:13 ELSE cpq.other:17 END [as=upsert_other:21]
  └── f-k-checks
       └── f-k-checks-item: cpq(p,q) -> pq(p,q)
            └── anti-join (hash)
@@ -702,43 +702,43 @@ upsert cpq
  ├── fetch columns: c:15 cpq.p:16 cpq.q:17 cpq.other:18
  ├── insert-mapping:
  │    ├── x:6 => c:1
- │    ├── column12:12 => cpq.p:2
- │    ├── column13:13 => cpq.q:3
- │    └── column14:14 => cpq.other:4
+ │    ├── p_default:12 => cpq.p:2
+ │    ├── q_default:13 => cpq.q:3
+ │    └── other_default:14 => cpq.other:4
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_c:20 upsert_p:21 upsert_q:22 upsert_other:23 x:6 column12:12!null column13:13!null column14:14 c:15 cpq.p:16 cpq.q:17 cpq.other:18 cpq.crdb_internal_mvcc_timestamp:19
+ │    ├── columns: upsert_c:20 upsert_p:21 upsert_q:22 upsert_other:23 x:6 p_default:12!null q_default:13!null other_default:14 c:15 cpq.p:16 cpq.q:17 cpq.other:18 cpq.crdb_internal_mvcc_timestamp:19
  │    ├── left-join (hash)
- │    │    ├── columns: x:6 column12:12!null column13:13!null column14:14 c:15 cpq.p:16 cpq.q:17 cpq.other:18 cpq.crdb_internal_mvcc_timestamp:19
+ │    │    ├── columns: x:6 p_default:12!null q_default:13!null other_default:14 c:15 cpq.p:16 cpq.q:17 cpq.other:18 cpq.crdb_internal_mvcc_timestamp:19
  │    │    ├── ensure-upsert-distinct-on
- │    │    │    ├── columns: x:6 column12:12!null column13:13!null column14:14
+ │    │    │    ├── columns: x:6 p_default:12!null q_default:13!null other_default:14
  │    │    │    ├── grouping columns: x:6
  │    │    │    ├── project
- │    │    │    │    ├── columns: column12:12!null column13:13!null column14:14 x:6
+ │    │    │    │    ├── columns: p_default:12!null q_default:13!null other_default:14 x:6
  │    │    │    │    ├── project
  │    │    │    │    │    ├── columns: x:6
  │    │    │    │    │    └── scan xyzw
  │    │    │    │    │         └── columns: x:6 y:7 z:8 w:9 rowid:10!null xyzw.crdb_internal_mvcc_timestamp:11
  │    │    │    │    └── projections
- │    │    │    │         ├── 4 [as=column12:12]
- │    │    │    │         ├── 8 [as=column13:13]
- │    │    │    │         └── NULL::INT8 [as=column14:14]
+ │    │    │    │         ├── 4 [as=p_default:12]
+ │    │    │    │         ├── 8 [as=q_default:13]
+ │    │    │    │         └── NULL::INT8 [as=other_default:14]
  │    │    │    └── aggregations
- │    │    │         ├── first-agg [as=column12:12]
- │    │    │         │    └── column12:12
- │    │    │         ├── first-agg [as=column13:13]
- │    │    │         │    └── column13:13
- │    │    │         └── first-agg [as=column14:14]
- │    │    │              └── column14:14
+ │    │    │         ├── first-agg [as=p_default:12]
+ │    │    │         │    └── p_default:12
+ │    │    │         ├── first-agg [as=q_default:13]
+ │    │    │         │    └── q_default:13
+ │    │    │         └── first-agg [as=other_default:14]
+ │    │    │              └── other_default:14
  │    │    ├── scan cpq
  │    │    │    └── columns: c:15!null cpq.p:16 cpq.q:17 cpq.other:18 cpq.crdb_internal_mvcc_timestamp:19
  │    │    └── filters
  │    │         └── x:6 = c:15
  │    └── projections
  │         ├── CASE WHEN c:15 IS NULL THEN x:6 ELSE c:15 END [as=upsert_c:20]
- │         ├── CASE WHEN c:15 IS NULL THEN column12:12 ELSE cpq.p:16 END [as=upsert_p:21]
- │         ├── CASE WHEN c:15 IS NULL THEN column13:13 ELSE cpq.q:17 END [as=upsert_q:22]
- │         └── CASE WHEN c:15 IS NULL THEN column14:14 ELSE cpq.other:18 END [as=upsert_other:23]
+ │         ├── CASE WHEN c:15 IS NULL THEN p_default:12 ELSE cpq.p:16 END [as=upsert_p:21]
+ │         ├── CASE WHEN c:15 IS NULL THEN q_default:13 ELSE cpq.q:17 END [as=upsert_q:22]
+ │         └── CASE WHEN c:15 IS NULL THEN other_default:14 ELSE cpq.other:18 END [as=upsert_other:23]
  └── f-k-checks
       └── f-k-checks-item: cpq(p,q) -> pq(p,q)
            └── anti-join (hash)
@@ -768,20 +768,20 @@ upsert cpq
  ├── columns: <none>
  ├── upsert-mapping:
  │    ├── x:6 => c:1
- │    ├── column12:12 => cpq.p:2
- │    ├── column13:13 => cpq.q:3
- │    └── column14:14 => cpq.other:4
+ │    ├── p_default:12 => cpq.p:2
+ │    ├── q_default:13 => cpq.q:3
+ │    └── other_default:14 => cpq.other:4
  ├── input binding: &1
  ├── project
- │    ├── columns: column12:12!null column13:13!null column14:14 x:6
+ │    ├── columns: p_default:12!null q_default:13!null other_default:14 x:6
  │    ├── project
  │    │    ├── columns: x:6
  │    │    └── scan xyzw
  │    │         └── columns: x:6 y:7 z:8 w:9 rowid:10!null xyzw.crdb_internal_mvcc_timestamp:11
  │    └── projections
- │         ├── 4 [as=column12:12]
- │         ├── 8 [as=column13:13]
- │         └── NULL::INT8 [as=column14:14]
+ │         ├── 4 [as=p_default:12]
+ │         ├── 8 [as=q_default:13]
+ │         └── NULL::INT8 [as=other_default:14]
  └── f-k-checks
       └── f-k-checks-item: cpq(p,q) -> pq(p,q)
            └── anti-join (hash)
@@ -789,8 +789,8 @@ upsert cpq
                 ├── with-scan &1
                 │    ├── columns: p:15!null q:16!null
                 │    └── mapping:
-                │         ├──  column12:12 => p:15
-                │         └──  column13:13 => q:16
+                │         ├──  p_default:12 => p:15
+                │         └──  q_default:13 => q:16
                 ├── scan pq
                 │    └── columns: pq.p:18 pq.q:19
                 └── filters
@@ -807,38 +807,38 @@ upsert cpq
  ├── fetch columns: c:10 cpq.p:11 cpq.q:12 cpq.other:13
  ├── insert-mapping:
  │    ├── column1:6 => c:1
- │    ├── column7:7 => cpq.p:2
- │    ├── column8:8 => cpq.q:3
- │    └── column9:9 => cpq.other:4
+ │    ├── p_default:7 => cpq.p:2
+ │    ├── q_default:8 => cpq.q:3
+ │    └── other_default:9 => cpq.other:4
  ├── update-mapping:
  │    └── upsert_p:17 => cpq.p:2
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_c:16 upsert_p:17!null upsert_q:18 upsert_other:19 column1:6!null column7:7!null column8:8!null column9:9 c:10 cpq.p:11 cpq.q:12 cpq.other:13 cpq.crdb_internal_mvcc_timestamp:14 p_new:15!null
+ │    ├── columns: upsert_c:16 upsert_p:17!null upsert_q:18 upsert_other:19 column1:6!null p_default:7!null q_default:8!null other_default:9 c:10 cpq.p:11 cpq.q:12 cpq.other:13 cpq.crdb_internal_mvcc_timestamp:14 p_new:15!null
  │    ├── project
- │    │    ├── columns: p_new:15!null column1:6!null column7:7!null column8:8!null column9:9 c:10 cpq.p:11 cpq.q:12 cpq.other:13 cpq.crdb_internal_mvcc_timestamp:14
+ │    │    ├── columns: p_new:15!null column1:6!null p_default:7!null q_default:8!null other_default:9 c:10 cpq.p:11 cpq.q:12 cpq.other:13 cpq.crdb_internal_mvcc_timestamp:14
  │    │    ├── left-join (hash)
- │    │    │    ├── columns: column1:6!null column7:7!null column8:8!null column9:9 c:10 cpq.p:11 cpq.q:12 cpq.other:13 cpq.crdb_internal_mvcc_timestamp:14
+ │    │    │    ├── columns: column1:6!null p_default:7!null q_default:8!null other_default:9 c:10 cpq.p:11 cpq.q:12 cpq.other:13 cpq.crdb_internal_mvcc_timestamp:14
  │    │    │    ├── ensure-upsert-distinct-on
- │    │    │    │    ├── columns: column1:6!null column7:7!null column8:8!null column9:9
+ │    │    │    │    ├── columns: column1:6!null p_default:7!null q_default:8!null other_default:9
  │    │    │    │    ├── grouping columns: column1:6!null
  │    │    │    │    ├── project
- │    │    │    │    │    ├── columns: column7:7!null column8:8!null column9:9 column1:6!null
+ │    │    │    │    │    ├── columns: p_default:7!null q_default:8!null other_default:9 column1:6!null
  │    │    │    │    │    ├── values
  │    │    │    │    │    │    ├── columns: column1:6!null
  │    │    │    │    │    │    ├── (1,)
  │    │    │    │    │    │    └── (2,)
  │    │    │    │    │    └── projections
- │    │    │    │    │         ├── 4 [as=column7:7]
- │    │    │    │    │         ├── 8 [as=column8:8]
- │    │    │    │    │         └── NULL::INT8 [as=column9:9]
+ │    │    │    │    │         ├── 4 [as=p_default:7]
+ │    │    │    │    │         ├── 8 [as=q_default:8]
+ │    │    │    │    │         └── NULL::INT8 [as=other_default:9]
  │    │    │    │    └── aggregations
- │    │    │    │         ├── first-agg [as=column7:7]
- │    │    │    │         │    └── column7:7
- │    │    │    │         ├── first-agg [as=column8:8]
- │    │    │    │         │    └── column8:8
- │    │    │    │         └── first-agg [as=column9:9]
- │    │    │    │              └── column9:9
+ │    │    │    │         ├── first-agg [as=p_default:7]
+ │    │    │    │         │    └── p_default:7
+ │    │    │    │         ├── first-agg [as=q_default:8]
+ │    │    │    │         │    └── q_default:8
+ │    │    │    │         └── first-agg [as=other_default:9]
+ │    │    │    │              └── other_default:9
  │    │    │    ├── scan cpq
  │    │    │    │    └── columns: c:10!null cpq.p:11 cpq.q:12 cpq.other:13 cpq.crdb_internal_mvcc_timestamp:14
  │    │    │    └── filters
@@ -847,9 +847,9 @@ upsert cpq
  │    │         └── 10 [as=p_new:15]
  │    └── projections
  │         ├── CASE WHEN c:10 IS NULL THEN column1:6 ELSE c:10 END [as=upsert_c:16]
- │         ├── CASE WHEN c:10 IS NULL THEN column7:7 ELSE p_new:15 END [as=upsert_p:17]
- │         ├── CASE WHEN c:10 IS NULL THEN column8:8 ELSE cpq.q:12 END [as=upsert_q:18]
- │         └── CASE WHEN c:10 IS NULL THEN column9:9 ELSE cpq.other:13 END [as=upsert_other:19]
+ │         ├── CASE WHEN c:10 IS NULL THEN p_default:7 ELSE p_new:15 END [as=upsert_p:17]
+ │         ├── CASE WHEN c:10 IS NULL THEN q_default:8 ELSE cpq.q:12 END [as=upsert_q:18]
+ │         └── CASE WHEN c:10 IS NULL THEN other_default:9 ELSE cpq.other:13 END [as=upsert_other:19]
  └── f-k-checks
       └── f-k-checks-item: cpq(p,q) -> pq(p,q)
            └── anti-join (hash)
@@ -938,30 +938,30 @@ upsert cmulti
  │    ├── x:6 => cmulti.a:1
  │    ├── y:7 => cmulti.b:2
  │    ├── z:8 => cmulti.c:3
- │    └── column12:12 => d:4
+ │    └── d_default:12 => d:4
  ├── update-mapping:
  │    └── z:8 => cmulti.c:3
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_a:18 upsert_b:19 upsert_d:20 x:6 y:7 z:8 column12:12!null cmulti.a:13 cmulti.b:14 cmulti.c:15 d:16 cmulti.crdb_internal_mvcc_timestamp:17
+ │    ├── columns: upsert_a:18 upsert_b:19 upsert_d:20 x:6 y:7 z:8 d_default:12!null cmulti.a:13 cmulti.b:14 cmulti.c:15 d:16 cmulti.crdb_internal_mvcc_timestamp:17
  │    ├── left-join (hash)
- │    │    ├── columns: x:6 y:7 z:8 column12:12!null cmulti.a:13 cmulti.b:14 cmulti.c:15 d:16 cmulti.crdb_internal_mvcc_timestamp:17
+ │    │    ├── columns: x:6 y:7 z:8 d_default:12!null cmulti.a:13 cmulti.b:14 cmulti.c:15 d:16 cmulti.crdb_internal_mvcc_timestamp:17
  │    │    ├── ensure-upsert-distinct-on
- │    │    │    ├── columns: x:6 y:7 z:8 column12:12!null
+ │    │    │    ├── columns: x:6 y:7 z:8 d_default:12!null
  │    │    │    ├── grouping columns: x:6 y:7
  │    │    │    ├── project
- │    │    │    │    ├── columns: column12:12!null x:6 y:7 z:8
+ │    │    │    │    ├── columns: d_default:12!null x:6 y:7 z:8
  │    │    │    │    ├── project
  │    │    │    │    │    ├── columns: x:6 y:7 z:8
  │    │    │    │    │    └── scan xyzw
  │    │    │    │    │         └── columns: x:6 y:7 z:8 w:9 rowid:10!null xyzw.crdb_internal_mvcc_timestamp:11
  │    │    │    │    └── projections
- │    │    │    │         └── 8 [as=column12:12]
+ │    │    │    │         └── 8 [as=d_default:12]
  │    │    │    └── aggregations
  │    │    │         ├── first-agg [as=z:8]
  │    │    │         │    └── z:8
- │    │    │         └── first-agg [as=column12:12]
- │    │    │              └── column12:12
+ │    │    │         └── first-agg [as=d_default:12]
+ │    │    │              └── d_default:12
  │    │    ├── scan cmulti
  │    │    │    └── columns: cmulti.a:13!null cmulti.b:14!null cmulti.c:15 d:16 cmulti.crdb_internal_mvcc_timestamp:17
  │    │    └── filters
@@ -970,7 +970,7 @@ upsert cmulti
  │    └── projections
  │         ├── CASE WHEN cmulti.a:13 IS NULL THEN x:6 ELSE cmulti.a:13 END [as=upsert_a:18]
  │         ├── CASE WHEN cmulti.a:13 IS NULL THEN y:7 ELSE cmulti.b:14 END [as=upsert_b:19]
- │         └── CASE WHEN cmulti.a:13 IS NULL THEN column12:12 ELSE d:16 END [as=upsert_d:20]
+ │         └── CASE WHEN cmulti.a:13 IS NULL THEN d_default:12 ELSE d:16 END [as=upsert_d:20]
  └── f-k-checks
       ├── f-k-checks-item: cmulti(a) -> p(p)
       │    └── anti-join (hash)
@@ -1440,32 +1440,32 @@ upsert p2
  ├── fetch columns: p:6 fk:7
  ├── insert-mapping:
  │    ├── column1:4 => p:1
- │    └── column5:5 => fk:2
+ │    └── fk_default:5 => fk:2
  └── project
-      ├── columns: upsert_p:9 upsert_fk:10 column1:4!null column5:5 p:6 fk:7 crdb_internal_mvcc_timestamp:8
+      ├── columns: upsert_p:9 upsert_fk:10 column1:4!null fk_default:5 p:6 fk:7 crdb_internal_mvcc_timestamp:8
       ├── left-join (hash)
-      │    ├── columns: column1:4!null column5:5 p:6 fk:7 crdb_internal_mvcc_timestamp:8
+      │    ├── columns: column1:4!null fk_default:5 p:6 fk:7 crdb_internal_mvcc_timestamp:8
       │    ├── ensure-upsert-distinct-on
-      │    │    ├── columns: column1:4!null column5:5
+      │    │    ├── columns: column1:4!null fk_default:5
       │    │    ├── grouping columns: column1:4!null
       │    │    ├── project
-      │    │    │    ├── columns: column5:5 column1:4!null
+      │    │    │    ├── columns: fk_default:5 column1:4!null
       │    │    │    ├── values
       │    │    │    │    ├── columns: column1:4!null
       │    │    │    │    ├── (1,)
       │    │    │    │    └── (2,)
       │    │    │    └── projections
-      │    │    │         └── NULL::INT8 [as=column5:5]
+      │    │    │         └── NULL::INT8 [as=fk_default:5]
       │    │    └── aggregations
-      │    │         └── first-agg [as=column5:5]
-      │    │              └── column5:5
+      │    │         └── first-agg [as=fk_default:5]
+      │    │              └── fk_default:5
       │    ├── scan p2
       │    │    └── columns: p:6!null fk:7 crdb_internal_mvcc_timestamp:8
       │    └── filters
       │         └── column1:4 = p:6
       └── projections
            ├── CASE WHEN p:6 IS NULL THEN column1:4 ELSE p:6 END [as=upsert_p:9]
-           └── CASE WHEN p:6 IS NULL THEN column5:5 ELSE fk:7 END [as=upsert_fk:10]
+           └── CASE WHEN p:6 IS NULL THEN fk_default:5 ELSE fk:7 END [as=upsert_fk:10]
 
 # ------------------------------------------
 # Inbound FK tests with multiple FK columns
@@ -1570,36 +1570,36 @@ upsert pq
  ├── fetch columns: k:8 p:9 q:10 other:11
  ├── insert-mapping:
  │    ├── column1:6 => k:1
- │    ├── column7:7 => p:2
- │    ├── column7:7 => q:3
- │    └── column7:7 => other:4
+ │    ├── p_default:7 => p:2
+ │    ├── p_default:7 => q:3
+ │    └── p_default:7 => other:4
  └── project
-      ├── columns: upsert_k:13 upsert_p:14 upsert_q:15 upsert_other:16 column1:6!null column7:7 k:8 p:9 q:10 other:11 crdb_internal_mvcc_timestamp:12
+      ├── columns: upsert_k:13 upsert_p:14 upsert_q:15 upsert_other:16 column1:6!null p_default:7 k:8 p:9 q:10 other:11 crdb_internal_mvcc_timestamp:12
       ├── left-join (hash)
-      │    ├── columns: column1:6!null column7:7 k:8 p:9 q:10 other:11 crdb_internal_mvcc_timestamp:12
+      │    ├── columns: column1:6!null p_default:7 k:8 p:9 q:10 other:11 crdb_internal_mvcc_timestamp:12
       │    ├── ensure-upsert-distinct-on
-      │    │    ├── columns: column1:6!null column7:7
+      │    │    ├── columns: column1:6!null p_default:7
       │    │    ├── grouping columns: column1:6!null
       │    │    ├── project
-      │    │    │    ├── columns: column7:7 column1:6!null
+      │    │    │    ├── columns: p_default:7 column1:6!null
       │    │    │    ├── values
       │    │    │    │    ├── columns: column1:6!null
       │    │    │    │    ├── (1,)
       │    │    │    │    └── (2,)
       │    │    │    └── projections
-      │    │    │         └── NULL::INT8 [as=column7:7]
+      │    │    │         └── NULL::INT8 [as=p_default:7]
       │    │    └── aggregations
-      │    │         └── first-agg [as=column7:7]
-      │    │              └── column7:7
+      │    │         └── first-agg [as=p_default:7]
+      │    │              └── p_default:7
       │    ├── scan pq
       │    │    └── columns: k:8!null p:9 q:10 other:11 crdb_internal_mvcc_timestamp:12
       │    └── filters
       │         └── column1:6 = k:8
       └── projections
            ├── CASE WHEN k:8 IS NULL THEN column1:6 ELSE k:8 END [as=upsert_k:13]
-           ├── CASE WHEN k:8 IS NULL THEN column7:7 ELSE p:9 END [as=upsert_p:14]
-           ├── CASE WHEN k:8 IS NULL THEN column7:7 ELSE q:10 END [as=upsert_q:15]
-           └── CASE WHEN k:8 IS NULL THEN column7:7 ELSE other:11 END [as=upsert_other:16]
+           ├── CASE WHEN k:8 IS NULL THEN p_default:7 ELSE p:9 END [as=upsert_p:14]
+           ├── CASE WHEN k:8 IS NULL THEN p_default:7 ELSE q:10 END [as=upsert_q:15]
+           └── CASE WHEN k:8 IS NULL THEN p_default:7 ELSE other:11 END [as=upsert_other:16]
 
 build
 UPSERT INTO pq (k,q) VALUES (1, 1), (2, 2)
@@ -1611,40 +1611,40 @@ upsert pq
  ├── fetch columns: k:9 pq.p:10 pq.q:11 pq.other:12
  ├── insert-mapping:
  │    ├── column1:6 => k:1
- │    ├── column8:8 => pq.p:2
+ │    ├── p_default:8 => pq.p:2
  │    ├── column2:7 => pq.q:3
- │    └── column8:8 => pq.other:4
+ │    └── p_default:8 => pq.other:4
  ├── update-mapping:
  │    └── column2:7 => pq.q:3
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_k:14 upsert_p:15 upsert_other:16 column1:6!null column2:7!null column8:8 k:9 pq.p:10 pq.q:11 pq.other:12 pq.crdb_internal_mvcc_timestamp:13
+ │    ├── columns: upsert_k:14 upsert_p:15 upsert_other:16 column1:6!null column2:7!null p_default:8 k:9 pq.p:10 pq.q:11 pq.other:12 pq.crdb_internal_mvcc_timestamp:13
  │    ├── left-join (hash)
- │    │    ├── columns: column1:6!null column2:7!null column8:8 k:9 pq.p:10 pq.q:11 pq.other:12 pq.crdb_internal_mvcc_timestamp:13
+ │    │    ├── columns: column1:6!null column2:7!null p_default:8 k:9 pq.p:10 pq.q:11 pq.other:12 pq.crdb_internal_mvcc_timestamp:13
  │    │    ├── ensure-upsert-distinct-on
- │    │    │    ├── columns: column1:6!null column2:7!null column8:8
+ │    │    │    ├── columns: column1:6!null column2:7!null p_default:8
  │    │    │    ├── grouping columns: column1:6!null
  │    │    │    ├── project
- │    │    │    │    ├── columns: column8:8 column1:6!null column2:7!null
+ │    │    │    │    ├── columns: p_default:8 column1:6!null column2:7!null
  │    │    │    │    ├── values
  │    │    │    │    │    ├── columns: column1:6!null column2:7!null
  │    │    │    │    │    ├── (1, 1)
  │    │    │    │    │    └── (2, 2)
  │    │    │    │    └── projections
- │    │    │    │         └── NULL::INT8 [as=column8:8]
+ │    │    │    │         └── NULL::INT8 [as=p_default:8]
  │    │    │    └── aggregations
  │    │    │         ├── first-agg [as=column2:7]
  │    │    │         │    └── column2:7
- │    │    │         └── first-agg [as=column8:8]
- │    │    │              └── column8:8
+ │    │    │         └── first-agg [as=p_default:8]
+ │    │    │              └── p_default:8
  │    │    ├── scan pq
  │    │    │    └── columns: k:9!null pq.p:10 pq.q:11 pq.other:12 pq.crdb_internal_mvcc_timestamp:13
  │    │    └── filters
  │    │         └── column1:6 = k:9
  │    └── projections
  │         ├── CASE WHEN k:9 IS NULL THEN column1:6 ELSE k:9 END [as=upsert_k:14]
- │         ├── CASE WHEN k:9 IS NULL THEN column8:8 ELSE pq.p:10 END [as=upsert_p:15]
- │         └── CASE WHEN k:9 IS NULL THEN column8:8 ELSE pq.other:12 END [as=upsert_other:16]
+ │         ├── CASE WHEN k:9 IS NULL THEN p_default:8 ELSE pq.p:10 END [as=upsert_p:15]
+ │         └── CASE WHEN k:9 IS NULL THEN p_default:8 ELSE pq.other:12 END [as=upsert_other:16]
  └── f-k-checks
       ├── f-k-checks-item: cpq(p,q) -> pq(p,q)
       │    └── semi-join (hash)

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-delete-set-default
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-delete-set-default
@@ -146,13 +146,13 @@ root
            │    ├── c:15 => child_multicol.p:10
            │    ├── q_new:24 => child_multicol.q:11
            │    ├── r_new:25 => child_multicol.r:12
-           │    └── column26:26 => x:13
+           │    └── x_comp:26 => x:13
            ├── check columns: check1:27
            ├── input binding: &2
            ├── project
-           │    ├── columns: check1:27!null c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19 q_new:24 r_new:25 column26:26
+           │    ├── columns: check1:27!null c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19 q_new:24 r_new:25 x_comp:26
            │    ├── project
-           │    │    ├── columns: column26:26 c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19 q_new:24 r_new:25
+           │    │    ├── columns: x_comp:26 c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19 q_new:24 r_new:25
            │    │    ├── project
            │    │    │    ├── columns: q_new:24 r_new:25 c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19
            │    │    │    ├── semi-join (hash)
@@ -176,7 +176,7 @@ root
            │    │    │         ├── child_multicol.p:16 + 1 [as=q_new:24]
            │    │    │         └── child_multicol.p:16 + child_multicol.q:17 [as=r_new:25]
            │    │    └── projections
-           │    │         └── (c:15 + q_new:24) + r_new:25 [as=column26:26]
+           │    │         └── (c:15 + q_new:24) + r_new:25 [as=x_comp:26]
            │    └── projections
            │         └── (c:15 > 100) OR (c:15 > c:15) [as=check1:27]
            └── f-k-checks

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-delete-set-null
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-delete-set-null
@@ -85,12 +85,12 @@ root
            │    ├── p_new:24 => child_multicol.p:10
            │    ├── p_new:24 => child_multicol.q:11
            │    ├── p_new:24 => child_multicol.r:12
-           │    └── column25:25 => x:13
+           │    └── x_comp:25 => x:13
            ├── check columns: check1:26
            └── project
-                ├── columns: check1:26!null c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19 p_new:24 column25:25
+                ├── columns: check1:26!null c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19 p_new:24 x_comp:25
                 ├── project
-                │    ├── columns: column25:25 c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19 p_new:24
+                │    ├── columns: x_comp:25 c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19 p_new:24
                 │    ├── project
                 │    │    ├── columns: p_new:24 c:15!null child_multicol.p:16 child_multicol.q:17 child_multicol.r:18 x:19
                 │    │    ├── semi-join (hash)
@@ -115,7 +115,7 @@ root
                 │    │    └── projections
                 │    │         └── NULL::INT8 [as=p_new:24]
                 │    └── projections
-                │         └── (p_new:24 + p_new:24) + p_new:24 [as=column25:25]
+                │         └── (p_new:24 + p_new:24) + p_new:24 [as=x_comp:25]
                 └── projections
                      └── (c:15 > 100) OR (p_new:24 IS NOT NULL) [as=check1:26]
 

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-cascade
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-cascade
@@ -317,39 +317,39 @@ root
  │    ├── insert-mapping:
  │    │    ├── column1:5 => pk:1
  │    │    ├── column2:6 => p:2
- │    │    └── column7:7 => q:3
+ │    │    └── q_default:7 => q:3
  │    ├── update-mapping:
  │    │    └── column2:6 => p:2
  │    ├── input binding: &1
  │    ├── cascades
  │    │    └── fk
  │    └── project
- │         ├── columns: upsert_pk:12 upsert_q:13 column1:5!null column2:6!null column7:7 pk:8 p:9 q:10 crdb_internal_mvcc_timestamp:11
+ │         ├── columns: upsert_pk:12 upsert_q:13 column1:5!null column2:6!null q_default:7 pk:8 p:9 q:10 crdb_internal_mvcc_timestamp:11
  │         ├── left-join (hash)
- │         │    ├── columns: column1:5!null column2:6!null column7:7 pk:8 p:9 q:10 crdb_internal_mvcc_timestamp:11
+ │         │    ├── columns: column1:5!null column2:6!null q_default:7 pk:8 p:9 q:10 crdb_internal_mvcc_timestamp:11
  │         │    ├── ensure-upsert-distinct-on
- │         │    │    ├── columns: column1:5!null column2:6!null column7:7
+ │         │    │    ├── columns: column1:5!null column2:6!null q_default:7
  │         │    │    ├── grouping columns: column1:5!null
  │         │    │    ├── project
- │         │    │    │    ├── columns: column7:7 column1:5!null column2:6!null
+ │         │    │    │    ├── columns: q_default:7 column1:5!null column2:6!null
  │         │    │    │    ├── values
  │         │    │    │    │    ├── columns: column1:5!null column2:6!null
  │         │    │    │    │    ├── (1, 10)
  │         │    │    │    │    └── (2, 20)
  │         │    │    │    └── projections
- │         │    │    │         └── NULL::INT8 [as=column7:7]
+ │         │    │    │         └── NULL::INT8 [as=q_default:7]
  │         │    │    └── aggregations
  │         │    │         ├── first-agg [as=column2:6]
  │         │    │         │    └── column2:6
- │         │    │         └── first-agg [as=column7:7]
- │         │    │              └── column7:7
+ │         │    │         └── first-agg [as=q_default:7]
+ │         │    │              └── q_default:7
  │         │    ├── scan parent_multi
  │         │    │    └── columns: pk:8!null p:9 q:10 crdb_internal_mvcc_timestamp:11
  │         │    └── filters
  │         │         └── column1:5 = pk:8
  │         └── projections
  │              ├── CASE WHEN pk:8 IS NULL THEN column1:5 ELSE pk:8 END [as=upsert_pk:12]
- │              └── CASE WHEN pk:8 IS NULL THEN column7:7 ELSE q:10 END [as=upsert_q:13]
+ │              └── CASE WHEN pk:8 IS NULL THEN q_default:7 ELSE q:10 END [as=upsert_q:13]
  └── cascade
       └── update child_multi
            ├── columns: <none>
@@ -932,32 +932,32 @@ root
  │    ├── fetch columns: pk:7 p:8 q:9
  │    ├── insert-mapping:
  │    │    ├── column1:5 => pk:1
- │    │    ├── column6:6 => p:2
- │    │    └── column6:6 => q:3
+ │    │    ├── p_default:6 => p:2
+ │    │    └── p_default:6 => q:3
  │    ├── update-mapping:
- │    │    ├── column6:6 => p:2
- │    │    └── column6:6 => q:3
+ │    │    ├── p_default:6 => p:2
+ │    │    └── p_default:6 => q:3
  │    ├── input binding: &1
  │    ├── cascades
  │    │    └── fk
  │    └── project
- │         ├── columns: upsert_pk:11 column1:5!null column6:6 pk:7 p:8 q:9 crdb_internal_mvcc_timestamp:10
+ │         ├── columns: upsert_pk:11 column1:5!null p_default:6 pk:7 p:8 q:9 crdb_internal_mvcc_timestamp:10
  │         ├── left-join (hash)
- │         │    ├── columns: column1:5!null column6:6 pk:7 p:8 q:9 crdb_internal_mvcc_timestamp:10
+ │         │    ├── columns: column1:5!null p_default:6 pk:7 p:8 q:9 crdb_internal_mvcc_timestamp:10
  │         │    ├── ensure-upsert-distinct-on
- │         │    │    ├── columns: column1:5!null column6:6
+ │         │    │    ├── columns: column1:5!null p_default:6
  │         │    │    ├── grouping columns: column1:5!null
  │         │    │    ├── project
- │         │    │    │    ├── columns: column6:6 column1:5!null
+ │         │    │    │    ├── columns: p_default:6 column1:5!null
  │         │    │    │    ├── values
  │         │    │    │    │    ├── columns: column1:5!null
  │         │    │    │    │    ├── (1,)
  │         │    │    │    │    └── (2,)
  │         │    │    │    └── projections
- │         │    │    │         └── NULL::INT8 [as=column6:6]
+ │         │    │    │         └── NULL::INT8 [as=p_default:6]
  │         │    │    └── aggregations
- │         │    │         └── first-agg [as=column6:6]
- │         │    │              └── column6:6
+ │         │    │         └── first-agg [as=p_default:6]
+ │         │    │              └── p_default:6
  │         │    ├── scan parent_multi_partial
  │         │    │    └── columns: pk:7!null p:8 q:9 crdb_internal_mvcc_timestamp:10
  │         │    └── filters
@@ -969,15 +969,15 @@ root
            ├── columns: <none>
            ├── fetch columns: c:17 child_multi_partial.p:18 child_multi_partial.q:19 i:20
            ├── update-mapping:
-           │    ├── column6:24 => child_multi_partial.p:13
-           │    └── column6:25 => child_multi_partial.q:14
+           │    ├── p_default:24 => child_multi_partial.p:13
+           │    └── p_default:25 => child_multi_partial.q:14
            ├── partial index put columns: partial_index_put1:26 partial_index_put2:27
            ├── partial index del columns: partial_index_put1:26 partial_index_del2:28
            ├── input binding: &2
            ├── project
-           │    ├── columns: partial_index_put1:26 partial_index_put2:27 partial_index_del2:28!null c:17!null child_multi_partial.p:18!null child_multi_partial.q:19!null i:20 p:22!null q:23!null column6:24 column6:25
+           │    ├── columns: partial_index_put1:26 partial_index_put2:27 partial_index_del2:28!null c:17!null child_multi_partial.p:18!null child_multi_partial.q:19!null i:20 p:22!null q:23!null p_default:24 p_default:25
            │    ├── inner-join (hash)
-           │    │    ├── columns: c:17!null child_multi_partial.p:18!null child_multi_partial.q:19!null i:20 p:22!null q:23!null column6:24 column6:25
+           │    │    ├── columns: c:17!null child_multi_partial.p:18!null child_multi_partial.q:19!null i:20 p:22!null q:23!null p_default:24 p_default:25
            │    │    ├── scan child_multi_partial
            │    │    │    ├── columns: c:17!null child_multi_partial.p:18 child_multi_partial.q:19 i:20
            │    │    │    └── partial index predicates
@@ -986,22 +986,22 @@ root
            │    │    │         └── secondary: filters
            │    │    │              └── (child_multi_partial.p:18 > 0) AND (child_multi_partial.q:19 > 0)
            │    │    ├── select
-           │    │    │    ├── columns: p:22 q:23 column6:24 column6:25
+           │    │    │    ├── columns: p:22 q:23 p_default:24 p_default:25
            │    │    │    ├── with-scan &1
-           │    │    │    │    ├── columns: p:22 q:23 column6:24 column6:25
+           │    │    │    │    ├── columns: p:22 q:23 p_default:24 p_default:25
            │    │    │    │    └── mapping:
            │    │    │    │         ├──  parent_multi_partial.p:8 => p:22
            │    │    │    │         ├──  parent_multi_partial.q:9 => q:23
-           │    │    │    │         ├──  column6:6 => column6:24
-           │    │    │    │         └──  column6:6 => column6:25
+           │    │    │    │         ├──  p_default:6 => p_default:24
+           │    │    │    │         └──  p_default:6 => p_default:25
            │    │    │    └── filters
-           │    │    │         └── (p:22 IS DISTINCT FROM column6:24) OR (q:23 IS DISTINCT FROM column6:25)
+           │    │    │         └── (p:22 IS DISTINCT FROM p_default:24) OR (q:23 IS DISTINCT FROM p_default:25)
            │    │    └── filters
            │    │         ├── child_multi_partial.p:18 = p:22
            │    │         └── child_multi_partial.q:19 = q:23
            │    └── projections
            │         ├── i:20 > 0 [as=partial_index_put1:26]
-           │         ├── (column6:24 > 0) AND (column6:25 > 0) [as=partial_index_put2:27]
+           │         ├── (p_default:24 > 0) AND (p_default:25 > 0) [as=partial_index_put2:27]
            │         └── (child_multi_partial.p:18 > 0) AND (child_multi_partial.q:19 > 0) [as=partial_index_del2:28]
            └── f-k-checks
                 └── f-k-checks-item: child_multi_partial(p,q) -> parent_multi_partial(p,q)
@@ -1012,8 +1012,8 @@ root
                           │    ├── with-scan &2
                           │    │    ├── columns: p:29 q:30
                           │    │    └── mapping:
-                          │    │         ├──  column6:24 => p:29
-                          │    │         └──  column6:25 => q:30
+                          │    │         ├──  p_default:24 => p:29
+                          │    │         └──  p_default:25 => q:30
                           │    └── filters
                           │         ├── p:29 IS NOT NULL
                           │         └── q:30 IS NOT NULL
@@ -1069,13 +1069,13 @@ root
            ├── fetch columns: c:10 child_check_ambig.p_new:11 i:12
            ├── update-mapping:
            │    ├── p_new:15 => child_check_ambig.p_new:7
-           │    └── column16:16 => i:8
+           │    └── i_comp:16 => i:8
            ├── check columns: check1:17
            ├── input binding: &2
            ├── project
-           │    ├── columns: check1:17!null c:10!null child_check_ambig.p_new:11!null i:12 p:14!null p_new:15!null column16:16!null
+           │    ├── columns: check1:17!null c:10!null child_check_ambig.p_new:11!null i:12 p:14!null p_new:15!null i_comp:16!null
            │    ├── project
-           │    │    ├── columns: column16:16!null c:10!null child_check_ambig.p_new:11!null i:12 p:14!null p_new:15!null
+           │    │    ├── columns: i_comp:16!null c:10!null child_check_ambig.p_new:11!null i:12 p:14!null p_new:15!null
            │    │    ├── inner-join (hash)
            │    │    │    ├── columns: c:10!null child_check_ambig.p_new:11!null i:12 p:14!null p_new:15!null
            │    │    │    ├── scan child_check_ambig
@@ -1095,7 +1095,7 @@ root
            │    │    │    └── filters
            │    │    │         └── child_check_ambig.p_new:11 = p:14
            │    │    └── projections
-           │    │         └── p_new:15 * 2 [as=column16:16]
+           │    │         └── p_new:15 * 2 [as=i_comp:16]
            │    └── projections
            │         └── p_new:15 > 0 [as=check1:17]
            └── f-k-checks

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-default
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-default
@@ -499,39 +499,39 @@ root
  │    ├── insert-mapping:
  │    │    ├── column1:5 => pk:1
  │    │    ├── column2:6 => p:2
- │    │    └── column7:7 => q:3
+ │    │    └── q_default:7 => q:3
  │    ├── update-mapping:
  │    │    └── column2:6 => p:2
  │    ├── input binding: &1
  │    ├── cascades
  │    │    └── fk
  │    └── project
- │         ├── columns: upsert_pk:12 upsert_q:13 column1:5!null column2:6!null column7:7 pk:8 p:9 q:10 crdb_internal_mvcc_timestamp:11
+ │         ├── columns: upsert_pk:12 upsert_q:13 column1:5!null column2:6!null q_default:7 pk:8 p:9 q:10 crdb_internal_mvcc_timestamp:11
  │         ├── left-join (hash)
- │         │    ├── columns: column1:5!null column2:6!null column7:7 pk:8 p:9 q:10 crdb_internal_mvcc_timestamp:11
+ │         │    ├── columns: column1:5!null column2:6!null q_default:7 pk:8 p:9 q:10 crdb_internal_mvcc_timestamp:11
  │         │    ├── ensure-upsert-distinct-on
- │         │    │    ├── columns: column1:5!null column2:6!null column7:7
+ │         │    │    ├── columns: column1:5!null column2:6!null q_default:7
  │         │    │    ├── grouping columns: column1:5!null
  │         │    │    ├── project
- │         │    │    │    ├── columns: column7:7 column1:5!null column2:6!null
+ │         │    │    │    ├── columns: q_default:7 column1:5!null column2:6!null
  │         │    │    │    ├── values
  │         │    │    │    │    ├── columns: column1:5!null column2:6!null
  │         │    │    │    │    ├── (1, 10)
  │         │    │    │    │    └── (2, 20)
  │         │    │    │    └── projections
- │         │    │    │         └── NULL::INT8 [as=column7:7]
+ │         │    │    │         └── NULL::INT8 [as=q_default:7]
  │         │    │    └── aggregations
  │         │    │         ├── first-agg [as=column2:6]
  │         │    │         │    └── column2:6
- │         │    │         └── first-agg [as=column7:7]
- │         │    │              └── column7:7
+ │         │    │         └── first-agg [as=q_default:7]
+ │         │    │              └── q_default:7
  │         │    ├── scan parent_multi
  │         │    │    └── columns: pk:8!null p:9 q:10 crdb_internal_mvcc_timestamp:11
  │         │    └── filters
  │         │         └── column1:5 = pk:8
  │         └── projections
  │              ├── CASE WHEN pk:8 IS NULL THEN column1:5 ELSE pk:8 END [as=upsert_pk:12]
- │              └── CASE WHEN pk:8 IS NULL THEN column7:7 ELSE q:10 END [as=upsert_q:13]
+ │              └── CASE WHEN pk:8 IS NULL THEN q_default:7 ELSE q:10 END [as=upsert_q:13]
  └── cascade
       ├── update child_multi
       │    ├── columns: <none>

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-null
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-null
@@ -390,39 +390,39 @@ root
  │    ├── insert-mapping:
  │    │    ├── column1:5 => pk:1
  │    │    ├── column2:6 => p:2
- │    │    └── column7:7 => q:3
+ │    │    └── q_default:7 => q:3
  │    ├── update-mapping:
  │    │    └── column2:6 => p:2
  │    ├── input binding: &1
  │    ├── cascades
  │    │    └── fk
  │    └── project
- │         ├── columns: upsert_pk:12 upsert_q:13 column1:5!null column2:6!null column7:7 pk:8 p:9 q:10 crdb_internal_mvcc_timestamp:11
+ │         ├── columns: upsert_pk:12 upsert_q:13 column1:5!null column2:6!null q_default:7 pk:8 p:9 q:10 crdb_internal_mvcc_timestamp:11
  │         ├── left-join (hash)
- │         │    ├── columns: column1:5!null column2:6!null column7:7 pk:8 p:9 q:10 crdb_internal_mvcc_timestamp:11
+ │         │    ├── columns: column1:5!null column2:6!null q_default:7 pk:8 p:9 q:10 crdb_internal_mvcc_timestamp:11
  │         │    ├── ensure-upsert-distinct-on
- │         │    │    ├── columns: column1:5!null column2:6!null column7:7
+ │         │    │    ├── columns: column1:5!null column2:6!null q_default:7
  │         │    │    ├── grouping columns: column1:5!null
  │         │    │    ├── project
- │         │    │    │    ├── columns: column7:7 column1:5!null column2:6!null
+ │         │    │    │    ├── columns: q_default:7 column1:5!null column2:6!null
  │         │    │    │    ├── values
  │         │    │    │    │    ├── columns: column1:5!null column2:6!null
  │         │    │    │    │    ├── (1, 10)
  │         │    │    │    │    └── (2, 20)
  │         │    │    │    └── projections
- │         │    │    │         └── NULL::INT8 [as=column7:7]
+ │         │    │    │         └── NULL::INT8 [as=q_default:7]
  │         │    │    └── aggregations
  │         │    │         ├── first-agg [as=column2:6]
  │         │    │         │    └── column2:6
- │         │    │         └── first-agg [as=column7:7]
- │         │    │              └── column7:7
+ │         │    │         └── first-agg [as=q_default:7]
+ │         │    │              └── q_default:7
  │         │    ├── scan parent_multi
  │         │    │    └── columns: pk:8!null p:9 q:10 crdb_internal_mvcc_timestamp:11
  │         │    └── filters
  │         │         └── column1:5 = pk:8
  │         └── projections
  │              ├── CASE WHEN pk:8 IS NULL THEN column1:5 ELSE pk:8 END [as=upsert_pk:12]
- │              └── CASE WHEN pk:8 IS NULL THEN column7:7 ELSE q:10 END [as=upsert_q:13]
+ │              └── CASE WHEN pk:8 IS NULL THEN q_default:7 ELSE q:10 END [as=upsert_q:13]
  └── cascade
       ├── update child_multi
       │    ├── columns: <none>

--- a/pkg/sql/opt/optbuilder/testdata/insert
+++ b/pkg/sql/opt/optbuilder/testdata/insert
@@ -73,20 +73,20 @@ insert abcde
  │    ├── column1:8 => a:1
  │    ├── column2:9 => b:2
  │    ├── column3:10 => c:3
- │    ├── column12:12 => d:4
+ │    ├── d_comp:12 => d:4
  │    ├── column1:8 => e:5
- │    └── column11:11 => rowid:6
+ │    └── rowid_default:11 => rowid:6
  └── project
-      ├── columns: column12:12!null column1:8!null column2:9!null column3:10!null column11:11
+      ├── columns: d_comp:12!null column1:8!null column2:9!null column3:10!null rowid_default:11
       ├── project
-      │    ├── columns: column11:11 column1:8!null column2:9!null column3:10!null
+      │    ├── columns: rowid_default:11 column1:8!null column2:9!null column3:10!null
       │    ├── values
       │    │    ├── columns: column1:8!null column2:9!null column3:10!null
       │    │    └── (1, 2, 3)
       │    └── projections
-      │         └── unique_rowid() [as=column11:11]
+      │         └── unique_rowid() [as=rowid_default:11]
       └── projections
-           └── (column2:9 + column3:10) + 1 [as=column12:12]
+           └── (column2:9 + column3:10) + 1 [as=d_comp:12]
 
 # Don't specify values for null or default columns.
 build
@@ -96,24 +96,24 @@ insert abcde
  ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:8 => a:1
- │    ├── column9:9 => b:2
- │    ├── column10:10 => c:3
- │    ├── column12:12 => d:4
+ │    ├── b_default:9 => b:2
+ │    ├── c_default:10 => c:3
+ │    ├── d_comp:12 => d:4
  │    ├── column1:8 => e:5
- │    └── column11:11 => rowid:6
+ │    └── rowid_default:11 => rowid:6
  └── project
-      ├── columns: column12:12 column1:8!null column9:9 column10:10!null column11:11
+      ├── columns: d_comp:12 column1:8!null b_default:9 c_default:10!null rowid_default:11
       ├── project
-      │    ├── columns: column9:9 column10:10!null column11:11 column1:8!null
+      │    ├── columns: b_default:9 c_default:10!null rowid_default:11 column1:8!null
       │    ├── values
       │    │    ├── columns: column1:8!null
       │    │    └── (1,)
       │    └── projections
-      │         ├── NULL::INT8 [as=column9:9]
-      │         ├── 10 [as=column10:10]
-      │         └── unique_rowid() [as=column11:11]
+      │         ├── NULL::INT8 [as=b_default:9]
+      │         ├── 10 [as=c_default:10]
+      │         └── unique_rowid() [as=rowid_default:11]
       └── projections
-           └── (column9:9 + column10:10) + 1 [as=column12:12]
+           └── (b_default:9 + c_default:10) + 1 [as=d_comp:12]
 
 # Ordered input.
 build
@@ -123,15 +123,15 @@ insert abcde
  ├── columns: <none>
  ├── insert-mapping:
  │    ├── y:9 => a:1
- │    ├── column12:12 => b:2
- │    ├── column13:13 => c:3
- │    ├── column15:15 => d:4
+ │    ├── b_default:12 => b:2
+ │    ├── c_default:13 => c:3
+ │    ├── d_comp:15 => d:4
  │    ├── y:9 => e:5
- │    └── column14:14 => rowid:6
+ │    └── rowid_default:14 => rowid:6
  └── project
-      ├── columns: column15:15 y:9 column12:12 column13:13!null column14:14
+      ├── columns: d_comp:15 y:9 b_default:12 c_default:13!null rowid_default:14
       ├── project
-      │    ├── columns: column12:12 column13:13!null column14:14 y:9
+      │    ├── columns: b_default:12 c_default:13!null rowid_default:14 y:9
       │    ├── limit
       │    │    ├── columns: y:9 z:10
       │    │    ├── internal-ordering: +9,+10
@@ -145,11 +145,11 @@ insert abcde
       │    │    │              └── columns: x:8!null y:9 z:10 xyz.crdb_internal_mvcc_timestamp:11
       │    │    └── 10
       │    └── projections
-      │         ├── NULL::INT8 [as=column12:12]
-      │         ├── 10 [as=column13:13]
-      │         └── unique_rowid() [as=column14:14]
+      │         ├── NULL::INT8 [as=b_default:12]
+      │         ├── 10 [as=c_default:13]
+      │         └── unique_rowid() [as=rowid_default:14]
       └── projections
-           └── (column12:12 + column13:13) + 1 [as=column15:15]
+           └── (b_default:12 + c_default:13) + 1 [as=d_comp:15]
 
 # Ignore ORDER BY without LIMIT.
 build
@@ -159,25 +159,25 @@ insert abcde
  ├── columns: <none>
  ├── insert-mapping:
  │    ├── y:9 => a:1
- │    ├── column12:12 => b:2
- │    ├── column13:13 => c:3
- │    ├── column15:15 => d:4
+ │    ├── b_default:12 => b:2
+ │    ├── c_default:13 => c:3
+ │    ├── d_comp:15 => d:4
  │    ├── y:9 => e:5
- │    └── column14:14 => rowid:6
+ │    └── rowid_default:14 => rowid:6
  └── project
-      ├── columns: column15:15 y:9 column12:12 column13:13!null column14:14
+      ├── columns: d_comp:15 y:9 b_default:12 c_default:13!null rowid_default:14
       ├── project
-      │    ├── columns: column12:12 column13:13!null column14:14 y:9
+      │    ├── columns: b_default:12 c_default:13!null rowid_default:14 y:9
       │    ├── project
       │    │    ├── columns: y:9 z:10
       │    │    └── scan xyz
       │    │         └── columns: x:8!null y:9 z:10 xyz.crdb_internal_mvcc_timestamp:11
       │    └── projections
-      │         ├── NULL::INT8 [as=column12:12]
-      │         ├── 10 [as=column13:13]
-      │         └── unique_rowid() [as=column14:14]
+      │         ├── NULL::INT8 [as=b_default:12]
+      │         ├── 10 [as=c_default:13]
+      │         └── unique_rowid() [as=rowid_default:14]
       └── projections
-           └── (column12:12 + column13:13) + 1 [as=column15:15]
+           └── (b_default:12 + c_default:13) + 1 [as=d_comp:15]
 
 # Use placeholders.
 build
@@ -203,20 +203,20 @@ insert abcde
  │    ├── column1:8 => a:1
  │    ├── column2:9 => b:2
  │    ├── column3:10 => c:3
- │    ├── column12:12 => d:4
+ │    ├── d_comp:12 => d:4
  │    ├── column1:8 => e:5
- │    └── column11:11 => rowid:6
+ │    └── rowid_default:11 => rowid:6
  └── project
-      ├── columns: column12:12 column1:8!null column2:9 column3:10 column11:11
+      ├── columns: d_comp:12 column1:8!null column2:9 column3:10 rowid_default:11
       ├── project
-      │    ├── columns: column11:11 column1:8!null column2:9 column3:10
+      │    ├── columns: rowid_default:11 column1:8!null column2:9 column3:10
       │    ├── values
       │    │    ├── columns: column1:8!null column2:9 column3:10
       │    │    └── (2, NULL::INT8, NULL::INT8)
       │    └── projections
-      │         └── unique_rowid() [as=column11:11]
+      │         └── unique_rowid() [as=rowid_default:11]
       └── projections
-           └── (column2:9 + column3:10) + 1 [as=column12:12]
+           └── (column2:9 + column3:10) + 1 [as=d_comp:12]
 
 # Duplicate expressions.
 build
@@ -228,13 +228,13 @@ insert abcde
  │    ├── "?column?":8 => a:1
  │    ├── "?column?":9 => b:2
  │    ├── "?column?":9 => c:3
- │    ├── column11:11 => d:4
+ │    ├── d_comp:11 => d:4
  │    ├── "?column?":8 => e:5
- │    └── column10:10 => rowid:6
+ │    └── rowid_default:10 => rowid:6
  └── project
-      ├── columns: column11:11 "?column?":8!null "?column?":9 column10:10
+      ├── columns: d_comp:11 "?column?":8!null "?column?":9 rowid_default:10
       ├── project
-      │    ├── columns: column10:10 "?column?":8!null "?column?":9
+      │    ├── columns: rowid_default:10 "?column?":8!null "?column?":9
       │    ├── project
       │    │    ├── columns: "?column?":8!null "?column?":9
       │    │    ├── values
@@ -243,9 +243,9 @@ insert abcde
       │    │         ├── 2 [as="?column?":8]
       │    │         └── $1 + 1 [as="?column?":9]
       │    └── projections
-      │         └── unique_rowid() [as=column10:10]
+      │         └── unique_rowid() [as=rowid_default:10]
       └── projections
-           └── ("?column?":9 + "?column?":9) + 1 [as=column11:11]
+           └── ("?column?":9 + "?column?":9) + 1 [as=d_comp:11]
 
 # Use DEFAULT VALUES.
 build
@@ -254,17 +254,17 @@ INSERT INTO uv DEFAULT VALUES
 insert uv
  ├── columns: <none>
  ├── insert-mapping:
- │    ├── column5:5 => u:1
- │    ├── column6:6 => v:2
- │    └── column7:7 => rowid:3
+ │    ├── u_default:5 => u:1
+ │    ├── v_default:6 => v:2
+ │    └── rowid_default:7 => rowid:3
  └── project
-      ├── columns: column5:5 column6:6 column7:7
+      ├── columns: u_default:5 v_default:6 rowid_default:7
       ├── values
       │    └── ()
       └── projections
-           ├── NULL::DECIMAL [as=column5:5]
-           ├── NULL::BYTES [as=column6:6]
-           └── unique_rowid() [as=column7:7]
+           ├── NULL::DECIMAL [as=u_default:5]
+           ├── NULL::BYTES [as=v_default:6]
+           └── unique_rowid() [as=rowid_default:7]
 
 # Use DEFAULT expressions in VALUES expression.
 build
@@ -276,13 +276,13 @@ insert abcde
  │    ├── column1:8 => a:1
  │    ├── column2:9 => b:2
  │    ├── column3:10 => c:3
- │    ├── column12:12 => d:4
+ │    ├── d_comp:12 => d:4
  │    ├── column1:8 => e:5
- │    └── column11:11 => rowid:6
+ │    └── rowid_default:11 => rowid:6
  └── project
-      ├── columns: column12:12 column1:8!null column2:9 column3:10!null column11:11
+      ├── columns: d_comp:12 column1:8!null column2:9 column3:10!null rowid_default:11
       ├── project
-      │    ├── columns: column11:11 column1:8!null column2:9 column3:10!null
+      │    ├── columns: rowid_default:11 column1:8!null column2:9 column3:10!null
       │    ├── values
       │    │    ├── columns: column1:8!null column2:9 column3:10!null
       │    │    ├── (1, NULL::INT8, 2)
@@ -290,9 +290,9 @@ insert abcde
       │    │    ├── (3, 2, 10)
       │    │    └── (4, NULL::INT8, 10)
       │    └── projections
-      │         └── unique_rowid() [as=column11:11]
+      │         └── unique_rowid() [as=rowid_default:11]
       └── projections
-           └── (column2:9 + column3:10) + 1 [as=column12:12]
+           └── (column2:9 + column3:10) + 1 [as=d_comp:12]
 
 # Use DEFAULT expressions in VALUES expression wrapped by WITH clause (error).
 build
@@ -316,15 +316,15 @@ project
       ├── columns: a:1!null b:2 c:3!null d:4 e:5!null rowid:6!null
       ├── insert-mapping:
       │    ├── "?column?":8 => a:1
-      │    ├── column9:9 => b:2
-      │    ├── column10:10 => c:3
-      │    ├── column12:12 => d:4
+      │    ├── b_default:9 => b:2
+      │    ├── c_default:10 => c:3
+      │    ├── d_comp:12 => d:4
       │    ├── "?column?":8 => e:5
-      │    └── column11:11 => rowid:6
+      │    └── rowid_default:11 => rowid:6
       └── project
-           ├── columns: column12:12 "?column?":8!null column9:9 column10:10!null column11:11
+           ├── columns: d_comp:12 "?column?":8!null b_default:9 c_default:10!null rowid_default:11
            ├── project
-           │    ├── columns: column9:9 column10:10!null column11:11 "?column?":8!null
+           │    ├── columns: b_default:9 c_default:10!null rowid_default:11 "?column?":8!null
            │    ├── project
            │    │    ├── columns: "?column?":8!null
            │    │    ├── values
@@ -332,11 +332,11 @@ project
            │    │    └── projections
            │    │         └── 1 [as="?column?":8]
            │    └── projections
-           │         ├── NULL::INT8 [as=column9:9]
-           │         ├── 10 [as=column10:10]
-           │         └── unique_rowid() [as=column11:11]
+           │         ├── NULL::INT8 [as=b_default:9]
+           │         ├── 10 [as=c_default:10]
+           │         └── unique_rowid() [as=rowid_default:11]
            └── projections
-                └── (column9:9 + column10:10) + 1 [as=column12:12]
+                └── (b_default:9 + c_default:10) + 1 [as=d_comp:12]
 
 # Return values from aliased table.
 build
@@ -348,15 +348,15 @@ project
  │    ├── columns: a:1!null b:2 c:3!null d:4 e:5!null rowid:6!null
  │    ├── insert-mapping:
  │    │    ├── "?column?":8 => a:1
- │    │    ├── column9:9 => b:2
- │    │    ├── column10:10 => c:3
- │    │    ├── column12:12 => d:4
+ │    │    ├── b_default:9 => b:2
+ │    │    ├── c_default:10 => c:3
+ │    │    ├── d_comp:12 => d:4
  │    │    ├── "?column?":8 => e:5
- │    │    └── column11:11 => rowid:6
+ │    │    └── rowid_default:11 => rowid:6
  │    └── project
- │         ├── columns: column12:12 "?column?":8!null column9:9 column10:10!null column11:11
+ │         ├── columns: d_comp:12 "?column?":8!null b_default:9 c_default:10!null rowid_default:11
  │         ├── project
- │         │    ├── columns: column9:9 column10:10!null column11:11 "?column?":8!null
+ │         │    ├── columns: b_default:9 c_default:10!null rowid_default:11 "?column?":8!null
  │         │    ├── project
  │         │    │    ├── columns: "?column?":8!null
  │         │    │    ├── values
@@ -364,11 +364,11 @@ project
  │         │    │    └── projections
  │         │    │         └── 1 [as="?column?":8]
  │         │    └── projections
- │         │         ├── NULL::INT8 [as=column9:9]
- │         │         ├── 10 [as=column10:10]
- │         │         └── unique_rowid() [as=column11:11]
+ │         │         ├── NULL::INT8 [as=b_default:9]
+ │         │         ├── 10 [as=c_default:10]
+ │         │         └── unique_rowid() [as=rowid_default:11]
  │         └── projections
- │              └── (column9:9 + column10:10) + 1 [as=column12:12]
+ │              └── (b_default:9 + c_default:10) + 1 [as=d_comp:12]
  └── projections
       ├── a:1 + 1 [as="?column?":13]
       └── b:2 * c:3 [as="?column?":14]
@@ -385,24 +385,24 @@ with &1
  │         ├── columns: abcde.a:1!null abcde.b:2 abcde.c:3!null abcde.d:4 abcde.e:5!null rowid:6!null
  │         ├── insert-mapping:
  │         │    ├── column1:8 => abcde.a:1
- │         │    ├── column9:9 => abcde.b:2
- │         │    ├── column10:10 => abcde.c:3
- │         │    ├── column12:12 => abcde.d:4
+ │         │    ├── b_default:9 => abcde.b:2
+ │         │    ├── c_default:10 => abcde.c:3
+ │         │    ├── d_comp:12 => abcde.d:4
  │         │    ├── column1:8 => abcde.e:5
- │         │    └── column11:11 => rowid:6
+ │         │    └── rowid_default:11 => rowid:6
  │         └── project
- │              ├── columns: column12:12 column1:8!null column9:9 column10:10!null column11:11
+ │              ├── columns: d_comp:12 column1:8!null b_default:9 c_default:10!null rowid_default:11
  │              ├── project
- │              │    ├── columns: column9:9 column10:10!null column11:11 column1:8!null
+ │              │    ├── columns: b_default:9 c_default:10!null rowid_default:11 column1:8!null
  │              │    ├── values
  │              │    │    ├── columns: column1:8!null
  │              │    │    └── (1,)
  │              │    └── projections
- │              │         ├── NULL::INT8 [as=column9:9]
- │              │         ├── 10 [as=column10:10]
- │              │         └── unique_rowid() [as=column11:11]
+ │              │         ├── NULL::INT8 [as=b_default:9]
+ │              │         ├── 10 [as=c_default:10]
+ │              │         └── unique_rowid() [as=rowid_default:11]
  │              └── projections
- │                   └── (column9:9 + column10:10) + 1 [as=column12:12]
+ │                   └── (b_default:9 + c_default:10) + 1 [as=d_comp:12]
  └── with-scan &1
       ├── columns: a:13!null b:14 c:15!null d:16 e:17!null
       └── mapping:
@@ -446,24 +446,24 @@ with &1 (a)
       ├── insert-mapping:
       │    ├── y:13 => a:6
       │    ├── "?column?":14 => b:7
-      │    ├── column15:15 => c:8
-      │    ├── column17:17 => d:9
+      │    ├── c_default:15 => c:8
+      │    ├── d_comp:17 => d:9
       │    ├── y:13 => e:10
-      │    └── column16:16 => rowid:11
+      │    └── rowid_default:16 => rowid:11
       └── project
-           ├── columns: column17:17 y:13 "?column?":14 column15:15!null column16:16
+           ├── columns: d_comp:17 y:13 "?column?":14 c_default:15!null rowid_default:16
            ├── project
-           │    ├── columns: column15:15!null column16:16 y:13 "?column?":14
+           │    ├── columns: c_default:15!null rowid_default:16 y:13 "?column?":14
            │    ├── with-scan &1 (a)
            │    │    ├── columns: y:13 "?column?":14
            │    │    └── mapping:
            │    │         ├──  xyz.y:2 => y:13
            │    │         └──  "?column?":5 => "?column?":14
            │    └── projections
-           │         ├── 10 [as=column15:15]
-           │         └── unique_rowid() [as=column16:16]
+           │         ├── 10 [as=c_default:15]
+           │         └── unique_rowid() [as=rowid_default:16]
            └── projections
-                └── ("?column?":14 + column15:15) + 1 [as=column17:17]
+                └── ("?column?":14 + c_default:15) + 1 [as=d_comp:17]
 
 # Use CTE with multiple variables.
 build
@@ -489,14 +489,14 @@ with &1 (a)
            ├── insert-mapping:
            │    ├── y:22 => a:11
            │    ├── "?column?":23 => b:12
-           │    ├── column24:24 => c:13
-           │    ├── column26:26 => d:14
+           │    ├── c_default:24 => c:13
+           │    ├── d_comp:26 => d:14
            │    ├── y:22 => e:15
-           │    └── column25:25 => rowid:16
+           │    └── rowid_default:25 => rowid:16
            └── project
-                ├── columns: column26:26 y:22 "?column?":23 column24:24!null column25:25
+                ├── columns: d_comp:26 y:22 "?column?":23 c_default:24!null rowid_default:25
                 ├── project
-                │    ├── columns: column24:24!null column25:25 y:22 "?column?":23
+                │    ├── columns: c_default:24!null rowid_default:25 y:22 "?column?":23
                 │    ├── union
                 │    │    ├── columns: y:22 "?column?":23
                 │    │    ├── left columns: y:18 "?column?":19
@@ -512,10 +512,10 @@ with &1 (a)
                 │    │              ├──  "?column?":10 => "?column?":20
                 │    │              └──  xyz.y:7 => y:21
                 │    └── projections
-                │         ├── 10 [as=column24:24]
-                │         └── unique_rowid() [as=column25:25]
+                │         ├── 10 [as=c_default:24]
+                │         └── unique_rowid() [as=rowid_default:25]
                 └── projections
-                     └── ("?column?":23 + column24:24) + 1 [as=column26:26]
+                     └── ("?column?":23 + c_default:24) + 1 [as=d_comp:26]
 
 # Non-referenced CTE with mutation.
 build
@@ -528,24 +528,24 @@ with &1
  │         ├── columns: abcde.a:1!null abcde.b:2 abcde.c:3!null abcde.d:4 abcde.e:5!null rowid:6!null
  │         ├── insert-mapping:
  │         │    ├── column1:8 => abcde.a:1
- │         │    ├── column9:9 => abcde.b:2
- │         │    ├── column10:10 => abcde.c:3
- │         │    ├── column12:12 => abcde.d:4
+ │         │    ├── b_default:9 => abcde.b:2
+ │         │    ├── c_default:10 => abcde.c:3
+ │         │    ├── d_comp:12 => abcde.d:4
  │         │    ├── column1:8 => abcde.e:5
- │         │    └── column11:11 => rowid:6
+ │         │    └── rowid_default:11 => rowid:6
  │         └── project
- │              ├── columns: column12:12 column1:8!null column9:9 column10:10!null column11:11
+ │              ├── columns: d_comp:12 column1:8!null b_default:9 c_default:10!null rowid_default:11
  │              ├── project
- │              │    ├── columns: column9:9 column10:10!null column11:11 column1:8!null
+ │              │    ├── columns: b_default:9 c_default:10!null rowid_default:11 column1:8!null
  │              │    ├── values
  │              │    │    ├── columns: column1:8!null
  │              │    │    └── (1,)
  │              │    └── projections
- │              │         ├── NULL::INT8 [as=column9:9]
- │              │         ├── 10 [as=column10:10]
- │              │         └── unique_rowid() [as=column11:11]
+ │              │         ├── NULL::INT8 [as=b_default:9]
+ │              │         ├── 10 [as=c_default:10]
+ │              │         └── unique_rowid() [as=rowid_default:11]
  │              └── projections
- │                   └── (column9:9 + column10:10) + 1 [as=column12:12]
+ │                   └── (b_default:9 + c_default:10) + 1 [as=d_comp:12]
  └── with &2 (cte)
       ├── project
       │    ├── columns: b:14
@@ -561,24 +561,24 @@ with &1
            ├── columns: <none>
            ├── insert-mapping:
            │    ├── column1:25 => abcde.a:18
-           │    ├── column26:26 => abcde.b:19
-           │    ├── column27:27 => abcde.c:20
-           │    ├── column29:29 => abcde.d:21
+           │    ├── b_default:26 => abcde.b:19
+           │    ├── c_default:27 => abcde.c:20
+           │    ├── d_comp:29 => abcde.d:21
            │    ├── column1:25 => abcde.e:22
-           │    └── column28:28 => rowid:23
+           │    └── rowid_default:28 => rowid:23
            └── project
-                ├── columns: column29:29 column1:25!null column26:26 column27:27!null column28:28
+                ├── columns: d_comp:29 column1:25!null b_default:26 c_default:27!null rowid_default:28
                 ├── project
-                │    ├── columns: column26:26 column27:27!null column28:28 column1:25!null
+                │    ├── columns: b_default:26 c_default:27!null rowid_default:28 column1:25!null
                 │    ├── values
                 │    │    ├── columns: column1:25!null
                 │    │    └── (1,)
                 │    └── projections
-                │         ├── NULL::INT8 [as=column26:26]
-                │         ├── 10 [as=column27:27]
-                │         └── unique_rowid() [as=column28:28]
+                │         ├── NULL::INT8 [as=b_default:26]
+                │         ├── 10 [as=c_default:27]
+                │         └── unique_rowid() [as=rowid_default:28]
                 └── projections
-                     └── (column26:26 + column27:27) + 1 [as=column29:29]
+                     └── (b_default:26 + c_default:27) + 1 [as=d_comp:29]
 
 # Insert CTE that returns no columns.
 build
@@ -606,20 +606,20 @@ insert abcde
  │    ├── column3:10 => a:1
  │    ├── column2:9 => b:2
  │    ├── column1:8 => c:3
- │    ├── column12:12 => d:4
+ │    ├── d_comp:12 => d:4
  │    ├── column3:10 => e:5
- │    └── column11:11 => rowid:6
+ │    └── rowid_default:11 => rowid:6
  └── project
-      ├── columns: column12:12!null column1:8!null column2:9!null column3:10!null column11:11
+      ├── columns: d_comp:12!null column1:8!null column2:9!null column3:10!null rowid_default:11
       ├── project
-      │    ├── columns: column11:11 column1:8!null column2:9!null column3:10!null
+      │    ├── columns: rowid_default:11 column1:8!null column2:9!null column3:10!null
       │    ├── values
       │    │    ├── columns: column1:8!null column2:9!null column3:10!null
       │    │    └── (1, 2, 3)
       │    └── projections
-      │         └── unique_rowid() [as=column11:11]
+      │         └── unique_rowid() [as=rowid_default:11]
       └── projections
-           └── (column2:9 + column1:8) + 1 [as=column12:12]
+           └── (column2:9 + column1:8) + 1 [as=d_comp:12]
 
 # Don't specify values for null or default columns.
 build
@@ -629,24 +629,24 @@ insert abcde
  ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:8 => a:1
- │    ├── column9:9 => b:2
- │    ├── column10:10 => c:3
- │    ├── column12:12 => d:4
+ │    ├── b_default:9 => b:2
+ │    ├── c_default:10 => c:3
+ │    ├── d_comp:12 => d:4
  │    ├── column1:8 => e:5
- │    └── column11:11 => rowid:6
+ │    └── rowid_default:11 => rowid:6
  └── project
-      ├── columns: column12:12 column1:8!null column9:9 column10:10!null column11:11
+      ├── columns: d_comp:12 column1:8!null b_default:9 c_default:10!null rowid_default:11
       ├── project
-      │    ├── columns: column9:9 column10:10!null column11:11 column1:8!null
+      │    ├── columns: b_default:9 c_default:10!null rowid_default:11 column1:8!null
       │    ├── values
       │    │    ├── columns: column1:8!null
       │    │    └── (1,)
       │    └── projections
-      │         ├── NULL::INT8 [as=column9:9]
-      │         ├── 10 [as=column10:10]
-      │         └── unique_rowid() [as=column11:11]
+      │         ├── NULL::INT8 [as=b_default:9]
+      │         ├── 10 [as=c_default:10]
+      │         └── unique_rowid() [as=rowid_default:11]
       └── projections
-           └── (column9:9 + column10:10) + 1 [as=column12:12]
+           └── (b_default:9 + c_default:10) + 1 [as=d_comp:12]
 
 # Insert value into hidden rowid column.
 build
@@ -658,23 +658,23 @@ project
       ├── columns: a:1!null b:2 c:3!null d:4 e:5!null rowid:6!null
       ├── insert-mapping:
       │    ├── column1:8 => a:1
-      │    ├── column10:10 => b:2
-      │    ├── column11:11 => c:3
-      │    ├── column12:12 => d:4
+      │    ├── b_default:10 => b:2
+      │    ├── c_default:11 => c:3
+      │    ├── d_comp:12 => d:4
       │    ├── column1:8 => e:5
       │    └── column2:9 => rowid:6
       └── project
-           ├── columns: column12:12 column1:8!null column2:9!null column10:10 column11:11!null
+           ├── columns: d_comp:12 column1:8!null column2:9!null b_default:10 c_default:11!null
            ├── project
-           │    ├── columns: column10:10 column11:11!null column1:8!null column2:9!null
+           │    ├── columns: b_default:10 c_default:11!null column1:8!null column2:9!null
            │    ├── values
            │    │    ├── columns: column1:8!null column2:9!null
            │    │    └── (1, 2)
            │    └── projections
-           │         ├── NULL::INT8 [as=column10:10]
-           │         └── 10 [as=column11:11]
+           │         ├── NULL::INT8 [as=b_default:10]
+           │         └── 10 [as=c_default:11]
            └── projections
-                └── (column10:10 + column11:11) + 1 [as=column12:12]
+                └── (b_default:10 + c_default:11) + 1 [as=d_comp:12]
 
 # Use DEFAULT expressions in VALUES expression.
 build
@@ -688,18 +688,18 @@ insert abcde
  │    ├── column3:10 => a:1
  │    ├── column2:9 => b:2
  │    ├── column1:8 => c:3
- │    ├── column12:12 => d:4
+ │    ├── d_comp:12 => d:4
  │    ├── column3:10 => e:5
  │    └── column4:11 => rowid:6
  └── project
-      ├── columns: column12:12 column1:8!null column2:9 column3:10!null column4:11
+      ├── columns: d_comp:12 column1:8!null column2:9 column3:10!null column4:11
       ├── values
       │    ├── columns: column1:8!null column2:9 column3:10!null column4:11
       │    ├── (10, NULL::INT8, 1, unique_rowid())
       │    ├── (3, 2, 1, unique_rowid())
       │    └── (10, NULL::INT8, 2, 100)
       └── projections
-           └── (column2:9 + column1:8) + 1 [as=column12:12]
+           └── (column2:9 + column1:8) + 1 [as=d_comp:12]
 
 # Verify that there is no compile-time error when trying to insert a NULL
 # DEFAULT value into a not-null column (it will fail at runtime).
@@ -710,24 +710,24 @@ insert abcde
  ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:8 => a:1
- │    ├── column9:9 => b:2
- │    ├── column10:10 => c:3
- │    ├── column12:12 => d:4
+ │    ├── b_default:9 => b:2
+ │    ├── c_default:10 => c:3
+ │    ├── d_comp:12 => d:4
  │    ├── column1:8 => e:5
- │    └── column11:11 => rowid:6
+ │    └── rowid_default:11 => rowid:6
  └── project
-      ├── columns: column12:12 column1:8 column9:9 column10:10!null column11:11
+      ├── columns: d_comp:12 column1:8 b_default:9 c_default:10!null rowid_default:11
       ├── project
-      │    ├── columns: column9:9 column10:10!null column11:11 column1:8
+      │    ├── columns: b_default:9 c_default:10!null rowid_default:11 column1:8
       │    ├── values
       │    │    ├── columns: column1:8
       │    │    └── (NULL::INT8,)
       │    └── projections
-      │         ├── NULL::INT8 [as=column9:9]
-      │         ├── 10 [as=column10:10]
-      │         └── unique_rowid() [as=column11:11]
+      │         ├── NULL::INT8 [as=b_default:9]
+      │         ├── 10 [as=c_default:10]
+      │         └── unique_rowid() [as=rowid_default:11]
       └── projections
-           └── (column9:9 + column10:10) + 1 [as=column12:12]
+           └── (b_default:9 + c_default:10) + 1 [as=d_comp:12]
 
 # Mismatched type.
 build
@@ -782,14 +782,14 @@ project
       ├── insert-mapping:
       │    ├── y:9 => a:1
       │    ├── x:12 => b:2
-      │    ├── column13:13 => c:3
-      │    ├── column15:15 => d:4
+      │    ├── c_default:13 => c:3
+      │    ├── d_comp:15 => d:4
       │    ├── y:9 => e:5
-      │    └── column14:14 => rowid:6
+      │    └── rowid_default:14 => rowid:6
       └── project
-           ├── columns: column15:15!null y:9 x:12!null column13:13!null column14:14
+           ├── columns: d_comp:15!null y:9 x:12!null c_default:13!null rowid_default:14
            ├── project
-           │    ├── columns: column13:13!null column14:14 y:9 x:12!null
+           │    ├── columns: c_default:13!null rowid_default:14 y:9 x:12!null
            │    ├── project
            │    │    ├── columns: x:12!null y:9
            │    │    ├── scan xyz
@@ -797,10 +797,10 @@ project
            │    │    └── projections
            │    │         └── xyz.x:8::INT8 [as=x:12]
            │    └── projections
-           │         ├── 10 [as=column13:13]
-           │         └── unique_rowid() [as=column14:14]
+           │         ├── 10 [as=c_default:13]
+           │         └── unique_rowid() [as=rowid_default:14]
            └── projections
-                └── (x:12 + column13:13) + 1 [as=column15:15]
+                └── (x:12 + c_default:13) + 1 [as=d_comp:15]
 
 # Return hidden column.
 build
@@ -810,23 +810,23 @@ insert abcde
  ├── columns: a:1!null b:2 c:3!null d:4 e:5!null rowid:6!null
  ├── insert-mapping:
  │    ├── column2:9 => a:1
- │    ├── column10:10 => b:2
- │    ├── column11:11 => c:3
- │    ├── column12:12 => d:4
+ │    ├── b_default:10 => b:2
+ │    ├── c_default:11 => c:3
+ │    ├── d_comp:12 => d:4
  │    ├── column2:9 => e:5
  │    └── column1:8 => rowid:6
  └── project
-      ├── columns: column12:12 column1:8!null column2:9!null column10:10 column11:11!null
+      ├── columns: d_comp:12 column1:8!null column2:9!null b_default:10 c_default:11!null
       ├── project
-      │    ├── columns: column10:10 column11:11!null column1:8!null column2:9!null
+      │    ├── columns: b_default:10 c_default:11!null column1:8!null column2:9!null
       │    ├── values
       │    │    ├── columns: column1:8!null column2:9!null
       │    │    └── (1, 2)
       │    └── projections
-      │         ├── NULL::INT8 [as=column10:10]
-      │         └── 10 [as=column11:11]
+      │         ├── NULL::INT8 [as=b_default:10]
+      │         └── 10 [as=c_default:11]
       └── projections
-           └── (column10:10 + column11:11) + 1 [as=column12:12]
+           └── (b_default:10 + c_default:11) + 1 [as=d_comp:12]
 
 # Use returning INSERT as a FROM expression.
 build
@@ -841,14 +841,14 @@ with &1
  │         ├── insert-mapping:
  │         │    ├── "?column?":12 => abcde.a:1
  │         │    ├── y:9 => abcde.b:2
- │         │    ├── column13:13 => abcde.c:3
- │         │    ├── column15:15 => abcde.d:4
+ │         │    ├── c_default:13 => abcde.c:3
+ │         │    ├── d_comp:15 => abcde.d:4
  │         │    ├── "?column?":12 => abcde.e:5
- │         │    └── column14:14 => rowid:6
+ │         │    └── rowid_default:14 => rowid:6
  │         └── project
- │              ├── columns: column15:15 y:9 "?column?":12 column13:13!null column14:14
+ │              ├── columns: d_comp:15 y:9 "?column?":12 c_default:13!null rowid_default:14
  │              ├── project
- │              │    ├── columns: column13:13!null column14:14 y:9 "?column?":12
+ │              │    ├── columns: c_default:13!null rowid_default:14 y:9 "?column?":12
  │              │    ├── project
  │              │    │    ├── columns: "?column?":12 y:9
  │              │    │    ├── scan xyz
@@ -856,10 +856,10 @@ with &1
  │              │    │    └── projections
  │              │    │         └── y:9 + 1 [as="?column?":12]
  │              │    └── projections
- │              │         ├── 10 [as=column13:13]
- │              │         └── unique_rowid() [as=column14:14]
+ │              │         ├── 10 [as=c_default:13]
+ │              │         └── unique_rowid() [as=rowid_default:14]
  │              └── projections
- │                   └── (y:9 + column13:13) + 1 [as=column15:15]
+ │                   └── (y:9 + c_default:13) + 1 [as=d_comp:15]
  └── with-scan &1
       ├── columns: a:16!null b:17 c:18!null d:19 e:20
       └── mapping:
@@ -1014,22 +1014,22 @@ insert mutation
  ├── insert-mapping:
  │    ├── column1:7 => m:1
  │    ├── column2:8 => n:2
- │    ├── column9:9 => o:3
- │    └── column10:10 => p:4
+ │    ├── o_default:9 => o:3
+ │    └── p_comp:10 => p:4
  ├── check columns: check1:11
  └── project
-      ├── columns: check1:11!null column1:7!null column2:8!null column9:9!null column10:10!null
+      ├── columns: check1:11!null column1:7!null column2:8!null o_default:9!null p_comp:10!null
       ├── project
-      │    ├── columns: column10:10!null column1:7!null column2:8!null column9:9!null
+      │    ├── columns: p_comp:10!null column1:7!null column2:8!null o_default:9!null
       │    ├── project
-      │    │    ├── columns: column9:9!null column1:7!null column2:8!null
+      │    │    ├── columns: o_default:9!null column1:7!null column2:8!null
       │    │    ├── values
       │    │    │    ├── columns: column1:7!null column2:8!null
       │    │    │    └── (1, 2)
       │    │    └── projections
-      │    │         └── 10 [as=column9:9]
+      │    │         └── 10 [as=o_default:9]
       │    └── projections
-      │         └── column9:9 + column2:8 [as=column10:10]
+      │         └── o_default:9 + column2:8 [as=p_comp:10]
       └── projections
            └── column1:7 > 0 [as=check1:11]
 
@@ -1042,22 +1042,22 @@ insert mutation
  ├── insert-mapping:
  │    ├── column1:7 => m:1
  │    ├── column2:8 => n:2
- │    ├── column9:9 => o:3
- │    └── column10:10 => p:4
+ │    ├── o_default:9 => o:3
+ │    └── p_comp:10 => p:4
  ├── check columns: check1:11
  └── project
-      ├── columns: check1:11!null column1:7!null column2:8!null column9:9!null column10:10!null
+      ├── columns: check1:11!null column1:7!null column2:8!null o_default:9!null p_comp:10!null
       ├── project
-      │    ├── columns: column10:10!null column1:7!null column2:8!null column9:9!null
+      │    ├── columns: p_comp:10!null column1:7!null column2:8!null o_default:9!null
       │    ├── project
-      │    │    ├── columns: column9:9!null column1:7!null column2:8!null
+      │    │    ├── columns: o_default:9!null column1:7!null column2:8!null
       │    │    ├── values
       │    │    │    ├── columns: column1:7!null column2:8!null
       │    │    │    └── (1, 2)
       │    │    └── projections
-      │    │         └── 10 [as=column9:9]
+      │    │         └── 10 [as=o_default:9]
       │    └── projections
-      │         └── column9:9 + column2:8 [as=column10:10]
+      │         └── o_default:9 + column2:8 [as=p_comp:10]
       └── projections
            └── column1:7 > 0 [as=check1:11]
 
@@ -1093,19 +1093,19 @@ insert checks
  │    ├── column1:6 => a:1
  │    ├── column2:7 => b:2
  │    ├── column3:8 => c:3
- │    └── column9:9 => d:4
+ │    └── d_comp:9 => d:4
  ├── check columns: check1:10 check2:11
  └── project
-      ├── columns: check1:10!null check2:11!null column1:6!null column2:7!null column3:8!null column9:9!null
+      ├── columns: check1:10!null check2:11!null column1:6!null column2:7!null column3:8!null d_comp:9!null
       ├── project
-      │    ├── columns: column9:9!null column1:6!null column2:7!null column3:8!null
+      │    ├── columns: d_comp:9!null column1:6!null column2:7!null column3:8!null
       │    ├── values
       │    │    ├── columns: column1:6!null column2:7!null column3:8!null
       │    │    └── (1, 2, 3)
       │    └── projections
-      │         └── column3:8 + 1 [as=column9:9]
+      │         └── column3:8 + 1 [as=d_comp:9]
       └── projections
-           ├── column2:7 < column9:9 [as=check1:10]
+           ├── column2:7 < d_comp:9 [as=check1:10]
            └── column1:6 > 0 [as=check2:11]
 
 # Insert results of SELECT.
@@ -1118,12 +1118,12 @@ insert checks
  │    ├── abcde.a:6 => checks.a:1
  │    ├── abcde.b:7 => checks.b:2
  │    ├── abcde.c:8 => checks.c:3
- │    └── column13:13 => checks.d:4
+ │    └── d_comp:13 => checks.d:4
  ├── check columns: check1:14 check2:15
  └── project
-      ├── columns: check1:14 check2:15!null abcde.a:6!null abcde.b:7 abcde.c:8 column13:13
+      ├── columns: check1:14 check2:15!null abcde.a:6!null abcde.b:7 abcde.c:8 d_comp:13
       ├── project
-      │    ├── columns: column13:13 abcde.a:6!null abcde.b:7 abcde.c:8
+      │    ├── columns: d_comp:13 abcde.a:6!null abcde.b:7 abcde.c:8
       │    ├── project
       │    │    ├── columns: abcde.a:6!null abcde.b:7 abcde.c:8
       │    │    └── scan abcde
@@ -1134,9 +1134,9 @@ insert checks
       │    │              └── e:10
       │    │                   └── abcde.a:6
       │    └── projections
-      │         └── abcde.c:8 + 1 [as=column13:13]
+      │         └── abcde.c:8 + 1 [as=d_comp:13]
       └── projections
-           ├── abcde.b:7 < column13:13 [as=check1:14]
+           ├── abcde.b:7 < d_comp:13 [as=check1:14]
            └── abcde.a:6 > 0 [as=check2:15]
 
 # ------------------------------------------------------------------------------
@@ -1151,32 +1151,32 @@ insert decimals
  ├── insert-mapping:
  │    ├── a:9 => decimals.a:1
  │    ├── b:10 => decimals.b:2
- │    ├── c:11 => decimals.c:3
- │    └── d:13 => decimals.d:4
+ │    ├── c_default:11 => c:3
+ │    └── d_comp:13 => d:4
  ├── check columns: check1:14 check2:15
  └── project
-      ├── columns: check1:14 check2:15 a:9 b:10 c:11 d:13
+      ├── columns: check1:14 check2:15 a:9 b:10 c_default:11 d_comp:13
       ├── project
-      │    ├── columns: d:13 a:9 b:10 c:11
+      │    ├── columns: d_comp:13 a:9 b:10 c_default:11
       │    ├── project
-      │    │    ├── columns: column12:12 a:9 b:10 c:11
+      │    │    ├── columns: d_comp:12 a:9 b:10 c_default:11
       │    │    ├── project
-      │    │    │    ├── columns: a:9 b:10 c:11
+      │    │    │    ├── columns: a:9 b:10 c_default:11
       │    │    │    ├── project
-      │    │    │    │    ├── columns: column8:8!null column1:6!null column2:7
+      │    │    │    │    ├── columns: c_default:8!null column1:6!null column2:7
       │    │    │    │    ├── values
       │    │    │    │    │    ├── columns: column1:6!null column2:7
       │    │    │    │    │    └── (1.1, ARRAY[0.95,NULL,15])
       │    │    │    │    └── projections
-      │    │    │    │         └── 1.23 [as=column8:8]
+      │    │    │    │         └── 1.23 [as=c_default:8]
       │    │    │    └── projections
       │    │    │         ├── crdb_internal.round_decimal_values(column1:6, 0) [as=a:9]
       │    │    │         ├── crdb_internal.round_decimal_values(column2:7, 1) [as=b:10]
-      │    │    │         └── crdb_internal.round_decimal_values(column8:8, 1) [as=c:11]
+      │    │    │         └── crdb_internal.round_decimal_values(c_default:8, 1) [as=c_default:11]
       │    │    └── projections
-      │    │         └── a:9 + c:11 [as=column12:12]
+      │    │         └── a:9 + c_default:11 [as=d_comp:12]
       │    └── projections
-      │         └── crdb_internal.round_decimal_values(column12:12, 1) [as=d:13]
+      │         └── crdb_internal.round_decimal_values(d_comp:12, 1) [as=d_comp:13]
       └── projections
            ├── round(a:9) = a:9 [as=check1:14]
            └── b:10[0] > 1 [as=check2:15]
@@ -1197,16 +1197,16 @@ insert defvals
  ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:5 => id:1
- │    ├── column6:6 => arr1:2
- │    └── column7:7 => arr2:3
+ │    ├── arr1_default:6 => arr1:2
+ │    └── arr2_default:7 => arr2:3
  └── project
-      ├── columns: column6:6!null column7:7!null column1:5!null
+      ├── columns: arr1_default:6!null arr2_default:7!null column1:5!null
       ├── values
       │    ├── columns: column1:5!null
       │    └── (1,)
       └── projections
-           ├── ARRAY[] [as=column6:6]
-           └── ARRAY[] [as=column7:7]
+           ├── ARRAY[] [as=arr1_default:6]
+           └── ARRAY[] [as=arr2_default:7]
 
 exec-ddl
 CREATE TABLE defvals2 (
@@ -1223,13 +1223,13 @@ insert defvals2
  ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:5 => id:1
- │    ├── column6:6 => arr1:2
- │    └── column7:7 => arr2:3
+ │    ├── arr1_default:6 => arr1:2
+ │    └── arr2_default:7 => arr2:3
  └── project
-      ├── columns: column6:6 column7:7 column1:5!null
+      ├── columns: arr1_default:6 arr2_default:7 column1:5!null
       ├── values
       │    ├── columns: column1:5!null
       │    └── (1,)
       └── projections
-           ├── ARRAY[NULL] [as=column6:6]
-           └── ARRAY[NULL] [as=column7:7]
+           ├── ARRAY[NULL] [as=arr1_default:6]
+           └── ARRAY[NULL] [as=arr2_default:7]

--- a/pkg/sql/opt/optbuilder/testdata/partial-indexes
+++ b/pkg/sql/opt/optbuilder/testdata/partial-indexes
@@ -123,20 +123,20 @@ insert ambig
  │    ├── column1:6 => ambig.partial_index_put1:1
  │    ├── column2:7 => partial_index_del1:2
  │    ├── column3:8 => ambig.check1:3
- │    └── column9:9 => rowid:4
+ │    └── rowid_default:9 => rowid:4
  ├── check columns: check1:10
  ├── partial index put columns: partial_index_put1:11 partial_index_put2:12 partial_index_put3:13
  └── project
-      ├── columns: partial_index_put1:11!null partial_index_put2:12!null partial_index_put3:13!null column1:6!null column2:7!null column3:8!null column9:9 check1:10!null
+      ├── columns: partial_index_put1:11!null partial_index_put2:12!null partial_index_put3:13!null column1:6!null column2:7!null column3:8!null rowid_default:9 check1:10!null
       ├── project
-      │    ├── columns: check1:10!null column1:6!null column2:7!null column3:8!null column9:9
+      │    ├── columns: check1:10!null column1:6!null column2:7!null column3:8!null rowid_default:9
       │    ├── project
-      │    │    ├── columns: column9:9 column1:6!null column2:7!null column3:8!null
+      │    │    ├── columns: rowid_default:9 column1:6!null column2:7!null column3:8!null
       │    │    ├── values
       │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
       │    │    │    └── (1, 2, 3)
       │    │    └── projections
-      │    │         └── unique_rowid() [as=column9:9]
+      │    │         └── unique_rowid() [as=rowid_default:9]
       │    └── projections
       │         └── column1:6 > 10 [as=check1:10]
       └── projections
@@ -153,22 +153,22 @@ insert comp
  │    ├── column1:7 => a:1
  │    ├── column2:8 => b:2
  │    ├── column3:9 => c:3
- │    ├── column10:10 => d:4
- │    └── column11:11 => e:5
+ │    ├── d_comp:10 => d:4
+ │    └── e_comp:11 => e:5
  ├── partial index put columns: partial_index_put1:12 partial_index_put2:13
  └── project
-      ├── columns: partial_index_put1:12 partial_index_put2:13 column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      ├── columns: partial_index_put1:12 partial_index_put2:13 column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11
       ├── project
-      │    ├── columns: column10:10 column11:11 column1:7!null column2:8!null column3:9!null
+      │    ├── columns: d_comp:10 e_comp:11 column1:7!null column2:8!null column3:9!null
       │    ├── values
       │    │    ├── columns: column1:7!null column2:8!null column3:9!null
       │    │    └── (2, 1, 'Foo')
       │    └── projections
-      │         ├── lower(column3:9) [as=column10:10]
-      │         └── upper(column3:9) [as=column11:11]
+      │         ├── lower(column3:9) [as=d_comp:10]
+      │         └── upper(column3:9) [as=e_comp:11]
       └── projections
-           ├── column10:10 = 'foo' [as=partial_index_put1:12]
-           └── column11:11 = 'FOO' [as=partial_index_put2:13]
+           ├── d_comp:10 = 'foo' [as=partial_index_put1:12]
+           └── e_comp:11 = 'FOO' [as=partial_index_put2:13]
 
 # Regression test for issue #52546. Building partial index predicate expressions
 # that are only a single column reference should not panic.
@@ -185,15 +185,15 @@ insert t52546
  ├── insert-mapping:
  │    ├── column1:5 => a:1
  │    ├── column2:6 => b:2
- │    └── column7:7 => rowid:3
+ │    └── rowid_default:7 => rowid:3
  ├── partial index put columns: column2:6
  └── project
-      ├── columns: column7:7 column1:5!null column2:6!null
+      ├── columns: rowid_default:7 column1:5!null column2:6!null
       ├── values
       │    ├── columns: column1:5!null column2:6!null
       │    └── (1, true)
       └── projections
-           └── unique_rowid() [as=column7:7]
+           └── unique_rowid() [as=rowid_default:7]
 
 # -- DELETE tests --
 
@@ -460,9 +460,9 @@ update comp
  ├── partial index put columns: partial_index_put1:16 partial_index_put2:17
  ├── partial index del columns: partial_index_put1:16 partial_index_put2:17
  └── project
-      ├── columns: partial_index_put1:16 partial_index_put2:17 a:7!null b:8 c:9 d:10 e:11 crdb_internal_mvcc_timestamp:12 b_new:13!null column14:14 column15:15
+      ├── columns: partial_index_put1:16 partial_index_put2:17 a:7!null b:8 c:9 d:10 e:11 crdb_internal_mvcc_timestamp:12 b_new:13!null d_comp:14 e_comp:15
       ├── project
-      │    ├── columns: column14:14 column15:15 a:7!null b:8 c:9 d:10 e:11 crdb_internal_mvcc_timestamp:12 b_new:13!null
+      │    ├── columns: d_comp:14 e_comp:15 a:7!null b:8 c:9 d:10 e:11 crdb_internal_mvcc_timestamp:12 b_new:13!null
       │    ├── project
       │    │    ├── columns: b_new:13!null a:7!null b:8 c:9 d:10 e:11 crdb_internal_mvcc_timestamp:12
       │    │    ├── project
@@ -484,8 +484,8 @@ update comp
       │    │    └── projections
       │    │         └── 1 [as=b_new:13]
       │    └── projections
-      │         ├── lower(c:9) [as=column14:14]
-      │         └── upper(c:9) [as=column15:15]
+      │         ├── lower(c:9) [as=d_comp:14]
+      │         └── upper(c:9) [as=e_comp:15]
       └── projections
            ├── d:10 = 'foo' [as=partial_index_put1:16]
            └── e:11 = 'FOO' [as=partial_index_put2:17]
@@ -498,14 +498,14 @@ update comp
  ├── fetch columns: a:7 b:8 c:9 d:10 e:11
  ├── update-mapping:
  │    ├── c_new:13 => c:3
- │    ├── column14:14 => d:4
- │    └── column15:15 => e:5
+ │    ├── d_comp:14 => d:4
+ │    └── e_comp:15 => e:5
  ├── partial index put columns: partial_index_put1:16 partial_index_put2:18
  ├── partial index del columns: partial_index_del1:17 partial_index_del2:19
  └── project
-      ├── columns: partial_index_put1:16 partial_index_del1:17 partial_index_put2:18 partial_index_del2:19 a:7!null b:8 c:9 d:10 e:11 crdb_internal_mvcc_timestamp:12 c_new:13!null column14:14 column15:15
+      ├── columns: partial_index_put1:16 partial_index_del1:17 partial_index_put2:18 partial_index_del2:19 a:7!null b:8 c:9 d:10 e:11 crdb_internal_mvcc_timestamp:12 c_new:13!null d_comp:14 e_comp:15
       ├── project
-      │    ├── columns: column14:14 column15:15 a:7!null b:8 c:9 d:10 e:11 crdb_internal_mvcc_timestamp:12 c_new:13!null
+      │    ├── columns: d_comp:14 e_comp:15 a:7!null b:8 c:9 d:10 e:11 crdb_internal_mvcc_timestamp:12 c_new:13!null
       │    ├── project
       │    │    ├── columns: c_new:13!null a:7!null b:8 c:9 d:10 e:11 crdb_internal_mvcc_timestamp:12
       │    │    ├── project
@@ -527,12 +527,12 @@ update comp
       │    │    └── projections
       │    │         └── 'Bar' [as=c_new:13]
       │    └── projections
-      │         ├── lower(c_new:13) [as=column14:14]
-      │         └── upper(c_new:13) [as=column15:15]
+      │         ├── lower(c_new:13) [as=d_comp:14]
+      │         └── upper(c_new:13) [as=e_comp:15]
       └── projections
-           ├── column14:14 = 'foo' [as=partial_index_put1:16]
+           ├── d_comp:14 = 'foo' [as=partial_index_put1:16]
            ├── d:10 = 'foo' [as=partial_index_del1:17]
-           ├── column15:15 = 'FOO' [as=partial_index_put2:18]
+           ├── e_comp:15 = 'FOO' [as=partial_index_put2:18]
            └── e:11 = 'FOO' [as=partial_index_del2:19]
 
 # Regression test for #61520. The new value for column a (project as b:8) should
@@ -794,24 +794,24 @@ insert comp
  │    ├── column1:7 => a:1
  │    ├── column2:8 => b:2
  │    ├── column3:9 => c:3
- │    ├── column10:10 => d:4
- │    └── column11:11 => e:5
+ │    ├── d_comp:10 => d:4
+ │    └── e_comp:11 => e:5
  ├── partial index put columns: partial_index_put1:18 partial_index_put2:19
  └── project
-      ├── columns: partial_index_put1:18 partial_index_put2:19 column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      ├── columns: partial_index_put1:18 partial_index_put2:19 column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11
       ├── upsert-distinct-on
-      │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      │    ├── columns: column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11
       │    ├── grouping columns: column1:7!null
       │    ├── anti-join (hash)
-      │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      │    │    ├── columns: column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11
       │    │    ├── project
-      │    │    │    ├── columns: column10:10 column11:11 column1:7!null column2:8!null column3:9!null
+      │    │    │    ├── columns: d_comp:10 e_comp:11 column1:7!null column2:8!null column3:9!null
       │    │    │    ├── values
       │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null
       │    │    │    │    └── (2, 1, 'Foo')
       │    │    │    └── projections
-      │    │    │         ├── lower(column3:9) [as=column10:10]
-      │    │    │         └── upper(column3:9) [as=column11:11]
+      │    │    │         ├── lower(column3:9) [as=d_comp:10]
+      │    │    │         └── upper(column3:9) [as=e_comp:11]
       │    │    ├── project
       │    │    │    ├── columns: d:15 a:12!null b:13 c:14 e:16
       │    │    │    ├── scan comp
@@ -835,13 +835,13 @@ insert comp
       │         │    └── column2:8
       │         ├── first-agg [as=column3:9]
       │         │    └── column3:9
-      │         ├── first-agg [as=column10:10]
-      │         │    └── column10:10
-      │         └── first-agg [as=column11:11]
-      │              └── column11:11
+      │         ├── first-agg [as=d_comp:10]
+      │         │    └── d_comp:10
+      │         └── first-agg [as=e_comp:11]
+      │              └── e_comp:11
       └── projections
-           ├── column10:10 = 'foo' [as=partial_index_put1:18]
-           └── column11:11 = 'FOO' [as=partial_index_put2:19]
+           ├── d_comp:10 = 'foo' [as=partial_index_put1:18]
+           └── e_comp:11 = 'FOO' [as=partial_index_put2:19]
 
 build
 INSERT INTO comp VALUES (2, 1, 'Foo') ON CONFLICT (a) DO UPDATE SET b = comp.b + 1, c = 'Bar'
@@ -855,8 +855,8 @@ upsert comp
  │    ├── column1:7 => a:1
  │    ├── column2:8 => b:2
  │    ├── column3:9 => c:3
- │    ├── column10:10 => d:4
- │    └── column11:11 => e:5
+ │    ├── d_comp:10 => d:4
+ │    └── e_comp:11 => e:5
  ├── update-mapping:
  │    ├── upsert_b:23 => b:2
  │    ├── upsert_c:24 => c:3
@@ -865,35 +865,35 @@ upsert comp
  ├── partial index put columns: partial_index_put1:27 partial_index_put2:29
  ├── partial index del columns: partial_index_del1:28 partial_index_del2:30
  └── project
-      ├── columns: partial_index_put1:27 partial_index_del1:28 partial_index_put2:29 partial_index_del2:30 column1:7!null column2:8!null column3:9!null column10:10 column11:11 a:12 b:13 c:14 d:15 e:16 crdb_internal_mvcc_timestamp:17 b_new:18 c_new:19!null column20:20 column21:21 upsert_a:22 upsert_b:23 upsert_c:24!null upsert_d:25 upsert_e:26
+      ├── columns: partial_index_put1:27 partial_index_del1:28 partial_index_put2:29 partial_index_del2:30 column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11 a:12 b:13 c:14 d:15 e:16 crdb_internal_mvcc_timestamp:17 b_new:18 c_new:19!null d_comp:20 e_comp:21 upsert_a:22 upsert_b:23 upsert_c:24!null upsert_d:25 upsert_e:26
       ├── project
-      │    ├── columns: upsert_a:22 upsert_b:23 upsert_c:24!null upsert_d:25 upsert_e:26 column1:7!null column2:8!null column3:9!null column10:10 column11:11 a:12 b:13 c:14 d:15 e:16 crdb_internal_mvcc_timestamp:17 b_new:18 c_new:19!null column20:20 column21:21
+      │    ├── columns: upsert_a:22 upsert_b:23 upsert_c:24!null upsert_d:25 upsert_e:26 column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11 a:12 b:13 c:14 d:15 e:16 crdb_internal_mvcc_timestamp:17 b_new:18 c_new:19!null d_comp:20 e_comp:21
       │    ├── project
-      │    │    ├── columns: column20:20 column21:21 column1:7!null column2:8!null column3:9!null column10:10 column11:11 a:12 b:13 c:14 d:15 e:16 crdb_internal_mvcc_timestamp:17 b_new:18 c_new:19!null
+      │    │    ├── columns: d_comp:20 e_comp:21 column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11 a:12 b:13 c:14 d:15 e:16 crdb_internal_mvcc_timestamp:17 b_new:18 c_new:19!null
       │    │    ├── project
-      │    │    │    ├── columns: b_new:18 c_new:19!null column1:7!null column2:8!null column3:9!null column10:10 column11:11 a:12 b:13 c:14 d:15 e:16 crdb_internal_mvcc_timestamp:17
+      │    │    │    ├── columns: b_new:18 c_new:19!null column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11 a:12 b:13 c:14 d:15 e:16 crdb_internal_mvcc_timestamp:17
       │    │    │    ├── left-join (hash)
-      │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11 a:12 b:13 c:14 d:15 e:16 crdb_internal_mvcc_timestamp:17
+      │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11 a:12 b:13 c:14 d:15 e:16 crdb_internal_mvcc_timestamp:17
       │    │    │    │    ├── ensure-upsert-distinct-on
-      │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11
       │    │    │    │    │    ├── grouping columns: column1:7!null
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: column10:10 column11:11 column1:7!null column2:8!null column3:9!null
+      │    │    │    │    │    │    ├── columns: d_comp:10 e_comp:11 column1:7!null column2:8!null column3:9!null
       │    │    │    │    │    │    ├── values
       │    │    │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null
       │    │    │    │    │    │    │    └── (2, 1, 'Foo')
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         ├── lower(column3:9) [as=column10:10]
-      │    │    │    │    │    │         └── upper(column3:9) [as=column11:11]
+      │    │    │    │    │    │         ├── lower(column3:9) [as=d_comp:10]
+      │    │    │    │    │    │         └── upper(column3:9) [as=e_comp:11]
       │    │    │    │    │    └── aggregations
       │    │    │    │    │         ├── first-agg [as=column2:8]
       │    │    │    │    │         │    └── column2:8
       │    │    │    │    │         ├── first-agg [as=column3:9]
       │    │    │    │    │         │    └── column3:9
-      │    │    │    │    │         ├── first-agg [as=column10:10]
-      │    │    │    │    │         │    └── column10:10
-      │    │    │    │    │         └── first-agg [as=column11:11]
-      │    │    │    │    │              └── column11:11
+      │    │    │    │    │         ├── first-agg [as=d_comp:10]
+      │    │    │    │    │         │    └── d_comp:10
+      │    │    │    │    │         └── first-agg [as=e_comp:11]
+      │    │    │    │    │              └── e_comp:11
       │    │    │    │    ├── project
       │    │    │    │    │    ├── columns: d:15 a:12!null b:13 c:14 e:16 crdb_internal_mvcc_timestamp:17
       │    │    │    │    │    ├── scan comp
@@ -916,14 +916,14 @@ upsert comp
       │    │    │         ├── b:13 + 1 [as=b_new:18]
       │    │    │         └── 'Bar' [as=c_new:19]
       │    │    └── projections
-      │    │         ├── lower(c_new:19) [as=column20:20]
-      │    │         └── upper(c_new:19) [as=column21:21]
+      │    │         ├── lower(c_new:19) [as=d_comp:20]
+      │    │         └── upper(c_new:19) [as=e_comp:21]
       │    └── projections
       │         ├── CASE WHEN a:12 IS NULL THEN column1:7 ELSE a:12 END [as=upsert_a:22]
       │         ├── CASE WHEN a:12 IS NULL THEN column2:8 ELSE b_new:18 END [as=upsert_b:23]
       │         ├── CASE WHEN a:12 IS NULL THEN column3:9 ELSE c_new:19 END [as=upsert_c:24]
-      │         ├── CASE WHEN a:12 IS NULL THEN column10:10 ELSE column20:20 END [as=upsert_d:25]
-      │         └── CASE WHEN a:12 IS NULL THEN column11:11 ELSE column21:21 END [as=upsert_e:26]
+      │         ├── CASE WHEN a:12 IS NULL THEN d_comp:10 ELSE d_comp:20 END [as=upsert_d:25]
+      │         └── CASE WHEN a:12 IS NULL THEN e_comp:11 ELSE e_comp:21 END [as=upsert_e:26]
       └── projections
            ├── upsert_d:25 = 'foo' [as=partial_index_put1:27]
            ├── d:15 = 'foo' [as=partial_index_del1:28]
@@ -942,41 +942,41 @@ upsert comp
  │    ├── column1:7 => a:1
  │    ├── column2:8 => b:2
  │    ├── column3:9 => c:3
- │    ├── column10:10 => d:4
- │    └── column11:11 => e:5
+ │    ├── d_comp:10 => d:4
+ │    └── e_comp:11 => e:5
  ├── update-mapping:
  │    ├── column2:8 => b:2
  │    ├── column3:9 => c:3
- │    ├── column10:10 => d:4
- │    └── column11:11 => e:5
+ │    ├── d_comp:10 => d:4
+ │    └── e_comp:11 => e:5
  ├── partial index put columns: partial_index_put1:19 partial_index_put2:21
  ├── partial index del columns: partial_index_del1:20 partial_index_del2:22
  └── project
-      ├── columns: partial_index_put1:19 partial_index_del1:20 partial_index_put2:21 partial_index_del2:22 column1:7!null column2:8!null column3:9!null column10:10 column11:11 a:12 b:13 c:14 d:15 e:16 crdb_internal_mvcc_timestamp:17 upsert_a:18
+      ├── columns: partial_index_put1:19 partial_index_del1:20 partial_index_put2:21 partial_index_del2:22 column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11 a:12 b:13 c:14 d:15 e:16 crdb_internal_mvcc_timestamp:17 upsert_a:18
       ├── project
-      │    ├── columns: upsert_a:18 column1:7!null column2:8!null column3:9!null column10:10 column11:11 a:12 b:13 c:14 d:15 e:16 crdb_internal_mvcc_timestamp:17
+      │    ├── columns: upsert_a:18 column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11 a:12 b:13 c:14 d:15 e:16 crdb_internal_mvcc_timestamp:17
       │    ├── left-join (hash)
-      │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11 a:12 b:13 c:14 d:15 e:16 crdb_internal_mvcc_timestamp:17
+      │    │    ├── columns: column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11 a:12 b:13 c:14 d:15 e:16 crdb_internal_mvcc_timestamp:17
       │    │    ├── ensure-upsert-distinct-on
-      │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11
       │    │    │    ├── grouping columns: column1:7!null
       │    │    │    ├── project
-      │    │    │    │    ├── columns: column10:10 column11:11 column1:7!null column2:8!null column3:9!null
+      │    │    │    │    ├── columns: d_comp:10 e_comp:11 column1:7!null column2:8!null column3:9!null
       │    │    │    │    ├── values
       │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null
       │    │    │    │    │    └── (2, 1, 'Foo')
       │    │    │    │    └── projections
-      │    │    │    │         ├── lower(column3:9) [as=column10:10]
-      │    │    │    │         └── upper(column3:9) [as=column11:11]
+      │    │    │    │         ├── lower(column3:9) [as=d_comp:10]
+      │    │    │    │         └── upper(column3:9) [as=e_comp:11]
       │    │    │    └── aggregations
       │    │    │         ├── first-agg [as=column2:8]
       │    │    │         │    └── column2:8
       │    │    │         ├── first-agg [as=column3:9]
       │    │    │         │    └── column3:9
-      │    │    │         ├── first-agg [as=column10:10]
-      │    │    │         │    └── column10:10
-      │    │    │         └── first-agg [as=column11:11]
-      │    │    │              └── column11:11
+      │    │    │         ├── first-agg [as=d_comp:10]
+      │    │    │         │    └── d_comp:10
+      │    │    │         └── first-agg [as=e_comp:11]
+      │    │    │              └── e_comp:11
       │    │    ├── project
       │    │    │    ├── columns: d:15 a:12!null b:13 c:14 e:16 crdb_internal_mvcc_timestamp:17
       │    │    │    ├── scan comp
@@ -998,9 +998,9 @@ upsert comp
       │    └── projections
       │         └── CASE WHEN a:12 IS NULL THEN column1:7 ELSE a:12 END [as=upsert_a:18]
       └── projections
-           ├── column10:10 = 'foo' [as=partial_index_put1:19]
+           ├── d_comp:10 = 'foo' [as=partial_index_put1:19]
            ├── d:15 = 'foo' [as=partial_index_del1:20]
-           ├── column11:11 = 'FOO' [as=partial_index_put2:21]
+           ├── e_comp:11 = 'FOO' [as=partial_index_put2:21]
            └── e:16 = 'FOO' [as=partial_index_del2:22]
 
 build
@@ -1345,8 +1345,8 @@ upsert ambig
  ├── insert-mapping:
  │    ├── column1:6 => ambig.partial_index_put1:1
  │    ├── column2:7 => ambig.partial_index_del1:2
- │    ├── column8:8 => ambig.check1:3
- │    └── column9:9 => rowid:4
+ │    ├── check1_default:8 => ambig.check1:3
+ │    └── rowid_default:9 => rowid:4
  ├── update-mapping:
  │    ├── upsert_partial_index_put1:18 => ambig.partial_index_put1:1
  │    └── upsert_partial_index_del1:19 => ambig.partial_index_del1:2
@@ -1354,39 +1354,39 @@ upsert ambig
  ├── partial index put columns: partial_index_put1:23 partial_index_put2:25 partial_index_put3:27
  ├── partial index del columns: partial_index_del1:24 partial_index_del2:26 partial_index_del3:28
  └── project
-      ├── columns: partial_index_put1:23!null partial_index_del1:24 partial_index_put2:25!null partial_index_del2:26 partial_index_put3:27 partial_index_del3:28 column1:6!null column2:7!null column8:8 column9:9 ambig.partial_index_put1:11 ambig.partial_index_del1:12 ambig.check1:13 rowid:14 crdb_internal_mvcc_timestamp:15 partial_index_put1_new:16!null partial_index_del1_new:17!null upsert_partial_index_put1:18!null upsert_partial_index_del1:19!null upsert_check1:20 upsert_rowid:21 check1:22!null
+      ├── columns: partial_index_put1:23!null partial_index_del1:24 partial_index_put2:25!null partial_index_del2:26 partial_index_put3:27 partial_index_del3:28 column1:6!null column2:7!null check1_default:8 rowid_default:9 ambig.partial_index_put1:11 ambig.partial_index_del1:12 ambig.check1:13 rowid:14 crdb_internal_mvcc_timestamp:15 partial_index_put1_new:16!null partial_index_del1_new:17!null upsert_partial_index_put1:18!null upsert_partial_index_del1:19!null upsert_check1:20 upsert_rowid:21 check1:22!null
       ├── project
-      │    ├── columns: check1:22!null column1:6!null column2:7!null column8:8 column9:9 ambig.partial_index_put1:11 ambig.partial_index_del1:12 ambig.check1:13 rowid:14 crdb_internal_mvcc_timestamp:15 partial_index_put1_new:16!null partial_index_del1_new:17!null upsert_partial_index_put1:18!null upsert_partial_index_del1:19!null upsert_check1:20 upsert_rowid:21
+      │    ├── columns: check1:22!null column1:6!null column2:7!null check1_default:8 rowid_default:9 ambig.partial_index_put1:11 ambig.partial_index_del1:12 ambig.check1:13 rowid:14 crdb_internal_mvcc_timestamp:15 partial_index_put1_new:16!null partial_index_del1_new:17!null upsert_partial_index_put1:18!null upsert_partial_index_del1:19!null upsert_check1:20 upsert_rowid:21
       │    ├── project
-      │    │    ├── columns: upsert_partial_index_put1:18!null upsert_partial_index_del1:19!null upsert_check1:20 upsert_rowid:21 column1:6!null column2:7!null column8:8 column9:9 ambig.partial_index_put1:11 ambig.partial_index_del1:12 ambig.check1:13 rowid:14 crdb_internal_mvcc_timestamp:15 partial_index_put1_new:16!null partial_index_del1_new:17!null
+      │    │    ├── columns: upsert_partial_index_put1:18!null upsert_partial_index_del1:19!null upsert_check1:20 upsert_rowid:21 column1:6!null column2:7!null check1_default:8 rowid_default:9 ambig.partial_index_put1:11 ambig.partial_index_del1:12 ambig.check1:13 rowid:14 crdb_internal_mvcc_timestamp:15 partial_index_put1_new:16!null partial_index_del1_new:17!null
       │    │    ├── project
-      │    │    │    ├── columns: partial_index_put1_new:16!null partial_index_del1_new:17!null column1:6!null column2:7!null column8:8 column9:9 ambig.partial_index_put1:11 ambig.partial_index_del1:12 ambig.check1:13 rowid:14 crdb_internal_mvcc_timestamp:15
+      │    │    │    ├── columns: partial_index_put1_new:16!null partial_index_del1_new:17!null column1:6!null column2:7!null check1_default:8 rowid_default:9 ambig.partial_index_put1:11 ambig.partial_index_del1:12 ambig.check1:13 rowid:14 crdb_internal_mvcc_timestamp:15
       │    │    │    ├── left-join (hash)
-      │    │    │    │    ├── columns: column1:6!null column2:7!null column8:8 column9:9 ambig.partial_index_put1:11 ambig.partial_index_del1:12 ambig.check1:13 rowid:14 crdb_internal_mvcc_timestamp:15
+      │    │    │    │    ├── columns: column1:6!null column2:7!null check1_default:8 rowid_default:9 ambig.partial_index_put1:11 ambig.partial_index_del1:12 ambig.check1:13 rowid:14 crdb_internal_mvcc_timestamp:15
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: column1:6!null column2:7!null column8:8 column9:9
+      │    │    │    │    │    ├── columns: column1:6!null column2:7!null check1_default:8 rowid_default:9
       │    │    │    │    │    └── ensure-upsert-distinct-on
-      │    │    │    │    │         ├── columns: column1:6!null column2:7!null column8:8 column9:9 arbiter_secondary_distinct:10
+      │    │    │    │    │         ├── columns: column1:6!null column2:7!null check1_default:8 rowid_default:9 arbiter_secondary_distinct:10
       │    │    │    │    │         ├── grouping columns: column1:6!null arbiter_secondary_distinct:10
       │    │    │    │    │         ├── project
-      │    │    │    │    │         │    ├── columns: arbiter_secondary_distinct:10 column1:6!null column2:7!null column8:8 column9:9
+      │    │    │    │    │         │    ├── columns: arbiter_secondary_distinct:10 column1:6!null column2:7!null check1_default:8 rowid_default:9
       │    │    │    │    │         │    ├── project
-      │    │    │    │    │         │    │    ├── columns: column8:8 column9:9 column1:6!null column2:7!null
+      │    │    │    │    │         │    │    ├── columns: check1_default:8 rowid_default:9 column1:6!null column2:7!null
       │    │    │    │    │         │    │    ├── values
       │    │    │    │    │         │    │    │    ├── columns: column1:6!null column2:7!null
       │    │    │    │    │         │    │    │    └── (1, 2)
       │    │    │    │    │         │    │    └── projections
-      │    │    │    │    │         │    │         ├── NULL::INT8 [as=column8:8]
-      │    │    │    │    │         │    │         └── unique_rowid() [as=column9:9]
+      │    │    │    │    │         │    │         ├── NULL::INT8 [as=check1_default:8]
+      │    │    │    │    │         │    │         └── unique_rowid() [as=rowid_default:9]
       │    │    │    │    │         │    └── projections
       │    │    │    │    │         │         └── (column1:6 > 0) OR NULL::BOOL [as=arbiter_secondary_distinct:10]
       │    │    │    │    │         └── aggregations
       │    │    │    │    │              ├── first-agg [as=column2:7]
       │    │    │    │    │              │    └── column2:7
-      │    │    │    │    │              ├── first-agg [as=column8:8]
-      │    │    │    │    │              │    └── column8:8
-      │    │    │    │    │              └── first-agg [as=column9:9]
-      │    │    │    │    │                   └── column9:9
+      │    │    │    │    │              ├── first-agg [as=check1_default:8]
+      │    │    │    │    │              │    └── check1_default:8
+      │    │    │    │    │              └── first-agg [as=rowid_default:9]
+      │    │    │    │    │                   └── rowid_default:9
       │    │    │    │    ├── select
       │    │    │    │    │    ├── columns: ambig.partial_index_put1:11!null ambig.partial_index_del1:12 ambig.check1:13 rowid:14!null crdb_internal_mvcc_timestamp:15
       │    │    │    │    │    ├── scan ambig
@@ -1409,8 +1409,8 @@ upsert ambig
       │    │    └── projections
       │    │         ├── CASE WHEN rowid:14 IS NULL THEN column1:6 ELSE partial_index_put1_new:16 END [as=upsert_partial_index_put1:18]
       │    │         ├── CASE WHEN rowid:14 IS NULL THEN column2:7 ELSE partial_index_del1_new:17 END [as=upsert_partial_index_del1:19]
-      │    │         ├── CASE WHEN rowid:14 IS NULL THEN column8:8 ELSE ambig.check1:13 END [as=upsert_check1:20]
-      │    │         └── CASE WHEN rowid:14 IS NULL THEN column9:9 ELSE rowid:14 END [as=upsert_rowid:21]
+      │    │         ├── CASE WHEN rowid:14 IS NULL THEN check1_default:8 ELSE ambig.check1:13 END [as=upsert_check1:20]
+      │    │         └── CASE WHEN rowid:14 IS NULL THEN rowid_default:9 ELSE rowid:14 END [as=upsert_rowid:21]
       │    └── projections
       │         └── upsert_partial_index_put1:18 > 10 [as=check1:22]
       └── projections
@@ -1435,33 +1435,33 @@ insert comp
  │    ├── column1:7 => a:1
  │    ├── column2:8 => b:2
  │    ├── column3:9 => c:3
- │    ├── column10:10 => d:4
- │    └── column11:11 => e:5
+ │    ├── d_comp:10 => d:4
+ │    └── e_comp:11 => e:5
  ├── partial index put columns: partial_index_put1:25 partial_index_put2:26 partial_index_put1:25
  └── project
-      ├── columns: partial_index_put1:25 partial_index_put2:26 column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      ├── columns: partial_index_put1:25 partial_index_put2:26 column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11
       ├── project
-      │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      │    ├── columns: column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11
       │    └── upsert-distinct-on
-      │         ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11 arbiter_u1_distinct:24
+      │         ├── columns: column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11 arbiter_u1_distinct:24
       │         ├── grouping columns: column2:8!null arbiter_u1_distinct:24
       │         ├── project
-      │         │    ├── columns: arbiter_u1_distinct:24 column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      │         │    ├── columns: arbiter_u1_distinct:24 column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11
       │         │    ├── upsert-distinct-on
-      │         │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      │         │    │    ├── columns: column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11
       │         │    │    ├── grouping columns: column1:7!null
       │         │    │    ├── anti-join (hash)
-      │         │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      │         │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11
       │         │    │    │    ├── anti-join (hash)
-      │         │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      │         │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11
       │         │    │    │    │    ├── project
-      │         │    │    │    │    │    ├── columns: column10:10 column11:11 column1:7!null column2:8!null column3:9!null
+      │         │    │    │    │    │    ├── columns: d_comp:10 e_comp:11 column1:7!null column2:8!null column3:9!null
       │         │    │    │    │    │    ├── values
       │         │    │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null
       │         │    │    │    │    │    │    └── (1, 1, 'bar')
       │         │    │    │    │    │    └── projections
-      │         │    │    │    │    │         ├── lower(column3:9) [as=column10:10]
-      │         │    │    │    │    │         └── upper(column3:9) [as=column11:11]
+      │         │    │    │    │    │         ├── lower(column3:9) [as=d_comp:10]
+      │         │    │    │    │    │         └── upper(column3:9) [as=e_comp:11]
       │         │    │    │    │    ├── project
       │         │    │    │    │    │    ├── columns: d:15 a:12!null b:13 c:14 e:16
       │         │    │    │    │    │    ├── scan comp
@@ -1506,30 +1506,30 @@ insert comp
       │         │    │    │    │         └── d:21 = 'foo'
       │         │    │    │    └── filters
       │         │    │    │         ├── column2:8 = b:19
-      │         │    │    │         └── column10:10 = 'foo'
+      │         │    │    │         └── d_comp:10 = 'foo'
       │         │    │    └── aggregations
       │         │    │         ├── first-agg [as=column2:8]
       │         │    │         │    └── column2:8
       │         │    │         ├── first-agg [as=column3:9]
       │         │    │         │    └── column3:9
-      │         │    │         ├── first-agg [as=column10:10]
-      │         │    │         │    └── column10:10
-      │         │    │         └── first-agg [as=column11:11]
-      │         │    │              └── column11:11
+      │         │    │         ├── first-agg [as=d_comp:10]
+      │         │    │         │    └── d_comp:10
+      │         │    │         └── first-agg [as=e_comp:11]
+      │         │    │              └── e_comp:11
       │         │    └── projections
-      │         │         └── (column10:10 = 'foo') OR NULL::BOOL [as=arbiter_u1_distinct:24]
+      │         │         └── (d_comp:10 = 'foo') OR NULL::BOOL [as=arbiter_u1_distinct:24]
       │         └── aggregations
       │              ├── first-agg [as=column1:7]
       │              │    └── column1:7
       │              ├── first-agg [as=column3:9]
       │              │    └── column3:9
-      │              ├── first-agg [as=column10:10]
-      │              │    └── column10:10
-      │              └── first-agg [as=column11:11]
-      │                   └── column11:11
+      │              ├── first-agg [as=d_comp:10]
+      │              │    └── d_comp:10
+      │              └── first-agg [as=e_comp:11]
+      │                   └── e_comp:11
       └── projections
-           ├── column10:10 = 'foo' [as=partial_index_put1:25]
-           └── column11:11 = 'FOO' [as=partial_index_put2:26]
+           ├── d_comp:10 = 'foo' [as=partial_index_put1:25]
+           └── e_comp:11 = 'FOO' [as=partial_index_put2:26]
 
 exec-ddl
 CREATE UNIQUE INDEX u2 ON comp (b) WHERE e = 'bar'
@@ -1547,37 +1547,37 @@ insert comp
  │    ├── column1:7 => a:1
  │    ├── column2:8 => b:2
  │    ├── column3:9 => c:3
- │    ├── column10:10 => d:4
- │    └── column11:11 => e:5
+ │    ├── d_comp:10 => d:4
+ │    └── e_comp:11 => e:5
  ├── partial index put columns: partial_index_put1:26 partial_index_put2:27 partial_index_put1:26 partial_index_put4:28
  └── project
-      ├── columns: partial_index_put1:26 partial_index_put2:27 partial_index_put4:28 column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      ├── columns: partial_index_put1:26 partial_index_put2:27 partial_index_put4:28 column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11
       ├── project
-      │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      │    ├── columns: column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11
       │    └── upsert-distinct-on
-      │         ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11 arbiter_u2_distinct:25
+      │         ├── columns: column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11 arbiter_u2_distinct:25
       │         ├── grouping columns: column2:8!null arbiter_u2_distinct:25
       │         ├── project
-      │         │    ├── columns: arbiter_u2_distinct:25 column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      │         │    ├── columns: arbiter_u2_distinct:25 column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11
       │         │    ├── project
-      │         │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      │         │    │    ├── columns: column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11
       │         │    │    └── upsert-distinct-on
-      │         │    │         ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11 arbiter_u1_distinct:24
+      │         │    │         ├── columns: column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11 arbiter_u1_distinct:24
       │         │    │         ├── grouping columns: column2:8!null arbiter_u1_distinct:24
       │         │    │         ├── project
-      │         │    │         │    ├── columns: arbiter_u1_distinct:24 column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      │         │    │         │    ├── columns: arbiter_u1_distinct:24 column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11
       │         │    │         │    ├── anti-join (hash)
-      │         │    │         │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      │         │    │         │    │    ├── columns: column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11
       │         │    │         │    │    ├── anti-join (hash)
-      │         │    │         │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      │         │    │         │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11
       │         │    │         │    │    │    ├── project
-      │         │    │         │    │    │    │    ├── columns: column10:10 column11:11 column1:7!null column2:8!null column3:9!null
+      │         │    │         │    │    │    │    ├── columns: d_comp:10 e_comp:11 column1:7!null column2:8!null column3:9!null
       │         │    │         │    │    │    │    ├── values
       │         │    │         │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null
       │         │    │         │    │    │    │    │    └── (1, 1, 'bar')
       │         │    │         │    │    │    │    └── projections
-      │         │    │         │    │    │    │         ├── lower(column3:9) [as=column10:10]
-      │         │    │         │    │    │    │         └── upper(column3:9) [as=column11:11]
+      │         │    │         │    │    │    │         ├── lower(column3:9) [as=d_comp:10]
+      │         │    │         │    │    │    │         └── upper(column3:9) [as=e_comp:11]
       │         │    │         │    │    │    ├── select
       │         │    │         │    │    │    │    ├── columns: a:12!null b:13 c:14 d:15!null e:16
       │         │    │         │    │    │    │    ├── project
@@ -1604,7 +1604,7 @@ insert comp
       │         │    │         │    │    │    │         └── d:15 = 'foo'
       │         │    │         │    │    │    └── filters
       │         │    │         │    │    │         ├── column2:8 = b:13
-      │         │    │         │    │    │         └── column10:10 = 'foo'
+      │         │    │         │    │    │         └── d_comp:10 = 'foo'
       │         │    │         │    │    ├── select
       │         │    │         │    │    │    ├── columns: a:18!null b:19 c:20 d:21 e:22!null
       │         │    │         │    │    │    ├── project
@@ -1631,33 +1631,33 @@ insert comp
       │         │    │         │    │    │         └── e:22 = 'bar'
       │         │    │         │    │    └── filters
       │         │    │         │    │         ├── column2:8 = b:19
-      │         │    │         │    │         └── column11:11 = 'bar'
+      │         │    │         │    │         └── e_comp:11 = 'bar'
       │         │    │         │    └── projections
-      │         │    │         │         └── (column10:10 = 'foo') OR NULL::BOOL [as=arbiter_u1_distinct:24]
+      │         │    │         │         └── (d_comp:10 = 'foo') OR NULL::BOOL [as=arbiter_u1_distinct:24]
       │         │    │         └── aggregations
       │         │    │              ├── first-agg [as=column1:7]
       │         │    │              │    └── column1:7
       │         │    │              ├── first-agg [as=column3:9]
       │         │    │              │    └── column3:9
-      │         │    │              ├── first-agg [as=column10:10]
-      │         │    │              │    └── column10:10
-      │         │    │              └── first-agg [as=column11:11]
-      │         │    │                   └── column11:11
+      │         │    │              ├── first-agg [as=d_comp:10]
+      │         │    │              │    └── d_comp:10
+      │         │    │              └── first-agg [as=e_comp:11]
+      │         │    │                   └── e_comp:11
       │         │    └── projections
-      │         │         └── (column11:11 = 'bar') OR NULL::BOOL [as=arbiter_u2_distinct:25]
+      │         │         └── (e_comp:11 = 'bar') OR NULL::BOOL [as=arbiter_u2_distinct:25]
       │         └── aggregations
       │              ├── first-agg [as=column1:7]
       │              │    └── column1:7
       │              ├── first-agg [as=column3:9]
       │              │    └── column3:9
-      │              ├── first-agg [as=column10:10]
-      │              │    └── column10:10
-      │              └── first-agg [as=column11:11]
-      │                   └── column11:11
+      │              ├── first-agg [as=d_comp:10]
+      │              │    └── d_comp:10
+      │              └── first-agg [as=e_comp:11]
+      │                   └── e_comp:11
       └── projections
-           ├── column10:10 = 'foo' [as=partial_index_put1:26]
-           ├── column11:11 = 'FOO' [as=partial_index_put2:27]
-           └── column11:11 = 'bar' [as=partial_index_put4:28]
+           ├── d_comp:10 = 'foo' [as=partial_index_put1:26]
+           ├── e_comp:11 = 'FOO' [as=partial_index_put2:27]
+           └── e_comp:11 = 'bar' [as=partial_index_put4:28]
 
 # Error when no arbiter is found because the arbiter predicate in the query
 # (non-existent in this case) does not imply any unique partial index predicates
@@ -1684,24 +1684,24 @@ insert comp
  │    ├── column1:7 => a:1
  │    ├── column2:8 => b:2
  │    ├── column3:9 => c:3
- │    ├── column10:10 => d:4
- │    └── column11:11 => e:5
+ │    ├── d_comp:10 => d:4
+ │    └── e_comp:11 => e:5
  ├── partial index put columns: partial_index_put1:18 partial_index_put2:19 partial_index_put1:18 partial_index_put4:20
  └── project
-      ├── columns: partial_index_put1:18 partial_index_put2:19 partial_index_put4:20 column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      ├── columns: partial_index_put1:18 partial_index_put2:19 partial_index_put4:20 column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11
       ├── upsert-distinct-on
-      │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      │    ├── columns: column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11
       │    ├── grouping columns: column2:8!null
       │    ├── anti-join (hash)
-      │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      │    │    ├── columns: column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11
       │    │    ├── project
-      │    │    │    ├── columns: column10:10 column11:11 column1:7!null column2:8!null column3:9!null
+      │    │    │    ├── columns: d_comp:10 e_comp:11 column1:7!null column2:8!null column3:9!null
       │    │    │    ├── values
       │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null
       │    │    │    │    └── (1, 1, 'bar')
       │    │    │    └── projections
-      │    │    │         ├── lower(column3:9) [as=column10:10]
-      │    │    │         └── upper(column3:9) [as=column11:11]
+      │    │    │         ├── lower(column3:9) [as=d_comp:10]
+      │    │    │         └── upper(column3:9) [as=e_comp:11]
       │    │    ├── project
       │    │    │    ├── columns: d:15 a:12!null b:13 c:14 e:16
       │    │    │    ├── scan comp
@@ -1729,14 +1729,14 @@ insert comp
       │         │    └── column1:7
       │         ├── first-agg [as=column3:9]
       │         │    └── column3:9
-      │         ├── first-agg [as=column10:10]
-      │         │    └── column10:10
-      │         └── first-agg [as=column11:11]
-      │              └── column11:11
+      │         ├── first-agg [as=d_comp:10]
+      │         │    └── d_comp:10
+      │         └── first-agg [as=e_comp:11]
+      │              └── e_comp:11
       └── projections
-           ├── column10:10 = 'foo' [as=partial_index_put1:18]
-           ├── column11:11 = 'FOO' [as=partial_index_put2:19]
-           └── column11:11 = 'bar' [as=partial_index_put4:20]
+           ├── d_comp:10 = 'foo' [as=partial_index_put1:18]
+           ├── e_comp:11 = 'FOO' [as=partial_index_put2:19]
+           └── e_comp:11 = 'bar' [as=partial_index_put4:20]
 
 exec-ddl
 DROP INDEX u3
@@ -1760,48 +1760,48 @@ upsert comp
  │    ├── column1:7 => a:1
  │    ├── column2:8 => b:2
  │    ├── column3:9 => c:3
- │    ├── column10:10 => d:4
- │    └── column11:11 => e:5
+ │    ├── d_comp:10 => d:4
+ │    └── e_comp:11 => e:5
  ├── update-mapping:
  │    └── upsert_b:23 => b:2
  ├── partial index put columns: partial_index_put1:27 partial_index_put2:29 partial_index_put1:27 partial_index_put4:31
  ├── partial index del columns: partial_index_del1:28 partial_index_del2:30 partial_index_del1:28 partial_index_del4:32
  └── project
-      ├── columns: partial_index_put1:27 partial_index_del1:28 partial_index_put2:29 partial_index_del2:30 partial_index_put4:31 partial_index_del4:32 column1:7!null column2:8!null column3:9!null column10:10 column11:11 a:13 b:14 c:15 d:16 e:17 crdb_internal_mvcc_timestamp:18 b_new:19!null column20:20 column21:21 upsert_a:22 upsert_b:23!null upsert_c:24 upsert_d:25 upsert_e:26
+      ├── columns: partial_index_put1:27 partial_index_del1:28 partial_index_put2:29 partial_index_del2:30 partial_index_put4:31 partial_index_del4:32 column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11 a:13 b:14 c:15 d:16 e:17 crdb_internal_mvcc_timestamp:18 b_new:19!null d_comp:20 e_comp:21 upsert_a:22 upsert_b:23!null upsert_c:24 upsert_d:25 upsert_e:26
       ├── project
-      │    ├── columns: upsert_a:22 upsert_b:23!null upsert_c:24 upsert_d:25 upsert_e:26 column1:7!null column2:8!null column3:9!null column10:10 column11:11 a:13 b:14 c:15 d:16 e:17 crdb_internal_mvcc_timestamp:18 b_new:19!null column20:20 column21:21
+      │    ├── columns: upsert_a:22 upsert_b:23!null upsert_c:24 upsert_d:25 upsert_e:26 column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11 a:13 b:14 c:15 d:16 e:17 crdb_internal_mvcc_timestamp:18 b_new:19!null d_comp:20 e_comp:21
       │    ├── project
-      │    │    ├── columns: column20:20 column21:21 column1:7!null column2:8!null column3:9!null column10:10 column11:11 a:13 b:14 c:15 d:16 e:17 crdb_internal_mvcc_timestamp:18 b_new:19!null
+      │    │    ├── columns: d_comp:20 e_comp:21 column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11 a:13 b:14 c:15 d:16 e:17 crdb_internal_mvcc_timestamp:18 b_new:19!null
       │    │    ├── project
-      │    │    │    ├── columns: b_new:19!null column1:7!null column2:8!null column3:9!null column10:10 column11:11 a:13 b:14 c:15 d:16 e:17 crdb_internal_mvcc_timestamp:18
+      │    │    │    ├── columns: b_new:19!null column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11 a:13 b:14 c:15 d:16 e:17 crdb_internal_mvcc_timestamp:18
       │    │    │    ├── left-join (hash)
-      │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11 a:13 b:14 c:15 d:16 e:17 crdb_internal_mvcc_timestamp:18
+      │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11 a:13 b:14 c:15 d:16 e:17 crdb_internal_mvcc_timestamp:18
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11
       │    │    │    │    │    └── ensure-upsert-distinct-on
-      │    │    │    │    │         ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11 arbiter_u1_distinct:12
+      │    │    │    │    │         ├── columns: column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11 arbiter_u1_distinct:12
       │    │    │    │    │         ├── grouping columns: column2:8!null arbiter_u1_distinct:12
       │    │    │    │    │         ├── project
-      │    │    │    │    │         │    ├── columns: arbiter_u1_distinct:12 column1:7!null column2:8!null column3:9!null column10:10 column11:11
+      │    │    │    │    │         │    ├── columns: arbiter_u1_distinct:12 column1:7!null column2:8!null column3:9!null d_comp:10 e_comp:11
       │    │    │    │    │         │    ├── project
-      │    │    │    │    │         │    │    ├── columns: column10:10 column11:11 column1:7!null column2:8!null column3:9!null
+      │    │    │    │    │         │    │    ├── columns: d_comp:10 e_comp:11 column1:7!null column2:8!null column3:9!null
       │    │    │    │    │         │    │    ├── values
       │    │    │    │    │         │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null
       │    │    │    │    │         │    │    │    └── (1, 1, 'bar')
       │    │    │    │    │         │    │    └── projections
-      │    │    │    │    │         │    │         ├── lower(column3:9) [as=column10:10]
-      │    │    │    │    │         │    │         └── upper(column3:9) [as=column11:11]
+      │    │    │    │    │         │    │         ├── lower(column3:9) [as=d_comp:10]
+      │    │    │    │    │         │    │         └── upper(column3:9) [as=e_comp:11]
       │    │    │    │    │         │    └── projections
-      │    │    │    │    │         │         └── (column10:10 = 'foo') OR NULL::BOOL [as=arbiter_u1_distinct:12]
+      │    │    │    │    │         │         └── (d_comp:10 = 'foo') OR NULL::BOOL [as=arbiter_u1_distinct:12]
       │    │    │    │    │         └── aggregations
       │    │    │    │    │              ├── first-agg [as=column1:7]
       │    │    │    │    │              │    └── column1:7
       │    │    │    │    │              ├── first-agg [as=column3:9]
       │    │    │    │    │              │    └── column3:9
-      │    │    │    │    │              ├── first-agg [as=column10:10]
-      │    │    │    │    │              │    └── column10:10
-      │    │    │    │    │              └── first-agg [as=column11:11]
-      │    │    │    │    │                   └── column11:11
+      │    │    │    │    │              ├── first-agg [as=d_comp:10]
+      │    │    │    │    │              │    └── d_comp:10
+      │    │    │    │    │              └── first-agg [as=e_comp:11]
+      │    │    │    │    │                   └── e_comp:11
       │    │    │    │    ├── select
       │    │    │    │    │    ├── columns: a:13!null b:14 c:15 d:16!null e:17 crdb_internal_mvcc_timestamp:18
       │    │    │    │    │    ├── project
@@ -1828,18 +1828,18 @@ upsert comp
       │    │    │    │    │         └── d:16 = 'foo'
       │    │    │    │    └── filters
       │    │    │    │         ├── column2:8 = b:14
-      │    │    │    │         └── column10:10 = 'foo'
+      │    │    │    │         └── d_comp:10 = 'foo'
       │    │    │    └── projections
       │    │    │         └── 10 [as=b_new:19]
       │    │    └── projections
-      │    │         ├── lower(c:15) [as=column20:20]
-      │    │         └── upper(c:15) [as=column21:21]
+      │    │         ├── lower(c:15) [as=d_comp:20]
+      │    │         └── upper(c:15) [as=e_comp:21]
       │    └── projections
       │         ├── CASE WHEN a:13 IS NULL THEN column1:7 ELSE a:13 END [as=upsert_a:22]
       │         ├── CASE WHEN a:13 IS NULL THEN column2:8 ELSE b_new:19 END [as=upsert_b:23]
       │         ├── CASE WHEN a:13 IS NULL THEN column3:9 ELSE c:15 END [as=upsert_c:24]
-      │         ├── CASE WHEN a:13 IS NULL THEN column10:10 ELSE d:16 END [as=upsert_d:25]
-      │         └── CASE WHEN a:13 IS NULL THEN column11:11 ELSE e:17 END [as=upsert_e:26]
+      │         ├── CASE WHEN a:13 IS NULL THEN d_comp:10 ELSE d:16 END [as=upsert_d:25]
+      │         └── CASE WHEN a:13 IS NULL THEN e_comp:11 ELSE e:17 END [as=upsert_e:26]
       └── projections
            ├── upsert_d:25 = 'foo' [as=partial_index_put1:27]
            ├── d:16 = 'foo' [as=partial_index_del1:28]

--- a/pkg/sql/opt/optbuilder/testdata/projection-reuse
+++ b/pkg/sql/opt/optbuilder/testdata/projection-reuse
@@ -88,14 +88,14 @@ insert ab
  ├── insert-mapping:
  │    ├── column1:5 => a:1
  │    ├── column2:6 => b:2
- │    └── column7:7 => rowid:3
+ │    └── rowid_default:7 => rowid:3
  └── project
-      ├── columns: column7:7 column1:5 column2:6
+      ├── columns: rowid_default:7 column1:5 column2:6
       ├── values
       │    ├── columns: column1:5 column2:6
       │    └── (random(), random())
       └── projections
-           └── unique_rowid() [as=column7:7]
+           └── unique_rowid() [as=rowid_default:7]
 
 # Make sure impure default expressions are not deduplicated.
 exec-ddl
@@ -110,18 +110,18 @@ insert abcd
  ├── insert-mapping:
  │    ├── column1:7 => a:1
  │    ├── column2:8 => b:2
- │    ├── column9:9 => c:3
- │    ├── column10:10 => d:4
- │    └── column11:11 => rowid:5
+ │    ├── c_default:9 => c:3
+ │    ├── d_default:10 => d:4
+ │    └── rowid_default:11 => rowid:5
  └── project
-      ├── columns: column9:9 column10:10 column11:11 column1:7!null column2:8!null
+      ├── columns: c_default:9 d_default:10 rowid_default:11 column1:7!null column2:8!null
       ├── values
       │    ├── columns: column1:7!null column2:8!null
       │    └── (1.0, 1.0)
       └── projections
-           ├── random() [as=column9:9]
-           ├── random() [as=column10:10]
-           └── unique_rowid() [as=column11:11]
+           ├── random() [as=c_default:9]
+           ├── random() [as=d_default:10]
+           └── unique_rowid() [as=rowid_default:11]
 
 build
 INSERT INTO abcd VALUES (random(), random())
@@ -131,18 +131,18 @@ insert abcd
  ├── insert-mapping:
  │    ├── column1:7 => a:1
  │    ├── column2:8 => b:2
- │    ├── column9:9 => c:3
- │    ├── column10:10 => d:4
- │    └── column11:11 => rowid:5
+ │    ├── c_default:9 => c:3
+ │    ├── d_default:10 => d:4
+ │    └── rowid_default:11 => rowid:5
  └── project
-      ├── columns: column9:9 column10:10 column11:11 column1:7 column2:8
+      ├── columns: c_default:9 d_default:10 rowid_default:11 column1:7 column2:8
       ├── values
       │    ├── columns: column1:7 column2:8
       │    └── (random(), random())
       └── projections
-           ├── random() [as=column9:9]
-           ├── random() [as=column10:10]
-           └── unique_rowid() [as=column11:11]
+           ├── random() [as=c_default:9]
+           ├── random() [as=d_default:10]
+           └── unique_rowid() [as=rowid_default:11]
 
 build
 UPSERT INTO abcd VALUES (1, 1)
@@ -152,18 +152,18 @@ upsert abcd
  ├── upsert-mapping:
  │    ├── column1:7 => a:1
  │    ├── column2:8 => b:2
- │    ├── column9:9 => c:3
- │    ├── column10:10 => d:4
- │    └── column11:11 => rowid:5
+ │    ├── c_default:9 => c:3
+ │    ├── d_default:10 => d:4
+ │    └── rowid_default:11 => rowid:5
  └── project
-      ├── columns: column9:9 column10:10 column11:11 column1:7!null column2:8!null
+      ├── columns: c_default:9 d_default:10 rowid_default:11 column1:7!null column2:8!null
       ├── values
       │    ├── columns: column1:7!null column2:8!null
       │    └── (1.0, 1.0)
       └── projections
-           ├── random() [as=column9:9]
-           ├── random() [as=column10:10]
-           └── unique_rowid() [as=column11:11]
+           ├── random() [as=c_default:9]
+           ├── random() [as=d_default:10]
+           └── unique_rowid() [as=rowid_default:11]
 
 build
 UPSERT INTO abcd VALUES (random(), random())
@@ -173,18 +173,18 @@ upsert abcd
  ├── upsert-mapping:
  │    ├── column1:7 => a:1
  │    ├── column2:8 => b:2
- │    ├── column9:9 => c:3
- │    ├── column10:10 => d:4
- │    └── column11:11 => rowid:5
+ │    ├── c_default:9 => c:3
+ │    ├── d_default:10 => d:4
+ │    └── rowid_default:11 => rowid:5
  └── project
-      ├── columns: column9:9 column10:10 column11:11 column1:7 column2:8
+      ├── columns: c_default:9 d_default:10 rowid_default:11 column1:7 column2:8
       ├── values
       │    ├── columns: column1:7 column2:8
       │    └── (random(), random())
       └── projections
-           ├── random() [as=column9:9]
-           ├── random() [as=column10:10]
-           └── unique_rowid() [as=column11:11]
+           ├── random() [as=c_default:9]
+           ├── random() [as=d_default:10]
+           └── unique_rowid() [as=rowid_default:11]
 
 build
 UPDATE abcd SET a = random(), b = random() WHERE a=1

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -1261,15 +1261,15 @@ with &1
  │    ├── columns: abc.a:1!null abc.b:2 abc.c:3
  │    ├── insert-mapping:
  │    │    ├── column1:5 => abc.a:1
- │    │    ├── column6:6 => abc.b:2
- │    │    └── column6:6 => abc.c:3
+ │    │    ├── b_default:6 => abc.b:2
+ │    │    └── b_default:6 => abc.c:3
  │    └── project
- │         ├── columns: column6:6 column1:5!null
+ │         ├── columns: b_default:6 column1:5!null
  │         ├── values
  │         │    ├── columns: column1:5!null
  │         │    └── (1,)
  │         └── projections
- │              └── NULL::INT8 [as=column6:6]
+ │              └── NULL::INT8 [as=b_default:6]
  └── with &2 (cte)
       ├── columns: abc.a:10!null abc.b:11 abc.c:12
       ├── limit
@@ -1440,14 +1440,14 @@ insert inaccessible
  ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:4 => k:1
- │    └── column5:5 => v:2
+ │    └── v_default:5 => v:2
  └── project
-      ├── columns: column5:5 column1:4!null
+      ├── columns: v_default:5 column1:4!null
       ├── values
       │    ├── columns: column1:4!null
       │    └── (1,)
       └── projections
-           └── NULL::INT8 [as=column5:5]
+           └── NULL::INT8 [as=v_default:5]
 
 build
 INSERT INTO inaccessible VALUES (1) RETURNING v

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
@@ -641,16 +641,16 @@ insert uniq_hidden_pk
  │    ├── column2:8 => uniq_hidden_pk.b:2
  │    ├── column3:9 => uniq_hidden_pk.c:3
  │    ├── column4:10 => uniq_hidden_pk.d:4
- │    └── column11:11 => uniq_hidden_pk.rowid:5
+ │    └── rowid_default:11 => uniq_hidden_pk.rowid:5
  ├── input binding: &1
  ├── project
- │    ├── columns: column11:11 column1:7!null column2:8!null column3:9!null column4:10!null
+ │    ├── columns: rowid_default:11 column1:7!null column2:8!null column3:9!null column4:10!null
  │    ├── values
  │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null
  │    │    ├── (1, 1, 1, 1)
  │    │    └── (2, 2, 2, 2)
  │    └── projections
- │         └── unique_rowid() [as=column11:11]
+ │         └── unique_rowid() [as=rowid_default:11]
  └── unique-checks
       ├── unique-checks-item: uniq_hidden_pk(b,c)
       │    └── project
@@ -664,7 +664,7 @@ insert uniq_hidden_pk
       │              │         ├──  column2:8 => b:19
       │              │         ├──  column3:9 => c:20
       │              │         ├──  column4:10 => d:21
-      │              │         └──  column11:11 => rowid:22
+      │              │         └──  rowid_default:11 => rowid:22
       │              ├── scan uniq_hidden_pk
       │              │    └── columns: uniq_hidden_pk.a:12 uniq_hidden_pk.b:13 uniq_hidden_pk.c:14 uniq_hidden_pk.d:15 uniq_hidden_pk.rowid:16!null
       │              └── filters
@@ -683,7 +683,7 @@ insert uniq_hidden_pk
       │              │         ├──  column2:8 => b:30
       │              │         ├──  column3:9 => c:31
       │              │         ├──  column4:10 => d:32
-      │              │         └──  column11:11 => rowid:33
+      │              │         └──  rowid_default:11 => rowid:33
       │              ├── scan uniq_hidden_pk
       │              │    └── columns: uniq_hidden_pk.a:23 uniq_hidden_pk.b:24 uniq_hidden_pk.c:25 uniq_hidden_pk.d:26 uniq_hidden_pk.rowid:27!null
       │              └── filters
@@ -703,7 +703,7 @@ insert uniq_hidden_pk
                      │         ├──  column2:8 => b:41
                      │         ├──  column3:9 => c:42
                      │         ├──  column4:10 => d:43
-                     │         └──  column11:11 => rowid:44
+                     │         └──  rowid_default:11 => rowid:44
                      ├── scan uniq_hidden_pk
                      │    └── columns: uniq_hidden_pk.a:34 uniq_hidden_pk.b:35 uniq_hidden_pk.c:36 uniq_hidden_pk.d:37 uniq_hidden_pk.rowid:38!null
                      └── filters
@@ -722,16 +722,16 @@ insert uniq_hidden_pk
  │    ├── v:8 => uniq_hidden_pk.b:2
  │    ├── x:10 => uniq_hidden_pk.c:3
  │    ├── y:11 => uniq_hidden_pk.d:4
- │    └── column14:14 => uniq_hidden_pk.rowid:5
+ │    └── rowid_default:14 => uniq_hidden_pk.rowid:5
  ├── input binding: &1
  ├── project
- │    ├── columns: column14:14 k:7 v:8 x:10 y:11
+ │    ├── columns: rowid_default:14 k:7 v:8 x:10 y:11
  │    ├── project
  │    │    ├── columns: k:7 v:8 x:10 y:11
  │    │    └── scan other
  │    │         └── columns: k:7 v:8 w:9!null x:10 y:11 other.rowid:12!null other.crdb_internal_mvcc_timestamp:13
  │    └── projections
- │         └── unique_rowid() [as=column14:14]
+ │         └── unique_rowid() [as=rowid_default:14]
  └── unique-checks
       ├── unique-checks-item: uniq_hidden_pk(b,c)
       │    └── project
@@ -745,7 +745,7 @@ insert uniq_hidden_pk
       │              │         ├──  v:8 => b:22
       │              │         ├──  x:10 => c:23
       │              │         ├──  y:11 => d:24
-      │              │         └──  column14:14 => rowid:25
+      │              │         └──  rowid_default:14 => rowid:25
       │              ├── scan uniq_hidden_pk
       │              │    └── columns: uniq_hidden_pk.a:15 uniq_hidden_pk.b:16 uniq_hidden_pk.c:17 uniq_hidden_pk.d:18 uniq_hidden_pk.rowid:19!null
       │              └── filters
@@ -764,7 +764,7 @@ insert uniq_hidden_pk
       │              │         ├──  v:8 => b:33
       │              │         ├──  x:10 => c:34
       │              │         ├──  y:11 => d:35
-      │              │         └──  column14:14 => rowid:36
+      │              │         └──  rowid_default:14 => rowid:36
       │              ├── scan uniq_hidden_pk
       │              │    └── columns: uniq_hidden_pk.a:26 uniq_hidden_pk.b:27 uniq_hidden_pk.c:28 uniq_hidden_pk.d:29 uniq_hidden_pk.rowid:30!null
       │              └── filters
@@ -784,7 +784,7 @@ insert uniq_hidden_pk
                      │         ├──  v:8 => b:44
                      │         ├──  x:10 => c:45
                      │         ├──  y:11 => d:46
-                     │         └──  column14:14 => rowid:47
+                     │         └──  rowid_default:14 => rowid:47
                      ├── scan uniq_hidden_pk
                      │    └── columns: uniq_hidden_pk.a:37 uniq_hidden_pk.b:38 uniq_hidden_pk.c:39 uniq_hidden_pk.d:40 uniq_hidden_pk.rowid:41!null
                      └── filters
@@ -1215,18 +1215,18 @@ insert uniq_partial_hidden_pk
  ├── insert-mapping:
  │    ├── column1:6 => uniq_partial_hidden_pk.a:1
  │    ├── column2:7 => uniq_partial_hidden_pk.b:2
- │    ├── column8:8 => uniq_partial_hidden_pk.c:3
- │    └── column9:9 => uniq_partial_hidden_pk.rowid:4
+ │    ├── c_default:8 => uniq_partial_hidden_pk.c:3
+ │    └── rowid_default:9 => uniq_partial_hidden_pk.rowid:4
  ├── input binding: &1
  ├── project
- │    ├── columns: column8:8 column9:9 column1:6!null column2:7!null
+ │    ├── columns: c_default:8 rowid_default:9 column1:6!null column2:7!null
  │    ├── values
  │    │    ├── columns: column1:6!null column2:7!null
  │    │    ├── (1, 1)
  │    │    └── (2, 2)
  │    └── projections
- │         ├── NULL::INT8 [as=column8:8]
- │         └── unique_rowid() [as=column9:9]
+ │         ├── NULL::INT8 [as=c_default:8]
+ │         └── unique_rowid() [as=rowid_default:9]
  └── unique-checks
       └── unique-checks-item: uniq_partial_hidden_pk(b)
            └── project
@@ -1238,8 +1238,8 @@ insert uniq_partial_hidden_pk
                      │    └── mapping:
                      │         ├──  column1:6 => a:15
                      │         ├──  column2:7 => b:16
-                     │         ├──  column8:8 => c:17
-                     │         └──  column9:9 => rowid:18
+                     │         ├──  c_default:8 => c:17
+                     │         └──  rowid_default:9 => rowid:18
                      ├── scan uniq_partial_hidden_pk
                      │    └── columns: uniq_partial_hidden_pk.a:10 uniq_partial_hidden_pk.b:11 uniq_partial_hidden_pk.c:12 uniq_partial_hidden_pk.rowid:13!null
                      └── filters
@@ -1257,18 +1257,18 @@ insert uniq_partial_hidden_pk
  ├── insert-mapping:
  │    ├── k:6 => uniq_partial_hidden_pk.a:1
  │    ├── v:7 => uniq_partial_hidden_pk.b:2
- │    ├── column13:13 => uniq_partial_hidden_pk.c:3
- │    └── column14:14 => uniq_partial_hidden_pk.rowid:4
+ │    ├── c_default:13 => uniq_partial_hidden_pk.c:3
+ │    └── rowid_default:14 => uniq_partial_hidden_pk.rowid:4
  ├── input binding: &1
  ├── project
- │    ├── columns: column13:13 column14:14 k:6 v:7
+ │    ├── columns: c_default:13 rowid_default:14 k:6 v:7
  │    ├── project
  │    │    ├── columns: k:6 v:7
  │    │    └── scan other
  │    │         └── columns: k:6 v:7 w:8!null x:9 y:10 other.rowid:11!null other.crdb_internal_mvcc_timestamp:12
  │    └── projections
- │         ├── NULL::INT8 [as=column13:13]
- │         └── unique_rowid() [as=column14:14]
+ │         ├── NULL::INT8 [as=c_default:13]
+ │         └── unique_rowid() [as=rowid_default:14]
  └── unique-checks
       └── unique-checks-item: uniq_partial_hidden_pk(b)
            └── project
@@ -1280,8 +1280,8 @@ insert uniq_partial_hidden_pk
                      │    └── mapping:
                      │         ├──  k:6 => a:20
                      │         ├──  v:7 => b:21
-                     │         ├──  column13:13 => c:22
-                     │         └──  column14:14 => rowid:23
+                     │         ├──  c_default:13 => c:22
+                     │         └──  rowid_default:14 => rowid:23
                      ├── scan uniq_partial_hidden_pk
                      │    └── columns: uniq_partial_hidden_pk.a:15 uniq_partial_hidden_pk.b:16 uniq_partial_hidden_pk.c:17 uniq_partial_hidden_pk.rowid:18!null
                      └── filters
@@ -1526,20 +1526,20 @@ insert uniq_computed_pk
  │    ├── column1:9 => uniq_computed_pk.i:1
  │    ├── column2:10 => uniq_computed_pk.s:2
  │    ├── column3:11 => uniq_computed_pk.d:3
- │    ├── column12:12 => uniq_computed_pk.c_i_expr:4
+ │    ├── c_i_expr_comp:12 => uniq_computed_pk.c_i_expr:4
  │    ├── column2:10 => uniq_computed_pk.c_s:5
  │    ├── column3:11 => uniq_computed_pk.c_d:6
- │    └── column13:13 => uniq_computed_pk.c_d_expr:7
+ │    └── c_d_expr_comp:13 => uniq_computed_pk.c_d_expr:7
  ├── input binding: &1
  ├── project
- │    ├── columns: column12:12!null column13:13!null column1:9!null column2:10!null column3:11!null
+ │    ├── columns: c_i_expr_comp:12!null c_d_expr_comp:13!null column1:9!null column2:10!null column3:11!null
  │    ├── values
  │    │    ├── columns: column1:9!null column2:10!null column3:11!null
  │    │    ├── (1, 'a', 1.0)
  │    │    └── (2, 'b', 2.0)
  │    └── projections
- │         ├── CASE WHEN column1:9 < 0 THEN 'foo' ELSE 'bar' END [as=column12:12]
- │         └── column3:11::STRING [as=column13:13]
+ │         ├── CASE WHEN column1:9 < 0 THEN 'foo' ELSE 'bar' END [as=c_i_expr_comp:12]
+ │         └── column3:11::STRING [as=c_d_expr_comp:13]
  └── unique-checks
       └── unique-checks-item: uniq_computed_pk(d)
            └── project
@@ -1552,10 +1552,10 @@ insert uniq_computed_pk
                      │         ├──  column1:9 => i:38
                      │         ├──  column2:10 => s:39
                      │         ├──  column3:11 => d:40
-                     │         ├──  column12:12 => c_i_expr:41
+                     │         ├──  c_i_expr_comp:12 => c_i_expr:41
                      │         ├──  column2:10 => c_s:42
                      │         ├──  column3:11 => c_d:43
-                     │         └──  column13:13 => c_d_expr:44
+                     │         └──  c_d_expr_comp:13 => c_d_expr:44
                      ├── project
                      │    ├── columns: uniq_computed_pk.c_s:34 uniq_computed_pk.i:30!null uniq_computed_pk.s:31 uniq_computed_pk.d:32 uniq_computed_pk.c_i_expr:33!null uniq_computed_pk.c_d:35 uniq_computed_pk.c_d_expr:36
                      │    ├── scan uniq_computed_pk

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-update
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-update
@@ -1093,13 +1093,13 @@ update uniq_computed_pk
  │    ├── i_new:17 => uniq_computed_pk.i:1
  │    ├── s_new:18 => uniq_computed_pk.s:2
  │    ├── d_new:19 => uniq_computed_pk.d:3
- │    ├── column20:20 => uniq_computed_pk.c_i_expr:4
+ │    ├── c_i_expr_comp:20 => uniq_computed_pk.c_i_expr:4
  │    ├── s_new:18 => uniq_computed_pk.c_s:5
  │    ├── d_new:19 => uniq_computed_pk.c_d:6
- │    └── column21:21 => uniq_computed_pk.c_d_expr:7
+ │    └── c_d_expr_comp:21 => uniq_computed_pk.c_d_expr:7
  ├── input binding: &1
  ├── project
- │    ├── columns: column20:20!null column21:21!null uniq_computed_pk.i:9!null uniq_computed_pk.s:10 uniq_computed_pk.d:11 uniq_computed_pk.c_i_expr:12!null uniq_computed_pk.c_s:13 uniq_computed_pk.c_d:14 uniq_computed_pk.c_d_expr:15 crdb_internal_mvcc_timestamp:16 i_new:17!null s_new:18!null d_new:19!null
+ │    ├── columns: c_i_expr_comp:20!null c_d_expr_comp:21!null uniq_computed_pk.i:9!null uniq_computed_pk.s:10 uniq_computed_pk.d:11 uniq_computed_pk.c_i_expr:12!null uniq_computed_pk.c_s:13 uniq_computed_pk.c_d:14 uniq_computed_pk.c_d_expr:15 crdb_internal_mvcc_timestamp:16 i_new:17!null s_new:18!null d_new:19!null
  │    ├── project
  │    │    ├── columns: i_new:17!null s_new:18!null d_new:19!null uniq_computed_pk.i:9!null uniq_computed_pk.s:10 uniq_computed_pk.d:11 uniq_computed_pk.c_i_expr:12!null uniq_computed_pk.c_s:13 uniq_computed_pk.c_d:14 uniq_computed_pk.c_d_expr:15 crdb_internal_mvcc_timestamp:16
  │    │    ├── project
@@ -1122,8 +1122,8 @@ update uniq_computed_pk
  │    │         ├── 'a' [as=s_new:18]
  │    │         └── 1.0 [as=d_new:19]
  │    └── projections
- │         ├── CASE WHEN i_new:17 < 0 THEN 'foo' ELSE 'bar' END [as=column20:20]
- │         └── d_new:19::STRING [as=column21:21]
+ │         ├── CASE WHEN i_new:17 < 0 THEN 'foo' ELSE 'bar' END [as=c_i_expr_comp:20]
+ │         └── d_new:19::STRING [as=c_d_expr_comp:21]
  └── unique-checks
       └── unique-checks-item: uniq_computed_pk(d)
            └── project
@@ -1136,10 +1136,10 @@ update uniq_computed_pk
                      │         ├──  i_new:17 => i:46
                      │         ├──  s_new:18 => s:47
                      │         ├──  d_new:19 => d:48
-                     │         ├──  column20:20 => c_i_expr:49
+                     │         ├──  c_i_expr_comp:20 => c_i_expr:49
                      │         ├──  s_new:18 => c_s:50
                      │         ├──  d_new:19 => c_d:51
-                     │         └──  column21:21 => c_d_expr:52
+                     │         └──  c_d_expr_comp:21 => c_d_expr:52
                      ├── project
                      │    ├── columns: uniq_computed_pk.c_s:42 uniq_computed_pk.i:38!null uniq_computed_pk.s:39 uniq_computed_pk.d:40 uniq_computed_pk.c_i_expr:41!null uniq_computed_pk.c_d:43 uniq_computed_pk.c_d_expr:44
                      │    ├── scan uniq_computed_pk

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-upsert
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-upsert
@@ -113,45 +113,45 @@ upsert uniq
  │    ├── column1:7 => uniq.k:1
  │    ├── column2:8 => uniq.v:2
  │    ├── column3:9 => uniq.w:3
- │    ├── column10:10 => uniq.x:4
- │    └── column11:11 => uniq.y:5
+ │    ├── x_default:10 => uniq.x:4
+ │    └── y_default:11 => uniq.y:5
  ├── update-mapping:
  │    ├── column2:8 => uniq.v:2
  │    └── column3:9 => uniq.w:3
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_k:18 upsert_x:19 upsert_y:20 column1:7!null column2:8!null column3:9!null column10:10 column11:11!null uniq.k:12 uniq.v:13 uniq.w:14 uniq.x:15 uniq.y:16 crdb_internal_mvcc_timestamp:17
+ │    ├── columns: upsert_k:18 upsert_x:19 upsert_y:20 column1:7!null column2:8!null column3:9!null x_default:10 y_default:11!null uniq.k:12 uniq.v:13 uniq.w:14 uniq.x:15 uniq.y:16 crdb_internal_mvcc_timestamp:17
  │    ├── left-join (hash)
- │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11!null uniq.k:12 uniq.v:13 uniq.w:14 uniq.x:15 uniq.y:16 crdb_internal_mvcc_timestamp:17
+ │    │    ├── columns: column1:7!null column2:8!null column3:9!null x_default:10 y_default:11!null uniq.k:12 uniq.v:13 uniq.w:14 uniq.x:15 uniq.y:16 crdb_internal_mvcc_timestamp:17
  │    │    ├── ensure-upsert-distinct-on
- │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11!null
+ │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null x_default:10 y_default:11!null
  │    │    │    ├── grouping columns: column1:7!null
  │    │    │    ├── project
- │    │    │    │    ├── columns: column10:10 column11:11!null column1:7!null column2:8!null column3:9!null
+ │    │    │    │    ├── columns: x_default:10 y_default:11!null column1:7!null column2:8!null column3:9!null
  │    │    │    │    ├── values
  │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null
  │    │    │    │    │    ├── (1, 1, 1)
  │    │    │    │    │    └── (2, 2, 2)
  │    │    │    │    └── projections
- │    │    │    │         ├── NULL::INT8 [as=column10:10]
- │    │    │    │         └── 5 [as=column11:11]
+ │    │    │    │         ├── NULL::INT8 [as=x_default:10]
+ │    │    │    │         └── 5 [as=y_default:11]
  │    │    │    └── aggregations
  │    │    │         ├── first-agg [as=column2:8]
  │    │    │         │    └── column2:8
  │    │    │         ├── first-agg [as=column3:9]
  │    │    │         │    └── column3:9
- │    │    │         ├── first-agg [as=column10:10]
- │    │    │         │    └── column10:10
- │    │    │         └── first-agg [as=column11:11]
- │    │    │              └── column11:11
+ │    │    │         ├── first-agg [as=x_default:10]
+ │    │    │         │    └── x_default:10
+ │    │    │         └── first-agg [as=y_default:11]
+ │    │    │              └── y_default:11
  │    │    ├── scan uniq
  │    │    │    └── columns: uniq.k:12!null uniq.v:13 uniq.w:14 uniq.x:15 uniq.y:16 crdb_internal_mvcc_timestamp:17
  │    │    └── filters
  │    │         └── column1:7 = uniq.k:12
  │    └── projections
  │         ├── CASE WHEN uniq.k:12 IS NULL THEN column1:7 ELSE uniq.k:12 END [as=upsert_k:18]
- │         ├── CASE WHEN uniq.k:12 IS NULL THEN column10:10 ELSE uniq.x:15 END [as=upsert_x:19]
- │         └── CASE WHEN uniq.k:12 IS NULL THEN column11:11 ELSE uniq.y:16 END [as=upsert_y:20]
+ │         ├── CASE WHEN uniq.k:12 IS NULL THEN x_default:10 ELSE uniq.x:15 END [as=upsert_x:19]
+ │         └── CASE WHEN uniq.k:12 IS NULL THEN y_default:11 ELSE uniq.y:16 END [as=upsert_y:20]
  └── unique-checks
       ├── unique-checks-item: uniq(w)
       │    └── project
@@ -204,47 +204,47 @@ upsert uniq
  ├── fetch columns: uniq.k:12 uniq.v:13 uniq.w:14 uniq.x:15 uniq.y:16
  ├── insert-mapping:
  │    ├── column1:7 => uniq.k:1
- │    ├── column10:10 => uniq.v:2
+ │    ├── v_default:10 => uniq.v:2
  │    ├── column2:8 => uniq.w:3
  │    ├── column3:9 => uniq.x:4
- │    └── column11:11 => uniq.y:5
+ │    └── y_default:11 => uniq.y:5
  ├── update-mapping:
  │    ├── column2:8 => uniq.w:3
  │    └── column3:9 => uniq.x:4
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_k:18 upsert_v:19 upsert_y:20 column1:7!null column2:8 column3:9 column10:10 column11:11!null uniq.k:12 uniq.v:13 uniq.w:14 uniq.x:15 uniq.y:16 crdb_internal_mvcc_timestamp:17
+ │    ├── columns: upsert_k:18 upsert_v:19 upsert_y:20 column1:7!null column2:8 column3:9 v_default:10 y_default:11!null uniq.k:12 uniq.v:13 uniq.w:14 uniq.x:15 uniq.y:16 crdb_internal_mvcc_timestamp:17
  │    ├── left-join (hash)
- │    │    ├── columns: column1:7!null column2:8 column3:9 column10:10 column11:11!null uniq.k:12 uniq.v:13 uniq.w:14 uniq.x:15 uniq.y:16 crdb_internal_mvcc_timestamp:17
+ │    │    ├── columns: column1:7!null column2:8 column3:9 v_default:10 y_default:11!null uniq.k:12 uniq.v:13 uniq.w:14 uniq.x:15 uniq.y:16 crdb_internal_mvcc_timestamp:17
  │    │    ├── ensure-upsert-distinct-on
- │    │    │    ├── columns: column1:7!null column2:8 column3:9 column10:10 column11:11!null
+ │    │    │    ├── columns: column1:7!null column2:8 column3:9 v_default:10 y_default:11!null
  │    │    │    ├── grouping columns: column1:7!null
  │    │    │    ├── project
- │    │    │    │    ├── columns: column10:10 column11:11!null column1:7!null column2:8 column3:9
+ │    │    │    │    ├── columns: v_default:10 y_default:11!null column1:7!null column2:8 column3:9
  │    │    │    │    ├── values
  │    │    │    │    │    ├── columns: column1:7!null column2:8 column3:9
  │    │    │    │    │    ├── (1, NULL::INT8, 1)
  │    │    │    │    │    └── (2, NULL::INT8, NULL::INT8)
  │    │    │    │    └── projections
- │    │    │    │         ├── NULL::INT8 [as=column10:10]
- │    │    │    │         └── 5 [as=column11:11]
+ │    │    │    │         ├── NULL::INT8 [as=v_default:10]
+ │    │    │    │         └── 5 [as=y_default:11]
  │    │    │    └── aggregations
  │    │    │         ├── first-agg [as=column2:8]
  │    │    │         │    └── column2:8
  │    │    │         ├── first-agg [as=column3:9]
  │    │    │         │    └── column3:9
- │    │    │         ├── first-agg [as=column10:10]
- │    │    │         │    └── column10:10
- │    │    │         └── first-agg [as=column11:11]
- │    │    │              └── column11:11
+ │    │    │         ├── first-agg [as=v_default:10]
+ │    │    │         │    └── v_default:10
+ │    │    │         └── first-agg [as=y_default:11]
+ │    │    │              └── y_default:11
  │    │    ├── scan uniq
  │    │    │    └── columns: uniq.k:12!null uniq.v:13 uniq.w:14 uniq.x:15 uniq.y:16 crdb_internal_mvcc_timestamp:17
  │    │    └── filters
  │    │         └── column1:7 = uniq.k:12
  │    └── projections
  │         ├── CASE WHEN uniq.k:12 IS NULL THEN column1:7 ELSE uniq.k:12 END [as=upsert_k:18]
- │         ├── CASE WHEN uniq.k:12 IS NULL THEN column10:10 ELSE uniq.v:13 END [as=upsert_v:19]
- │         └── CASE WHEN uniq.k:12 IS NULL THEN column11:11 ELSE uniq.y:16 END [as=upsert_y:20]
+ │         ├── CASE WHEN uniq.k:12 IS NULL THEN v_default:10 ELSE uniq.v:13 END [as=upsert_v:19]
+ │         └── CASE WHEN uniq.k:12 IS NULL THEN y_default:11 ELSE uniq.y:16 END [as=upsert_y:20]
  └── unique-checks
       ├── unique-checks-item: uniq(w)
       │    └── project
@@ -299,39 +299,39 @@ upsert uniq
  │    ├── other.k:7 => uniq.k:1
  │    ├── other.v:8 => uniq.v:2
  │    ├── other.w:9 => uniq.w:3
- │    ├── column14:14 => uniq.x:4
- │    └── column15:15 => uniq.y:5
+ │    ├── x_default:14 => uniq.x:4
+ │    └── y_default:15 => uniq.y:5
  ├── update-mapping:
  │    ├── other.v:8 => uniq.v:2
  │    ├── other.w:9 => uniq.w:3
- │    ├── column14:14 => uniq.x:4
- │    └── column15:15 => uniq.y:5
+ │    ├── x_default:14 => uniq.x:4
+ │    └── y_default:15 => uniq.y:5
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_k:22 other.k:7 other.v:8 other.w:9!null column14:14 column15:15!null uniq.k:16 uniq.v:17 uniq.w:18 uniq.x:19 uniq.y:20 uniq.crdb_internal_mvcc_timestamp:21
+ │    ├── columns: upsert_k:22 other.k:7 other.v:8 other.w:9!null x_default:14 y_default:15!null uniq.k:16 uniq.v:17 uniq.w:18 uniq.x:19 uniq.y:20 uniq.crdb_internal_mvcc_timestamp:21
  │    ├── left-join (hash)
- │    │    ├── columns: other.k:7 other.v:8 other.w:9!null column14:14 column15:15!null uniq.k:16 uniq.v:17 uniq.w:18 uniq.x:19 uniq.y:20 uniq.crdb_internal_mvcc_timestamp:21
+ │    │    ├── columns: other.k:7 other.v:8 other.w:9!null x_default:14 y_default:15!null uniq.k:16 uniq.v:17 uniq.w:18 uniq.x:19 uniq.y:20 uniq.crdb_internal_mvcc_timestamp:21
  │    │    ├── ensure-upsert-distinct-on
- │    │    │    ├── columns: other.k:7 other.v:8 other.w:9!null column14:14 column15:15!null
+ │    │    │    ├── columns: other.k:7 other.v:8 other.w:9!null x_default:14 y_default:15!null
  │    │    │    ├── grouping columns: other.k:7
  │    │    │    ├── project
- │    │    │    │    ├── columns: column14:14 column15:15!null other.k:7 other.v:8 other.w:9!null
+ │    │    │    │    ├── columns: x_default:14 y_default:15!null other.k:7 other.v:8 other.w:9!null
  │    │    │    │    ├── project
  │    │    │    │    │    ├── columns: other.k:7 other.v:8 other.w:9!null
  │    │    │    │    │    └── scan other
  │    │    │    │    │         └── columns: other.k:7 other.v:8 other.w:9!null other.x:10 other.y:11 rowid:12!null other.crdb_internal_mvcc_timestamp:13
  │    │    │    │    └── projections
- │    │    │    │         ├── NULL::INT8 [as=column14:14]
- │    │    │    │         └── 5 [as=column15:15]
+ │    │    │    │         ├── NULL::INT8 [as=x_default:14]
+ │    │    │    │         └── 5 [as=y_default:15]
  │    │    │    └── aggregations
  │    │    │         ├── first-agg [as=other.v:8]
  │    │    │         │    └── other.v:8
  │    │    │         ├── first-agg [as=other.w:9]
  │    │    │         │    └── other.w:9
- │    │    │         ├── first-agg [as=column14:14]
- │    │    │         │    └── column14:14
- │    │    │         └── first-agg [as=column15:15]
- │    │    │              └── column15:15
+ │    │    │         ├── first-agg [as=x_default:14]
+ │    │    │         │    └── x_default:14
+ │    │    │         └── first-agg [as=y_default:15]
+ │    │    │              └── y_default:15
  │    │    ├── scan uniq
  │    │    │    └── columns: uniq.k:16!null uniq.v:17 uniq.w:18 uniq.x:19 uniq.y:20 uniq.crdb_internal_mvcc_timestamp:21
  │    │    └── filters
@@ -350,8 +350,8 @@ upsert uniq
       │              │         ├──  upsert_k:22 => k:29
       │              │         ├──  other.v:8 => v:30
       │              │         ├──  other.w:9 => w:31
-      │              │         ├──  column14:14 => x:32
-      │              │         └──  column15:15 => y:33
+      │              │         ├──  x_default:14 => x:32
+      │              │         └──  y_default:15 => y:33
       │              ├── scan uniq
       │              │    └── columns: uniq.k:23!null uniq.v:24 uniq.w:25 uniq.x:26 uniq.y:27
       │              └── filters
@@ -368,8 +368,8 @@ upsert uniq
                      │         ├──  upsert_k:22 => k:40
                      │         ├──  other.v:8 => v:41
                      │         ├──  other.w:9 => w:42
-                     │         ├──  column14:14 => x:43
-                     │         └──  column15:15 => y:44
+                     │         ├──  x_default:14 => x:43
+                     │         └──  y_default:15 => y:44
                      ├── scan uniq
                      │    └── columns: uniq.k:34!null uniq.v:35 uniq.w:36 uniq.x:37 uniq.y:38
                      └── filters
@@ -392,49 +392,49 @@ upsert uniq
  ├── insert-mapping:
  │    ├── column1:7 => uniq.k:1
  │    ├── column2:8 => uniq.v:2
- │    ├── column9:9 => uniq.w:3
- │    ├── column9:9 => uniq.x:4
- │    └── column10:10 => uniq.y:5
+ │    ├── w_default:9 => uniq.w:3
+ │    ├── w_default:9 => uniq.x:4
+ │    └── y_default:10 => uniq.y:5
  ├── update-mapping:
  │    └── upsert_w:20 => uniq.w:3
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_k:18 upsert_v:19 upsert_w:20 upsert_x:21 upsert_y:22 column1:7!null column2:8!null column9:9 column10:10!null uniq.k:11 uniq.v:12 uniq.w:13 uniq.x:14 uniq.y:15 crdb_internal_mvcc_timestamp:16 w_new:17
+ │    ├── columns: upsert_k:18 upsert_v:19 upsert_w:20 upsert_x:21 upsert_y:22 column1:7!null column2:8!null w_default:9 y_default:10!null uniq.k:11 uniq.v:12 uniq.w:13 uniq.x:14 uniq.y:15 crdb_internal_mvcc_timestamp:16 w_new:17
  │    ├── project
- │    │    ├── columns: w_new:17 column1:7!null column2:8!null column9:9 column10:10!null uniq.k:11 uniq.v:12 uniq.w:13 uniq.x:14 uniq.y:15 crdb_internal_mvcc_timestamp:16
+ │    │    ├── columns: w_new:17 column1:7!null column2:8!null w_default:9 y_default:10!null uniq.k:11 uniq.v:12 uniq.w:13 uniq.x:14 uniq.y:15 crdb_internal_mvcc_timestamp:16
  │    │    ├── left-join (hash)
- │    │    │    ├── columns: column1:7!null column2:8!null column9:9 column10:10!null uniq.k:11 uniq.v:12 uniq.w:13 uniq.x:14 uniq.y:15 crdb_internal_mvcc_timestamp:16
+ │    │    │    ├── columns: column1:7!null column2:8!null w_default:9 y_default:10!null uniq.k:11 uniq.v:12 uniq.w:13 uniq.x:14 uniq.y:15 crdb_internal_mvcc_timestamp:16
  │    │    │    ├── ensure-upsert-distinct-on
- │    │    │    │    ├── columns: column1:7!null column2:8!null column9:9 column10:10!null
+ │    │    │    │    ├── columns: column1:7!null column2:8!null w_default:9 y_default:10!null
  │    │    │    │    ├── grouping columns: column1:7!null
  │    │    │    │    ├── project
- │    │    │    │    │    ├── columns: column9:9 column10:10!null column1:7!null column2:8!null
+ │    │    │    │    │    ├── columns: w_default:9 y_default:10!null column1:7!null column2:8!null
  │    │    │    │    │    ├── values
  │    │    │    │    │    │    ├── columns: column1:7!null column2:8!null
  │    │    │    │    │    │    ├── (100, 1)
  │    │    │    │    │    │    └── (200, 1)
  │    │    │    │    │    └── projections
- │    │    │    │    │         ├── NULL::INT8 [as=column9:9]
- │    │    │    │    │         └── 5 [as=column10:10]
+ │    │    │    │    │         ├── NULL::INT8 [as=w_default:9]
+ │    │    │    │    │         └── 5 [as=y_default:10]
  │    │    │    │    └── aggregations
  │    │    │    │         ├── first-agg [as=column2:8]
  │    │    │    │         │    └── column2:8
- │    │    │    │         ├── first-agg [as=column9:9]
- │    │    │    │         │    └── column9:9
- │    │    │    │         └── first-agg [as=column10:10]
- │    │    │    │              └── column10:10
+ │    │    │    │         ├── first-agg [as=w_default:9]
+ │    │    │    │         │    └── w_default:9
+ │    │    │    │         └── first-agg [as=y_default:10]
+ │    │    │    │              └── y_default:10
  │    │    │    ├── scan uniq
  │    │    │    │    └── columns: uniq.k:11!null uniq.v:12 uniq.w:13 uniq.x:14 uniq.y:15 crdb_internal_mvcc_timestamp:16
  │    │    │    └── filters
  │    │    │         └── column1:7 = uniq.k:11
  │    │    └── projections
- │    │         └── column9:9 + 1 [as=w_new:17]
+ │    │         └── w_default:9 + 1 [as=w_new:17]
  │    └── projections
  │         ├── CASE WHEN uniq.k:11 IS NULL THEN column1:7 ELSE uniq.k:11 END [as=upsert_k:18]
  │         ├── CASE WHEN uniq.k:11 IS NULL THEN column2:8 ELSE uniq.v:12 END [as=upsert_v:19]
- │         ├── CASE WHEN uniq.k:11 IS NULL THEN column9:9 ELSE w_new:17 END [as=upsert_w:20]
- │         ├── CASE WHEN uniq.k:11 IS NULL THEN column9:9 ELSE uniq.x:14 END [as=upsert_x:21]
- │         └── CASE WHEN uniq.k:11 IS NULL THEN column10:10 ELSE uniq.y:15 END [as=upsert_y:22]
+ │         ├── CASE WHEN uniq.k:11 IS NULL THEN w_default:9 ELSE w_new:17 END [as=upsert_w:20]
+ │         ├── CASE WHEN uniq.k:11 IS NULL THEN w_default:9 ELSE uniq.x:14 END [as=upsert_x:21]
+ │         └── CASE WHEN uniq.k:11 IS NULL THEN y_default:10 ELSE uniq.y:15 END [as=upsert_y:22]
  └── unique-checks
       ├── unique-checks-item: uniq(w)
       │    └── project
@@ -488,37 +488,37 @@ upsert uniq
  ├── insert-mapping:
  │    ├── other.k:7 => uniq.k:1
  │    ├── other.v:8 => uniq.v:2
- │    ├── column14:14 => uniq.w:3
- │    ├── column14:14 => uniq.x:4
- │    └── column15:15 => uniq.y:5
+ │    ├── w_default:14 => uniq.w:3
+ │    ├── w_default:14 => uniq.x:4
+ │    └── y_default:15 => uniq.y:5
  ├── update-mapping:
  │    └── upsert_w:25 => uniq.w:3
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_k:23 upsert_v:24 upsert_w:25 upsert_x:26 upsert_y:27 other.k:7 other.v:8 column14:14 column15:15!null uniq.k:16 uniq.v:17 uniq.w:18 uniq.x:19 uniq.y:20 uniq.crdb_internal_mvcc_timestamp:21 w_new:22
+ │    ├── columns: upsert_k:23 upsert_v:24 upsert_w:25 upsert_x:26 upsert_y:27 other.k:7 other.v:8 w_default:14 y_default:15!null uniq.k:16 uniq.v:17 uniq.w:18 uniq.x:19 uniq.y:20 uniq.crdb_internal_mvcc_timestamp:21 w_new:22
  │    ├── project
- │    │    ├── columns: w_new:22 other.k:7 other.v:8 column14:14 column15:15!null uniq.k:16 uniq.v:17 uniq.w:18 uniq.x:19 uniq.y:20 uniq.crdb_internal_mvcc_timestamp:21
+ │    │    ├── columns: w_new:22 other.k:7 other.v:8 w_default:14 y_default:15!null uniq.k:16 uniq.v:17 uniq.w:18 uniq.x:19 uniq.y:20 uniq.crdb_internal_mvcc_timestamp:21
  │    │    ├── left-join (hash)
- │    │    │    ├── columns: other.k:7 other.v:8 column14:14 column15:15!null uniq.k:16 uniq.v:17 uniq.w:18 uniq.x:19 uniq.y:20 uniq.crdb_internal_mvcc_timestamp:21
+ │    │    │    ├── columns: other.k:7 other.v:8 w_default:14 y_default:15!null uniq.k:16 uniq.v:17 uniq.w:18 uniq.x:19 uniq.y:20 uniq.crdb_internal_mvcc_timestamp:21
  │    │    │    ├── ensure-upsert-distinct-on
- │    │    │    │    ├── columns: other.k:7 other.v:8 column14:14 column15:15!null
+ │    │    │    │    ├── columns: other.k:7 other.v:8 w_default:14 y_default:15!null
  │    │    │    │    ├── grouping columns: other.k:7
  │    │    │    │    ├── project
- │    │    │    │    │    ├── columns: column14:14 column15:15!null other.k:7 other.v:8
+ │    │    │    │    │    ├── columns: w_default:14 y_default:15!null other.k:7 other.v:8
  │    │    │    │    │    ├── project
  │    │    │    │    │    │    ├── columns: other.k:7 other.v:8
  │    │    │    │    │    │    └── scan other
  │    │    │    │    │    │         └── columns: other.k:7 other.v:8 other.w:9!null other.x:10 other.y:11 rowid:12!null other.crdb_internal_mvcc_timestamp:13
  │    │    │    │    │    └── projections
- │    │    │    │    │         ├── NULL::INT8 [as=column14:14]
- │    │    │    │    │         └── 5 [as=column15:15]
+ │    │    │    │    │         ├── NULL::INT8 [as=w_default:14]
+ │    │    │    │    │         └── 5 [as=y_default:15]
  │    │    │    │    └── aggregations
  │    │    │    │         ├── first-agg [as=other.v:8]
  │    │    │    │         │    └── other.v:8
- │    │    │    │         ├── first-agg [as=column14:14]
- │    │    │    │         │    └── column14:14
- │    │    │    │         └── first-agg [as=column15:15]
- │    │    │    │              └── column15:15
+ │    │    │    │         ├── first-agg [as=w_default:14]
+ │    │    │    │         │    └── w_default:14
+ │    │    │    │         └── first-agg [as=y_default:15]
+ │    │    │    │              └── y_default:15
  │    │    │    ├── scan uniq
  │    │    │    │    └── columns: uniq.k:16!null uniq.v:17 uniq.w:18 uniq.x:19 uniq.y:20 uniq.crdb_internal_mvcc_timestamp:21
  │    │    │    └── filters
@@ -528,9 +528,9 @@ upsert uniq
  │    └── projections
  │         ├── CASE WHEN uniq.k:16 IS NULL THEN other.k:7 ELSE uniq.k:16 END [as=upsert_k:23]
  │         ├── CASE WHEN uniq.k:16 IS NULL THEN other.v:8 ELSE uniq.v:17 END [as=upsert_v:24]
- │         ├── CASE WHEN uniq.k:16 IS NULL THEN column14:14 ELSE w_new:22 END [as=upsert_w:25]
- │         ├── CASE WHEN uniq.k:16 IS NULL THEN column14:14 ELSE uniq.x:19 END [as=upsert_x:26]
- │         └── CASE WHEN uniq.k:16 IS NULL THEN column15:15 ELSE uniq.y:20 END [as=upsert_y:27]
+ │         ├── CASE WHEN uniq.k:16 IS NULL THEN w_default:14 ELSE w_new:22 END [as=upsert_w:25]
+ │         ├── CASE WHEN uniq.k:16 IS NULL THEN w_default:14 ELSE uniq.x:19 END [as=upsert_x:26]
+ │         └── CASE WHEN uniq.k:16 IS NULL THEN y_default:15 ELSE uniq.y:20 END [as=upsert_y:27]
  └── unique-checks
       ├── unique-checks-item: uniq(w)
       │    └── project
@@ -584,38 +584,38 @@ upsert uniq
  │    ├── column1:7 => uniq.k:1
  │    ├── column2:8 => uniq.v:2
  │    ├── column3:9 => uniq.w:3
- │    ├── column10:10 => uniq.x:4
- │    └── column11:11 => uniq.y:5
+ │    ├── x_default:10 => uniq.x:4
+ │    └── y_default:11 => uniq.y:5
  ├── update-mapping:
  │    └── upsert_w:21 => uniq.w:3
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_k:19 upsert_v:20 upsert_w:21!null upsert_x:22 upsert_y:23 column1:7!null column2:8!null column3:9!null column10:10 column11:11!null uniq.k:12 uniq.v:13 uniq.w:14 uniq.x:15 uniq.y:16 crdb_internal_mvcc_timestamp:17 w_new:18!null
+ │    ├── columns: upsert_k:19 upsert_v:20 upsert_w:21!null upsert_x:22 upsert_y:23 column1:7!null column2:8!null column3:9!null x_default:10 y_default:11!null uniq.k:12 uniq.v:13 uniq.w:14 uniq.x:15 uniq.y:16 crdb_internal_mvcc_timestamp:17 w_new:18!null
  │    ├── project
- │    │    ├── columns: w_new:18!null column1:7!null column2:8!null column3:9!null column10:10 column11:11!null uniq.k:12 uniq.v:13 uniq.w:14 uniq.x:15 uniq.y:16 crdb_internal_mvcc_timestamp:17
+ │    │    ├── columns: w_new:18!null column1:7!null column2:8!null column3:9!null x_default:10 y_default:11!null uniq.k:12 uniq.v:13 uniq.w:14 uniq.x:15 uniq.y:16 crdb_internal_mvcc_timestamp:17
  │    │    ├── left-join (hash)
- │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11!null uniq.k:12 uniq.v:13 uniq.w:14 uniq.x:15 uniq.y:16 crdb_internal_mvcc_timestamp:17
+ │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null x_default:10 y_default:11!null uniq.k:12 uniq.v:13 uniq.w:14 uniq.x:15 uniq.y:16 crdb_internal_mvcc_timestamp:17
  │    │    │    ├── ensure-upsert-distinct-on
- │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11!null
+ │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null x_default:10 y_default:11!null
  │    │    │    │    ├── grouping columns: column3:9!null
  │    │    │    │    ├── project
- │    │    │    │    │    ├── columns: column10:10 column11:11!null column1:7!null column2:8!null column3:9!null
+ │    │    │    │    │    ├── columns: x_default:10 y_default:11!null column1:7!null column2:8!null column3:9!null
  │    │    │    │    │    ├── values
  │    │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null
  │    │    │    │    │    │    ├── (100, 10, 1)
  │    │    │    │    │    │    └── (200, 20, 2)
  │    │    │    │    │    └── projections
- │    │    │    │    │         ├── NULL::INT8 [as=column10:10]
- │    │    │    │    │         └── 5 [as=column11:11]
+ │    │    │    │    │         ├── NULL::INT8 [as=x_default:10]
+ │    │    │    │    │         └── 5 [as=y_default:11]
  │    │    │    │    └── aggregations
  │    │    │    │         ├── first-agg [as=column1:7]
  │    │    │    │         │    └── column1:7
  │    │    │    │         ├── first-agg [as=column2:8]
  │    │    │    │         │    └── column2:8
- │    │    │    │         ├── first-agg [as=column10:10]
- │    │    │    │         │    └── column10:10
- │    │    │    │         └── first-agg [as=column11:11]
- │    │    │    │              └── column11:11
+ │    │    │    │         ├── first-agg [as=x_default:10]
+ │    │    │    │         │    └── x_default:10
+ │    │    │    │         └── first-agg [as=y_default:11]
+ │    │    │    │              └── y_default:11
  │    │    │    ├── scan uniq
  │    │    │    │    └── columns: uniq.k:12!null uniq.v:13 uniq.w:14 uniq.x:15 uniq.y:16 crdb_internal_mvcc_timestamp:17
  │    │    │    └── filters
@@ -626,8 +626,8 @@ upsert uniq
  │         ├── CASE WHEN uniq.k:12 IS NULL THEN column1:7 ELSE uniq.k:12 END [as=upsert_k:19]
  │         ├── CASE WHEN uniq.k:12 IS NULL THEN column2:8 ELSE uniq.v:13 END [as=upsert_v:20]
  │         ├── CASE WHEN uniq.k:12 IS NULL THEN column3:9 ELSE w_new:18 END [as=upsert_w:21]
- │         ├── CASE WHEN uniq.k:12 IS NULL THEN column10:10 ELSE uniq.x:15 END [as=upsert_x:22]
- │         └── CASE WHEN uniq.k:12 IS NULL THEN column11:11 ELSE uniq.y:16 END [as=upsert_y:23]
+ │         ├── CASE WHEN uniq.k:12 IS NULL THEN x_default:10 ELSE uniq.x:15 END [as=upsert_x:22]
+ │         └── CASE WHEN uniq.k:12 IS NULL THEN y_default:11 ELSE uniq.y:16 END [as=upsert_y:23]
  └── unique-checks
       ├── unique-checks-item: uniq(w)
       │    └── project
@@ -850,16 +850,16 @@ upsert uniq_overlaps_pk
  │    ├── k:6 => uniq_overlaps_pk.a:1
  │    ├── v:7 => uniq_overlaps_pk.b:2
  │    ├── x:9 => uniq_overlaps_pk.c:3
- │    └── column13:13 => uniq_overlaps_pk.d:4
+ │    └── d_default:13 => uniq_overlaps_pk.d:4
  ├── input binding: &1
  ├── project
- │    ├── columns: column13:13 k:6 v:7 x:9
+ │    ├── columns: d_default:13 k:6 v:7 x:9
  │    ├── project
  │    │    ├── columns: k:6 v:7 x:9
  │    │    └── scan other
  │    │         └── columns: k:6 v:7 w:8!null x:9 y:10 rowid:11!null other.crdb_internal_mvcc_timestamp:12
  │    └── projections
- │         └── NULL::INT8 [as=column13:13]
+ │         └── NULL::INT8 [as=d_default:13]
  └── unique-checks
       ├── unique-checks-item: uniq_overlaps_pk(b,c)
       │    └── project
@@ -872,7 +872,7 @@ upsert uniq_overlaps_pk
       │              │         ├──  k:6 => a:19
       │              │         ├──  v:7 => b:20
       │              │         ├──  x:9 => c:21
-      │              │         └──  column13:13 => d:22
+      │              │         └──  d_default:13 => d:22
       │              ├── scan uniq_overlaps_pk
       │              │    └── columns: uniq_overlaps_pk.a:14!null uniq_overlaps_pk.b:15!null uniq_overlaps_pk.c:16 uniq_overlaps_pk.d:17
       │              └── filters
@@ -890,7 +890,7 @@ upsert uniq_overlaps_pk
                      │         ├──  k:6 => a:28
                      │         ├──  v:7 => b:29
                      │         ├──  x:9 => c:30
-                     │         └──  column13:13 => d:31
+                     │         └──  d_default:13 => d:31
                      ├── scan uniq_overlaps_pk
                      │    └── columns: uniq_overlaps_pk.a:23!null uniq_overlaps_pk.b:24!null uniq_overlaps_pk.c:25 uniq_overlaps_pk.d:26
                      └── filters
@@ -1110,30 +1110,30 @@ upsert uniq_hidden_pk
  ├── insert-mapping:
  │    ├── column1:7 => uniq_hidden_pk.a:1
  │    ├── column2:8 => uniq_hidden_pk.b:2
- │    ├── column10:10 => uniq_hidden_pk.c:3
+ │    ├── c_default:10 => uniq_hidden_pk.c:3
  │    ├── column3:9 => uniq_hidden_pk.d:4
- │    └── column11:11 => uniq_hidden_pk.rowid:5
+ │    └── rowid_default:11 => uniq_hidden_pk.rowid:5
  ├── update-mapping:
  │    ├── column1:7 => uniq_hidden_pk.a:1
  │    ├── column2:8 => uniq_hidden_pk.b:2
  │    └── column3:9 => uniq_hidden_pk.d:4
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_c:18 upsert_rowid:19 column1:7!null column2:8!null column3:9!null column10:10 column11:11 uniq_hidden_pk.a:12 uniq_hidden_pk.b:13 uniq_hidden_pk.c:14 uniq_hidden_pk.d:15 uniq_hidden_pk.rowid:16 crdb_internal_mvcc_timestamp:17
+ │    ├── columns: upsert_c:18 upsert_rowid:19 column1:7!null column2:8!null column3:9!null c_default:10 rowid_default:11 uniq_hidden_pk.a:12 uniq_hidden_pk.b:13 uniq_hidden_pk.c:14 uniq_hidden_pk.d:15 uniq_hidden_pk.rowid:16 crdb_internal_mvcc_timestamp:17
  │    ├── left-join (hash)
- │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11 uniq_hidden_pk.a:12 uniq_hidden_pk.b:13 uniq_hidden_pk.c:14 uniq_hidden_pk.d:15 uniq_hidden_pk.rowid:16 crdb_internal_mvcc_timestamp:17
+ │    │    ├── columns: column1:7!null column2:8!null column3:9!null c_default:10 rowid_default:11 uniq_hidden_pk.a:12 uniq_hidden_pk.b:13 uniq_hidden_pk.c:14 uniq_hidden_pk.d:15 uniq_hidden_pk.rowid:16 crdb_internal_mvcc_timestamp:17
  │    │    ├── ensure-upsert-distinct-on
- │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10 column11:11
- │    │    │    ├── grouping columns: column11:11
+ │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null c_default:10 rowid_default:11
+ │    │    │    ├── grouping columns: rowid_default:11
  │    │    │    ├── project
- │    │    │    │    ├── columns: column10:10 column11:11 column1:7!null column2:8!null column3:9!null
+ │    │    │    │    ├── columns: c_default:10 rowid_default:11 column1:7!null column2:8!null column3:9!null
  │    │    │    │    ├── values
  │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null
  │    │    │    │    │    ├── (1, 1, 1)
  │    │    │    │    │    └── (2, 2, 2)
  │    │    │    │    └── projections
- │    │    │    │         ├── NULL::INT8 [as=column10:10]
- │    │    │    │         └── unique_rowid() [as=column11:11]
+ │    │    │    │         ├── NULL::INT8 [as=c_default:10]
+ │    │    │    │         └── unique_rowid() [as=rowid_default:11]
  │    │    │    └── aggregations
  │    │    │         ├── first-agg [as=column1:7]
  │    │    │         │    └── column1:7
@@ -1141,15 +1141,15 @@ upsert uniq_hidden_pk
  │    │    │         │    └── column2:8
  │    │    │         ├── first-agg [as=column3:9]
  │    │    │         │    └── column3:9
- │    │    │         └── first-agg [as=column10:10]
- │    │    │              └── column10:10
+ │    │    │         └── first-agg [as=c_default:10]
+ │    │    │              └── c_default:10
  │    │    ├── scan uniq_hidden_pk
  │    │    │    └── columns: uniq_hidden_pk.a:12 uniq_hidden_pk.b:13 uniq_hidden_pk.c:14 uniq_hidden_pk.d:15 uniq_hidden_pk.rowid:16!null crdb_internal_mvcc_timestamp:17
  │    │    └── filters
- │    │         └── column11:11 = uniq_hidden_pk.rowid:16
+ │    │         └── rowid_default:11 = uniq_hidden_pk.rowid:16
  │    └── projections
- │         ├── CASE WHEN uniq_hidden_pk.rowid:16 IS NULL THEN column10:10 ELSE uniq_hidden_pk.c:14 END [as=upsert_c:18]
- │         └── CASE WHEN uniq_hidden_pk.rowid:16 IS NULL THEN column11:11 ELSE uniq_hidden_pk.rowid:16 END [as=upsert_rowid:19]
+ │         ├── CASE WHEN uniq_hidden_pk.rowid:16 IS NULL THEN c_default:10 ELSE uniq_hidden_pk.c:14 END [as=upsert_c:18]
+ │         └── CASE WHEN uniq_hidden_pk.rowid:16 IS NULL THEN rowid_default:11 ELSE uniq_hidden_pk.rowid:16 END [as=upsert_rowid:19]
  └── unique-checks
       ├── unique-checks-item: uniq_hidden_pk(b,c)
       │    └── project
@@ -1221,16 +1221,16 @@ upsert uniq_hidden_pk
  │    ├── v:8 => uniq_hidden_pk.b:2
  │    ├── x:10 => uniq_hidden_pk.c:3
  │    ├── y:11 => uniq_hidden_pk.d:4
- │    └── column14:14 => uniq_hidden_pk.rowid:5
+ │    └── rowid_default:14 => uniq_hidden_pk.rowid:5
  ├── input binding: &1
  ├── project
- │    ├── columns: column14:14 k:7 v:8 x:10 y:11
+ │    ├── columns: rowid_default:14 k:7 v:8 x:10 y:11
  │    ├── project
  │    │    ├── columns: k:7 v:8 x:10 y:11
  │    │    └── scan other
  │    │         └── columns: k:7 v:8 w:9!null x:10 y:11 other.rowid:12!null other.crdb_internal_mvcc_timestamp:13
  │    └── projections
- │         └── unique_rowid() [as=column14:14]
+ │         └── unique_rowid() [as=rowid_default:14]
  └── unique-checks
       ├── unique-checks-item: uniq_hidden_pk(b,c)
       │    └── project
@@ -1244,7 +1244,7 @@ upsert uniq_hidden_pk
       │              │         ├──  v:8 => b:22
       │              │         ├──  x:10 => c:23
       │              │         ├──  y:11 => d:24
-      │              │         └──  column14:14 => rowid:25
+      │              │         └──  rowid_default:14 => rowid:25
       │              ├── scan uniq_hidden_pk
       │              │    └── columns: uniq_hidden_pk.a:15 uniq_hidden_pk.b:16 uniq_hidden_pk.c:17 uniq_hidden_pk.d:18 uniq_hidden_pk.rowid:19!null
       │              └── filters
@@ -1263,7 +1263,7 @@ upsert uniq_hidden_pk
       │              │         ├──  v:8 => b:33
       │              │         ├──  x:10 => c:34
       │              │         ├──  y:11 => d:35
-      │              │         └──  column14:14 => rowid:36
+      │              │         └──  rowid_default:14 => rowid:36
       │              ├── scan uniq_hidden_pk
       │              │    └── columns: uniq_hidden_pk.a:26 uniq_hidden_pk.b:27 uniq_hidden_pk.c:28 uniq_hidden_pk.d:29 uniq_hidden_pk.rowid:30!null
       │              └── filters
@@ -1283,7 +1283,7 @@ upsert uniq_hidden_pk
                      │         ├──  v:8 => b:44
                      │         ├──  x:10 => c:45
                      │         ├──  y:11 => d:46
-                     │         └──  column14:14 => rowid:47
+                     │         └──  rowid_default:14 => rowid:47
                      ├── scan uniq_hidden_pk
                      │    └── columns: uniq_hidden_pk.a:37 uniq_hidden_pk.b:38 uniq_hidden_pk.c:39 uniq_hidden_pk.d:40 uniq_hidden_pk.rowid:41!null
                      └── filters
@@ -1305,31 +1305,31 @@ upsert uniq_hidden_pk
  │    ├── column2:8 => uniq_hidden_pk.b:2
  │    ├── column3:9 => uniq_hidden_pk.c:3
  │    ├── column4:10 => uniq_hidden_pk.d:4
- │    └── column11:11 => uniq_hidden_pk.rowid:5
+ │    └── rowid_default:11 => uniq_hidden_pk.rowid:5
  ├── update-mapping:
  │    └── upsert_a:19 => uniq_hidden_pk.a:1
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_a:19!null upsert_b:20 upsert_c:21 upsert_d:22 upsert_rowid:23 column1:7!null column2:8!null column3:9!null column4:10!null column11:11 uniq_hidden_pk.a:12 uniq_hidden_pk.b:13 uniq_hidden_pk.c:14 uniq_hidden_pk.d:15 uniq_hidden_pk.rowid:16 crdb_internal_mvcc_timestamp:17 a_new:18!null
+ │    ├── columns: upsert_a:19!null upsert_b:20 upsert_c:21 upsert_d:22 upsert_rowid:23 column1:7!null column2:8!null column3:9!null column4:10!null rowid_default:11 uniq_hidden_pk.a:12 uniq_hidden_pk.b:13 uniq_hidden_pk.c:14 uniq_hidden_pk.d:15 uniq_hidden_pk.rowid:16 crdb_internal_mvcc_timestamp:17 a_new:18!null
  │    ├── project
- │    │    ├── columns: a_new:18!null column1:7!null column2:8!null column3:9!null column4:10!null column11:11 uniq_hidden_pk.a:12 uniq_hidden_pk.b:13 uniq_hidden_pk.c:14 uniq_hidden_pk.d:15 uniq_hidden_pk.rowid:16 crdb_internal_mvcc_timestamp:17
+ │    │    ├── columns: a_new:18!null column1:7!null column2:8!null column3:9!null column4:10!null rowid_default:11 uniq_hidden_pk.a:12 uniq_hidden_pk.b:13 uniq_hidden_pk.c:14 uniq_hidden_pk.d:15 uniq_hidden_pk.rowid:16 crdb_internal_mvcc_timestamp:17
  │    │    ├── left-join (hash)
- │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column11:11 uniq_hidden_pk.a:12 uniq_hidden_pk.b:13 uniq_hidden_pk.c:14 uniq_hidden_pk.d:15 uniq_hidden_pk.rowid:16 crdb_internal_mvcc_timestamp:17
+ │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null rowid_default:11 uniq_hidden_pk.a:12 uniq_hidden_pk.b:13 uniq_hidden_pk.c:14 uniq_hidden_pk.d:15 uniq_hidden_pk.rowid:16 crdb_internal_mvcc_timestamp:17
  │    │    │    ├── ensure-upsert-distinct-on
- │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null column11:11
+ │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null rowid_default:11
  │    │    │    │    ├── grouping columns: column1:7!null column2:8!null column4:10!null
  │    │    │    │    ├── project
- │    │    │    │    │    ├── columns: column11:11 column1:7!null column2:8!null column3:9!null column4:10!null
+ │    │    │    │    │    ├── columns: rowid_default:11 column1:7!null column2:8!null column3:9!null column4:10!null
  │    │    │    │    │    ├── values
  │    │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null
  │    │    │    │    │    │    └── (1, 2, 3, 4)
  │    │    │    │    │    └── projections
- │    │    │    │    │         └── unique_rowid() [as=column11:11]
+ │    │    │    │    │         └── unique_rowid() [as=rowid_default:11]
  │    │    │    │    └── aggregations
  │    │    │    │         ├── first-agg [as=column3:9]
  │    │    │    │         │    └── column3:9
- │    │    │    │         └── first-agg [as=column11:11]
- │    │    │    │              └── column11:11
+ │    │    │    │         └── first-agg [as=rowid_default:11]
+ │    │    │    │              └── rowid_default:11
  │    │    │    ├── scan uniq_hidden_pk
  │    │    │    │    └── columns: uniq_hidden_pk.a:12 uniq_hidden_pk.b:13 uniq_hidden_pk.c:14 uniq_hidden_pk.d:15 uniq_hidden_pk.rowid:16!null crdb_internal_mvcc_timestamp:17
  │    │    │    └── filters
@@ -1343,7 +1343,7 @@ upsert uniq_hidden_pk
  │         ├── CASE WHEN uniq_hidden_pk.rowid:16 IS NULL THEN column2:8 ELSE uniq_hidden_pk.b:13 END [as=upsert_b:20]
  │         ├── CASE WHEN uniq_hidden_pk.rowid:16 IS NULL THEN column3:9 ELSE uniq_hidden_pk.c:14 END [as=upsert_c:21]
  │         ├── CASE WHEN uniq_hidden_pk.rowid:16 IS NULL THEN column4:10 ELSE uniq_hidden_pk.d:15 END [as=upsert_d:22]
- │         └── CASE WHEN uniq_hidden_pk.rowid:16 IS NULL THEN column11:11 ELSE uniq_hidden_pk.rowid:16 END [as=upsert_rowid:23]
+ │         └── CASE WHEN uniq_hidden_pk.rowid:16 IS NULL THEN rowid_default:11 ELSE uniq_hidden_pk.rowid:16 END [as=upsert_rowid:23]
  └── unique-checks
       ├── unique-checks-item: uniq_hidden_pk(b,c)
       │    └── project
@@ -1433,33 +1433,33 @@ upsert uniq_fk_parent
  ├── fetch columns: uniq_fk_parent.a:6 uniq_fk_parent.rowid:7
  ├── insert-mapping:
  │    ├── column1:4 => uniq_fk_parent.a:1
- │    └── column5:5 => uniq_fk_parent.rowid:2
+ │    └── rowid_default:5 => uniq_fk_parent.rowid:2
  ├── update-mapping:
  │    └── column1:4 => uniq_fk_parent.a:1
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_rowid:9 column1:4!null column5:5 uniq_fk_parent.a:6 uniq_fk_parent.rowid:7 uniq_fk_parent.crdb_internal_mvcc_timestamp:8
+ │    ├── columns: upsert_rowid:9 column1:4!null rowid_default:5 uniq_fk_parent.a:6 uniq_fk_parent.rowid:7 uniq_fk_parent.crdb_internal_mvcc_timestamp:8
  │    ├── left-join (hash)
- │    │    ├── columns: column1:4!null column5:5 uniq_fk_parent.a:6 uniq_fk_parent.rowid:7 uniq_fk_parent.crdb_internal_mvcc_timestamp:8
+ │    │    ├── columns: column1:4!null rowid_default:5 uniq_fk_parent.a:6 uniq_fk_parent.rowid:7 uniq_fk_parent.crdb_internal_mvcc_timestamp:8
  │    │    ├── ensure-upsert-distinct-on
- │    │    │    ├── columns: column1:4!null column5:5
- │    │    │    ├── grouping columns: column5:5
+ │    │    │    ├── columns: column1:4!null rowid_default:5
+ │    │    │    ├── grouping columns: rowid_default:5
  │    │    │    ├── project
- │    │    │    │    ├── columns: column5:5 column1:4!null
+ │    │    │    │    ├── columns: rowid_default:5 column1:4!null
  │    │    │    │    ├── values
  │    │    │    │    │    ├── columns: column1:4!null
  │    │    │    │    │    └── (1,)
  │    │    │    │    └── projections
- │    │    │    │         └── unique_rowid() [as=column5:5]
+ │    │    │    │         └── unique_rowid() [as=rowid_default:5]
  │    │    │    └── aggregations
  │    │    │         └── first-agg [as=column1:4]
  │    │    │              └── column1:4
  │    │    ├── scan uniq_fk_parent
  │    │    │    └── columns: uniq_fk_parent.a:6 uniq_fk_parent.rowid:7!null uniq_fk_parent.crdb_internal_mvcc_timestamp:8
  │    │    └── filters
- │    │         └── column5:5 = uniq_fk_parent.rowid:7
+ │    │         └── rowid_default:5 = uniq_fk_parent.rowid:7
  │    └── projections
- │         └── CASE WHEN uniq_fk_parent.rowid:7 IS NULL THEN column5:5 ELSE uniq_fk_parent.rowid:7 END [as=upsert_rowid:9]
+ │         └── CASE WHEN uniq_fk_parent.rowid:7 IS NULL THEN rowid_default:5 ELSE uniq_fk_parent.rowid:7 END [as=upsert_rowid:9]
  ├── unique-checks
  │    └── unique-checks-item: uniq_fk_parent(a)
  │         └── project
@@ -1543,33 +1543,33 @@ upsert t
  ├── fetch columns: t.i:6 t.rowid:7
  ├── insert-mapping:
  │    ├── column1:4 => t.i:1
- │    └── column5:5 => t.rowid:2
+ │    └── rowid_default:5 => t.rowid:2
  ├── update-mapping:
  │    └── upsert_i:10 => t.i:1
  ├── partial index put columns: partial_index_put1:12
  ├── partial index del columns: partial_index_del1:13
  ├── input binding: &1
  ├── project
- │    ├── columns: partial_index_put1:12!null partial_index_del1:13 column1:4!null column5:5 t.i:6 t.rowid:7 crdb_internal_mvcc_timestamp:8 i_new:9!null upsert_i:10!null upsert_rowid:11
+ │    ├── columns: partial_index_put1:12!null partial_index_del1:13 column1:4!null rowid_default:5 t.i:6 t.rowid:7 crdb_internal_mvcc_timestamp:8 i_new:9!null upsert_i:10!null upsert_rowid:11
  │    ├── project
- │    │    ├── columns: upsert_i:10!null upsert_rowid:11 column1:4!null column5:5 t.i:6 t.rowid:7 crdb_internal_mvcc_timestamp:8 i_new:9!null
+ │    │    ├── columns: upsert_i:10!null upsert_rowid:11 column1:4!null rowid_default:5 t.i:6 t.rowid:7 crdb_internal_mvcc_timestamp:8 i_new:9!null
  │    │    ├── project
- │    │    │    ├── columns: i_new:9!null column1:4!null column5:5 t.i:6 t.rowid:7 crdb_internal_mvcc_timestamp:8
+ │    │    │    ├── columns: i_new:9!null column1:4!null rowid_default:5 t.i:6 t.rowid:7 crdb_internal_mvcc_timestamp:8
  │    │    │    ├── left-join (hash)
- │    │    │    │    ├── columns: column1:4!null column5:5 t.i:6 t.rowid:7 crdb_internal_mvcc_timestamp:8
+ │    │    │    │    ├── columns: column1:4!null rowid_default:5 t.i:6 t.rowid:7 crdb_internal_mvcc_timestamp:8
  │    │    │    │    ├── ensure-upsert-distinct-on
- │    │    │    │    │    ├── columns: column1:4!null column5:5
+ │    │    │    │    │    ├── columns: column1:4!null rowid_default:5
  │    │    │    │    │    ├── grouping columns: column1:4!null
  │    │    │    │    │    ├── project
- │    │    │    │    │    │    ├── columns: column5:5 column1:4!null
+ │    │    │    │    │    │    ├── columns: rowid_default:5 column1:4!null
  │    │    │    │    │    │    ├── values
  │    │    │    │    │    │    │    ├── columns: column1:4!null
  │    │    │    │    │    │    │    └── (1,)
  │    │    │    │    │    │    └── projections
- │    │    │    │    │    │         └── unique_rowid() [as=column5:5]
+ │    │    │    │    │    │         └── unique_rowid() [as=rowid_default:5]
  │    │    │    │    │    └── aggregations
- │    │    │    │    │         └── first-agg [as=column5:5]
- │    │    │    │    │              └── column5:5
+ │    │    │    │    │         └── first-agg [as=rowid_default:5]
+ │    │    │    │    │              └── rowid_default:5
  │    │    │    │    ├── scan t
  │    │    │    │    │    ├── columns: t.i:6 t.rowid:7!null crdb_internal_mvcc_timestamp:8
  │    │    │    │    │    └── partial index predicates
@@ -1581,7 +1581,7 @@ upsert t
  │    │    │         └── 2 [as=i_new:9]
  │    │    └── projections
  │    │         ├── CASE WHEN t.rowid:7 IS NULL THEN column1:4 ELSE i_new:9 END [as=upsert_i:10]
- │    │         └── CASE WHEN t.rowid:7 IS NULL THEN column5:5 ELSE t.rowid:7 END [as=upsert_rowid:11]
+ │    │         └── CASE WHEN t.rowid:7 IS NULL THEN rowid_default:5 ELSE t.rowid:7 END [as=upsert_rowid:11]
  │    └── projections
  │         ├── upsert_i:10 > 0 [as=partial_index_put1:12]
  │         └── t.i:6 > 0 [as=partial_index_del1:13]
@@ -1986,42 +1986,42 @@ upsert uniq_computed_pk
  │    ├── column1:9 => uniq_computed_pk.i:1
  │    ├── column2:10 => uniq_computed_pk.s:2
  │    ├── column3:11 => uniq_computed_pk.d:3
- │    ├── column12:12 => uniq_computed_pk.c_i_expr:4
+ │    ├── c_i_expr_comp:12 => uniq_computed_pk.c_i_expr:4
  │    ├── column2:10 => uniq_computed_pk.c_s:5
  │    ├── column3:11 => uniq_computed_pk.c_d:6
- │    └── column13:13 => uniq_computed_pk.c_d_expr:7
+ │    └── c_d_expr_comp:13 => uniq_computed_pk.c_d_expr:7
  ├── update-mapping:
  │    ├── column2:10 => uniq_computed_pk.s:2
  │    ├── column3:11 => uniq_computed_pk.d:3
  │    ├── column2:10 => uniq_computed_pk.c_s:5
  │    ├── column3:11 => uniq_computed_pk.c_d:6
- │    └── column13:13 => uniq_computed_pk.c_d_expr:7
+ │    └── c_d_expr_comp:13 => uniq_computed_pk.c_d_expr:7
  ├── input binding: &1
  ├── project
- │    ├── columns: upsert_i:23 upsert_c_i_expr:24 column1:9!null column2:10!null column3:11!null column12:12!null column13:13!null uniq_computed_pk.i:14 uniq_computed_pk.s:15 uniq_computed_pk.d:16 uniq_computed_pk.c_i_expr:17 uniq_computed_pk.c_s:18 uniq_computed_pk.c_d:19 uniq_computed_pk.c_d_expr:20 crdb_internal_mvcc_timestamp:21 column22:22
+ │    ├── columns: upsert_i:23 upsert_c_i_expr:24 column1:9!null column2:10!null column3:11!null c_i_expr_comp:12!null c_d_expr_comp:13!null uniq_computed_pk.i:14 uniq_computed_pk.s:15 uniq_computed_pk.d:16 uniq_computed_pk.c_i_expr:17 uniq_computed_pk.c_s:18 uniq_computed_pk.c_d:19 uniq_computed_pk.c_d_expr:20 crdb_internal_mvcc_timestamp:21 c_i_expr_comp:22
  │    ├── project
- │    │    ├── columns: column22:22 column1:9!null column2:10!null column3:11!null column12:12!null column13:13!null uniq_computed_pk.i:14 uniq_computed_pk.s:15 uniq_computed_pk.d:16 uniq_computed_pk.c_i_expr:17 uniq_computed_pk.c_s:18 uniq_computed_pk.c_d:19 uniq_computed_pk.c_d_expr:20 crdb_internal_mvcc_timestamp:21
+ │    │    ├── columns: c_i_expr_comp:22 column1:9!null column2:10!null column3:11!null c_i_expr_comp:12!null c_d_expr_comp:13!null uniq_computed_pk.i:14 uniq_computed_pk.s:15 uniq_computed_pk.d:16 uniq_computed_pk.c_i_expr:17 uniq_computed_pk.c_s:18 uniq_computed_pk.c_d:19 uniq_computed_pk.c_d_expr:20 crdb_internal_mvcc_timestamp:21
  │    │    ├── left-join (hash)
- │    │    │    ├── columns: column1:9!null column2:10!null column3:11!null column12:12!null column13:13!null uniq_computed_pk.i:14 uniq_computed_pk.s:15 uniq_computed_pk.d:16 uniq_computed_pk.c_i_expr:17 uniq_computed_pk.c_s:18 uniq_computed_pk.c_d:19 uniq_computed_pk.c_d_expr:20 crdb_internal_mvcc_timestamp:21
+ │    │    │    ├── columns: column1:9!null column2:10!null column3:11!null c_i_expr_comp:12!null c_d_expr_comp:13!null uniq_computed_pk.i:14 uniq_computed_pk.s:15 uniq_computed_pk.d:16 uniq_computed_pk.c_i_expr:17 uniq_computed_pk.c_s:18 uniq_computed_pk.c_d:19 uniq_computed_pk.c_d_expr:20 crdb_internal_mvcc_timestamp:21
  │    │    │    ├── ensure-upsert-distinct-on
- │    │    │    │    ├── columns: column1:9!null column2:10!null column3:11!null column12:12!null column13:13!null
- │    │    │    │    ├── grouping columns: column1:9!null column12:12!null
+ │    │    │    │    ├── columns: column1:9!null column2:10!null column3:11!null c_i_expr_comp:12!null c_d_expr_comp:13!null
+ │    │    │    │    ├── grouping columns: column1:9!null c_i_expr_comp:12!null
  │    │    │    │    ├── project
- │    │    │    │    │    ├── columns: column12:12!null column13:13!null column1:9!null column2:10!null column3:11!null
+ │    │    │    │    │    ├── columns: c_i_expr_comp:12!null c_d_expr_comp:13!null column1:9!null column2:10!null column3:11!null
  │    │    │    │    │    ├── values
  │    │    │    │    │    │    ├── columns: column1:9!null column2:10!null column3:11!null
  │    │    │    │    │    │    ├── (1, 'a', 1.0)
  │    │    │    │    │    │    └── (2, 'b', 2.0)
  │    │    │    │    │    └── projections
- │    │    │    │    │         ├── CASE WHEN column1:9 < 0 THEN 'foo' ELSE 'bar' END [as=column12:12]
- │    │    │    │    │         └── column3:11::STRING [as=column13:13]
+ │    │    │    │    │         ├── CASE WHEN column1:9 < 0 THEN 'foo' ELSE 'bar' END [as=c_i_expr_comp:12]
+ │    │    │    │    │         └── column3:11::STRING [as=c_d_expr_comp:13]
  │    │    │    │    └── aggregations
  │    │    │    │         ├── first-agg [as=column2:10]
  │    │    │    │         │    └── column2:10
  │    │    │    │         ├── first-agg [as=column3:11]
  │    │    │    │         │    └── column3:11
- │    │    │    │         └── first-agg [as=column13:13]
- │    │    │    │              └── column13:13
+ │    │    │    │         └── first-agg [as=c_d_expr_comp:13]
+ │    │    │    │              └── c_d_expr_comp:13
  │    │    │    ├── project
  │    │    │    │    ├── columns: uniq_computed_pk.c_s:18 uniq_computed_pk.i:14!null uniq_computed_pk.s:15 uniq_computed_pk.d:16 uniq_computed_pk.c_i_expr:17!null uniq_computed_pk.c_d:19 uniq_computed_pk.c_d_expr:20 crdb_internal_mvcc_timestamp:21
  │    │    │    │    ├── scan uniq_computed_pk
@@ -2039,12 +2039,12 @@ upsert uniq_computed_pk
  │    │    │    │         └── uniq_computed_pk.s:15 [as=uniq_computed_pk.c_s:18]
  │    │    │    └── filters
  │    │    │         ├── column1:9 = uniq_computed_pk.i:14
- │    │    │         └── column12:12 = uniq_computed_pk.c_i_expr:17
+ │    │    │         └── c_i_expr_comp:12 = uniq_computed_pk.c_i_expr:17
  │    │    └── projections
- │    │         └── CASE WHEN uniq_computed_pk.i:14 < 0 THEN 'foo' ELSE 'bar' END [as=column22:22]
+ │    │         └── CASE WHEN uniq_computed_pk.i:14 < 0 THEN 'foo' ELSE 'bar' END [as=c_i_expr_comp:22]
  │    └── projections
  │         ├── CASE WHEN uniq_computed_pk.c_i_expr:17 IS NULL THEN column1:9 ELSE uniq_computed_pk.i:14 END [as=upsert_i:23]
- │         └── CASE WHEN uniq_computed_pk.c_i_expr:17 IS NULL THEN column12:12 ELSE uniq_computed_pk.c_i_expr:17 END [as=upsert_c_i_expr:24]
+ │         └── CASE WHEN uniq_computed_pk.c_i_expr:17 IS NULL THEN c_i_expr_comp:12 ELSE uniq_computed_pk.c_i_expr:17 END [as=upsert_c_i_expr:24]
  └── unique-checks
       └── unique-checks-item: uniq_computed_pk(d)
            └── project
@@ -2060,7 +2060,7 @@ upsert uniq_computed_pk
                      │         ├──  upsert_c_i_expr:24 => c_i_expr:52
                      │         ├──  column2:10 => c_s:53
                      │         ├──  column3:11 => c_d:54
-                     │         └──  column13:13 => c_d_expr:55
+                     │         └──  c_d_expr_comp:13 => c_d_expr:55
                      ├── project
                      │    ├── columns: uniq_computed_pk.c_s:45 uniq_computed_pk.i:41!null uniq_computed_pk.s:42 uniq_computed_pk.d:43 uniq_computed_pk.c_i_expr:44!null uniq_computed_pk.c_d:46 uniq_computed_pk.c_d_expr:47
                      │    ├── scan uniq_computed_pk

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -68,7 +68,7 @@ update abcde
  │    ├── a_new:15 => a:1
  │    └── a_new:15 => e:5
  └── project
-      ├── columns: column16:16 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 a_new:15!null
+      ├── columns: d_comp:16 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 a_new:15!null
       ├── project
       │    ├── columns: a_new:15!null a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14
       │    ├── select
@@ -85,7 +85,7 @@ update abcde
       │    └── projections
       │         └── 2 [as=a_new:15]
       └── projections
-           └── (b:9 + c:10) + 1 [as=column16:16]
+           └── (b:9 + c:10) + 1 [as=d_comp:16]
 
 # Set all non-computed columns.
 build
@@ -98,11 +98,11 @@ update abcde
  │    ├── a_new:15 => a:1
  │    ├── b_new:16 => b:2
  │    ├── c_new:17 => c:3
- │    ├── column19:19 => d:4
+ │    ├── d_comp:19 => d:4
  │    ├── a_new:15 => e:5
  │    └── rowid_new:18 => rowid:6
  └── project
-      ├── columns: column19:19!null a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 a_new:15!null b_new:16!null c_new:17!null rowid_new:18!null
+      ├── columns: d_comp:19!null a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 a_new:15!null b_new:16!null c_new:17!null rowid_new:18!null
       ├── project
       │    ├── columns: a_new:15!null b_new:16!null c_new:17!null rowid_new:18!null a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14
       │    ├── scan abcde
@@ -118,7 +118,7 @@ update abcde
       │         ├── 3 [as=c_new:17]
       │         └── 4 [as=rowid_new:18]
       └── projections
-           └── (b_new:16 + c_new:17) + 1 [as=column19:19]
+           └── (b_new:16 + c_new:17) + 1 [as=d_comp:19]
 
 # Set all non-computed columns in reverse order.
 build
@@ -131,11 +131,11 @@ update abcde
  │    ├── a_new:18 => a:1
  │    ├── b_new:17 => b:2
  │    ├── c_new:16 => c:3
- │    ├── column19:19 => d:4
+ │    ├── d_comp:19 => d:4
  │    ├── a_new:18 => e:5
  │    └── rowid_new:15 => rowid:6
  └── project
-      ├── columns: column19:19!null a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 rowid_new:15!null c_new:16!null b_new:17!null a_new:18!null
+      ├── columns: d_comp:19!null a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 rowid_new:15!null c_new:16!null b_new:17!null a_new:18!null
       ├── project
       │    ├── columns: rowid_new:15!null c_new:16!null b_new:17!null a_new:18!null a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14
       │    ├── scan abcde
@@ -151,7 +151,7 @@ update abcde
       │         ├── 3 [as=b_new:17]
       │         └── 4 [as=a_new:18]
       └── projections
-           └── (b_new:17 + c_new:16) + 1 [as=column19:19]
+           └── (b_new:17 + c_new:16) + 1 [as=d_comp:19]
 
 # Set all non-computed columns to NULL.
 build
@@ -164,11 +164,11 @@ update abcde
  │    ├── a_new:15 => a:1
  │    ├── a_new:15 => b:2
  │    ├── a_new:15 => c:3
- │    ├── column16:16 => d:4
+ │    ├── d_comp:16 => d:4
  │    ├── a_new:15 => e:5
  │    └── a_new:15 => rowid:6
  └── project
-      ├── columns: column16:16 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 a_new:15
+      ├── columns: d_comp:16 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 a_new:15
       ├── project
       │    ├── columns: a_new:15 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14
       │    ├── scan abcde
@@ -181,7 +181,7 @@ update abcde
       │    └── projections
       │         └── NULL::INT8 [as=a_new:15]
       └── projections
-           └── (a_new:15 + a_new:15) + 1 [as=column16:16]
+           └── (a_new:15 + a_new:15) + 1 [as=d_comp:16]
 
 # Set columns using variable expressions.
 build
@@ -193,10 +193,10 @@ update abcde
  ├── update-mapping:
  │    ├── a_new:15 => a:1
  │    ├── b_new:16 => b:2
- │    ├── column17:17 => d:4
+ │    ├── d_comp:17 => d:4
  │    └── a_new:15 => e:5
  └── project
-      ├── columns: column17:17 a:8!null b:9!null c:10 d:11 e:12!null rowid:13!null crdb_internal_mvcc_timestamp:14 a_new:15!null b_new:16
+      ├── columns: d_comp:17 a:8!null b:9!null c:10 d:11 e:12!null rowid:13!null crdb_internal_mvcc_timestamp:14 a_new:15!null b_new:16
       ├── project
       │    ├── columns: a_new:15!null b_new:16 a:8!null b:9!null c:10 d:11 e:12!null rowid:13!null crdb_internal_mvcc_timestamp:14
       │    ├── select
@@ -214,7 +214,7 @@ update abcde
       │         ├── a:8 + 1 [as=a_new:15]
       │         └── b:9 * c:10 [as=b_new:16]
       └── projections
-           └── (b_new:16 + c:10) + 1 [as=column17:17]
+           └── (b_new:16 + c:10) + 1 [as=d_comp:17]
 
 # Set columns using aliased expressions.
 build
@@ -226,10 +226,10 @@ update abcde [as=foo]
  ├── update-mapping:
  │    ├── b:9 => a:1
  │    ├── c:10 => b:2
- │    ├── column15:15 => d:4
+ │    ├── d_comp:15 => d:4
  │    └── b:9 => e:5
  └── project
-      ├── columns: column15:15 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14
+      ├── columns: d_comp:15 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14
       ├── scan abcde [as=foo]
       │    ├── columns: a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14
       │    └── computed column expressions
@@ -238,7 +238,7 @@ update abcde [as=foo]
       │         └── e:12
       │              └── a:8
       └── projections
-           └── (c:10 + c:10) + 1 [as=column15:15]
+           └── (c:10 + c:10) + 1 [as=d_comp:15]
 
 # Use WHERE, ORDER BY, LIMIT.
 build
@@ -249,9 +249,9 @@ update abcde
  ├── fetch columns: a:8 b:9 c:10 d:11 e:12 rowid:13
  ├── update-mapping:
  │    ├── b_new:15 => b:2
- │    └── column16:16 => d:4
+ │    └── d_comp:16 => d:4
  └── project
-      ├── columns: column16:16 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 b_new:15!null
+      ├── columns: d_comp:16 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 b_new:15!null
       ├── project
       │    ├── columns: b_new:15!null a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14
       │    ├── limit
@@ -276,7 +276,7 @@ update abcde
       │    └── projections
       │         └── 1 [as=b_new:15]
       └── projections
-           └── (b_new:15 + c:10) + 1 [as=column16:16]
+           └── (b_new:15 + c:10) + 1 [as=d_comp:16]
 
 # UPDATE with index hints.
 exec-ddl
@@ -443,10 +443,10 @@ update abcde
  ├── update-mapping:
  │    ├── a_new:15 => a:1
  │    ├── a_new:15 => b:2
- │    ├── column16:16 => d:4
+ │    ├── d_comp:16 => d:4
  │    └── a_new:15 => e:5
  └── project
-      ├── columns: column16:16 a:8!null b:9 c:10!null d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 a_new:15
+      ├── columns: d_comp:16 a:8!null b:9 c:10!null d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 a_new:15
       ├── project
       │    ├── columns: a_new:15 a:8!null b:9 c:10!null d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14
       │    ├── select
@@ -463,7 +463,7 @@ update abcde
       │    └── projections
       │         └── $1 + 1 [as=a_new:15]
       └── projections
-           └── (a_new:15 + c:10) + 1 [as=column16:16]
+           └── (a_new:15 + c:10) + 1 [as=d_comp:16]
 
 
 # Unknown target table.
@@ -502,10 +502,10 @@ with &1
  │         ├── fetch columns: abcde.a:8 abcde.b:9 abcde.c:10 abcde.d:11 abcde.e:12 rowid:13
  │         ├── update-mapping:
  │         │    ├── abcde.b:9 => abcde.a:1
- │         │    ├── column15:15 => abcde.d:4
+ │         │    ├── d_comp:15 => abcde.d:4
  │         │    └── abcde.b:9 => abcde.e:5
  │         └── project
- │              ├── columns: column15:15 abcde.a:8!null abcde.b:9 abcde.c:10 abcde.d:11 abcde.e:12 rowid:13!null crdb_internal_mvcc_timestamp:14
+ │              ├── columns: d_comp:15 abcde.a:8!null abcde.b:9 abcde.c:10 abcde.d:11 abcde.e:12 rowid:13!null crdb_internal_mvcc_timestamp:14
  │              ├── scan abcde
  │              │    ├── columns: abcde.a:8!null abcde.b:9 abcde.c:10 abcde.d:11 abcde.e:12 rowid:13!null crdb_internal_mvcc_timestamp:14
  │              │    └── computed column expressions
@@ -514,7 +514,7 @@ with &1
  │              │         └── abcde.e:12
  │              │              └── abcde.a:8
  │              └── projections
- │                   └── (abcde.b:9 + abcde.c:10) + 1 [as=column15:15]
+ │                   └── (abcde.b:9 + abcde.c:10) + 1 [as=d_comp:15]
  └── with &2 (cte)
       ├── project
       │    ├── columns: b:17
@@ -531,10 +531,10 @@ with &1
            ├── fetch columns: abcde.a:28 abcde.b:29 abcde.c:30 abcde.d:31 abcde.e:32 rowid:33
            ├── update-mapping:
            │    ├── abcde.b:29 => abcde.a:21
-           │    ├── column35:35 => abcde.d:24
+           │    ├── d_comp:35 => abcde.d:24
            │    └── abcde.b:29 => abcde.e:25
            └── project
-                ├── columns: column35:35 abcde.a:28!null abcde.b:29 abcde.c:30 abcde.d:31 abcde.e:32 rowid:33!null crdb_internal_mvcc_timestamp:34
+                ├── columns: d_comp:35 abcde.a:28!null abcde.b:29 abcde.c:30 abcde.d:31 abcde.e:32 rowid:33!null crdb_internal_mvcc_timestamp:34
                 ├── scan abcde
                 │    ├── columns: abcde.a:28!null abcde.b:29 abcde.c:30 abcde.d:31 abcde.e:32 rowid:33!null crdb_internal_mvcc_timestamp:34
                 │    └── computed column expressions
@@ -543,7 +543,7 @@ with &1
                 │         └── abcde.e:32
                 │              └── abcde.a:28
                 └── projections
-                     └── (abcde.b:29 + abcde.c:30) + 1 [as=column35:35]
+                     └── (abcde.b:29 + abcde.c:30) + 1 [as=d_comp:35]
 
 # With alias, original table name should be inaccessible.
 build
@@ -574,7 +574,7 @@ project
       │    ├── a_new:15 => a:1
       │    └── a_new:15 => e:5
       └── project
-           ├── columns: column16:16 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 a_new:15!null
+           ├── columns: d_comp:16 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 a_new:15!null
            ├── project
            │    ├── columns: a_new:15!null a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14
            │    ├── select
@@ -591,7 +591,7 @@ project
            │    └── projections
            │         └── 2 [as=a_new:15]
            └── projections
-                └── (b:9 + c:10) + 1 [as=column16:16]
+                └── (b:9 + c:10) + 1 [as=d_comp:16]
 
 # Return values from aliased table.
 build
@@ -606,7 +606,7 @@ project
  │    │    ├── a_new:15 => a:1
  │    │    └── a_new:15 => e:5
  │    └── project
- │         ├── columns: column16:16 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 a_new:15!null
+ │         ├── columns: d_comp:16 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 a_new:15!null
  │         ├── project
  │         │    ├── columns: a_new:15!null a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14
  │         │    ├── select
@@ -623,7 +623,7 @@ project
  │         │    └── projections
  │         │         └── 2 [as=a_new:15]
  │         └── projections
- │              └── (b:9 + c:10) + 1 [as=column16:16]
+ │              └── (b:9 + c:10) + 1 [as=d_comp:16]
  └── projections
       ├── a:1 + 1 [as="?column?":17]
       └── b:2 * d:4 [as="?column?":18]
@@ -643,7 +643,7 @@ with &1
  │         │    ├── a_new:15 => abcde.a:1
  │         │    └── a_new:15 => abcde.e:5
  │         └── project
- │              ├── columns: column16:16 abcde.a:8!null abcde.b:9 abcde.c:10 abcde.d:11 abcde.e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 a_new:15!null
+ │              ├── columns: d_comp:16 abcde.a:8!null abcde.b:9 abcde.c:10 abcde.d:11 abcde.e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 a_new:15!null
  │              ├── project
  │              │    ├── columns: a_new:15!null abcde.a:8!null abcde.b:9 abcde.c:10 abcde.d:11 abcde.e:12 rowid:13!null crdb_internal_mvcc_timestamp:14
  │              │    ├── limit
@@ -668,7 +668,7 @@ with &1
  │              │    └── projections
  │              │         └── 2 [as=a_new:15]
  │              └── projections
- │                   └── (abcde.b:9 + abcde.c:10) + 1 [as=column16:16]
+ │                   └── (abcde.b:9 + abcde.c:10) + 1 [as=d_comp:16]
  └── project
       ├── columns: a:17!null d:20
       └── with-scan &1
@@ -692,7 +692,7 @@ project
       ├── update-mapping:
       │    └── rowid_new:15 => rowid:6
       └── project
-           ├── columns: column16:16 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 rowid_new:15!null
+           ├── columns: d_comp:16 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 rowid_new:15!null
            ├── project
            │    ├── columns: rowid_new:15!null a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14
            │    ├── scan abcde
@@ -705,7 +705,7 @@ project
            │    └── projections
            │         └── rowid:13 + 1 [as=rowid_new:15]
            └── projections
-                └── (b:9 + c:10) + 1 [as=column16:16]
+                └── (b:9 + c:10) + 1 [as=d_comp:16]
 
 # Try to use aggregate function in RETURNING clause.
 build
@@ -733,9 +733,9 @@ update abcde
  ├── update-mapping:
  │    ├── b_new:15 => b:2
  │    ├── c_new:16 => c:3
- │    └── column17:17 => d:4
+ │    └── d_comp:17 => d:4
  └── project
-      ├── columns: column17:17 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 b_new:15 c_new:16!null
+      ├── columns: d_comp:17 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 b_new:15 c_new:16!null
       ├── project
       │    ├── columns: b_new:15 c_new:16!null a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14
       │    ├── scan abcde
@@ -749,7 +749,7 @@ update abcde
       │         ├── NULL::INT8 [as=b_new:15]
       │         └── 10 [as=c_new:16]
       └── projections
-           └── (b_new:15 + c_new:16) + 1 [as=column17:17]
+           └── (b_new:15 + c_new:16) + 1 [as=d_comp:17]
 
 # Allow not-null column to be updated with NULL DEFAULT value (would fail at
 # runtime if there are any rows to update).
@@ -763,7 +763,7 @@ update abcde
  │    ├── a_new:15 => a:1
  │    └── a_new:15 => e:5
  └── project
-      ├── columns: column16:16 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 a_new:15
+      ├── columns: d_comp:16 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 a_new:15
       ├── project
       │    ├── columns: a_new:15 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14
       │    ├── scan abcde
@@ -776,7 +776,7 @@ update abcde
       │    └── projections
       │         └── NULL::INT8 [as=a_new:15]
       └── projections
-           └── (b:9 + c:10) + 1 [as=column16:16]
+           └── (b:9 + c:10) + 1 [as=d_comp:16]
 
 build
 UPDATE abcde SET c=1+DEFAULT
@@ -797,10 +797,10 @@ update abcde
  │    ├── a_new:15 => a:1
  │    ├── b_new:16 => b:2
  │    ├── c_new:17 => c:3
- │    ├── column18:18 => d:4
+ │    ├── d_comp:18 => d:4
  │    └── a_new:15 => e:5
  └── project
-      ├── columns: column18:18!null a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 a_new:15!null b_new:16!null c_new:17!null
+      ├── columns: d_comp:18!null a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 a_new:15!null b_new:16!null c_new:17!null
       ├── project
       │    ├── columns: a_new:15!null b_new:16!null c_new:17!null a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14
       │    ├── scan abcde
@@ -815,7 +815,7 @@ update abcde
       │         ├── 2 [as=b_new:16]
       │         └── 3 [as=c_new:17]
       └── projections
-           └── (b_new:16 + c_new:17) + 1 [as=column18:18]
+           └── (b_new:16 + c_new:17) + 1 [as=d_comp:18]
 
 build
 UPDATE abcde SET (c) = (NULL), (b, a) = (1, 2)
@@ -827,10 +827,10 @@ update abcde
  │    ├── a_new:17 => a:1
  │    ├── b_new:16 => b:2
  │    ├── c_new:15 => c:3
- │    ├── column18:18 => d:4
+ │    ├── d_comp:18 => d:4
  │    └── a_new:17 => e:5
  └── project
-      ├── columns: column18:18 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 c_new:15 b_new:16!null a_new:17!null
+      ├── columns: d_comp:18 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 c_new:15 b_new:16!null a_new:17!null
       ├── project
       │    ├── columns: c_new:15 b_new:16!null a_new:17!null a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14
       │    ├── scan abcde
@@ -845,7 +845,7 @@ update abcde
       │         ├── 1 [as=b_new:16]
       │         └── 2 [as=a_new:17]
       └── projections
-           └── (b_new:16 + c_new:15) + 1 [as=column18:18]
+           └── (b_new:16 + c_new:15) + 1 [as=d_comp:18]
 
 # Tuples + DEFAULT.
 build
@@ -857,9 +857,9 @@ update abcde
  ├── update-mapping:
  │    ├── b_new:15 => b:2
  │    ├── c_new:16 => c:3
- │    └── column17:17 => d:4
+ │    └── d_comp:17 => d:4
  └── project
-      ├── columns: column17:17 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 b_new:15 c_new:16!null
+      ├── columns: d_comp:17 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 b_new:15 c_new:16!null
       ├── project
       │    ├── columns: b_new:15 c_new:16!null a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14
       │    ├── scan abcde
@@ -873,7 +873,7 @@ update abcde
       │         ├── NULL::INT8 [as=b_new:15]
       │         └── 10 [as=c_new:16]
       └── projections
-           └── (b_new:15 + c_new:16) + 1 [as=column17:17]
+           └── (b_new:15 + c_new:16) + 1 [as=d_comp:17]
 
 # Tuples + non-null DEFAULT.
 build
@@ -885,10 +885,10 @@ update abcde
  ├── update-mapping:
  │    ├── a_new:15 => a:1
  │    ├── a_new:15 => b:2
- │    ├── column16:16 => d:4
+ │    ├── d_comp:16 => d:4
  │    └── a_new:15 => e:5
  └── project
-      ├── columns: column16:16 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 a_new:15
+      ├── columns: d_comp:16 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 a_new:15
       ├── project
       │    ├── columns: a_new:15 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14
       │    ├── scan abcde
@@ -901,7 +901,7 @@ update abcde
       │    └── projections
       │         └── NULL::INT8 [as=a_new:15]
       └── projections
-           └── (a_new:15 + c:10) + 1 [as=column16:16]
+           └── (a_new:15 + c:10) + 1 [as=d_comp:16]
 
 build
 UPDATE abcde SET (a, b)=(1, 2, 3)
@@ -938,7 +938,7 @@ update abcde
  │    ├── one:15 => a:1
  │    └── one:15 => e:5
  └── project
-      ├── columns: column16:16 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 one:15
+      ├── columns: d_comp:16 a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 one:15
       ├── left-join-apply
       │    ├── columns: a:8!null b:9 c:10 d:11 e:12 rowid:13!null crdb_internal_mvcc_timestamp:14 one:15
       │    ├── scan abcde
@@ -958,7 +958,7 @@ update abcde
       │    │              └── 1 [as=one:15]
       │    └── filters (true)
       └── projections
-           └── (b:9 + c:10) + 1 [as=column16:16]
+           └── (b:9 + c:10) + 1 [as=d_comp:16]
 
 # Update all updatable columns.
 build
@@ -971,11 +971,11 @@ update abcde
  │    ├── x:19 => a:1
  │    ├── y:16 => b:2
  │    ├── z:20 => c:3
- │    ├── column22:22 => d:4
+ │    ├── d_comp:22 => d:4
  │    ├── x:19 => e:5
  │    └── y1:21 => rowid:6
  └── project
-      ├── columns: column22:22 a:8!null b:9 c:10 d:11 e:12 rowid:13!null abcde.crdb_internal_mvcc_timestamp:14 y:16 x:19 z:20 y1:21
+      ├── columns: d_comp:22 a:8!null b:9 c:10 d:11 e:12 rowid:13!null abcde.crdb_internal_mvcc_timestamp:14 y:16 x:19 z:20 y1:21
       ├── left-join-apply
       │    ├── columns: a:8!null b:9 c:10 d:11 e:12 rowid:13!null abcde.crdb_internal_mvcc_timestamp:14 y:16 x:19 z:20 y1:21
       │    ├── scan abcde
@@ -997,7 +997,7 @@ update abcde
       │    │              └── y:16 + 1 [as=y1:21]
       │    └── filters (true)
       └── projections
-           └── (y:16 + z:20) + 1 [as=column22:22]
+           └── (y:16 + z:20) + 1 [as=d_comp:22]
 
 # Update using combination of subquery and tuple SET expressions.
 build
@@ -1010,11 +1010,11 @@ update abcde
  │    ├── y:16 => a:1
  │    ├── y1:19 => b:2
  │    ├── c_new:20 => c:3
- │    ├── column22:22 => d:4
+ │    ├── d_comp:22 => d:4
  │    ├── y:16 => e:5
  │    └── rowid_new:21 => rowid:6
  └── project
-      ├── columns: column22:22 a:8!null b:9 c:10 d:11 e:12 rowid:13!null abcde.crdb_internal_mvcc_timestamp:14 y:16 y1:19 c_new:20!null rowid_new:21!null
+      ├── columns: d_comp:22 a:8!null b:9 c:10 d:11 e:12 rowid:13!null abcde.crdb_internal_mvcc_timestamp:14 y:16 y1:19 c_new:20!null rowid_new:21!null
       ├── project
       │    ├── columns: c_new:20!null rowid_new:21!null a:8!null b:9 c:10 d:11 e:12 rowid:13!null abcde.crdb_internal_mvcc_timestamp:14 y:16 y1:19
       │    ├── left-join-apply
@@ -1039,7 +1039,7 @@ update abcde
       │         ├── 1 [as=c_new:20]
       │         └── 2 [as=rowid_new:21]
       └── projections
-           └── (y1:19 + c_new:20) + 1 [as=column22:22]
+           └── (y1:19 + c_new:20) + 1 [as=d_comp:22]
 
 # Use subquery SET expression after other expressions.
 build
@@ -1052,11 +1052,11 @@ update abcde
  │    ├── a_new:20 => a:1
  │    ├── b_new:21 => b:2
  │    ├── y:16 => c:3
- │    ├── column22:22 => d:4
+ │    ├── d_comp:22 => d:4
  │    ├── a_new:20 => e:5
  │    └── y1:19 => rowid:6
  └── project
-      ├── columns: column22:22 a:8!null b:9 c:10 d:11 e:12 rowid:13!null abcde.crdb_internal_mvcc_timestamp:14 y:16 y1:19 a_new:20!null b_new:21!null
+      ├── columns: d_comp:22 a:8!null b:9 c:10 d:11 e:12 rowid:13!null abcde.crdb_internal_mvcc_timestamp:14 y:16 y1:19 a_new:20!null b_new:21!null
       ├── project
       │    ├── columns: a_new:20!null b_new:21!null a:8!null b:9 c:10 d:11 e:12 rowid:13!null abcde.crdb_internal_mvcc_timestamp:14 y:16 y1:19
       │    ├── left-join-apply
@@ -1081,7 +1081,7 @@ update abcde
       │         ├── 1 [as=a_new:20]
       │         └── 2 [as=b_new:21]
       └── projections
-           └── (b_new:21 + y:16) + 1 [as=column22:22]
+           └── (b_new:21 + y:16) + 1 [as=d_comp:22]
 
 # Multiple subqueries in SET expressions.
 build
@@ -1094,11 +1094,11 @@ update abcde
  │    ├── y1:19 => a:1
  │    ├── y:16 => b:2
  │    ├── one:20 => c:3
- │    ├── column22:22 => d:4
+ │    ├── d_comp:22 => d:4
  │    ├── y1:19 => e:5
  │    └── two:21 => rowid:6
  └── project
-      ├── columns: column22:22 a:8!null b:9 c:10 d:11 e:12 rowid:13!null abcde.crdb_internal_mvcc_timestamp:14 y:16 y1:19 one:20 two:21
+      ├── columns: d_comp:22 a:8!null b:9 c:10 d:11 e:12 rowid:13!null abcde.crdb_internal_mvcc_timestamp:14 y:16 y1:19 one:20 two:21
       ├── left-join-apply
       │    ├── columns: a:8!null b:9 c:10 d:11 e:12 rowid:13!null abcde.crdb_internal_mvcc_timestamp:14 y:16 y1:19 one:20 two:21
       │    ├── left-join-apply
@@ -1130,7 +1130,7 @@ update abcde
       │    │              └── 2 [as=two:21]
       │    └── filters (true)
       └── projections
-           └── (y:16 + one:20) + 1 [as=column22:22]
+           └── (y:16 + one:20) + 1 [as=d_comp:22]
 
 # Incorporate desired types when compiling subquery.
 build
@@ -1173,9 +1173,9 @@ project
       ├── fetch columns: abcde1.a:8 abcde1.b:9 abcde1.c:10 abcde1.d:11 abcde1.e:12 abcde1.rowid:13
       ├── update-mapping:
       │    ├── b_new:22 => abcde1.b:2
-      │    └── column23:23 => abcde1.d:4
+      │    └── d_comp:23 => abcde1.d:4
       └── project
-           ├── columns: column23:23 abcde1.a:8!null abcde1.b:9 abcde1.c:10 abcde1.d:11 abcde1.e:12 abcde1.rowid:13!null abcde1.crdb_internal_mvcc_timestamp:14 b_new:22
+           ├── columns: d_comp:23 abcde1.a:8!null abcde1.b:9 abcde1.c:10 abcde1.d:11 abcde1.e:12 abcde1.rowid:13!null abcde1.crdb_internal_mvcc_timestamp:14 b_new:22
            ├── project
            │    ├── columns: b_new:22 abcde1.a:8!null abcde1.b:9 abcde1.c:10 abcde1.d:11 abcde1.e:12 abcde1.rowid:13!null abcde1.crdb_internal_mvcc_timestamp:14
            │    ├── scan abcde [as=abcde1]
@@ -1203,7 +1203,7 @@ project
            │                             └── filters
            │                                  └── abcde2.rowid:20 = abcde1.a:8
            └── projections
-                └── (b_new:22 + abcde1.c:10) + 1 [as=column23:23]
+                └── (b_new:22 + abcde1.c:10) + 1 [as=d_comp:23]
 
 # Too many values.
 build
@@ -1247,10 +1247,10 @@ with &1 (cte)
       ├── fetch columns: a:12 b:13 c:14 d:15 e:16 rowid:17
       ├── update-mapping:
       │    ├── b:13 => a:5
-      │    ├── column20:20 => d:8
+      │    ├── d_comp:20 => d:8
       │    └── b:13 => e:9
       └── project
-           ├── columns: column20:20 a:12!null b:13 c:14 d:15 e:16 rowid:17!null abcde.crdb_internal_mvcc_timestamp:18
+           ├── columns: d_comp:20 a:12!null b:13 c:14 d:15 e:16 rowid:17!null abcde.crdb_internal_mvcc_timestamp:18
            ├── select
            │    ├── columns: a:12!null b:13 c:14 d:15 e:16 rowid:17!null abcde.crdb_internal_mvcc_timestamp:18
            │    ├── scan abcde
@@ -1267,7 +1267,7 @@ with &1 (cte)
            │                   └── mapping:
            │                        └──  xyz.x:1 => x:19
            └── projections
-                └── (b:13 + c:14) + 1 [as=column20:20]
+                └── (b:13 + c:14) + 1 [as=d_comp:20]
 
 # Use CTE within SET expression.
 build
@@ -1286,10 +1286,10 @@ with &1 (a)
       ├── update-mapping:
       │    ├── y:20 => a:6
       │    ├── y1:21 => b:7
-      │    ├── column22:22 => d:9
+      │    ├── d_comp:22 => d:9
       │    └── y:20 => e:10
       └── project
-           ├── columns: column22:22 a:13!null b:14 c:15 d:16 e:17 rowid:18!null abcde.crdb_internal_mvcc_timestamp:19 y:20 y1:21
+           ├── columns: d_comp:22 a:13!null b:14 c:15 d:16 e:17 rowid:18!null abcde.crdb_internal_mvcc_timestamp:19 y:20 y1:21
            ├── left-join-apply
            │    ├── columns: a:13!null b:14 c:15 d:16 e:17 rowid:18!null abcde.crdb_internal_mvcc_timestamp:19 y:20 y1:21
            │    ├── scan abcde
@@ -1308,7 +1308,7 @@ with &1 (a)
            │    │              └──  y1:5 => y1:21
            │    └── filters (true)
            └── projections
-                └── (y1:21 + c:15) + 1 [as=column22:22]
+                └── (y1:21 + c:15) + 1 [as=d_comp:22]
 
 # ------------------------------------------------------------------------------
 # Tests with mutations.
@@ -1323,15 +1323,15 @@ update mutation
  ├── fetch columns: m:7 n:8 o:9 p:10 q:11
  ├── update-mapping:
  │    ├── m_new:13 => m:1
- │    ├── column14:14 => o:3
- │    └── column15:15 => p:4
+ │    ├── o_default:14 => o:3
+ │    └── p_comp:15 => p:4
  ├── check columns: check1:16
  └── project
-      ├── columns: check1:16!null m:7!null n:8 o:9 p:10 q:11 crdb_internal_mvcc_timestamp:12 m_new:13!null column14:14!null column15:15
+      ├── columns: check1:16!null m:7!null n:8 o:9 p:10 q:11 crdb_internal_mvcc_timestamp:12 m_new:13!null o_default:14!null p_comp:15
       ├── project
-      │    ├── columns: column15:15 m:7!null n:8 o:9 p:10 q:11 crdb_internal_mvcc_timestamp:12 m_new:13!null column14:14!null
+      │    ├── columns: p_comp:15 m:7!null n:8 o:9 p:10 q:11 crdb_internal_mvcc_timestamp:12 m_new:13!null o_default:14!null
       │    ├── project
-      │    │    ├── columns: column14:14!null m:7!null n:8 o:9 p:10 q:11 crdb_internal_mvcc_timestamp:12 m_new:13!null
+      │    │    ├── columns: o_default:14!null m:7!null n:8 o:9 p:10 q:11 crdb_internal_mvcc_timestamp:12 m_new:13!null
       │    │    ├── project
       │    │    │    ├── columns: m_new:13!null m:7!null n:8 o:9 p:10 q:11 crdb_internal_mvcc_timestamp:12
       │    │    │    ├── scan mutation
@@ -1341,9 +1341,9 @@ update mutation
       │    │    │    └── projections
       │    │    │         └── 1 [as=m_new:13]
       │    │    └── projections
-      │    │         └── 10 [as=column14:14]
+      │    │         └── 10 [as=o_default:14]
       │    └── projections
-      │         └── column14:14 + n:8 [as=column15:15]
+      │         └── o_default:14 + n:8 [as=p_comp:15]
       └── projections
            └── m_new:13 > 0 [as=check1:16]
 
@@ -1357,15 +1357,15 @@ update mutation
  ├── update-mapping:
  │    ├── m_new:13 => m:1
  │    ├── n_new:14 => n:2
- │    ├── column15:15 => o:3
- │    └── column16:16 => p:4
+ │    ├── o_default:15 => o:3
+ │    └── p_comp:16 => p:4
  ├── check columns: check1:17
  └── project
-      ├── columns: check1:17!null m:7!null n:8 o:9 p:10 q:11 crdb_internal_mvcc_timestamp:12 m_new:13!null n_new:14!null column15:15!null column16:16!null
+      ├── columns: check1:17!null m:7!null n:8 o:9 p:10 q:11 crdb_internal_mvcc_timestamp:12 m_new:13!null n_new:14!null o_default:15!null p_comp:16!null
       ├── project
-      │    ├── columns: column16:16!null m:7!null n:8 o:9 p:10 q:11 crdb_internal_mvcc_timestamp:12 m_new:13!null n_new:14!null column15:15!null
+      │    ├── columns: p_comp:16!null m:7!null n:8 o:9 p:10 q:11 crdb_internal_mvcc_timestamp:12 m_new:13!null n_new:14!null o_default:15!null
       │    ├── project
-      │    │    ├── columns: column15:15!null m:7!null n:8 o:9 p:10 q:11 crdb_internal_mvcc_timestamp:12 m_new:13!null n_new:14!null
+      │    │    ├── columns: o_default:15!null m:7!null n:8 o:9 p:10 q:11 crdb_internal_mvcc_timestamp:12 m_new:13!null n_new:14!null
       │    │    ├── project
       │    │    │    ├── columns: m_new:13!null n_new:14!null m:7!null n:8 o:9 p:10 q:11 crdb_internal_mvcc_timestamp:12
       │    │    │    ├── scan mutation
@@ -1376,9 +1376,9 @@ update mutation
       │    │    │         ├── 1 [as=m_new:13]
       │    │    │         └── 2 [as=n_new:14]
       │    │    └── projections
-      │    │         └── 10 [as=column15:15]
+      │    │         └── 10 [as=o_default:15]
       │    └── projections
-      │         └── column15:15 + n_new:14 [as=column16:16]
+      │         └── o_default:15 + n_new:14 [as=p_comp:16]
       └── projections
            └── m_new:13 > 0 [as=check1:17]
 
@@ -1391,15 +1391,15 @@ update mutation
  ├── fetch columns: m:7 n:8 o:9 p:10 q:11
  ├── update-mapping:
  │    ├── m_new:13 => m:1
- │    ├── column14:14 => o:3
- │    └── column15:15 => p:4
+ │    ├── o_default:14 => o:3
+ │    └── p_comp:15 => p:4
  ├── check columns: check1:16
  └── project
-      ├── columns: check1:16!null m:7!null n:8 o:9 p:10 q:11 crdb_internal_mvcc_timestamp:12 m_new:13!null column14:14!null column15:15
+      ├── columns: check1:16!null m:7!null n:8 o:9 p:10 q:11 crdb_internal_mvcc_timestamp:12 m_new:13!null o_default:14!null p_comp:15
       ├── project
-      │    ├── columns: column15:15 m:7!null n:8 o:9 p:10 q:11 crdb_internal_mvcc_timestamp:12 m_new:13!null column14:14!null
+      │    ├── columns: p_comp:15 m:7!null n:8 o:9 p:10 q:11 crdb_internal_mvcc_timestamp:12 m_new:13!null o_default:14!null
       │    ├── project
-      │    │    ├── columns: column14:14!null m:7!null n:8 o:9 p:10 q:11 crdb_internal_mvcc_timestamp:12 m_new:13!null
+      │    │    ├── columns: o_default:14!null m:7!null n:8 o:9 p:10 q:11 crdb_internal_mvcc_timestamp:12 m_new:13!null
       │    │    ├── project
       │    │    │    ├── columns: m_new:13!null m:7!null n:8 o:9 p:10 q:11 crdb_internal_mvcc_timestamp:12
       │    │    │    ├── limit
@@ -1418,9 +1418,9 @@ update mutation
       │    │    │    └── projections
       │    │    │         └── 1 [as=m_new:13]
       │    │    └── projections
-      │    │         └── 10 [as=column14:14]
+      │    │         └── 10 [as=o_default:14]
       │    └── projections
-      │         └── column14:14 + n:8 [as=column15:15]
+      │         └── o_default:14 + n:8 [as=p_comp:15]
       └── projections
            └── m_new:13 > 0 [as=check1:16]
 
@@ -1469,12 +1469,12 @@ update checks
  │    ├── a_new:11 => a:1
  │    ├── b_new:12 => b:2
  │    ├── c_new:13 => c:3
- │    └── column14:14 => d:4
+ │    └── d_comp:14 => d:4
  ├── check columns: check1:15 check2:16
  └── project
-      ├── columns: check1:15!null check2:16!null a:6!null b:7 c:8 d:9 crdb_internal_mvcc_timestamp:10 a_new:11!null b_new:12!null c_new:13!null column14:14!null
+      ├── columns: check1:15!null check2:16!null a:6!null b:7 c:8 d:9 crdb_internal_mvcc_timestamp:10 a_new:11!null b_new:12!null c_new:13!null d_comp:14!null
       ├── project
-      │    ├── columns: column14:14!null a:6!null b:7 c:8 d:9 crdb_internal_mvcc_timestamp:10 a_new:11!null b_new:12!null c_new:13!null
+      │    ├── columns: d_comp:14!null a:6!null b:7 c:8 d:9 crdb_internal_mvcc_timestamp:10 a_new:11!null b_new:12!null c_new:13!null
       │    ├── project
       │    │    ├── columns: a_new:11!null b_new:12!null c_new:13!null a:6!null b:7 c:8 d:9 crdb_internal_mvcc_timestamp:10
       │    │    ├── scan checks
@@ -1489,9 +1489,9 @@ update checks
       │    │         ├── 2 [as=b_new:12]
       │    │         └── 3 [as=c_new:13]
       │    └── projections
-      │         └── c_new:13 + 1 [as=column14:14]
+      │         └── c_new:13 + 1 [as=d_comp:14]
       └── projections
-           ├── b_new:12 < column14:14 [as=check1:15]
+           ├── b_new:12 < d_comp:14 [as=check1:15]
            └── a_new:11 > 0 [as=check2:16]
 
 # Do not update columns for one of the constraints.
@@ -1505,9 +1505,9 @@ update checks
  │    └── a_new:11 => a:1
  ├── check columns: check2:14
  └── project
-      ├── columns: check1:13 check2:14!null a:6!null b:7 c:8 d:9 crdb_internal_mvcc_timestamp:10 a_new:11!null column12:12
+      ├── columns: check1:13 check2:14!null a:6!null b:7 c:8 d:9 crdb_internal_mvcc_timestamp:10 a_new:11!null d_comp:12
       ├── project
-      │    ├── columns: column12:12 a:6!null b:7 c:8 d:9 crdb_internal_mvcc_timestamp:10 a_new:11!null
+      │    ├── columns: d_comp:12 a:6!null b:7 c:8 d:9 crdb_internal_mvcc_timestamp:10 a_new:11!null
       │    ├── project
       │    │    ├── columns: a_new:11!null a:6!null b:7 c:8 d:9 crdb_internal_mvcc_timestamp:10
       │    │    ├── scan checks
@@ -1520,7 +1520,7 @@ update checks
       │    │    └── projections
       │    │         └── 1 [as=a_new:11]
       │    └── projections
-      │         └── c:8 + 1 [as=column12:12]
+      │         └── c:8 + 1 [as=d_comp:12]
       └── projections
            ├── b:7 < d:9 [as=check1:13]
            └── a_new:11 > 0 [as=check2:14]
@@ -1536,9 +1536,9 @@ update checks
  │    └── b_new:11 => b:2
  ├── check columns: check1:13
  └── project
-      ├── columns: check1:13 check2:14!null a:6!null b:7 c:8 d:9 crdb_internal_mvcc_timestamp:10 b_new:11!null column12:12
+      ├── columns: check1:13 check2:14!null a:6!null b:7 c:8 d:9 crdb_internal_mvcc_timestamp:10 b_new:11!null d_comp:12
       ├── project
-      │    ├── columns: column12:12 a:6!null b:7 c:8 d:9 crdb_internal_mvcc_timestamp:10 b_new:11!null
+      │    ├── columns: d_comp:12 a:6!null b:7 c:8 d:9 crdb_internal_mvcc_timestamp:10 b_new:11!null
       │    ├── project
       │    │    ├── columns: b_new:11!null a:6!null b:7 c:8 d:9 crdb_internal_mvcc_timestamp:10
       │    │    ├── scan checks
@@ -1551,7 +1551,7 @@ update checks
       │    │    └── projections
       │    │         └── 2 [as=b_new:11]
       │    └── projections
-      │         └── c:8 + 1 [as=column12:12]
+      │         └── c:8 + 1 [as=d_comp:12]
       └── projections
            ├── b_new:11 < d:9 [as=check1:13]
            └── a:6 > 0 [as=check2:14]
@@ -1568,9 +1568,9 @@ update checks
  │    └── abcde.b:12 => checks.b:2
  ├── check columns: check1:19 check2:20
  └── project
-      ├── columns: check1:19 check2:20 checks.a:6!null checks.b:7 checks.c:8 checks.d:9 checks.crdb_internal_mvcc_timestamp:10 abcde.a:11 abcde.b:12 column18:18
+      ├── columns: check1:19 check2:20 checks.a:6!null checks.b:7 checks.c:8 checks.d:9 checks.crdb_internal_mvcc_timestamp:10 abcde.a:11 abcde.b:12 d_comp:18
       ├── project
-      │    ├── columns: column18:18 checks.a:6!null checks.b:7 checks.c:8 checks.d:9 checks.crdb_internal_mvcc_timestamp:10 abcde.a:11 abcde.b:12
+      │    ├── columns: d_comp:18 checks.a:6!null checks.b:7 checks.c:8 checks.d:9 checks.crdb_internal_mvcc_timestamp:10 abcde.a:11 abcde.b:12
       │    ├── left-join-apply
       │    │    ├── columns: checks.a:6!null checks.b:7 checks.c:8 checks.d:9 checks.crdb_internal_mvcc_timestamp:10 abcde.a:11 abcde.b:12
       │    │    ├── scan checks
@@ -1597,7 +1597,7 @@ update checks
       │    │    │                   └── abcde.a:11 = checks.a:6
       │    │    └── filters (true)
       │    └── projections
-      │         └── checks.c:8 + 1 [as=column18:18]
+      │         └── checks.c:8 + 1 [as=d_comp:18]
       └── projections
            ├── abcde.b:12 < checks.d:9 [as=check1:19]
            └── abcde.a:11 > 0 [as=check2:20]
@@ -1611,26 +1611,26 @@ UPDATE decimals SET a=1.1, b=ARRAY[0.95, NULL, 15]
 ----
 update decimals
  ├── columns: <none>
- ├── fetch columns: a:6 b:7 c:8 decimals.d:9
+ ├── fetch columns: a:6 b:7 c:8 d:9
  ├── update-mapping:
  │    ├── a_new:13 => a:1
  │    ├── b_new:14 => b:2
- │    └── d:16 => decimals.d:4
+ │    └── d_comp:16 => d:4
  ├── check columns: check1:17 check2:18
  └── project
-      ├── columns: check1:17 check2:18 a:6!null b:7 c:8 decimals.d:9 crdb_internal_mvcc_timestamp:10 a_new:13 b_new:14 d:16
+      ├── columns: check1:17 check2:18 a:6!null b:7 c:8 d:9 crdb_internal_mvcc_timestamp:10 a_new:13 b_new:14 d_comp:16
       ├── project
-      │    ├── columns: d:16 a:6!null b:7 c:8 decimals.d:9 crdb_internal_mvcc_timestamp:10 a_new:13 b_new:14
+      │    ├── columns: d_comp:16 a:6!null b:7 c:8 d:9 crdb_internal_mvcc_timestamp:10 a_new:13 b_new:14
       │    ├── project
-      │    │    ├── columns: column15:15 a:6!null b:7 c:8 decimals.d:9 crdb_internal_mvcc_timestamp:10 a_new:13 b_new:14
+      │    │    ├── columns: d_comp:15 a:6!null b:7 c:8 d:9 crdb_internal_mvcc_timestamp:10 a_new:13 b_new:14
       │    │    ├── project
-      │    │    │    ├── columns: a_new:13 b_new:14 a:6!null b:7 c:8 decimals.d:9 crdb_internal_mvcc_timestamp:10
+      │    │    │    ├── columns: a_new:13 b_new:14 a:6!null b:7 c:8 d:9 crdb_internal_mvcc_timestamp:10
       │    │    │    ├── project
-      │    │    │    │    ├── columns: a_new:11!null b_new:12 a:6!null b:7 c:8 decimals.d:9 crdb_internal_mvcc_timestamp:10
+      │    │    │    │    ├── columns: a_new:11!null b_new:12 a:6!null b:7 c:8 d:9 crdb_internal_mvcc_timestamp:10
       │    │    │    │    ├── scan decimals
-      │    │    │    │    │    ├── columns: a:6!null b:7 c:8 decimals.d:9 crdb_internal_mvcc_timestamp:10
+      │    │    │    │    │    ├── columns: a:6!null b:7 c:8 d:9 crdb_internal_mvcc_timestamp:10
       │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │         └── decimals.d:9
+      │    │    │    │    │         └── d:9
       │    │    │    │    │              └── a:6::DECIMAL + c:8::DECIMAL
       │    │    │    │    └── projections
       │    │    │    │         ├── 1.1 [as=a_new:11]
@@ -1639,9 +1639,9 @@ update decimals
       │    │    │         ├── crdb_internal.round_decimal_values(a_new:11, 0) [as=a_new:13]
       │    │    │         └── crdb_internal.round_decimal_values(b_new:12, 1) [as=b_new:14]
       │    │    └── projections
-      │    │         └── a_new:13 + c:8::DECIMAL [as=column15:15]
+      │    │         └── a_new:13 + c:8::DECIMAL [as=d_comp:15]
       │    └── projections
-      │         └── crdb_internal.round_decimal_values(column15:15, 1) [as=d:16]
+      │         └── crdb_internal.round_decimal_values(d_comp:15, 1) [as=d_comp:16]
       └── projections
            ├── round(a_new:13) = a_new:13 [as=check1:17]
            └── b_new:14[0] > 1 [as=check2:18]

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -1611,37 +1611,37 @@ UPDATE decimals SET a=1.1, b=ARRAY[0.95, NULL, 15]
 ----
 update decimals
  ├── columns: <none>
- ├── fetch columns: decimals.a:6 decimals.b:7 c:8 decimals.d:9
+ ├── fetch columns: a:6 b:7 c:8 decimals.d:9
  ├── update-mapping:
- │    ├── a:13 => decimals.a:1
- │    ├── b:14 => decimals.b:2
+ │    ├── a_new:13 => a:1
+ │    ├── b_new:14 => b:2
  │    └── d:16 => decimals.d:4
  ├── check columns: check1:17 check2:18
  └── project
-      ├── columns: check1:17 check2:18 decimals.a:6!null decimals.b:7 c:8 decimals.d:9 crdb_internal_mvcc_timestamp:10 a:13 b:14 d:16
+      ├── columns: check1:17 check2:18 a:6!null b:7 c:8 decimals.d:9 crdb_internal_mvcc_timestamp:10 a_new:13 b_new:14 d:16
       ├── project
-      │    ├── columns: d:16 decimals.a:6!null decimals.b:7 c:8 decimals.d:9 crdb_internal_mvcc_timestamp:10 a:13 b:14
+      │    ├── columns: d:16 a:6!null b:7 c:8 decimals.d:9 crdb_internal_mvcc_timestamp:10 a_new:13 b_new:14
       │    ├── project
-      │    │    ├── columns: column15:15 decimals.a:6!null decimals.b:7 c:8 decimals.d:9 crdb_internal_mvcc_timestamp:10 a:13 b:14
+      │    │    ├── columns: column15:15 a:6!null b:7 c:8 decimals.d:9 crdb_internal_mvcc_timestamp:10 a_new:13 b_new:14
       │    │    ├── project
-      │    │    │    ├── columns: a:13 b:14 decimals.a:6!null decimals.b:7 c:8 decimals.d:9 crdb_internal_mvcc_timestamp:10
+      │    │    │    ├── columns: a_new:13 b_new:14 a:6!null b:7 c:8 decimals.d:9 crdb_internal_mvcc_timestamp:10
       │    │    │    ├── project
-      │    │    │    │    ├── columns: a_new:11!null b_new:12 decimals.a:6!null decimals.b:7 c:8 decimals.d:9 crdb_internal_mvcc_timestamp:10
+      │    │    │    │    ├── columns: a_new:11!null b_new:12 a:6!null b:7 c:8 decimals.d:9 crdb_internal_mvcc_timestamp:10
       │    │    │    │    ├── scan decimals
-      │    │    │    │    │    ├── columns: decimals.a:6!null decimals.b:7 c:8 decimals.d:9 crdb_internal_mvcc_timestamp:10
+      │    │    │    │    │    ├── columns: a:6!null b:7 c:8 decimals.d:9 crdb_internal_mvcc_timestamp:10
       │    │    │    │    │    └── computed column expressions
       │    │    │    │    │         └── decimals.d:9
-      │    │    │    │    │              └── decimals.a:6::DECIMAL + c:8::DECIMAL
+      │    │    │    │    │              └── a:6::DECIMAL + c:8::DECIMAL
       │    │    │    │    └── projections
       │    │    │    │         ├── 1.1 [as=a_new:11]
       │    │    │    │         └── ARRAY[0.95,NULL,15] [as=b_new:12]
       │    │    │    └── projections
-      │    │    │         ├── crdb_internal.round_decimal_values(a_new:11, 0) [as=a:13]
-      │    │    │         └── crdb_internal.round_decimal_values(b_new:12, 1) [as=b:14]
+      │    │    │         ├── crdb_internal.round_decimal_values(a_new:11, 0) [as=a_new:13]
+      │    │    │         └── crdb_internal.round_decimal_values(b_new:12, 1) [as=b_new:14]
       │    │    └── projections
-      │    │         └── a:13 + c:8::DECIMAL [as=column15:15]
+      │    │         └── a_new:13 + c:8::DECIMAL [as=column15:15]
       │    └── projections
       │         └── crdb_internal.round_decimal_values(column15:15, 1) [as=d:16]
       └── projections
-           ├── round(a:13) = a:13 [as=check1:17]
-           └── b:14[0] > 1 [as=check2:18]
+           ├── round(a_new:13) = a_new:13 [as=check1:17]
+           └── b_new:14[0] > 1 [as=check2:18]

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -92,40 +92,40 @@ upsert abc
  ├── insert-mapping:
  │    ├── x:6 => a:1
  │    ├── y:7 => b:2
- │    ├── column11:11 => c:3
- │    └── column10:10 => rowid:4
+ │    ├── c_comp:11 => c:3
+ │    └── rowid_default:10 => rowid:4
  ├── update-mapping:
  │    └── upsert_a:19 => a:1
  └── project
-      ├── columns: upsert_a:19!null upsert_b:20 upsert_c:21 upsert_rowid:22 x:6!null y:7 column10:10 column11:11 a:12 b:13 c:14 rowid:15 abc.crdb_internal_mvcc_timestamp:16 a_new:17!null column18:18
+      ├── columns: upsert_a:19!null upsert_b:20 upsert_c:21 upsert_rowid:22 x:6!null y:7 rowid_default:10 c_comp:11 a:12 b:13 c:14 rowid:15 abc.crdb_internal_mvcc_timestamp:16 a_new:17!null c_comp:18
       ├── project
-      │    ├── columns: column18:18 x:6!null y:7 column10:10 column11:11 a:12 b:13 c:14 rowid:15 abc.crdb_internal_mvcc_timestamp:16 a_new:17!null
+      │    ├── columns: c_comp:18 x:6!null y:7 rowid_default:10 c_comp:11 a:12 b:13 c:14 rowid:15 abc.crdb_internal_mvcc_timestamp:16 a_new:17!null
       │    ├── project
-      │    │    ├── columns: a_new:17!null x:6!null y:7 column10:10 column11:11 a:12 b:13 c:14 rowid:15 abc.crdb_internal_mvcc_timestamp:16
+      │    │    ├── columns: a_new:17!null x:6!null y:7 rowid_default:10 c_comp:11 a:12 b:13 c:14 rowid:15 abc.crdb_internal_mvcc_timestamp:16
       │    │    ├── left-join (hash)
-      │    │    │    ├── columns: x:6!null y:7 column10:10 column11:11 a:12 b:13 c:14 rowid:15 abc.crdb_internal_mvcc_timestamp:16
+      │    │    │    ├── columns: x:6!null y:7 rowid_default:10 c_comp:11 a:12 b:13 c:14 rowid:15 abc.crdb_internal_mvcc_timestamp:16
       │    │    │    ├── ensure-upsert-distinct-on
-      │    │    │    │    ├── columns: x:6!null y:7 column10:10 column11:11
+      │    │    │    │    ├── columns: x:6!null y:7 rowid_default:10 c_comp:11
       │    │    │    │    ├── grouping columns: x:6!null
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: column11:11 x:6!null y:7 column10:10
+      │    │    │    │    │    ├── columns: c_comp:11 x:6!null y:7 rowid_default:10
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: column10:10 x:6!null y:7
+      │    │    │    │    │    │    ├── columns: rowid_default:10 x:6!null y:7
       │    │    │    │    │    │    ├── project
       │    │    │    │    │    │    │    ├── columns: x:6!null y:7
       │    │    │    │    │    │    │    └── scan xyz
       │    │    │    │    │    │    │         └── columns: x:6!null y:7 z:8 xyz.crdb_internal_mvcc_timestamp:9
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── unique_rowid() [as=column10:10]
+      │    │    │    │    │    │         └── unique_rowid() [as=rowid_default:10]
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── y:7 + 1 [as=column11:11]
+      │    │    │    │    │         └── y:7 + 1 [as=c_comp:11]
       │    │    │    │    └── aggregations
       │    │    │    │         ├── first-agg [as=y:7]
       │    │    │    │         │    └── y:7
-      │    │    │    │         ├── first-agg [as=column10:10]
-      │    │    │    │         │    └── column10:10
-      │    │    │    │         └── first-agg [as=column11:11]
-      │    │    │    │              └── column11:11
+      │    │    │    │         ├── first-agg [as=rowid_default:10]
+      │    │    │    │         │    └── rowid_default:10
+      │    │    │    │         └── first-agg [as=c_comp:11]
+      │    │    │    │              └── c_comp:11
       │    │    │    ├── scan abc
       │    │    │    │    ├── columns: a:12!null b:13 c:14 rowid:15!null abc.crdb_internal_mvcc_timestamp:16
       │    │    │    │    └── computed column expressions
@@ -136,12 +136,12 @@ upsert abc
       │    │    └── projections
       │    │         └── 5 [as=a_new:17]
       │    └── projections
-      │         └── b:13 + 1 [as=column18:18]
+      │         └── b:13 + 1 [as=c_comp:18]
       └── projections
            ├── CASE WHEN a:12 IS NULL THEN x:6 ELSE a_new:17 END [as=upsert_a:19]
            ├── CASE WHEN a:12 IS NULL THEN y:7 ELSE b:13 END [as=upsert_b:20]
-           ├── CASE WHEN a:12 IS NULL THEN column11:11 ELSE c:14 END [as=upsert_c:21]
-           └── CASE WHEN a:12 IS NULL THEN column10:10 ELSE rowid:15 END [as=upsert_rowid:22]
+           ├── CASE WHEN a:12 IS NULL THEN c_comp:11 ELSE c:14 END [as=upsert_c:21]
+           └── CASE WHEN a:12 IS NULL THEN rowid_default:10 ELSE rowid:15 END [as=upsert_rowid:22]
 
 # Set all columns, multi-column conflict.
 build
@@ -161,7 +161,7 @@ project
       ├── insert-mapping:
       │    ├── x:6 => a:1
       │    ├── y:7 => b:2
-      │    ├── column10:10 => c:3
+      │    ├── c_comp:10 => c:3
       │    └── z:8 => rowid:4
       ├── update-mapping:
       │    ├── upsert_a:20 => a:1
@@ -174,24 +174,24 @@ project
       │    ├── upsert_c:22 => c:3
       │    └── upsert_rowid:23 => rowid:4
       └── project
-           ├── columns: upsert_a:20!null upsert_b:21 upsert_c:22 upsert_rowid:23 x:6!null y:7 z:8 column10:10 a:11 b:12 c:13 rowid:14 abc.crdb_internal_mvcc_timestamp:15 a_new:16!null b_new:17!null rowid_new:18!null column19:19!null
+           ├── columns: upsert_a:20!null upsert_b:21 upsert_c:22 upsert_rowid:23 x:6!null y:7 z:8 c_comp:10 a:11 b:12 c:13 rowid:14 abc.crdb_internal_mvcc_timestamp:15 a_new:16!null b_new:17!null rowid_new:18!null c_comp:19!null
            ├── project
-           │    ├── columns: column19:19!null x:6!null y:7 z:8 column10:10 a:11 b:12 c:13 rowid:14 abc.crdb_internal_mvcc_timestamp:15 a_new:16!null b_new:17!null rowid_new:18!null
+           │    ├── columns: c_comp:19!null x:6!null y:7 z:8 c_comp:10 a:11 b:12 c:13 rowid:14 abc.crdb_internal_mvcc_timestamp:15 a_new:16!null b_new:17!null rowid_new:18!null
            │    ├── project
-           │    │    ├── columns: a_new:16!null b_new:17!null rowid_new:18!null x:6!null y:7 z:8 column10:10 a:11 b:12 c:13 rowid:14 abc.crdb_internal_mvcc_timestamp:15
+           │    │    ├── columns: a_new:16!null b_new:17!null rowid_new:18!null x:6!null y:7 z:8 c_comp:10 a:11 b:12 c:13 rowid:14 abc.crdb_internal_mvcc_timestamp:15
            │    │    ├── left-join (hash)
-           │    │    │    ├── columns: x:6!null y:7 z:8 column10:10 a:11 b:12 c:13 rowid:14 abc.crdb_internal_mvcc_timestamp:15
+           │    │    │    ├── columns: x:6!null y:7 z:8 c_comp:10 a:11 b:12 c:13 rowid:14 abc.crdb_internal_mvcc_timestamp:15
            │    │    │    ├── ensure-upsert-distinct-on
-           │    │    │    │    ├── columns: x:6!null y:7 z:8 column10:10
-           │    │    │    │    ├── grouping columns: y:7 column10:10
+           │    │    │    │    ├── columns: x:6!null y:7 z:8 c_comp:10
+           │    │    │    │    ├── grouping columns: y:7 c_comp:10
            │    │    │    │    ├── project
-           │    │    │    │    │    ├── columns: column10:10 x:6!null y:7 z:8
+           │    │    │    │    │    ├── columns: c_comp:10 x:6!null y:7 z:8
            │    │    │    │    │    ├── project
            │    │    │    │    │    │    ├── columns: x:6!null y:7 z:8
            │    │    │    │    │    │    └── scan xyz
            │    │    │    │    │    │         └── columns: x:6!null y:7 z:8 xyz.crdb_internal_mvcc_timestamp:9
            │    │    │    │    │    └── projections
-           │    │    │    │    │         └── y:7 + 1 [as=column10:10]
+           │    │    │    │    │         └── y:7 + 1 [as=c_comp:10]
            │    │    │    │    └── aggregations
            │    │    │    │         ├── first-agg [as=x:6]
            │    │    │    │         │    └── x:6
@@ -204,17 +204,17 @@ project
            │    │    │    │              └── b:12 + 1
            │    │    │    └── filters
            │    │    │         ├── y:7 = b:12
-           │    │    │         └── column10:10 = c:13
+           │    │    │         └── c_comp:10 = c:13
            │    │    └── projections
            │    │         ├── 1 [as=a_new:16]
            │    │         ├── 2 [as=b_new:17]
            │    │         └── 3 [as=rowid_new:18]
            │    └── projections
-           │         └── b_new:17 + 1 [as=column19:19]
+           │         └── b_new:17 + 1 [as=c_comp:19]
            └── projections
                 ├── CASE WHEN rowid:14 IS NULL THEN x:6 ELSE a_new:16 END [as=upsert_a:20]
                 ├── CASE WHEN rowid:14 IS NULL THEN y:7 ELSE b_new:17 END [as=upsert_b:21]
-                ├── CASE WHEN rowid:14 IS NULL THEN column10:10 ELSE column19:19 END [as=upsert_c:22]
+                ├── CASE WHEN rowid:14 IS NULL THEN c_comp:10 ELSE c_comp:19 END [as=upsert_c:22]
                 └── CASE WHEN rowid:14 IS NULL THEN z:8 ELSE rowid_new:18 END [as=upsert_rowid:23]
 
 # UPDATE + WHERE clause.
@@ -233,43 +233,43 @@ upsert abc
  ├── insert-mapping:
  │    ├── x:6 => a:1
  │    ├── y:7 => b:2
- │    ├── column11:11 => c:3
- │    └── column10:10 => rowid:4
+ │    ├── c_comp:11 => c:3
+ │    └── rowid_default:10 => rowid:4
  ├── update-mapping:
  │    ├── upsert_b:20 => b:2
  │    └── upsert_c:21 => c:3
  └── project
-      ├── columns: upsert_a:19 upsert_b:20 upsert_c:21 upsert_rowid:22 x:6!null y:7 column10:10 column11:11 a:12 b:13 c:14 rowid:15 abc.crdb_internal_mvcc_timestamp:16 b_new:17!null column18:18!null
+      ├── columns: upsert_a:19 upsert_b:20 upsert_c:21 upsert_rowid:22 x:6!null y:7 rowid_default:10 c_comp:11 a:12 b:13 c:14 rowid:15 abc.crdb_internal_mvcc_timestamp:16 b_new:17!null c_comp:18!null
       ├── project
-      │    ├── columns: column18:18!null x:6!null y:7 column10:10 column11:11 a:12 b:13 c:14 rowid:15 abc.crdb_internal_mvcc_timestamp:16 b_new:17!null
+      │    ├── columns: c_comp:18!null x:6!null y:7 rowid_default:10 c_comp:11 a:12 b:13 c:14 rowid:15 abc.crdb_internal_mvcc_timestamp:16 b_new:17!null
       │    ├── project
-      │    │    ├── columns: b_new:17!null x:6!null y:7 column10:10 column11:11 a:12 b:13 c:14 rowid:15 abc.crdb_internal_mvcc_timestamp:16
+      │    │    ├── columns: b_new:17!null x:6!null y:7 rowid_default:10 c_comp:11 a:12 b:13 c:14 rowid:15 abc.crdb_internal_mvcc_timestamp:16
       │    │    ├── select
-      │    │    │    ├── columns: x:6!null y:7 column10:10 column11:11 a:12 b:13 c:14 rowid:15 abc.crdb_internal_mvcc_timestamp:16
+      │    │    │    ├── columns: x:6!null y:7 rowid_default:10 c_comp:11 a:12 b:13 c:14 rowid:15 abc.crdb_internal_mvcc_timestamp:16
       │    │    │    ├── left-join (hash)
-      │    │    │    │    ├── columns: x:6!null y:7 column10:10 column11:11 a:12 b:13 c:14 rowid:15 abc.crdb_internal_mvcc_timestamp:16
+      │    │    │    │    ├── columns: x:6!null y:7 rowid_default:10 c_comp:11 a:12 b:13 c:14 rowid:15 abc.crdb_internal_mvcc_timestamp:16
       │    │    │    │    ├── ensure-upsert-distinct-on
-      │    │    │    │    │    ├── columns: x:6!null y:7 column10:10 column11:11
+      │    │    │    │    │    ├── columns: x:6!null y:7 rowid_default:10 c_comp:11
       │    │    │    │    │    ├── grouping columns: x:6!null
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: column11:11 x:6!null y:7 column10:10
+      │    │    │    │    │    │    ├── columns: c_comp:11 x:6!null y:7 rowid_default:10
       │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    ├── columns: column10:10 x:6!null y:7
+      │    │    │    │    │    │    │    ├── columns: rowid_default:10 x:6!null y:7
       │    │    │    │    │    │    │    ├── project
       │    │    │    │    │    │    │    │    ├── columns: x:6!null y:7
       │    │    │    │    │    │    │    │    └── scan xyz
       │    │    │    │    │    │    │    │         └── columns: x:6!null y:7 z:8 xyz.crdb_internal_mvcc_timestamp:9
       │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │         └── unique_rowid() [as=column10:10]
+      │    │    │    │    │    │    │         └── unique_rowid() [as=rowid_default:10]
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── y:7 + 1 [as=column11:11]
+      │    │    │    │    │    │         └── y:7 + 1 [as=c_comp:11]
       │    │    │    │    │    └── aggregations
       │    │    │    │    │         ├── first-agg [as=y:7]
       │    │    │    │    │         │    └── y:7
-      │    │    │    │    │         ├── first-agg [as=column10:10]
-      │    │    │    │    │         │    └── column10:10
-      │    │    │    │    │         └── first-agg [as=column11:11]
-      │    │    │    │    │              └── column11:11
+      │    │    │    │    │         ├── first-agg [as=rowid_default:10]
+      │    │    │    │    │         │    └── rowid_default:10
+      │    │    │    │    │         └── first-agg [as=c_comp:11]
+      │    │    │    │    │              └── c_comp:11
       │    │    │    │    ├── scan abc
       │    │    │    │    │    ├── columns: a:12!null b:13 c:14 rowid:15!null abc.crdb_internal_mvcc_timestamp:16
       │    │    │    │    │    └── computed column expressions
@@ -282,12 +282,12 @@ upsert abc
       │    │    └── projections
       │    │         └── 10 [as=b_new:17]
       │    └── projections
-      │         └── b_new:17 + 1 [as=column18:18]
+      │         └── b_new:17 + 1 [as=c_comp:18]
       └── projections
            ├── CASE WHEN a:12 IS NULL THEN x:6 ELSE a:12 END [as=upsert_a:19]
            ├── CASE WHEN a:12 IS NULL THEN y:7 ELSE b_new:17 END [as=upsert_b:20]
-           ├── CASE WHEN a:12 IS NULL THEN column11:11 ELSE column18:18 END [as=upsert_c:21]
-           └── CASE WHEN a:12 IS NULL THEN column10:10 ELSE rowid:15 END [as=upsert_rowid:22]
+           ├── CASE WHEN a:12 IS NULL THEN c_comp:11 ELSE c_comp:18 END [as=upsert_c:21]
+           └── CASE WHEN a:12 IS NULL THEN rowid_default:10 ELSE rowid:15 END [as=upsert_rowid:22]
 
 # Use RETURNING INSERT..ON CONFLICT as a FROM clause.
 build
@@ -310,8 +310,8 @@ sort
       │         ├── insert-mapping:
       │         │    ├── column1:6 => abc.a:1
       │         │    ├── column2:7 => abc.b:2
-      │         │    ├── column9:9 => abc.c:3
-      │         │    └── column8:8 => rowid:4
+      │         │    ├── c_comp:9 => abc.c:3
+      │         │    └── rowid_default:8 => rowid:4
       │         ├── update-mapping:
       │         │    ├── upsert_b:18 => abc.b:2
       │         │    └── upsert_c:19 => abc.c:3
@@ -321,35 +321,35 @@ sort
       │         │    ├── upsert_c:19 => abc.c:3
       │         │    └── upsert_rowid:20 => rowid:4
       │         └── project
-      │              ├── columns: upsert_a:17 upsert_b:18!null upsert_c:19!null upsert_rowid:20 column1:6!null column2:7!null column8:8 column9:9!null abc.a:10 abc.b:11 abc.c:12 rowid:13 crdb_internal_mvcc_timestamp:14 b_new:15!null column16:16!null
+      │              ├── columns: upsert_a:17 upsert_b:18!null upsert_c:19!null upsert_rowid:20 column1:6!null column2:7!null rowid_default:8 c_comp:9!null abc.a:10 abc.b:11 abc.c:12 rowid:13 crdb_internal_mvcc_timestamp:14 b_new:15!null c_comp:16!null
       │              ├── project
-      │              │    ├── columns: column16:16!null column1:6!null column2:7!null column8:8 column9:9!null abc.a:10 abc.b:11 abc.c:12 rowid:13 crdb_internal_mvcc_timestamp:14 b_new:15!null
+      │              │    ├── columns: c_comp:16!null column1:6!null column2:7!null rowid_default:8 c_comp:9!null abc.a:10 abc.b:11 abc.c:12 rowid:13 crdb_internal_mvcc_timestamp:14 b_new:15!null
       │              │    ├── project
-      │              │    │    ├── columns: b_new:15!null column1:6!null column2:7!null column8:8 column9:9!null abc.a:10 abc.b:11 abc.c:12 rowid:13 crdb_internal_mvcc_timestamp:14
+      │              │    │    ├── columns: b_new:15!null column1:6!null column2:7!null rowid_default:8 c_comp:9!null abc.a:10 abc.b:11 abc.c:12 rowid:13 crdb_internal_mvcc_timestamp:14
       │              │    │    ├── left-join (hash)
-      │              │    │    │    ├── columns: column1:6!null column2:7!null column8:8 column9:9!null abc.a:10 abc.b:11 abc.c:12 rowid:13 crdb_internal_mvcc_timestamp:14
+      │              │    │    │    ├── columns: column1:6!null column2:7!null rowid_default:8 c_comp:9!null abc.a:10 abc.b:11 abc.c:12 rowid:13 crdb_internal_mvcc_timestamp:14
       │              │    │    │    ├── ensure-upsert-distinct-on
-      │              │    │    │    │    ├── columns: column1:6!null column2:7!null column8:8 column9:9!null
+      │              │    │    │    │    ├── columns: column1:6!null column2:7!null rowid_default:8 c_comp:9!null
       │              │    │    │    │    ├── grouping columns: column1:6!null
       │              │    │    │    │    ├── project
-      │              │    │    │    │    │    ├── columns: column9:9!null column1:6!null column2:7!null column8:8
+      │              │    │    │    │    │    ├── columns: c_comp:9!null column1:6!null column2:7!null rowid_default:8
       │              │    │    │    │    │    ├── project
-      │              │    │    │    │    │    │    ├── columns: column8:8 column1:6!null column2:7!null
+      │              │    │    │    │    │    │    ├── columns: rowid_default:8 column1:6!null column2:7!null
       │              │    │    │    │    │    │    ├── values
       │              │    │    │    │    │    │    │    ├── columns: column1:6!null column2:7!null
       │              │    │    │    │    │    │    │    ├── (1, 2)
       │              │    │    │    │    │    │    │    └── (3, 4)
       │              │    │    │    │    │    │    └── projections
-      │              │    │    │    │    │    │         └── unique_rowid() [as=column8:8]
+      │              │    │    │    │    │    │         └── unique_rowid() [as=rowid_default:8]
       │              │    │    │    │    │    └── projections
-      │              │    │    │    │    │         └── column2:7 + 1 [as=column9:9]
+      │              │    │    │    │    │         └── column2:7 + 1 [as=c_comp:9]
       │              │    │    │    │    └── aggregations
       │              │    │    │    │         ├── first-agg [as=column2:7]
       │              │    │    │    │         │    └── column2:7
-      │              │    │    │    │         ├── first-agg [as=column8:8]
-      │              │    │    │    │         │    └── column8:8
-      │              │    │    │    │         └── first-agg [as=column9:9]
-      │              │    │    │    │              └── column9:9
+      │              │    │    │    │         ├── first-agg [as=rowid_default:8]
+      │              │    │    │    │         │    └── rowid_default:8
+      │              │    │    │    │         └── first-agg [as=c_comp:9]
+      │              │    │    │    │              └── c_comp:9
       │              │    │    │    ├── scan abc
       │              │    │    │    │    ├── columns: abc.a:10!null abc.b:11 abc.c:12 rowid:13!null crdb_internal_mvcc_timestamp:14
       │              │    │    │    │    └── computed column expressions
@@ -360,12 +360,12 @@ sort
       │              │    │    └── projections
       │              │    │         └── 1 [as=b_new:15]
       │              │    └── projections
-      │              │         └── b_new:15 + 1 [as=column16:16]
+      │              │         └── b_new:15 + 1 [as=c_comp:16]
       │              └── projections
       │                   ├── CASE WHEN abc.a:10 IS NULL THEN column1:6 ELSE abc.a:10 END [as=upsert_a:17]
       │                   ├── CASE WHEN abc.a:10 IS NULL THEN column2:7 ELSE b_new:15 END [as=upsert_b:18]
-      │                   ├── CASE WHEN abc.a:10 IS NULL THEN column9:9 ELSE column16:16 END [as=upsert_c:19]
-      │                   └── CASE WHEN abc.a:10 IS NULL THEN column8:8 ELSE rowid:13 END [as=upsert_rowid:20]
+      │                   ├── CASE WHEN abc.a:10 IS NULL THEN c_comp:9 ELSE c_comp:16 END [as=upsert_c:19]
+      │                   └── CASE WHEN abc.a:10 IS NULL THEN rowid_default:8 ELSE rowid:13 END [as=upsert_rowid:20]
       └── with-scan &1
            ├── columns: a:21!null b:22!null c:23!null
            └── mapping:
@@ -388,39 +388,39 @@ upsert abc [as=tab]
  ├── insert-mapping:
  │    ├── column1:6 => a:1
  │    ├── column2:7 => b:2
- │    ├── column9:9 => c:3
- │    └── column8:8 => rowid:4
+ │    ├── c_comp:9 => c:3
+ │    └── rowid_default:8 => rowid:4
  ├── update-mapping:
  │    └── upsert_a:17 => a:1
  └── project
-      ├── columns: upsert_a:17 upsert_b:18 upsert_c:19 upsert_rowid:20 column1:6!null column2:7!null column8:8 column9:9!null a:10 b:11 c:12 rowid:13 crdb_internal_mvcc_timestamp:14 a_new:15 column16:16
+      ├── columns: upsert_a:17 upsert_b:18 upsert_c:19 upsert_rowid:20 column1:6!null column2:7!null rowid_default:8 c_comp:9!null a:10 b:11 c:12 rowid:13 crdb_internal_mvcc_timestamp:14 a_new:15 c_comp:16
       ├── project
-      │    ├── columns: column16:16 column1:6!null column2:7!null column8:8 column9:9!null a:10 b:11 c:12 rowid:13 crdb_internal_mvcc_timestamp:14 a_new:15
+      │    ├── columns: c_comp:16 column1:6!null column2:7!null rowid_default:8 c_comp:9!null a:10 b:11 c:12 rowid:13 crdb_internal_mvcc_timestamp:14 a_new:15
       │    ├── project
-      │    │    ├── columns: a_new:15 column1:6!null column2:7!null column8:8 column9:9!null a:10 b:11 c:12 rowid:13 crdb_internal_mvcc_timestamp:14
+      │    │    ├── columns: a_new:15 column1:6!null column2:7!null rowid_default:8 c_comp:9!null a:10 b:11 c:12 rowid:13 crdb_internal_mvcc_timestamp:14
       │    │    ├── left-join (hash)
-      │    │    │    ├── columns: column1:6!null column2:7!null column8:8 column9:9!null a:10 b:11 c:12 rowid:13 crdb_internal_mvcc_timestamp:14
+      │    │    │    ├── columns: column1:6!null column2:7!null rowid_default:8 c_comp:9!null a:10 b:11 c:12 rowid:13 crdb_internal_mvcc_timestamp:14
       │    │    │    ├── ensure-upsert-distinct-on
-      │    │    │    │    ├── columns: column1:6!null column2:7!null column8:8 column9:9!null
+      │    │    │    │    ├── columns: column1:6!null column2:7!null rowid_default:8 c_comp:9!null
       │    │    │    │    ├── grouping columns: column1:6!null
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: column9:9!null column1:6!null column2:7!null column8:8
+      │    │    │    │    │    ├── columns: c_comp:9!null column1:6!null column2:7!null rowid_default:8
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: column8:8 column1:6!null column2:7!null
+      │    │    │    │    │    │    ├── columns: rowid_default:8 column1:6!null column2:7!null
       │    │    │    │    │    │    ├── values
       │    │    │    │    │    │    │    ├── columns: column1:6!null column2:7!null
       │    │    │    │    │    │    │    └── (1, 2)
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── unique_rowid() [as=column8:8]
+      │    │    │    │    │    │         └── unique_rowid() [as=rowid_default:8]
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── column2:7 + 1 [as=column9:9]
+      │    │    │    │    │         └── column2:7 + 1 [as=c_comp:9]
       │    │    │    │    └── aggregations
       │    │    │    │         ├── first-agg [as=column2:7]
       │    │    │    │         │    └── column2:7
-      │    │    │    │         ├── first-agg [as=column8:8]
-      │    │    │    │         │    └── column8:8
-      │    │    │    │         └── first-agg [as=column9:9]
-      │    │    │    │              └── column9:9
+      │    │    │    │         ├── first-agg [as=rowid_default:8]
+      │    │    │    │         │    └── rowid_default:8
+      │    │    │    │         └── first-agg [as=c_comp:9]
+      │    │    │    │              └── c_comp:9
       │    │    │    ├── scan abc [as=tab]
       │    │    │    │    ├── columns: a:10!null b:11 c:12 rowid:13!null crdb_internal_mvcc_timestamp:14
       │    │    │    │    └── computed column expressions
@@ -431,12 +431,12 @@ upsert abc [as=tab]
       │    │    └── projections
       │    │         └── a:10 * column1:6 [as=a_new:15]
       │    └── projections
-      │         └── b:11 + 1 [as=column16:16]
+      │         └── b:11 + 1 [as=c_comp:16]
       └── projections
            ├── CASE WHEN a:10 IS NULL THEN column1:6 ELSE a_new:15 END [as=upsert_a:17]
            ├── CASE WHEN a:10 IS NULL THEN column2:7 ELSE b:11 END [as=upsert_b:18]
-           ├── CASE WHEN a:10 IS NULL THEN column9:9 ELSE c:12 END [as=upsert_c:19]
-           └── CASE WHEN a:10 IS NULL THEN column8:8 ELSE rowid:13 END [as=upsert_rowid:20]
+           ├── CASE WHEN a:10 IS NULL THEN c_comp:9 ELSE c:12 END [as=upsert_c:19]
+           └── CASE WHEN a:10 IS NULL THEN rowid_default:8 ELSE rowid:13 END [as=upsert_rowid:20]
 
 # Conflict columns are in different order than index key columns.
 build
@@ -453,37 +453,37 @@ upsert abc
  ├── insert-mapping:
  │    ├── column1:6 => a:1
  │    ├── column2:7 => b:2
- │    ├── column9:9 => c:3
- │    └── column8:8 => rowid:4
+ │    ├── c_comp:9 => c:3
+ │    └── rowid_default:8 => rowid:4
  ├── update-mapping:
  │    └── upsert_a:17 => a:1
  └── project
-      ├── columns: upsert_a:17!null upsert_b:18 upsert_c:19 upsert_rowid:20 column1:6!null column2:7!null column8:8 column9:9!null a:10 b:11 c:12 rowid:13 crdb_internal_mvcc_timestamp:14 a_new:15!null column16:16
+      ├── columns: upsert_a:17!null upsert_b:18 upsert_c:19 upsert_rowid:20 column1:6!null column2:7!null rowid_default:8 c_comp:9!null a:10 b:11 c:12 rowid:13 crdb_internal_mvcc_timestamp:14 a_new:15!null c_comp:16
       ├── project
-      │    ├── columns: column16:16 column1:6!null column2:7!null column8:8 column9:9!null a:10 b:11 c:12 rowid:13 crdb_internal_mvcc_timestamp:14 a_new:15!null
+      │    ├── columns: c_comp:16 column1:6!null column2:7!null rowid_default:8 c_comp:9!null a:10 b:11 c:12 rowid:13 crdb_internal_mvcc_timestamp:14 a_new:15!null
       │    ├── project
-      │    │    ├── columns: a_new:15!null column1:6!null column2:7!null column8:8 column9:9!null a:10 b:11 c:12 rowid:13 crdb_internal_mvcc_timestamp:14
+      │    │    ├── columns: a_new:15!null column1:6!null column2:7!null rowid_default:8 c_comp:9!null a:10 b:11 c:12 rowid:13 crdb_internal_mvcc_timestamp:14
       │    │    ├── left-join (hash)
-      │    │    │    ├── columns: column1:6!null column2:7!null column8:8 column9:9!null a:10 b:11 c:12 rowid:13 crdb_internal_mvcc_timestamp:14
+      │    │    │    ├── columns: column1:6!null column2:7!null rowid_default:8 c_comp:9!null a:10 b:11 c:12 rowid:13 crdb_internal_mvcc_timestamp:14
       │    │    │    ├── ensure-upsert-distinct-on
-      │    │    │    │    ├── columns: column1:6!null column2:7!null column8:8 column9:9!null
-      │    │    │    │    ├── grouping columns: column2:7!null column9:9!null
+      │    │    │    │    ├── columns: column1:6!null column2:7!null rowid_default:8 c_comp:9!null
+      │    │    │    │    ├── grouping columns: column2:7!null c_comp:9!null
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: column9:9!null column1:6!null column2:7!null column8:8
+      │    │    │    │    │    ├── columns: c_comp:9!null column1:6!null column2:7!null rowid_default:8
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: column8:8 column1:6!null column2:7!null
+      │    │    │    │    │    │    ├── columns: rowid_default:8 column1:6!null column2:7!null
       │    │    │    │    │    │    ├── values
       │    │    │    │    │    │    │    ├── columns: column1:6!null column2:7!null
       │    │    │    │    │    │    │    └── (1, 2)
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── unique_rowid() [as=column8:8]
+      │    │    │    │    │    │         └── unique_rowid() [as=rowid_default:8]
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── column2:7 + 1 [as=column9:9]
+      │    │    │    │    │         └── column2:7 + 1 [as=c_comp:9]
       │    │    │    │    └── aggregations
       │    │    │    │         ├── first-agg [as=column1:6]
       │    │    │    │         │    └── column1:6
-      │    │    │    │         └── first-agg [as=column8:8]
-      │    │    │    │              └── column8:8
+      │    │    │    │         └── first-agg [as=rowid_default:8]
+      │    │    │    │              └── rowid_default:8
       │    │    │    ├── scan abc
       │    │    │    │    ├── columns: a:10!null b:11 c:12 rowid:13!null crdb_internal_mvcc_timestamp:14
       │    │    │    │    └── computed column expressions
@@ -491,16 +491,16 @@ upsert abc
       │    │    │    │              └── b:11 + 1
       │    │    │    └── filters
       │    │    │         ├── column2:7 = b:11
-      │    │    │         └── column9:9 = c:12
+      │    │    │         └── c_comp:9 = c:12
       │    │    └── projections
       │    │         └── 5 [as=a_new:15]
       │    └── projections
-      │         └── b:11 + 1 [as=column16:16]
+      │         └── b:11 + 1 [as=c_comp:16]
       └── projections
            ├── CASE WHEN rowid:13 IS NULL THEN column1:6 ELSE a_new:15 END [as=upsert_a:17]
            ├── CASE WHEN rowid:13 IS NULL THEN column2:7 ELSE b:11 END [as=upsert_b:18]
-           ├── CASE WHEN rowid:13 IS NULL THEN column9:9 ELSE c:12 END [as=upsert_c:19]
-           └── CASE WHEN rowid:13 IS NULL THEN column8:8 ELSE rowid:13 END [as=upsert_rowid:20]
+           ├── CASE WHEN rowid:13 IS NULL THEN c_comp:9 ELSE c:12 END [as=upsert_c:19]
+           └── CASE WHEN rowid:13 IS NULL THEN rowid_default:8 ELSE rowid:13 END [as=upsert_rowid:20]
 
 # Conflict columns don't match unique index (too few columns).
 build
@@ -787,41 +787,41 @@ upsert abc
  ├── insert-mapping:
  │    ├── column1:6 => a:1
  │    ├── column2:7 => b:2
- │    ├── column9:9 => c:3
- │    └── column8:8 => rowid:4
+ │    ├── c_comp:9 => c:3
+ │    └── rowid_default:8 => rowid:4
  ├── update-mapping:
  │    ├── upsert_a:21 => a:1
  │    ├── upsert_b:22 => b:2
  │    └── upsert_c:23 => c:3
  └── project
-      ├── columns: upsert_a:21 upsert_b:22 upsert_c:23 upsert_rowid:24 column1:6!null column2:7!null column8:8 column9:9!null a:10 b:11 c:12 rowid:13 abc.crdb_internal_mvcc_timestamp:14 x:15 "?column?":19 column20:20
+      ├── columns: upsert_a:21 upsert_b:22 upsert_c:23 upsert_rowid:24 column1:6!null column2:7!null rowid_default:8 c_comp:9!null a:10 b:11 c:12 rowid:13 abc.crdb_internal_mvcc_timestamp:14 x:15 "?column?":19 c_comp:20
       ├── project
-      │    ├── columns: column20:20 column1:6!null column2:7!null column8:8 column9:9!null a:10 b:11 c:12 rowid:13 abc.crdb_internal_mvcc_timestamp:14 x:15 "?column?":19
+      │    ├── columns: c_comp:20 column1:6!null column2:7!null rowid_default:8 c_comp:9!null a:10 b:11 c:12 rowid:13 abc.crdb_internal_mvcc_timestamp:14 x:15 "?column?":19
       │    ├── left-join-apply
-      │    │    ├── columns: column1:6!null column2:7!null column8:8 column9:9!null a:10 b:11 c:12 rowid:13 abc.crdb_internal_mvcc_timestamp:14 x:15 "?column?":19
+      │    │    ├── columns: column1:6!null column2:7!null rowid_default:8 c_comp:9!null a:10 b:11 c:12 rowid:13 abc.crdb_internal_mvcc_timestamp:14 x:15 "?column?":19
       │    │    ├── left-join (hash)
-      │    │    │    ├── columns: column1:6!null column2:7!null column8:8 column9:9!null a:10 b:11 c:12 rowid:13 abc.crdb_internal_mvcc_timestamp:14
+      │    │    │    ├── columns: column1:6!null column2:7!null rowid_default:8 c_comp:9!null a:10 b:11 c:12 rowid:13 abc.crdb_internal_mvcc_timestamp:14
       │    │    │    ├── ensure-upsert-distinct-on
-      │    │    │    │    ├── columns: column1:6!null column2:7!null column8:8 column9:9!null
+      │    │    │    │    ├── columns: column1:6!null column2:7!null rowid_default:8 c_comp:9!null
       │    │    │    │    ├── grouping columns: column1:6!null
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: column9:9!null column1:6!null column2:7!null column8:8
+      │    │    │    │    │    ├── columns: c_comp:9!null column1:6!null column2:7!null rowid_default:8
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: column8:8 column1:6!null column2:7!null
+      │    │    │    │    │    │    ├── columns: rowid_default:8 column1:6!null column2:7!null
       │    │    │    │    │    │    ├── values
       │    │    │    │    │    │    │    ├── columns: column1:6!null column2:7!null
       │    │    │    │    │    │    │    └── (1, 2)
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── unique_rowid() [as=column8:8]
+      │    │    │    │    │    │         └── unique_rowid() [as=rowid_default:8]
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── column2:7 + 1 [as=column9:9]
+      │    │    │    │    │         └── column2:7 + 1 [as=c_comp:9]
       │    │    │    │    └── aggregations
       │    │    │    │         ├── first-agg [as=column2:7]
       │    │    │    │         │    └── column2:7
-      │    │    │    │         ├── first-agg [as=column8:8]
-      │    │    │    │         │    └── column8:8
-      │    │    │    │         └── first-agg [as=column9:9]
-      │    │    │    │              └── column9:9
+      │    │    │    │         ├── first-agg [as=rowid_default:8]
+      │    │    │    │         │    └── rowid_default:8
+      │    │    │    │         └── first-agg [as=c_comp:9]
+      │    │    │    │              └── c_comp:9
       │    │    │    ├── scan abc
       │    │    │    │    ├── columns: a:10!null b:11 c:12 rowid:13!null abc.crdb_internal_mvcc_timestamp:14
       │    │    │    │    └── computed column expressions
@@ -843,12 +843,12 @@ upsert abc
       │    │    │              └── y:16 + column2:7 [as="?column?":19]
       │    │    └── filters (true)
       │    └── projections
-      │         └── x:15 + 1 [as=column20:20]
+      │         └── x:15 + 1 [as=c_comp:20]
       └── projections
            ├── CASE WHEN a:10 IS NULL THEN column1:6 ELSE "?column?":19 END [as=upsert_a:21]
            ├── CASE WHEN a:10 IS NULL THEN column2:7 ELSE x:15 END [as=upsert_b:22]
-           ├── CASE WHEN a:10 IS NULL THEN column9:9 ELSE column20:20 END [as=upsert_c:23]
-           └── CASE WHEN a:10 IS NULL THEN column8:8 ELSE rowid:13 END [as=upsert_rowid:24]
+           ├── CASE WHEN a:10 IS NULL THEN c_comp:9 ELSE c_comp:20 END [as=upsert_c:23]
+           └── CASE WHEN a:10 IS NULL THEN rowid_default:8 ELSE rowid:13 END [as=upsert_rowid:24]
 
 # Default expressions.
 build
@@ -865,41 +865,41 @@ upsert abc
  ├── insert-mapping:
  │    ├── column1:6 => a:1
  │    ├── column2:7 => b:2
- │    ├── column9:9 => c:3
- │    └── column8:8 => rowid:4
+ │    ├── c_comp:9 => c:3
+ │    └── rowid_default:8 => rowid:4
  ├── update-mapping:
  │    ├── upsert_a:18 => a:1
  │    ├── upsert_b:19 => b:2
  │    └── upsert_c:20 => c:3
  └── project
-      ├── columns: upsert_a:18 upsert_b:19!null upsert_c:20!null upsert_rowid:21 column1:6!null column2:7!null column8:8 column9:9!null a:10 b:11 c:12 rowid:13 crdb_internal_mvcc_timestamp:14 a_new:15 b_new:16!null column17:17!null
+      ├── columns: upsert_a:18 upsert_b:19!null upsert_c:20!null upsert_rowid:21 column1:6!null column2:7!null rowid_default:8 c_comp:9!null a:10 b:11 c:12 rowid:13 crdb_internal_mvcc_timestamp:14 a_new:15 b_new:16!null c_comp:17!null
       ├── project
-      │    ├── columns: column17:17!null column1:6!null column2:7!null column8:8 column9:9!null a:10 b:11 c:12 rowid:13 crdb_internal_mvcc_timestamp:14 a_new:15 b_new:16!null
+      │    ├── columns: c_comp:17!null column1:6!null column2:7!null rowid_default:8 c_comp:9!null a:10 b:11 c:12 rowid:13 crdb_internal_mvcc_timestamp:14 a_new:15 b_new:16!null
       │    ├── project
-      │    │    ├── columns: a_new:15 b_new:16!null column1:6!null column2:7!null column8:8 column9:9!null a:10 b:11 c:12 rowid:13 crdb_internal_mvcc_timestamp:14
+      │    │    ├── columns: a_new:15 b_new:16!null column1:6!null column2:7!null rowid_default:8 c_comp:9!null a:10 b:11 c:12 rowid:13 crdb_internal_mvcc_timestamp:14
       │    │    ├── left-join (hash)
-      │    │    │    ├── columns: column1:6!null column2:7!null column8:8 column9:9!null a:10 b:11 c:12 rowid:13 crdb_internal_mvcc_timestamp:14
+      │    │    │    ├── columns: column1:6!null column2:7!null rowid_default:8 c_comp:9!null a:10 b:11 c:12 rowid:13 crdb_internal_mvcc_timestamp:14
       │    │    │    ├── ensure-upsert-distinct-on
-      │    │    │    │    ├── columns: column1:6!null column2:7!null column8:8 column9:9!null
+      │    │    │    │    ├── columns: column1:6!null column2:7!null rowid_default:8 c_comp:9!null
       │    │    │    │    ├── grouping columns: column1:6!null
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: column9:9!null column1:6!null column2:7!null column8:8
+      │    │    │    │    │    ├── columns: c_comp:9!null column1:6!null column2:7!null rowid_default:8
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: column8:8 column1:6!null column2:7!null
+      │    │    │    │    │    │    ├── columns: rowid_default:8 column1:6!null column2:7!null
       │    │    │    │    │    │    ├── values
       │    │    │    │    │    │    │    ├── columns: column1:6!null column2:7!null
       │    │    │    │    │    │    │    └── (1, 2)
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── unique_rowid() [as=column8:8]
+      │    │    │    │    │    │         └── unique_rowid() [as=rowid_default:8]
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── column2:7 + 1 [as=column9:9]
+      │    │    │    │    │         └── column2:7 + 1 [as=c_comp:9]
       │    │    │    │    └── aggregations
       │    │    │    │         ├── first-agg [as=column2:7]
       │    │    │    │         │    └── column2:7
-      │    │    │    │         ├── first-agg [as=column8:8]
-      │    │    │    │         │    └── column8:8
-      │    │    │    │         └── first-agg [as=column9:9]
-      │    │    │    │              └── column9:9
+      │    │    │    │         ├── first-agg [as=rowid_default:8]
+      │    │    │    │         │    └── rowid_default:8
+      │    │    │    │         └── first-agg [as=c_comp:9]
+      │    │    │    │              └── c_comp:9
       │    │    │    ├── scan abc
       │    │    │    │    ├── columns: a:10!null b:11 c:12 rowid:13!null crdb_internal_mvcc_timestamp:14
       │    │    │    │    └── computed column expressions
@@ -911,12 +911,12 @@ upsert abc
       │    │         ├── NULL::INT8 [as=a_new:15]
       │    │         └── 10 [as=b_new:16]
       │    └── projections
-      │         └── b_new:16 + 1 [as=column17:17]
+      │         └── b_new:16 + 1 [as=c_comp:17]
       └── projections
            ├── CASE WHEN a:10 IS NULL THEN column1:6 ELSE a_new:15 END [as=upsert_a:18]
            ├── CASE WHEN a:10 IS NULL THEN column2:7 ELSE b_new:16 END [as=upsert_b:19]
-           ├── CASE WHEN a:10 IS NULL THEN column9:9 ELSE column17:17 END [as=upsert_c:20]
-           └── CASE WHEN a:10 IS NULL THEN column8:8 ELSE rowid:13 END [as=upsert_rowid:21]
+           ├── CASE WHEN a:10 IS NULL THEN c_comp:9 ELSE c_comp:17 END [as=upsert_c:20]
+           └── CASE WHEN a:10 IS NULL THEN rowid_default:8 ELSE rowid:13 END [as=upsert_rowid:21]
 
 # ------------------------------------------------------------------------------
 # Test mutation columns.
@@ -936,44 +936,44 @@ upsert mutation
  ├── insert-mapping:
  │    ├── column1:7 => m:1
  │    ├── column2:8 => n:2
- │    ├── column9:9 => o:3
- │    └── column10:10 => p:4
+ │    ├── o_default:9 => o:3
+ │    └── p_comp:10 => p:4
  ├── update-mapping:
  │    ├── upsert_m:19 => m:1
- │    ├── column9:9 => o:3
+ │    ├── o_default:9 => o:3
  │    └── upsert_p:21 => p:4
  ├── check columns: check1:22
  └── project
-      ├── columns: check1:22 column1:7!null column2:8!null column9:9!null column10:10!null m:11 n:12 o:13 p:14 q:15 crdb_internal_mvcc_timestamp:16 m_new:17 column18:18 upsert_m:19 upsert_n:20 upsert_p:21
+      ├── columns: check1:22 column1:7!null column2:8!null o_default:9!null p_comp:10!null m:11 n:12 o:13 p:14 q:15 crdb_internal_mvcc_timestamp:16 m_new:17 p_comp:18 upsert_m:19 upsert_n:20 upsert_p:21
       ├── project
-      │    ├── columns: upsert_m:19 upsert_n:20 upsert_p:21 column1:7!null column2:8!null column9:9!null column10:10!null m:11 n:12 o:13 p:14 q:15 crdb_internal_mvcc_timestamp:16 m_new:17 column18:18
+      │    ├── columns: upsert_m:19 upsert_n:20 upsert_p:21 column1:7!null column2:8!null o_default:9!null p_comp:10!null m:11 n:12 o:13 p:14 q:15 crdb_internal_mvcc_timestamp:16 m_new:17 p_comp:18
       │    ├── project
-      │    │    ├── columns: column18:18 column1:7!null column2:8!null column9:9!null column10:10!null m:11 n:12 o:13 p:14 q:15 crdb_internal_mvcc_timestamp:16 m_new:17
+      │    │    ├── columns: p_comp:18 column1:7!null column2:8!null o_default:9!null p_comp:10!null m:11 n:12 o:13 p:14 q:15 crdb_internal_mvcc_timestamp:16 m_new:17
       │    │    ├── project
-      │    │    │    ├── columns: m_new:17 column1:7!null column2:8!null column9:9!null column10:10!null m:11 n:12 o:13 p:14 q:15 crdb_internal_mvcc_timestamp:16
+      │    │    │    ├── columns: m_new:17 column1:7!null column2:8!null o_default:9!null p_comp:10!null m:11 n:12 o:13 p:14 q:15 crdb_internal_mvcc_timestamp:16
       │    │    │    ├── left-join (hash)
-      │    │    │    │    ├── columns: column1:7!null column2:8!null column9:9!null column10:10!null m:11 n:12 o:13 p:14 q:15 crdb_internal_mvcc_timestamp:16
+      │    │    │    │    ├── columns: column1:7!null column2:8!null o_default:9!null p_comp:10!null m:11 n:12 o:13 p:14 q:15 crdb_internal_mvcc_timestamp:16
       │    │    │    │    ├── ensure-upsert-distinct-on
-      │    │    │    │    │    ├── columns: column1:7!null column2:8!null column9:9!null column10:10!null
+      │    │    │    │    │    ├── columns: column1:7!null column2:8!null o_default:9!null p_comp:10!null
       │    │    │    │    │    ├── grouping columns: column1:7!null
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: column10:10!null column1:7!null column2:8!null column9:9!null
+      │    │    │    │    │    │    ├── columns: p_comp:10!null column1:7!null column2:8!null o_default:9!null
       │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    ├── columns: column9:9!null column1:7!null column2:8!null
+      │    │    │    │    │    │    │    ├── columns: o_default:9!null column1:7!null column2:8!null
       │    │    │    │    │    │    │    ├── values
       │    │    │    │    │    │    │    │    ├── columns: column1:7!null column2:8!null
       │    │    │    │    │    │    │    │    └── (1, 2)
       │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │         └── 10 [as=column9:9]
+      │    │    │    │    │    │    │         └── 10 [as=o_default:9]
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── column9:9 + column2:8 [as=column10:10]
+      │    │    │    │    │    │         └── o_default:9 + column2:8 [as=p_comp:10]
       │    │    │    │    │    └── aggregations
       │    │    │    │    │         ├── first-agg [as=column2:8]
       │    │    │    │    │         │    └── column2:8
-      │    │    │    │    │         ├── first-agg [as=column9:9]
-      │    │    │    │    │         │    └── column9:9
-      │    │    │    │    │         └── first-agg [as=column10:10]
-      │    │    │    │    │              └── column10:10
+      │    │    │    │    │         ├── first-agg [as=o_default:9]
+      │    │    │    │    │         │    └── o_default:9
+      │    │    │    │    │         └── first-agg [as=p_comp:10]
+      │    │    │    │    │              └── p_comp:10
       │    │    │    │    ├── scan mutation
       │    │    │    │    │    ├── columns: m:11!null n:12 o:13 p:14 q:15 crdb_internal_mvcc_timestamp:16
       │    │    │    │    │    └── check constraint expressions
@@ -983,11 +983,11 @@ upsert mutation
       │    │    │    └── projections
       │    │    │         └── m:11 + 1 [as=m_new:17]
       │    │    └── projections
-      │    │         └── column9:9 + n:12 [as=column18:18]
+      │    │         └── o_default:9 + n:12 [as=p_comp:18]
       │    └── projections
       │         ├── CASE WHEN m:11 IS NULL THEN column1:7 ELSE m_new:17 END [as=upsert_m:19]
       │         ├── CASE WHEN m:11 IS NULL THEN column2:8 ELSE n:12 END [as=upsert_n:20]
-      │         └── CASE WHEN m:11 IS NULL THEN column10:10 ELSE column18:18 END [as=upsert_p:21]
+      │         └── CASE WHEN m:11 IS NULL THEN p_comp:10 ELSE p_comp:18 END [as=upsert_p:21]
       └── projections
            └── upsert_m:19 > 0 [as=check1:22]
 
@@ -1006,28 +1006,28 @@ upsert xyz
  ├── fetch columns: x:7 y:8 z:9
  ├── insert-mapping:
  │    ├── column1:5 => x:1
- │    ├── column6:6 => y:2
- │    └── column6:6 => z:3
+ │    ├── y_default:6 => y:2
+ │    └── y_default:6 => z:3
  ├── update-mapping:
- │    ├── column6:6 => y:2
- │    └── column6:6 => z:3
+ │    ├── y_default:6 => y:2
+ │    └── y_default:6 => z:3
  └── project
-      ├── columns: upsert_x:11 column1:5!null column6:6 x:7 y:8 z:9 crdb_internal_mvcc_timestamp:10
+      ├── columns: upsert_x:11 column1:5!null y_default:6 x:7 y:8 z:9 crdb_internal_mvcc_timestamp:10
       ├── left-join (hash)
-      │    ├── columns: column1:5!null column6:6 x:7 y:8 z:9 crdb_internal_mvcc_timestamp:10
+      │    ├── columns: column1:5!null y_default:6 x:7 y:8 z:9 crdb_internal_mvcc_timestamp:10
       │    ├── ensure-upsert-distinct-on
-      │    │    ├── columns: column1:5!null column6:6
+      │    │    ├── columns: column1:5!null y_default:6
       │    │    ├── grouping columns: column1:5!null
       │    │    ├── project
-      │    │    │    ├── columns: column6:6 column1:5!null
+      │    │    │    ├── columns: y_default:6 column1:5!null
       │    │    │    ├── values
       │    │    │    │    ├── columns: column1:5!null
       │    │    │    │    └── (1,)
       │    │    │    └── projections
-      │    │    │         └── NULL::INT8 [as=column6:6]
+      │    │    │         └── NULL::INT8 [as=y_default:6]
       │    │    └── aggregations
-      │    │         └── first-agg [as=column6:6]
-      │    │              └── column6:6
+      │    │         └── first-agg [as=y_default:6]
+      │    │              └── y_default:6
       │    ├── scan xyz
       │    │    └── columns: x:7!null y:8 z:9 crdb_internal_mvcc_timestamp:10
       │    └── filters
@@ -1064,51 +1064,51 @@ with &1
  │         ├── insert-mapping:
  │         │    ├── column1:6 => abc.a:1
  │         │    ├── column2:7 => abc.b:2
- │         │    ├── column9:9 => abc.c:3
- │         │    └── column8:8 => rowid:4
+ │         │    ├── c_comp:9 => abc.c:3
+ │         │    └── rowid_default:8 => rowid:4
  │         ├── update-mapping:
  │         │    ├── column1:6 => abc.a:1
  │         │    ├── column2:7 => abc.b:2
- │         │    └── column9:9 => abc.c:3
+ │         │    └── c_comp:9 => abc.c:3
  │         ├── return-mapping:
  │         │    ├── column1:6 => abc.a:1
  │         │    ├── column2:7 => abc.b:2
- │         │    ├── column9:9 => abc.c:3
+ │         │    ├── c_comp:9 => abc.c:3
  │         │    └── upsert_rowid:15 => rowid:4
  │         └── project
- │              ├── columns: upsert_rowid:15 column1:6!null column2:7!null column8:8 column9:9!null abc.a:10 abc.b:11 abc.c:12 rowid:13 crdb_internal_mvcc_timestamp:14
+ │              ├── columns: upsert_rowid:15 column1:6!null column2:7!null rowid_default:8 c_comp:9!null abc.a:10 abc.b:11 abc.c:12 rowid:13 crdb_internal_mvcc_timestamp:14
  │              ├── left-join (hash)
- │              │    ├── columns: column1:6!null column2:7!null column8:8 column9:9!null abc.a:10 abc.b:11 abc.c:12 rowid:13 crdb_internal_mvcc_timestamp:14
+ │              │    ├── columns: column1:6!null column2:7!null rowid_default:8 c_comp:9!null abc.a:10 abc.b:11 abc.c:12 rowid:13 crdb_internal_mvcc_timestamp:14
  │              │    ├── ensure-upsert-distinct-on
- │              │    │    ├── columns: column1:6!null column2:7!null column8:8 column9:9!null
- │              │    │    ├── grouping columns: column8:8
+ │              │    │    ├── columns: column1:6!null column2:7!null rowid_default:8 c_comp:9!null
+ │              │    │    ├── grouping columns: rowid_default:8
  │              │    │    ├── project
- │              │    │    │    ├── columns: column9:9!null column1:6!null column2:7!null column8:8
+ │              │    │    │    ├── columns: c_comp:9!null column1:6!null column2:7!null rowid_default:8
  │              │    │    │    ├── project
- │              │    │    │    │    ├── columns: column8:8 column1:6!null column2:7!null
+ │              │    │    │    │    ├── columns: rowid_default:8 column1:6!null column2:7!null
  │              │    │    │    │    ├── values
  │              │    │    │    │    │    ├── columns: column1:6!null column2:7!null
  │              │    │    │    │    │    └── (1, 2)
  │              │    │    │    │    └── projections
- │              │    │    │    │         └── unique_rowid() [as=column8:8]
+ │              │    │    │    │         └── unique_rowid() [as=rowid_default:8]
  │              │    │    │    └── projections
- │              │    │    │         └── column2:7 + 1 [as=column9:9]
+ │              │    │    │         └── column2:7 + 1 [as=c_comp:9]
  │              │    │    └── aggregations
  │              │    │         ├── first-agg [as=column1:6]
  │              │    │         │    └── column1:6
  │              │    │         ├── first-agg [as=column2:7]
  │              │    │         │    └── column2:7
- │              │    │         └── first-agg [as=column9:9]
- │              │    │              └── column9:9
+ │              │    │         └── first-agg [as=c_comp:9]
+ │              │    │              └── c_comp:9
  │              │    ├── scan abc
  │              │    │    ├── columns: abc.a:10!null abc.b:11 abc.c:12 rowid:13!null crdb_internal_mvcc_timestamp:14
  │              │    │    └── computed column expressions
  │              │    │         └── abc.c:12
  │              │    │              └── abc.b:11 + 1
  │              │    └── filters
- │              │         └── column8:8 = rowid:13
+ │              │         └── rowid_default:8 = rowid:13
  │              └── projections
- │                   └── CASE WHEN rowid:13 IS NULL THEN column8:8 ELSE rowid:13 END [as=upsert_rowid:15]
+ │                   └── CASE WHEN rowid:13 IS NULL THEN rowid_default:8 ELSE rowid:13 END [as=upsert_rowid:15]
  └── with-scan &1
       ├── columns: a:16!null b:17!null c:18!null
       └── mapping:
@@ -1185,35 +1185,35 @@ upsert checks
  │    ├── column1:6 => a:1
  │    ├── column2:7 => b:2
  │    ├── column3:8 => c:3
- │    └── column9:9 => d:4
+ │    └── d_comp:9 => d:4
  ├── update-mapping:
  │    ├── column2:7 => b:2
  │    ├── column3:8 => c:3
- │    └── column9:9 => d:4
+ │    └── d_comp:9 => d:4
  ├── check columns: check1:16 check2:17
  └── project
-      ├── columns: check1:16!null check2:17 column1:6!null column2:7!null column3:8!null column9:9!null a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 upsert_a:15
+      ├── columns: check1:16!null check2:17 column1:6!null column2:7!null column3:8!null d_comp:9!null a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 upsert_a:15
       ├── project
-      │    ├── columns: upsert_a:15 column1:6!null column2:7!null column3:8!null column9:9!null a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14
+      │    ├── columns: upsert_a:15 column1:6!null column2:7!null column3:8!null d_comp:9!null a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14
       │    ├── left-join (hash)
-      │    │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9!null a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14
+      │    │    ├── columns: column1:6!null column2:7!null column3:8!null d_comp:9!null a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14
       │    │    ├── ensure-upsert-distinct-on
-      │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null column9:9!null
+      │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null d_comp:9!null
       │    │    │    ├── grouping columns: column1:6!null
       │    │    │    ├── project
-      │    │    │    │    ├── columns: column9:9!null column1:6!null column2:7!null column3:8!null
+      │    │    │    │    ├── columns: d_comp:9!null column1:6!null column2:7!null column3:8!null
       │    │    │    │    ├── values
       │    │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
       │    │    │    │    │    └── (1, 2, 3)
       │    │    │    │    └── projections
-      │    │    │    │         └── column3:8 + 1 [as=column9:9]
+      │    │    │    │         └── column3:8 + 1 [as=d_comp:9]
       │    │    │    └── aggregations
       │    │    │         ├── first-agg [as=column2:7]
       │    │    │         │    └── column2:7
       │    │    │         ├── first-agg [as=column3:8]
       │    │    │         │    └── column3:8
-      │    │    │         └── first-agg [as=column9:9]
-      │    │    │              └── column9:9
+      │    │    │         └── first-agg [as=d_comp:9]
+      │    │    │              └── d_comp:9
       │    │    ├── scan checks
       │    │    │    ├── columns: a:10!null b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14
       │    │    │    ├── check constraint expressions
@@ -1226,7 +1226,7 @@ upsert checks
       │    └── projections
       │         └── CASE WHEN a:10 IS NULL THEN column1:6 ELSE a:10 END [as=upsert_a:15]
       └── projections
-           ├── column2:7 < column9:9 [as=check1:16]
+           ├── column2:7 < d_comp:9 [as=check1:16]
            └── upsert_a:15 > 0 [as=check2:17]
 
 # Ensure that mutation columns are set by the insert and update. Use explicit
@@ -1242,40 +1242,40 @@ upsert mutation
  ├── insert-mapping:
  │    ├── column1:7 => m:1
  │    ├── column2:8 => n:2
- │    ├── column9:9 => o:3
- │    └── column10:10 => p:4
+ │    ├── o_default:9 => o:3
+ │    └── p_comp:10 => p:4
  ├── update-mapping:
  │    ├── column2:8 => n:2
- │    ├── column9:9 => o:3
- │    └── column10:10 => p:4
+ │    ├── o_default:9 => o:3
+ │    └── p_comp:10 => p:4
  ├── check columns: check1:18
  └── project
-      ├── columns: check1:18 column1:7!null column2:8!null column9:9!null column10:10!null m:11 n:12 o:13 p:14 q:15 crdb_internal_mvcc_timestamp:16 upsert_m:17
+      ├── columns: check1:18 column1:7!null column2:8!null o_default:9!null p_comp:10!null m:11 n:12 o:13 p:14 q:15 crdb_internal_mvcc_timestamp:16 upsert_m:17
       ├── project
-      │    ├── columns: upsert_m:17 column1:7!null column2:8!null column9:9!null column10:10!null m:11 n:12 o:13 p:14 q:15 crdb_internal_mvcc_timestamp:16
+      │    ├── columns: upsert_m:17 column1:7!null column2:8!null o_default:9!null p_comp:10!null m:11 n:12 o:13 p:14 q:15 crdb_internal_mvcc_timestamp:16
       │    ├── left-join (hash)
-      │    │    ├── columns: column1:7!null column2:8!null column9:9!null column10:10!null m:11 n:12 o:13 p:14 q:15 crdb_internal_mvcc_timestamp:16
+      │    │    ├── columns: column1:7!null column2:8!null o_default:9!null p_comp:10!null m:11 n:12 o:13 p:14 q:15 crdb_internal_mvcc_timestamp:16
       │    │    ├── ensure-upsert-distinct-on
-      │    │    │    ├── columns: column1:7!null column2:8!null column9:9!null column10:10!null
+      │    │    │    ├── columns: column1:7!null column2:8!null o_default:9!null p_comp:10!null
       │    │    │    ├── grouping columns: column1:7!null
       │    │    │    ├── project
-      │    │    │    │    ├── columns: column10:10!null column1:7!null column2:8!null column9:9!null
+      │    │    │    │    ├── columns: p_comp:10!null column1:7!null column2:8!null o_default:9!null
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: column9:9!null column1:7!null column2:8!null
+      │    │    │    │    │    ├── columns: o_default:9!null column1:7!null column2:8!null
       │    │    │    │    │    ├── values
       │    │    │    │    │    │    ├── columns: column1:7!null column2:8!null
       │    │    │    │    │    │    └── (1, 2)
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── 10 [as=column9:9]
+      │    │    │    │    │         └── 10 [as=o_default:9]
       │    │    │    │    └── projections
-      │    │    │    │         └── column9:9 + column2:8 [as=column10:10]
+      │    │    │    │         └── o_default:9 + column2:8 [as=p_comp:10]
       │    │    │    └── aggregations
       │    │    │         ├── first-agg [as=column2:8]
       │    │    │         │    └── column2:8
-      │    │    │         ├── first-agg [as=column9:9]
-      │    │    │         │    └── column9:9
-      │    │    │         └── first-agg [as=column10:10]
-      │    │    │              └── column10:10
+      │    │    │         ├── first-agg [as=o_default:9]
+      │    │    │         │    └── o_default:9
+      │    │    │         └── first-agg [as=p_comp:10]
+      │    │    │              └── p_comp:10
       │    │    ├── scan mutation
       │    │    │    ├── columns: m:11!null n:12 o:13 p:14 q:15 crdb_internal_mvcc_timestamp:16
       │    │    │    └── check constraint expressions
@@ -1300,40 +1300,40 @@ upsert mutation
  ├── insert-mapping:
  │    ├── column1:7 => m:1
  │    ├── column2:8 => n:2
- │    ├── column9:9 => o:3
- │    └── column10:10 => p:4
+ │    ├── o_default:9 => o:3
+ │    └── p_comp:10 => p:4
  ├── update-mapping:
  │    ├── column2:8 => n:2
- │    ├── column9:9 => o:3
- │    └── column10:10 => p:4
+ │    ├── o_default:9 => o:3
+ │    └── p_comp:10 => p:4
  ├── check columns: check1:18
  └── project
-      ├── columns: check1:18 column1:7!null column2:8!null column9:9!null column10:10!null m:11 n:12 o:13 p:14 q:15 crdb_internal_mvcc_timestamp:16 upsert_m:17
+      ├── columns: check1:18 column1:7!null column2:8!null o_default:9!null p_comp:10!null m:11 n:12 o:13 p:14 q:15 crdb_internal_mvcc_timestamp:16 upsert_m:17
       ├── project
-      │    ├── columns: upsert_m:17 column1:7!null column2:8!null column9:9!null column10:10!null m:11 n:12 o:13 p:14 q:15 crdb_internal_mvcc_timestamp:16
+      │    ├── columns: upsert_m:17 column1:7!null column2:8!null o_default:9!null p_comp:10!null m:11 n:12 o:13 p:14 q:15 crdb_internal_mvcc_timestamp:16
       │    ├── left-join (hash)
-      │    │    ├── columns: column1:7!null column2:8!null column9:9!null column10:10!null m:11 n:12 o:13 p:14 q:15 crdb_internal_mvcc_timestamp:16
+      │    │    ├── columns: column1:7!null column2:8!null o_default:9!null p_comp:10!null m:11 n:12 o:13 p:14 q:15 crdb_internal_mvcc_timestamp:16
       │    │    ├── ensure-upsert-distinct-on
-      │    │    │    ├── columns: column1:7!null column2:8!null column9:9!null column10:10!null
+      │    │    │    ├── columns: column1:7!null column2:8!null o_default:9!null p_comp:10!null
       │    │    │    ├── grouping columns: column1:7!null
       │    │    │    ├── project
-      │    │    │    │    ├── columns: column10:10!null column1:7!null column2:8!null column9:9!null
+      │    │    │    │    ├── columns: p_comp:10!null column1:7!null column2:8!null o_default:9!null
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: column9:9!null column1:7!null column2:8!null
+      │    │    │    │    │    ├── columns: o_default:9!null column1:7!null column2:8!null
       │    │    │    │    │    ├── values
       │    │    │    │    │    │    ├── columns: column1:7!null column2:8!null
       │    │    │    │    │    │    └── (1, 2)
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── 10 [as=column9:9]
+      │    │    │    │    │         └── 10 [as=o_default:9]
       │    │    │    │    └── projections
-      │    │    │    │         └── column9:9 + column2:8 [as=column10:10]
+      │    │    │    │         └── o_default:9 + column2:8 [as=p_comp:10]
       │    │    │    └── aggregations
       │    │    │         ├── first-agg [as=column2:8]
       │    │    │         │    └── column2:8
-      │    │    │         ├── first-agg [as=column9:9]
-      │    │    │         │    └── column9:9
-      │    │    │         └── first-agg [as=column10:10]
-      │    │    │              └── column10:10
+      │    │    │         ├── first-agg [as=o_default:9]
+      │    │    │         │    └── o_default:9
+      │    │    │         └── first-agg [as=p_comp:10]
+      │    │    │              └── p_comp:10
       │    │    ├── scan mutation
       │    │    │    ├── columns: m:11!null n:12 o:13 p:14 q:15 crdb_internal_mvcc_timestamp:16
       │    │    │    └── check constraint expressions
@@ -1367,44 +1367,44 @@ upsert checks
  ├── insert-mapping:
  │    ├── column1:6 => a:1
  │    ├── column2:7 => b:2
- │    ├── column8:8 => c:3
- │    └── column9:9 => d:4
+ │    ├── c_default:8 => c:3
+ │    └── d_comp:9 => d:4
  ├── update-mapping:
  │    ├── upsert_b:19 => b:2
  │    ├── upsert_c:20 => c:3
  │    └── upsert_d:21 => d:4
  ├── check columns: check1:22 check2:23
  └── project
-      ├── columns: check1:22 check2:23 column1:6!null column2:7!null column8:8 column9:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 b_new:15!null c_new:16!null column17:17!null upsert_a:18 upsert_b:19!null upsert_c:20 upsert_d:21
+      ├── columns: check1:22 check2:23 column1:6!null column2:7!null c_default:8 d_comp:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 b_new:15!null c_new:16!null d_comp:17!null upsert_a:18 upsert_b:19!null upsert_c:20 upsert_d:21
       ├── project
-      │    ├── columns: upsert_a:18 upsert_b:19!null upsert_c:20 upsert_d:21 column1:6!null column2:7!null column8:8 column9:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 b_new:15!null c_new:16!null column17:17!null
+      │    ├── columns: upsert_a:18 upsert_b:19!null upsert_c:20 upsert_d:21 column1:6!null column2:7!null c_default:8 d_comp:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 b_new:15!null c_new:16!null d_comp:17!null
       │    ├── project
-      │    │    ├── columns: column17:17!null column1:6!null column2:7!null column8:8 column9:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 b_new:15!null c_new:16!null
+      │    │    ├── columns: d_comp:17!null column1:6!null column2:7!null c_default:8 d_comp:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 b_new:15!null c_new:16!null
       │    │    ├── project
-      │    │    │    ├── columns: b_new:15!null c_new:16!null column1:6!null column2:7!null column8:8 column9:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14
+      │    │    │    ├── columns: b_new:15!null c_new:16!null column1:6!null column2:7!null c_default:8 d_comp:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14
       │    │    │    ├── left-join (hash)
-      │    │    │    │    ├── columns: column1:6!null column2:7!null column8:8 column9:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14
+      │    │    │    │    ├── columns: column1:6!null column2:7!null c_default:8 d_comp:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14
       │    │    │    │    ├── ensure-upsert-distinct-on
-      │    │    │    │    │    ├── columns: column1:6!null column2:7!null column8:8 column9:9
+      │    │    │    │    │    ├── columns: column1:6!null column2:7!null c_default:8 d_comp:9
       │    │    │    │    │    ├── grouping columns: column1:6!null
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: column9:9 column1:6!null column2:7!null column8:8
+      │    │    │    │    │    │    ├── columns: d_comp:9 column1:6!null column2:7!null c_default:8
       │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    ├── columns: column8:8 column1:6!null column2:7!null
+      │    │    │    │    │    │    │    ├── columns: c_default:8 column1:6!null column2:7!null
       │    │    │    │    │    │    │    ├── values
       │    │    │    │    │    │    │    │    ├── columns: column1:6!null column2:7!null
       │    │    │    │    │    │    │    │    └── (1, 2)
       │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │         └── NULL::INT8 [as=column8:8]
+      │    │    │    │    │    │    │         └── NULL::INT8 [as=c_default:8]
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── column8:8 + 1 [as=column9:9]
+      │    │    │    │    │    │         └── c_default:8 + 1 [as=d_comp:9]
       │    │    │    │    │    └── aggregations
       │    │    │    │    │         ├── first-agg [as=column2:7]
       │    │    │    │    │         │    └── column2:7
-      │    │    │    │    │         ├── first-agg [as=column8:8]
-      │    │    │    │    │         │    └── column8:8
-      │    │    │    │    │         └── first-agg [as=column9:9]
-      │    │    │    │    │              └── column9:9
+      │    │    │    │    │         ├── first-agg [as=c_default:8]
+      │    │    │    │    │         │    └── c_default:8
+      │    │    │    │    │         └── first-agg [as=d_comp:9]
+      │    │    │    │    │              └── d_comp:9
       │    │    │    │    ├── scan checks
       │    │    │    │    │    ├── columns: a:10!null b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14
       │    │    │    │    │    ├── check constraint expressions
@@ -1418,12 +1418,12 @@ upsert checks
       │    │    │         ├── 3 [as=b_new:15]
       │    │    │         └── 4 [as=c_new:16]
       │    │    └── projections
-      │    │         └── c_new:16 + 1 [as=column17:17]
+      │    │         └── c_new:16 + 1 [as=d_comp:17]
       │    └── projections
       │         ├── CASE WHEN a:10 IS NULL THEN column1:6 ELSE a:10 END [as=upsert_a:18]
       │         ├── CASE WHEN a:10 IS NULL THEN column2:7 ELSE b_new:15 END [as=upsert_b:19]
-      │         ├── CASE WHEN a:10 IS NULL THEN column8:8 ELSE c_new:16 END [as=upsert_c:20]
-      │         └── CASE WHEN a:10 IS NULL THEN column9:9 ELSE column17:17 END [as=upsert_d:21]
+      │         ├── CASE WHEN a:10 IS NULL THEN c_default:8 ELSE c_new:16 END [as=upsert_c:20]
+      │         └── CASE WHEN a:10 IS NULL THEN d_comp:9 ELSE d_comp:17 END [as=upsert_d:21]
       └── projections
            ├── upsert_b:19 < upsert_d:21 [as=check1:22]
            └── upsert_a:18 > 0 [as=check2:23]
@@ -1438,27 +1438,27 @@ insert checks
  ├── insert-mapping:
  │    ├── column1:6 => a:1
  │    ├── column2:7 => b:2
- │    ├── column8:8 => c:3
- │    └── column9:9 => d:4
+ │    ├── c_default:8 => c:3
+ │    └── d_comp:9 => d:4
  ├── check columns: check1:15 check2:16
  └── project
-      ├── columns: check1:15 check2:16!null column1:6!null column2:7!null column8:8 column9:9
+      ├── columns: check1:15 check2:16!null column1:6!null column2:7!null c_default:8 d_comp:9
       ├── upsert-distinct-on
-      │    ├── columns: column1:6!null column2:7!null column8:8 column9:9
+      │    ├── columns: column1:6!null column2:7!null c_default:8 d_comp:9
       │    ├── grouping columns: column1:6!null
       │    ├── anti-join (hash)
-      │    │    ├── columns: column1:6!null column2:7!null column8:8 column9:9
+      │    │    ├── columns: column1:6!null column2:7!null c_default:8 d_comp:9
       │    │    ├── project
-      │    │    │    ├── columns: column9:9 column1:6!null column2:7!null column8:8
+      │    │    │    ├── columns: d_comp:9 column1:6!null column2:7!null c_default:8
       │    │    │    ├── project
-      │    │    │    │    ├── columns: column8:8 column1:6!null column2:7!null
+      │    │    │    │    ├── columns: c_default:8 column1:6!null column2:7!null
       │    │    │    │    ├── values
       │    │    │    │    │    ├── columns: column1:6!null column2:7!null
       │    │    │    │    │    └── (1, 2)
       │    │    │    │    └── projections
-      │    │    │    │         └── NULL::INT8 [as=column8:8]
+      │    │    │    │         └── NULL::INT8 [as=c_default:8]
       │    │    │    └── projections
-      │    │    │         └── column8:8 + 1 [as=column9:9]
+      │    │    │         └── c_default:8 + 1 [as=d_comp:9]
       │    │    ├── scan checks
       │    │    │    ├── columns: a:10!null b:11 c:12 d:13
       │    │    │    ├── check constraint expressions
@@ -1471,12 +1471,12 @@ insert checks
       │    └── aggregations
       │         ├── first-agg [as=column2:7]
       │         │    └── column2:7
-      │         ├── first-agg [as=column8:8]
-      │         │    └── column8:8
-      │         └── first-agg [as=column9:9]
-      │              └── column9:9
+      │         ├── first-agg [as=c_default:8]
+      │         │    └── c_default:8
+      │         └── first-agg [as=d_comp:9]
+      │              └── d_comp:9
       └── projections
-           ├── column2:7 < column9:9 [as=check1:15]
+           ├── column2:7 < d_comp:9 [as=check1:15]
            └── column1:6 > 0 [as=check2:16]
 
 # UPSERT
@@ -1491,40 +1491,40 @@ upsert checks
  ├── insert-mapping:
  │    ├── column1:6 => a:1
  │    ├── column2:7 => b:2
- │    ├── column8:8 => c:3
- │    └── column9:9 => d:4
+ │    ├── c_default:8 => c:3
+ │    └── d_comp:9 => d:4
  ├── update-mapping:
  │    └── column2:7 => b:2
  ├── check columns: check1:19 check2:20
  └── project
-      ├── columns: check1:19 check2:20 column1:6!null column2:7!null column8:8 column9:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 column15:15 upsert_a:16 upsert_c:17 upsert_d:18
+      ├── columns: check1:19 check2:20 column1:6!null column2:7!null c_default:8 d_comp:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 d_comp:15 upsert_a:16 upsert_c:17 upsert_d:18
       ├── project
-      │    ├── columns: upsert_a:16 upsert_c:17 upsert_d:18 column1:6!null column2:7!null column8:8 column9:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 column15:15
+      │    ├── columns: upsert_a:16 upsert_c:17 upsert_d:18 column1:6!null column2:7!null c_default:8 d_comp:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 d_comp:15
       │    ├── project
-      │    │    ├── columns: column15:15 column1:6!null column2:7!null column8:8 column9:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14
+      │    │    ├── columns: d_comp:15 column1:6!null column2:7!null c_default:8 d_comp:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14
       │    │    ├── left-join (hash)
-      │    │    │    ├── columns: column1:6!null column2:7!null column8:8 column9:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14
+      │    │    │    ├── columns: column1:6!null column2:7!null c_default:8 d_comp:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14
       │    │    │    ├── ensure-upsert-distinct-on
-      │    │    │    │    ├── columns: column1:6!null column2:7!null column8:8 column9:9
+      │    │    │    │    ├── columns: column1:6!null column2:7!null c_default:8 d_comp:9
       │    │    │    │    ├── grouping columns: column1:6!null
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: column9:9 column1:6!null column2:7!null column8:8
+      │    │    │    │    │    ├── columns: d_comp:9 column1:6!null column2:7!null c_default:8
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: column8:8 column1:6!null column2:7!null
+      │    │    │    │    │    │    ├── columns: c_default:8 column1:6!null column2:7!null
       │    │    │    │    │    │    ├── values
       │    │    │    │    │    │    │    ├── columns: column1:6!null column2:7!null
       │    │    │    │    │    │    │    └── (1, 2)
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── NULL::INT8 [as=column8:8]
+      │    │    │    │    │    │         └── NULL::INT8 [as=c_default:8]
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── column8:8 + 1 [as=column9:9]
+      │    │    │    │    │         └── c_default:8 + 1 [as=d_comp:9]
       │    │    │    │    └── aggregations
       │    │    │    │         ├── first-agg [as=column2:7]
       │    │    │    │         │    └── column2:7
-      │    │    │    │         ├── first-agg [as=column8:8]
-      │    │    │    │         │    └── column8:8
-      │    │    │    │         └── first-agg [as=column9:9]
-      │    │    │    │              └── column9:9
+      │    │    │    │         ├── first-agg [as=c_default:8]
+      │    │    │    │         │    └── c_default:8
+      │    │    │    │         └── first-agg [as=d_comp:9]
+      │    │    │    │              └── d_comp:9
       │    │    │    ├── scan checks
       │    │    │    │    ├── columns: a:10!null b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14
       │    │    │    │    ├── check constraint expressions
@@ -1535,11 +1535,11 @@ upsert checks
       │    │    │    └── filters
       │    │    │         └── column1:6 = a:10
       │    │    └── projections
-      │    │         └── c:12 + 1 [as=column15:15]
+      │    │         └── c:12 + 1 [as=d_comp:15]
       │    └── projections
       │         ├── CASE WHEN a:10 IS NULL THEN column1:6 ELSE a:10 END [as=upsert_a:16]
-      │         ├── CASE WHEN a:10 IS NULL THEN column8:8 ELSE c:12 END [as=upsert_c:17]
-      │         └── CASE WHEN a:10 IS NULL THEN column9:9 ELSE d:13 END [as=upsert_d:18]
+      │         ├── CASE WHEN a:10 IS NULL THEN c_default:8 ELSE c:12 END [as=upsert_c:17]
+      │         └── CASE WHEN a:10 IS NULL THEN d_comp:9 ELSE d:13 END [as=upsert_d:18]
       └── projections
            ├── column2:7 < upsert_d:18 [as=check1:19]
            └── upsert_a:16 > 0 [as=check2:20]
@@ -1558,29 +1558,29 @@ upsert checks
  ├── insert-mapping:
  │    ├── abc.a:6 => checks.a:1
  │    ├── abc.b:7 => checks.b:2
- │    ├── column11:11 => checks.c:3
- │    └── column12:12 => d:4
+ │    ├── c_default:11 => checks.c:3
+ │    └── d_comp:12 => d:4
  ├── update-mapping:
  │    ├── abc.a:6 => checks.a:1
  │    └── upsert_b:24 => checks.b:2
  ├── check columns: check1:27 check2:28
  └── project
-      ├── columns: check1:27 check2:28!null abc.a:6!null abc.b:7 column11:11 column12:12 checks.a:13 checks.b:14 checks.c:15 d:16 checks.crdb_internal_mvcc_timestamp:17 b_new:22 column23:23 upsert_b:24 upsert_c:25 upsert_d:26
+      ├── columns: check1:27 check2:28!null abc.a:6!null abc.b:7 c_default:11 d_comp:12 checks.a:13 checks.b:14 checks.c:15 d:16 checks.crdb_internal_mvcc_timestamp:17 b_new:22 d_comp:23 upsert_b:24 upsert_c:25 upsert_d:26
       ├── project
-      │    ├── columns: upsert_b:24 upsert_c:25 upsert_d:26 abc.a:6!null abc.b:7 column11:11 column12:12 checks.a:13 checks.b:14 checks.c:15 d:16 checks.crdb_internal_mvcc_timestamp:17 b_new:22 column23:23
+      │    ├── columns: upsert_b:24 upsert_c:25 upsert_d:26 abc.a:6!null abc.b:7 c_default:11 d_comp:12 checks.a:13 checks.b:14 checks.c:15 d:16 checks.crdb_internal_mvcc_timestamp:17 b_new:22 d_comp:23
       │    ├── project
-      │    │    ├── columns: column23:23 abc.a:6!null abc.b:7 column11:11 column12:12 checks.a:13 checks.b:14 checks.c:15 d:16 checks.crdb_internal_mvcc_timestamp:17 b_new:22
+      │    │    ├── columns: d_comp:23 abc.a:6!null abc.b:7 c_default:11 d_comp:12 checks.a:13 checks.b:14 checks.c:15 d:16 checks.crdb_internal_mvcc_timestamp:17 b_new:22
       │    │    ├── project
-      │    │    │    ├── columns: b_new:22 abc.a:6!null abc.b:7 column11:11 column12:12 checks.a:13 checks.b:14 checks.c:15 d:16 checks.crdb_internal_mvcc_timestamp:17
+      │    │    │    ├── columns: b_new:22 abc.a:6!null abc.b:7 c_default:11 d_comp:12 checks.a:13 checks.b:14 checks.c:15 d:16 checks.crdb_internal_mvcc_timestamp:17
       │    │    │    ├── left-join (hash)
-      │    │    │    │    ├── columns: abc.a:6!null abc.b:7 column11:11 column12:12 checks.a:13 checks.b:14 checks.c:15 d:16 checks.crdb_internal_mvcc_timestamp:17
+      │    │    │    │    ├── columns: abc.a:6!null abc.b:7 c_default:11 d_comp:12 checks.a:13 checks.b:14 checks.c:15 d:16 checks.crdb_internal_mvcc_timestamp:17
       │    │    │    │    ├── ensure-upsert-distinct-on
-      │    │    │    │    │    ├── columns: abc.a:6!null abc.b:7 column11:11 column12:12
+      │    │    │    │    │    ├── columns: abc.a:6!null abc.b:7 c_default:11 d_comp:12
       │    │    │    │    │    ├── grouping columns: abc.a:6!null
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: column12:12 abc.a:6!null abc.b:7 column11:11
+      │    │    │    │    │    │    ├── columns: d_comp:12 abc.a:6!null abc.b:7 c_default:11
       │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    ├── columns: column11:11 abc.a:6!null abc.b:7
+      │    │    │    │    │    │    │    ├── columns: c_default:11 abc.a:6!null abc.b:7
       │    │    │    │    │    │    │    ├── project
       │    │    │    │    │    │    │    │    ├── columns: abc.a:6!null abc.b:7
       │    │    │    │    │    │    │    │    └── scan abc
@@ -1589,16 +1589,16 @@ upsert checks
       │    │    │    │    │    │    │    │              └── abc.c:8
       │    │    │    │    │    │    │    │                   └── abc.b:7 + 1
       │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │         └── NULL::INT8 [as=column11:11]
+      │    │    │    │    │    │    │         └── NULL::INT8 [as=c_default:11]
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── column11:11 + 1 [as=column12:12]
+      │    │    │    │    │    │         └── c_default:11 + 1 [as=d_comp:12]
       │    │    │    │    │    └── aggregations
       │    │    │    │    │         ├── first-agg [as=abc.b:7]
       │    │    │    │    │         │    └── abc.b:7
-      │    │    │    │    │         ├── first-agg [as=column11:11]
-      │    │    │    │    │         │    └── column11:11
-      │    │    │    │    │         └── first-agg [as=column12:12]
-      │    │    │    │    │              └── column12:12
+      │    │    │    │    │         ├── first-agg [as=c_default:11]
+      │    │    │    │    │         │    └── c_default:11
+      │    │    │    │    │         └── first-agg [as=d_comp:12]
+      │    │    │    │    │              └── d_comp:12
       │    │    │    │    ├── scan checks
       │    │    │    │    │    ├── columns: checks.a:13!null checks.b:14 checks.c:15 d:16 checks.crdb_internal_mvcc_timestamp:17
       │    │    │    │    │    ├── check constraint expressions
@@ -1621,11 +1621,11 @@ upsert checks
       │    │    │                             └── filters
       │    │    │                                  └── x:18 = checks.a:13
       │    │    └── projections
-      │    │         └── checks.c:15 + 1 [as=column23:23]
+      │    │         └── checks.c:15 + 1 [as=d_comp:23]
       │    └── projections
       │         ├── CASE WHEN checks.a:13 IS NULL THEN abc.b:7 ELSE b_new:22 END [as=upsert_b:24]
-      │         ├── CASE WHEN checks.a:13 IS NULL THEN column11:11 ELSE checks.c:15 END [as=upsert_c:25]
-      │         └── CASE WHEN checks.a:13 IS NULL THEN column12:12 ELSE d:16 END [as=upsert_d:26]
+      │         ├── CASE WHEN checks.a:13 IS NULL THEN c_default:11 ELSE checks.c:15 END [as=upsert_c:25]
+      │         └── CASE WHEN checks.a:13 IS NULL THEN d_comp:12 ELSE d:16 END [as=upsert_d:26]
       └── projections
            ├── upsert_b:24 < upsert_d:26 [as=check1:27]
            └── abc.a:6 > 0 [as=check2:28]
@@ -1690,67 +1690,67 @@ upsert decimals
  ├── columns: <none>
  ├── arbiter indexes: primary
  ├── canary column: decimals.a:14
- ├── fetch columns: decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17
+ ├── fetch columns: decimals.a:14 decimals.b:15 c:16 d:17
  ├── insert-mapping:
  │    ├── a:9 => decimals.a:1
  │    ├── b:10 => decimals.b:2
- │    ├── c:11 => decimals.c:3
- │    └── d:13 => decimals.d:4
+ │    ├── c_default:11 => c:3
+ │    └── d_comp:13 => d:4
  ├── update-mapping:
  │    └── b:10 => decimals.b:2
  ├── check columns: check1:23 check2:24
  └── project
-      ├── columns: check1:23 check2:24 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18 column19:19 upsert_a:20 upsert_c:21 upsert_d:22
+      ├── columns: check1:23 check2:24 a:9 b:10 c_default:11 d_comp:13 decimals.a:14 decimals.b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18 d_comp:19 upsert_a:20 upsert_c:21 upsert_d:22
       ├── project
-      │    ├── columns: upsert_a:20 upsert_c:21 upsert_d:22 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18 column19:19
+      │    ├── columns: upsert_a:20 upsert_c:21 upsert_d:22 a:9 b:10 c_default:11 d_comp:13 decimals.a:14 decimals.b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18 d_comp:19
       │    ├── project
-      │    │    ├── columns: column19:19 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
+      │    │    ├── columns: d_comp:19 a:9 b:10 c_default:11 d_comp:13 decimals.a:14 decimals.b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18
       │    │    ├── left-join (hash)
-      │    │    │    ├── columns: a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
+      │    │    │    ├── columns: a:9 b:10 c_default:11 d_comp:13 decimals.a:14 decimals.b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18
       │    │    │    ├── ensure-upsert-distinct-on
-      │    │    │    │    ├── columns: a:9 b:10 c:11 d:13
+      │    │    │    │    ├── columns: a:9 b:10 c_default:11 d_comp:13
       │    │    │    │    ├── grouping columns: a:9
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: d:13 a:9 b:10 c:11
+      │    │    │    │    │    ├── columns: d_comp:13 a:9 b:10 c_default:11
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: column12:12 a:9 b:10 c:11
+      │    │    │    │    │    │    ├── columns: d_comp:12 a:9 b:10 c_default:11
       │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    ├── columns: a:9 b:10 c:11
+      │    │    │    │    │    │    │    ├── columns: a:9 b:10 c_default:11
       │    │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    │    ├── columns: column8:8!null column1:6!null column2:7
+      │    │    │    │    │    │    │    │    ├── columns: c_default:8!null column1:6!null column2:7
       │    │    │    │    │    │    │    │    ├── values
       │    │    │    │    │    │    │    │    │    ├── columns: column1:6!null column2:7
       │    │    │    │    │    │    │    │    │    └── (1.1, ARRAY[0.95])
       │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │         └── 1.23 [as=column8:8]
+      │    │    │    │    │    │    │    │         └── 1.23 [as=c_default:8]
       │    │    │    │    │    │    │    └── projections
       │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column1:6, 0) [as=a:9]
       │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column2:7, 1) [as=b:10]
-      │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(column8:8, 1) [as=c:11]
+      │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(c_default:8, 1) [as=c_default:11]
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── a:9 + c:11 [as=column12:12]
+      │    │    │    │    │    │         └── a:9 + c_default:11 [as=d_comp:12]
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── crdb_internal.round_decimal_values(column12:12, 1) [as=d:13]
+      │    │    │    │    │         └── crdb_internal.round_decimal_values(d_comp:12, 1) [as=d_comp:13]
       │    │    │    │    └── aggregations
       │    │    │    │         ├── first-agg [as=b:10]
       │    │    │    │         │    └── b:10
-      │    │    │    │         ├── first-agg [as=c:11]
-      │    │    │    │         │    └── c:11
-      │    │    │    │         └── first-agg [as=d:13]
-      │    │    │    │              └── d:13
+      │    │    │    │         ├── first-agg [as=c_default:11]
+      │    │    │    │         │    └── c_default:11
+      │    │    │    │         └── first-agg [as=d_comp:13]
+      │    │    │    │              └── d_comp:13
       │    │    │    ├── scan decimals
-      │    │    │    │    ├── columns: decimals.a:14!null decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
+      │    │    │    │    ├── columns: decimals.a:14!null decimals.b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18
       │    │    │    │    └── computed column expressions
-      │    │    │    │         └── decimals.d:17
-      │    │    │    │              └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL
+      │    │    │    │         └── d:17
+      │    │    │    │              └── decimals.a:14::DECIMAL + c:16::DECIMAL
       │    │    │    └── filters
       │    │    │         └── a:9 = decimals.a:14
       │    │    └── projections
-      │    │         └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL [as=column19:19]
+      │    │         └── decimals.a:14::DECIMAL + c:16::DECIMAL [as=d_comp:19]
       │    └── projections
       │         ├── CASE WHEN decimals.a:14 IS NULL THEN a:9 ELSE decimals.a:14 END [as=upsert_a:20]
-      │         ├── CASE WHEN decimals.a:14 IS NULL THEN c:11 ELSE decimals.c:16 END [as=upsert_c:21]
-      │         └── CASE WHEN decimals.a:14 IS NULL THEN d:13 ELSE decimals.d:17 END [as=upsert_d:22]
+      │         ├── CASE WHEN decimals.a:14 IS NULL THEN c_default:11 ELSE c:16 END [as=upsert_c:21]
+      │         └── CASE WHEN decimals.a:14 IS NULL THEN d_comp:13 ELSE d:17 END [as=upsert_d:22]
       └── projections
            ├── round(upsert_a:20) = upsert_a:20 [as=check1:23]
            └── b:10[0] > 1 [as=check2:24]
@@ -1763,67 +1763,67 @@ upsert decimals
  ├── columns: <none>
  ├── arbiter indexes: primary
  ├── canary column: decimals.a:14
- ├── fetch columns: decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17
+ ├── fetch columns: decimals.a:14 b:15 c:16 d:17
  ├── insert-mapping:
  │    ├── a:9 => decimals.a:1
- │    ├── b:10 => decimals.b:2
- │    ├── c:11 => decimals.c:3
- │    └── d:13 => decimals.d:4
+ │    ├── b_default:10 => b:2
+ │    ├── c_default:11 => c:3
+ │    └── d_comp:13 => d:4
  ├── check columns: check1:24 check2:25
  └── project
-      ├── columns: check1:24 check2:25 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18 column19:19 upsert_a:20 upsert_b:21 upsert_c:22 upsert_d:23
+      ├── columns: check1:24 check2:25 a:9 b_default:10 c_default:11 d_comp:13 decimals.a:14 b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18 d_comp:19 upsert_a:20 upsert_b:21 upsert_c:22 upsert_d:23
       ├── project
-      │    ├── columns: upsert_a:20 upsert_b:21 upsert_c:22 upsert_d:23 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18 column19:19
+      │    ├── columns: upsert_a:20 upsert_b:21 upsert_c:22 upsert_d:23 a:9 b_default:10 c_default:11 d_comp:13 decimals.a:14 b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18 d_comp:19
       │    ├── project
-      │    │    ├── columns: column19:19 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
+      │    │    ├── columns: d_comp:19 a:9 b_default:10 c_default:11 d_comp:13 decimals.a:14 b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18
       │    │    ├── left-join (hash)
-      │    │    │    ├── columns: a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
+      │    │    │    ├── columns: a:9 b_default:10 c_default:11 d_comp:13 decimals.a:14 b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18
       │    │    │    ├── ensure-upsert-distinct-on
-      │    │    │    │    ├── columns: a:9 b:10 c:11 d:13
+      │    │    │    │    ├── columns: a:9 b_default:10 c_default:11 d_comp:13
       │    │    │    │    ├── grouping columns: a:9
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: d:13 a:9 b:10 c:11
+      │    │    │    │    │    ├── columns: d_comp:13 a:9 b_default:10 c_default:11
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: column12:12 a:9 b:10 c:11
+      │    │    │    │    │    │    ├── columns: d_comp:12 a:9 b_default:10 c_default:11
       │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    ├── columns: a:9 b:10 c:11
+      │    │    │    │    │    │    │    ├── columns: a:9 b_default:10 c_default:11
       │    │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    │    ├── columns: column7:7 column8:8!null column1:6!null
+      │    │    │    │    │    │    │    │    ├── columns: b_default:7 c_default:8!null column1:6!null
       │    │    │    │    │    │    │    │    ├── values
       │    │    │    │    │    │    │    │    │    ├── columns: column1:6!null
       │    │    │    │    │    │    │    │    │    └── (1.1,)
       │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │         ├── NULL::DECIMAL(5,1)[] [as=column7:7]
-      │    │    │    │    │    │    │    │         └── 1.23 [as=column8:8]
+      │    │    │    │    │    │    │    │         ├── NULL::DECIMAL(5,1)[] [as=b_default:7]
+      │    │    │    │    │    │    │    │         └── 1.23 [as=c_default:8]
       │    │    │    │    │    │    │    └── projections
       │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column1:6, 0) [as=a:9]
-      │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column7:7, 1) [as=b:10]
-      │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(column8:8, 1) [as=c:11]
+      │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(b_default:7, 1) [as=b_default:10]
+      │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(c_default:8, 1) [as=c_default:11]
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── a:9 + c:11 [as=column12:12]
+      │    │    │    │    │    │         └── a:9 + c_default:11 [as=d_comp:12]
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── crdb_internal.round_decimal_values(column12:12, 1) [as=d:13]
+      │    │    │    │    │         └── crdb_internal.round_decimal_values(d_comp:12, 1) [as=d_comp:13]
       │    │    │    │    └── aggregations
-      │    │    │    │         ├── first-agg [as=b:10]
-      │    │    │    │         │    └── b:10
-      │    │    │    │         ├── first-agg [as=c:11]
-      │    │    │    │         │    └── c:11
-      │    │    │    │         └── first-agg [as=d:13]
-      │    │    │    │              └── d:13
+      │    │    │    │         ├── first-agg [as=b_default:10]
+      │    │    │    │         │    └── b_default:10
+      │    │    │    │         ├── first-agg [as=c_default:11]
+      │    │    │    │         │    └── c_default:11
+      │    │    │    │         └── first-agg [as=d_comp:13]
+      │    │    │    │              └── d_comp:13
       │    │    │    ├── scan decimals
-      │    │    │    │    ├── columns: decimals.a:14!null decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
+      │    │    │    │    ├── columns: decimals.a:14!null b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18
       │    │    │    │    └── computed column expressions
-      │    │    │    │         └── decimals.d:17
-      │    │    │    │              └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL
+      │    │    │    │         └── d:17
+      │    │    │    │              └── decimals.a:14::DECIMAL + c:16::DECIMAL
       │    │    │    └── filters
       │    │    │         └── a:9 = decimals.a:14
       │    │    └── projections
-      │    │         └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL [as=column19:19]
+      │    │         └── decimals.a:14::DECIMAL + c:16::DECIMAL [as=d_comp:19]
       │    └── projections
       │         ├── CASE WHEN decimals.a:14 IS NULL THEN a:9 ELSE decimals.a:14 END [as=upsert_a:20]
-      │         ├── CASE WHEN decimals.a:14 IS NULL THEN b:10 ELSE decimals.b:15 END [as=upsert_b:21]
-      │         ├── CASE WHEN decimals.a:14 IS NULL THEN c:11 ELSE decimals.c:16 END [as=upsert_c:22]
-      │         └── CASE WHEN decimals.a:14 IS NULL THEN d:13 ELSE decimals.d:17 END [as=upsert_d:23]
+      │         ├── CASE WHEN decimals.a:14 IS NULL THEN b_default:10 ELSE b:15 END [as=upsert_b:21]
+      │         ├── CASE WHEN decimals.a:14 IS NULL THEN c_default:11 ELSE c:16 END [as=upsert_c:22]
+      │         └── CASE WHEN decimals.a:14 IS NULL THEN d_comp:13 ELSE d:17 END [as=upsert_d:23]
       └── projections
            ├── round(upsert_a:20) = upsert_a:20 [as=check1:24]
            └── upsert_b:21[0] > 1 [as=check2:25]
@@ -1838,63 +1838,63 @@ upsert decimals
  ├── columns: <none>
  ├── arbiter indexes: primary
  ├── canary column: decimals.a:14
- ├── fetch columns: decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17
+ ├── fetch columns: decimals.a:14 decimals.b:15 c:16 d:17
  ├── insert-mapping:
  │    ├── a:9 => decimals.a:1
  │    ├── b:10 => decimals.b:2
- │    ├── c:11 => decimals.c:3
- │    └── d:13 => decimals.d:4
+ │    ├── c_default:11 => c:3
+ │    └── d_comp:13 => d:4
  ├── update-mapping:
  │    └── upsert_b:23 => decimals.b:2
  ├── check columns: check1:26 check2:27
  └── project
-      ├── columns: check1:26 check2:27 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18 b_new:20 column21:21 upsert_a:22 upsert_b:23 upsert_c:24 upsert_d:25
+      ├── columns: check1:26 check2:27 a:9 b:10 c_default:11 d_comp:13 decimals.a:14 decimals.b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18 b_new:20 d_comp:21 upsert_a:22 upsert_b:23 upsert_c:24 upsert_d:25
       ├── project
-      │    ├── columns: upsert_a:22 upsert_b:23 upsert_c:24 upsert_d:25 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18 b_new:20 column21:21
+      │    ├── columns: upsert_a:22 upsert_b:23 upsert_c:24 upsert_d:25 a:9 b:10 c_default:11 d_comp:13 decimals.a:14 decimals.b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18 b_new:20 d_comp:21
       │    ├── project
-      │    │    ├── columns: column21:21 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18 b_new:20
+      │    │    ├── columns: d_comp:21 a:9 b:10 c_default:11 d_comp:13 decimals.a:14 decimals.b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18 b_new:20
       │    │    ├── project
-      │    │    │    ├── columns: b_new:20 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
+      │    │    │    ├── columns: b_new:20 a:9 b:10 c_default:11 d_comp:13 decimals.a:14 decimals.b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18
       │    │    │    ├── project
-      │    │    │    │    ├── columns: b_new:19!null a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
+      │    │    │    │    ├── columns: b_new:19!null a:9 b:10 c_default:11 d_comp:13 decimals.a:14 decimals.b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18
       │    │    │    │    ├── left-join (hash)
-      │    │    │    │    │    ├── columns: a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
+      │    │    │    │    │    ├── columns: a:9 b:10 c_default:11 d_comp:13 decimals.a:14 decimals.b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18
       │    │    │    │    │    ├── ensure-upsert-distinct-on
-      │    │    │    │    │    │    ├── columns: a:9 b:10 c:11 d:13
+      │    │    │    │    │    │    ├── columns: a:9 b:10 c_default:11 d_comp:13
       │    │    │    │    │    │    ├── grouping columns: a:9
       │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    ├── columns: d:13 a:9 b:10 c:11
+      │    │    │    │    │    │    │    ├── columns: d_comp:13 a:9 b:10 c_default:11
       │    │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    │    ├── columns: column12:12 a:9 b:10 c:11
+      │    │    │    │    │    │    │    │    ├── columns: d_comp:12 a:9 b:10 c_default:11
       │    │    │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    │    │    ├── columns: a:9 b:10 c:11
+      │    │    │    │    │    │    │    │    │    ├── columns: a:9 b:10 c_default:11
       │    │    │    │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    │    │    │    ├── columns: column8:8!null column1:6!null column2:7
+      │    │    │    │    │    │    │    │    │    │    ├── columns: c_default:8!null column1:6!null column2:7
       │    │    │    │    │    │    │    │    │    │    ├── values
       │    │    │    │    │    │    │    │    │    │    │    ├── columns: column1:6!null column2:7
       │    │    │    │    │    │    │    │    │    │    │    └── (1.1, ARRAY[0.95])
       │    │    │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │    │    │         └── 1.23 [as=column8:8]
+      │    │    │    │    │    │    │    │    │    │         └── 1.23 [as=c_default:8]
       │    │    │    │    │    │    │    │    │    └── projections
       │    │    │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column1:6, 0) [as=a:9]
       │    │    │    │    │    │    │    │    │         ├── crdb_internal.round_decimal_values(column2:7, 1) [as=b:10]
-      │    │    │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(column8:8, 1) [as=c:11]
+      │    │    │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(c_default:8, 1) [as=c_default:11]
       │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │         └── a:9 + c:11 [as=column12:12]
+      │    │    │    │    │    │    │    │         └── a:9 + c_default:11 [as=d_comp:12]
       │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(column12:12, 1) [as=d:13]
+      │    │    │    │    │    │    │         └── crdb_internal.round_decimal_values(d_comp:12, 1) [as=d_comp:13]
       │    │    │    │    │    │    └── aggregations
       │    │    │    │    │    │         ├── first-agg [as=b:10]
       │    │    │    │    │    │         │    └── b:10
-      │    │    │    │    │    │         ├── first-agg [as=c:11]
-      │    │    │    │    │    │         │    └── c:11
-      │    │    │    │    │    │         └── first-agg [as=d:13]
-      │    │    │    │    │    │              └── d:13
+      │    │    │    │    │    │         ├── first-agg [as=c_default:11]
+      │    │    │    │    │    │         │    └── c_default:11
+      │    │    │    │    │    │         └── first-agg [as=d_comp:13]
+      │    │    │    │    │    │              └── d_comp:13
       │    │    │    │    │    ├── scan decimals
-      │    │    │    │    │    │    ├── columns: decimals.a:14!null decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
+      │    │    │    │    │    │    ├── columns: decimals.a:14!null decimals.b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18
       │    │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │    │         └── decimals.d:17
-      │    │    │    │    │    │              └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL
+      │    │    │    │    │    │         └── d:17
+      │    │    │    │    │    │              └── decimals.a:14::DECIMAL + c:16::DECIMAL
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── a:9 = decimals.a:14
       │    │    │    │    └── projections
@@ -1902,12 +1902,12 @@ upsert decimals
       │    │    │    └── projections
       │    │    │         └── crdb_internal.round_decimal_values(b_new:19, 1) [as=b_new:20]
       │    │    └── projections
-      │    │         └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL [as=column21:21]
+      │    │         └── decimals.a:14::DECIMAL + c:16::DECIMAL [as=d_comp:21]
       │    └── projections
       │         ├── CASE WHEN decimals.a:14 IS NULL THEN a:9 ELSE decimals.a:14 END [as=upsert_a:22]
       │         ├── CASE WHEN decimals.a:14 IS NULL THEN b:10 ELSE b_new:20 END [as=upsert_b:23]
-      │         ├── CASE WHEN decimals.a:14 IS NULL THEN c:11 ELSE decimals.c:16 END [as=upsert_c:24]
-      │         └── CASE WHEN decimals.a:14 IS NULL THEN d:13 ELSE decimals.d:17 END [as=upsert_d:25]
+      │         ├── CASE WHEN decimals.a:14 IS NULL THEN c_default:11 ELSE c:16 END [as=upsert_c:24]
+      │         └── CASE WHEN decimals.a:14 IS NULL THEN d_comp:13 ELSE d:17 END [as=upsert_d:25]
       └── projections
            ├── round(upsert_a:22) = upsert_a:22 [as=check1:26]
            └── upsert_b:23[0] > 1 [as=check2:27]

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -1848,13 +1848,13 @@ upsert decimals
  │    └── upsert_b:23 => decimals.b:2
  ├── check columns: check1:26 check2:27
  └── project
-      ├── columns: check1:26 check2:27 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18 b:20 column21:21 upsert_a:22 upsert_b:23 upsert_c:24 upsert_d:25
+      ├── columns: check1:26 check2:27 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18 b_new:20 column21:21 upsert_a:22 upsert_b:23 upsert_c:24 upsert_d:25
       ├── project
-      │    ├── columns: upsert_a:22 upsert_b:23 upsert_c:24 upsert_d:25 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18 b:20 column21:21
+      │    ├── columns: upsert_a:22 upsert_b:23 upsert_c:24 upsert_d:25 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18 b_new:20 column21:21
       │    ├── project
-      │    │    ├── columns: column21:21 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18 b:20
+      │    │    ├── columns: column21:21 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18 b_new:20
       │    │    ├── project
-      │    │    │    ├── columns: b:20 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
+      │    │    │    ├── columns: b_new:20 a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
       │    │    │    ├── project
       │    │    │    │    ├── columns: b_new:19!null a:9 b:10 c:11 d:13 decimals.a:14 decimals.b:15 decimals.c:16 decimals.d:17 crdb_internal_mvcc_timestamp:18
       │    │    │    │    ├── left-join (hash)
@@ -1900,12 +1900,12 @@ upsert decimals
       │    │    │    │    └── projections
       │    │    │    │         └── ARRAY[0.99] [as=b_new:19]
       │    │    │    └── projections
-      │    │    │         └── crdb_internal.round_decimal_values(b_new:19, 1) [as=b:20]
+      │    │    │         └── crdb_internal.round_decimal_values(b_new:19, 1) [as=b_new:20]
       │    │    └── projections
       │    │         └── decimals.a:14::DECIMAL + decimals.c:16::DECIMAL [as=column21:21]
       │    └── projections
       │         ├── CASE WHEN decimals.a:14 IS NULL THEN a:9 ELSE decimals.a:14 END [as=upsert_a:22]
-      │         ├── CASE WHEN decimals.a:14 IS NULL THEN b:10 ELSE b:20 END [as=upsert_b:23]
+      │         ├── CASE WHEN decimals.a:14 IS NULL THEN b:10 ELSE b_new:20 END [as=upsert_b:23]
       │         ├── CASE WHEN decimals.a:14 IS NULL THEN c:11 ELSE decimals.c:16 END [as=upsert_c:24]
       │         └── CASE WHEN decimals.a:14 IS NULL THEN d:13 ELSE decimals.d:17 END [as=upsert_d:25]
       └── projections

--- a/pkg/sql/opt/optbuilder/testdata/virtual-columns
+++ b/pkg/sql/opt/optbuilder/testdata/virtual-columns
@@ -97,14 +97,14 @@ insert t
  ├── insert-mapping:
  │    ├── column1:5 => a:1
  │    ├── column2:6 => b:2
- │    └── column7:7 => v:3
+ │    └── v_comp:7 => v:3
  └── project
-      ├── columns: column7:7!null column1:5!null column2:6!null
+      ├── columns: v_comp:7!null column1:5!null column2:6!null
       ├── values
       │    ├── columns: column1:5!null column2:6!null
       │    └── (1, 1)
       └── projections
-           └── column1:5 + column2:6 [as=column7:7]
+           └── column1:5 + column2:6 [as=v_comp:7]
 
 build
 INSERT INTO t(a) VALUES (1)
@@ -113,19 +113,19 @@ insert t
  ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:5 => a:1
- │    ├── column6:6 => b:2
- │    └── column7:7 => v:3
+ │    ├── b_default:6 => b:2
+ │    └── v_comp:7 => v:3
  └── project
-      ├── columns: column7:7 column1:5!null column6:6
+      ├── columns: v_comp:7 column1:5!null b_default:6
       ├── project
-      │    ├── columns: column6:6 column1:5!null
+      │    ├── columns: b_default:6 column1:5!null
       │    ├── values
       │    │    ├── columns: column1:5!null
       │    │    └── (1,)
       │    └── projections
-      │         └── NULL::INT8 [as=column6:6]
+      │         └── NULL::INT8 [as=b_default:6]
       └── projections
-           └── column1:5 + column6:6 [as=column7:7]
+           └── column1:5 + b_default:6 [as=v_comp:7]
 
 build
 INSERT INTO t(a, b, v) VALUES (1, 1, 1)
@@ -142,14 +142,14 @@ project
       ├── insert-mapping:
       │    ├── column1:5 => a:1
       │    ├── column2:6 => b:2
-      │    └── column7:7 => v:3
+      │    └── v_comp:7 => v:3
       └── project
-           ├── columns: column7:7!null column1:5!null column2:6!null
+           ├── columns: v_comp:7!null column1:5!null column2:6!null
            ├── values
            │    ├── columns: column1:5!null column2:6!null
            │    └── (1, 1)
            └── projections
-                └── column1:5 + column2:6 [as=column7:7]
+                └── column1:5 + column2:6 [as=v_comp:7]
 
 build
 INSERT INTO t_idx VALUES (1, 1)
@@ -159,14 +159,14 @@ insert t_idx
  ├── insert-mapping:
  │    ├── column1:5 => a:1
  │    ├── column2:6 => b:2
- │    └── column7:7 => v:3
+ │    └── v_comp:7 => v:3
  └── project
-      ├── columns: column7:7!null column1:5!null column2:6!null
+      ├── columns: v_comp:7!null column1:5!null column2:6!null
       ├── values
       │    ├── columns: column1:5!null column2:6!null
       │    └── (1, 1)
       └── projections
-           └── column1:5 + column2:6 [as=column7:7]
+           └── column1:5 + column2:6 [as=v_comp:7]
 
 build
 INSERT INTO t_check VALUES (1, 1)
@@ -176,22 +176,22 @@ insert t_check
  ├── insert-mapping:
  │    ├── column1:6 => a:1
  │    ├── column2:7 => b:2
- │    ├── column8:8 => v:3
- │    └── column9:9 => w:4
+ │    ├── v_comp:8 => v:3
+ │    └── w_comp:9 => w:4
  ├── check columns: check1:10 check2:11
  └── project
-      ├── columns: check1:10!null check2:11!null column1:6!null column2:7!null column8:8!null column9:9!null
+      ├── columns: check1:10!null check2:11!null column1:6!null column2:7!null v_comp:8!null w_comp:9!null
       ├── project
-      │    ├── columns: column8:8!null column9:9!null column1:6!null column2:7!null
+      │    ├── columns: v_comp:8!null w_comp:9!null column1:6!null column2:7!null
       │    ├── values
       │    │    ├── columns: column1:6!null column2:7!null
       │    │    └── (1, 1)
       │    └── projections
-      │         ├── column1:6 + column2:7 [as=column8:8]
-      │         └── column1:6 * column2:7 [as=column9:9]
+      │         ├── column1:6 + column2:7 [as=v_comp:8]
+      │         └── column1:6 * column2:7 [as=w_comp:9]
       └── projections
-           ├── column8:8 < column9:9 [as=check1:10]
-           └── column8:8 >= 10 [as=check2:11]
+           ├── v_comp:8 < w_comp:9 [as=check1:10]
+           └── v_comp:8 >= 10 [as=check2:11]
 
 # -- DELETE tests --
 
@@ -420,9 +420,9 @@ update t
  ├── fetch columns: a:5 b:6 v:7
  ├── update-mapping:
  │    ├── a_new:9 => a:1
- │    └── column10:10 => v:3
+ │    └── v_comp:10 => v:3
  └── project
-      ├── columns: column10:10 a:5!null b:6 v:7 crdb_internal_mvcc_timestamp:8 a_new:9!null
+      ├── columns: v_comp:10 a:5!null b:6 v:7 crdb_internal_mvcc_timestamp:8 a_new:9!null
       ├── project
       │    ├── columns: a_new:9!null a:5!null b:6 v:7 crdb_internal_mvcc_timestamp:8
       │    ├── project
@@ -437,7 +437,7 @@ update t
       │    └── projections
       │         └── a:5 + 1 [as=a_new:9]
       └── projections
-           └── a_new:9 + b:6 [as=column10:10]
+           └── a_new:9 + b:6 [as=v_comp:10]
 
 build
 UPDATE t SET a=a+1 WHERE v=1
@@ -447,9 +447,9 @@ update t
  ├── fetch columns: a:5 b:6 v:7
  ├── update-mapping:
  │    ├── a_new:9 => a:1
- │    └── column10:10 => v:3
+ │    └── v_comp:10 => v:3
  └── project
-      ├── columns: column10:10 a:5!null b:6 v:7!null crdb_internal_mvcc_timestamp:8 a_new:9!null
+      ├── columns: v_comp:10 a:5!null b:6 v:7!null crdb_internal_mvcc_timestamp:8 a_new:9!null
       ├── project
       │    ├── columns: a_new:9!null a:5!null b:6 v:7!null crdb_internal_mvcc_timestamp:8
       │    ├── select
@@ -468,7 +468,7 @@ update t
       │    └── projections
       │         └── a:5 + 1 [as=a_new:9]
       └── projections
-           └── a_new:9 + b:6 [as=column10:10]
+           └── a_new:9 + b:6 [as=v_comp:10]
 
 build
 UPDATE t SET a=a+1 WHERE a+b=1
@@ -478,9 +478,9 @@ update t
  ├── fetch columns: a:5 b:6 v:7
  ├── update-mapping:
  │    ├── a_new:9 => a:1
- │    └── column10:10 => v:3
+ │    └── v_comp:10 => v:3
  └── project
-      ├── columns: column10:10 a:5!null b:6 v:7 crdb_internal_mvcc_timestamp:8 a_new:9!null
+      ├── columns: v_comp:10 a:5!null b:6 v:7 crdb_internal_mvcc_timestamp:8 a_new:9!null
       ├── project
       │    ├── columns: a_new:9!null a:5!null b:6 v:7 crdb_internal_mvcc_timestamp:8
       │    ├── select
@@ -499,7 +499,7 @@ update t
       │    └── projections
       │         └── a:5 + 1 [as=a_new:9]
       └── projections
-           └── a_new:9 + b:6 [as=column10:10]
+           └── a_new:9 + b:6 [as=v_comp:10]
 
 build
 UPDATE t_idx SET a=a+1
@@ -509,9 +509,9 @@ update t_idx
  ├── fetch columns: a:5 b:6 v:7
  ├── update-mapping:
  │    ├── a_new:9 => a:1
- │    └── column10:10 => v:3
+ │    └── v_comp:10 => v:3
  └── project
-      ├── columns: column10:10 a:5!null b:6 v:7 crdb_internal_mvcc_timestamp:8 a_new:9!null
+      ├── columns: v_comp:10 a:5!null b:6 v:7 crdb_internal_mvcc_timestamp:8 a_new:9!null
       ├── project
       │    ├── columns: a_new:9!null a:5!null b:6 v:7 crdb_internal_mvcc_timestamp:8
       │    ├── project
@@ -526,7 +526,7 @@ update t_idx
       │    └── projections
       │         └── a:5 + 1 [as=a_new:9]
       └── projections
-           └── a_new:9 + b:6 [as=column10:10]
+           └── a_new:9 + b:6 [as=v_comp:10]
 
 build
 UPDATE t_idx SET a=a+1 WHERE v=1
@@ -536,9 +536,9 @@ update t_idx
  ├── fetch columns: a:5 b:6 v:7
  ├── update-mapping:
  │    ├── a_new:9 => a:1
- │    └── column10:10 => v:3
+ │    └── v_comp:10 => v:3
  └── project
-      ├── columns: column10:10 a:5!null b:6 v:7!null crdb_internal_mvcc_timestamp:8 a_new:9!null
+      ├── columns: v_comp:10 a:5!null b:6 v:7!null crdb_internal_mvcc_timestamp:8 a_new:9!null
       ├── project
       │    ├── columns: a_new:9!null a:5!null b:6 v:7!null crdb_internal_mvcc_timestamp:8
       │    ├── select
@@ -557,7 +557,7 @@ update t_idx
       │    └── projections
       │         └── a:5 + 1 [as=a_new:9]
       └── projections
-           └── a_new:9 + b:6 [as=column10:10]
+           └── a_new:9 + b:6 [as=v_comp:10]
 
 build
 UPDATE t_idx SET a=a+1 WHERE a+b=1
@@ -567,9 +567,9 @@ update t_idx
  ├── fetch columns: a:5 b:6 v:7
  ├── update-mapping:
  │    ├── a_new:9 => a:1
- │    └── column10:10 => v:3
+ │    └── v_comp:10 => v:3
  └── project
-      ├── columns: column10:10 a:5!null b:6 v:7 crdb_internal_mvcc_timestamp:8 a_new:9!null
+      ├── columns: v_comp:10 a:5!null b:6 v:7 crdb_internal_mvcc_timestamp:8 a_new:9!null
       ├── project
       │    ├── columns: a_new:9!null a:5!null b:6 v:7 crdb_internal_mvcc_timestamp:8
       │    ├── select
@@ -588,7 +588,7 @@ update t_idx
       │    └── projections
       │         └── a:5 + 1 [as=a_new:9]
       └── projections
-           └── a_new:9 + b:6 [as=column10:10]
+           └── a_new:9 + b:6 [as=v_comp:10]
 
 build
 UPDATE t_idx SET b=b+1 RETURNING v
@@ -600,9 +600,9 @@ project
       ├── fetch columns: a:5 b:6 v:7
       ├── update-mapping:
       │    ├── b_new:9 => b:2
-      │    └── column10:10 => v:3
+      │    └── v_comp:10 => v:3
       └── project
-           ├── columns: column10:10 a:5!null b:6 v:7 crdb_internal_mvcc_timestamp:8 b_new:9
+           ├── columns: v_comp:10 a:5!null b:6 v:7 crdb_internal_mvcc_timestamp:8 b_new:9
            ├── project
            │    ├── columns: b_new:9 a:5!null b:6 v:7 crdb_internal_mvcc_timestamp:8
            │    ├── project
@@ -617,7 +617,7 @@ project
            │    └── projections
            │         └── b:6 + 1 [as=b_new:9]
            └── projections
-                └── a:5 + b_new:9 [as=column10:10]
+                └── a:5 + b_new:9 [as=v_comp:10]
 
 build
 UPDATE t_idx2 SET b=b+1 RETURNING w
@@ -629,9 +629,9 @@ project
       ├── fetch columns: a:7 b:8 c:9 v:10 w:11
       ├── update-mapping:
       │    ├── b_new:13 => b:2
-      │    └── column14:14 => v:4
+      │    └── v_comp:14 => v:4
       └── project
-           ├── columns: column14:14 column15:15 a:7!null b:8 c:9 v:10 w:11 crdb_internal_mvcc_timestamp:12 b_new:13
+           ├── columns: v_comp:14 w_comp:15 a:7!null b:8 c:9 v:10 w:11 crdb_internal_mvcc_timestamp:12 b_new:13
            ├── project
            │    ├── columns: b_new:13 a:7!null b:8 c:9 v:10 w:11 crdb_internal_mvcc_timestamp:12
            │    ├── project
@@ -649,8 +649,8 @@ project
            │    └── projections
            │         └── b:8 + 1 [as=b_new:13]
            └── projections
-                ├── a:7 + b_new:13 [as=column14:14]
-                └── c:9 + 1 [as=column15:15]
+                ├── a:7 + b_new:13 [as=v_comp:14]
+                └── c:9 + 1 [as=w_comp:15]
 
 build
 UPDATE t_check SET b=b+1
@@ -660,13 +660,13 @@ update t_check
  ├── fetch columns: a:6 b:7 v:8 w:9
  ├── update-mapping:
  │    ├── b_new:11 => b:2
- │    ├── column12:12 => v:3
- │    └── column13:13 => w:4
+ │    ├── v_comp:12 => v:3
+ │    └── w_comp:13 => w:4
  ├── check columns: check1:14 check2:15
  └── project
-      ├── columns: check1:14 check2:15 a:6!null b:7 v:8 w:9 crdb_internal_mvcc_timestamp:10 b_new:11 column12:12 column13:13
+      ├── columns: check1:14 check2:15 a:6!null b:7 v:8 w:9 crdb_internal_mvcc_timestamp:10 b_new:11 v_comp:12 w_comp:13
       ├── project
-      │    ├── columns: column12:12 column13:13 a:6!null b:7 v:8 w:9 crdb_internal_mvcc_timestamp:10 b_new:11
+      │    ├── columns: v_comp:12 w_comp:13 a:6!null b:7 v:8 w:9 crdb_internal_mvcc_timestamp:10 b_new:11
       │    ├── project
       │    │    ├── columns: b_new:11 a:6!null b:7 v:8 w:9 crdb_internal_mvcc_timestamp:10
       │    │    ├── project
@@ -684,11 +684,11 @@ update t_check
       │    │    └── projections
       │    │         └── b:7 + 1 [as=b_new:11]
       │    └── projections
-      │         ├── a:6 + b_new:11 [as=column12:12]
-      │         └── a:6 * b_new:11 [as=column13:13]
+      │         ├── a:6 + b_new:11 [as=v_comp:12]
+      │         └── a:6 * b_new:11 [as=w_comp:13]
       └── projections
-           ├── column12:12 < column13:13 [as=check1:14]
-           └── column12:12 >= 10 [as=check2:15]
+           ├── v_comp:12 < w_comp:13 [as=check1:14]
+           └── v_comp:12 >= 10 [as=check2:15]
 
 # -- UPSERT / INSERT ON CONFLICT tests --
 
@@ -700,14 +700,14 @@ upsert t
  ├── upsert-mapping:
  │    ├── column1:5 => a:1
  │    ├── column2:6 => b:2
- │    └── column7:7 => v:3
+ │    └── v_comp:7 => v:3
  └── project
-      ├── columns: column7:7!null column1:5!null column2:6!null
+      ├── columns: v_comp:7!null column1:5!null column2:6!null
       ├── values
       │    ├── columns: column1:5!null column2:6!null
       │    └── (1, 1)
       └── projections
-           └── column1:5 + column2:6 [as=column7:7]
+           └── column1:5 + column2:6 [as=v_comp:7]
 
 build
 UPSERT INTO t(a) VALUES (1)
@@ -719,33 +719,33 @@ upsert t
  ├── fetch columns: a:8 b:9 v:10
  ├── insert-mapping:
  │    ├── column1:5 => a:1
- │    ├── column6:6 => b:2
- │    └── column7:7 => v:3
+ │    ├── b_default:6 => b:2
+ │    └── v_comp:7 => v:3
  └── project
-      ├── columns: upsert_a:13 upsert_b:14 upsert_v:15 column1:5!null column6:6 column7:7 a:8 b:9 v:10 crdb_internal_mvcc_timestamp:11 column12:12
+      ├── columns: upsert_a:13 upsert_b:14 upsert_v:15 column1:5!null b_default:6 v_comp:7 a:8 b:9 v:10 crdb_internal_mvcc_timestamp:11 v_comp:12
       ├── project
-      │    ├── columns: column12:12 column1:5!null column6:6 column7:7 a:8 b:9 v:10 crdb_internal_mvcc_timestamp:11
+      │    ├── columns: v_comp:12 column1:5!null b_default:6 v_comp:7 a:8 b:9 v:10 crdb_internal_mvcc_timestamp:11
       │    ├── left-join (hash)
-      │    │    ├── columns: column1:5!null column6:6 column7:7 a:8 b:9 v:10 crdb_internal_mvcc_timestamp:11
+      │    │    ├── columns: column1:5!null b_default:6 v_comp:7 a:8 b:9 v:10 crdb_internal_mvcc_timestamp:11
       │    │    ├── ensure-upsert-distinct-on
-      │    │    │    ├── columns: column1:5!null column6:6 column7:7
+      │    │    │    ├── columns: column1:5!null b_default:6 v_comp:7
       │    │    │    ├── grouping columns: column1:5!null
       │    │    │    ├── project
-      │    │    │    │    ├── columns: column7:7 column1:5!null column6:6
+      │    │    │    │    ├── columns: v_comp:7 column1:5!null b_default:6
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: column6:6 column1:5!null
+      │    │    │    │    │    ├── columns: b_default:6 column1:5!null
       │    │    │    │    │    ├── values
       │    │    │    │    │    │    ├── columns: column1:5!null
       │    │    │    │    │    │    └── (1,)
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── NULL::INT8 [as=column6:6]
+      │    │    │    │    │         └── NULL::INT8 [as=b_default:6]
       │    │    │    │    └── projections
-      │    │    │    │         └── column1:5 + column6:6 [as=column7:7]
+      │    │    │    │         └── column1:5 + b_default:6 [as=v_comp:7]
       │    │    │    └── aggregations
-      │    │    │         ├── first-agg [as=column6:6]
-      │    │    │         │    └── column6:6
-      │    │    │         └── first-agg [as=column7:7]
-      │    │    │              └── column7:7
+      │    │    │         ├── first-agg [as=b_default:6]
+      │    │    │         │    └── b_default:6
+      │    │    │         └── first-agg [as=v_comp:7]
+      │    │    │              └── v_comp:7
       │    │    ├── project
       │    │    │    ├── columns: v:10 a:8!null b:9 crdb_internal_mvcc_timestamp:11
       │    │    │    ├── scan t
@@ -758,11 +758,11 @@ upsert t
       │    │    └── filters
       │    │         └── column1:5 = a:8
       │    └── projections
-      │         └── a:8 + b:9 [as=column12:12]
+      │         └── a:8 + b:9 [as=v_comp:12]
       └── projections
            ├── CASE WHEN a:8 IS NULL THEN column1:5 ELSE a:8 END [as=upsert_a:13]
-           ├── CASE WHEN a:8 IS NULL THEN column6:6 ELSE b:9 END [as=upsert_b:14]
-           └── CASE WHEN a:8 IS NULL THEN column7:7 ELSE v:10 END [as=upsert_v:15]
+           ├── CASE WHEN a:8 IS NULL THEN b_default:6 ELSE b:9 END [as=upsert_b:14]
+           └── CASE WHEN a:8 IS NULL THEN v_comp:7 ELSE v:10 END [as=upsert_v:15]
 
 build
 UPSERT INTO t(a, b, v) VALUES (1)
@@ -779,14 +779,14 @@ project
       ├── upsert-mapping:
       │    ├── column1:5 => a:1
       │    ├── column2:6 => b:2
-      │    └── column7:7 => v:3
+      │    └── v_comp:7 => v:3
       └── project
-           ├── columns: column7:7!null column1:5!null column2:6!null
+           ├── columns: v_comp:7!null column1:5!null column2:6!null
            ├── values
            │    ├── columns: column1:5!null column2:6!null
            │    └── (1, 1)
            └── projections
-                └── column1:5 + column2:6 [as=column7:7]
+                └── column1:5 + column2:6 [as=v_comp:7]
 
 build
 UPSERT INTO t_check VALUES (1, 1)
@@ -796,22 +796,22 @@ upsert t_check
  ├── upsert-mapping:
  │    ├── column1:6 => a:1
  │    ├── column2:7 => b:2
- │    ├── column8:8 => v:3
- │    └── column9:9 => w:4
+ │    ├── v_comp:8 => v:3
+ │    └── w_comp:9 => w:4
  ├── check columns: check1:10 check2:11
  └── project
-      ├── columns: check1:10!null check2:11!null column1:6!null column2:7!null column8:8!null column9:9!null
+      ├── columns: check1:10!null check2:11!null column1:6!null column2:7!null v_comp:8!null w_comp:9!null
       ├── project
-      │    ├── columns: column8:8!null column9:9!null column1:6!null column2:7!null
+      │    ├── columns: v_comp:8!null w_comp:9!null column1:6!null column2:7!null
       │    ├── values
       │    │    ├── columns: column1:6!null column2:7!null
       │    │    └── (1, 1)
       │    └── projections
-      │         ├── column1:6 + column2:7 [as=column8:8]
-      │         └── column1:6 * column2:7 [as=column9:9]
+      │         ├── column1:6 + column2:7 [as=v_comp:8]
+      │         └── column1:6 * column2:7 [as=w_comp:9]
       └── projections
-           ├── column8:8 < column9:9 [as=check1:10]
-           └── column8:8 >= 10 [as=check2:11]
+           ├── v_comp:8 < w_comp:9 [as=check1:10]
+           └── v_comp:8 >= 10 [as=check2:11]
 
 build
 INSERT INTO t VALUES (1, 1) ON CONFLICT DO NOTHING RETURNING v
@@ -824,19 +824,19 @@ project
       ├── insert-mapping:
       │    ├── column1:5 => a:1
       │    ├── column2:6 => b:2
-      │    └── column7:7 => v:3
+      │    └── v_comp:7 => v:3
       └── upsert-distinct-on
-           ├── columns: column1:5!null column2:6!null column7:7!null
+           ├── columns: column1:5!null column2:6!null v_comp:7!null
            ├── grouping columns: column1:5!null
            ├── anti-join (hash)
-           │    ├── columns: column1:5!null column2:6!null column7:7!null
+           │    ├── columns: column1:5!null column2:6!null v_comp:7!null
            │    ├── project
-           │    │    ├── columns: column7:7!null column1:5!null column2:6!null
+           │    │    ├── columns: v_comp:7!null column1:5!null column2:6!null
            │    │    ├── values
            │    │    │    ├── columns: column1:5!null column2:6!null
            │    │    │    └── (1, 1)
            │    │    └── projections
-           │    │         └── column1:5 + column2:6 [as=column7:7]
+           │    │         └── column1:5 + column2:6 [as=v_comp:7]
            │    ├── project
            │    │    ├── columns: v:10 a:8!null b:9
            │    │    ├── scan t
@@ -851,8 +851,8 @@ project
            └── aggregations
                 ├── first-agg [as=column2:6]
                 │    └── column2:6
-                └── first-agg [as=column7:7]
-                     └── column7:7
+                └── first-agg [as=v_comp:7]
+                     └── v_comp:7
 
 build
 INSERT INTO t_idx2 VALUES (1, 1, 1) ON CONFLICT (w) DO NOTHING
@@ -864,21 +864,21 @@ insert t_idx2
  │    ├── column1:7 => a:1
  │    ├── column2:8 => b:2
  │    ├── column3:9 => c:3
- │    ├── column10:10 => v:4
- │    └── column11:11 => w:5
+ │    ├── v_comp:10 => v:4
+ │    └── w_comp:11 => w:5
  └── upsert-distinct-on
-      ├── columns: column1:7!null column2:8!null column3:9!null column10:10!null column11:11!null
-      ├── grouping columns: column11:11!null
+      ├── columns: column1:7!null column2:8!null column3:9!null v_comp:10!null w_comp:11!null
+      ├── grouping columns: w_comp:11!null
       ├── anti-join (hash)
-      │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10!null column11:11!null
+      │    ├── columns: column1:7!null column2:8!null column3:9!null v_comp:10!null w_comp:11!null
       │    ├── project
-      │    │    ├── columns: column10:10!null column11:11!null column1:7!null column2:8!null column3:9!null
+      │    │    ├── columns: v_comp:10!null w_comp:11!null column1:7!null column2:8!null column3:9!null
       │    │    ├── values
       │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null
       │    │    │    └── (1, 1, 1)
       │    │    └── projections
-      │    │         ├── column1:7 + column2:8 [as=column10:10]
-      │    │         └── column3:9 + 1 [as=column11:11]
+      │    │         ├── column1:7 + column2:8 [as=v_comp:10]
+      │    │         └── column3:9 + 1 [as=w_comp:11]
       │    ├── project
       │    │    ├── columns: v:15 w:16 a:12!null b:13 c:14
       │    │    ├── scan t_idx2
@@ -892,7 +892,7 @@ insert t_idx2
       │    │         ├── a:12 + b:13 [as=v:15]
       │    │         └── c:14 + 1 [as=w:16]
       │    └── filters
-      │         └── column11:11 = w:16
+      │         └── w_comp:11 = w:16
       └── aggregations
            ├── first-agg [as=column1:7]
            │    └── column1:7
@@ -900,8 +900,8 @@ insert t_idx2
            │    └── column2:8
            ├── first-agg [as=column3:9]
            │    └── column3:9
-           └── first-agg [as=column10:10]
-                └── column10:10
+           └── first-agg [as=v_comp:10]
+                └── v_comp:10
 
 build
 INSERT INTO t_idx2 VALUES (1, 1, 1) ON CONFLICT DO NOTHING
@@ -913,26 +913,26 @@ insert t_idx2
  │    ├── column1:7 => a:1
  │    ├── column2:8 => b:2
  │    ├── column3:9 => c:3
- │    ├── column10:10 => v:4
- │    └── column11:11 => w:5
+ │    ├── v_comp:10 => v:4
+ │    └── w_comp:11 => w:5
  └── upsert-distinct-on
-      ├── columns: column1:7!null column2:8!null column3:9!null column10:10!null column11:11!null
-      ├── grouping columns: column11:11!null
+      ├── columns: column1:7!null column2:8!null column3:9!null v_comp:10!null w_comp:11!null
+      ├── grouping columns: w_comp:11!null
       ├── upsert-distinct-on
-      │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10!null column11:11!null
+      │    ├── columns: column1:7!null column2:8!null column3:9!null v_comp:10!null w_comp:11!null
       │    ├── grouping columns: column1:7!null
       │    ├── anti-join (hash)
-      │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10!null column11:11!null
+      │    │    ├── columns: column1:7!null column2:8!null column3:9!null v_comp:10!null w_comp:11!null
       │    │    ├── anti-join (hash)
-      │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10!null column11:11!null
+      │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null v_comp:10!null w_comp:11!null
       │    │    │    ├── project
-      │    │    │    │    ├── columns: column10:10!null column11:11!null column1:7!null column2:8!null column3:9!null
+      │    │    │    │    ├── columns: v_comp:10!null w_comp:11!null column1:7!null column2:8!null column3:9!null
       │    │    │    │    ├── values
       │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null
       │    │    │    │    │    └── (1, 1, 1)
       │    │    │    │    └── projections
-      │    │    │    │         ├── column1:7 + column2:8 [as=column10:10]
-      │    │    │    │         └── column3:9 + 1 [as=column11:11]
+      │    │    │    │         ├── column1:7 + column2:8 [as=v_comp:10]
+      │    │    │    │         └── column3:9 + 1 [as=w_comp:11]
       │    │    │    ├── project
       │    │    │    │    ├── columns: v:15 w:16 a:12!null b:13 c:14
       │    │    │    │    ├── scan t_idx2
@@ -960,16 +960,16 @@ insert t_idx2
       │    │    │         ├── a:18 + b:19 [as=v:21]
       │    │    │         └── c:20 + 1 [as=w:22]
       │    │    └── filters
-      │    │         └── column11:11 = w:22
+      │    │         └── w_comp:11 = w:22
       │    └── aggregations
       │         ├── first-agg [as=column2:8]
       │         │    └── column2:8
       │         ├── first-agg [as=column3:9]
       │         │    └── column3:9
-      │         ├── first-agg [as=column10:10]
-      │         │    └── column10:10
-      │         └── first-agg [as=column11:11]
-      │              └── column11:11
+      │         ├── first-agg [as=v_comp:10]
+      │         │    └── v_comp:10
+      │         └── first-agg [as=w_comp:11]
+      │              └── w_comp:11
       └── aggregations
            ├── first-agg [as=column1:7]
            │    └── column1:7
@@ -977,8 +977,8 @@ insert t_idx2
            │    └── column2:8
            ├── first-agg [as=column3:9]
            │    └── column3:9
-           └── first-agg [as=column10:10]
-                └── column10:10
+           └── first-agg [as=v_comp:10]
+                └── v_comp:10
 
 build
 INSERT INTO t VALUES (1, 1) ON CONFLICT (a) DO UPDATE SET a=t.v+1
@@ -991,33 +991,33 @@ upsert t
  ├── insert-mapping:
  │    ├── column1:5 => a:1
  │    ├── column2:6 => b:2
- │    └── column7:7 => v:3
+ │    └── v_comp:7 => v:3
  ├── update-mapping:
  │    ├── upsert_a:14 => a:1
  │    └── upsert_v:16 => v:3
  └── project
-      ├── columns: upsert_a:14 upsert_b:15 upsert_v:16 column1:5!null column2:6!null column7:7!null a:8 b:9 v:10 crdb_internal_mvcc_timestamp:11 a_new:12 column13:13
+      ├── columns: upsert_a:14 upsert_b:15 upsert_v:16 column1:5!null column2:6!null v_comp:7!null a:8 b:9 v:10 crdb_internal_mvcc_timestamp:11 a_new:12 v_comp:13
       ├── project
-      │    ├── columns: column13:13 column1:5!null column2:6!null column7:7!null a:8 b:9 v:10 crdb_internal_mvcc_timestamp:11 a_new:12
+      │    ├── columns: v_comp:13 column1:5!null column2:6!null v_comp:7!null a:8 b:9 v:10 crdb_internal_mvcc_timestamp:11 a_new:12
       │    ├── project
-      │    │    ├── columns: a_new:12 column1:5!null column2:6!null column7:7!null a:8 b:9 v:10 crdb_internal_mvcc_timestamp:11
+      │    │    ├── columns: a_new:12 column1:5!null column2:6!null v_comp:7!null a:8 b:9 v:10 crdb_internal_mvcc_timestamp:11
       │    │    ├── left-join (hash)
-      │    │    │    ├── columns: column1:5!null column2:6!null column7:7!null a:8 b:9 v:10 crdb_internal_mvcc_timestamp:11
+      │    │    │    ├── columns: column1:5!null column2:6!null v_comp:7!null a:8 b:9 v:10 crdb_internal_mvcc_timestamp:11
       │    │    │    ├── ensure-upsert-distinct-on
-      │    │    │    │    ├── columns: column1:5!null column2:6!null column7:7!null
+      │    │    │    │    ├── columns: column1:5!null column2:6!null v_comp:7!null
       │    │    │    │    ├── grouping columns: column1:5!null
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: column7:7!null column1:5!null column2:6!null
+      │    │    │    │    │    ├── columns: v_comp:7!null column1:5!null column2:6!null
       │    │    │    │    │    ├── values
       │    │    │    │    │    │    ├── columns: column1:5!null column2:6!null
       │    │    │    │    │    │    └── (1, 1)
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── column1:5 + column2:6 [as=column7:7]
+      │    │    │    │    │         └── column1:5 + column2:6 [as=v_comp:7]
       │    │    │    │    └── aggregations
       │    │    │    │         ├── first-agg [as=column2:6]
       │    │    │    │         │    └── column2:6
-      │    │    │    │         └── first-agg [as=column7:7]
-      │    │    │    │              └── column7:7
+      │    │    │    │         └── first-agg [as=v_comp:7]
+      │    │    │    │              └── v_comp:7
       │    │    │    ├── project
       │    │    │    │    ├── columns: v:10 a:8!null b:9 crdb_internal_mvcc_timestamp:11
       │    │    │    │    ├── scan t
@@ -1032,11 +1032,11 @@ upsert t
       │    │    └── projections
       │    │         └── v:10 + 1 [as=a_new:12]
       │    └── projections
-      │         └── a_new:12 + b:9 [as=column13:13]
+      │         └── a_new:12 + b:9 [as=v_comp:13]
       └── projections
            ├── CASE WHEN a:8 IS NULL THEN column1:5 ELSE a_new:12 END [as=upsert_a:14]
            ├── CASE WHEN a:8 IS NULL THEN column2:6 ELSE b:9 END [as=upsert_b:15]
-           └── CASE WHEN a:8 IS NULL THEN column7:7 ELSE column13:13 END [as=upsert_v:16]
+           └── CASE WHEN a:8 IS NULL THEN v_comp:7 ELSE v_comp:13 END [as=upsert_v:16]
 
 build
 INSERT INTO t VALUES (1, 1) ON CONFLICT (a) DO UPDATE SET a=excluded.v+1
@@ -1049,33 +1049,33 @@ upsert t
  ├── insert-mapping:
  │    ├── column1:5 => a:1
  │    ├── column2:6 => b:2
- │    └── column7:7 => v:3
+ │    └── v_comp:7 => v:3
  ├── update-mapping:
  │    ├── upsert_a:14 => a:1
  │    └── upsert_v:16 => v:3
  └── project
-      ├── columns: upsert_a:14!null upsert_b:15 upsert_v:16 column1:5!null column2:6!null column7:7!null a:8 b:9 v:10 crdb_internal_mvcc_timestamp:11 a_new:12!null column13:13
+      ├── columns: upsert_a:14!null upsert_b:15 upsert_v:16 column1:5!null column2:6!null v_comp:7!null a:8 b:9 v:10 crdb_internal_mvcc_timestamp:11 a_new:12!null v_comp:13
       ├── project
-      │    ├── columns: column13:13 column1:5!null column2:6!null column7:7!null a:8 b:9 v:10 crdb_internal_mvcc_timestamp:11 a_new:12!null
+      │    ├── columns: v_comp:13 column1:5!null column2:6!null v_comp:7!null a:8 b:9 v:10 crdb_internal_mvcc_timestamp:11 a_new:12!null
       │    ├── project
-      │    │    ├── columns: a_new:12!null column1:5!null column2:6!null column7:7!null a:8 b:9 v:10 crdb_internal_mvcc_timestamp:11
+      │    │    ├── columns: a_new:12!null column1:5!null column2:6!null v_comp:7!null a:8 b:9 v:10 crdb_internal_mvcc_timestamp:11
       │    │    ├── left-join (hash)
-      │    │    │    ├── columns: column1:5!null column2:6!null column7:7!null a:8 b:9 v:10 crdb_internal_mvcc_timestamp:11
+      │    │    │    ├── columns: column1:5!null column2:6!null v_comp:7!null a:8 b:9 v:10 crdb_internal_mvcc_timestamp:11
       │    │    │    ├── ensure-upsert-distinct-on
-      │    │    │    │    ├── columns: column1:5!null column2:6!null column7:7!null
+      │    │    │    │    ├── columns: column1:5!null column2:6!null v_comp:7!null
       │    │    │    │    ├── grouping columns: column1:5!null
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: column7:7!null column1:5!null column2:6!null
+      │    │    │    │    │    ├── columns: v_comp:7!null column1:5!null column2:6!null
       │    │    │    │    │    ├── values
       │    │    │    │    │    │    ├── columns: column1:5!null column2:6!null
       │    │    │    │    │    │    └── (1, 1)
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── column1:5 + column2:6 [as=column7:7]
+      │    │    │    │    │         └── column1:5 + column2:6 [as=v_comp:7]
       │    │    │    │    └── aggregations
       │    │    │    │         ├── first-agg [as=column2:6]
       │    │    │    │         │    └── column2:6
-      │    │    │    │         └── first-agg [as=column7:7]
-      │    │    │    │              └── column7:7
+      │    │    │    │         └── first-agg [as=v_comp:7]
+      │    │    │    │              └── v_comp:7
       │    │    │    ├── project
       │    │    │    │    ├── columns: v:10 a:8!null b:9 crdb_internal_mvcc_timestamp:11
       │    │    │    │    ├── scan t
@@ -1088,13 +1088,13 @@ upsert t
       │    │    │    └── filters
       │    │    │         └── column1:5 = a:8
       │    │    └── projections
-      │    │         └── column7:7 + 1 [as=a_new:12]
+      │    │         └── v_comp:7 + 1 [as=a_new:12]
       │    └── projections
-      │         └── a_new:12 + b:9 [as=column13:13]
+      │         └── a_new:12 + b:9 [as=v_comp:13]
       └── projections
            ├── CASE WHEN a:8 IS NULL THEN column1:5 ELSE a_new:12 END [as=upsert_a:14]
            ├── CASE WHEN a:8 IS NULL THEN column2:6 ELSE b:9 END [as=upsert_b:15]
-           └── CASE WHEN a:8 IS NULL THEN column7:7 ELSE column13:13 END [as=upsert_v:16]
+           └── CASE WHEN a:8 IS NULL THEN v_comp:7 ELSE v_comp:13 END [as=upsert_v:16]
 
 build
 INSERT INTO t_idx2 VALUES (1, 1, 1) ON CONFLICT (w) DO UPDATE SET c=10
@@ -1108,30 +1108,30 @@ upsert t_idx2
  │    ├── column1:7 => a:1
  │    ├── column2:8 => b:2
  │    ├── column3:9 => c:3
- │    ├── column10:10 => v:4
- │    └── column11:11 => w:5
+ │    ├── v_comp:10 => v:4
+ │    └── w_comp:11 => w:5
  ├── update-mapping:
  │    ├── upsert_c:23 => c:3
  │    └── upsert_w:25 => w:5
  └── project
-      ├── columns: upsert_a:21 upsert_b:22 upsert_c:23!null upsert_v:24 upsert_w:25!null column1:7!null column2:8!null column3:9!null column10:10!null column11:11!null a:12 b:13 c:14 v:15 w:16 crdb_internal_mvcc_timestamp:17 c_new:18!null column19:19 column20:20!null
+      ├── columns: upsert_a:21 upsert_b:22 upsert_c:23!null upsert_v:24 upsert_w:25!null column1:7!null column2:8!null column3:9!null v_comp:10!null w_comp:11!null a:12 b:13 c:14 v:15 w:16 crdb_internal_mvcc_timestamp:17 c_new:18!null v_comp:19 w_comp:20!null
       ├── project
-      │    ├── columns: column19:19 column20:20!null column1:7!null column2:8!null column3:9!null column10:10!null column11:11!null a:12 b:13 c:14 v:15 w:16 crdb_internal_mvcc_timestamp:17 c_new:18!null
+      │    ├── columns: v_comp:19 w_comp:20!null column1:7!null column2:8!null column3:9!null v_comp:10!null w_comp:11!null a:12 b:13 c:14 v:15 w:16 crdb_internal_mvcc_timestamp:17 c_new:18!null
       │    ├── project
-      │    │    ├── columns: c_new:18!null column1:7!null column2:8!null column3:9!null column10:10!null column11:11!null a:12 b:13 c:14 v:15 w:16 crdb_internal_mvcc_timestamp:17
+      │    │    ├── columns: c_new:18!null column1:7!null column2:8!null column3:9!null v_comp:10!null w_comp:11!null a:12 b:13 c:14 v:15 w:16 crdb_internal_mvcc_timestamp:17
       │    │    ├── left-join (hash)
-      │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10!null column11:11!null a:12 b:13 c:14 v:15 w:16 crdb_internal_mvcc_timestamp:17
+      │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null v_comp:10!null w_comp:11!null a:12 b:13 c:14 v:15 w:16 crdb_internal_mvcc_timestamp:17
       │    │    │    ├── ensure-upsert-distinct-on
-      │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10!null column11:11!null
-      │    │    │    │    ├── grouping columns: column11:11!null
+      │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null v_comp:10!null w_comp:11!null
+      │    │    │    │    ├── grouping columns: w_comp:11!null
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: column10:10!null column11:11!null column1:7!null column2:8!null column3:9!null
+      │    │    │    │    │    ├── columns: v_comp:10!null w_comp:11!null column1:7!null column2:8!null column3:9!null
       │    │    │    │    │    ├── values
       │    │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null
       │    │    │    │    │    │    └── (1, 1, 1)
       │    │    │    │    │    └── projections
-      │    │    │    │    │         ├── column1:7 + column2:8 [as=column10:10]
-      │    │    │    │    │         └── column3:9 + 1 [as=column11:11]
+      │    │    │    │    │         ├── column1:7 + column2:8 [as=v_comp:10]
+      │    │    │    │    │         └── column3:9 + 1 [as=w_comp:11]
       │    │    │    │    └── aggregations
       │    │    │    │         ├── first-agg [as=column1:7]
       │    │    │    │         │    └── column1:7
@@ -1139,8 +1139,8 @@ upsert t_idx2
       │    │    │    │         │    └── column2:8
       │    │    │    │         ├── first-agg [as=column3:9]
       │    │    │    │         │    └── column3:9
-      │    │    │    │         └── first-agg [as=column10:10]
-      │    │    │    │              └── column10:10
+      │    │    │    │         └── first-agg [as=v_comp:10]
+      │    │    │    │              └── v_comp:10
       │    │    │    ├── project
       │    │    │    │    ├── columns: v:15 w:16 a:12!null b:13 c:14 crdb_internal_mvcc_timestamp:17
       │    │    │    │    ├── scan t_idx2
@@ -1154,18 +1154,18 @@ upsert t_idx2
       │    │    │    │         ├── a:12 + b:13 [as=v:15]
       │    │    │    │         └── c:14 + 1 [as=w:16]
       │    │    │    └── filters
-      │    │    │         └── column11:11 = w:16
+      │    │    │         └── w_comp:11 = w:16
       │    │    └── projections
       │    │         └── 10 [as=c_new:18]
       │    └── projections
-      │         ├── a:12 + b:13 [as=column19:19]
-      │         └── c_new:18 + 1 [as=column20:20]
+      │         ├── a:12 + b:13 [as=v_comp:19]
+      │         └── c_new:18 + 1 [as=w_comp:20]
       └── projections
            ├── CASE WHEN a:12 IS NULL THEN column1:7 ELSE a:12 END [as=upsert_a:21]
            ├── CASE WHEN a:12 IS NULL THEN column2:8 ELSE b:13 END [as=upsert_b:22]
            ├── CASE WHEN a:12 IS NULL THEN column3:9 ELSE c_new:18 END [as=upsert_c:23]
-           ├── CASE WHEN a:12 IS NULL THEN column10:10 ELSE v:15 END [as=upsert_v:24]
-           └── CASE WHEN a:12 IS NULL THEN column11:11 ELSE column20:20 END [as=upsert_w:25]
+           ├── CASE WHEN a:12 IS NULL THEN v_comp:10 ELSE v:15 END [as=upsert_v:24]
+           └── CASE WHEN a:12 IS NULL THEN w_comp:11 ELSE w_comp:20 END [as=upsert_w:25]
 
 build
 INSERT INTO t_idx2 VALUES (1, 1, 1) ON CONFLICT (w) DO UPDATE SET c=t_idx2.v+1
@@ -1179,30 +1179,30 @@ upsert t_idx2
  │    ├── column1:7 => a:1
  │    ├── column2:8 => b:2
  │    ├── column3:9 => c:3
- │    ├── column10:10 => v:4
- │    └── column11:11 => w:5
+ │    ├── v_comp:10 => v:4
+ │    └── w_comp:11 => w:5
  ├── update-mapping:
  │    ├── upsert_c:23 => c:3
  │    └── upsert_w:25 => w:5
  └── project
-      ├── columns: upsert_a:21 upsert_b:22 upsert_c:23 upsert_v:24 upsert_w:25 column1:7!null column2:8!null column3:9!null column10:10!null column11:11!null a:12 b:13 c:14 v:15 w:16 crdb_internal_mvcc_timestamp:17 c_new:18 column19:19 column20:20
+      ├── columns: upsert_a:21 upsert_b:22 upsert_c:23 upsert_v:24 upsert_w:25 column1:7!null column2:8!null column3:9!null v_comp:10!null w_comp:11!null a:12 b:13 c:14 v:15 w:16 crdb_internal_mvcc_timestamp:17 c_new:18 v_comp:19 w_comp:20
       ├── project
-      │    ├── columns: column19:19 column20:20 column1:7!null column2:8!null column3:9!null column10:10!null column11:11!null a:12 b:13 c:14 v:15 w:16 crdb_internal_mvcc_timestamp:17 c_new:18
+      │    ├── columns: v_comp:19 w_comp:20 column1:7!null column2:8!null column3:9!null v_comp:10!null w_comp:11!null a:12 b:13 c:14 v:15 w:16 crdb_internal_mvcc_timestamp:17 c_new:18
       │    ├── project
-      │    │    ├── columns: c_new:18 column1:7!null column2:8!null column3:9!null column10:10!null column11:11!null a:12 b:13 c:14 v:15 w:16 crdb_internal_mvcc_timestamp:17
+      │    │    ├── columns: c_new:18 column1:7!null column2:8!null column3:9!null v_comp:10!null w_comp:11!null a:12 b:13 c:14 v:15 w:16 crdb_internal_mvcc_timestamp:17
       │    │    ├── left-join (hash)
-      │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10!null column11:11!null a:12 b:13 c:14 v:15 w:16 crdb_internal_mvcc_timestamp:17
+      │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null v_comp:10!null w_comp:11!null a:12 b:13 c:14 v:15 w:16 crdb_internal_mvcc_timestamp:17
       │    │    │    ├── ensure-upsert-distinct-on
-      │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column10:10!null column11:11!null
-      │    │    │    │    ├── grouping columns: column11:11!null
+      │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null v_comp:10!null w_comp:11!null
+      │    │    │    │    ├── grouping columns: w_comp:11!null
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: column10:10!null column11:11!null column1:7!null column2:8!null column3:9!null
+      │    │    │    │    │    ├── columns: v_comp:10!null w_comp:11!null column1:7!null column2:8!null column3:9!null
       │    │    │    │    │    ├── values
       │    │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null
       │    │    │    │    │    │    └── (1, 1, 1)
       │    │    │    │    │    └── projections
-      │    │    │    │    │         ├── column1:7 + column2:8 [as=column10:10]
-      │    │    │    │    │         └── column3:9 + 1 [as=column11:11]
+      │    │    │    │    │         ├── column1:7 + column2:8 [as=v_comp:10]
+      │    │    │    │    │         └── column3:9 + 1 [as=w_comp:11]
       │    │    │    │    └── aggregations
       │    │    │    │         ├── first-agg [as=column1:7]
       │    │    │    │         │    └── column1:7
@@ -1210,8 +1210,8 @@ upsert t_idx2
       │    │    │    │         │    └── column2:8
       │    │    │    │         ├── first-agg [as=column3:9]
       │    │    │    │         │    └── column3:9
-      │    │    │    │         └── first-agg [as=column10:10]
-      │    │    │    │              └── column10:10
+      │    │    │    │         └── first-agg [as=v_comp:10]
+      │    │    │    │              └── v_comp:10
       │    │    │    ├── project
       │    │    │    │    ├── columns: v:15 w:16 a:12!null b:13 c:14 crdb_internal_mvcc_timestamp:17
       │    │    │    │    ├── scan t_idx2
@@ -1225,18 +1225,18 @@ upsert t_idx2
       │    │    │    │         ├── a:12 + b:13 [as=v:15]
       │    │    │    │         └── c:14 + 1 [as=w:16]
       │    │    │    └── filters
-      │    │    │         └── column11:11 = w:16
+      │    │    │         └── w_comp:11 = w:16
       │    │    └── projections
       │    │         └── v:15 + 1 [as=c_new:18]
       │    └── projections
-      │         ├── a:12 + b:13 [as=column19:19]
-      │         └── c_new:18 + 1 [as=column20:20]
+      │         ├── a:12 + b:13 [as=v_comp:19]
+      │         └── c_new:18 + 1 [as=w_comp:20]
       └── projections
            ├── CASE WHEN a:12 IS NULL THEN column1:7 ELSE a:12 END [as=upsert_a:21]
            ├── CASE WHEN a:12 IS NULL THEN column2:8 ELSE b:13 END [as=upsert_b:22]
            ├── CASE WHEN a:12 IS NULL THEN column3:9 ELSE c_new:18 END [as=upsert_c:23]
-           ├── CASE WHEN a:12 IS NULL THEN column10:10 ELSE v:15 END [as=upsert_v:24]
-           └── CASE WHEN a:12 IS NULL THEN column11:11 ELSE column20:20 END [as=upsert_w:25]
+           ├── CASE WHEN a:12 IS NULL THEN v_comp:10 ELSE v:15 END [as=upsert_v:24]
+           └── CASE WHEN a:12 IS NULL THEN w_comp:11 ELSE w_comp:20 END [as=upsert_w:25]
 
 # Test that virtual column expressions are forced to have the column type.
 exec-ddl

--- a/pkg/sql/opt/optbuilder/testdata/with
+++ b/pkg/sql/opt/optbuilder/testdata/with
@@ -661,10 +661,10 @@ with &1 (t)
            ├── columns: x.a:5 b:6 rowid:7!null
            ├── insert-mapping:
            │    ├── "?column?":10 => x.a:5
-           │    ├── column11:11 => b:6
-           │    └── column12:12 => rowid:7
+           │    ├── b_default:11 => b:6
+           │    └── rowid_default:12 => rowid:7
            └── project
-                ├── columns: column11:11 column12:12 "?column?":10
+                ├── columns: b_default:11 rowid_default:12 "?column?":10
                 ├── project
                 │    ├── columns: "?column?":10
                 │    ├── with-scan &1 (t)
@@ -674,8 +674,8 @@ with &1 (t)
                 │    └── projections
                 │         └── a:9 + 20 [as="?column?":10]
                 └── projections
-                     ├── NULL::INT8 [as=column11:11]
-                     └── unique_rowid() [as=column12:12]
+                     ├── NULL::INT8 [as=b_default:11]
+                     └── unique_rowid() [as=rowid_default:12]
 
 build
 WITH t AS (SELECT a FROM x) UPDATE x SET a = (SELECT * FROM t) RETURNING *
@@ -1409,15 +1409,15 @@ with &2
  │         ├── insert-mapping:
  │         │    ├── column1:11 => x.a:7
  │         │    ├── column2:12 => x.b:8
- │         │    └── column13:13 => rowid:9
+ │         │    └── rowid_default:13 => rowid:9
  │         └── project
- │              ├── columns: column13:13 column1:11!null column2:12!null
+ │              ├── columns: rowid_default:13 column1:11!null column2:12!null
  │              ├── values
  │              │    ├── columns: column1:11!null column2:12!null
  │              │    ├── (1, 1)
  │              │    └── (2, 2)
  │              └── projections
- │                   └── unique_rowid() [as=column13:13]
+ │                   └── unique_rowid() [as=rowid_default:13]
  └── with &3 (cte)
       ├── columns: x:18 y:19
       ├── recursive-c-t-e
@@ -1634,14 +1634,14 @@ explain
       │         ├── columns: y.a:1!null rowid:2!null
       │         ├── insert-mapping:
       │         │    ├── column1:4 => y.a:1
-      │         │    └── column5:5 => rowid:2
+      │         │    └── rowid_default:5 => rowid:2
       │         └── project
-      │              ├── columns: column5:5 column1:4!null
+      │              ├── columns: rowid_default:5 column1:4!null
       │              ├── values
       │              │    ├── columns: column1:4!null
       │              │    └── (1,)
       │              └── projections
-      │                   └── unique_rowid() [as=column5:5]
+      │                   └── unique_rowid() [as=rowid_default:5]
       └── with-scan &1 (foo)
            ├── columns: a:6!null
            └── mapping:
@@ -1665,9 +1665,9 @@ with &1 (b)
       ├── columns: <none>
       ├── insert-mapping:
       │    ├── w:6 => x:1
-      │    └── column7:7 => rowid:2
+      │    └── rowid_default:7 => rowid:2
       └── project
-           ├── columns: column7:7 w:6!null
+           ├── columns: rowid_default:7 w:6!null
            ├── project
            │    ├── columns: w:6!null
            │    ├── with-scan &1 (b)
@@ -1677,7 +1677,7 @@ with &1 (b)
            │    └── projections
            │         └── z:5 + 1 [as=w:6]
            └── projections
-                └── unique_rowid() [as=column7:7]
+                └── unique_rowid() [as=rowid_default:7]
 
 # Subquery as a whole is correlated, but the WITH is not.
 build

--- a/pkg/sql/opt/optbuilder/union.go
+++ b/pkg/sql/opt/optbuilder/union.go
@@ -64,7 +64,7 @@ func (b *Builder) buildSetOp(
 		outScope.cols = make([]scopeColumn, 0, len(leftScope.cols))
 		for i := range leftScope.cols {
 			c := &leftScope.cols[i]
-			b.synthesizeColumn(outScope, string(c.name), c.typ, nil, nil /* scalar */)
+			b.synthesizeColumn(outScope, c.name, c.typ, nil, nil /* scalar */)
 		}
 	} else {
 		outScope.appendColumnsFromScope(leftScope)
@@ -205,7 +205,7 @@ func (b *Builder) addCasts(dst *scope, outTypes []*types.T) *scope {
 		if !dstCols[i].typ.Identical(outTypes[i]) {
 			// Create a new column which casts the old column to the correct type.
 			castExpr := b.factory.ConstructCast(b.factory.ConstructVariable(dstCols[i].id), outTypes[i])
-			b.synthesizeColumn(dst, string(dstCols[i].name), outTypes[i], nil /* expr */, castExpr)
+			b.synthesizeColumn(dst, dstCols[i].name, outTypes[i], nil /* expr */, castExpr)
 		} else {
 			// The column is already the correct type, so add it as a passthrough
 			// column.

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -197,9 +197,6 @@ func (mb *mutationBuilder) addUpdateCols(exprs tree.UpdateExprs) {
 
 		// Add source column ID to the list of columns to update.
 		mb.updateColIDs[ord] = sourceCol.id
-
-		// Rename the column to match the target column being updated.
-		sourceCol.name = mb.tab.Column(ord).ColName()
 	}
 
 	addCol := func(expr tree.Expr, targetColID opt.ColumnID) {
@@ -227,7 +224,10 @@ func (mb *mutationBuilder) addUpdateCols(exprs tree.UpdateExprs) {
 		targetColMeta := mb.md.ColumnMeta(targetColID)
 		desiredType := targetColMeta.Type
 		texpr := inScope.resolveType(expr, desiredType)
-		scopeCol := projectionsScope.addColumn(targetColMeta.Alias+"_new", texpr)
+		colName := scopeColName(tree.Name(targetColMeta.Alias)).WithMetadataName(
+			targetColMeta.Alias + "_new",
+		)
+		scopeCol := projectionsScope.addColumn(colName, texpr)
 		mb.b.buildScalar(texpr, inScope, projectionsScope, scopeCol, nil)
 
 		checkCol(scopeCol, targetColID)
@@ -246,6 +246,8 @@ func (mb *mutationBuilder) addUpdateCols(exprs tree.UpdateExprs) {
 				// Type check and rename columns.
 				for i := range subqueryScope.cols {
 					checkCol(&subqueryScope.cols[i], mb.targetColList[n])
+					ord := mb.tabID.ColumnOrdinal(mb.targetColList[n])
+					subqueryScope.cols[i].name = scopeColName(mb.tab.Column(ord).ColName())
 					n++
 				}
 

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -121,7 +121,7 @@ func (b *Builder) expandStar(
 			col := &refScope.cols[i]
 			if col.table == *src && col.visibility == cat.Visible {
 				exprs = append(exprs, col)
-				aliases = append(aliases, string(col.name))
+				aliases = append(aliases, string(col.name.ReferenceName()))
 			}
 		}
 
@@ -136,7 +136,7 @@ func (b *Builder) expandStar(
 			col := &inScope.cols[i]
 			if col.visibility == cat.Visible {
 				exprs = append(exprs, col)
-				aliases = append(aliases, string(col.name))
+				aliases = append(aliases, string(col.name.ReferenceName()))
 			}
 		}
 
@@ -180,7 +180,7 @@ func (b *Builder) expandStarAndResolveType(
 //
 // scope  The scope is passed in so it can can be updated with the newly bound
 //        variable.
-// alias  This is an optional alias for the new column (e.g., if specified with
+// name   This is the name for the new column (e.g., if specified with
 //        the AS keyword).
 // typ    The type of the column.
 // expr   The expression this column refers to (if any).
@@ -188,10 +188,9 @@ func (b *Builder) expandStarAndResolveType(
 //
 // The new column is returned as a scopeColumn object.
 func (b *Builder) synthesizeColumn(
-	scope *scope, alias string, typ *types.T, expr tree.TypedExpr, scalar opt.ScalarExpr,
+	scope *scope, name scopeColumnName, typ *types.T, expr tree.TypedExpr, scalar opt.ScalarExpr,
 ) *scopeColumn {
-	name := tree.Name(alias)
-	colID := b.factory.Metadata().AddColumn(alias, typ)
+	colID := b.factory.Metadata().AddColumn(name.MetadataName(), typ)
 	scope.cols = append(scope.cols, scopeColumn{
 		name:   name,
 		typ:    typ,
@@ -205,7 +204,7 @@ func (b *Builder) synthesizeColumn(
 // populateSynthesizedColumn is similar to synthesizeColumn, but it fills in
 // the given existing column rather than allocating a new one.
 func (b *Builder) populateSynthesizedColumn(col *scopeColumn, scalar opt.ScalarExpr) {
-	colID := b.factory.Metadata().AddColumn(string(col.name), col.typ)
+	colID := b.factory.Metadata().AddColumn(col.name.MetadataName(), col.typ)
 	col.id = colID
 	col.scalar = scalar
 }
@@ -223,7 +222,7 @@ func (b *Builder) populateSynthesizedColumn(col *scopeColumn, scalar opt.ScalarE
 // - expr, exprStr and typ in dst already correspond to the expression and type
 //   of the src column.
 func (b *Builder) projectColumn(dst *scopeColumn, src *scopeColumn) {
-	if dst.name == "" {
+	if dst.name.IsAnonymous() {
 		dst.name = src.name
 	}
 	dst.id = src.id
@@ -246,7 +245,7 @@ func (b *Builder) shouldCreateDefaultColumn(texpr tree.TypedExpr) bool {
 
 func (b *Builder) synthesizeResultColumns(scope *scope, cols colinfo.ResultColumns) {
 	for i := range cols {
-		c := b.synthesizeColumn(scope, cols[i].Name, cols[i].Typ, nil /* expr */, nil /* scalar */)
+		c := b.synthesizeColumn(scope, scopeColName(tree.Name(cols[i].Name)), cols[i].Typ, nil /* expr */, nil /* scalar */)
 		if cols[i].Hidden {
 			c.visibility = cat.Hidden
 		}
@@ -323,12 +322,12 @@ func colIdxByProjectionAlias(expr tree.Expr, op string, scope *scope) int {
 			target := c.ColumnName
 			for j := range scope.cols {
 				col := &scope.cols[j]
-				if col.name != target {
+				if !col.name.MatchesReferenceName(target) {
 					continue
 				}
 
 				if col.mutation {
-					panic(makeBackfillError(col.name))
+					panic(makeBackfillError(col.name.ReferenceName()))
 				}
 
 				if index != -1 {

--- a/pkg/sql/opt/optbuilder/values.go
+++ b/pkg/sql/opt/optbuilder/values.go
@@ -114,8 +114,8 @@ func (b *Builder) buildValuesClause(
 	outScope = inScope.push()
 	for colIdx := 0; colIdx < numCols; colIdx++ {
 		// The column names for VALUES are column1, column2, etc.
-		alias := fmt.Sprintf("column%d", colIdx+1)
-		b.synthesizeColumn(outScope, alias, colTypes[colIdx], nil, nil /* scalar */)
+		colName := scopeColName(tree.Name(fmt.Sprintf("column%d", colIdx+1)))
+		b.synthesizeColumn(outScope, colName, colTypes[colIdx], nil, nil /* scalar */)
 	}
 
 	colList := colsToColList(outScope.cols)

--- a/pkg/sql/opt/optbuilder/window.go
+++ b/pkg/sql/opt/optbuilder/window.go
@@ -347,9 +347,14 @@ func (b *Builder) buildWindowArgs(
 	for j, a := range argExprs {
 		col := outScope.findExistingCol(a, false /* allowSideEffects */)
 		if col == nil {
+			// Use an anonymous name because the column cannot be referenced
+			// in other expressions.
+			colName := scopeColName("").WithMetadataName(
+				fmt.Sprintf("%s_%d_arg%d", funcName, windowIndex+1, j+1),
+			)
 			col = b.synthesizeColumn(
 				outScope,
-				fmt.Sprintf("%s_%d_arg%d", funcName, windowIndex+1, j+1),
+				colName,
 				a.ResolvedType(),
 				a,
 				b.buildScalar(a, inScope, nil, nil, nil),
@@ -375,9 +380,14 @@ func (b *Builder) buildWindowPartition(
 	for j, e := range cols {
 		col := outScope.findExistingCol(e, false /* allowSideEffects */)
 		if col == nil {
+			// Use an anonymous name because the column cannot be referenced
+			// in other expressions.
+			colName := scopeColName("").WithMetadataName(
+				fmt.Sprintf("%s_%d_partition_%d", funcName, windowIndex+1, j+1),
+			)
 			col = b.synthesizeColumn(
 				outScope,
-				fmt.Sprintf("%s_%d_partition_%d", funcName, windowIndex+1, j+1),
+				colName,
 				e.ResolvedType(),
 				e,
 				b.buildScalar(e, inScope, nil, nil, nil),
@@ -401,9 +411,14 @@ func (b *Builder) buildWindowOrdering(
 		for _, e := range cols {
 			col := outScope.findExistingCol(e, false /* allowSideEffects */)
 			if col == nil {
+				// Use an anonymous name because the column cannot be referenced
+				// in other expressions.
+				colName := scopeColName("").WithMetadataName(
+					fmt.Sprintf("%s_%d_orderby_%d", funcName, windowIndex+1, j+1),
+				)
 				col = b.synthesizeColumn(
 					outScope,
-					fmt.Sprintf("%s_%d_orderby_%d", funcName, windowIndex+1, j+1),
+					colName,
 					te.ResolvedType(),
 					te,
 					b.buildScalar(e, inScope, nil, nil, nil),
@@ -426,9 +441,14 @@ func (b *Builder) buildFilterCol(
 
 	col := outScope.findExistingCol(te, false /* allowSideEffects */)
 	if col == nil {
+		// Use an anonymous name because the column cannot be referenced
+		// in other expressions.
+		colName := scopeColName("").WithMetadataName(
+			fmt.Sprintf("%s_%d_filter", funcName, windowIndex+1),
+		)
 		col = b.synthesizeColumn(
 			outScope,
-			fmt.Sprintf("%s_%d_filter", funcName, windowIndex+1),
+			colName,
 			te.ResolvedType(),
 			te,
 			b.buildScalar(te, inScope, nil, nil, nil),
@@ -562,7 +582,7 @@ func (b *Builder) constructScalarWindowGroup(
 		defaultNullVal, requiresProjection := b.overrideDefaultNullValue(aggInfos[i])
 		aggregateCol := aggInfos[i].col
 		if requiresProjection {
-			aggregateCol = b.synthesizeColumn(outScope, aggregateCol.name.String(), aggregateCol.typ, aggregateCol.expr, varExpr)
+			aggregateCol = b.synthesizeColumn(outScope, aggregateCol.name, aggregateCol.typ, aggregateCol.expr, varExpr)
 		}
 
 		aggs = append(aggs, b.factory.ConstructAggregationsItem(varExpr, aggregateCol.id))

--- a/pkg/sql/opt/optbuilder/with.go
+++ b/pkg/sql/opt/optbuilder/with.go
@@ -296,7 +296,7 @@ func (b *Builder) buildCTE(
 	// initial columns directly because they might contain duplicate IDs (e.g.
 	// consider initial query SELECT 0, 0).
 	for i, c := range cteSrc.cols {
-		newCol := b.synthesizeColumn(outScope, c.Alias, initialTypes[i], nil /* expr */, nil /* scalar */)
+		newCol := b.synthesizeColumn(outScope, scopeColName(tree.Name(c.Alias)), initialTypes[i], nil /* expr */, nil /* scalar */)
 		cteSrc.cols[i].ID = newCol.id
 	}
 

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -146,14 +146,14 @@ insert order
  │    ├── column3:12 => "order".o_w_id:3
  │    ├── column4:13 => "order".o_c_id:4
  │    ├── column5:14 => o_entry_d:5
- │    ├── column17:17 => o_carrier_id:6
+ │    ├── o_carrier_id_default:17 => o_carrier_id:6
  │    ├── column6:15 => o_ol_cnt:7
  │    └── column7:16 => o_all_local:8
  ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
- │    ├── columns: column1:10!null column2:11!null column3:12!null column4:13!null column5:14!null column6:15!null column7:16!null column17:17
+ │    ├── columns: column1:10!null column2:11!null column3:12!null column4:13!null column5:14!null column6:15!null column7:16!null o_carrier_id_default:17
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(10-17)
@@ -364,7 +364,7 @@ insert order_line
  │    ├── column4:15 => ol_number:4
  │    ├── column5:16 => order_line.ol_i_id:5
  │    ├── column6:17 => order_line.ol_supply_w_id:6
- │    ├── column21:21 => ol_delivery_d:7
+ │    ├── ol_delivery_d_default:21 => ol_delivery_d:7
  │    ├── column7:18 => ol_quantity:8
  │    ├── ol_amount:22 => order_line.ol_amount:9
  │    └── column9:20 => ol_dist_info:10
@@ -372,7 +372,7 @@ insert order_line
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── project
- │    ├── columns: ol_amount:22 column21:21 column1:12!null column2:13!null column3:14!null column4:15!null column5:16!null column6:17!null column7:18!null column9:20!null
+ │    ├── columns: ol_amount:22 ol_delivery_d_default:21 column1:12!null column2:13!null column3:14!null column4:15!null column5:16!null column6:17!null column7:18!null column9:20!null
  │    ├── cardinality: [6 - 6]
  │    ├── immutable
  │    ├── fd: ()-->(21)
@@ -387,7 +387,7 @@ insert order_line
  │    │    └── (3045, 2, 10, 6, 92966, 0, 4, 366.760000, 'saCXoEzmssaF9m9cdLXe0Yhg')
  │    └── projections
  │         ├── crdb_internal.round_decimal_values(column8:19, 2) [as=ol_amount:22, outer=(19), immutable]
- │         └── CAST(NULL AS TIMESTAMP) [as=column21:21]
+ │         └── CAST(NULL AS TIMESTAMP) [as=ol_delivery_d_default:21]
  └── f-k-checks
       ├── f-k-checks-item: order_line(ol_w_id,ol_d_id,ol_o_id) -> order(o_w_id,o_d_id,o_id)
       │    └── anti-join (lookup order)
@@ -600,7 +600,7 @@ VALUES
 insert history
  ├── columns: <none>
  ├── insert-mapping:
- │    ├── column19:19 => rowid:1
+ │    ├── rowid_default:19 => rowid:1
  │    ├── column1:11 => history.h_c_id:2
  │    ├── column2:12 => history.h_c_d_id:3
  │    ├── column3:13 => history.h_c_w_id:4
@@ -613,7 +613,7 @@ insert history
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
- │    ├── columns: column1:11!null column2:12!null column3:13!null column4:14!null column5:15!null column7:17!null column8:18!null column19:19 h_amount:20!null
+ │    ├── columns: column1:11!null column2:12!null column3:13!null column4:14!null column5:15!null column7:17!null column8:18!null rowid_default:19 h_amount:20!null
  │    ├── cardinality: [1 - 1]
  │    ├── volatile
  │    ├── key: ()

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -438,27 +438,27 @@ project
  ├── fd: ()-->(2-7)
  └── update warehouse
       ├── columns: w_id:1!null w_name:2 w_street_1:3 w_street_2:4 w_city:5 w_state:6 w_zip:7
-      ├── fetch columns: w_id:11 w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 w_tax:18 warehouse.w_ytd:19
+      ├── fetch columns: w_id:11 w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 w_tax:18 w_ytd:19
       ├── update-mapping:
-      │    └── w_ytd:22 => warehouse.w_ytd:9
+      │    └── w_ytd_new:22 => w_ytd:9
       ├── cardinality: [0 - 1]
       ├── volatile, mutations
       ├── key: ()
       ├── fd: ()-->(1-7)
       └── project
-           ├── columns: w_ytd:22 w_id:11!null w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 w_tax:18 warehouse.w_ytd:19
+           ├── columns: w_ytd_new:22 w_id:11!null w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 w_tax:18 w_ytd:19
            ├── cardinality: [0 - 1]
            ├── immutable
            ├── key: ()
            ├── fd: ()-->(11-19,22)
            ├── scan warehouse
-           │    ├── columns: w_id:11!null w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 w_tax:18 warehouse.w_ytd:19
+           │    ├── columns: w_id:11!null w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 w_tax:18 w_ytd:19
            │    ├── constraint: /11: [/10 - /10]
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
            │    └── fd: ()-->(11-19)
            └── projections
-                └── crdb_internal.round_decimal_values(warehouse.w_ytd:19::DECIMAL + 3860.61, 2) [as=w_ytd:22, outer=(19), immutable]
+                └── crdb_internal.round_decimal_values(w_ytd:19::DECIMAL + 3860.61, 2) [as=w_ytd_new:22, outer=(19), immutable]
 
 opt format=hide-qual
 UPDATE district SET d_ytd = d_ytd + 3860.61 WHERE (d_w_id = 10) AND (d_id = 5)
@@ -472,27 +472,27 @@ project
  ├── fd: ()-->(3-8)
  └── update district
       ├── columns: d_id:1!null d_w_id:2!null d_name:3 d_street_1:4 d_street_2:5 d_city:6 d_state:7 d_zip:8
-      ├── fetch columns: d_id:13 d_w_id:14 d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 district.d_ytd:22 d_next_o_id:23
+      ├── fetch columns: d_id:13 d_w_id:14 d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 d_ytd:22 d_next_o_id:23
       ├── update-mapping:
-      │    └── d_ytd:26 => district.d_ytd:10
+      │    └── d_ytd_new:26 => d_ytd:10
       ├── cardinality: [0 - 1]
       ├── volatile, mutations
       ├── key: ()
       ├── fd: ()-->(1-8)
       └── project
-           ├── columns: d_ytd:26 d_id:13!null d_w_id:14!null d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 district.d_ytd:22 d_next_o_id:23
+           ├── columns: d_ytd_new:26 d_id:13!null d_w_id:14!null d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 d_ytd:22 d_next_o_id:23
            ├── cardinality: [0 - 1]
            ├── immutable
            ├── key: ()
            ├── fd: ()-->(13-23,26)
            ├── scan district
-           │    ├── columns: d_id:13!null d_w_id:14!null d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 district.d_ytd:22 d_next_o_id:23
+           │    ├── columns: d_id:13!null d_w_id:14!null d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 d_ytd:22 d_next_o_id:23
            │    ├── constraint: /14/13: [/10/5 - /10/5]
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
            │    └── fd: ()-->(13-23)
            └── projections
-                └── crdb_internal.round_decimal_values(district.d_ytd:22::DECIMAL + 3860.61, 2) [as=d_ytd:26, outer=(22), immutable]
+                └── crdb_internal.round_decimal_values(d_ytd:22::DECIMAL + 3860.61, 2) [as=d_ytd_new:26, outer=(22), immutable]
 
 opt format=hide-qual
 SELECT c_id
@@ -560,11 +560,11 @@ project
  ├── key: ()
  ├── fd: ()-->(4-17,51)
  ├── update customer
- │    ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_middle:5 c_last:6 c_street_1:7 c_street_2:8 c_city:9 c_state:10 c_zip:11 c_phone:12 c_since:13 c_credit:14 c_credit_lim:15 c_discount:16 customer.c_balance:17 c_data:21
- │    ├── fetch columns: c_id:23 c_d_id:24 c_w_id:25 c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 customer.c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
+ │    ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_middle:5 c_last:6 c_street_1:7 c_street_2:8 c_city:9 c_state:10 c_zip:11 c_phone:12 c_since:13 c_credit:14 c_credit_lim:15 c_discount:16 c_balance:17 c_data:21
+ │    ├── fetch columns: c_id:23 c_d_id:24 c_w_id:25 c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
  │    ├── update-mapping:
- │    │    ├── c_balance:49 => customer.c_balance:17
- │    │    ├── c_ytd_payment:50 => customer.c_ytd_payment:18
+ │    │    ├── c_balance_new:49 => c_balance:17
+ │    │    ├── c_ytd_payment_new:50 => c_ytd_payment:18
  │    │    ├── c_payment_cnt_new:47 => c_payment_cnt:19
  │    │    └── c_data_new:48 => c_data:21
  │    ├── cardinality: [0 - 1]
@@ -572,20 +572,20 @@ project
  │    ├── key: ()
  │    ├── fd: ()-->(1-17,21)
  │    └── project
- │         ├── columns: c_balance:49 c_ytd_payment:50 c_payment_cnt_new:47 c_data_new:48 c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 customer.c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
+ │         ├── columns: c_balance_new:49 c_ytd_payment_new:50 c_payment_cnt_new:47 c_data_new:48 c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
  │         ├── cardinality: [0 - 1]
  │         ├── immutable
  │         ├── key: ()
  │         ├── fd: ()-->(23-43,47-50)
  │         ├── scan customer
- │         │    ├── columns: c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 customer.c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
+ │         │    ├── columns: c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
  │         │    ├── constraint: /25/24/23: [/10/5/1343 - /10/5/1343]
  │         │    ├── cardinality: [0 - 1]
  │         │    ├── key: ()
  │         │    └── fd: ()-->(23-43)
  │         └── projections
- │              ├── crdb_internal.round_decimal_values(customer.c_balance:39::DECIMAL - 3860.61, 2) [as=c_balance:49, outer=(39), immutable]
- │              ├── crdb_internal.round_decimal_values(customer.c_ytd_payment:40::DECIMAL + 3860.61, 2) [as=c_ytd_payment:50, outer=(40), immutable]
+ │              ├── crdb_internal.round_decimal_values(c_balance:39::DECIMAL - 3860.61, 2) [as=c_balance_new:49, outer=(39), immutable]
+ │              ├── crdb_internal.round_decimal_values(c_ytd_payment:40::DECIMAL + 3860.61, 2) [as=c_ytd_payment_new:50, outer=(40), immutable]
  │              ├── c_payment_cnt:41 + 1 [as=c_payment_cnt_new:47, outer=(41), immutable]
  │              └── CASE c_credit:36 WHEN 'BC' THEN left((((((c_id:23::STRING || c_d_id:24::STRING) || c_w_id:25::STRING) || '5') || '10') || '3860.61') || c_data:43::STRING, 500) ELSE c_data:43::STRING END [as=c_data_new:48, outer=(23-25,36,43), immutable]
  └── projections
@@ -877,20 +877,20 @@ WHERE c_w_id = 10 AND (c_d_id, c_id) IN (
 ----
 update customer
  ├── columns: <none>
- ├── fetch columns: c_id:23 c_d_id:24 c_w_id:25 c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
+ ├── fetch columns: c_id:23 c_d_id:24 c_w_id:25 c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
  ├── update-mapping:
- │    ├── c_balance:47 => customer.c_balance:17
+ │    ├── c_balance_new:47 => c_balance:17
  │    └── c_delivery_cnt_new:45 => c_delivery_cnt:20
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: c_balance:47 c_delivery_cnt_new:45 c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
+      ├── columns: c_balance_new:47 c_delivery_cnt_new:45 c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
       ├── cardinality: [0 - 10]
       ├── immutable
       ├── key: (23,24)
       ├── fd: ()-->(25), (23,24)-->(26-43,47), (42)-->(45)
       ├── scan customer
-      │    ├── columns: c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
+      │    ├── columns: c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
       │    ├── constraint: /25/24/23
       │    │    ├── [/10/1/1405 - /10/1/1405]
       │    │    ├── [/10/2/137 - /10/2/137]
@@ -906,7 +906,7 @@ update customer
       │    ├── key: (23,24)
       │    └── fd: ()-->(25), (23,24)-->(26-43)
       └── projections
-           ├── crdb_internal.round_decimal_values(customer.c_balance:39::DECIMAL + CASE c_d_id:24 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 ELSE CAST(NULL AS DECIMAL) END, 2) [as=c_balance:47, outer=(24,39), immutable]
+           ├── crdb_internal.round_decimal_values(c_balance:39::DECIMAL + CASE c_d_id:24 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 ELSE CAST(NULL AS DECIMAL) END, 2) [as=c_balance_new:47, outer=(24,39), immutable]
            └── c_delivery_cnt:42 + 1 [as=c_delivery_cnt_new:45, outer=(42), immutable]
 
 opt format=hide-qual

--- a/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
@@ -441,27 +441,27 @@ project
  ├── fd: ()-->(2-7)
  └── update warehouse
       ├── columns: w_id:1!null w_name:2 w_street_1:3 w_street_2:4 w_city:5 w_state:6 w_zip:7
-      ├── fetch columns: w_id:11 w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 w_tax:18 warehouse.w_ytd:19
+      ├── fetch columns: w_id:11 w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 w_tax:18 w_ytd:19
       ├── update-mapping:
-      │    └── w_ytd:22 => warehouse.w_ytd:9
+      │    └── w_ytd_new:22 => w_ytd:9
       ├── cardinality: [0 - 1]
       ├── volatile, mutations
       ├── key: ()
       ├── fd: ()-->(1-7)
       └── project
-           ├── columns: w_ytd:22 w_id:11!null w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 w_tax:18 warehouse.w_ytd:19
+           ├── columns: w_ytd_new:22 w_id:11!null w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 w_tax:18 w_ytd:19
            ├── cardinality: [0 - 1]
            ├── immutable
            ├── key: ()
            ├── fd: ()-->(11-19,22)
            ├── scan warehouse
-           │    ├── columns: w_id:11!null w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 w_tax:18 warehouse.w_ytd:19
+           │    ├── columns: w_id:11!null w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 w_tax:18 w_ytd:19
            │    ├── constraint: /11: [/10 - /10]
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
            │    └── fd: ()-->(11-19)
            └── projections
-                └── crdb_internal.round_decimal_values(warehouse.w_ytd:19::DECIMAL + 3860.61, 2) [as=w_ytd:22, outer=(19), immutable]
+                └── crdb_internal.round_decimal_values(w_ytd:19::DECIMAL + 3860.61, 2) [as=w_ytd_new:22, outer=(19), immutable]
 
 opt format=hide-qual
 UPDATE district SET d_ytd = d_ytd + 3860.61 WHERE (d_w_id = 10) AND (d_id = 5)
@@ -475,27 +475,27 @@ project
  ├── fd: ()-->(3-8)
  └── update district
       ├── columns: d_id:1!null d_w_id:2!null d_name:3 d_street_1:4 d_street_2:5 d_city:6 d_state:7 d_zip:8
-      ├── fetch columns: d_id:13 d_w_id:14 d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 district.d_ytd:22 d_next_o_id:23
+      ├── fetch columns: d_id:13 d_w_id:14 d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 d_ytd:22 d_next_o_id:23
       ├── update-mapping:
-      │    └── d_ytd:26 => district.d_ytd:10
+      │    └── d_ytd_new:26 => d_ytd:10
       ├── cardinality: [0 - 1]
       ├── volatile, mutations
       ├── key: ()
       ├── fd: ()-->(1-8)
       └── project
-           ├── columns: d_ytd:26 d_id:13!null d_w_id:14!null d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 district.d_ytd:22 d_next_o_id:23
+           ├── columns: d_ytd_new:26 d_id:13!null d_w_id:14!null d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 d_ytd:22 d_next_o_id:23
            ├── cardinality: [0 - 1]
            ├── immutable
            ├── key: ()
            ├── fd: ()-->(13-23,26)
            ├── scan district
-           │    ├── columns: d_id:13!null d_w_id:14!null d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 district.d_ytd:22 d_next_o_id:23
+           │    ├── columns: d_id:13!null d_w_id:14!null d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 d_ytd:22 d_next_o_id:23
            │    ├── constraint: /14/13: [/10/5 - /10/5]
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
            │    └── fd: ()-->(13-23)
            └── projections
-                └── crdb_internal.round_decimal_values(district.d_ytd:22::DECIMAL + 3860.61, 2) [as=d_ytd:26, outer=(22), immutable]
+                └── crdb_internal.round_decimal_values(d_ytd:22::DECIMAL + 3860.61, 2) [as=d_ytd_new:26, outer=(22), immutable]
 
 opt format=hide-qual
 SELECT c_id
@@ -563,11 +563,11 @@ project
  ├── key: ()
  ├── fd: ()-->(4-17,51)
  ├── update customer
- │    ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_middle:5 c_last:6 c_street_1:7 c_street_2:8 c_city:9 c_state:10 c_zip:11 c_phone:12 c_since:13 c_credit:14 c_credit_lim:15 c_discount:16 customer.c_balance:17 c_data:21
- │    ├── fetch columns: c_id:23 c_d_id:24 c_w_id:25 c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 customer.c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
+ │    ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_middle:5 c_last:6 c_street_1:7 c_street_2:8 c_city:9 c_state:10 c_zip:11 c_phone:12 c_since:13 c_credit:14 c_credit_lim:15 c_discount:16 c_balance:17 c_data:21
+ │    ├── fetch columns: c_id:23 c_d_id:24 c_w_id:25 c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
  │    ├── update-mapping:
- │    │    ├── c_balance:49 => customer.c_balance:17
- │    │    ├── c_ytd_payment:50 => customer.c_ytd_payment:18
+ │    │    ├── c_balance_new:49 => c_balance:17
+ │    │    ├── c_ytd_payment_new:50 => c_ytd_payment:18
  │    │    ├── c_payment_cnt_new:47 => c_payment_cnt:19
  │    │    └── c_data_new:48 => c_data:21
  │    ├── cardinality: [0 - 1]
@@ -575,20 +575,20 @@ project
  │    ├── key: ()
  │    ├── fd: ()-->(1-17,21)
  │    └── project
- │         ├── columns: c_balance:49 c_ytd_payment:50 c_payment_cnt_new:47 c_data_new:48 c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 customer.c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
+ │         ├── columns: c_balance_new:49 c_ytd_payment_new:50 c_payment_cnt_new:47 c_data_new:48 c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
  │         ├── cardinality: [0 - 1]
  │         ├── immutable
  │         ├── key: ()
  │         ├── fd: ()-->(23-43,47-50)
  │         ├── scan customer
- │         │    ├── columns: c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 customer.c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
+ │         │    ├── columns: c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
  │         │    ├── constraint: /25/24/23: [/10/5/1343 - /10/5/1343]
  │         │    ├── cardinality: [0 - 1]
  │         │    ├── key: ()
  │         │    └── fd: ()-->(23-43)
  │         └── projections
- │              ├── crdb_internal.round_decimal_values(customer.c_balance:39::DECIMAL - 3860.61, 2) [as=c_balance:49, outer=(39), immutable]
- │              ├── crdb_internal.round_decimal_values(customer.c_ytd_payment:40::DECIMAL + 3860.61, 2) [as=c_ytd_payment:50, outer=(40), immutable]
+ │              ├── crdb_internal.round_decimal_values(c_balance:39::DECIMAL - 3860.61, 2) [as=c_balance_new:49, outer=(39), immutable]
+ │              ├── crdb_internal.round_decimal_values(c_ytd_payment:40::DECIMAL + 3860.61, 2) [as=c_ytd_payment_new:50, outer=(40), immutable]
  │              ├── c_payment_cnt:41 + 1 [as=c_payment_cnt_new:47, outer=(41), immutable]
  │              └── CASE c_credit:36 WHEN 'BC' THEN left((((((c_id:23::STRING || c_d_id:24::STRING) || c_w_id:25::STRING) || '5') || '10') || '3860.61') || c_data:43::STRING, 500) ELSE c_data:43::STRING END [as=c_data_new:48, outer=(23-25,36,43), immutable]
  └── projections
@@ -880,20 +880,20 @@ WHERE c_w_id = 10 AND (c_d_id, c_id) IN (
 ----
 update customer
  ├── columns: <none>
- ├── fetch columns: c_id:23 c_d_id:24 c_w_id:25 c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
+ ├── fetch columns: c_id:23 c_d_id:24 c_w_id:25 c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
  ├── update-mapping:
- │    ├── c_balance:47 => customer.c_balance:17
+ │    ├── c_balance_new:47 => c_balance:17
  │    └── c_delivery_cnt_new:45 => c_delivery_cnt:20
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: c_balance:47 c_delivery_cnt_new:45 c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
+      ├── columns: c_balance_new:47 c_delivery_cnt_new:45 c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
       ├── cardinality: [0 - 10]
       ├── immutable
       ├── key: (23,24)
       ├── fd: ()-->(25), (23,24)-->(26-43,47), (42)-->(45)
       ├── scan customer
-      │    ├── columns: c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
+      │    ├── columns: c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
       │    ├── constraint: /25/24/23
       │    │    ├── [/10/1/1405 - /10/1/1405]
       │    │    ├── [/10/2/137 - /10/2/137]
@@ -909,7 +909,7 @@ update customer
       │    ├── key: (23,24)
       │    └── fd: ()-->(25), (23,24)-->(26-43)
       └── projections
-           ├── crdb_internal.round_decimal_values(customer.c_balance:39::DECIMAL + CASE c_d_id:24 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 ELSE CAST(NULL AS DECIMAL) END, 2) [as=c_balance:47, outer=(24,39), immutable]
+           ├── crdb_internal.round_decimal_values(c_balance:39::DECIMAL + CASE c_d_id:24 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 ELSE CAST(NULL AS DECIMAL) END, 2) [as=c_balance_new:47, outer=(24,39), immutable]
            └── c_delivery_cnt:42 + 1 [as=c_delivery_cnt_new:45, outer=(42), immutable]
 
 opt format=hide-qual

--- a/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
@@ -149,14 +149,14 @@ insert order
  │    ├── column3:12 => "order".o_w_id:3
  │    ├── column4:13 => "order".o_c_id:4
  │    ├── column5:14 => o_entry_d:5
- │    ├── column17:17 => o_carrier_id:6
+ │    ├── o_carrier_id_default:17 => o_carrier_id:6
  │    ├── column6:15 => o_ol_cnt:7
  │    └── column7:16 => o_all_local:8
  ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
- │    ├── columns: column1:10!null column2:11!null column3:12!null column4:13!null column5:14!null column6:15!null column7:16!null column17:17
+ │    ├── columns: column1:10!null column2:11!null column3:12!null column4:13!null column5:14!null column6:15!null column7:16!null o_carrier_id_default:17
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(10-17)
@@ -367,7 +367,7 @@ insert order_line
  │    ├── column4:15 => ol_number:4
  │    ├── column5:16 => order_line.ol_i_id:5
  │    ├── column6:17 => order_line.ol_supply_w_id:6
- │    ├── column21:21 => ol_delivery_d:7
+ │    ├── ol_delivery_d_default:21 => ol_delivery_d:7
  │    ├── column7:18 => ol_quantity:8
  │    ├── ol_amount:22 => order_line.ol_amount:9
  │    └── column9:20 => ol_dist_info:10
@@ -375,7 +375,7 @@ insert order_line
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── project
- │    ├── columns: ol_amount:22 column21:21 column1:12!null column2:13!null column3:14!null column4:15!null column5:16!null column6:17!null column7:18!null column9:20!null
+ │    ├── columns: ol_amount:22 ol_delivery_d_default:21 column1:12!null column2:13!null column3:14!null column4:15!null column5:16!null column6:17!null column7:18!null column9:20!null
  │    ├── cardinality: [6 - 6]
  │    ├── immutable
  │    ├── fd: ()-->(21)
@@ -390,7 +390,7 @@ insert order_line
  │    │    └── (3045, 2, 10, 6, 92966, 0, 4, 366.760000, 'saCXoEzmssaF9m9cdLXe0Yhg')
  │    └── projections
  │         ├── crdb_internal.round_decimal_values(column8:19, 2) [as=ol_amount:22, outer=(19), immutable]
- │         └── CAST(NULL AS TIMESTAMP) [as=column21:21]
+ │         └── CAST(NULL AS TIMESTAMP) [as=ol_delivery_d_default:21]
  └── f-k-checks
       ├── f-k-checks-item: order_line(ol_w_id,ol_d_id,ol_o_id) -> order(o_w_id,o_d_id,o_id)
       │    └── anti-join (lookup order)
@@ -603,7 +603,7 @@ VALUES
 insert history
  ├── columns: <none>
  ├── insert-mapping:
- │    ├── column19:19 => rowid:1
+ │    ├── rowid_default:19 => rowid:1
  │    ├── column1:11 => history.h_c_id:2
  │    ├── column2:12 => history.h_c_d_id:3
  │    ├── column3:13 => history.h_c_w_id:4
@@ -616,7 +616,7 @@ insert history
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
- │    ├── columns: column1:11!null column2:12!null column3:13!null column4:14!null column5:15!null column7:17!null column8:18!null column19:19 h_amount:20!null
+ │    ├── columns: column1:11!null column2:12!null column3:13!null column4:14!null column5:15!null column7:17!null column8:18!null rowid_default:19 h_amount:20!null
  │    ├── cardinality: [1 - 1]
  │    ├── volatile
  │    ├── key: ()

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -143,14 +143,14 @@ insert order
  │    ├── column3:12 => "order".o_w_id:3
  │    ├── column4:13 => "order".o_c_id:4
  │    ├── column5:14 => o_entry_d:5
- │    ├── column17:17 => o_carrier_id:6
+ │    ├── o_carrier_id_default:17 => o_carrier_id:6
  │    ├── column6:15 => o_ol_cnt:7
  │    └── column7:16 => o_all_local:8
  ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
- │    ├── columns: column1:10!null column2:11!null column3:12!null column4:13!null column5:14!null column6:15!null column7:16!null column17:17
+ │    ├── columns: column1:10!null column2:11!null column3:12!null column4:13!null column5:14!null column6:15!null column7:16!null o_carrier_id_default:17
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(10-17)
@@ -361,7 +361,7 @@ insert order_line
  │    ├── column4:15 => ol_number:4
  │    ├── column5:16 => order_line.ol_i_id:5
  │    ├── column6:17 => order_line.ol_supply_w_id:6
- │    ├── column21:21 => ol_delivery_d:7
+ │    ├── ol_delivery_d_default:21 => ol_delivery_d:7
  │    ├── column7:18 => ol_quantity:8
  │    ├── ol_amount:22 => order_line.ol_amount:9
  │    └── column9:20 => ol_dist_info:10
@@ -369,7 +369,7 @@ insert order_line
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── project
- │    ├── columns: ol_amount:22 column21:21 column1:12!null column2:13!null column3:14!null column4:15!null column5:16!null column6:17!null column7:18!null column9:20!null
+ │    ├── columns: ol_amount:22 ol_delivery_d_default:21 column1:12!null column2:13!null column3:14!null column4:15!null column5:16!null column6:17!null column7:18!null column9:20!null
  │    ├── cardinality: [6 - 6]
  │    ├── immutable
  │    ├── fd: ()-->(21)
@@ -384,7 +384,7 @@ insert order_line
  │    │    └── (3045, 2, 10, 6, 92966, 0, 4, 366.760000, 'saCXoEzmssaF9m9cdLXe0Yhg')
  │    └── projections
  │         ├── crdb_internal.round_decimal_values(column8:19, 2) [as=ol_amount:22, outer=(19), immutable]
- │         └── CAST(NULL AS TIMESTAMP) [as=column21:21]
+ │         └── CAST(NULL AS TIMESTAMP) [as=ol_delivery_d_default:21]
  └── f-k-checks
       ├── f-k-checks-item: order_line(ol_w_id,ol_d_id,ol_o_id) -> order(o_w_id,o_d_id,o_id)
       │    └── anti-join (lookup order)
@@ -597,7 +597,7 @@ VALUES
 insert history
  ├── columns: <none>
  ├── insert-mapping:
- │    ├── column19:19 => rowid:1
+ │    ├── rowid_default:19 => rowid:1
  │    ├── column1:11 => history.h_c_id:2
  │    ├── column2:12 => history.h_c_d_id:3
  │    ├── column3:13 => history.h_c_w_id:4
@@ -610,7 +610,7 @@ insert history
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── values
- │    ├── columns: column1:11!null column2:12!null column3:13!null column4:14!null column5:15!null column7:17!null column8:18!null column19:19 h_amount:20!null
+ │    ├── columns: column1:11!null column2:12!null column3:13!null column4:14!null column5:15!null column7:17!null column8:18!null rowid_default:19 h_amount:20!null
  │    ├── cardinality: [1 - 1]
  │    ├── volatile
  │    ├── key: ()

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -435,27 +435,27 @@ project
  ├── fd: ()-->(2-7)
  └── update warehouse
       ├── columns: w_id:1!null w_name:2 w_street_1:3 w_street_2:4 w_city:5 w_state:6 w_zip:7
-      ├── fetch columns: w_id:11 w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 w_tax:18 warehouse.w_ytd:19
+      ├── fetch columns: w_id:11 w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 w_tax:18 w_ytd:19
       ├── update-mapping:
-      │    └── w_ytd:22 => warehouse.w_ytd:9
+      │    └── w_ytd_new:22 => w_ytd:9
       ├── cardinality: [0 - 1]
       ├── volatile, mutations
       ├── key: ()
       ├── fd: ()-->(1-7)
       └── project
-           ├── columns: w_ytd:22 w_id:11!null w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 w_tax:18 warehouse.w_ytd:19
+           ├── columns: w_ytd_new:22 w_id:11!null w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 w_tax:18 w_ytd:19
            ├── cardinality: [0 - 1]
            ├── immutable
            ├── key: ()
            ├── fd: ()-->(11-19,22)
            ├── scan warehouse
-           │    ├── columns: w_id:11!null w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 w_tax:18 warehouse.w_ytd:19
+           │    ├── columns: w_id:11!null w_name:12 w_street_1:13 w_street_2:14 w_city:15 w_state:16 w_zip:17 w_tax:18 w_ytd:19
            │    ├── constraint: /11: [/10 - /10]
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
            │    └── fd: ()-->(11-19)
            └── projections
-                └── crdb_internal.round_decimal_values(warehouse.w_ytd:19::DECIMAL + 3860.61, 2) [as=w_ytd:22, outer=(19), immutable]
+                └── crdb_internal.round_decimal_values(w_ytd:19::DECIMAL + 3860.61, 2) [as=w_ytd_new:22, outer=(19), immutable]
 
 opt format=hide-qual
 UPDATE district SET d_ytd = d_ytd + 3860.61 WHERE (d_w_id = 10) AND (d_id = 5)
@@ -469,27 +469,27 @@ project
  ├── fd: ()-->(3-8)
  └── update district
       ├── columns: d_id:1!null d_w_id:2!null d_name:3 d_street_1:4 d_street_2:5 d_city:6 d_state:7 d_zip:8
-      ├── fetch columns: d_id:13 d_w_id:14 d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 district.d_ytd:22 d_next_o_id:23
+      ├── fetch columns: d_id:13 d_w_id:14 d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 d_ytd:22 d_next_o_id:23
       ├── update-mapping:
-      │    └── d_ytd:26 => district.d_ytd:10
+      │    └── d_ytd_new:26 => d_ytd:10
       ├── cardinality: [0 - 1]
       ├── volatile, mutations
       ├── key: ()
       ├── fd: ()-->(1-8)
       └── project
-           ├── columns: d_ytd:26 d_id:13!null d_w_id:14!null d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 district.d_ytd:22 d_next_o_id:23
+           ├── columns: d_ytd_new:26 d_id:13!null d_w_id:14!null d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 d_ytd:22 d_next_o_id:23
            ├── cardinality: [0 - 1]
            ├── immutable
            ├── key: ()
            ├── fd: ()-->(13-23,26)
            ├── scan district
-           │    ├── columns: d_id:13!null d_w_id:14!null d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 district.d_ytd:22 d_next_o_id:23
+           │    ├── columns: d_id:13!null d_w_id:14!null d_name:15 d_street_1:16 d_street_2:17 d_city:18 d_state:19 d_zip:20 d_tax:21 d_ytd:22 d_next_o_id:23
            │    ├── constraint: /14/13: [/10/5 - /10/5]
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
            │    └── fd: ()-->(13-23)
            └── projections
-                └── crdb_internal.round_decimal_values(district.d_ytd:22::DECIMAL + 3860.61, 2) [as=d_ytd:26, outer=(22), immutable]
+                └── crdb_internal.round_decimal_values(d_ytd:22::DECIMAL + 3860.61, 2) [as=d_ytd_new:26, outer=(22), immutable]
 
 opt format=hide-qual
 SELECT c_id
@@ -557,11 +557,11 @@ project
  ├── key: ()
  ├── fd: ()-->(4-17,51)
  ├── update customer
- │    ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_middle:5 c_last:6 c_street_1:7 c_street_2:8 c_city:9 c_state:10 c_zip:11 c_phone:12 c_since:13 c_credit:14 c_credit_lim:15 c_discount:16 customer.c_balance:17 c_data:21
- │    ├── fetch columns: c_id:23 c_d_id:24 c_w_id:25 c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 customer.c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
+ │    ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_middle:5 c_last:6 c_street_1:7 c_street_2:8 c_city:9 c_state:10 c_zip:11 c_phone:12 c_since:13 c_credit:14 c_credit_lim:15 c_discount:16 c_balance:17 c_data:21
+ │    ├── fetch columns: c_id:23 c_d_id:24 c_w_id:25 c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
  │    ├── update-mapping:
- │    │    ├── c_balance:49 => customer.c_balance:17
- │    │    ├── c_ytd_payment:50 => customer.c_ytd_payment:18
+ │    │    ├── c_balance_new:49 => c_balance:17
+ │    │    ├── c_ytd_payment_new:50 => c_ytd_payment:18
  │    │    ├── c_payment_cnt_new:47 => c_payment_cnt:19
  │    │    └── c_data_new:48 => c_data:21
  │    ├── cardinality: [0 - 1]
@@ -569,20 +569,20 @@ project
  │    ├── key: ()
  │    ├── fd: ()-->(1-17,21)
  │    └── project
- │         ├── columns: c_balance:49 c_ytd_payment:50 c_payment_cnt_new:47 c_data_new:48 c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 customer.c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
+ │         ├── columns: c_balance_new:49 c_ytd_payment_new:50 c_payment_cnt_new:47 c_data_new:48 c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
  │         ├── cardinality: [0 - 1]
  │         ├── immutable
  │         ├── key: ()
  │         ├── fd: ()-->(23-43,47-50)
  │         ├── scan customer
- │         │    ├── columns: c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 customer.c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
+ │         │    ├── columns: c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
  │         │    ├── constraint: /25/24/23: [/10/5/1343 - /10/5/1343]
  │         │    ├── cardinality: [0 - 1]
  │         │    ├── key: ()
  │         │    └── fd: ()-->(23-43)
  │         └── projections
- │              ├── crdb_internal.round_decimal_values(customer.c_balance:39::DECIMAL - 3860.61, 2) [as=c_balance:49, outer=(39), immutable]
- │              ├── crdb_internal.round_decimal_values(customer.c_ytd_payment:40::DECIMAL + 3860.61, 2) [as=c_ytd_payment:50, outer=(40), immutable]
+ │              ├── crdb_internal.round_decimal_values(c_balance:39::DECIMAL - 3860.61, 2) [as=c_balance_new:49, outer=(39), immutable]
+ │              ├── crdb_internal.round_decimal_values(c_ytd_payment:40::DECIMAL + 3860.61, 2) [as=c_ytd_payment_new:50, outer=(40), immutable]
  │              ├── c_payment_cnt:41 + 1 [as=c_payment_cnt_new:47, outer=(41), immutable]
  │              └── CASE c_credit:36 WHEN 'BC' THEN left((((((c_id:23::STRING || c_d_id:24::STRING) || c_w_id:25::STRING) || '5') || '10') || '3860.61') || c_data:43::STRING, 500) ELSE c_data:43::STRING END [as=c_data_new:48, outer=(23-25,36,43), immutable]
  └── projections
@@ -879,20 +879,20 @@ WHERE c_w_id = 10 AND (c_d_id, c_id) IN (
 ----
 update customer
  ├── columns: <none>
- ├── fetch columns: c_id:23 c_d_id:24 c_w_id:25 c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
+ ├── fetch columns: c_id:23 c_d_id:24 c_w_id:25 c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
  ├── update-mapping:
- │    ├── c_balance:47 => customer.c_balance:17
+ │    ├── c_balance_new:47 => c_balance:17
  │    └── c_delivery_cnt_new:45 => c_delivery_cnt:20
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: c_balance:47 c_delivery_cnt_new:45 c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
+      ├── columns: c_balance_new:47 c_delivery_cnt_new:45 c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
       ├── cardinality: [0 - 10]
       ├── immutable
       ├── key: (23,24)
       ├── fd: ()-->(25), (23,24)-->(26-43,47), (42)-->(45)
       ├── scan customer
-      │    ├── columns: c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 customer.c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
+      │    ├── columns: c_id:23!null c_d_id:24!null c_w_id:25!null c_first:26 c_middle:27 c_last:28 c_street_1:29 c_street_2:30 c_city:31 c_state:32 c_zip:33 c_phone:34 c_since:35 c_credit:36 c_credit_lim:37 c_discount:38 c_balance:39 c_ytd_payment:40 c_payment_cnt:41 c_delivery_cnt:42 c_data:43
       │    ├── constraint: /25/24/23
       │    │    ├── [/10/1/1405 - /10/1/1405]
       │    │    ├── [/10/2/137 - /10/2/137]
@@ -908,7 +908,7 @@ update customer
       │    ├── key: (23,24)
       │    └── fd: ()-->(25), (23,24)-->(26-43)
       └── projections
-           ├── crdb_internal.round_decimal_values(customer.c_balance:39::DECIMAL + CASE c_d_id:24 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 ELSE CAST(NULL AS DECIMAL) END, 2) [as=c_balance:47, outer=(24,39), immutable]
+           ├── crdb_internal.round_decimal_values(c_balance:39::DECIMAL + CASE c_d_id:24 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 ELSE CAST(NULL AS DECIMAL) END, 2) [as=c_balance_new:47, outer=(24,39), immutable]
            └── c_delivery_cnt:42 + 1 [as=c_delivery_cnt_new:45, outer=(42), immutable]
 
 opt format=hide-qual

--- a/pkg/sql/opt/xform/testdata/external/tpce
+++ b/pkg/sql/opt/xform/testdata/external/tpce
@@ -344,27 +344,27 @@ UPDATE last_trade
 ----
 update last_trade
  ├── columns: <none>
- ├── fetch columns: lt_s_symb:7 lt_dts:8 last_trade.lt_price:9 lt_open_price:10 lt_vol:11
+ ├── fetch columns: lt_s_symb:7 lt_dts:8 lt_price:9 lt_open_price:10 lt_vol:11
  ├── update-mapping:
  │    ├── lt_dts_new:15 => lt_dts:2
- │    ├── lt_price:16 => last_trade.lt_price:3
+ │    ├── lt_price_new:16 => lt_price:3
  │    └── lt_vol_new:14 => lt_vol:5
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: lt_price:16!null lt_vol_new:14!null lt_dts_new:15!null lt_s_symb:7!null lt_dts:8!null last_trade.lt_price:9!null lt_open_price:10!null lt_vol:11!null
+      ├── columns: lt_price_new:16!null lt_vol_new:14!null lt_dts_new:15!null lt_s_symb:7!null lt_dts:8!null lt_price:9!null lt_open_price:10!null lt_vol:11!null
       ├── cardinality: [0 - 1]
       ├── immutable
       ├── key: ()
       ├── fd: ()-->(7-11,14-16)
       ├── scan last_trade
-      │    ├── columns: lt_s_symb:7!null lt_dts:8!null last_trade.lt_price:9!null lt_open_price:10!null lt_vol:11!null
+      │    ├── columns: lt_s_symb:7!null lt_dts:8!null lt_price:9!null lt_open_price:10!null lt_vol:11!null
       │    ├── constraint: /7: [/'SYMB' - /'SYMB']
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    └── fd: ()-->(7-11)
       └── projections
-           ├── 1E+2 [as=lt_price:16]
+           ├── 1E+2 [as=lt_price_new:16]
            ├── lt_vol:11 + 20 [as=lt_vol_new:14, outer=(11), immutable]
            └── '2020-06-17 22:27:42.148484' [as=lt_dts_new:15]
 
@@ -2551,26 +2551,26 @@ UPDATE trade SET t_tax = '0.00':::FLOAT8::DECIMAL WHERE t_id = 0
 ----
 update trade
  ├── columns: <none>
- ├── fetch columns: t_id:17 t_dts:18 t_st_id:19 t_tt_id:20 t_is_cash:21 t_s_symb:22 t_qty:23 t_bid_price:24 t_ca_id:25 t_exec_name:26 t_trade_price:27 t_chrg:28 t_comm:29 trade.t_tax:30 t_lifo:31
+ ├── fetch columns: t_id:17 t_dts:18 t_st_id:19 t_tt_id:20 t_is_cash:21 t_s_symb:22 t_qty:23 t_bid_price:24 t_ca_id:25 t_exec_name:26 t_trade_price:27 t_chrg:28 t_comm:29 t_tax:30 t_lifo:31
  ├── update-mapping:
- │    └── t_tax:34 => trade.t_tax:14
+ │    └── t_tax_new:34 => t_tax:14
  ├── check columns: check5:39
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: check5:39!null t_tax:34!null t_id:17!null t_dts:18!null t_st_id:19!null t_tt_id:20!null t_is_cash:21!null t_s_symb:22!null t_qty:23!null t_bid_price:24 t_ca_id:25!null t_exec_name:26!null t_trade_price:27 t_chrg:28!null t_comm:29!null trade.t_tax:30!null t_lifo:31!null
+      ├── columns: check5:39!null t_tax_new:34!null t_id:17!null t_dts:18!null t_st_id:19!null t_tt_id:20!null t_is_cash:21!null t_s_symb:22!null t_qty:23!null t_bid_price:24 t_ca_id:25!null t_exec_name:26!null t_trade_price:27 t_chrg:28!null t_comm:29!null t_tax:30!null t_lifo:31!null
       ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(17-31,34,39)
       ├── scan trade
-      │    ├── columns: t_id:17!null t_dts:18!null t_st_id:19!null t_tt_id:20!null t_is_cash:21!null t_s_symb:22!null t_qty:23!null t_bid_price:24 t_ca_id:25!null t_exec_name:26!null t_trade_price:27 t_chrg:28!null t_comm:29!null trade.t_tax:30!null t_lifo:31!null
+      │    ├── columns: t_id:17!null t_dts:18!null t_st_id:19!null t_tt_id:20!null t_is_cash:21!null t_s_symb:22!null t_qty:23!null t_bid_price:24 t_ca_id:25!null t_exec_name:26!null t_trade_price:27 t_chrg:28!null t_comm:29!null t_tax:30!null t_lifo:31!null
       │    ├── constraint: /17: [/0 - /0]
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    └── fd: ()-->(17-31)
       └── projections
            ├── true [as=check5:39]
-           └── 0 [as=t_tax:34]
+           └── 0 [as=t_tax_new:34]
 
 # Q19
 opt
@@ -2655,31 +2655,31 @@ UPDATE trade
 ----
 update trade
  ├── columns: <none>
- ├── fetch columns: t_id:17 t_dts:18 trade.t_st_id:19 t_tt_id:20 t_is_cash:21 t_s_symb:22 t_qty:23 t_bid_price:24 t_ca_id:25 t_exec_name:26 trade.t_trade_price:27 t_chrg:28 trade.t_comm:29 t_tax:30 t_lifo:31
+ ├── fetch columns: t_id:17 t_dts:18 trade.t_st_id:19 t_tt_id:20 t_is_cash:21 t_s_symb:22 t_qty:23 t_bid_price:24 t_ca_id:25 t_exec_name:26 t_trade_price:27 t_chrg:28 t_comm:29 t_tax:30 t_lifo:31
  ├── update-mapping:
  │    ├── t_dts_new:34 => t_dts:2
  │    ├── t_st_id_new:35 => trade.t_st_id:3
- │    ├── t_trade_price:37 => trade.t_trade_price:11
- │    └── t_comm:38 => trade.t_comm:13
+ │    ├── t_trade_price_new:37 => t_trade_price:11
+ │    └── t_comm_new:38 => t_comm:13
  ├── check columns: check4:42
  ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── project
- │    ├── columns: check4:42!null t_comm:38!null t_trade_price:37!null t_dts_new:34!null t_st_id_new:35!null t_id:17!null t_dts:18!null trade.t_st_id:19!null t_tt_id:20!null t_is_cash:21!null t_s_symb:22!null t_qty:23!null t_bid_price:24 t_ca_id:25!null t_exec_name:26!null trade.t_trade_price:27 t_chrg:28!null trade.t_comm:29!null t_tax:30!null t_lifo:31!null
+ │    ├── columns: check4:42!null t_comm_new:38!null t_trade_price_new:37!null t_dts_new:34!null t_st_id_new:35!null t_id:17!null t_dts:18!null trade.t_st_id:19!null t_tt_id:20!null t_is_cash:21!null t_s_symb:22!null t_qty:23!null t_bid_price:24 t_ca_id:25!null t_exec_name:26!null t_trade_price:27 t_chrg:28!null t_comm:29!null t_tax:30!null t_lifo:31!null
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(17-31,34,35,37,38,42)
  │    ├── scan trade
- │    │    ├── columns: t_id:17!null t_dts:18!null trade.t_st_id:19!null t_tt_id:20!null t_is_cash:21!null t_s_symb:22!null t_qty:23!null t_bid_price:24 t_ca_id:25!null t_exec_name:26!null trade.t_trade_price:27 t_chrg:28!null trade.t_comm:29!null t_tax:30!null t_lifo:31!null
+ │    │    ├── columns: t_id:17!null t_dts:18!null trade.t_st_id:19!null t_tt_id:20!null t_is_cash:21!null t_s_symb:22!null t_qty:23!null t_bid_price:24 t_ca_id:25!null t_exec_name:26!null t_trade_price:27 t_chrg:28!null t_comm:29!null t_tax:30!null t_lifo:31!null
  │    │    ├── constraint: /17: [/0 - /0]
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
  │    │    └── fd: ()-->(17-31)
  │    └── projections
  │         ├── true [as=check4:42]
- │         ├── 0 [as=t_comm:38]
- │         ├── 1E+2 [as=t_trade_price:37]
+ │         ├── 0 [as=t_comm_new:38]
+ │         ├── 1E+2 [as=t_trade_price_new:37]
  │         ├── '2020-06-17 22:27:42.148484' [as=t_dts_new:34]
  │         └── 'SBMT' [as=t_st_id_new:35]
  └── f-k-checks
@@ -2763,26 +2763,26 @@ UPDATE broker
 ----
 update broker
  ├── columns: <none>
- ├── fetch columns: b_id:7 b_st_id:8 b_name:9 b_num_trades:10 broker.b_comm_total:11
+ ├── fetch columns: b_id:7 b_st_id:8 b_name:9 b_num_trades:10 b_comm_total:11
  ├── update-mapping:
  │    ├── b_num_trades_new:14 => b_num_trades:4
- │    └── b_comm_total:15 => broker.b_comm_total:5
+ │    └── b_comm_total_new:15 => b_comm_total:5
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: b_comm_total:15 b_num_trades_new:14!null b_id:7!null b_st_id:8!null b_name:9!null b_num_trades:10!null broker.b_comm_total:11!null
+      ├── columns: b_comm_total_new:15 b_num_trades_new:14!null b_id:7!null b_st_id:8!null b_name:9!null b_num_trades:10!null b_comm_total:11!null
       ├── cardinality: [0 - 1]
       ├── immutable
       ├── key: ()
       ├── fd: ()-->(7-11,14,15)
       ├── scan broker
-      │    ├── columns: b_id:7!null b_st_id:8!null b_name:9!null b_num_trades:10!null broker.b_comm_total:11!null
+      │    ├── columns: b_id:7!null b_st_id:8!null b_name:9!null b_num_trades:10!null b_comm_total:11!null
       │    ├── constraint: /7: [/0 - /0]
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    └── fd: ()-->(7-11)
       └── projections
-           ├── crdb_internal.round_decimal_values(broker.b_comm_total:11::DECIMAL, 2) [as=b_comm_total:15, outer=(11), immutable]
+           ├── crdb_internal.round_decimal_values(b_comm_total:11::DECIMAL, 2) [as=b_comm_total_new:15, outer=(11), immutable]
            └── b_num_trades:10 + 1 [as=b_num_trades_new:14, outer=(10), immutable]
 
 # Q25
@@ -2841,13 +2841,13 @@ project
  │    ├── columns: ca_id:1!null customer_account.ca_bal:6!null
  │    ├── fetch columns: ca_id:8 ca_b_id:9 ca_c_id:10 ca_name:11 ca_tax_st:12 customer_account.ca_bal:13
  │    ├── update-mapping:
- │    │    └── ca_bal:16 => customer_account.ca_bal:6
+ │    │    └── ca_bal_new:16 => customer_account.ca_bal:6
  │    ├── cardinality: [0 - 1]
  │    ├── volatile, mutations
  │    ├── key: ()
  │    ├── fd: ()-->(1,6)
  │    └── project
- │         ├── columns: ca_bal:16 ca_id:8!null ca_b_id:9!null ca_c_id:10!null ca_name:11 ca_tax_st:12!null customer_account.ca_bal:13!null
+ │         ├── columns: ca_bal_new:16 ca_id:8!null ca_b_id:9!null ca_c_id:10!null ca_name:11 ca_tax_st:12!null customer_account.ca_bal:13!null
  │         ├── cardinality: [0 - 1]
  │         ├── immutable
  │         ├── key: ()
@@ -2859,7 +2859,7 @@ project
  │         │    ├── key: ()
  │         │    └── fd: ()-->(8-13)
  │         └── projections
- │              └── crdb_internal.round_decimal_values(customer_account.ca_bal:13::DECIMAL + 1E+2, 2) [as=ca_bal:16, outer=(13), immutable]
+ │              └── crdb_internal.round_decimal_values(customer_account.ca_bal:13::DECIMAL + 1E+2, 2) [as=ca_bal_new:16, outer=(13), immutable]
  └── projections
       └── customer_account.ca_bal:6::FLOAT8 [as=ca_bal:18, outer=(6), immutable]
 

--- a/pkg/sql/opt/xform/testdata/external/tpce-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpce-no-stats
@@ -334,27 +334,27 @@ UPDATE last_trade
 ----
 update last_trade
  ├── columns: <none>
- ├── fetch columns: lt_s_symb:7 lt_dts:8 last_trade.lt_price:9 lt_open_price:10 lt_vol:11
+ ├── fetch columns: lt_s_symb:7 lt_dts:8 lt_price:9 lt_open_price:10 lt_vol:11
  ├── update-mapping:
  │    ├── lt_dts_new:15 => lt_dts:2
- │    ├── lt_price:16 => last_trade.lt_price:3
+ │    ├── lt_price_new:16 => lt_price:3
  │    └── lt_vol_new:14 => lt_vol:5
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: lt_price:16!null lt_vol_new:14!null lt_dts_new:15!null lt_s_symb:7!null lt_dts:8!null last_trade.lt_price:9!null lt_open_price:10!null lt_vol:11!null
+      ├── columns: lt_price_new:16!null lt_vol_new:14!null lt_dts_new:15!null lt_s_symb:7!null lt_dts:8!null lt_price:9!null lt_open_price:10!null lt_vol:11!null
       ├── cardinality: [0 - 1]
       ├── immutable
       ├── key: ()
       ├── fd: ()-->(7-11,14-16)
       ├── scan last_trade
-      │    ├── columns: lt_s_symb:7!null lt_dts:8!null last_trade.lt_price:9!null lt_open_price:10!null lt_vol:11!null
+      │    ├── columns: lt_s_symb:7!null lt_dts:8!null lt_price:9!null lt_open_price:10!null lt_vol:11!null
       │    ├── constraint: /7: [/'SYMB' - /'SYMB']
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    └── fd: ()-->(7-11)
       └── projections
-           ├── 1E+2 [as=lt_price:16]
+           ├── 1E+2 [as=lt_price_new:16]
            ├── lt_vol:11 + 20 [as=lt_vol_new:14, outer=(11), immutable]
            └── '2020-06-17 22:27:42.148484' [as=lt_dts_new:15]
 
@@ -2572,26 +2572,26 @@ UPDATE trade SET t_tax = '0.00':::FLOAT8::DECIMAL WHERE t_id = 0
 ----
 update trade
  ├── columns: <none>
- ├── fetch columns: t_id:17 t_dts:18 t_st_id:19 t_tt_id:20 t_is_cash:21 t_s_symb:22 t_qty:23 t_bid_price:24 t_ca_id:25 t_exec_name:26 t_trade_price:27 t_chrg:28 t_comm:29 trade.t_tax:30 t_lifo:31
+ ├── fetch columns: t_id:17 t_dts:18 t_st_id:19 t_tt_id:20 t_is_cash:21 t_s_symb:22 t_qty:23 t_bid_price:24 t_ca_id:25 t_exec_name:26 t_trade_price:27 t_chrg:28 t_comm:29 t_tax:30 t_lifo:31
  ├── update-mapping:
- │    └── t_tax:34 => trade.t_tax:14
+ │    └── t_tax_new:34 => t_tax:14
  ├── check columns: check5:39
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: check5:39!null t_tax:34!null t_id:17!null t_dts:18!null t_st_id:19!null t_tt_id:20!null t_is_cash:21!null t_s_symb:22!null t_qty:23!null t_bid_price:24 t_ca_id:25!null t_exec_name:26!null t_trade_price:27 t_chrg:28!null t_comm:29!null trade.t_tax:30!null t_lifo:31!null
+      ├── columns: check5:39!null t_tax_new:34!null t_id:17!null t_dts:18!null t_st_id:19!null t_tt_id:20!null t_is_cash:21!null t_s_symb:22!null t_qty:23!null t_bid_price:24 t_ca_id:25!null t_exec_name:26!null t_trade_price:27 t_chrg:28!null t_comm:29!null t_tax:30!null t_lifo:31!null
       ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(17-31,34,39)
       ├── scan trade
-      │    ├── columns: t_id:17!null t_dts:18!null t_st_id:19!null t_tt_id:20!null t_is_cash:21!null t_s_symb:22!null t_qty:23!null t_bid_price:24 t_ca_id:25!null t_exec_name:26!null t_trade_price:27 t_chrg:28!null t_comm:29!null trade.t_tax:30!null t_lifo:31!null
+      │    ├── columns: t_id:17!null t_dts:18!null t_st_id:19!null t_tt_id:20!null t_is_cash:21!null t_s_symb:22!null t_qty:23!null t_bid_price:24 t_ca_id:25!null t_exec_name:26!null t_trade_price:27 t_chrg:28!null t_comm:29!null t_tax:30!null t_lifo:31!null
       │    ├── constraint: /17: [/0 - /0]
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    └── fd: ()-->(17-31)
       └── projections
            ├── true [as=check5:39]
-           └── 0 [as=t_tax:34]
+           └── 0 [as=t_tax_new:34]
 
 # Q19
 opt
@@ -2675,31 +2675,31 @@ UPDATE trade
 ----
 update trade
  ├── columns: <none>
- ├── fetch columns: t_id:17 t_dts:18 trade.t_st_id:19 t_tt_id:20 t_is_cash:21 t_s_symb:22 t_qty:23 t_bid_price:24 t_ca_id:25 t_exec_name:26 trade.t_trade_price:27 t_chrg:28 trade.t_comm:29 t_tax:30 t_lifo:31
+ ├── fetch columns: t_id:17 t_dts:18 trade.t_st_id:19 t_tt_id:20 t_is_cash:21 t_s_symb:22 t_qty:23 t_bid_price:24 t_ca_id:25 t_exec_name:26 t_trade_price:27 t_chrg:28 t_comm:29 t_tax:30 t_lifo:31
  ├── update-mapping:
  │    ├── t_dts_new:34 => t_dts:2
  │    ├── t_st_id_new:35 => trade.t_st_id:3
- │    ├── t_trade_price:37 => trade.t_trade_price:11
- │    └── t_comm:38 => trade.t_comm:13
+ │    ├── t_trade_price_new:37 => t_trade_price:11
+ │    └── t_comm_new:38 => t_comm:13
  ├── check columns: check4:42
  ├── input binding: &1
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── project
- │    ├── columns: check4:42!null t_comm:38!null t_trade_price:37!null t_dts_new:34!null t_st_id_new:35!null t_id:17!null t_dts:18!null trade.t_st_id:19!null t_tt_id:20!null t_is_cash:21!null t_s_symb:22!null t_qty:23!null t_bid_price:24 t_ca_id:25!null t_exec_name:26!null trade.t_trade_price:27 t_chrg:28!null trade.t_comm:29!null t_tax:30!null t_lifo:31!null
+ │    ├── columns: check4:42!null t_comm_new:38!null t_trade_price_new:37!null t_dts_new:34!null t_st_id_new:35!null t_id:17!null t_dts:18!null trade.t_st_id:19!null t_tt_id:20!null t_is_cash:21!null t_s_symb:22!null t_qty:23!null t_bid_price:24 t_ca_id:25!null t_exec_name:26!null t_trade_price:27 t_chrg:28!null t_comm:29!null t_tax:30!null t_lifo:31!null
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(17-31,34,35,37,38,42)
  │    ├── scan trade
- │    │    ├── columns: t_id:17!null t_dts:18!null trade.t_st_id:19!null t_tt_id:20!null t_is_cash:21!null t_s_symb:22!null t_qty:23!null t_bid_price:24 t_ca_id:25!null t_exec_name:26!null trade.t_trade_price:27 t_chrg:28!null trade.t_comm:29!null t_tax:30!null t_lifo:31!null
+ │    │    ├── columns: t_id:17!null t_dts:18!null trade.t_st_id:19!null t_tt_id:20!null t_is_cash:21!null t_s_symb:22!null t_qty:23!null t_bid_price:24 t_ca_id:25!null t_exec_name:26!null t_trade_price:27 t_chrg:28!null t_comm:29!null t_tax:30!null t_lifo:31!null
  │    │    ├── constraint: /17: [/0 - /0]
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
  │    │    └── fd: ()-->(17-31)
  │    └── projections
  │         ├── true [as=check4:42]
- │         ├── 0 [as=t_comm:38]
- │         ├── 1E+2 [as=t_trade_price:37]
+ │         ├── 0 [as=t_comm_new:38]
+ │         ├── 1E+2 [as=t_trade_price_new:37]
  │         ├── '2020-06-17 22:27:42.148484' [as=t_dts_new:34]
  │         └── 'SBMT' [as=t_st_id_new:35]
  └── f-k-checks
@@ -2783,26 +2783,26 @@ UPDATE broker
 ----
 update broker
  ├── columns: <none>
- ├── fetch columns: b_id:7 b_st_id:8 b_name:9 b_num_trades:10 broker.b_comm_total:11
+ ├── fetch columns: b_id:7 b_st_id:8 b_name:9 b_num_trades:10 b_comm_total:11
  ├── update-mapping:
  │    ├── b_num_trades_new:14 => b_num_trades:4
- │    └── b_comm_total:15 => broker.b_comm_total:5
+ │    └── b_comm_total_new:15 => b_comm_total:5
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: b_comm_total:15 b_num_trades_new:14!null b_id:7!null b_st_id:8!null b_name:9!null b_num_trades:10!null broker.b_comm_total:11!null
+      ├── columns: b_comm_total_new:15 b_num_trades_new:14!null b_id:7!null b_st_id:8!null b_name:9!null b_num_trades:10!null b_comm_total:11!null
       ├── cardinality: [0 - 1]
       ├── immutable
       ├── key: ()
       ├── fd: ()-->(7-11,14,15)
       ├── scan broker
-      │    ├── columns: b_id:7!null b_st_id:8!null b_name:9!null b_num_trades:10!null broker.b_comm_total:11!null
+      │    ├── columns: b_id:7!null b_st_id:8!null b_name:9!null b_num_trades:10!null b_comm_total:11!null
       │    ├── constraint: /7: [/0 - /0]
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    └── fd: ()-->(7-11)
       └── projections
-           ├── crdb_internal.round_decimal_values(broker.b_comm_total:11::DECIMAL, 2) [as=b_comm_total:15, outer=(11), immutable]
+           ├── crdb_internal.round_decimal_values(b_comm_total:11::DECIMAL, 2) [as=b_comm_total_new:15, outer=(11), immutable]
            └── b_num_trades:10 + 1 [as=b_num_trades_new:14, outer=(10), immutable]
 
 # Q25
@@ -2861,13 +2861,13 @@ project
  │    ├── columns: ca_id:1!null customer_account.ca_bal:6!null
  │    ├── fetch columns: ca_id:8 ca_b_id:9 ca_c_id:10 ca_name:11 ca_tax_st:12 customer_account.ca_bal:13
  │    ├── update-mapping:
- │    │    └── ca_bal:16 => customer_account.ca_bal:6
+ │    │    └── ca_bal_new:16 => customer_account.ca_bal:6
  │    ├── cardinality: [0 - 1]
  │    ├── volatile, mutations
  │    ├── key: ()
  │    ├── fd: ()-->(1,6)
  │    └── project
- │         ├── columns: ca_bal:16 ca_id:8!null ca_b_id:9!null ca_c_id:10!null ca_name:11 ca_tax_st:12!null customer_account.ca_bal:13!null
+ │         ├── columns: ca_bal_new:16 ca_id:8!null ca_b_id:9!null ca_c_id:10!null ca_name:11 ca_tax_st:12!null customer_account.ca_bal:13!null
  │         ├── cardinality: [0 - 1]
  │         ├── immutable
  │         ├── key: ()
@@ -2879,7 +2879,7 @@ project
  │         │    ├── key: ()
  │         │    └── fd: ()-->(8-13)
  │         └── projections
- │              └── crdb_internal.round_decimal_values(customer_account.ca_bal:13::DECIMAL + 1E+2, 2) [as=ca_bal:16, outer=(13), immutable]
+ │              └── crdb_internal.round_decimal_values(customer_account.ca_bal:13::DECIMAL + 1E+2, 2) [as=ca_bal_new:16, outer=(13), immutable]
  └── projections
       └── customer_account.ca_bal:6::FLOAT8 [as=ca_bal:18, outer=(6), immutable]
 

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -1261,11 +1261,11 @@ insert transactions
  │    ├── column4:12 => accountname:4
  │    ├── column5:13 => customername:5
  │    ├── column6:14 => operationid:6
- │    └── column15:15 => version:7
+ │    └── version_default:15 => version:7
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── values
-      ├── columns: column1:9!null column2:10!null column3:11!null column4:12!null column5:13!null column6:14!null column15:15
+      ├── columns: column1:9!null column2:10!null column3:11!null column4:12!null column5:13!null column6:14!null version_default:15
       ├── cardinality: [1 - 1]
       ├── volatile
       ├── key: ()
@@ -1289,7 +1289,7 @@ upsert transactions
  │    ├── column4:12 => accountname:4
  │    ├── column5:13 => customername:5
  │    ├── column6:14 => operationid:6
- │    └── column15:15 => version:7
+ │    └── version_default:15 => version:7
  ├── update-mapping:
  │    ├── column4:12 => accountname:4
  │    ├── column5:13 => customername:5
@@ -1297,14 +1297,14 @@ upsert transactions
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── left-join (cross)
-      ├── columns: column1:9!null column2:10!null column3:11!null column4:12!null column5:13!null column6:14!null column15:15 dealerid:16 isbuy:17 date:18 accountname:19 customername:20 operationid:21 version:22
+      ├── columns: column1:9!null column2:10!null column3:11!null column4:12!null column5:13!null column6:14!null version_default:15 dealerid:16 isbuy:17 date:18 accountname:19 customername:20 operationid:21 version:22
       ├── cardinality: [1 - 1]
       ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
       ├── volatile
       ├── key: ()
       ├── fd: ()-->(9-22)
       ├── values
-      │    ├── columns: column1:9!null column2:10!null column3:11!null column4:12!null column5:13!null column6:14!null column15:15
+      │    ├── columns: column1:9!null column2:10!null column3:11!null column4:12!null column5:13!null column6:14!null version_default:15
       │    ├── cardinality: [1 - 1]
       │    ├── volatile
       │    ├── key: ()
@@ -1346,7 +1346,7 @@ upsert transactiondetails
  │    ├── int8:16 => quantity:6
  │    ├── sellprice:20 => transactiondetails.sellprice:7
  │    ├── buyprice:21 => transactiondetails.buyprice:8
- │    └── column19:19 => transactiondetails.version:9
+ │    └── version_default:19 => transactiondetails.version:9
  ├── update-mapping:
  │    ├── sellprice:20 => transactiondetails.sellprice:7
  │    └── buyprice:21 => transactiondetails.buyprice:8
@@ -1354,13 +1354,13 @@ upsert transactiondetails
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── project
- │    ├── columns: upsert_dealerid:31 upsert_isbuy:32 upsert_transactiondate:33 upsert_cardid:34 "?column?":12!null bool:13!null current_timestamp:14!null int8:15!null int8:16!null column19:19 sellprice:20 buyprice:21 transactiondetails.dealerid:22 transactiondetails.isbuy:23 transactiondetails.transactiondate:24 transactiondetails.cardid:25 quantity:26 transactiondetails.sellprice:27 transactiondetails.buyprice:28 transactiondetails.version:29
+ │    ├── columns: upsert_dealerid:31 upsert_isbuy:32 upsert_transactiondate:33 upsert_cardid:34 "?column?":12!null bool:13!null current_timestamp:14!null int8:15!null int8:16!null version_default:19 sellprice:20 buyprice:21 transactiondetails.dealerid:22 transactiondetails.isbuy:23 transactiondetails.transactiondate:24 transactiondetails.cardid:25 quantity:26 transactiondetails.sellprice:27 transactiondetails.buyprice:28 transactiondetails.version:29
  │    ├── cardinality: [1 - 2]
  │    ├── volatile
  │    ├── key: (15,16)
  │    ├── fd: ()-->(12-14), (15,16)-->(19-29), (22-26)-->(27-29), (22)-->(31), (22,23)-->(32), (22,24)-->(33), (15,22,25)-->(34)
  │    ├── left-join (lookup transactiondetails)
- │    │    ├── columns: "?column?":12!null bool:13!null current_timestamp:14!null int8:15!null int8:16!null column19:19 sellprice:20 buyprice:21 transactiondetails.dealerid:22 transactiondetails.isbuy:23 transactiondetails.transactiondate:24 transactiondetails.cardid:25 quantity:26 transactiondetails.sellprice:27 transactiondetails.buyprice:28 transactiondetails.version:29
+ │    │    ├── columns: "?column?":12!null bool:13!null current_timestamp:14!null int8:15!null int8:16!null version_default:19 sellprice:20 buyprice:21 transactiondetails.dealerid:22 transactiondetails.isbuy:23 transactiondetails.transactiondate:24 transactiondetails.cardid:25 quantity:26 transactiondetails.sellprice:27 transactiondetails.buyprice:28 transactiondetails.version:29
  │    │    ├── key columns: [12 13 14 15 16] = [22 23 24 25 26]
  │    │    ├── lookup columns are key
  │    │    ├── cardinality: [1 - 2]
@@ -1368,7 +1368,7 @@ upsert transactiondetails
  │    │    ├── key: (15,16)
  │    │    ├── fd: ()-->(12-14), (15,16)-->(19-29), (22-26)-->(27-29)
  │    │    ├── ensure-upsert-distinct-on
- │    │    │    ├── columns: "?column?":12!null bool:13!null current_timestamp:14!null int8:15!null int8:16!null column19:19 sellprice:20 buyprice:21
+ │    │    │    ├── columns: "?column?":12!null bool:13!null current_timestamp:14!null int8:15!null int8:16!null version_default:19 sellprice:20 buyprice:21
  │    │    │    ├── grouping columns: int8:15!null int8:16!null
  │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
  │    │    │    ├── cardinality: [1 - 2]
@@ -1376,7 +1376,7 @@ upsert transactiondetails
  │    │    │    ├── key: (15,16)
  │    │    │    ├── fd: ()-->(12-14), (15,16)-->(12-14,19-21)
  │    │    │    ├── project
- │    │    │    │    ├── columns: sellprice:20 buyprice:21 column19:19 "?column?":12!null bool:13!null current_timestamp:14!null int8:15!null int8:16!null
+ │    │    │    │    ├── columns: sellprice:20 buyprice:21 version_default:19 "?column?":12!null bool:13!null current_timestamp:14!null int8:15!null int8:16!null
  │    │    │    │    ├── cardinality: [2 - 2]
  │    │    │    │    ├── volatile
  │    │    │    │    ├── fd: ()-->(12-14)
@@ -1388,7 +1388,7 @@ upsert transactiondetails
  │    │    │    │    └── projections
  │    │    │    │         ├── crdb_internal.round_decimal_values(detail_s:59::STRING::DECIMAL(10,4), 4) [as=sellprice:20, outer=(59), immutable]
  │    │    │    │         ├── crdb_internal.round_decimal_values(detail_b:56::STRING::DECIMAL(10,4), 4) [as=buyprice:21, outer=(56), immutable]
- │    │    │    │         ├── cluster_logical_timestamp() [as=column19:19, volatile]
+ │    │    │    │         ├── cluster_logical_timestamp() [as=version_default:19, volatile]
  │    │    │    │         ├── 1 [as="?column?":12]
  │    │    │    │         ├── false [as=bool:13]
  │    │    │    │         ├── '2017-05-10 13:00:00+00:00' [as=current_timestamp:14]
@@ -1399,8 +1399,8 @@ upsert transactiondetails
  │    │    │         │    └── sellprice:20
  │    │    │         ├── first-agg [as=buyprice:21, outer=(21)]
  │    │    │         │    └── buyprice:21
- │    │    │         ├── first-agg [as=column19:19, outer=(19)]
- │    │    │         │    └── column19:19
+ │    │    │         ├── first-agg [as=version_default:19, outer=(19)]
+ │    │    │         │    └── version_default:19
  │    │    │         ├── const-agg [as="?column?":12, outer=(12)]
  │    │    │         │    └── "?column?":12
  │    │    │         ├── const-agg [as=bool:13, outer=(13)]

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -1265,12 +1265,12 @@ insert transactions
  │    ├── column4:14 => accountname:4
  │    ├── column5:15 => customername:5
  │    ├── column6:16 => operationid:6
- │    ├── column17:17 => version:7
- │    └── column18:18 => olddate:8
+ │    ├── version_default:17 => version:7
+ │    └── olddate_default:18 => olddate:8
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── values
-      ├── columns: column1:11!null column2:12!null column3:13!null column4:14!null column5:15!null column6:16!null column17:17 column18:18!null
+      ├── columns: column1:11!null column2:12!null column3:13!null column4:14!null column5:15!null column6:16!null version_default:17 olddate_default:18!null
       ├── cardinality: [1 - 1]
       ├── volatile
       ├── key: ()
@@ -1294,24 +1294,24 @@ upsert transactions
  │    ├── column4:14 => accountname:4
  │    ├── column5:15 => customername:5
  │    ├── column6:16 => operationid:6
- │    ├── column17:17 => version:7
- │    └── column18:18 => olddate:8
+ │    ├── version_default:17 => version:7
+ │    └── olddate_default:18 => olddate:8
  ├── update-mapping:
  │    ├── column4:14 => accountname:4
  │    ├── column5:15 => customername:5
  │    ├── column6:16 => operationid:6
- │    └── column18:18 => olddate:8
+ │    └── olddate_default:18 => olddate:8
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── left-join (cross)
-      ├── columns: column1:11!null column2:12!null column3:13!null column4:14!null column5:15!null column6:16!null column17:17 column18:18!null dealerid:19 isbuy:20 date:21 accountname:22 customername:23 operationid:24 version:25 olddate:26 extra:27
+      ├── columns: column1:11!null column2:12!null column3:13!null column4:14!null column5:15!null column6:16!null version_default:17 olddate_default:18!null dealerid:19 isbuy:20 date:21 accountname:22 customername:23 operationid:24 version:25 olddate:26 extra:27
       ├── cardinality: [1 - 1]
       ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
       ├── volatile
       ├── key: ()
       ├── fd: ()-->(11-27)
       ├── values
-      │    ├── columns: column1:11!null column2:12!null column3:13!null column4:14!null column5:15!null column6:16!null column17:17 column18:18!null
+      │    ├── columns: column1:11!null column2:12!null column3:13!null column4:14!null column5:15!null column6:16!null version_default:17 olddate_default:18!null
       │    ├── cardinality: [1 - 1]
       │    ├── volatile
       │    ├── key: ()
@@ -1344,7 +1344,7 @@ upsert transactiondetails
  ├── columns: <none>
  ├── arbiter indexes: detailsprimarykey
  ├── canary column: transactiondetails.dealerid:26
- ├── fetch columns: transactiondetails.dealerid:26 transactiondetails.isbuy:27 transactiondetails.transactiondate:28 transactiondetails.cardid:29 quantity:30 transactiondetails.sellprice:31 transactiondetails.buyprice:32 transactiondetails.version:33 transactiondetails.discount:34 transactiondetails.extra:35
+ ├── fetch columns: transactiondetails.dealerid:26 transactiondetails.isbuy:27 transactiondetails.transactiondate:28 transactiondetails.cardid:29 quantity:30 transactiondetails.sellprice:31 transactiondetails.buyprice:32 transactiondetails.version:33 discount:34 transactiondetails.extra:35
  ├── insert-mapping:
  │    ├── "?column?":14 => transactiondetails.dealerid:2
  │    ├── bool:15 => transactiondetails.isbuy:3
@@ -1353,23 +1353,23 @@ upsert transactiondetails
  │    ├── int8:18 => quantity:6
  │    ├── sellprice:23 => transactiondetails.sellprice:7
  │    ├── buyprice:24 => transactiondetails.buyprice:8
- │    ├── column21:21 => transactiondetails.version:9
- │    └── discount:25 => transactiondetails.discount:10
+ │    ├── version_default:21 => transactiondetails.version:9
+ │    └── discount_default:25 => discount:10
  ├── update-mapping:
  │    ├── sellprice:23 => transactiondetails.sellprice:7
  │    ├── buyprice:24 => transactiondetails.buyprice:8
- │    └── discount:25 => transactiondetails.discount:10
+ │    └── discount_default:25 => discount:10
  ├── input binding: &2
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── project
- │    ├── columns: upsert_dealerid:37 upsert_isbuy:38 upsert_transactiondate:39 upsert_cardid:40 "?column?":14!null bool:15!null current_timestamp:16!null int8:17!null int8:18!null column21:21 sellprice:23 buyprice:24 discount:25!null transactiondetails.dealerid:26 transactiondetails.isbuy:27 transactiondetails.transactiondate:28 transactiondetails.cardid:29 quantity:30 transactiondetails.sellprice:31 transactiondetails.buyprice:32 transactiondetails.version:33 transactiondetails.discount:34 transactiondetails.extra:35
+ │    ├── columns: upsert_dealerid:37 upsert_isbuy:38 upsert_transactiondate:39 upsert_cardid:40 "?column?":14!null bool:15!null current_timestamp:16!null int8:17!null int8:18!null version_default:21 sellprice:23 buyprice:24 discount_default:25!null transactiondetails.dealerid:26 transactiondetails.isbuy:27 transactiondetails.transactiondate:28 transactiondetails.cardid:29 quantity:30 transactiondetails.sellprice:31 transactiondetails.buyprice:32 transactiondetails.version:33 discount:34 transactiondetails.extra:35
  │    ├── cardinality: [1 - 2]
  │    ├── volatile
  │    ├── key: (17,18)
  │    ├── fd: ()-->(14-16,25), (17,18)-->(21,23,24,26-35), (26-30)-->(31-35), (26)-->(37), (26,27)-->(38), (26,28)-->(39), (17,26,29)-->(40)
  │    ├── left-join (lookup transactiondetails)
- │    │    ├── columns: "?column?":14!null bool:15!null current_timestamp:16!null int8:17!null int8:18!null column21:21 sellprice:23 buyprice:24 discount:25!null transactiondetails.dealerid:26 transactiondetails.isbuy:27 transactiondetails.transactiondate:28 transactiondetails.cardid:29 quantity:30 transactiondetails.sellprice:31 transactiondetails.buyprice:32 transactiondetails.version:33 transactiondetails.discount:34 transactiondetails.extra:35
+ │    │    ├── columns: "?column?":14!null bool:15!null current_timestamp:16!null int8:17!null int8:18!null version_default:21 sellprice:23 buyprice:24 discount_default:25!null transactiondetails.dealerid:26 transactiondetails.isbuy:27 transactiondetails.transactiondate:28 transactiondetails.cardid:29 quantity:30 transactiondetails.sellprice:31 transactiondetails.buyprice:32 transactiondetails.version:33 discount:34 transactiondetails.extra:35
  │    │    ├── key columns: [14 15 16 17 18] = [26 27 28 29 30]
  │    │    ├── lookup columns are key
  │    │    ├── cardinality: [1 - 2]
@@ -1377,7 +1377,7 @@ upsert transactiondetails
  │    │    ├── key: (17,18)
  │    │    ├── fd: ()-->(14-16,25), (17,18)-->(21,23,24,26-35), (26-30)-->(31-35)
  │    │    ├── ensure-upsert-distinct-on
- │    │    │    ├── columns: "?column?":14!null bool:15!null current_timestamp:16!null int8:17!null int8:18!null column21:21 sellprice:23 buyprice:24 discount:25!null
+ │    │    │    ├── columns: "?column?":14!null bool:15!null current_timestamp:16!null int8:17!null int8:18!null version_default:21 sellprice:23 buyprice:24 discount_default:25!null
  │    │    │    ├── grouping columns: int8:17!null int8:18!null
  │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
  │    │    │    ├── cardinality: [1 - 2]
@@ -1385,7 +1385,7 @@ upsert transactiondetails
  │    │    │    ├── key: (17,18)
  │    │    │    ├── fd: ()-->(14-16,25), (17,18)-->(14-16,21,23-25)
  │    │    │    ├── project
- │    │    │    │    ├── columns: sellprice:23 buyprice:24 discount:25!null column21:21 "?column?":14!null bool:15!null current_timestamp:16!null int8:17!null int8:18!null
+ │    │    │    │    ├── columns: sellprice:23 buyprice:24 discount_default:25!null version_default:21 "?column?":14!null bool:15!null current_timestamp:16!null int8:17!null int8:18!null
  │    │    │    │    ├── cardinality: [2 - 2]
  │    │    │    │    ├── volatile
  │    │    │    │    ├── fd: ()-->(14-16,25)
@@ -1397,8 +1397,8 @@ upsert transactiondetails
  │    │    │    │    └── projections
  │    │    │    │         ├── crdb_internal.round_decimal_values(detail_s:67::STRING::DECIMAL(10,4), 4) [as=sellprice:23, outer=(67), immutable]
  │    │    │    │         ├── crdb_internal.round_decimal_values(detail_b:64::STRING::DECIMAL(10,4), 4) [as=buyprice:24, outer=(64), immutable]
- │    │    │    │         ├── 0.0000 [as=discount:25]
- │    │    │    │         ├── cluster_logical_timestamp() [as=column21:21, volatile]
+ │    │    │    │         ├── 0.0000 [as=discount_default:25]
+ │    │    │    │         ├── cluster_logical_timestamp() [as=version_default:21, volatile]
  │    │    │    │         ├── 1 [as="?column?":14]
  │    │    │    │         ├── false [as=bool:15]
  │    │    │    │         ├── '2017-05-10 13:00:00+00:00' [as=current_timestamp:16]
@@ -1409,10 +1409,10 @@ upsert transactiondetails
  │    │    │         │    └── sellprice:23
  │    │    │         ├── first-agg [as=buyprice:24, outer=(24)]
  │    │    │         │    └── buyprice:24
- │    │    │         ├── first-agg [as=column21:21, outer=(21)]
- │    │    │         │    └── column21:21
- │    │    │         ├── first-agg [as=discount:25, outer=(25)]
- │    │    │         │    └── discount:25
+ │    │    │         ├── first-agg [as=version_default:21, outer=(21)]
+ │    │    │         │    └── version_default:21
+ │    │    │         ├── first-agg [as=discount_default:25, outer=(25)]
+ │    │    │         │    └── discount_default:25
  │    │    │         ├── const-agg [as="?column?":14, outer=(14)]
  │    │    │         │    └── "?column?":14
  │    │    │         ├── const-agg [as=bool:15, outer=(15)]
@@ -1490,41 +1490,41 @@ WHERE ci.cardid = Updates.c AND ci.dealerid = 1
 ----
 update cardsinfo [as=ci]
  ├── columns: <none>
- ├── fetch columns: ci.dealerid:20 ci.cardid:21 buyprice:22 sellprice:23 discount:24 desiredinventory:25 actualinventory:26 maxinventory:27 ci.version:28 ci.discountbuyprice:29 notes:30 oldinventory:31 ci.extra:32
+ ├── fetch columns: ci.dealerid:20 ci.cardid:21 buyprice:22 sellprice:23 discount:24 desiredinventory:25 actualinventory:26 maxinventory:27 ci.version:28 discountbuyprice:29 notes:30 oldinventory:31 ci.extra:32
  ├── update-mapping:
  │    ├── actualinventory_new:46 => actualinventory:12
- │    ├── discountbuyprice:50 => ci.discountbuyprice:15
- │    ├── column47:47 => notes:16
- │    └── column48:48 => oldinventory:17
+ │    ├── discountbuyprice_comp:50 => discountbuyprice:15
+ │    ├── notes_default:47 => notes:16
+ │    └── oldinventory_default:48 => oldinventory:17
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: discountbuyprice:50 column47:47 column48:48!null actualinventory_new:46 ci.dealerid:20!null ci.cardid:21!null buyprice:22!null sellprice:23!null discount:24!null desiredinventory:25!null actualinventory:26!null maxinventory:27!null ci.version:28!null ci.discountbuyprice:29 notes:30 oldinventory:31 ci.extra:32 c:34!null q:35!null
+      ├── columns: discountbuyprice_comp:50 notes_default:47 oldinventory_default:48!null actualinventory_new:46 ci.dealerid:20!null ci.cardid:21!null buyprice:22!null sellprice:23!null discount:24!null desiredinventory:25!null actualinventory:26!null maxinventory:27!null ci.version:28!null discountbuyprice:29 notes:30 oldinventory:31 ci.extra:32 c:34!null q:35!null
       ├── immutable
       ├── key: (21)
       ├── fd: ()-->(20,47,48), (21)-->(22-32,34,35,46,50), (28)-->(21-27,29-32), (21)==(34), (34)==(21)
       ├── group-by
-      │    ├── columns: ci.dealerid:20!null ci.cardid:21!null buyprice:22!null sellprice:23!null discount:24!null desiredinventory:25!null actualinventory:26!null maxinventory:27!null ci.version:28!null ci.discountbuyprice:29 notes:30 oldinventory:31 ci.extra:32 c:34!null q:35!null sum_int:44
+      │    ├── columns: ci.dealerid:20!null ci.cardid:21!null buyprice:22!null sellprice:23!null discount:24!null desiredinventory:25!null actualinventory:26!null maxinventory:27!null ci.version:28!null discountbuyprice:29 notes:30 oldinventory:31 ci.extra:32 c:34!null q:35!null sum_int:44
       │    ├── grouping columns: ci.cardid:21!null
       │    ├── key: (21)
       │    ├── fd: ()-->(20), (21)-->(20,22-32,34,35,44), (28)-->(21-27,29-32), (21)==(34), (34)==(21)
       │    ├── left-join (lookup inventorydetails [as=id])
-      │    │    ├── columns: ci.dealerid:20!null ci.cardid:21!null buyprice:22!null sellprice:23!null discount:24!null desiredinventory:25!null actualinventory:26!null maxinventory:27!null ci.version:28!null ci.discountbuyprice:29 notes:30 oldinventory:31 ci.extra:32 c:34!null q:35!null id.dealerid:36 id.cardid:37 quantity:39
+      │    │    ├── columns: ci.dealerid:20!null ci.cardid:21!null buyprice:22!null sellprice:23!null discount:24!null desiredinventory:25!null actualinventory:26!null maxinventory:27!null ci.version:28!null discountbuyprice:29 notes:30 oldinventory:31 ci.extra:32 c:34!null q:35!null id.dealerid:36 id.cardid:37 quantity:39
       │    │    ├── key columns: [53 21] = [36 37]
       │    │    ├── fd: ()-->(20), (21)-->(22-32,34,35), (28)-->(21-27,29-32), (21)==(34), (34)==(21)
       │    │    ├── project
-      │    │    │    ├── columns: "lookup_join_const_col_@36":53!null ci.dealerid:20!null ci.cardid:21!null buyprice:22!null sellprice:23!null discount:24!null desiredinventory:25!null actualinventory:26!null maxinventory:27!null ci.version:28!null ci.discountbuyprice:29 notes:30 oldinventory:31 ci.extra:32 c:34!null q:35!null
+      │    │    │    ├── columns: "lookup_join_const_col_@36":53!null ci.dealerid:20!null ci.cardid:21!null buyprice:22!null sellprice:23!null discount:24!null desiredinventory:25!null actualinventory:26!null maxinventory:27!null ci.version:28!null discountbuyprice:29 notes:30 oldinventory:31 ci.extra:32 c:34!null q:35!null
       │    │    │    ├── cardinality: [0 - 2]
       │    │    │    ├── key: (21)
       │    │    │    ├── fd: ()-->(20,53), (21)-->(22-32,34,35), (28)-->(21-27,29-32), (21)==(34), (34)==(21)
       │    │    │    ├── distinct-on
-      │    │    │    │    ├── columns: ci.dealerid:20!null ci.cardid:21!null buyprice:22!null sellprice:23!null discount:24!null desiredinventory:25!null actualinventory:26!null maxinventory:27!null ci.version:28!null ci.discountbuyprice:29 notes:30 oldinventory:31 ci.extra:32 c:34!null q:35!null
+      │    │    │    │    ├── columns: ci.dealerid:20!null ci.cardid:21!null buyprice:22!null sellprice:23!null discount:24!null desiredinventory:25!null actualinventory:26!null maxinventory:27!null ci.version:28!null discountbuyprice:29 notes:30 oldinventory:31 ci.extra:32 c:34!null q:35!null
       │    │    │    │    ├── grouping columns: ci.cardid:21!null
       │    │    │    │    ├── cardinality: [0 - 2]
       │    │    │    │    ├── key: (21)
       │    │    │    │    ├── fd: ()-->(20), (21)-->(20,22-32,34,35), (28)-->(21-27,29-32), (21)==(34), (34)==(21)
       │    │    │    │    ├── inner-join (lookup cardsinfo [as=ci])
-      │    │    │    │    │    ├── columns: ci.dealerid:20!null ci.cardid:21!null buyprice:22!null sellprice:23!null discount:24!null desiredinventory:25!null actualinventory:26!null maxinventory:27!null ci.version:28!null ci.discountbuyprice:29 notes:30 oldinventory:31 ci.extra:32 c:34!null q:35!null
+      │    │    │    │    │    ├── columns: ci.dealerid:20!null ci.cardid:21!null buyprice:22!null sellprice:23!null discount:24!null desiredinventory:25!null actualinventory:26!null maxinventory:27!null ci.version:28!null discountbuyprice:29 notes:30 oldinventory:31 ci.extra:32 c:34!null q:35!null
       │    │    │    │    │    ├── key columns: [51 34] = [20 21]
       │    │    │    │    │    ├── lookup columns are key
       │    │    │    │    │    ├── cardinality: [0 - 2]
@@ -1556,8 +1556,8 @@ update cardsinfo [as=ci]
       │    │    │    │         │    └── maxinventory:27
       │    │    │    │         ├── first-agg [as=ci.version:28, outer=(28)]
       │    │    │    │         │    └── ci.version:28
-      │    │    │    │         ├── first-agg [as=ci.discountbuyprice:29, outer=(29)]
-      │    │    │    │         │    └── ci.discountbuyprice:29
+      │    │    │    │         ├── first-agg [as=discountbuyprice:29, outer=(29)]
+      │    │    │    │         │    └── discountbuyprice:29
       │    │    │    │         ├── first-agg [as=notes:30, outer=(30)]
       │    │    │    │         │    └── notes:30
       │    │    │    │         ├── first-agg [as=oldinventory:31, outer=(31)]
@@ -1592,8 +1592,8 @@ update cardsinfo [as=ci]
       │         │    └── maxinventory:27
       │         ├── const-agg [as=ci.version:28, outer=(28)]
       │         │    └── ci.version:28
-      │         ├── const-agg [as=ci.discountbuyprice:29, outer=(29)]
-      │         │    └── ci.discountbuyprice:29
+      │         ├── const-agg [as=discountbuyprice:29, outer=(29)]
+      │         │    └── discountbuyprice:29
       │         ├── const-agg [as=notes:30, outer=(30)]
       │         │    └── notes:30
       │         ├── const-agg [as=oldinventory:31, outer=(31)]
@@ -1605,7 +1605,7 @@ update cardsinfo [as=ci]
       │         └── const-agg [as=q:35, outer=(35)]
       │              └── q:35
       └── projections
-           ├── crdb_internal.round_decimal_values(buyprice:22::DECIMAL - discount:24::DECIMAL, 4) [as=discountbuyprice:50, outer=(22,24), immutable]
-           ├── CAST(NULL AS STRING) [as=column47:47]
-           ├── 0 [as=column48:48]
+           ├── crdb_internal.round_decimal_values(buyprice:22::DECIMAL - discount:24::DECIMAL, 4) [as=discountbuyprice_comp:50, outer=(22,24), immutable]
+           ├── CAST(NULL AS STRING) [as=notes_default:47]
+           ├── 0 [as=oldinventory_default:48]
            └── COALESCE(sum_int:44, 0) [as=actualinventory_new:46, outer=(44)]

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -7560,18 +7560,18 @@ with &1
  │    │    ├── columns: abc.rowid:9!null
  │    │    ├── insert-mapping:
  │    │    │    ├── "?column?":16 => abc.a:6
- │    │    │    ├── column17:17 => abc.b:7
- │    │    │    ├── column17:17 => abc.c:8
- │    │    │    └── column18:18 => abc.rowid:9
+ │    │    │    ├── b_default:17 => abc.b:7
+ │    │    │    ├── b_default:17 => abc.c:8
+ │    │    │    └── rowid_default:18 => abc.rowid:9
  │    │    ├── volatile, mutations
  │    │    └── project
- │    │         ├── columns: column17:17 column18:18 "?column?":16!null
+ │    │         ├── columns: b_default:17 rowid_default:18 "?column?":16!null
  │    │         ├── volatile
  │    │         ├── fd: ()-->(16,17)
  │    │         ├── scan abc
  │    │         └── projections
- │    │              ├── CAST(NULL AS INT8) [as=column17:17]
- │    │              ├── unique_rowid() [as=column18:18, volatile]
+ │    │              ├── CAST(NULL AS INT8) [as=b_default:17]
+ │    │              ├── unique_rowid() [as=rowid_default:18, volatile]
  │    │              └── 1 [as="?column?":16]
  │    └── projections
  │         └── 1 [as="?column?":19]


### PR DESCRIPTION
#### optbuilder: add scopeColumnName struct

This commit adds the `scopeColumnName` struct. This struct makes it
possible for a `scopeColumn` to have a name it can be referenced by, and
another name in the metadata. Separating these names allows a column to
be referenced by one name while optbuilder builds expressions, but added
to the metadata and displayed in opt trees with another. This is useful
for:

  1. Creating more descriptive metadata names, while having descriptive
     refNames that are required for column resolution while building a
     expressions. This is particularly useful in mutations where there
     are multiple versions of target table columns for fetching,
     inserting, and updating that must be referenced by the same name.
  2. Creating descriptive metadata names for anonymous columns that
     cannot be referenced. This is useful for columns like synthesized
     check constraint columns and partial index columns which cannot be
     referenced by other expressions. Prior to the creation of
     scopeColumnName, the same descriptive name added to the metadata
     could be referenced, making optbuilder vulnerable to "ambiguous
     column" bugs when a user table had a column with the same name.

This commit updates a few places were a non-anonymous scope column was
created but should not have been. Therefore, there is a non-zero chance
that this commit fixes undiscovered "ambiguous column" bugs described in
(2).

Release note: None

#### optbuilder: use descriptive default and computed column metadata names

Column names for synthesized default columns and computed columns in
mutations are now more descriptive. For default columns, the name is the
target column's name suffixed with "_default". For computed columns, the
name is the target column's name suffixed with "_comp". Both column
types can still be referenced by other expressions with the name of the
target column.

Release note: None
