### PR TITLE
colexec: implement values operator

### DIFF
--- a/pkg/sql/colexec/BUILD.bazel
+++ b/pkg/sql/colexec/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "tuple_proj_op.go",
         "unordered_distinct.go",
         "utils.go",
+        "values.go",
         ":gen-exec",  # keep
         ":gen-sort-partitioner",  # keep
     ],
@@ -47,6 +48,7 @@ go_library(
         "//pkg/server/telemetry",  # keep
         "//pkg/settings",
         "//pkg/sql/catalog/colinfo",  # keep
+        "//pkg/sql/catalog/descpb",
         "//pkg/sql/colcontainer",
         "//pkg/sql/colconv",
         "//pkg/sql/colexec/colexecagg",  # keep

--- a/pkg/sql/colexec/BUILD.bazel
+++ b/pkg/sql/colexec/BUILD.bazel
@@ -125,6 +125,7 @@ go_test(
         "sorttopk_test.go",
         "types_integration_test.go",
         "utils_test.go",
+        "values_test.go",
     ],
     embed = [":colexec"],
     deps = [
@@ -157,6 +158,7 @@ go_test(
         "//pkg/sql/parser",
         "//pkg/sql/randgen",
         "//pkg/sql/rowenc",
+        "//pkg/sql/rowexec",
         "//pkg/sql/sem/builtins",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -216,9 +216,6 @@ func supportedNatively(spec *execinfrapb.ProcessorSpec) error {
 		return nil
 
 	case spec.Core.Values != nil:
-		if spec.Core.Values.NumRows != 0 && len(spec.Core.Values.Columns) != 0 {
-			return errors.Newf("values core is supported only with zero rows or zero columns")
-		}
 		return nil
 
 	case spec.Core.TableReader != nil:
@@ -763,13 +760,13 @@ func NewColOperator(
 			if err := checkNumIn(inputs, 0); err != nil {
 				return r, err
 			}
-			if core.Values.NumRows != 0 && len(core.Values.Columns) != 0 {
-				return r, errors.AssertionFailedf(
-					"values core is supported only with zero rows or zero columns, %d rows, %d columns given",
-					core.Values.NumRows, len(core.Values.Columns),
-				)
+			if core.Values.NumRows == 0 || len(core.Values.Columns) == 0 {
+				// To simplify valuesOp we handle some special cases with
+				// fixedNumTuplesNoInputOp.
+				result.Root = colexecutils.NewFixedNumTuplesNoInputOp(streamingAllocator, int(core.Values.NumRows), nil /* opToInitialize */)
+			} else {
+				result.Root = colexec.NewValuesOp(streamingAllocator, core.Values)
 			}
-			result.Root = colexecutils.NewFixedNumTuplesNoInputOp(streamingAllocator, int(core.Values.NumRows), nil /* opToInitialize */)
 			result.ColumnTypes = make([]*types.T, len(core.Values.Columns))
 			for i, col := range core.Values.Columns {
 				result.ColumnTypes[i] = col.Type

--- a/pkg/sql/colexec/colexectestutils/utils.go
+++ b/pkg/sql/colexec/colexectestutils/utils.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 	"testing/quick"
+	"time"
 
 	"github.com/cockroachdb/apd/v2"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -135,6 +136,31 @@ func (t Tuple) less(other Tuple, evalCtx *tree.EvalContext, tupleFromOtherSet Tu
 			if lhsStr == rhsStr {
 				continue
 			} else if lhsStr < rhsStr {
+				return true
+			} else {
+				return false
+			}
+		}
+
+		if lhsVal.Type().Name() == "Duration" {
+			lhsDuration := lhsVal.Interface().(duration.Duration)
+			rhsDuration := rhsVal.Interface().(duration.Duration)
+			cmp := lhsDuration.Compare(rhsDuration)
+			if cmp == 0 {
+				continue
+			} else if cmp == -1 {
+				return true
+			} else {
+				return false
+			}
+		}
+
+		if lhsVal.Type().Name() == "Time" {
+			lhsTime := lhsVal.Interface().(time.Time)
+			rhsTime := rhsVal.Interface().(time.Time)
+			if lhsTime.Equal(rhsTime) {
+				continue
+			} else if lhsTime.Before(rhsTime) {
 				return true
 			} else {
 				return false

--- a/pkg/sql/colexec/values.go
+++ b/pkg/sql/colexec/values.go
@@ -1,0 +1,132 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colexec
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/errors"
+)
+
+// valuesOp holds a fixed set of encoded rows, which are decoded and emitted in
+// batches.
+type valuesOp struct {
+	colexecop.ZeroInputNode
+	colexecop.InitHelper
+
+	// Type of each column.
+	typs []*types.T
+	// Raw bytes of serialized rows, one row per []byte.
+	data [][]byte
+
+	allocator *colmem.Allocator
+	dalloc    rowenc.DatumAlloc
+	batch     coldata.Batch
+	rowsBuf   rowenc.EncDatumRows
+}
+
+var _ colexecop.Operator = &valuesOp{}
+
+// NewValuesOp returns a new values operator, which has no input and outputs a
+// fixed set of rows.
+func NewValuesOp(allocator *colmem.Allocator, spec *execinfrapb.ValuesCoreSpec) colexecop.Operator {
+	// For zero-column sets, ValuesCoreSpec uses a nil RawBytes as an
+	// optimization, only using NumRows to represent the cardinality. To simplify
+	// valuesOp slightly we do not handle this case.
+	if uint64(len(spec.RawBytes)) != spec.NumRows {
+		colexecerror.InternalError(errors.AssertionFailedf(
+			"Values operator cannot handle ValuesCoreSpec with rows %d != NumRows %d",
+			len(spec.RawBytes),
+			spec.NumRows,
+		))
+	}
+
+	v := &valuesOp{
+		typs:      make([]*types.T, len(spec.Columns)),
+		data:      spec.RawBytes,
+		allocator: allocator,
+	}
+
+	for i := range spec.Columns {
+		v.typs[i] = spec.Columns[i].Type
+	}
+	return v
+}
+
+func (v *valuesOp) Init(ctx context.Context) {
+	if !v.InitHelper.Init(ctx) {
+		return
+	}
+
+	capacity := len(v.data)
+	if capacity > coldata.BatchSize() {
+		capacity = coldata.BatchSize()
+	}
+	v.batch = v.allocator.NewMemBatchWithFixedCapacity(v.typs, capacity)
+
+	v.rowsBuf = make(rowenc.EncDatumRows, v.batch.Capacity())
+	for i := range v.rowsBuf {
+		v.rowsBuf[i] = make(rowenc.EncDatumRow, len(v.typs))
+	}
+}
+
+func (v *valuesOp) Next() coldata.Batch {
+	if len(v.data) == 0 {
+		return coldata.ZeroBatch
+	}
+
+	v.batch.ResetInternalBatch()
+
+	// Decode rows up to the capacity of the batch.
+	nRows := 0
+	for ; nRows < v.batch.Capacity() && len(v.data) > 0; nRows++ {
+		rowData := v.data[0]
+		for i := 0; i < len(v.typs); i++ {
+			var err error
+			v.rowsBuf[nRows][i], rowData, err = rowenc.EncDatumFromBuffer(
+				v.typs[i], descpb.DatumEncoding_VALUE, rowData,
+			)
+			if err != nil {
+				colexecerror.InternalError(err)
+			}
+		}
+		if len(rowData) != 0 {
+			colexecerror.InternalError(errors.AssertionFailedf(
+				"malformed ValuesCoreSpec row: %x, rows left %d", rowData, len(v.data),
+			))
+		}
+		v.data = v.data[1:]
+	}
+
+	// Check if we have buffered more rows than the current allocation size and
+	// increase it if so.
+	if v.dalloc.AllocSize < nRows {
+		v.dalloc.AllocSize = nRows
+	}
+
+	outputRows := v.rowsBuf[:nRows]
+	for i, typ := range v.typs {
+		err := EncDatumRowsToColVec(v.allocator, outputRows, v.batch.ColVec(i), i, typ, &v.dalloc)
+		if err != nil {
+			colexecerror.InternalError(err)
+		}
+	}
+	v.batch.SetLength(nRows)
+	return v.batch
+}

--- a/pkg/sql/colexec/values_test.go
+++ b/pkg/sql/colexec/values_test.go
@@ -1,0 +1,166 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colexec
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/colconv"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexectestutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+// typeConvFn returns a conversion function if the given datum type can be
+// converted to a Go type. If there is no conversion function it returns nil.
+func typeConvFn(t *types.T) (fn func(tree.Datum) interface{}) {
+	defer func() {
+		// GetDatumToPhysicalFn panics if it cannot find a conversion function, but
+		// we simply don't use the type in that case, so discard the error.
+		if err := recover(); err != nil {
+			fn = nil //nolint:returnerrcheck
+		}
+	}()
+	return colconv.GetDatumToPhysicalFn(t)
+}
+
+func randTypes(rng *rand.Rand, numCols int) ([]*types.T, []func(tree.Datum) interface{}) {
+	colTypes := make([]*types.T, numCols)
+	convFns := make([]func(tree.Datum) interface{}, numCols)
+	for i := range colTypes {
+		for convFns[i] == nil {
+			colTypes[i] = randgen.RandEncodableType(rng)
+			convFns[i] = typeConvFn(colTypes[i])
+		}
+	}
+	return colTypes, convFns
+}
+
+func TestValues(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	rng, _ := randutil.NewPseudoRand()
+	for _, numRows := range []int{0, 1, 10, 13, 15} {
+		for _, numCols := range []int{1, 3} {
+			colTypes, convFns := randTypes(rng, numCols)
+
+			expected := make(colexectestutils.Tuples, numRows)
+			rows := make(rowenc.EncDatumRows, numRows)
+			for i := range expected {
+				expected[i] = make(colexectestutils.Tuple, numCols)
+				rows[i] = make(rowenc.EncDatumRow, numCols)
+				for j, typ := range colTypes {
+					val := randgen.RandDatum(rng, typ, true /* nullOk */)
+					if val == tree.DNull {
+						expected[i][j] = nil
+					} else {
+						expected[i][j] = convFns[j](val)
+					}
+					rows[i][j] = rowenc.DatumToEncDatum(typ, val)
+				}
+			}
+
+			colexectestutils.RunTests(t, testAllocator, nil, expected, colexectestutils.OrderedVerifier,
+				func(inputs []colexecop.Operator) (colexecop.Operator, error) {
+					spec, err := execinfra.GenerateValuesSpec(colTypes, rows)
+					if err != nil {
+						return nil, err
+					}
+					return NewValuesOp(testAllocator, &spec), nil
+				})
+		}
+	}
+}
+
+func subBenchmarkValues(
+	ctx context.Context,
+	b *testing.B,
+	numRows int,
+	numCols int,
+	name string,
+	build func(*execinfrapb.ValuesCoreSpec) (colexecop.Operator, error),
+) {
+	b.Run(fmt.Sprintf("rows=%d,cols=%d,%s", numRows, numCols, name),
+		func(b *testing.B) {
+			typs := types.MakeIntCols(numCols)
+			rows := randgen.MakeIntRows(numRows, numCols)
+			spec, err := execinfra.GenerateValuesSpec(typs, rows)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			b.SetBytes(int64(numRows * numCols * 8))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				op, err := build(&spec)
+				if err != nil {
+					b.Fatal(err)
+				}
+				op.Init(ctx)
+				for batch := op.Next(); batch.Length() > 0; batch = op.Next() {
+				}
+			}
+		})
+}
+
+func BenchmarkValues(b *testing.B) {
+	defer log.Scope(b).Close(b)
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+
+	flowCtx := execinfra.FlowCtx{
+		Cfg:     &execinfra.ServerConfig{Settings: st},
+		EvalCtx: &evalCtx,
+	}
+	post := execinfrapb.PostProcessSpec{}
+
+	for _, numRows := range []int{1 << 4, 1 << 8, 1 << 12, 1 << 16} {
+		for _, numCols := range []int{1, 2, 4} {
+			// Measure the vectorized values operator.
+			subBenchmarkValues(ctx, b, numRows, numCols, "valuesOpNative",
+				func(spec *execinfrapb.ValuesCoreSpec) (colexecop.Operator, error) {
+					return NewValuesOp(testAllocator, spec), nil
+				})
+
+			// For comparison, also measure the row-based values processor wrapped in
+			// a columnarizer, which the vectorized values operator replaces.
+			subBenchmarkValues(ctx, b, numRows, numCols, "valuesProcWrap",
+				func(spec *execinfrapb.ValuesCoreSpec) (colexecop.Operator, error) {
+					var core execinfrapb.ProcessorCoreUnion
+					core.Values = spec
+					proc, err := rowexec.NewProcessor(
+						ctx, &flowCtx, 0 /* processorID */, &core, &post, nil, /* inputs */
+						[]execinfra.RowReceiver{nil} /* outputs */, nil, /* localProcessors */
+					)
+					if err != nil {
+						b.Fatal(err)
+					}
+					return NewBufferingColumnarizer(
+						testAllocator, &flowCtx, 0, proc.(execinfra.RowSource),
+					)
+				})
+		}
+	}
+}

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -3005,6 +3005,11 @@ func (dsp *DistSQLPlanner) createValuesSpecFromTuples(
 	var a rowenc.DatumAlloc
 	evalCtx := &planCtx.ExtendedEvalCtx.EvalContext
 	numRows := len(tuples)
+	if len(resultTypes) == 0 {
+		// Optimization for zero-column sets.
+		spec := dsp.createValuesSpec(planCtx, resultTypes, numRows, nil /* rawBytes */)
+		return spec, nil
+	}
 	rawBytes := make([][]byte, numRows)
 	for rowIdx, tuple := range tuples {
 		var buf []byte

--- a/pkg/sql/execinfrapb/processors_sql.pb.go
+++ b/pkg/sql/execinfrapb/processors_sql.pb.go
@@ -512,12 +512,13 @@ func (WindowerSpec_Frame_Exclusion) EnumDescriptor() ([]byte, []int) {
 // "pre-canned" rows. This is not intended to be used for very large datasets.
 type ValuesCoreSpec struct {
 	// There is one DatumInfo for each element in a row. Can be empty, in which
-	// case raw_bytes must be empty.
+	// case raw_bytes will be empty.
 	Columns []DatumInfo `protobuf:"bytes,1,rep,name=columns" json:"columns"`
 	// The number of rows is especially useful when we have zero columns.
 	NumRows uint64 `protobuf:"varint,3,opt,name=num_rows,json=numRows" json:"num_rows"`
-	// Each raw block encodes one or more data rows; each datum is encoded
-	// according to the corresponding DatumInfo.
+	// Each raw block encodes one row; each datum is encoded according to the
+	// corresponding DatumInfo. As an optimization, if columns is empty, this will
+	// be empty rather than containing empty byte strings.
 	RawBytes [][]byte `protobuf:"bytes,2,rep,name=raw_bytes,json=rawBytes" json:"raw_bytes,omitempty"`
 }
 

--- a/pkg/sql/execinfrapb/processors_sql.proto
+++ b/pkg/sql/execinfrapb/processors_sql.proto
@@ -32,14 +32,15 @@ import "gogoproto/gogo.proto";
 // "pre-canned" rows. This is not intended to be used for very large datasets.
 message ValuesCoreSpec {
   // There is one DatumInfo for each element in a row. Can be empty, in which
-  // case raw_bytes must be empty.
+  // case raw_bytes will be empty.
   repeated DatumInfo columns = 1 [(gogoproto.nullable) = false];
 
   // The number of rows is especially useful when we have zero columns.
   optional uint64 num_rows = 3 [(gogoproto.nullable) = false];
 
-  // Each raw block encodes one or more data rows; each datum is encoded
-  // according to the corresponding DatumInfo.
+  // Each raw block encodes one row; each datum is encoded according to the
+  // corresponding DatumInfo. As an optimization, if columns is empty, this will
+  // be empty rather than containing empty byte strings.
   repeated bytes raw_bytes = 2;
 }
 

--- a/pkg/sql/rowexec/BUILD.bazel
+++ b/pkg/sql/rowexec/BUILD.bazel
@@ -57,7 +57,6 @@ go_library(
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",
-        "//pkg/sql/flowinfra",
         "//pkg/sql/inverted",
         "//pkg/sql/opt/invertedexpr",
         "//pkg/sql/opt/invertedidx",

--- a/pkg/sql/rowexec/values_test.go
+++ b/pkg/sql/rowexec/values_test.go
@@ -32,74 +32,71 @@ func TestValuesProcessor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	rng, _ := randutil.NewPseudoRand()
 	for _, numRows := range []int{0, 1, 10, 13, 15} {
-		for _, numCols := range []int{1, 3} {
-			for _, rowsPerChunk := range []int{1, 2, 5} {
-				t.Run(fmt.Sprintf("%d-%d-%d", numRows, numCols, rowsPerChunk), func(t *testing.T) {
-					inRows, colTypes := randgen.RandEncDatumRows(rng, numRows, numCols)
+		for _, numCols := range []int{0, 1, 3} {
+			t.Run(fmt.Sprintf("%d-%d", numRows, numCols), func(t *testing.T) {
+				inRows, colTypes := randgen.RandEncDatumRows(rng, numRows, numCols)
 
-					spec, err := execinfra.GenerateValuesSpec(colTypes, inRows, rowsPerChunk)
-					if err != nil {
-						t.Fatal(err)
-					}
+				spec, err := execinfra.GenerateValuesSpec(colTypes, inRows)
+				if err != nil {
+					t.Fatal(err)
+				}
 
-					out := &distsqlutils.RowBuffer{}
-					st := cluster.MakeTestingClusterSettings()
-					evalCtx := tree.NewTestingEvalContext(st)
-					defer evalCtx.Stop(context.Background())
-					flowCtx := execinfra.FlowCtx{
-						Cfg:     &execinfra.ServerConfig{Settings: st},
-						EvalCtx: evalCtx,
-					}
+				out := &distsqlutils.RowBuffer{}
+				st := cluster.MakeTestingClusterSettings()
+				evalCtx := tree.NewTestingEvalContext(st)
+				defer evalCtx.Stop(context.Background())
+				flowCtx := execinfra.FlowCtx{
+					Cfg:     &execinfra.ServerConfig{Settings: st},
+					EvalCtx: evalCtx,
+				}
 
-					v, err := newValuesProcessor(&flowCtx, 0 /* processorID */, &spec, &execinfrapb.PostProcessSpec{}, out)
-					if err != nil {
-						t.Fatal(err)
-					}
-					v.Run(context.Background())
-					if !out.ProducerClosed() {
-						t.Fatalf("output RowReceiver not closed")
-					}
+				v, err := newValuesProcessor(&flowCtx, 0 /* processorID */, &spec, &execinfrapb.PostProcessSpec{}, out)
+				if err != nil {
+					t.Fatal(err)
+				}
+				v.Run(context.Background())
+				if !out.ProducerClosed() {
+					t.Fatalf("output RowReceiver not closed")
+				}
 
-					var res rowenc.EncDatumRows
-					for {
-						row := out.NextNoMeta(t)
-						if row == nil {
-							break
+				var res rowenc.EncDatumRows
+				for {
+					row := out.NextNoMeta(t)
+					if row == nil {
+						break
+					}
+					res = append(res, row)
+				}
+
+				if len(res) != numRows {
+					t.Fatalf("incorrect number of rows %d, expected %d", len(res), numRows)
+				}
+
+				var a rowenc.DatumAlloc
+				for i := 0; i < numRows; i++ {
+					if len(res[i]) != numCols {
+						t.Fatalf("row %d incorrect length %d, expected %d", i, len(res[i]), numCols)
+					}
+					for j, val := range res[i] {
+						cmp, err := val.Compare(colTypes[j], &a, evalCtx, &inRows[i][j])
+						if err != nil {
+							t.Fatal(err)
 						}
-						res = append(res, row)
-					}
-
-					if len(res) != numRows {
-						t.Fatalf("incorrect number of rows %d, expected %d", len(res), numRows)
-					}
-
-					var a rowenc.DatumAlloc
-					for i := 0; i < numRows; i++ {
-						if len(res[i]) != numCols {
-							t.Fatalf("row %d incorrect length %d, expected %d", i, len(res[i]), numCols)
-						}
-						for j, val := range res[i] {
-							cmp, err := val.Compare(colTypes[j], &a, evalCtx, &inRows[i][j])
-							if err != nil {
-								t.Fatal(err)
-							}
-							if cmp != 0 {
-								t.Errorf(
-									"row %d, column %d: received %s, expected %s",
-									i, j, val.String(colTypes[j]), inRows[i][j].String(colTypes[j]),
-								)
-							}
+						if cmp != 0 {
+							t.Errorf(
+								"row %d, column %d: received %s, expected %s",
+								i, j, val.String(colTypes[j]), inRows[i][j].String(colTypes[j]),
+							)
 						}
 					}
-				})
-			}
+				}
+			})
 		}
 	}
 }
 
 func BenchmarkValuesProcessor(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	const numCols = 2
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
@@ -113,10 +110,11 @@ func BenchmarkValuesProcessor(b *testing.B) {
 	post := execinfrapb.PostProcessSpec{}
 	output := rowDisposer{}
 	for _, numRows := range []int{1 << 4, 1 << 8, 1 << 12, 1 << 16} {
-		for _, rowsPerChunk := range []int{1, 4, 16} {
-			b.Run(fmt.Sprintf("rows=%d,chunkSize=%d", numRows, rowsPerChunk), func(b *testing.B) {
+		for _, numCols := range []int{1, 2, 4} {
+			b.Run(fmt.Sprintf("rows=%d,cols=%d", numRows, numCols), func(b *testing.B) {
+				typs := types.MakeIntCols(numCols)
 				rows := randgen.MakeIntRows(numRows, numCols)
-				spec, err := execinfra.GenerateValuesSpec(types.TwoIntCols, rows, rowsPerChunk)
+				spec, err := execinfra.GenerateValuesSpec(typs, rows)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -128,7 +126,7 @@ func BenchmarkValuesProcessor(b *testing.B) {
 					if err != nil {
 						b.Fatal(err)
 					}
-					v.Run(context.Background())
+					v.Run(ctx)
 				}
 			})
 		}

--- a/pkg/testutils/distsqlutils/row_buffer.go
+++ b/pkg/testutils/distsqlutils/row_buffer.go
@@ -110,7 +110,13 @@ func (rb *RowBuffer) Push(
 	}
 	// We mimic the behavior of RowChannel.
 	storeRow := func() {
-		rowCopy := append(rowenc.EncDatumRow(nil), row...)
+		var rowCopy rowenc.EncDatumRow
+		if len(row) == 0 && row != nil {
+			// Special handling for empty rows, to avoid pushing nil.
+			rowCopy = make(rowenc.EncDatumRow, 0)
+		} else {
+			rowCopy = append(rowCopy, row...)
+		}
 		rb.Mu.Records = append(rb.Mu.Records, BufferedRecord{row: rowCopy, Meta: meta})
 	}
 	status := execinfra.ConsumerStatus(atomic.LoadUint32((*uint32)(&rb.ConsumerStatus)))


### PR DESCRIPTION
Add a vectorized operator for values. This operator uses very similar
batching to the buffering Columnarizer, and will replace a
rowexec.valuesProcessor wrapped with a Columnarizer in vectorized plans.
Because of the similarity, I'm not expecting much of a performance
improvement, though skipping the flowinfra.StreamDecoder in
rowexec.valuesProcessor might help a little.

This fixes #50109.

Release note: None