### PR TITLE
release-21.1: roachtest: revive cancel roachtest

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -140,6 +140,7 @@ go_library(
         "//pkg/ts/tspb",
         "//pkg/util",
         "//pkg/util/binfetcher",
+        "//pkg/util/cancelchecker",
         "//pkg/util/contextutil",
         "//pkg/util/ctxgroup",
         "//pkg/util/httputil",

--- a/pkg/cmd/roachtest/cancel.go
+++ b/pkg/cmd/roachtest/cancel.go
@@ -113,7 +113,7 @@ func registerCancel(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:    fmt.Sprintf("cancel/tpcc/distsql/w=%d,nodes=%d", warehouses, numNodes),
-		Owner:   OwnerSQLExec,
+		Owner:   OwnerSQLQueries,
 		Cluster: makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runCancel(ctx, t, c, queries, warehouses, true /* useDistsql */)
@@ -122,7 +122,7 @@ func registerCancel(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:    fmt.Sprintf("cancel/tpcc/local/w=%d,nodes=%d", warehouses, numNodes),
-		Owner:   OwnerSQLExec,
+		Owner:   OwnerSQLQueries,
 		Cluster: makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runCancel(ctx, t, c, queries, warehouses, false /* useDistsql */)

--- a/pkg/cmd/roachtest/cancel.go
+++ b/pkg/cmd/roachtest/cancel.go
@@ -15,7 +15,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/workload/tpch"
+	"github.com/cockroachdb/errors"
 )
 
 // Motivation:
@@ -23,7 +26,7 @@ import (
 // insufficient in detecting problems with canceling long-running, multi-node
 // DistSQL queries. This is because, unlike local queries which only need to
 // cancel the transaction's context, DistSQL queries must cancel flow contexts
-// on each node involed in the query. Typical strategies for local execution
+// on each node involved in the query. Typical strategies for local execution
 // testing involve using a builtin like generate_series to create artificially
 // long-running queries, but these approaches don't create multi-node DistSQL
 // queries; the only way to do so is by querying a large dataset split across
@@ -33,41 +36,43 @@ import (
 // Once DistSQL queries provide more testing knobs, these tests can likely be
 // replaced with unit tests.
 func registerCancel(r *testRegistry) {
-	runCancel := func(ctx context.Context, t *test, c *cluster,
-		queries []string, warehouses int, useDistsql bool) {
-		t.Skip("skipping flaky cancel/tpcc test", "test needs to be updated see https://github.com/cockroachdb/cockroach/issues/42103")
+	runCancel := func(ctx context.Context, t *test, c *cluster, tpchQueriesToRun []int, useDistsql bool) {
 		c.Put(ctx, cockroach, "./cockroach", c.All())
-		c.Put(ctx, workload, "./workload", c.All())
 		c.Start(ctx, t, c.All())
 
 		m := newMonitor(ctx, c, c.All())
 		m.Go(func(ctx context.Context) error {
-			t.Status("importing TPCC fixture")
-			c.Run(ctx, c.Node(1), tpccImportCmd(warehouses))
+			t.Status("restoring TPCH dataset for Scale Factor 1")
+			if err := loadTPCHDataset(ctx, t, c, 1 /* sf */, newMonitor(ctx, c), c.All()); err != nil {
+				t.Fatal(err)
+			}
 
 			conn := c.Conn(ctx, 1)
 			defer conn.Close()
 
-			var queryPrefix string
+			queryPrefix := "USE tpch; "
 			if !useDistsql {
-				queryPrefix = "SET distsql = off;"
+				queryPrefix += "SET distsql = off; "
 			}
 
 			t.Status("running queries to cancel")
-			for _, q := range queries {
+			for _, queryNum := range tpchQueriesToRun {
 				sem := make(chan struct{}, 1)
-				go func(q string) {
-					t.l.Printf("executing \"%s\"\n", q)
+				go func(query string) {
+					t.l.Printf("executing \"%s\"\n", query)
 					sem <- struct{}{}
-					_, err := conn.Exec(queryPrefix + q)
+					_, err := conn.Exec(queryPrefix + query)
 					if err == nil {
 						close(sem)
 						t.Fatal("query completed before it could be canceled")
 					} else {
 						fmt.Printf("query failed with error: %s\n", err)
+						if !errors.Is(err, cancelchecker.QueryCanceledError) {
+							t.Fatal("unexpected error")
+						}
 					}
 					sem <- struct{}{}
-				}(q)
+				}(tpch.QueriesByNumber[queryNum])
 
 				<-sem
 
@@ -88,7 +93,7 @@ func registerCancel(r *testRegistry) {
 						t.Fatal("query could not be canceled")
 					}
 					timeToCancel := timeutil.Now().Sub(cancelStartTime)
-					fmt.Printf("canceling \"%s\" took %s\n", q, timeToCancel)
+					fmt.Printf("canceling q%d took %s\n", queryNum, timeToCancel)
 
 				case <-time.After(5 * time.Second):
 					t.Fatal("query took too long to respond to cancellation")
@@ -100,32 +105,26 @@ func registerCancel(r *testRegistry) {
 		m.Wait()
 	}
 
-	const warehouses = 10
 	const numNodes = 3
-	queries := []string{
-		`SELECT * FROM tpcc.stock`,
-		`SELECT * FROM tpcc.stock WHERE s_quantity > 100`,
-		`SELECT s_i_id, sum(s_quantity) FROM tpcc.stock GROUP BY s_i_id`,
-		`SELECT * FROM tpcc.stock ORDER BY s_quantity`,
-		`SELECT * FROM tpcc.order_line JOIN tpcc.stock ON s_i_id=ol_i_id`,
-		`SELECT ol_number, sum(s_quantity) FROM tpcc.stock JOIN tpcc.order_line ON s_i_id=ol_i_id WHERE ol_number > 10 GROUP BY ol_number ORDER BY ol_number`,
-	}
+	// Choose several longer running TPCH queries (each is taking at least 3s to
+	// complete).
+	tpchQueriesToRun := []int{7, 9, 20, 21}
 
 	r.Add(testSpec{
-		Name:    fmt.Sprintf("cancel/tpcc/distsql/w=%d,nodes=%d", warehouses, numNodes),
+		Name:    fmt.Sprintf("cancel/tpch/distsql/queries=%v,nodes=%d", tpchQueriesToRun, numNodes),
 		Owner:   OwnerSQLQueries,
 		Cluster: makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
-			runCancel(ctx, t, c, queries, warehouses, true /* useDistsql */)
+			runCancel(ctx, t, c, tpchQueriesToRun, true /* useDistsql */)
 		},
 	})
 
 	r.Add(testSpec{
-		Name:    fmt.Sprintf("cancel/tpcc/local/w=%d,nodes=%d", warehouses, numNodes),
+		Name:    fmt.Sprintf("cancel/tpch/local/queries=%v,nodes=%d", tpchQueriesToRun, numNodes),
 		Owner:   OwnerSQLQueries,
 		Cluster: makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
-			runCancel(ctx, t, c, queries, warehouses, false /* useDistsql */)
+			runCancel(ctx, t, c, tpchQueriesToRun, false /* useDistsql */)
 		},
 	})
 }

--- a/pkg/cmd/roachtest/scrub.go
+++ b/pkg/cmd/roachtest/scrub.go
@@ -48,7 +48,7 @@ func makeScrubTPCCTest(
 
 	return testSpec{
 		Name:    fmt.Sprintf("scrub/%s/tpcc/w=%d", optionName, warehouses),
-		Owner:   OwnerSQLExec,
+		Owner:   OwnerSQLQueries,
 		Cluster: makeClusterSpec(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runTPCC(ctx, t, c, tpccOptions{

--- a/pkg/cmd/roachtest/sqlsmith.go
+++ b/pkg/cmd/roachtest/sqlsmith.go
@@ -229,7 +229,7 @@ func registerSQLSmith(r *testRegistry) {
 		r.Add(testSpec{
 			Name: fmt.Sprintf("sqlsmith/setup=%s/setting=%s", setup, setting),
 			// NB: sqlsmith failures should never block a release.
-			Owner:      OwnerSQLExec,
+			Owner:      OwnerSQLQueries,
 			Cluster:    makeClusterSpec(4),
 			MinVersion: "v20.2.0",
 			Timeout:    time.Minute * 20,

--- a/pkg/cmd/roachtest/test_registry.go
+++ b/pkg/cmd/roachtest/test_registry.go
@@ -34,7 +34,7 @@ const (
 	OwnerCDC           Owner = `cdc`
 	OwnerKV            Owner = `kv`
 	OwnerPartitioning  Owner = `partitioning`
-	OwnerSQLExec       Owner = `sql-exec`
+	OwnerSQLQueries    Owner = `sql-queries`
 	OwnerSQLSchema     Owner = `sql-schema`
 	OwnerStorage       Owner = `storage`
 )
@@ -79,8 +79,8 @@ var roachtestOwners = map[Owner]OwnerMetadata{
 		// Partitioning issues get sent to the KV triage column for now.
 		TriageColumnID: 3550674,
 	},
-	OwnerSQLExec: {SlackRoom: `sql-execution-team`, ContactEmail: `alfonso@cockroachlabs.com`,
-		TriageColumnID: 6837155,
+	OwnerSQLQueries: {SlackRoom: `sql-queries`, ContactEmail: `yahor@cockroachlabs.com`,
+		TriageColumnID: 13549252,
 	},
 	OwnerSQLSchema: {SlackRoom: `sql-schema`, ContactEmail: `lucy@cockroachlabs.com`,
 		TriageColumnID: 8946818,

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -379,7 +379,7 @@ func registerTPCC(r *testRegistry) {
 	})
 	r.Add(testSpec{
 		Name:       "tpcc/interleaved/nodes=3/cpu=16/w=500",
-		Owner:      OwnerSQLExec,
+		Owner:      OwnerSQLQueries,
 		MinVersion: "v20.1.0",
 		Cluster:    makeClusterSpec(4, cpu(16)),
 		Timeout:    6 * time.Hour,

--- a/pkg/cmd/roachtest/tpcdsvec.go
+++ b/pkg/cmd/roachtest/tpcdsvec.go
@@ -168,7 +168,7 @@ func registerTPCDSVec(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:       "tpcdsvec",
-		Owner:      OwnerSQLExec,
+		Owner:      OwnerSQLQueries,
 		Cluster:    makeClusterSpec(3),
 		MinVersion: "v20.1.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/tpchbench.go
+++ b/pkg/cmd/roachtest/tpchbench.go
@@ -164,7 +164,7 @@ func registerTPCHBenchSpec(r *testRegistry, b tpchBenchSpec) {
 
 	r.Add(testSpec{
 		Name:       strings.Join(nameParts, "/"),
-		Owner:      OwnerSQLExec,
+		Owner:      OwnerSQLQueries,
 		Cluster:    makeClusterSpec(numNodes),
 		MinVersion: minVersion,
 		Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/tpchvec.go
+++ b/pkg/cmd/roachtest/tpchvec.go
@@ -647,7 +647,7 @@ const tpchVecNodeCount = 3
 func registerTPCHVec(r *testRegistry) {
 	r.Add(testSpec{
 		Name:       "tpchvec/perf",
-		Owner:      OwnerSQLExec,
+		Owner:      OwnerSQLQueries,
 		Cluster:    makeClusterSpec(tpchVecNodeCount),
 		MinVersion: "v19.2.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -657,7 +657,7 @@ func registerTPCHVec(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:    "tpchvec/disk",
-		Owner:   OwnerSQLExec,
+		Owner:   OwnerSQLQueries,
 		Cluster: makeClusterSpec(tpchVecNodeCount),
 		// 19.2 version doesn't have disk spilling nor memory monitoring, so
 		// there is no point in running this config on that version.
@@ -669,7 +669,7 @@ func registerTPCHVec(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:       "tpchvec/smithcmp",
-		Owner:      OwnerSQLExec,
+		Owner:      OwnerSQLQueries,
 		Cluster:    makeClusterSpec(tpchVecNodeCount),
 		MinVersion: "v20.1.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -679,7 +679,7 @@ func registerTPCHVec(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:       "tpchvec/perf_no_stats",
-		Owner:      OwnerSQLExec,
+		Owner:      OwnerSQLQueries,
 		Cluster:    makeClusterSpec(tpchVecNodeCount),
 		MinVersion: "v20.2.0",
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -689,7 +689,7 @@ func registerTPCHVec(r *testRegistry) {
 
 	r.Add(testSpec{
 		Name:       "tpchvec/bench",
-		Owner:      OwnerSQLExec,
+		Owner:      OwnerSQLQueries,
 		Cluster:    makeClusterSpec(tpchVecNodeCount),
 		MinVersion: "v20.2.0",
 		Skip: "This config can be used to perform some benchmarking and is not " +


### PR DESCRIPTION
Backport 2/2 commits from #63415.

/cc @cockroachdb/release

---

**roachtest: rename SQLExec to SQLQueries**

Release note: None

**roachtest: revive cancel roachtest**

`cancel` roachtest has been skipped for a long time now. Its idea is to
run some longer running queries and make sure that they can be canceled
with `CANCEL QUERIES`. Previously, we were using TPCC dataset with 10
warehouses and some arbitrary queries. Over time we have improved
significantly so that the execution took shorter time than we
anticipated which resulted in the test not being able to cancel the
query. This commit switches to using TPCH dataset of Scale Factor 1 and
uses several longer running queries (7, 9, 20, 21) to cancel (each is
taking at least 3s right now).

Fixes: #42103.

Release note: None
