### PR TITLE
release-20.2: opt: fix error when crdb_internal_mvcc_timestamp used in view

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/mvcc
+++ b/pkg/sql/opt/exec/execbuilder/testdata/mvcc
@@ -58,3 +58,12 @@ scan  ·              ·
 ·     missing stats  ·
 ·     table          t@primary
 ·     spans          FULL SCAN
+
+# Regression test for #62798. Using crdb_internal_mvcc_timestamp shouldn't cause
+# an index out of range error.
+
+statement error column name \"crdb_internal_mvcc_timestamp\" conflicts with a system column name
+CREATE VIEW v AS SELECT crdb_internal_mvcc_timestamp FROM t
+
+statement ok
+CREATE VIEW v AS SELECT crdb_internal_mvcc_timestamp AS ts FROM t

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1688,7 +1688,13 @@ func (ef *execFactory) ConstructCreateView(
 		if !d.ColumnOrdinals.Empty() {
 			ref.ColumnIDs = make([]descpb.ColumnID, 0, d.ColumnOrdinals.Len())
 			d.ColumnOrdinals.ForEach(func(ord int) {
-				ref.ColumnIDs = append(ref.ColumnIDs, desc.Columns[ord].ID)
+				if ord < len(desc.Columns) {
+					ref.ColumnIDs = append(ref.ColumnIDs, desc.Columns[ord].ID)
+				} else {
+					// This is a system column.
+					systemColOrd := ord - len(desc.Columns)
+					ref.ColumnIDs = append(ref.ColumnIDs, colinfo.AllSystemColumnDescs[systemColOrd].ID)
+				}
 			})
 		}
 		entry := planDeps[desc.ID]


### PR DESCRIPTION
Backport 1/1 commits from #63413.

/cc @cockroachdb/release

---

Prior to this commit, selecting `crdb_internal_mvcc_timestamp` in a view
caused an index out of range error since the `execFactory` tried to find
the column in the table descriptor's `PublicColumns()`. This commit fixes
the error by searching instead in `AllColumns()`.

Fixes #62798

Release note (bug fix): Fixed an index out of range error that could
occur when `crdb_internal_mvcc_timestamp` was selected as part of a view.
It is now possible to select `crdb_internal_mvcc_timestamp` as part of
a view as long as it is aliased with a different name.
