### PR TITLE
sqlsmith: do not generate INSERT with empty VALUES

### DIFF
--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -972,6 +972,11 @@ func (s *Smither) makeInsert(refs colRefs) (*tree.Insert, *tableRef, bool) {
 				row = append(row, rowenc.RandDatum(s.rnd, tree.MustBeStaticallyKnownType(c.Type), !notNull))
 			}
 		}
+
+		if len(names) == 0 {
+			return nil, nil, false
+		}
+
 		insert.Columns = names
 		insert.Rows = &tree.Select{
 			Select: &tree.ValuesClause{


### PR DESCRIPTION
A recent change to `sqlsmith` in #63255 made it possible to generate an
`INSERT` statement with an empty `VALUES` clause, such as:

    INSERT INTO t VALUES ()

This results in a syntax error, causing `sqlsmith` failures. This commit
prevents these statements from being generated.

Fixes #63528

Release note: None