### PR TITLE
sql/sem/tree: Add assertion against upgrading collation package

### DIFF
--- a/pkg/sql/sem/tree/collatedstring.go
+++ b/pkg/sql/sem/tree/collatedstring.go
@@ -10,5 +10,14 @@
 
 package tree
 
+import "golang.org/x/text/collate"
+
 // DefaultCollationTag is the "default" collation for strings.
 const DefaultCollationTag = "default"
+
+func init() {
+	if collate.CLDRVersion != "23" {
+		panic("This binary was built with an incompatible version of golang.org/x/text. " +
+			"See https://github.com/cockroachdb/cockroach/issues/63738 for details")
+	}
+}


### PR DESCRIPTION
Upgrading golang.org/x/text to a newere collate.CLDRVersion
will require a lot of work for compatibility (described in
issue #63738). Add an assertion to make sure such an upgrade
is not made accidentally.

Release note: None