### PR TITLE
release-21.1: sql: disallow dropping enum values used in default/computed columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type
@@ -374,22 +374,20 @@ statement ok
 INSERT INTO uses_alphabets_2 VALUES(1);
 
 # e was inserted as the default value, so we shouldn't be able to remove it.
-statement error pq: could not remove enum value "e" as it is being used by "uses_alphabets_2"
+statement error pq: could not remove enum value "e" as it is being used in a default expresion of "uses_alphabets_2"
 ALTER TYPE alphabets DROP VALUE 'e'
 
 statement ok
 TRUNCATE uses_alphabets_2
 
-statement ok
+statement error pq: could not remove enum value "e" as it is being used in a default expresion of "uses_alphabets_2"
 ALTER TYPE alphabets DROP VALUE 'e'
 
-statement error pq: could not find \[160\] in enum "public.alphabets"
+statement ok
 INSERT INTO uses_alphabets_2 VALUES(1);
 
-# Even though the default expr no longer works, we should be able to explicitly
-# insert a value.
 statement ok
-INSERT INTO uses_alphabets_2 VALUES (1, 'f')
+INSERT INTO uses_alphabets_2 VALUES (2, 'f')
 
 # Dropping the column should work.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1363,3 +1363,94 @@ query T
 SELECT * FROM arr_t3
 ----
 c
+
+
+# Test that if an enum value is being used by a default expression
+# or computed column, we disallow dropping it.
+subtest drop_used_enum_values
+
+statement ok
+SET enable_drop_enum_value = true
+
+statement ok
+CREATE TYPE default_abc AS ENUM ('a', 'b', 'c')
+
+statement ok
+CREATE TYPE default_abc2 AS ENUM('a', 'b', 'c')
+
+statement ok
+CREATE TABLE t (k INT PRIMARY KEY, v default_abc DEFAULT 'a')
+
+statement error pq: could not remove enum value "a" as it is being used in a default expresion of "t"
+ALTER TYPE default_abc DROP VALUE 'a'
+
+statement ok
+ALTER TYPE default_abc2 DROP VALUE 'a'
+
+statement ok
+CREATE TABLE t2 (k INT PRIMARY KEY, v string DEFAULT 'b'::default_abc::string)
+
+statement error pq: could not remove enum value "b" as it is being used in a default expresion of "t2"
+ALTER TYPE default_abc DROP VALUE 'b'
+
+statement ok
+ALTER TYPE default_abc DROP VALUE 'c'
+
+statement ok
+CREATE TABLE t3 (
+  x _default_abc2 DEFAULT ARRAY['b'::default_abc2],
+  y string DEFAULT ARRAY['c':::default_abc2][1]::string)
+
+statement error could not remove enum value "b" as it is being used in a default expresion of "t3"
+ALTER TYPE default_abc2 DROP VALUE 'b'
+
+statement error could not remove enum value "c" as it is being used in a default expresion of "t3"
+ALTER TYPE default_abc2 DROP VALUE 'c'
+
+statement ok
+CREATE TYPE default_abc3 AS ENUM ('a', 'b', 'c')
+
+statement ok
+CREATE TABLE t4 (
+  x default_abc3[] DEFAULT '{a}'::default_abc3[],
+  y string DEFAULT '{b}'::_default_abc3::string,
+  z default_abc3 DEFAULT ('{a, b, c}'::default_abc3[])[3])
+
+statement error could not remove enum value "a" as it is being used in a default expresion of "t4"
+ALTER TYPE default_abc3 DROP VALUE 'a'
+
+statement error could not remove enum value "b" as it is being used in a default expresion of "t4"
+ALTER TYPE default_abc3 DROP VALUE 'b'
+
+statement error could not remove enum value "c" as it is being used in a default expresion of "t4"
+ALTER TYPE default_abc3 DROP VALUE 'c'
+
+statement ok
+CREATE TYPE computed_abc AS ENUM ('a', 'b', 'c')
+
+statement ok
+CREATE TYPE computed_abc2 AS ENUM ('a', 'b', 'c')
+
+statement ok
+CREATE TABLE t5 (k INT PRIMARY KEY, y computed_abc AS ('a') STORED)
+
+statement error pq: could not remove enum value "a" as it is being used in a computed column of "t5"
+ALTER TYPE computed_abc DROP VALUE 'a'
+
+statement ok
+CREATE TABLE t6 (k INT PRIMARY KEY, y string AS ('b'::computed_abc::string) STORED)
+
+statement error pq: could not remove enum value "b" as it is being used in a computed column of "t6"
+ALTER TYPE computed_abc DROP VALUE 'b'
+
+statement ok
+ALTER TYPE computed_abc DROP VALUE 'c'
+
+statement ok
+CREATE TABLE t7 (x _computed_abc2 AS (ARRAY['a'::computed_abc2]) STORED, y computed_abc2[] AS (ARRAY['b':::computed_abc2]) STORED)
+
+statement error could not remove enum value "a" as it is being used in a computed column of "t7"
+ALTER TYPE computed_abc2 DROP VALUE 'a'
+
+statement error could not remove enum value "b" as it is being used in a computed column of "t7"
+ALTER TYPE computed_abc2 DROP VALUE 'b'

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/multiregion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -698,6 +699,92 @@ func convertToSQLStringRepresentation(bytes []byte) (string, error) {
 	return byteRep.String(), nil
 }
 
+// doesArrayContainEnumValues takes an array of enum values represented
+// as a string, along with an EnumMember, and checks if the
+// array contains the given EnumMember. Only works for arrays in the form
+// of something like {a, b, c}. Used to capture dependencies in
+// expressions in the form of something like '{a, b, c}'::typ[]
+func doesArrayContainEnumValues(s string, member *descpb.TypeDescriptor_EnumMember) bool {
+	enumValues := strings.Split(s[1:len(s)-1], ",")
+	for _, val := range enumValues {
+		if strings.TrimSpace(val) == member.LogicalRepresentation {
+			return true
+		}
+	}
+	return false
+}
+
+// findUsagesOfEnumValue takes an expr, type ID and a enum member of that type,
+// and checks if the expr uses that enum member.
+func findUsagesOfEnumValue(
+	exprStr string, member *descpb.TypeDescriptor_EnumMember, typeID descpb.ID,
+) (bool, error) {
+	expr, err := parser.ParseExpr(exprStr)
+	if err != nil {
+		return false, err
+	}
+	var foundUsage bool
+
+	visitFunc := func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
+		switch t := expr.(type) {
+		// Case for types being used regularly, which are serialized like '\x80':::@100053.
+		case *tree.AnnotateTypeExpr:
+			// Check if this expr's type is the one we're dropping the enum value from.
+			typeOid, ok := t.Type.(*tree.OIDTypeReference)
+			if !ok {
+				return true, expr, nil
+			}
+			id := typedesc.UserDefinedTypeOIDToID(typeOid.OID)
+			if id != typeID {
+				return true, expr, nil
+			}
+
+			// Check if this expr uses the enum value we're dropping.
+			strVal, ok := t.Expr.(*tree.StrVal)
+			if !ok {
+				return true, expr, nil
+			}
+			physicalRep := []byte(strVal.RawString())
+			if bytes.Equal(physicalRep, member.PhysicalRepresentation) {
+				foundUsage = true
+			}
+			return false, expr, nil
+
+		// Case for types used in string arrays, serialized like '{a, b, c}':::STRING::@100053.
+		case *tree.CastExpr:
+			typeOid, ok := t.Type.(*tree.OIDTypeReference)
+			if !ok {
+				return true, expr, nil
+			}
+			// -1 since the type of this CastExpr is the array type.
+			id := typedesc.UserDefinedTypeOIDToID(typeOid.OID) - 1
+			if id != typeID {
+				return true, expr, nil
+			}
+
+			// Extract the array and check if it contains the enum member.
+			annotateType, ok := t.Expr.(*tree.AnnotateTypeExpr)
+			if !ok {
+				return true, expr, nil
+			}
+			strVal, ok := annotateType.Expr.(*tree.StrVal)
+			if !ok {
+				return true, expr, nil
+			}
+			foundUsage = doesArrayContainEnumValues(strVal.RawString(), member)
+			return false, expr, nil
+		default:
+			return true, expr, nil
+		}
+	}
+
+	_, err = tree.SimpleVisit(expr, visitFunc)
+	if err != nil {
+		return false, err
+	}
+	return foundUsage, nil
+}
+
 // canRemoveEnumValue returns an error if the enum value is in use and therefore
 // can't be removed.
 func (t *typeSchemaChanger) canRemoveEnumValue(
@@ -720,6 +807,32 @@ func (t *typeSchemaChanger) canRemoveEnumValue(
 		firstClause := true
 		validationQueryConstructed := false
 		for _, col := range desc.PublicColumns() {
+			// If this column has a default expression, check if it uses the enum member being dropped.
+			if col.HasDefault() {
+				foundUsage, err := findUsagesOfEnumValue(col.GetDefaultExpr(), member, typeDesc.ID)
+				if err != nil {
+					return err
+				}
+				if foundUsage {
+					return pgerror.Newf(pgcode.DependentObjectsStillExist,
+						"could not remove enum value %q as it is being used in a default expresion of %q",
+						member.LogicalRepresentation, desc.GetName())
+				}
+			}
+
+			// If this column is computed, check if it uses the enum member being dropped.
+			if col.IsComputed() {
+				foundUsage, err := findUsagesOfEnumValue(col.GetComputeExpr(), member, typeDesc.ID)
+				if err != nil {
+					return err
+				}
+				if foundUsage {
+					return pgerror.Newf(pgcode.DependentObjectsStillExist,
+						"could not remove enum value %q as it is being used in a computed column of %q",
+						member.LogicalRepresentation, desc.GetName())
+				}
+			}
+
 			if typeDesc.ID == typedesc.GetTypeDescID(col.GetType()) {
 				if !firstClause {
 					query.WriteString(" OR")


### PR DESCRIPTION
Backport 1/1 commits from #62827.

/cc @cockroachdb/release

---

Previously, users could drop enum values
being used in default expressions or computed
columns, since we did not perform any checks beforehand.
This meant that default expressions and computed columns
could become corrupted after making such a drop.
This patch addresses this by walking default expressions
and computed columns when an enum member is dropped, and
disallows the drop if it finds any usages.

Partially fixes https://github.com/cockroachdb/cockroach/issues/59807 (this PR addresses the issue
in default/computed columns, and https://github.com/cockroachdb/cockroach/pull/62736 addresses the 
issue in views).

Release note: None
