### PR TITLE
release-20.1: kvclient: add metrics for txns with condensed intents

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -246,7 +246,7 @@ func newRootTxnCoordSender(
 		// Various interceptors below rely on sequence number allocation,
 		// so the sequence number allocator is near the top of the stack.
 		&tcs.interceptorAlloc.txnSeqNumAllocator,
-		// The pipelinger sits above the span refresher because it will
+		// The pipeliner sits above the span refresher because it will
 		// never generate transaction retry errors that could be avoided
 		// with a refresh.
 		&tcs.interceptorAlloc.txnPipeliner,
@@ -282,8 +282,10 @@ func (tc *TxnCoordSender) initCommonInterceptors(
 		riGen.ds = ds
 	}
 	tc.interceptorAlloc.txnPipeliner = txnPipeliner{
-		st:    tcf.st,
-		riGen: riGen,
+		st:                     tcf.st,
+		riGen:                  riGen,
+		txnMetrics:             &tc.metrics,
+		condensedIntentsEveryN: &tc.TxnCoordSenderFactory.condensedIntentsEveryN,
 	}
 	tc.interceptorAlloc.txnSpanRefresher = txnSpanRefresher{
 		st:    tcf.st,

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_factory.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_factory.go
@@ -27,13 +27,14 @@ import (
 type TxnCoordSenderFactory struct {
 	log.AmbientContext
 
-	st                *cluster.Settings
-	wrapped           kv.Sender
-	clock             *hlc.Clock
-	heartbeatInterval time.Duration
-	linearizable      bool // enables linearizable behavior
-	stopper           *stop.Stopper
-	metrics           TxnMetrics
+	st                     *cluster.Settings
+	wrapped                kv.Sender
+	clock                  *hlc.Clock
+	heartbeatInterval      time.Duration
+	linearizable           bool // enables linearizable behavior
+	stopper                *stop.Stopper
+	metrics                TxnMetrics
+	condensedIntentsEveryN log.EveryN
 
 	testingKnobs ClientTestingKnobs
 }
@@ -62,15 +63,16 @@ func NewTxnCoordSenderFactory(
 	cfg TxnCoordSenderFactoryConfig, wrapped kv.Sender,
 ) *TxnCoordSenderFactory {
 	tcf := &TxnCoordSenderFactory{
-		AmbientContext:    cfg.AmbientCtx,
-		st:                cfg.Settings,
-		wrapped:           wrapped,
-		clock:             cfg.Clock,
-		stopper:           cfg.Stopper,
-		linearizable:      cfg.Linearizable,
-		heartbeatInterval: cfg.HeartbeatInterval,
-		metrics:           cfg.Metrics,
-		testingKnobs:      cfg.TestingKnobs,
+		AmbientContext:         cfg.AmbientCtx,
+		st:                     cfg.Settings,
+		wrapped:                wrapped,
+		clock:                  cfg.Clock,
+		stopper:                cfg.Stopper,
+		linearizable:           cfg.Linearizable,
+		heartbeatInterval:      cfg.HeartbeatInterval,
+		metrics:                cfg.Metrics,
+		condensedIntentsEveryN: log.Every(time.Second),
+		testingKnobs:           cfg.TestingKnobs,
 	}
 	if tcf.st == nil {
 		tcf.st = cluster.MakeTestingClusterSettings()

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -277,9 +277,15 @@ func TestTxnCoordSenderCondenseLockSpans(t *testing.T) {
 			t.Errorf("%d: keys size expected %d; got %d", i, e, a)
 		}
 	}
+
+	metrics := txn.Sender().(*TxnCoordSender).Metrics()
+	require.Equal(t, int64(1), metrics.TxnsWithCondensedIntents.Count())
+	require.Equal(t, int64(1), metrics.TxnsWithCondensedIntentsGauge.Value())
+
 	if err := txn.Commit(ctx); err != nil {
 		t.Fatal(err)
 	}
+	require.Zero(t, metrics.TxnsWithCondensedIntentsGauge.Value())
 }
 
 // Test that the theartbeat loop detects aborted transactions and stops.

--- a/pkg/kv/kvclient/kvcoord/txn_metrics.go
+++ b/pkg/kv/kvclient/kvcoord/txn_metrics.go
@@ -31,6 +31,9 @@ type TxnMetrics struct {
 
 	Durations *metric.Histogram
 
+	TxnsWithCondensedIntents      *metric.Counter
+	TxnsWithCondensedIntentsGauge *metric.Gauge
+
 	// Restarts is the number of times we had to restart the transaction.
 	Restarts *metric.Histogram
 
@@ -104,6 +107,22 @@ var (
 		Help:        "KV transaction durations",
 		Measurement: "KV Txn Duration",
 		Unit:        metric.Unit_NANOSECONDS,
+	}
+	metaTxnsWithCondensedIntentSpans = metric.Metadata{
+		Name: "txn.condensed_intent_spans",
+		Help: "KV transactions that have exceeded their intent tracking " +
+			"memory budget (kv.transaction.max_intents_bytes). See also " +
+			"txn.condensed_intent_spans_gauge for a gauge of such transactions currently running.",
+		Measurement: "KV Transactions",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaTxnsWithCondensedIntentSpansGauge = metric.Metadata{
+		Name: "txn.condensed_intent_spans_gauge",
+		Help: "KV transactions currently running that have exceeded their intent tracking " +
+			"memory budget (kv.transaction.max_intents_bytes). See also txn.condensed_intent_spans " +
+			"for a perpetual counter/rate.",
+		Measurement: "KV Transactions",
+		Unit:        metric.Unit_COUNT,
 	}
 	metaRestartsHistogram = metric.Metadata{
 		Name:        "txn.restarts",
@@ -201,6 +220,8 @@ func MakeTxnMetrics(histogramWindow time.Duration) TxnMetrics {
 		RefreshSuccess:                metric.NewCounter(metaRefreshSuccess),
 		RefreshMemoryLimitExceeded:    metric.NewCounter(metaRefreshMemoryLimitExceeded),
 		Durations:                     metric.NewLatency(metaDurationsHistograms, histogramWindow),
+		TxnsWithCondensedIntents:      metric.NewCounter(metaTxnsWithCondensedIntentSpans),
+		TxnsWithCondensedIntentsGauge: metric.NewGauge(metaTxnsWithCondensedIntentSpansGauge),
 		Restarts:                      metric.NewHistogram(metaRestartsHistogram, histogramWindow, 100, 3),
 		RestartsWriteTooOld:           telemetry.NewCounterWithMetric(metaRestartsWriteTooOld),
 		RestartsWriteTooOldMulti:      telemetry.NewCounterWithMetric(metaRestartsWriteTooOldMulti),

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -818,6 +818,20 @@ var charts = []sectionDescription{
 				Percentiles: true,
 				Metrics:     []string{"txn.restarts"},
 			},
+			{
+				Title:       "Intents condensing - historical",
+				Downsampler: DescribeAggregator_MAX,
+				Metrics: []string{
+					"txn.condensed_intent_spans",
+				},
+			},
+			{
+				Title:       "Intents condensing - current",
+				Downsampler: DescribeAggregator_MAX,
+				Metrics: []string{
+					"txn.condensed_intent_spans_gauge",
+				},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
Backport 1/2 commits from #62540.

/cc @cockroachdb/release

---

Two new metrics - txn.condensed_intent_spans and
txn.condensed_intent_spans_gauge - tracking transactions whose intent
spans have been collapsed with a loss of fidelity because the respective
transaction has exceeded kv.transaction.max_intents_bytes. Such
transactions are a potential source of instability because resolving
their intents might cost significant CPU (and also latency => contention
footprint).

Also new logging aiming aiming to provide the IDs of some such
transactions.

Release note: None
