### PR TITLE
release-20.1: rowenc: copy JSON bytes more efficiently in DecodeUntaggedDatum

### DIFF
--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -541,8 +541,9 @@ func decodeUntaggedDatum(a *DatumAlloc, t *types.T, buf []byte) (tree.Datum, []b
 		// We copy the byte buffer here, because the JSON decoding is lazy, and we
 		// do not want to hang on to the backing byte buffer, which might be an
 		// entire KV batch.
-		data = append([]byte{}, data...)
-		j, err := json.FromEncoding(data)
+		cpy := make([]byte, len(data))
+		copy(cpy, data)
+		j, err := json.FromEncoding(cpy)
 		if err != nil {
 			return nil, b, err
 		}


### PR DESCRIPTION
Backport 1/1 commits from #63481.

/cc @cockroachdb/release

---

This commit changes a few lines of code in `rowenc.DecodeUntaggedDatum`
that copy bytes from the `append([]byte{}, d...)` pattern to a
combination of `make` and `copy`. The new pattern is slightly more
efficient in Go 1.15.5, measured here:
https://gist.github.com/mgartner/625af5169155da795df42854d0c8b8e5

Release note: None
