### PR TITLE
cli: remove cgosymbolizer

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -296,13 +296,6 @@ def go_deps():
     )
 
     go_repository(
-        name = "com_github_benesch_cgosymbolizer",
-        build_file_proto_mode = "disable_global",
-        importpath = "github.com/benesch/cgosymbolizer",
-        sum = "h1:Llg88pHOiUbcFOFhr009G8fOBQL6gaVDnxUUeWZuLog=",
-        version = "v0.0.0-20180702220239-70e1ee2b39d3",
-    )
-    go_repository(
         name = "com_github_beorn7_perks",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/beorn7/perks",
@@ -1907,13 +1900,7 @@ def go_deps():
         sum = "h1:EPRgaDqXpLFUJLXZdGLnBTy1l6CLiNAPnvn2l+kHit0=",
         version = "v0.0.0-20141126152155-54553eb933fb",
     )
-    go_repository(
-        name = "com_github_ianlancetaylor_cgosymbolizer",
-        build_file_proto_mode = "disable_global",
-        importpath = "github.com/ianlancetaylor/cgosymbolizer",
-        sum = "h1:SgAfkQ7+MVwIQP9PPN+NrTsRvzLOfpDuMqaVhvjqMGA=",
-        version = "v0.0.0-20201002210021-dda951febc36",
-    )
+
     go_repository(
         name = "com_github_ianlancetaylor_demangle",
         build_file_proto_mode = "disable_global",

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/aws/aws-sdk-go v1.36.33
 	github.com/axiomhq/hyperloglog v0.0.0-20181223111420-4b99d0c2c99e
 	github.com/bazelbuild/rules_go v0.26.0
-	github.com/benesch/cgosymbolizer v0.0.0-20180702220239-70e1ee2b39d3
 	github.com/biogo/store v0.0.0-20160505134755-913427a1d5e8
 	github.com/cenkalti/backoff v2.1.1+incompatible
 	github.com/client9/misspell v0.3.4
@@ -85,7 +84,6 @@ require (
 	github.com/goware/modvendor v0.3.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
-	github.com/ianlancetaylor/cgosymbolizer v0.0.0-20201002210021-dda951febc36 // indirect
 	github.com/jackc/fake v0.0.0-20150926172116-812a484cc733 // indirect
 	github.com/jackc/pgconn v1.8.0
 	github.com/jackc/pgproto3/v2 v2.0.7

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,6 @@ github.com/axiomhq/hyperloglog v0.0.0-20181223111420-4b99d0c2c99e/go.mod h1:IOXA
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/bazelbuild/rules_go v0.26.0 h1:2F449QezDZcVW6Jt+kSs8Htd/YI3EXMcvd0aNfVNCI4=
 github.com/bazelbuild/rules_go v0.26.0/go.mod h1:MC23Dc/wkXEyk3Wpq6lCqz0ZAYOZDw2DR5y3N1q2i7M=
-github.com/benesch/cgosymbolizer v0.0.0-20180702220239-70e1ee2b39d3 h1:Llg88pHOiUbcFOFhr009G8fOBQL6gaVDnxUUeWZuLog=
-github.com/benesch/cgosymbolizer v0.0.0-20180702220239-70e1ee2b39d3/go.mod h1:eMD2XUcPsHYbakFEocKrWZp47G0MRJYoC60qFblGjpA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -722,8 +720,6 @@ github.com/huandu/xstrings v1.0.0/go.mod h1:4qWG/gcEcfX4z/mBDHJ++3ReCw9ibxbsNJbc
 github.com/huandu/xstrings v1.3.0 h1:gvV6jG9dTgFEncxo+AF7PH6MZXi/vZl25owA/8Dg8Wo=
 github.com/huandu/xstrings v1.3.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb/go.mod h1:qEIFzExnS6016fRpRfxrExeVn2gbClQA99gQhnIcdhE=
-github.com/ianlancetaylor/cgosymbolizer v0.0.0-20201002210021-dda951febc36 h1:SgAfkQ7+MVwIQP9PPN+NrTsRvzLOfpDuMqaVhvjqMGA=
-github.com/ianlancetaylor/cgosymbolizer v0.0.0-20201002210021-dda951febc36/go.mod h1:a5aratAVTWyz+nJMmDsN8O4XTfaLfdAsB1ysCmZX5Bw=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6 h1:UDMh68UUwekSh5iP2OMhRRZJiiBccgV7axzUG8vi56c=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/icrowley/fake v0.0.0-20180203215853-4178557ae428/go.mod h1:uhpZMVGznybq1itEKXj6RYw9I71qK4kH+OGMjRC4KEo=

--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -185,7 +185,6 @@ go_library(
         "//pkg/workload/tpch",
         "//pkg/workload/workloadsql",
         "//pkg/workload/ycsb",
-        "@com_github_benesch_cgosymbolizer//:cgosymbolizer",
         "@com_github_cockroachdb_apd_v2//:apd",
         "@com_github_cockroachdb_cockroach_go//crdb",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	_ "github.com/benesch/cgosymbolizer" // calls runtime.SetCgoTraceback on import
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	"github.com/cockroachdb/cockroach/pkg/util/log"


### PR DESCRIPTION
On macOS Big Sur, with the new async preemptive scheduler introduced
in Go 1.14, we would occasionally see goroutines get stuck on Cgo
`calloc` calls in Pebble. This turned out to be caused by
`cgosymbolizer`, as removing the import resolved the issue.

This patch removes the `cgosymbolizer` dependency entirely. It was
mostly useful for RocksDB, which is no longer used, and as an
experimental project it might cause further issues as well.

Resolves #63719.

Release note (bug fix): Fixed occasional stalls and excessive CPU usage
under macOS Big Sur when built with Go 1.14 or newer.