### PR TITLE
release-20.2: changefeedccl: Use memory monitor for kafka and cloud sinks.

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/cloudimpl"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -289,7 +290,8 @@ func changefeedPlanHook(
 			var nilOracle timestampLowerBoundOracle
 			canarySink, err := getSink(
 				ctx, details.SinkURI, nodeID, details.Opts, details.Targets,
-				settings, nilOracle, p.ExecCfg().DistSQLSrv.ExternalStorageFromURI, p.User(),
+				settings, nilOracle, p.ExecCfg().DistSQLSrv.ExternalStorageFromURI,
+				p.User(), mon.BoundAccount{},
 			)
 			if err != nil {
 				return MaybeStripRetryableErrorMarker(err)

--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/cloud"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/errors"
 	"github.com/google/btree"
 )
@@ -271,8 +272,8 @@ type cloudStorageSink struct {
 	settings          *cluster.Settings
 	partitionFormat   string
 
-	ext           string
-	recordDelimFn func(io.Writer) error
+	ext          string
+	rowDelimiter []byte
 
 	compression string
 
@@ -291,6 +292,9 @@ type cloudStorageSink struct {
 	dataFileTs        string
 	dataFilePartition string
 	prevFilename      string
+
+	// Memory used by this sink
+	mem mon.BoundAccount
 }
 
 const sinkCompressionGzip = "gzip"
@@ -307,6 +311,7 @@ func makeCloudStorageSink(
 	timestampOracle timestampLowerBoundOracle,
 	makeExternalStorageFromURI cloud.ExternalStorageFromURIFactory,
 	user string,
+	acc mon.BoundAccount,
 ) (Sink, error) {
 	// Date partitioning is pretty standard, so no override for now, but we could
 	// plumb one down if someone needs it.
@@ -323,6 +328,7 @@ func makeCloudStorageSink(
 		timestampOracle:   timestampOracle,
 		// TODO(dan,ajwerner): Use the jobs framework's session ID once that's available.
 		jobSessionID: generateChangefeedSessionID(),
+		mem:          acc,
 	}
 	if timestampOracle != nil {
 		s.dataFileTs = cloudStorageFormatTime(timestampOracle.inclusiveLowerBoundTS())
@@ -334,10 +340,7 @@ func makeCloudStorageSink(
 		// TODO(dan): It seems like these should be on the encoder, but that
 		// would require a bit of refactoring.
 		s.ext = `.ndjson`
-		s.recordDelimFn = func(w io.Writer) error {
-			_, err := w.Write([]byte{'\n'})
-			return err
-		}
+		s.rowDelimiter = []byte{'\n'}
 	default:
 		return nil, errors.Errorf(`this sink is incompatible with %s=%s`,
 			changefeedbase.OptFormat, opts[changefeedbase.OptFormat])
@@ -399,11 +402,17 @@ func (s *cloudStorageSink) EmitRow(
 
 	file := s.getOrCreateFile(table.GetName(), table.GetVersion())
 
-	// TODO(dan): Memory monitoring for this
+	oldCap := file.buf.Cap()
 	if _, err := file.Write(value); err != nil {
 		return err
 	}
-	if err := s.recordDelimFn(file); err != nil {
+	if _, err := file.Write(s.rowDelimiter); err != nil {
+		return err
+	}
+
+	// Grow buffered memory.  It's okay that we do it after the fact
+	// (and if not, we're in a deeper problem and probably OOMed by now).
+	if err := s.mem.Grow(ctx, int64(file.buf.Cap()-oldCap)); err != nil {
 		return err
 	}
 
@@ -529,12 +538,17 @@ func (s *cloudStorageSink) flushFile(ctx context.Context, file *cloudStorageSink
 			"precedes a file emitted before: %s", filename, s.prevFilename)
 	}
 	s.prevFilename = filename
-	return s.es.WriteFile(ctx, filepath.Join(s.dataFilePartition, filename), bytes.NewReader(file.buf.Bytes()))
+	if err := s.es.WriteFile(ctx, filepath.Join(s.dataFilePartition, filename), bytes.NewReader(file.buf.Bytes())); err != nil {
+		return err
+	}
+	s.mem.Shrink(ctx, int64(file.buf.Cap()))
+	return nil
 }
 
 // Close implements the Sink interface.
 func (s *cloudStorageSink) Close() error {
 	s.files = nil
+	s.mem.Close(context.Background())
 	return s.es.Close()
 }
 

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -109,6 +109,8 @@ func TestCloudStorageSink(t *testing.T) {
 	}
 
 	user := security.RootUser
+	memAcc, release := getBoundAccountWithBudget(memoryUnlimited)
+	defer release()
 
 	t.Run(`golden`, func(t *testing.T) {
 		t1 := tabledesc.NewImmutable(descpb.TableDescriptor{Name: `t1`})
@@ -118,13 +120,15 @@ func TestCloudStorageSink(t *testing.T) {
 		sinkDir := `golden`
 		s, err := makeCloudStorageSink(
 			ctx, `nodelocal://0/`+sinkDir, 1, unlimitedFileSize,
-			settings, opts, timestampOracle, externalStorageFromURI, user,
+			settings, opts, timestampOracle, externalStorageFromURI, user, memAcc,
 		)
 		require.NoError(t, err)
+		defer func() { require.NoError(t, s.Close()) }()
 		s.(*cloudStorageSink).sinkID = 7 // Force a deterministic sinkID.
 
 		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1)))
 		require.NoError(t, s.Flush(ctx))
+		require.EqualValues(t, 0, memAcc.Used())
 
 		require.Equal(t, []string{
 			"v1\n",
@@ -155,9 +159,10 @@ func TestCloudStorageSink(t *testing.T) {
 				dir := `single-node` + compression
 				s, err := makeCloudStorageSink(
 					ctx, `nodelocal://0/`+dir, 1, unlimitedFileSize,
-					settings, opts, timestampOracle, externalStorageFromURI, user,
+					settings, opts, timestampOracle, externalStorageFromURI, user, memAcc,
 				)
 				require.NoError(t, err)
+				defer func() { require.NoError(t, s.Close()) }()
 				s.(*cloudStorageSink).sinkID = 7 // Force a deterministic sinkID.
 
 				// Empty flush emits no files.
@@ -230,13 +235,15 @@ func TestCloudStorageSink(t *testing.T) {
 		dir := `multi-node`
 		s1, err := makeCloudStorageSink(
 			ctx, `nodelocal://0/`+dir, 1, unlimitedFileSize,
-			settings, opts, timestampOracle, externalStorageFromURI, user,
+			settings, opts, timestampOracle, externalStorageFromURI, user, memAcc,
 		)
 		require.NoError(t, err)
+		defer func() { require.NoError(t, s1.Close()) }()
 		s2, err := makeCloudStorageSink(
 			ctx, `nodelocal://0/`+dir, 2, unlimitedFileSize,
-			settings, opts, timestampOracle, externalStorageFromURI, user,
+			settings, opts, timestampOracle, externalStorageFromURI, user, memAcc,
 		)
+		defer func() { require.NoError(t, s2.Close()) }()
 		require.NoError(t, err)
 		// Hack into the sinks to pretend each is the first sink created on two
 		// different nodes, which is the worst case for them conflicting.
@@ -264,14 +271,16 @@ func TestCloudStorageSink(t *testing.T) {
 		// this is unavoidable.
 		s1R, err := makeCloudStorageSink(
 			ctx, `nodelocal://0/`+dir, 1, unlimitedFileSize,
-			settings, opts, timestampOracle, externalStorageFromURI, user,
+			settings, opts, timestampOracle, externalStorageFromURI, user, memAcc,
 		)
 		require.NoError(t, err)
+		defer func() { require.NoError(t, s1R.Close()) }()
 		s2R, err := makeCloudStorageSink(
 			ctx, `nodelocal://0/`+dir, 2, unlimitedFileSize,
-			settings, opts, timestampOracle, externalStorageFromURI, user,
+			settings, opts, timestampOracle, externalStorageFromURI, user, memAcc,
 		)
 		require.NoError(t, err)
+		defer func() { require.NoError(t, s2R.Close()) }()
 		// Nodes restart. s1 gets the same sink id it had last time but s2
 		// doesn't.
 		s1R.(*cloudStorageSink).sinkID = 0
@@ -310,16 +319,18 @@ func TestCloudStorageSink(t *testing.T) {
 		dir := `zombie`
 		s1, err := makeCloudStorageSink(
 			ctx, `nodelocal://0/`+dir, 1, unlimitedFileSize,
-			settings, opts, timestampOracle, externalStorageFromURI, user,
+			settings, opts, timestampOracle, externalStorageFromURI, user, memAcc,
 		)
 		require.NoError(t, err)
+		defer func() { require.NoError(t, s1.Close()) }()
 		s1.(*cloudStorageSink).sinkID = 7         // Force a deterministic sinkID.
 		s1.(*cloudStorageSink).jobSessionID = "a" // Force deterministic job session ID.
 		s2, err := makeCloudStorageSink(
 			ctx, `nodelocal://0/`+dir, 1, unlimitedFileSize,
-			settings, opts, timestampOracle, externalStorageFromURI, user,
+			settings, opts, timestampOracle, externalStorageFromURI, user, memAcc,
 		)
 		require.NoError(t, err)
+		defer func() { require.NoError(t, s2.Close()) }()
 		s2.(*cloudStorageSink).sinkID = 8         // Force a deterministic sinkID.
 		s2.(*cloudStorageSink).jobSessionID = "b" // Force deterministic job session ID.
 
@@ -352,9 +363,10 @@ func TestCloudStorageSink(t *testing.T) {
 		const targetMaxFileSize = 6
 		s, err := makeCloudStorageSink(
 			ctx, `nodelocal://0/`+dir, 1, targetMaxFileSize,
-			settings, opts, timestampOracle, externalStorageFromURI, user,
+			settings, opts, timestampOracle, externalStorageFromURI, user, memAcc,
 		)
 		require.NoError(t, err)
+		defer func() { require.NoError(t, s.Close()) }()
 		s.(*cloudStorageSink).sinkID = 7 // Force a deterministic sinkID.
 
 		// Writing more than the max file size chunks the file up and flushes it
@@ -439,10 +451,10 @@ func TestCloudStorageSink(t *testing.T) {
 		dir := `file-ordering`
 		s, err := makeCloudStorageSink(
 			ctx, `nodelocal://0/`+dir, 1, unlimitedFileSize,
-			settings, opts, timestampOracle, externalStorageFromURI, user,
+			settings, opts, timestampOracle, externalStorageFromURI, user, memAcc,
 		)
-
 		require.NoError(t, err)
+		defer func() { require.NoError(t, s.Close()) }()
 		s.(*cloudStorageSink).sinkID = 7 // Force a deterministic sinkID.
 
 		// Simulate initial scan, which emits data at a timestamp, then an equal
@@ -498,8 +510,9 @@ func TestCloudStorageSink(t *testing.T) {
 		dir := `ordering-among-schema-versions`
 		var targetMaxFileSize int64 = 10
 		s, err := makeCloudStorageSink(ctx, `nodelocal://0/`+dir, 1, targetMaxFileSize, settings,
-			opts, timestampOracle, externalStorageFromURI, user)
+			opts, timestampOracle, externalStorageFromURI, user, memAcc)
 		require.NoError(t, err)
+		defer func() { require.NoError(t, s.Close()) }()
 
 		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1)))
 		t1.Version = 1
@@ -535,5 +548,26 @@ func TestCloudStorageSink(t *testing.T) {
 			"x1\n",
 			"w1\n",
 		}, slurpDir(t, dir))
+	})
+	t.Run(`memory-limit`, func(t *testing.T) {
+		t1 := tabledesc.NewImmutable(descpb.TableDescriptor{Name: `t1`})
+		testSpan := roachpb.Span{Key: []byte("a"), EndKey: []byte("b")}
+		sf := span.MakeFrontier(testSpan)
+		timestampOracle := &changeAggregatorLowerBoundOracle{sf: sf}
+		sinkDir := `memory-limit`
+		limitedMem, release := getBoundAccountWithBudget(100)
+		defer release()
+		s, err := makeCloudStorageSink(
+			ctx, `nodelocal://0/`+sinkDir, 1, 101,
+			settings, opts, timestampOracle, externalStorageFromURI, user, limitedMem,
+		)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, s.Close()) }()
+		s.(*cloudStorageSink).sinkID = 7 // Force a deterministic sinkID.
+
+		for err == nil {
+			err = s.EmitRow(ctx, t1, noKey, []byte("hello"), ts(1))
+		}
+		require.Regexp(t, "memory budget exceeded", err)
 	})
 }


### PR DESCRIPTION
Backport 1/1 commits from #63406.

/cc @cockroachdb/release

---

Kafka, as well as cloud sinks, use internal buffering when emitting
events.  Use memory monitor to account for memory used in internal buffers.
If the downstream sink is unavailable for extended periods of time,
memory monitor will ensure that the amount of buffered data does not
grow to cause OOM issues.

Informs #63186
Informs #60697

Release Notes: Kafka and cloud storage sinks use memory monitor
to limit the amount of memory that can be used in internal buffers.
