### PR TITLE
optfmt: improve Let formatting

### DIFF
--- a/pkg/sql/opt/optgen/cmd/optfmt/testdata/test
+++ b/pkg/sql/opt/optgen/cmd/optfmt/testdata/test
@@ -78,9 +78,9 @@ define FiltersItem {
 	$filters:* &
 	    (Let ($a):(Foo $input) $a) &
 	    (Let ($a $b $c $ok):(SplitFilters $input $filters) $ok) &
-	    (Let ($filtersA $filtersB $filtersC $filtersD $filtersE $filtersF $filtersG $ok):(SplitFilters $input $filters) $ok) &
+	    (Let ($filtersA $filtersB $filtersC $filtersD $filtersE $ok):(SplitFilters $input $filters) $ok) &
 	    (Let ($a $b $c $ok):(SplitFilters $input $filters $long $arg $list) $ok) &
-	    (Let ($filtersA $filtersB $filtersC $filtersD $ok):(SplitFilters $input $filters $long $arg $list $longer) $ok) &
+	    (Let ($filtersA $filtersB $filtersC $ok):(SplitFilters $input $filters $long $arg $list $longer) $ok) &
 	    (IsValid (Let ($filtersX $filtersY):(SplitFilters $input $filters) $filtersX)) &
 	    (OuterFunc (InnerFunc (Let ($foo $bar):(SplitFilters $input $filters) $foo))) &
 	    (Let ($foo $bar $baz):(Split (Let ($foo $bar $baz):(SplitAgain $a $b $c) $a)) $foo)
@@ -176,17 +176,29 @@ define FiltersItem {
     $filters:* &
         (Let ($a):(Foo $input) $a) &
         (Let ($a $b $c $ok):(SplitFilters $input $filters) $ok) &
-        (Let ($filtersA $filtersB $filtersC $filtersD $filtersE
-            $filtersF $filtersG $ok):
-            (SplitFilters $input $filters)
+        (Let
+            (
+                $filtersA
+                $filtersB
+                $filtersC
+                $filtersD
+                $filtersE
+                $ok
+            ):(SplitFilters $input $filters)
             $ok
         ) &
-        (Let ($a $b $c $ok):
-            (SplitFilters $input $filters $long $arg $list)
+        (Let
+            ($a $b $c $ok):(SplitFilters
+                $input
+                $filters
+                $long
+                $arg
+                $list
+            )
             $ok
         ) &
-        (Let ($filtersA $filtersB $filtersC $filtersD $ok):
-            (SplitFilters
+        (Let
+            ($filtersA $filtersB $filtersC $ok):(SplitFilters
                 $input
                 $filters
                 $long
@@ -197,21 +209,23 @@ define FiltersItem {
             $ok
         ) &
         (IsValid
-            (Let ($filtersX $filtersY):
-                (SplitFilters $input $filters)
+            (Let
+                ($filtersX $filtersY):(SplitFilters
+                    $input
+                    $filters
+                )
                 $filtersX
             )
         ) &
         (OuterFunc
             (InnerFunc
-                (Let ($foo $bar):
-                    (SplitFilters $input $filters)
+                (Let ($foo $bar):(SplitFilters $input $filters)
                     $foo
                 )
             )
         ) &
-        (Let ($foo $bar $baz):
-            (Split
+        (Let
+            ($foo $bar $baz):(Split
                 (Let ($foo $bar $baz):(SplitAgain $a $b $c) $a)
             )
             $foo

--- a/pkg/sql/opt/xform/rules/select.opt
+++ b/pkg/sql/opt/xform/rules/select.opt
@@ -118,8 +118,13 @@
         ) &
         (HasStrictKey $input)
     $filters:* &
-        (Let ($leftFilter $rightFilter $itemToReplace $ok):
-            (SplitDisjunction $scanPrivate $filters)
+        (Let
+            (
+                $leftFilter
+                $rightFilter
+                $itemToReplace
+                $ok
+            ):(SplitDisjunction $scanPrivate $filters)
             $ok
         )
 )
@@ -197,8 +202,13 @@
         ) &
         ^(HasStrictKey $input)
     $filters:* &
-        (Let ($leftFilter $rightFilter $itemToReplace $ok):
-            (SplitDisjunction $scanPrivate $filters)
+        (Let
+            (
+                $leftFilter
+                $rightFilter
+                $itemToReplace
+                $ok
+            ):(SplitDisjunction $scanPrivate $filters)
             $ok
         )
 )

--- a/pkg/util/pretty/util.go
+++ b/pkg/util/pretty/util.go
@@ -87,13 +87,7 @@ func Stack(d ...Doc) Doc {
 // Fillwords fills lines with as many docs as will fit joined with a space or
 // line.
 func Fillwords(d ...Doc) Doc {
-	return FillwordsWithSeparator(textSpace, d...)
-}
-
-// FillwordsWithSeparator fills lines with as many docs as will fit joined with
-// sep or a line.
-func FillwordsWithSeparator(sep Doc, d ...Doc) Doc {
-	u := &union{sep, line{}}
+	u := &union{textSpace, line{}}
 	fill := func(a, b Doc) Doc {
 		return ConcatDoc(a, b, u)
 	}


### PR DESCRIPTION
Formatting for `Let` expressions now makes it more clear that the `:`
binds the variables on the left to the return values from the custom
function on the right. Previously, the formatting made it appear as if
both the `Let` results, a variable reference, was logically part of the
`:`.

Release note: None