### PR TITLE
multiregionccl: deflake TestIndexCleanupAfterAlterFromRegionalByRow

### DIFF
--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
         "//pkg/jobs",
         "//pkg/keys",
         "//pkg/kv",
+        "//pkg/kv/kvserver",
         "//pkg/roachpb",
         "//pkg/security",
         "//pkg/security/securitytest",


### PR DESCRIPTION
Under stress this test could time out. Looking at the failures, you see
a log of goroutines stuck in retry loops either in the DistSender or in
AdminMerge. Disabling the merge queue seems to deflake this behavior.

Fixes #63370.

Release note: None