### PR TITLE
roachtest: fail early if COCKROACH_DEV_LICENSE is not set

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -145,6 +145,7 @@ go_library(
         "//pkg/util/cancelchecker",
         "//pkg/util/contextutil",
         "//pkg/util/ctxgroup",
+        "//pkg/util/envutil",
         "//pkg/util/httputil",
         "//pkg/util/humanizeutil",
         "//pkg/util/log",

--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -585,9 +585,10 @@ func runCDCKafkaAuth(ctx context.Context, t *test, c *cluster) {
 
 func registerCDC(r *testRegistry) {
 	r.Add(testSpec{
-		Name:    "cdc/tpcc-1000",
-		Owner:   OwnerCDC,
-		Cluster: makeClusterSpec(4, cpu(16)),
+		Name:            "cdc/tpcc-1000",
+		Owner:           OwnerCDC,
+		Cluster:         makeClusterSpec(4, cpu(16)),
+		RequiresLicense: true,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
@@ -599,10 +600,11 @@ func registerCDC(r *testRegistry) {
 		},
 	})
 	r.Add(testSpec{
-		Name:    "cdc/tpcc-1000/sink=null",
-		Owner:   OwnerCDC,
-		Cluster: makeClusterSpec(4, cpu(16)),
-		Tags:    []string{"manual"},
+		Name:            "cdc/tpcc-1000/sink=null",
+		Owner:           OwnerCDC,
+		Cluster:         makeClusterSpec(4, cpu(16)),
+		Tags:            []string{"manual"},
+		RequiresLicense: true,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
@@ -615,9 +617,10 @@ func registerCDC(r *testRegistry) {
 		},
 	})
 	r.Add(testSpec{
-		Name:    "cdc/initial-scan",
-		Owner:   OwnerCDC,
-		Cluster: makeClusterSpec(4, cpu(16)),
+		Name:            "cdc/initial-scan",
+		Owner:           OwnerCDC,
+		Cluster:         makeClusterSpec(4, cpu(16)),
+		RequiresLicense: true,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
@@ -630,9 +633,10 @@ func registerCDC(r *testRegistry) {
 		},
 	})
 	r.Add(testSpec{
-		Name:    "cdc/sink-chaos",
-		Owner:   `cdc`,
-		Cluster: makeClusterSpec(4, cpu(16)),
+		Name:            "cdc/sink-chaos",
+		Owner:           `cdc`,
+		Cluster:         makeClusterSpec(4, cpu(16)),
+		RequiresLicense: true,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
@@ -645,9 +649,10 @@ func registerCDC(r *testRegistry) {
 		},
 	})
 	r.Add(testSpec{
-		Name:    "cdc/crdb-chaos",
-		Owner:   `cdc`,
-		Cluster: makeClusterSpec(4, cpu(16)),
+		Name:            "cdc/crdb-chaos",
+		Owner:           `cdc`,
+		Cluster:         makeClusterSpec(4, cpu(16)),
+		RequiresLicense: true,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             tpccWorkloadType,
@@ -667,7 +672,8 @@ func registerCDC(r *testRegistry) {
 		// TODO(mrtracy): This workload is designed to be running on a 20CPU nodes,
 		// but this cannot be allocated without some sort of configuration outside
 		// of this test. Look into it.
-		Cluster: makeClusterSpec(4, cpu(16)),
+		Cluster:         makeClusterSpec(4, cpu(16)),
+		RequiresLicense: true,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType:             ledgerWorkloadType,
@@ -680,9 +686,10 @@ func registerCDC(r *testRegistry) {
 		},
 	})
 	r.Add(testSpec{
-		Name:    "cdc/cloud-sink-gcs/rangefeed=true",
-		Owner:   `cdc`,
-		Cluster: makeClusterSpec(4, cpu(16)),
+		Name:            "cdc/cloud-sink-gcs/rangefeed=true",
+		Owner:           `cdc`,
+		Cluster:         makeClusterSpec(4, cpu(16)),
+		RequiresLicense: true,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			cdcBasicTest(ctx, t, c, cdcTestArgs{
 				workloadType: tpccWorkloadType,
@@ -700,25 +707,28 @@ func registerCDC(r *testRegistry) {
 		},
 	})
 	r.Add(testSpec{
-		Name:    "cdc/kafka-auth",
-		Owner:   `cdc`,
-		Cluster: makeClusterSpec(1),
+		Name:            "cdc/kafka-auth",
+		Owner:           `cdc`,
+		Cluster:         makeClusterSpec(1),
+		RequiresLicense: true,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runCDCKafkaAuth(ctx, t, c)
 		},
 	})
 	r.Add(testSpec{
-		Name:    "cdc/bank",
-		Owner:   `cdc`,
-		Cluster: makeClusterSpec(4),
+		Name:            "cdc/bank",
+		Owner:           `cdc`,
+		Cluster:         makeClusterSpec(4),
+		RequiresLicense: true,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runCDCBank(ctx, t, c)
 		},
 	})
 	r.Add(testSpec{
-		Name:    "cdc/schemareg",
-		Owner:   `cdc`,
-		Cluster: makeClusterSpec(1),
+		Name:            "cdc/schemareg",
+		Owner:           `cdc`,
+		Cluster:         makeClusterSpec(1),
+		RequiresLicense: true,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runCDCSchemaRegistry(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -74,6 +74,12 @@ type testSpec struct {
 	// still be run regularly.
 	NonReleaseBlocker bool
 
+	// RequiresLicense indicates that the test requires an
+	// enterprise license to run correctly. Use this to ensure
+	// tests will fail-early if COCKROACH_DEV_LICENSE is not set
+	// in the environment.
+	RequiresLicense bool
+
 	// Run is the test function.
 	Run func(ctx context.Context, t *test, c *cluster)
 }

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/internal/issues"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -161,6 +162,14 @@ func (r *testRunner) Run(
 	if len(tests) == 0 {
 		return fmt.Errorf("no test matched filters")
 	}
+
+	hasDevLicense := envutil.EnvOrDefaultString("COCKROACH_DEV_LICENSE", "") != ""
+	for _, t := range tests {
+		if t.RequiresLicense && !hasDevLicense {
+			return fmt.Errorf("test %q requires an enterprise license, set COCKROACH_DEV_LICENSE", t.Name)
+		}
+	}
+
 	if err := clustersOpt.validate(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Some tests require an enterprise license to run correctly. Currently,
if you don't have the license in your environment, you may only find
this out after several minutes of setup and after we've already spent
some money on cloud instances.

Tests that require an enterprise license can now indicate that they
need such a license by setting `RequiresLicense: true` in their
testSpec.

Release note: None