### PR TITLE
roachtest: add restore2TB config with large nodes

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -225,7 +225,7 @@ the test tags.
 		cmd.Flags().IntVar(
 			&httpPort, "port", 8080, "the port on which to serve the HTTP interface")
 		cmd.Flags().BoolVar(
-			&localSSD, "local-ssd", true, "Use a local SSD instead of an EBS volume (only for use with AWS) (defaults to true if instance type supports local SSDs)")
+			&localSSDArg, "local-ssd", true, "Use a local SSD instead of an EBS volume (only for use with AWS) (defaults to true if instance type supports local SSDs)")
 		cmd.Flags().StringSliceVar(
 			&createArgs, "create-args", []string{}, "extra args to pass onto the roachprod create command")
 	}

--- a/pkg/cmd/roachtest/restore.go
+++ b/pkg/cmd/roachtest/restore.go
@@ -306,17 +306,34 @@ func registerRestoreNodeShutdown(r *testRegistry) {
 }
 
 func registerRestore(r *testRegistry) {
+	largeVolumeSize := 2500 // the size in GB of disks in large volume configs
+
 	for _, item := range []struct {
-		nodes   int
+		nodes        int
+		cpus         int
+		largeVolumes bool
+
 		timeout time.Duration
 	}{
-		{10, 6 * time.Hour},
-		{32, 3 * time.Hour},
+		{nodes: 10, timeout: 6 * time.Hour},
+		{nodes: 32, timeout: 3 * time.Hour},
+		{nodes: 6, timeout: 4 * time.Hour, cpus: 16, largeVolumes: true},
 	} {
+		clusterOpts := make([]createOption, 0)
+		testName := fmt.Sprintf("restore2TB/nodes=%d", item.nodes)
+		if item.cpus != 0 {
+			clusterOpts = append(clusterOpts, cpu(item.cpus))
+			testName += fmt.Sprintf("/cpus=%d", item.cpus)
+		}
+		if item.largeVolumes {
+			clusterOpts = append(clusterOpts, volumeSize(largeVolumeSize))
+			testName += fmt.Sprintf("/pd-volume=%dGB", largeVolumeSize)
+		}
+
 		r.Add(testSpec{
-			Name:    fmt.Sprintf("restore2TB/nodes=%d", item.nodes),
+			Name:    testName,
 			Owner:   OwnerBulkIO,
-			Cluster: makeClusterSpec(item.nodes),
+			Cluster: makeClusterSpec(item.nodes, clusterOpts...),
 			Timeout: item.timeout,
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				// Randomize starting with encryption-at-rest enabled.


### PR DESCRIPTION
This test adds a new configuration to the restore2TB roachtest to test
the veritical scaling capabilities of restore on large nodes.

Release note: None