### PR TITLE
release-20.2: sql: wrap typed Array within IndirectionExpr in ParenExpr

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1218,3 +1218,25 @@ query T
 SELECT * FROM arr_t3
 ----
 c
+
+statement ok
+CREATE TABLE arr_t4 (i typ DEFAULT ARRAY['a'::typ][1], j typ DEFAULT ARRAY['a'::typ, 'b'::typ, 'c'::typ][2])
+
+statement ok
+INSERT INTO arr_t4 VALUES (default, default)
+
+query TT
+SELECT * from arr_t4
+----
+a  b
+
+statement ok
+CREATE TABLE arr_t5 (i typ[] default ARRAY['a'::typ, 'b'::typ])
+
+statement ok
+INSERT INTO arr_t5 VALUES (default)
+
+query T
+SELECT * from arr_t5
+----
+{a,b}

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -199,6 +199,7 @@ func TestTypeCheck(t *testing.T) {
 
 		{`(('{' || 'a' ||'}')::STRING[])[1]::STRING`, `((('{':::STRING || 'a':::STRING) || '}':::STRING)::STRING[])[1:::INT8]`},
 		{`(('{' || '1' ||'}')::INT[])[1]`, `((('{':::STRING || '1':::STRING) || '}':::STRING)::INT8[])[1:::INT8]`},
+		{`(ARRAY[1, 2, 3]::int[])[2]`, `(ARRAY[1:::INT8, 2:::INT8, 3:::INT8]:::INT8[])[2:::INT8]`},
 	}
 	ctx := context.Background()
 	for _, d := range testData {


### PR DESCRIPTION
Backport 1/1 commits from #63271.

/cc @cockroachdb/release

---

This patch adds a case that https://github.com/cockroachdb/cockroach/pull/63103 missed.

When we have something like `ARRAY['a'::typ, 'b'::typ]`,
we format it to `ARRAY['a'::typ, 'b'::typ]:::public.typ[]`.
This causes issues if used in an `IndirectionExpr`, such as
`ARRAY['a'::typ, 'b'::typ]:::public.typ[][1]`, as the `[1]`
is interpreted as part of the type.
This would result in errors when trying to use these
expressions in default expressions.
This patch checks for this specific case, and instead
formats it as `(ARRAY['a'::typ, 'b'::typ]:::public.typ[])[1]`.

Release note: None
