### PR TITLE
config: deflake TestMarshalableZoneConfigRoundTrip

### DIFF
--- a/pkg/config/zonepb/zone_yaml.go
+++ b/pkg/config/zonepb/zone_yaml.go
@@ -235,7 +235,11 @@ func zoneConfigToMarshalable(c ZoneConfig) marshalableZoneConfig {
 	if c.NumVoters != nil && *c.NumVoters != 0 {
 		m.NumVoters = proto.Int32(*c.NumVoters)
 	}
-	m.VoterConstraints = ConstraintsList{c.VoterConstraints, c.InheritedVoterConstraints()}
+	// NB: In order to preserve round-trippability, we're directly using
+	// `NullVoterConstraintsIsEmpty` as opposed to calling
+	// `c.InheritedVoterConstraints()`. This is copacetic as long as the value is
+	// unmarshalled correctly in zoneConfigFromMarshalable().
+	m.VoterConstraints = ConstraintsList{c.VoterConstraints, !c.NullVoterConstraintsIsEmpty}
 	if !c.InheritedLeasePreferences {
 		m.LeasePreferences = c.LeasePreferences
 	}


### PR DESCRIPTION
A previous change (#63079) made this test flakey by (needlessly) making
one of the marshalled fields a value derived from two other fields
(as opposed to just one). This commit fixes the flake.

Release note: None