### PR TITLE
hlc,sql: expose structured error for untrustworthy clocks, make it retriable in schema changes

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -157,6 +157,11 @@ func isPermanentSchemaChangeError(err error) bool {
 		return false
 	}
 
+	// Clock sync problems should not lead to permanently failed schema changes.
+	if hlc.IsUntrustworthyRemoteWallTimeError(err) {
+		return false
+	}
+
 	if pgerror.IsSQLRetryableError(err) {
 		return false
 	}

--- a/pkg/util/hlc/BUILD.bazel
+++ b/pkg/util/hlc/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     deps = [
         "//pkg/cli/exit",
         "//pkg/util/log",
+        "//pkg/util/protoutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//assert",


### PR DESCRIPTION
Two commits:

* Structure the error.
* Detect it in the schema changer.

Fixes #63636.
    
Release note (bug fix): Fixed a bug whereby transient clock synchronization
errors could result in permanent schema change failures.
