### PR TITLE
install: fix log flags in roachprod start

### DIFF
--- a/pkg/cmd/roachprod/install/cockroach.go
+++ b/pkg/cmd/roachprod/install/cockroach.go
@@ -457,9 +457,11 @@ func (h *crdbInstallHelper) generateStartArgs(
 	}
 
 	logDir := h.c.Impl.LogDir(h.c, nodes[nodeIdx])
-	if vers.AtLeast(version.MustParse("v21.1.0")) {
+	if vers.AtLeast(version.MustParse("v21.1.0-alpha.0")) {
 		// Specify exit-on-error=false to work around #62763.
 		args = append(args, `--log "file-defaults: {dir: '`+logDir+`', exit-on-error: false}"`)
+	} else {
+		args = append(args, "--log-dir="+logDir)
 	}
 
 	if vers.AtLeast(version.MustParse("v1.1.0")) {


### PR DESCRIPTION
I broke this in #63472, twofold.

1. if the version switch returned false, we weren't passing log flags
   at all, so there weren't any log files.
2. the version switch returned false on current master, since 21.1 is
   not tagged yet (we're still in the prerelease versions, currently
   at 21.1.0-alpha.3).

I tested that this fix works.

Release note: None
