### PR TITLE
roachprod: default to secure clusters

### DIFF
--- a/pkg/cmd/roachprod/README.md
+++ b/pkg/cmd/roachprod/README.md
@@ -54,6 +54,9 @@ roachprod start ${CLUSTER}
 
 # Check the admin UI.
 roachprod admin --open ${CLUSTER}:1
+# For secure clusters, create a user and grant admin privileges
+roachprod sql ${CLUSTER}:1 -- -e "CREATE USER craig WITH PASSWORD 'cockroach';"
+roachprod sql ${CLUSTER}:1 -- -e "GRANT ADMIN TO craig;"
 
 # Run a workload.
 roachprod run ${CLUSTER}:4 -- ./workload init kv

--- a/pkg/cmd/roachprod/install/cluster_synced.go
+++ b/pkg/cmd/roachprod/install/cluster_synced.go
@@ -67,7 +67,7 @@ type SyncedCluster struct {
 	VPCs       []string
 	// all other fields are populated in newCluster.
 	Nodes          []int
-	Secure         bool
+	Insecure       bool
 	Env            string
 	Args           []string
 	Tag            string

--- a/pkg/cmd/roachprod/install/cockroach.go
+++ b/pkg/cmd/roachprod/install/cockroach.go
@@ -260,11 +260,11 @@ func (Cockroach) CertsDir(c *SyncedCluster, index int) string {
 // NodeURL implements the ClusterImpl.NodeDir interface.
 func (Cockroach) NodeURL(c *SyncedCluster, host string, port int) string {
 	url := fmt.Sprintf("'postgres://root@%s:%d", host, port)
-	if c.Secure {
+	if c.Insecure {
+		url += "?sslmode=disable"
+	} else {
 		url += "?sslcert=certs%2Fclient.root.crt&sslkey=certs%2Fclient.root.key&" +
 			"sslrootcert=certs%2Fca.crt&sslmode=verify-full"
-	} else {
-		url += "?sslmode=disable"
 	}
 	url += "'"
 	return url
@@ -428,10 +428,10 @@ func (h *crdbInstallHelper) generateStartArgs(
 	nodes := h.c.ServerNodes()
 
 	args = append(args, "--background")
-	if h.c.Secure {
-		args = append(args, "--certs-dir="+h.c.Impl.CertsDir(h.c, nodes[nodeIdx]))
-	} else {
+	if h.c.Insecure {
 		args = append(args, "--insecure")
+	} else {
+		args = append(args, "--certs-dir="+h.c.Impl.CertsDir(h.c, nodes[nodeIdx]))
 	}
 
 	var storeDirs []string
@@ -646,7 +646,7 @@ func (h *crdbInstallHelper) useStartSingleNode(vers *version.Version) bool {
 // cluster and we're starting n1.
 func (h *crdbInstallHelper) distributeCerts() {
 	for _, node := range h.c.ServerNodes() {
-		if node == 1 && h.c.Secure {
+		if node == 1 && !h.c.Insecure {
 			h.c.DistributeCerts()
 			break
 		}

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -87,7 +87,7 @@ var (
 	listJSON          bool
 	listMine          bool
 	clusterType       = "cockroach"
-	secure            = false
+	insecure          = false
 	nodeEnv           = []string{
 		"COCKROACH_ENABLE_RPC_COMPRESSION=false",
 		"COCKROACH_UI_RELEASE_NOTES_SIGNUP_DISMISSED=true",
@@ -186,7 +186,7 @@ Available clusters:
 		}
 	}
 	c.Nodes = nodes
-	c.Secure = secure
+	c.Insecure = insecure
 	c.Env = strings.Join(nodeEnv, " ")
 	c.Args = nodeArgs
 	if tag != "" {
@@ -984,10 +984,11 @@ var startCmd = &cobra.Command{
 	Short: "start nodes on a cluster",
 	Long: `Start nodes on a cluster.
 
-The --secure flag can be used to start nodes in secure mode (i.e. using
-certs). When specified, there is a one time initialization for the cluster to
-create and distribute the certs. Note that running some modes in secure mode
-and others in insecure mode is not a supported Cockroach configuration.
+The --insecure flag can be used to start nodes in insecure mode (i.e. without
+using certs). When it is specified, the one time initialization for the
+cluster to create and distribute the certs is skipped. Note that running some
+nodes in insecure mode and others in secure mode is not a supported Cockroach
+configuration.
 
 As a debugging aid, the --sequential flag starts the nodes sequentially so node
 IDs match hostnames. Otherwise nodes are started are parallel.
@@ -1601,7 +1602,7 @@ Examples:
 			host := c.VMs[i]
 			port := install.GetAdminUIPort(c.Impl.NodePort(c, i))
 			scheme := "http"
-			if c.Secure {
+			if !c.Insecure {
 				scheme = "https"
 			}
 			outputFile := fmt.Sprintf("pprof-%s-%d-%s-%04d.out", profType, startTime, c.Name, i+1)
@@ -1716,9 +1717,9 @@ var adminurlCmd = &cobra.Command{
 				host = c.VMs[node-1]
 			}
 			port := install.GetAdminUIPort(c.Impl.NodePort(c, node))
-			scheme := "http"
-			if c.Secure {
-				scheme = "https"
+			scheme := "https"
+			if c.Insecure {
+				scheme = "http"
 			}
 			if !strings.HasPrefix(adminurlPath, "/") {
 				adminurlPath = "/" + adminurlPath
@@ -1921,7 +1922,7 @@ func main() {
 		&external, "external", false, "return external IP addresses")
 
 	runCmd.Flags().BoolVar(
-		&secure, "secure", false, "use a secure cluster")
+		&insecure, "insecure", false, "use an insecure cluster")
 
 	startCmd.Flags().IntVarP(&numRacks,
 		"racks", "r", 0, "the number of racks to partition the nodes into")
@@ -2008,7 +2009,7 @@ func main() {
 			fallthrough
 		case pgurlCmd, adminurlCmd:
 			cmd.Flags().BoolVar(
-				&secure, "secure", false, "use a secure cluster")
+				&insecure, "insecure", false, "use an insecure cluster")
 		}
 
 		if cmd.Long == "" {

--- a/pkg/cmd/roachtest/allocator.go
+++ b/pkg/cmd/roachtest/allocator.go
@@ -366,7 +366,7 @@ FROM crdb_internal.kv_store_status
 
 	decom := func(id int) {
 		c.Run(ctx, c.Node(1),
-			fmt.Sprintf("./cockroach node decommission --insecure --wait=none %d", id))
+			fmt.Sprintf("./cockroach node decommission %s --wait=none %d", c.secureFlags(), id))
 	}
 
 	// Decommission a node. The ranges should down-replicate to 7 replicas.

--- a/pkg/cmd/roachtest/autoupgrade.go
+++ b/pkg/cmd/roachtest/autoupgrade.go
@@ -69,7 +69,8 @@ func registerAutoUpgrade(r *testRegistry) {
 			t.WorkerStatus("decommission")
 			port := fmt.Sprintf("{pgport:%d}", node)
 			if err := c.RunE(ctx, c.Node(node),
-				fmt.Sprintf("./cockroach node decommission %d --insecure --port=%s", node, port)); err != nil {
+				fmt.Sprintf("./cockroach node decommission %d %s --port=%s", node, c.secureFlags(),
+					port)); err != nil {
 				return err
 			}
 			t.WorkerStatus("stop")

--- a/pkg/cmd/roachtest/backup.go
+++ b/pkg/cmd/roachtest/backup.go
@@ -152,8 +152,8 @@ func registerBackup(r *testRegistry) {
 			m := newMonitor(ctx, c)
 			m.Go(func(ctx context.Context) error {
 				t.Status(`running backup`)
-				c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "
-				BACKUP bank.bank TO 'gs://cockroachdb-backup-testing/`+dest+`'"`)
+				c.Run(ctx, c.Node(1),
+					fmt.Sprintf("./cockroach sql %s -e BACKUP bank.bank TO 'gs://cockroachdb-backup-testing/%s'", c.secureFlags(), dest))
 				return nil
 			})
 			m.Wait()

--- a/pkg/cmd/roachtest/cancel.go
+++ b/pkg/cmd/roachtest/cancel.go
@@ -84,7 +84,7 @@ func registerCancel(r *testRegistry) {
 
 				const cancelQuery = `CANCEL QUERIES
 	SELECT query_id FROM [SHOW CLUSTER QUERIES] WHERE query not like '%SHOW CLUSTER QUERIES%'`
-				c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "`+cancelQuery+`"`)
+				c.Run(ctx, c.Node(1), `./cockroach sql `+c.secureFlags()+` -e "`+cancelQuery+`"`)
 				cancelStartTime := timeutil.Now()
 
 				select {

--- a/pkg/cmd/roachtest/clearrange.go
+++ b/pkg/cmd/roachtest/clearrange.go
@@ -82,7 +82,9 @@ func runClearRange(ctx context.Context, t *test, c *cluster, aggressiveChecks bo
 	// Use a 120s connect timeout to work around the fact that the server will
 	// declare itself ready before it's actually 100% ready. See:
 	// https://github.com/cockroachdb/cockroach/issues/34897#issuecomment-465089057
-	c.Run(ctx, c.Node(1), `COCKROACH_CONNECT_TIMEOUT=120 ./cockroach sql --insecure -e "DROP DATABASE IF EXISTS tinybank"`)
+	c.Run(ctx, c.Node(1),
+		`COCKROACH_CONNECT_TIMEOUT=120 ./cockroach sql `+c.secureFlags()+
+			` -e "DROP DATABASE IF EXISTS tinybank"`)
 	c.Run(ctx, c.Node(1), "./cockroach", "workload", "fixtures", "import", "bank", "--db=tinybank",
 		"--payload-bytes=100", "--ranges=10", "--rows=800", "--seed=1")
 

--- a/pkg/cmd/roachtest/cli.go
+++ b/pkg/cmd/roachtest/cli.go
@@ -41,7 +41,7 @@ func runCLINodeStatus(ctx context.Context, t *test, c *cluster) {
 
 	nodeStatus := func() (raw string, _ []string) {
 		out, err := c.RunWithBuffer(ctx, t.l, c.Node(1),
-			"./cockroach node status --insecure -p {pgport:1}")
+			"./cockroach node status -p {pgport:1} "+c.secureFlags())
 		if err != nil {
 			t.Fatalf("%v\n%s", err, out)
 		}

--- a/pkg/cmd/roachtest/cluster_init.go
+++ b/pkg/cmd/roachtest/cluster_init.go
@@ -51,7 +51,7 @@ func runClusterInit(ctx context.Context, t *test, c *cluster) {
 					return c.RunE(ctx, c.Node(i),
 						fmt.Sprintf(
 							`mkdir -p {log-dir} && `+
-								`./cockroach start --insecure --background --store={store-dir} `+
+								`./cockroach start `+c.secureFlags()+` --background --store={store-dir} `+
 								`--log-dir={log-dir} --cache=10%% --max-sql-memory=10%% `+
 								`--listen-addr=:{pgport:%[1]d} --http-port=$[{pgport:%[1]d}+1] `+
 								`--join=`+strings.Join(addrs, ",")+
@@ -61,7 +61,11 @@ func runClusterInit(ctx context.Context, t *test, c *cluster) {
 
 			urlMap := make(map[int]string)
 			for i, addr := range c.ExternalAdminUIAddr(ctx, c.All()) {
-				urlMap[i+1] = `http://` + addr
+				urlSchema := "https://"
+				if insecure {
+					urlSchema = "http://"
+				}
+				urlMap[i+1] = urlSchema + addr
 			}
 
 			// Wait for the servers to bind their ports.
@@ -128,7 +132,7 @@ func runClusterInit(ctx context.Context, t *test, c *cluster) {
 							// The actual contents of the cookie don't matter; the presence of
 							// a valid encoded cookie is enough to trigger the authentication
 							// code paths.
-						}, false /* forHTTPSOnly - cluster is insecure */)
+						}, !insecure /* forHTTPSOnly - cluster is insecure */)
 						if err != nil {
 							t.Fatal(err)
 						}
@@ -149,7 +153,7 @@ func runClusterInit(ctx context.Context, t *test, c *cluster) {
 			}
 
 			c.Run(ctx, c.Node(initNode),
-				fmt.Sprintf(`./cockroach init --insecure --port={pgport:%d}`, initNode))
+				fmt.Sprintf(`./cockroach init %s --port={pgport:%d}`, c.secureFlags(), initNode))
 			if err := g.Wait(); err != nil {
 				t.Fatal(err)
 			}
@@ -158,10 +162,8 @@ func runClusterInit(ctx context.Context, t *test, c *cluster) {
 			waitForFullReplication(t, dbs[0])
 
 			execCLI := func(runNode int, extraArgs ...string) (string, error) {
-				args := []string{"./cockroach"}
+				args := []string{"./cockroach", c.secureFlags(), fmt.Sprintf("--port={pgport:%d}", runNode)}
 				args = append(args, extraArgs...)
-				args = append(args, "--insecure")
-				args = append(args, fmt.Sprintf("--port={pgport:%d}", runNode))
 				buf, err := c.RunWithBuffer(ctx, c.l, c.Node(runNode), args...)
 				t.l.Printf("%s\n", buf)
 				return string(buf), err

--- a/pkg/cmd/roachtest/disk_stall.go
+++ b/pkg/cmd/roachtest/disk_stall.go
@@ -104,7 +104,8 @@ func runDiskStalledDetection(
 		t.WorkerStatus("running server")
 		out, err := c.RunWithBuffer(ctx, l, n,
 			fmt.Sprintf("timeout --signal 9 %ds env COCKROACH_ENGINE_MAX_SYNC_DURATION_DEFAULT=%s COCKROACH_LOG_MAX_SYNC_DURATION=%s "+
-				"./cockroach start-single-node --insecure --store {store-dir}/%s --log '{sinks: {stderr: {filter: INFO}}, file-defaults: {dir: \"{store-dir}/%s\"}}'",
+				"./cockroach start-single-node "+c.secureFlags()+" --store {store-dir}/%s --log '{sinks: {stderr: {filter: INFO}}, "+
+				"file-defaults: {dir: \"{store-dir}/%s\"}}'",
 				int(dur.Seconds()), maxDataSync, maxLogSync, dataDir, logDir,
 			),
 		)

--- a/pkg/cmd/roachtest/election.go
+++ b/pkg/cmd/roachtest/election.go
@@ -38,7 +38,7 @@ func registerElectionAfterRestart(r *testRegistry) {
 			time.Sleep(3 * time.Second)
 
 			t.Status("creating table and splits")
-			c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "
+			c.Run(ctx, c.Node(1), `./cockroach sql `+c.secureFlags()+` -e "
         CREATE DATABASE IF NOT EXISTS test;
         CREATE TABLE test.kv (k INT PRIMARY KEY, v INT);
         -- Prevent the merge queue from immediately discarding our splits.
@@ -46,7 +46,7 @@ func registerElectionAfterRestart(r *testRegistry) {
         ALTER TABLE test.kv SPLIT AT SELECT generate_series(0, 10000, 100)"`)
 
 			start := timeutil.Now()
-			c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "
+			c.Run(ctx, c.Node(1), `./cockroach sql `+c.secureFlags()+` -e "
         SELECT * FROM test.kv"`)
 			duration := timeutil.Since(start)
 			t.l.Printf("pre-restart, query took %s\n", duration)
@@ -73,7 +73,8 @@ func registerElectionAfterRestart(r *testRegistry) {
 			// takes ages (perhaps due to some cli-internal query taking a
 			// very long time), we fail with the duration check below and
 			// not an opaque error from the cli.
-			buf, err := c.RunWithBuffer(ctx, t.l, c.Node(1), `COCKROACH_CONNECT_TIMEOUT=240 ./cockroach sql --insecure -e "
+			buf, err := c.RunWithBuffer(ctx, t.l, c.Node(1),
+				`COCKROACH_CONNECT_TIMEOUT=240 ./cockroach sql `+c.secureFlags()+` -e "
 SET TRACING = on;
 SELECT * FROM test.kv;
 SET TRACING = off;

--- a/pkg/cmd/roachtest/gossip.go
+++ b/pkg/cmd/roachtest/gossip.go
@@ -12,6 +12,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	gosql "database/sql"
 	"fmt"
 	"net"
@@ -135,7 +136,11 @@ type gossipUtil struct {
 func newGossipUtil(ctx context.Context, c *cluster) *gossipUtil {
 	urlMap := make(map[int]string)
 	for i, addr := range c.ExternalAdminUIAddr(ctx, c.All()) {
-		urlMap[i+1] = `http://` + addr
+		urlSchema := "https://"
+		if insecure {
+			urlSchema = "http://"
+		}
+		urlMap[i+1] = urlSchema + addr
 	}
 	return &gossipUtil{
 		waitTime: 30 * time.Second,
@@ -154,7 +159,11 @@ func (g *gossipUtil) check(ctx context.Context, c *cluster, f checkGossipFunc) e
 		var infoStatus gossip.InfoStatus
 		for i := 1; i <= c.spec.NodeCount; i++ {
 			url := g.urlMap[i] + `/_status/gossip/local`
-			if err := httputil.GetJSON(http.Client{}, url, &infoStatus); err != nil {
+			// TODO(rail): figure out the way to accept expected certs only
+			tr := &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			}
+			if err := httputil.GetJSON(http.Client{Transport: tr}, url, &infoStatus); err != nil {
 				return errors.Wrapf(err, "failed to get gossip status from node %d", i)
 			}
 			if err := f(infoStatus.Infos); err != nil {
@@ -399,7 +408,7 @@ SELECT count(replicas)
 	// connections. This will require node 1 to reach out to the other nodes in
 	// the cluster for gossip info.
 	err := c.RunE(ctx, c.Node(1),
-		`./cockroach start --insecure --background --store={store-dir} `+
+		`./cockroach start `+c.secureFlags()+` --background --store={store-dir} `+
 			`--log-dir={log-dir} --cache=10% --max-sql-memory=10% `+
 			`--listen-addr=:$[{pgport:1}+10000] --http-port=$[{pgport:1}+1] `+
 			`--join={pghost:1}:{pgport:1}`+

--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -305,7 +305,7 @@ func registerImportDecommissioned(r *testRegistry) {
 		// Decommission a node.
 		nodeToDecommission := 2
 		t.Status(fmt.Sprintf("decommissioning node %d", nodeToDecommission))
-		c.Run(ctx, c.Node(nodeToDecommission), `./cockroach node decommission --insecure --self --wait=all`)
+		c.Run(ctx, c.Node(nodeToDecommission), `./cockroach node decommission --self --wait=all `+c.secureFlags())
 
 		// Wait for a bit for node liveness leases to expire.
 		time.Sleep(10 * time.Second)

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -321,7 +321,8 @@ func registerKVQuiescenceDead(r *testRegistry) {
 				run(kv+" --seed 1 {pgurl:1}", true)
 			})
 			// Gracefully shut down third node (doesn't matter whether it's graceful or not).
-			c.Run(ctx, c.Node(nodes), "./cockroach quit --insecure --host=:{pgport:3}")
+			c.Run(ctx, c.Node(nodes),
+				"./cockroach quit --host=:{pgport:3} "+c.secureFlags())
 			c.Stop(ctx, c.Node(nodes))
 			// Measure qps with node down (i.e. without quiescence).
 			qpsOneDown := qps(func() {
@@ -487,7 +488,7 @@ func registerKVGracefulDraining(r *testRegistry) {
 						}
 					}
 					m.ExpectDeath()
-					c.Run(ctx, c.Node(nodes), "./cockroach quit --insecure --host=:{pgport:3}")
+					c.Run(ctx, c.Node(nodes), "./cockroach quit --host=:{pgport:3} "+c.secureFlags())
 					c.Stop(ctx, c.Node(nodes))
 					t.Status("letting workload run with one node down")
 					select {

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -87,6 +87,8 @@ func main() {
 	f := rootCmd.PersistentFlags().VarPF(
 		&encrypt, "encrypt", "", "start cluster with encryption at rest turned on")
 	f.NoOptDefVal = "true"
+	rootCmd.PersistentFlags().BoolVar(
+		&insecure, "insecure", false, "use an insecure cluster")
 
 	var listBench bool
 

--- a/pkg/cmd/roachtest/mixed_version_decommission.go
+++ b/pkg/cmd/roachtest/mixed_version_decommission.go
@@ -109,8 +109,8 @@ func cockroachBinaryPath(version string) string {
 func partialDecommissionStep(target, from int, binaryVersion string) versionStep {
 	return func(ctx context.Context, t *test, u *versionUpgradeTest) {
 		c := u.c
-		c.Run(ctx, c.Node(from), cockroachBinaryPath(binaryVersion), "node", "decommission",
-			"--wait=none", "--insecure", strconv.Itoa(target))
+		c.Run(ctx, c.Node(from), cockroachBinaryPath(binaryVersion), "node", "decommission", "--wait=none",
+			c.secureFlags(), strconv.Itoa(target))
 	}
 }
 
@@ -120,8 +120,9 @@ func partialDecommissionStep(target, from int, binaryVersion string) versionStep
 func recommissionAllStep(from int, binaryVersion string) versionStep {
 	return func(ctx context.Context, t *test, u *versionUpgradeTest) {
 		c := u.c
-		c.Run(ctx, c.Node(from), cockroachBinaryPath(binaryVersion), "node", "recommission",
-			"--insecure", c.All().nodeIDsString())
+		c.Run(ctx, c.Node(from), cockroachBinaryPath(binaryVersion), "node", "recommission", "--wait=none",
+			c.secureFlags(), c.All().nodeIDsString())
+
 	}
 }
 
@@ -130,8 +131,8 @@ func recommissionAllStep(from int, binaryVersion string) versionStep {
 func fullyDecommissionStep(target, from int, binaryVersion string) versionStep {
 	return func(ctx context.Context, t *test, u *versionUpgradeTest) {
 		c := u.c
-		c.Run(ctx, c.Node(from), cockroachBinaryPath(binaryVersion), "node", "decommission",
-			"--wait=all", "--insecure", strconv.Itoa(target))
+		c.Run(ctx, c.Node(from), cockroachBinaryPath(binaryVersion), "node", "decommission", "--wait=none",
+			c.secureFlags(), strconv.Itoa(target))
 	}
 }
 

--- a/pkg/cmd/roachtest/multitenant.go
+++ b/pkg/cmd/roachtest/multitenant.go
@@ -37,9 +37,6 @@ func runAcceptanceMultitenant(ctx context.Context, t *test, c *cluster) {
 	go func() {
 		errCh <- c.RunE(tenantCtx, c.Node(1),
 			"./cockroach", "mt", "start-sql",
-			// TODO(tbg): make this test secure.
-			// "--certs-dir", "certs",
-			"--insecure",
 			"--tenant-id", "123",
 			"--http-addr", "127.0.0.1:8081",
 			"--kv-addrs", strings.Join(kvAddrs, ","),
@@ -47,6 +44,7 @@ func runAcceptanceMultitenant(ctx context.Context, t *test, c *cluster) {
 			"--sql-addr", ifLocal("127.0.0.1", "0.0.0.0")+":36257",
 			// Ensure that log files get created.
 			"--log='file-defaults: {dir: .}'",
+			c.secureFlags(),
 		)
 		close(errCh)
 	}()

--- a/pkg/cmd/roachtest/quit.go
+++ b/pkg/cmd/roachtest/quit.go
@@ -361,9 +361,9 @@ func registerQuitTransfersLeases(r *testRegistry) {
 	// successfully even if if the process terminates non-gracefully.
 	registerTest("drain", "v20.1.0", func(ctx context.Context, t *test, c *cluster, nodeID int) {
 		buf, err := c.RunWithBuffer(ctx, t.l, c.Node(nodeID),
-			"./cockroach", "node", "drain", "--insecure", "--logtostderr=INFO",
+			"./cockroach", "node", "drain", "--logtostderr=INFO",
 			fmt.Sprintf("--port={pgport:%d}", nodeID),
-		)
+			c.secureFlags())
 		t.l.Printf("cockroach node drain:\n%s\n", buf)
 		if err != nil {
 			t.Fatal(err)
@@ -392,10 +392,12 @@ func registerQuitTransfersLeases(r *testRegistry) {
 }
 
 func runQuit(ctx context.Context, t *test, c *cluster, nodeID int, extraArgs ...string) []byte {
-	args := append([]string{
-		"./cockroach", "quit", "--insecure", "--logtostderr=INFO",
-		fmt.Sprintf("--port={pgport:%d}", nodeID)},
-		extraArgs...)
+	args := []string{
+		"./cockroach", "quit", "--logtostderr=INFO",
+		fmt.Sprintf("--port={pgport:%d}", nodeID),
+		c.secureFlags(),
+	}
+	args = append(args, extraArgs...)
 	buf, err := c.RunWithBuffer(ctx, t.l, c.Node(nodeID), args...)
 	t.l.Printf("cockroach quit:\n%s\n", buf)
 	if err != nil {

--- a/pkg/cmd/roachtest/rapid_restart.go
+++ b/pkg/cmd/roachtest/rapid_restart.go
@@ -47,7 +47,8 @@ func runRapidRestart(ctx context.Context, t *test, c *cluster) {
 			exitCh := make(chan error, 1)
 			go func() {
 				err := c.RunE(ctx, nodes,
-					`mkdir -p {log-dir} && ./cockroach start-single-node --insecure --store={store-dir} `+
+					`mkdir -p {log-dir} && ./cockroach start-single-node `+c.secureFlags()+
+						` --store={store-dir} `+
 						`--log-dir={log-dir} --cache=10% --max-sql-memory=10% `+
 						`--listen-addr=:{pgport:1} --http-port=$[{pgport:1}+1] `+
 						`> {log-dir}/cockroach.stdout 2> {log-dir}/cockroach.stderr`)

--- a/pkg/cmd/roachtest/reset_quorum.go
+++ b/pkg/cmd/roachtest/reset_quorum.go
@@ -109,9 +109,7 @@ OR
 
 	const nodeID = 1 // where to put the replica, matches node number in roachtest
 	for rangeID := range lostRangeIDs {
-		c.Run(ctx, c.Node(nodeID), "./cockroach", "debug", "reset-quorum",
-			fmt.Sprint(rangeID), "--insecure",
-		)
+		c.Run(ctx, c.Node(nodeID), "./cockroach", c.secureFlags(), "debug", "reset-quorum", fmt.Sprint(rangeID))
 	}
 
 	// Table should come back to life (though empty).

--- a/pkg/cmd/roachtest/restore.go
+++ b/pkg/cmd/roachtest/restore.go
@@ -347,10 +347,11 @@ func registerRestore(r *testRegistry) {
 					defer dul.Done()
 					defer hc.Done()
 					t.Status(`running restore`)
-					c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "CREATE DATABASE restore2tb"`)
+					c.Run(ctx, c.Node(1),
+						`./cockroach sql `+c.secureFlags()+` -e "CREATE DATABASE restore2tb"`)
 					// TODO(dan): It'd be nice if we could keep track over time of how
 					// long this next line took.
-					c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "
+					c.Run(ctx, c.Node(1), `./cockroach sql `+c.secureFlags()+` -e "
 				RESTORE csv.bank FROM
 				'gs://cockroach-fixtures/workload/bank/version=1.0.0,payload-bytes=10240,ranges=0,rows=65104166,seed=1/bank'
 				WITH into_db = 'restore2tb'"`)

--- a/pkg/cmd/roachtest/sysbench.go
+++ b/pkg/cmd/roachtest/sysbench.go
@@ -97,7 +97,7 @@ func runSysbench(ctx context.Context, t *test, c *cluster, opts sysbenchOptions)
 	if err := c.Install(ctx, t.l, loadNode, "haproxy"); err != nil {
 		t.Fatal(err)
 	}
-	c.Run(ctx, loadNode, "./cockroach gen haproxy --insecure --url {pgurl:1}")
+	c.Run(ctx, loadNode, "./cockroach gen haproxy "+c.secureFlags()+" --url {pgurl:1}")
 	c.Run(ctx, loadNode, "haproxy -f haproxy.cfg -D")
 
 	t.Status("installing sysbench")
@@ -108,7 +108,8 @@ func runSysbench(ctx context.Context, t *test, c *cluster, opts sysbenchOptions)
 	m := newMonitor(ctx, c, roachNodes)
 	m.Go(func(ctx context.Context) error {
 		t.Status("preparing workload")
-		c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "CREATE DATABASE sysbench"`)
+		c.Run(ctx, c.Node(1),
+			`./cockroach sql `+c.secureFlags()+` -e "CREATE DATABASE sysbench"`)
 		c.Run(ctx, loadNode, opts.cmd(false /* haproxy */)+" prepare")
 
 		t.Status("running workload")

--- a/pkg/cmd/roachtest/toxiproxy.go
+++ b/pkg/cmd/roachtest/toxiproxy.go
@@ -206,7 +206,9 @@ var measureRE = regexp.MustCompile(`real[^0-9]+([0-9.]+)`)
 // escaping. It's not useful for anything but simple sanity checks.
 func (tc *ToxiCluster) Measure(ctx context.Context, fromNode int, stmt string) time.Duration {
 	_, port := addrToHostPort(tc.cluster, tc.ExternalAddr(ctx, tc.Node(fromNode))[0])
-	b, err := tc.cluster.RunWithBuffer(ctx, tc.cluster.l, tc.cluster.Node(fromNode), "time", "-p", "./cockroach", "sql", "--insecure", "--port", strconv.Itoa(port), "-e", "'"+stmt+"'")
+	b, err := tc.cluster.RunWithBuffer(ctx, tc.cluster.l, tc.cluster.Node(fromNode),
+		"time", "-p", "./cockroach", "sql", tc.cluster.secureFlags(),
+		"--port", strconv.Itoa(port), "-e", "'"+stmt+"'")
 	tc.cluster.l.Printf("%s\n", b)
 	if err != nil {
 		tc.cluster.t.Fatal(err)

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -764,7 +764,8 @@ func runTPCCBench(ctx context.Context, t *test, c *cluster, b tpccBenchSpec) {
 			if err := c.Install(ctx, t.l, loadNodes, "haproxy"); err != nil {
 				t.Fatal(err)
 			}
-			c.Run(ctx, loadNodes, "./cockroach gen haproxy --insecure --url {pgurl:1}")
+			c.Run(ctx, loadNodes,
+				"./cockroach gen haproxy --url {pgurl:1} "+c.secureFlags())
 			// Increase the maximum connection limit to ensure that no TPC-C
 			// load gen workers get stuck during connection initialization.
 			// 10k warehouses requires at least 20,000 connections, so add a

--- a/pkg/util/httputil/client.go
+++ b/pkg/util/httputil/client.go
@@ -12,6 +12,7 @@ package httputil
 
 import (
 	"context"
+	"crypto/tls"
 	"io"
 	"net"
 	"net/http"
@@ -33,6 +34,9 @@ func NewClientWithTimeout(timeout time.Duration) *Client {
 			// much higher than on linux).
 			DialContext:       (&net.Dialer{Timeout: timeout}).DialContext,
 			DisableKeepAlives: true,
+			// TODO(rail): figure out how to accept certs properly
+			// TODO(rail): consider moving the tls config part somewhere else to avoid changing the current behaviour.
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		},
 	}}
 }


### PR DESCRIPTION
Before: roachprod defaulted to making insecure clusters and the useneeded
to use the --secure flag to create a secure cluster.

Why change? We tell our users that the best practice is to run in secure mode
but we don't dog food that configuration enough. Setting roachprod to secure
by default will require us to debug problems in secure mode, which means we'll
make it easer to run secure mode and we'll get better knowledge of how to run
in secure mode.

Now: clusters will be spun up in secure mode by default. To get an insecure
cluster, use the --insecure flag.

Fixes #38539.

Release note: None