### PR TITLE
release-20.2: geomfn;geogfn: fix check of st_segmentize when number of segments overflow 

### DIFF
--- a/pkg/geo/geomfn/segmentize_test.go
+++ b/pkg/geo/geomfn/segmentize_test.go
@@ -156,13 +156,6 @@ func TestSegmentizeCoords(t *testing.T) {
 			resultantCoordinates: []float64{0, 0, 0.3333333333333333, 0, 0.6666666666666666, 0},
 		},
 		{
-			desc:                 `Coordinate(1, 1) to Coordinate(0, 0), -1`,
-			a:                    geom.Coord{1, 1},
-			b:                    geom.Coord{0, 0},
-			segmentMaxLength:     -1,
-			resultantCoordinates: []float64{1, 1},
-		},
-		{
 			desc:                 `Coordinate(1, 1) to Coordinate(0, 0), 2`,
 			a:                    geom.Coord{1, 1},
 			b:                    geom.Coord{0, 0},
@@ -182,6 +175,35 @@ func TestSegmentizeCoords(t *testing.T) {
 			convertedPoints, err := segmentizeCoords(test.a, test.b, test.segmentMaxLength)
 			require.NoError(t, err)
 			require.Equal(t, test.resultantCoordinates, convertedPoints)
+		})
+	}
+
+	errorTestCases := []struct {
+		desc             string
+		a                geom.Coord
+		b                geom.Coord
+		segmentMaxLength float64
+		expectedErr      string
+	}{
+		{
+			desc:             "too many segments required",
+			a:                geom.Coord{0, 0},
+			b:                geom.Coord{100, 100},
+			segmentMaxLength: 0.001,
+			expectedErr:      fmt.Sprintf("attempting to segmentize into too many coordinates; need 282846 points between [0 0] and [100 100], max %d", geo.MaxAllowedSplitPoints),
+		},
+		{
+			desc:             "negative max segment length",
+			a:                geom.Coord{1, 1},
+			b:                geom.Coord{2, 2},
+			segmentMaxLength: -1,
+			expectedErr:      "maximum segment length must be positive",
+		},
+	}
+	for _, test := range errorTestCases {
+		t.Run(test.desc, func(t *testing.T) {
+			_, err := segmentizeCoords(test.a, test.b, test.segmentMaxLength)
+			require.EqualError(t, err, test.expectedErr)
 		})
 	}
 

--- a/pkg/geo/geosegmentize/geosegmentize.go
+++ b/pkg/geo/geosegmentize/geosegmentize.go
@@ -11,6 +11,10 @@
 package geosegmentize
 
 import (
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/geo"
 	"github.com/cockroachdb/errors"
 	"github.com/twpayne/go-geom"
 )
@@ -120,4 +124,19 @@ func Segmentize(
 		return segGeomCollection, nil
 	}
 	return nil, errors.Newf("unknown type: %T", geometry)
+}
+
+// CheckSegmentizeTooManyPoints checks whether segmentize would break down into
+// to many points.
+func CheckSegmentizeTooManyPoints(numPoints float64, a geom.Coord, b geom.Coord) error {
+	if numPoints > float64(geo.MaxAllowedSplitPoints) {
+		return errors.Newf(
+			"attempting to segmentize into too many coordinates; need %s points between %v and %v, max %d",
+			strings.TrimRight(strconv.FormatFloat(numPoints, 'f', -1, 64), "."),
+			a,
+			b,
+			geo.MaxAllowedSplitPoints,
+		)
+	}
+	return nil
 }


### PR DESCRIPTION
Backport:
  * 1/1 commits from "geomfn: fix check of st_segmentize when number of segments overflow" (#63136)
  * 1/1 commits from "geogfn: fix segmentize of >MaxInt64 coordinates" (#63263)

Please see individual PRs for details.

/cc @cockroachdb/release
