### PR TITLE
colflow: cancel flow on ungraceful stream shutdown in outbox

### DIFF
--- a/pkg/col/coldatatestutils/random_testutils.go
+++ b/pkg/col/coldatatestutils/random_testutils.go
@@ -314,14 +314,15 @@ type RandomDataOpArgs struct {
 	Nulls bool
 	// BatchAccumulator, if set, will be called before returning a coldata.Batch
 	// from Next.
-	BatchAccumulator func(b coldata.Batch, typs []*types.T)
+	BatchAccumulator func(ctx context.Context, b coldata.Batch, typs []*types.T)
 }
 
 // RandomDataOp is an operator that generates random data according to
 // RandomDataOpArgs. Call GetBuffer to get all data that was returned.
 type RandomDataOp struct {
+	ctx              context.Context
 	allocator        *colmem.Allocator
-	batchAccumulator func(b coldata.Batch, typs []*types.T)
+	batchAccumulator func(ctx context.Context, b coldata.Batch, typs []*types.T)
 	typs             []*types.T
 	rng              *rand.Rand
 	batchSize        int
@@ -373,7 +374,9 @@ func NewRandomDataOp(
 }
 
 // Init is part of the colexecop.Operator interface.
-func (o *RandomDataOp) Init(context.Context) {}
+func (o *RandomDataOp) Init(ctx context.Context) {
+	o.ctx = ctx
+}
 
 // Next is part of the colexecop.Operator interface.
 func (o *RandomDataOp) Next() coldata.Batch {
@@ -381,7 +384,7 @@ func (o *RandomDataOp) Next() coldata.Batch {
 		// Done.
 		b := coldata.ZeroBatch
 		if o.batchAccumulator != nil {
-			o.batchAccumulator(b, o.typs)
+			o.batchAccumulator(o.ctx, b, o.typs)
 		}
 		return b
 	}
@@ -406,7 +409,7 @@ func (o *RandomDataOp) Next() coldata.Batch {
 		}
 		o.numReturned++
 		if o.batchAccumulator != nil {
-			o.batchAccumulator(b, o.typs)
+			o.batchAccumulator(o.ctx, b, o.typs)
 		}
 		return b
 	}

--- a/pkg/sql/colcontainer/diskqueue_test.go
+++ b/pkg/sql/colcontainer/diskqueue_test.go
@@ -72,7 +72,7 @@ func TestDiskQueue(t *testing.T) {
 						NumBatches: cap(batches),
 						BatchSize:  1 + rng.Intn(coldata.BatchSize()),
 						Nulls:      true,
-						BatchAccumulator: func(b coldata.Batch, typs []*types.T) {
+						BatchAccumulator: func(_ context.Context, b coldata.Batch, typs []*types.T) {
 							batches = append(batches, coldatatestutils.CopyBatch(b, typs, testColumnFactory))
 						},
 					})

--- a/pkg/sql/colexec/colexecutils/spilling_queue_test.go
+++ b/pkg/sql/colexec/colexecutils/spilling_queue_test.go
@@ -93,7 +93,7 @@ func TestSpillingQueue(t *testing.T) {
 				NumBatches: numBatches,
 				BatchSize:  inputBatchSize,
 				Nulls:      true,
-				BatchAccumulator: func(b coldata.Batch, typs []*types.T) {
+				BatchAccumulator: func(_ context.Context, b coldata.Batch, typs []*types.T) {
 					if b.Length() == 0 {
 						return
 					}

--- a/pkg/sql/colflow/colrpc/BUILD.bazel
+++ b/pkg/sql/colflow/colrpc/BUILD.bazel
@@ -60,6 +60,7 @@ go_test(
         "//pkg/util/mon",
         "//pkg/util/randutil",
         "//pkg/util/stop",
+        "//pkg/util/timeutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",

--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
@@ -147,7 +148,7 @@ func TestOutboxInbox(t *testing.T) {
 		// flow.
 		streamCtxCancel
 		// readerCtxCancel models a scenario in which the Inbox host cancels the
-		// flow.
+		// flow. This is considered a graceful termination.
 		readerCtxCancel
 		// transportBreaks models a scenario in which the transport breaks.
 		transportBreaks
@@ -199,6 +200,10 @@ func TestOutboxInbox(t *testing.T) {
 			// probability before cancellation.
 			sleepBeforeCancellation = rng.Float64() <= 0.25
 			sleepTime               = time.Microsecond * time.Duration(rng.Intn(500))
+			// stopwatch is used to measure how long it takes for the outbox to
+			// exit once the transport broke.
+			stopwatch                    = timeutil.NewStopWatch()
+			transportBreaksProducerSleep = 4 * time.Second
 		)
 
 		// Test random selection as the Outbox should be deselecting before sending
@@ -208,15 +213,28 @@ func TestOutboxInbox(t *testing.T) {
 			DeterministicTyps: typs,
 			NumBatches:        64,
 			Selection:         true,
-			BatchAccumulator:  inputBuffer.Add,
+			BatchAccumulator: func(_ context.Context, b coldata.Batch, typs []*types.T) {
+				inputBuffer.Add(b, typs)
+			},
 		}
 
 		if cancellationScenario != noCancel {
 			// Crank up the number of batches so cancellation always happens in the
 			// middle of execution (or before).
 			args.NumBatches = math.MaxInt64
-			// Disable accumulation to avoid memory blowups.
-			args.BatchAccumulator = nil
+			if cancellationScenario == transportBreaks {
+				// Insert an artificial sleep in order to simulate that the
+				// input to the outbox takes a while to produce each batch.
+				args.BatchAccumulator = func(ctx context.Context, b coldata.Batch, typs []*types.T) {
+					select {
+					case <-ctx.Done():
+					case <-time.After(transportBreaksProducerSleep):
+					}
+				}
+			} else {
+				// Disable accumulation to avoid memory blowups.
+				args.BatchAccumulator = nil
+			}
 		}
 		inputMemAcc := testMemMonitor.MakeBoundAccount()
 		defer inputMemAcc.Close(ctx)
@@ -245,7 +263,15 @@ func TestOutboxInbox(t *testing.T) {
 		)
 		wg.Add(1)
 		go func() {
-			outbox.runWithStream(streamCtx, clientStream, func() { atomic.StoreUint32(&canceled, 1) })
+			// There is a bit of trickery going on here with the context
+			// management caused by the fact that we're using an internal
+			// runWithStream method rather than exported Run method. The goal is
+			// to create a context of the node on which the outbox runs and keep
+			// it different from the streamCtx. This matters in
+			// 'transportBreaks' scenario.
+			var flowCtxCancel context.CancelFunc
+			outbox.runnerCtx, flowCtxCancel = context.WithCancel(ctx)
+			outbox.runWithStream(streamCtx, clientStream, flowCtxCancel, func() { atomic.StoreUint32(&canceled, 1) })
 			wg.Done()
 		}()
 
@@ -264,6 +290,7 @@ func TestOutboxInbox(t *testing.T) {
 			case transportBreaks:
 				err := conn.Close() // nolint:grpcconnclose
 				require.NoError(t, err)
+				stopwatch.Start()
 			}
 			wg.Done()
 		}()
@@ -363,10 +390,11 @@ func TestOutboxInbox(t *testing.T) {
 			// cancellation (which is redundant) in the Outbox.
 			require.True(t, atomic.LoadUint32(&canceled) == 1)
 		case readerCtxCancel:
-			// If the reader context gets canceled, the Inbox should have returned
-			// from the stream handler.
-			require.Regexp(t, "context canceled", streamHandlerErr)
-			// The Inbox should propagate this error upwards.
+			// If the reader context gets canceled, it is treated as a graceful
+			// termination of the stream, so we expect no error from the stream
+			// handler.
+			require.Nil(t, streamHandlerErr)
+			// The Inbox should still propagate this error upwards.
 			require.True(t, testutils.IsError(readerErr, "context canceled"), readerErr)
 
 			// The cancellation should have been communicated to the Outbox, resulting
@@ -375,6 +403,10 @@ func TestOutboxInbox(t *testing.T) {
 		case transportBreaks:
 			// If the transport breaks, the scenario is very similar to
 			// streamCtxCancel. GRPC will cancel the stream handler's context.
+			stopwatch.Stop()
+			// We expect that the outbox exits much sooner than it receives the
+			// next batch from its input in this scenario.
+			require.Less(t, int64(stopwatch.Elapsed()), int64(transportBreaksProducerSleep/2), "Outbox took too long to exit on transport breakage")
 			require.True(t, testutils.IsError(streamHandlerErr, "context canceled"), streamHandlerErr)
 			require.True(t, testutils.IsError(readerErr, "context canceled"), readerErr)
 
@@ -528,7 +560,7 @@ func TestOutboxInboxMetadataPropagation(t *testing.T) {
 			)
 			wg.Add(1)
 			go func() {
-				outbox.runWithStream(ctx, clientStream, func() { atomic.StoreUint32(&canceled, 1) })
+				outbox.runWithStream(ctx, clientStream, nil /* flowCtxCancel */, func() { atomic.StoreUint32(&canceled, 1) })
 				wg.Done()
 			}()
 
@@ -602,7 +634,7 @@ func BenchmarkOutboxInbox(b *testing.B) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		outbox.runWithStream(ctx, clientStream, nil /* cancelFn */)
+		outbox.runWithStream(ctx, clientStream, nil /* flowCtxCancel */, nil /* outboxCtxCancel */)
 		wg.Done()
 	}()
 
@@ -667,7 +699,7 @@ func TestOutboxStreamIDPropagation(t *testing.T) {
 			roachpb.NodeID(0),
 			execinfrapb.FlowID{UUID: uuid.MakeV4()},
 			outboxStreamID,
-			nil, /* cancelFn */
+			nil, /* flowCtxCancel */
 			0,   /* connectionTimeout */
 		)
 		outboxDone <- struct{}{}

--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -150,10 +150,9 @@ func NewInbox(
 
 // close closes the inbox, ensuring that any call to RunWithStream will return
 // immediately. close is idempotent.
-// NOTE: It is very important to close the Inbox only when execution terminates
-// ungracefully or when DrainMeta has been called (which indicates a graceful
-// termination). DrainMeta will use the stream to read any remaining metadata
-// after Next returns a zero-length batch during normal execution.
+// NOTE: it is very important to close the Inbox only when execution terminates
+// in one way or another. DrainMeta will use the stream to read any remaining
+// metadata after Next returns a zero-length batch during normal execution.
 func (i *Inbox) close() {
 	if !i.done {
 		i.done = true
@@ -174,6 +173,7 @@ func (i *Inbox) RunWithStream(streamCtx context.Context, stream flowStreamServer
 	var readerCtx context.Context
 	select {
 	case err := <-i.errCh:
+		// nil will be read from errCh when the channel is closed.
 		return err
 	case readerCtx = <-i.contextCh:
 		log.VEvent(streamCtx, 2, "Inbox reader arrived")
@@ -189,8 +189,10 @@ func (i *Inbox) RunWithStream(streamCtx context.Context, stream flowStreamServer
 		// nil will be read from errCh when the channel is closed.
 		return err
 	case <-readerCtx.Done():
-		// The reader canceled the stream.
-		return fmt.Errorf("%s: readerCtx in Inbox stream handler (local reader canceled)", readerCtx.Err())
+		// The reader canceled the stream meaning that it no longer needs any
+		// more data from the outbox. This is a graceful termination, so we
+		// return nil.
+		return nil
 	case <-streamCtx.Done():
 		// The client canceled the stream.
 		return fmt.Errorf("%s: streamCtx in Inbox stream handler (remote client canceled)", streamCtx.Err())
@@ -209,7 +211,7 @@ func (i *Inbox) Init(ctx context.Context) {
 		return
 	}
 
-	i.Ctx = logtags.AddTag(ctx, "streamID", i.streamID)
+	i.Ctx = logtags.AddTag(i.Ctx, "streamID", i.streamID)
 	// Initializes the Inbox for operation by blocking until RunWithStream sets
 	// the stream to read from.
 	if err := func() error {
@@ -221,7 +223,11 @@ func (i *Inbox) Init(ctx context.Context) {
 			i.errCh <- fmt.Errorf("%s: remote stream arrived too late", err)
 			return err
 		case <-i.Ctx.Done():
-			i.errCh <- fmt.Errorf("%s: Inbox while waiting for stream", i.Ctx.Err())
+			// Our reader canceled the context meaning that it no longer needs
+			// any more data from the outbox. This is a graceful termination, so
+			// we don't send any error on errCh and only return an error. This
+			// will close the inbox (making the stream handler exit gracefully)
+			// and will stop the current goroutine from proceeding further.
 			return i.Ctx.Err()
 		}
 

--- a/pkg/sql/colflow/colrpc/inbox_test.go
+++ b/pkg/sql/colflow/colrpc/inbox_test.go
@@ -71,7 +71,9 @@ func TestInboxCancellation(t *testing.T) {
 		require.True(t, testutils.IsError(err, "context canceled"), err)
 		// Now, the remote stream arrives.
 		err = inbox.RunWithStream(context.Background(), mockFlowStreamServer{})
-		require.True(t, testutils.IsError(err, "while waiting for stream"), err)
+		// We expect no error from the stream handler since we canceled it
+		// ourselves (a graceful termination).
+		require.Nil(t, err)
 	})
 
 	t.Run("DuringRecv", func(t *testing.T) {
@@ -99,7 +101,9 @@ func TestInboxCancellation(t *testing.T) {
 		// Cancel the context.
 		cancelFn()
 		err = <-streamHandlerErrCh
-		require.True(t, testutils.IsError(err, "readerCtx in Inbox stream handler"), err)
+		// Reader context cancellation is a graceful termination, so no error
+		// should be returned.
+		require.Nil(t, err)
 
 		// The mock RPC layer does not unblock the Recv for us on the server side,
 		// so manually send an io.EOF to the reader goroutine.

--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -116,8 +116,10 @@ func (o *Outbox) close(ctx context.Context) {
 // coldata.Batches over the stream after sending a header with the provided flow
 // and stream ID. Note that an extra goroutine is spawned so that Recv may be
 // called concurrently wrt the Send goroutine to listen for drain signals.
-// If an io.EOF is received while sending, the outbox will call cancelFn to
-// indicate an unexpected termination of the stream.
+// If an io.EOF is received while sending, the outbox will cancel all components
+// from the same tree as the outbox.
+// If non-io.EOF is received while sending, the outbox will call flowCtxCancel
+// to shutdown all parts of the flow on this node.
 // If an error is encountered that cannot be sent over the stream, the error
 // will be logged but not returned.
 // There are several ways the bidirectional FlowStream RPC may terminate.
@@ -136,9 +138,17 @@ func (o *Outbox) Run(
 	nodeID roachpb.NodeID,
 	flowID execinfrapb.FlowID,
 	streamID execinfrapb.StreamID,
-	cancelFn context.CancelFunc,
+	flowCtxCancel context.CancelFunc,
 	connectionTimeout time.Duration,
 ) {
+	// Derive a child context so that we can cancel all components rooted in
+	// this outbox.
+	var outboxCtxCancel context.CancelFunc
+	ctx, outboxCtxCancel = context.WithCancel(ctx)
+	// Calling outboxCtxCancel is not strictly necessary, but we do it just to
+	// be safe.
+	defer outboxCtxCancel()
+
 	ctx, o.span = execinfra.ProcessorSpan(ctx, "outbox")
 	if o.span != nil {
 		defer o.span.Finish()
@@ -191,25 +201,25 @@ func (o *Outbox) Run(
 	}
 
 	log.VEvent(ctx, 2, "Outbox starting normal operation")
-	o.runWithStream(ctx, stream, cancelFn)
+	o.runWithStream(ctx, stream, flowCtxCancel, outboxCtxCancel)
 	log.VEvent(ctx, 2, "Outbox exiting")
 }
 
 // handleStreamErr is a utility method used to handle an error when calling
-// a method on a flowStreamClient. If err is an io.EOF, cancelFn is called. The
-// given error is logged with the associated opName.
+// a method on a flowStreamClient. If err is an io.EOF, outboxCtxCancel is
+// called, for all other error flowCtxCancel is. The given error is logged with
+// the associated opName.
 func (o *Outbox) handleStreamErr(
-	ctx context.Context, opName string, err error, cancelFn context.CancelFunc,
+	ctx context.Context, opName string, err error, flowCtxCancel, outboxCtxCancel context.CancelFunc,
 ) {
 	if err == io.EOF {
 		if log.V(1) {
-			log.Infof(ctx, "Outbox calling cancelFn after %s EOF", opName)
+			log.Infof(ctx, "Outbox calling outboxCtxCancel after %s EOF", opName)
 		}
-		cancelFn()
+		outboxCtxCancel()
 	} else {
-		if log.V(1) {
-			log.Warningf(ctx, "Outbox %s connection error: %+v", opName, err)
-		}
+		log.Warningf(ctx, "Outbox calling flowCtxCancel after %s connection error: %+v", opName, err)
+		flowCtxCancel()
 	}
 }
 
@@ -234,11 +244,13 @@ func (o *Outbox) moveToDraining(ctx context.Context) {
 //    stream as metadata.
 // 4) An error related to the stream occurs. In this case, the error is logged
 //    but not returned, as there is no way to propagate this error anywhere
-//    meaningful. false, nil is returned. NOTE: io.EOF is a special case. This
-//    indicates non-graceful termination initiated by the remote Inbox. cancelFn
-//    will be called in this case.
+//    meaningful. false, nil is returned.
+//    NOTE: if non-io.EOF error is encountered (indicating ungraceful shutdown
+//    of the stream), flowCtxCancel will be called. If an io.EOF is encountered
+//    (indicating a graceful shutdown initiated by the remote Inbox),
+//    outboxCtxCancel will be called.
 func (o *Outbox) sendBatches(
-	ctx context.Context, stream flowStreamClient, cancelFn context.CancelFunc,
+	ctx context.Context, stream flowStreamClient, flowCtxCancel, outboxCtxCancel context.CancelFunc,
 ) (terminatedGracefully bool, errToSend error) {
 	if o.runnerCtx == nil {
 		// In the non-testing path, runnerCtx has been set in Run() method;
@@ -275,7 +287,7 @@ func (o *Outbox) sendBatches(
 			// soon as the message is written to the control buffer. The message is
 			// marshaled (bytes are copied) before writing.
 			if err := stream.Send(o.scratch.msg); err != nil {
-				o.handleStreamErr(ctx, "Send (batches)", err, cancelFn)
+				o.handleStreamErr(ctx, "Send (batches)", err, flowCtxCancel, outboxCtxCancel)
 				return
 			}
 		}
@@ -319,17 +331,28 @@ func (o *Outbox) sendMetadata(ctx context.Context, stream flowStreamClient, errT
 // runWithStream should be called after sending the ProducerHeader on the
 // stream. It implements the behavior described in Run.
 func (o *Outbox) runWithStream(
-	ctx context.Context, stream flowStreamClient, cancelFn context.CancelFunc,
+	ctx context.Context, stream flowStreamClient, flowCtxCancel, outboxCtxCancel context.CancelFunc,
 ) {
+	if flowCtxCancel == nil {
+		// The flowCtxCancel might be nil in some tests, but we'll make it a
+		// noop for convenience.
+		flowCtxCancel = func() {}
+	}
 	waitCh := make(chan struct{})
 	go func() {
+		// This goroutine's job is to listen continually on the stream from the
+		// consumer for errors or drain requests, while the remainder of this
+		// function concurrently is producing data and sending it over the
+		// network. This goroutine will tear down the flow if non-io.EOF error
+		// is received - without it, a producer goroutine might spin doing work
+		// forever after a connection is closed, since it wouldn't notice a
+		// closed connection until it tried to Send over that connection.
 		for {
 			msg, err := stream.Recv()
 			if err != nil {
 				if err != io.EOF {
-					if log.V(1) {
-						log.Warningf(ctx, "Outbox Recv connection error: %+v", err)
-					}
+					log.Warningf(ctx, "Outbox calling flowCtxCancel after Recv connection error: %+v", err)
+					flowCtxCancel()
 				}
 				break
 			}
@@ -343,18 +366,18 @@ func (o *Outbox) runWithStream(
 		close(waitCh)
 	}()
 
-	terminatedGracefully, errToSend := o.sendBatches(ctx, stream, cancelFn)
+	terminatedGracefully, errToSend := o.sendBatches(ctx, stream, flowCtxCancel, outboxCtxCancel)
 	if terminatedGracefully || errToSend != nil {
 		o.moveToDraining(ctx)
 		if err := o.sendMetadata(ctx, stream, errToSend); err != nil {
-			o.handleStreamErr(ctx, "Send (metadata)", err, cancelFn)
+			o.handleStreamErr(ctx, "Send (metadata)", err, flowCtxCancel, outboxCtxCancel)
 		} else {
 			// Close the stream. Note that if this block isn't reached, the stream
 			// is unusable.
-			// The receiver goroutine will read from the stream until io.EOF is
-			// returned.
+			// The receiver goroutine will read from the stream until any error
+			// is returned (most likely an io.EOF).
 			if err := stream.CloseSend(); err != nil {
-				o.handleStreamErr(ctx, "CloseSend", err, cancelFn)
+				o.handleStreamErr(ctx, "CloseSend", err, flowCtxCancel, outboxCtxCancel)
 			}
 		}
 	}

--- a/pkg/sql/colflow/colrpc/outbox_test.go
+++ b/pkg/sql/colflow/colrpc/outbox_test.go
@@ -51,7 +51,7 @@ func TestOutboxCatchesPanics(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		outbox.runWithStream(ctx, rpcLayer.client, nil /* cancelFn */)
+		outbox.runWithStream(ctx, rpcLayer.client, nil /* flowCtxCancel */, nil /* outboxCtxCancel */)
 		wg.Done()
 	}()
 
@@ -123,7 +123,7 @@ func TestOutboxDrainsMetadataSources(t *testing.T) {
 		// Close the csChan to unblock the Recv goroutine (we don't need it for this
 		// test).
 		close(rpcLayer.client.csChan)
-		outbox.runWithStream(ctx, rpcLayer.client, nil /* cancelFn */)
+		outbox.runWithStream(ctx, rpcLayer.client, nil /* flowCtxCancel */, nil /* outboxCtxCancel */)
 
 		require.True(t, atomic.LoadUint32(sourceDrained) == 1)
 	})
@@ -140,7 +140,7 @@ func TestOutboxDrainsMetadataSources(t *testing.T) {
 		require.NoError(t, err)
 
 		close(rpcLayer.client.csChan)
-		outbox.runWithStream(ctx, rpcLayer.client, nil /* cancelFn */)
+		outbox.runWithStream(ctx, rpcLayer.client, nil /* flowCtxCancel */, nil /* outboxCtxCancel */)
 
 		require.True(t, atomic.LoadUint32(sourceDrained) == 1)
 	})

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -234,7 +234,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 				idToClosed.mapping = make(map[int]bool)
 				runOutboxInbox := func(
 					outboxCtx context.Context,
-					cancelFn context.CancelFunc,
+					flowCtxCancel context.CancelFunc,
 					outboxMemAcc *mon.BoundAccount,
 					outboxInput colexecop.Operator,
 					inbox *colrpc.Inbox,
@@ -267,7 +267,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 							execinfra.StaticNodeID,
 							flowID,
 							execinfrapb.StreamID(id),
-							cancelFn,
+							flowCtxCancel,
 							0, /* connectionTimeout */
 						)
 						wg.Done()

--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -36,7 +36,7 @@ const (
 
 // Startable is any component that can be started (a router or an outbox).
 type Startable interface {
-	Start(ctx context.Context, wg *sync.WaitGroup, ctxCancel context.CancelFunc)
+	Start(ctx context.Context, wg *sync.WaitGroup, flowCtxCancel context.CancelFunc)
 }
 
 // StartableFn is an adapter when a customer function (i.e. a custom goroutine)
@@ -44,8 +44,10 @@ type Startable interface {
 type StartableFn func(context.Context, *sync.WaitGroup, context.CancelFunc)
 
 // Start is a part of the Startable interface.
-func (f StartableFn) Start(ctx context.Context, wg *sync.WaitGroup, ctxCancel context.CancelFunc) {
-	f(ctx, wg, ctxCancel)
+func (f StartableFn) Start(
+	ctx context.Context, wg *sync.WaitGroup, flowCtxCancel context.CancelFunc,
+) {
+	f(ctx, wg, flowCtxCancel)
 }
 
 // FuseOpt specifies options for processor fusing at Flow.Setup() time.

--- a/pkg/sql/rowflow/routers.go
+++ b/pkg/sql/rowflow/routers.go
@@ -303,7 +303,7 @@ func (rb *routerBase) init(ctx context.Context, flowCtx *execinfra.FlowCtx, type
 }
 
 // Start must be called after init.
-func (rb *routerBase) Start(ctx context.Context, wg *sync.WaitGroup, ctxCancel context.CancelFunc) {
+func (rb *routerBase) Start(ctx context.Context, wg *sync.WaitGroup, _ context.CancelFunc) {
 	wg.Add(len(rb.outputs))
 	for i := range rb.outputs {
 		go func(ctx context.Context, rb *routerBase, ro *routerOutput, wg *sync.WaitGroup) {

--- a/pkg/sql/rowflow/routers_test.go
+++ b/pkg/sql/rowflow/routers_test.go
@@ -69,7 +69,7 @@ func setupRouter(
 	}
 	r.init(ctx, &flowCtx, inputTypes)
 	wg := &sync.WaitGroup{}
-	r.Start(ctx, wg, nil /* ctxCancel */)
+	r.Start(ctx, wg, nil /* flowCtxCancel */)
 	return r, wg
 }
 
@@ -678,7 +678,7 @@ func TestRouterBlocks(t *testing.T) {
 			}
 			router.init(ctx, &flowCtx, colTypes)
 			var wg sync.WaitGroup
-			router.Start(ctx, &wg, nil /* ctxCancel */)
+			router.Start(ctx, &wg, nil /* flowCtxCancel */)
 
 			// Set up a goroutine that tries to send rows until the stop channel
 			// is closed.

--- a/pkg/sql/rowflow/test_utils.go
+++ b/pkg/sql/rowflow/test_utils.go
@@ -33,6 +33,6 @@ func MakeTestRouter(
 		return nil, err
 	}
 	r.init(ctx, flowCtx, types)
-	r.Start(ctx, wg, nil /* ctxCancel */)
+	r.Start(ctx, wg, nil /* flowCtxCancel */)
 	return r, nil
 }


### PR DESCRIPTION
Previously, when an outbox `Recv`ed a non-`io.EOF` error from the gRPC
stream, we would simply log it. Such an error indicates an ungraceful
shutdown of the stream, and, instead, it should lead to the cancellation
of the whole stream. Previously, the main goroutine of the outbox would
keep on running and it would exit only the next time it attempted to
`Send` something on the stream. This is now fixed, and the flow ctx will
be canceled when a stream is shutdown ungracefully. This is what we do
in the row-based flows, and this commit adds this behavior the
vectorized outbox.

Fixes: https://github.com/cockroachlabs/support/issues/924.

Release note (bug fix): Previously, the remote flows of execution in the
vectorized engine could take quite a long time to shut down whenever a
node participating in the plan dies.