### PR TITLE
sql: use catalog.Mutation where possible

### DIFF
--- a/pkg/sql/catalog/table_elements.go
+++ b/pkg/sql/catalog/table_elements.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 )
 
@@ -272,6 +273,35 @@ type ConstraintToUpdate interface {
 
 	// ConstraintToUpdateDesc returns the underlying protobuf descriptor.
 	ConstraintToUpdateDesc() *descpb.ConstraintToUpdate
+
+	// GetName returns the name of this constraint update mutation.
+	GetName() string
+
+	// IsCheck returns true iff this is an update for a check constraint.
+	IsCheck() bool
+
+	// IsForeignKey returns true iff this is an update for a fk constraint.
+	IsForeignKey() bool
+
+	// IsNotNull returns true iff this is an update for a not-null constraint.
+	IsNotNull() bool
+
+	// IsUniqueWithoutIndex returns true iff this is an update for a unique
+	// without index constraint.
+	IsUniqueWithoutIndex() bool
+
+	// Check returns the underlying check constraint, if there is one.
+	Check() descpb.TableDescriptor_CheckConstraint
+
+	// ForeignKey returns the underlying fk constraint, if there is one.
+	ForeignKey() descpb.ForeignKeyConstraint
+
+	// NotNullColumnID returns the underlying not-null column ID, if there is one.
+	NotNullColumnID() descpb.ColumnID
+
+	// UniqueWithoutIndex returns the underlying unique without index constraint, if
+	// there is one.
+	UniqueWithoutIndex() descpb.UniqueWithoutIndexConstraint
 }
 
 // PrimaryKeySwap is an interface around a primary key swap mutation.
@@ -280,6 +310,26 @@ type PrimaryKeySwap interface {
 
 	// PrimaryKeySwapDesc returns the underlying protobuf descriptor.
 	PrimaryKeySwapDesc() *descpb.PrimaryKeySwap
+
+	// NumOldIndexes returns the number of old active indexes to swap out.
+	NumOldIndexes() int
+
+	// ForEachOldIndexIDs iterates through each of the old index IDs.
+	// iterutil.Done is supported.
+	ForEachOldIndexIDs(fn func(id descpb.IndexID) error) error
+
+	// NumNewIndexes returns the number of new active indexes to swap in.
+	NumNewIndexes() int
+
+	// ForEachNewIndexIDs iterates through each of the new index IDs.
+	// iterutil.Done is supported.
+	ForEachNewIndexIDs(fn func(id descpb.IndexID) error) error
+
+	// HasLocalityConfig returns true iff the locality config is swapped also.
+	HasLocalityConfig() bool
+
+	// LocalityConfigSwap returns the locality config swap, if there is one.
+	LocalityConfigSwap() descpb.PrimaryKeySwap_LocalityConfigSwap
 }
 
 // ComputedColumnSwap is an interface around a computed column swap mutation.
@@ -297,6 +347,21 @@ type MaterializedViewRefresh interface {
 
 	// MaterializedViewRefreshDesc returns the underlying protobuf descriptor.
 	MaterializedViewRefreshDesc() *descpb.MaterializedViewRefresh
+
+	// ShouldBackfill returns true iff the query should be backfilled into the
+	// indexes.
+	ShouldBackfill() bool
+
+	// AsOf returns the timestamp at which the query should be run.
+	AsOf() hlc.Timestamp
+
+	// ForEachIndexID iterates through each of the index IDs.
+	// iterutil.Done is supported.
+	ForEachIndexID(func(id descpb.IndexID) error) error
+
+	// TableWithNewIndexes returns a new TableDescriptor based on the old one
+	// but with the refreshed indexes put in.
+	TableWithNewIndexes(tbl TableDescriptor) TableDescriptor
 }
 
 func isIndexInSearchSet(desc TableDescriptor, opts IndexOpts, idx Index) bool {
@@ -489,4 +554,27 @@ func ColumnTypesWithVirtualCol(columns []Column, virtualCol Column) []*types.T {
 		}
 	}
 	return t
+}
+
+// ColumnNeedsBackfill returns true if adding or dropping (according to
+// the direction) the given column requires backfill.
+func ColumnNeedsBackfill(col Column) bool {
+	if col.IsVirtual() {
+		// Virtual columns are not stored in the primary index, so they do not need
+		// backfill.
+		return false
+	}
+	if col.Dropped() {
+		// In all other cases, DROP requires backfill.
+		return true
+	}
+	// ADD requires backfill for:
+	//  - columns with non-NULL default value
+	//  - computed columns
+	//  - non-nullable columns (note: if a non-nullable column doesn't have a
+	//    default value, the backfill will fail unless the table is empty).
+	if col.ColumnDesc().HasNullDefault() {
+		return false
+	}
+	return col.HasDefault() || !col.IsNullable() || col.IsComputed()
 }

--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//pkg/util/errorutil/unimplemented",
         "//pkg/util/hlc",
         "//pkg/util/interval",
+        "//pkg/util/iterutil",
         "//pkg/util/log",
         "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/catalog/tabledesc/helpers_test.go
+++ b/pkg/sql/catalog/tabledesc/helpers_test.go
@@ -12,6 +12,7 @@ package tabledesc
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/errors"
 )
 
@@ -34,3 +35,13 @@ func GetPostDeserializationChanges(
 }
 
 var FitColumnToFamily = fitColumnToFamily
+
+func TestingMakeColumn(
+	direction descpb.DescriptorMutation_Direction, desc *descpb.ColumnDescriptor,
+) catalog.Column {
+	return &column{
+		maybeMutation: maybeMutation{mutationDirection: direction},
+		desc:          desc,
+		ordinal:       0,
+	}
+}

--- a/pkg/sql/catalog/tabledesc/mutation.go
+++ b/pkg/sql/catalog/tabledesc/mutation.go
@@ -13,6 +13,8 @@ package tabledesc
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 )
 
 var _ catalog.TableElementMaybeMutation = maybeMutation{}
@@ -71,6 +73,7 @@ func (mm maybeMutation) Dropped() bool {
 }
 
 // constraintToUpdate implements the catalog.ConstraintToUpdate interface.
+// It also
 type constraintToUpdate struct {
 	maybeMutation
 	desc *descpb.ConstraintToUpdate
@@ -79,6 +82,53 @@ type constraintToUpdate struct {
 // ConstraintToUpdateDesc returns the underlying protobuf descriptor.
 func (c constraintToUpdate) ConstraintToUpdateDesc() *descpb.ConstraintToUpdate {
 	return c.desc
+}
+
+// GetName returns the name of this constraint update mutation.
+func (c constraintToUpdate) GetName() string {
+	return c.desc.Name
+}
+
+// IsCheck returns true iff this is an update for a check constraint.
+func (c constraintToUpdate) IsCheck() bool {
+	return c.desc.ConstraintType == descpb.ConstraintToUpdate_CHECK
+}
+
+// Check returns the underlying check constraint, if there is one.
+func (c constraintToUpdate) Check() descpb.TableDescriptor_CheckConstraint {
+	return c.desc.Check
+}
+
+// IsForeignKey returns true iff this is an update for a fk constraint.
+func (c constraintToUpdate) IsForeignKey() bool {
+	return c.desc.ConstraintType == descpb.ConstraintToUpdate_FOREIGN_KEY
+}
+
+// ForeignKey returns the underlying fk constraint, if there is one.
+func (c constraintToUpdate) ForeignKey() descpb.ForeignKeyConstraint {
+	return c.desc.ForeignKey
+}
+
+// IsNotNull returns true iff this is an update for a not-null constraint.
+func (c constraintToUpdate) IsNotNull() bool {
+	return c.desc.ConstraintType == descpb.ConstraintToUpdate_NOT_NULL
+}
+
+// NotNullColumnID returns the underlying not-null column ID, if there is one.
+func (c constraintToUpdate) NotNullColumnID() descpb.ColumnID {
+	return c.desc.NotNullColumn
+}
+
+// IsUniqueWithoutIndex returns true iff this is an update for a unique without
+// index constraint.
+func (c constraintToUpdate) IsUniqueWithoutIndex() bool {
+	return c.desc.ConstraintType == descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX
+}
+
+// UniqueWithoutIndex returns the underlying unique without index constraint, if
+// there is one.
+func (c constraintToUpdate) UniqueWithoutIndex() descpb.UniqueWithoutIndexConstraint {
+	return c.desc.UniqueWithoutIndexConstraint
 }
 
 // primaryKeySwap implements the catalog.PrimaryKeySwap interface.
@@ -90,6 +140,60 @@ type primaryKeySwap struct {
 // PrimaryKeySwapDesc returns the underlying protobuf descriptor.
 func (c primaryKeySwap) PrimaryKeySwapDesc() *descpb.PrimaryKeySwap {
 	return c.desc
+}
+
+// NumOldIndexes returns the number of old active indexes to swap out.
+func (c primaryKeySwap) NumOldIndexes() int {
+	return 1 + len(c.desc.OldIndexes)
+}
+
+// ForEachOldIndexIDs iterates through each of the old index IDs.
+// iterutil.Done is supported.
+func (c primaryKeySwap) ForEachOldIndexIDs(fn func(id descpb.IndexID) error) error {
+	return c.forEachIndexIDs(c.desc.OldPrimaryIndexId, c.desc.OldIndexes, fn)
+}
+
+// NumNewIndexes returns the number of new active indexes to swap in.
+func (c primaryKeySwap) NumNewIndexes() int {
+	return 1 + len(c.desc.NewIndexes)
+}
+
+// ForEachNewIndexIDs iterates through each of the new index IDs.
+// iterutil.Done is supported.
+func (c primaryKeySwap) ForEachNewIndexIDs(fn func(id descpb.IndexID) error) error {
+	return c.forEachIndexIDs(c.desc.NewPrimaryIndexId, c.desc.NewIndexes, fn)
+}
+
+func (c primaryKeySwap) forEachIndexIDs(
+	pkID descpb.IndexID, secIDs []descpb.IndexID, fn func(id descpb.IndexID) error,
+) error {
+	err := fn(pkID)
+	if err != nil {
+		if iterutil.Done(err) {
+			return nil
+		}
+		return err
+	}
+	for _, id := range secIDs {
+		err = fn(id)
+		if err != nil {
+			if iterutil.Done(err) {
+				return nil
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+// HasLocalityConfig returns true iff the locality config is swapped also.
+func (c primaryKeySwap) HasLocalityConfig() bool {
+	return c.desc.LocalityConfigSwap != nil
+}
+
+// LocalityConfigSwap returns the locality config swap, if there is one.
+func (c primaryKeySwap) LocalityConfigSwap() descpb.PrimaryKeySwap_LocalityConfigSwap {
+	return *c.desc.LocalityConfigSwap
 }
 
 // computedColumnSwap implements the catalog.ComputedColumnSwap interface.
@@ -112,6 +216,50 @@ type materializedViewRefresh struct {
 // MaterializedViewRefreshDesc returns the underlying protobuf descriptor.
 func (c materializedViewRefresh) MaterializedViewRefreshDesc() *descpb.MaterializedViewRefresh {
 	return c.desc
+}
+
+// ShouldBackfill returns true iff the query should be backfilled into the
+// indexes.
+func (c materializedViewRefresh) ShouldBackfill() bool {
+	return c.desc.ShouldBackfill
+}
+
+// AsOf returns the timestamp at which the query should be run.
+func (c materializedViewRefresh) AsOf() hlc.Timestamp {
+	return c.desc.AsOf
+}
+
+// ForEachIndexID iterates through each of the index IDs.
+// iterutil.Done is supported.
+func (c materializedViewRefresh) ForEachIndexID(fn func(id descpb.IndexID) error) error {
+	err := fn(c.desc.NewPrimaryIndex.ID)
+	if err != nil {
+		if iterutil.Done(err) {
+			return nil
+		}
+		return err
+	}
+	for i := range c.desc.NewIndexes {
+		err = fn(c.desc.NewIndexes[i].ID)
+		if err != nil {
+			if iterutil.Done(err) {
+				return nil
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+// TableWithNewIndexes returns a new TableDescriptor based on the old one
+// but with the refreshed indexes put in.
+func (c materializedViewRefresh) TableWithNewIndexes(
+	tbl catalog.TableDescriptor,
+) catalog.TableDescriptor {
+	deepCopy := NewBuilder(tbl.TableDesc()).BuildCreatedMutableTable().TableDesc()
+	deepCopy.PrimaryIndex = c.desc.NewPrimaryIndex
+	deepCopy.Indexes = c.desc.NewIndexes
+	return NewBuilder(deepCopy).BuildImmutableTable()
 }
 
 // mutation implements the

--- a/pkg/sql/catalog/tabledesc/structured_test.go
+++ b/pkg/sql/catalog/tabledesc/structured_test.go
@@ -446,10 +446,10 @@ func TestColumnNeedsBackfill(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		if ColumnNeedsBackfill(descpb.DescriptorMutation_ADD, &tc.desc) != tc.add {
+		if catalog.ColumnNeedsBackfill(TestingMakeColumn(descpb.DescriptorMutation_ADD, &tc.desc)) != tc.add {
 			t.Errorf("expected ColumnNeedsBackfill to be %v for adding %s", tc.add, tc.info)
 		}
-		if ColumnNeedsBackfill(descpb.DescriptorMutation_DROP, &tc.desc) != tc.drop {
+		if catalog.ColumnNeedsBackfill(TestingMakeColumn(descpb.DescriptorMutation_DROP, &tc.desc)) != tc.drop {
 			t.Errorf("expected ColumnNeedsBackfill to be %v for dropping %s", tc.drop, tc.info)
 		}
 	}

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -1481,12 +1481,11 @@ func (p *planner) validateZoneConfigForMultiRegionTable(
 	regionalByRowNewIndexes := make(map[uint32]struct{})
 	for _, mut := range desc.AllMutations() {
 		if pkSwap := mut.AsPrimaryKeySwap(); pkSwap != nil {
-			swapDesc := pkSwap.PrimaryKeySwapDesc()
-			if swapDesc.LocalityConfigSwap != nil {
-				for _, id := range swapDesc.NewIndexes {
+			if pkSwap.HasLocalityConfig() {
+				_ = pkSwap.ForEachNewIndexIDs(func(id descpb.IndexID) error {
 					regionalByRowNewIndexes[uint32(id)] = struct{}{}
-				}
-				regionalByRowNewIndexes[uint32(swapDesc.NewPrimaryIndexId)] = struct{}{}
+					return nil
+				})
 			}
 			// There can only be one pkSwap at a time, so break now.
 			break

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -220,10 +220,10 @@ func (e errTableVersionMismatch) Error() string {
 
 // refreshMaterializedView updates the physical data for a materialized view.
 func (sc *SchemaChanger) refreshMaterializedView(
-	ctx context.Context, table *tabledesc.Mutable, refresh *descpb.MaterializedViewRefresh,
+	ctx context.Context, table *tabledesc.Mutable, refresh catalog.MaterializedViewRefresh,
 ) error {
 	// If we aren't requested to backfill any data, then return immediately.
-	if !refresh.ShouldBackfill {
+	if !refresh.ShouldBackfill() {
 		return nil
 	}
 	// The data for the materialized view is stored under the current set of
@@ -233,14 +233,12 @@ func (sc *SchemaChanger) refreshMaterializedView(
 	// set of indexes. We then backfill into this modified table, which writes
 	// data only to the new desired indexes. In SchemaChanger.done(), we'll swap
 	// the indexes from the old versions into the new ones.
-	tableToRefresh := protoutil.Clone(table.TableDesc()).(*descpb.TableDescriptor)
-	tableToRefresh.PrimaryIndex = refresh.NewPrimaryIndex
-	tableToRefresh.Indexes = refresh.NewIndexes
-	return sc.backfillQueryIntoTable(ctx, tableToRefresh, table.ViewQuery, refresh.AsOf, "refreshView")
+	tableToRefresh := refresh.TableWithNewIndexes(table)
+	return sc.backfillQueryIntoTable(ctx, tableToRefresh, table.ViewQuery, refresh.AsOf(), "refreshView")
 }
 
 func (sc *SchemaChanger) backfillQueryIntoTable(
-	ctx context.Context, table *descpb.TableDescriptor, query string, ts hlc.Timestamp, desc string,
+	ctx context.Context, table catalog.TableDescriptor, query string, ts hlc.Timestamp, desc string,
 ) error {
 	if fn := sc.testingKnobs.RunBeforeQueryBackfill; fn != nil {
 		if err := fn(); err != nil {
@@ -329,7 +327,7 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 				localPlanner.curPlan.main,
 			).WillDistribute()
 			out := execinfrapb.ProcessorCoreUnion{BulkRowWriter: &execinfrapb.BulkRowWriterSpec{
-				Table: *table,
+				Table: *table.TableDesc(),
 			}}
 
 			PlanAndRunCTAS(ctx, sc.distSQLPlanner, localPlanner,
@@ -358,7 +356,7 @@ func (sc *SchemaChanger) maybeBackfillCreateTableAs(
 	}
 	log.Infof(ctx, "starting backfill for CREATE TABLE AS with query %q", table.GetCreateQuery())
 
-	return sc.backfillQueryIntoTable(ctx, table.TableDesc(), table.GetCreateQuery(), table.GetCreateAsOfTime(), "ctasBackfill")
+	return sc.backfillQueryIntoTable(ctx, table, table.GetCreateQuery(), table.GetCreateAsOfTime(), "ctasBackfill")
 }
 
 func (sc *SchemaChanger) maybeBackfillMaterializedView(
@@ -369,7 +367,7 @@ func (sc *SchemaChanger) maybeBackfillMaterializedView(
 	}
 	log.Infof(ctx, "starting backfill for CREATE MATERIALIZED VIEW with query %q", table.GetViewQuery())
 
-	return sc.backfillQueryIntoTable(ctx, table.TableDesc(), table.GetViewQuery(), table.GetCreateAsOfTime(), "materializedViewBackfill")
+	return sc.backfillQueryIntoTable(ctx, table, table.GetViewQuery(), table.GetCreateAsOfTime(), "materializedViewBackfill")
 }
 
 // maybe make a table PUBLIC if it's in the ADD state.
@@ -905,38 +903,30 @@ func (sc *SchemaChanger) RunStateMachineBeforeBackfill(ctx context.Context) erro
 		}
 		runStatus = ""
 		// Apply mutations belonging to the same version.
-		for i, mutation := range tbl.Mutations {
-			if mutation.MutationID != sc.mutationID {
+		for _, m := range tbl.AllMutations() {
+			if m.MutationID() != sc.mutationID {
 				// Mutations are applied in a FIFO order. Only apply the first set of
 				// mutations if they have the mutation ID we're looking for.
 				break
 			}
-			switch mutation.Direction {
-			case descpb.DescriptorMutation_ADD:
-				switch mutation.State {
-				case descpb.DescriptorMutation_DELETE_ONLY:
+			if m.Adding() {
+				if m.DeleteOnly() {
 					// TODO(vivek): while moving up the state is appropriate,
 					// it will be better to run the backfill of a unique index
 					// twice: once in the DELETE_ONLY state to confirm that
 					// the index can indeed be created, and subsequently in the
 					// DELETE_AND_WRITE_ONLY state to fill in the missing elements of the
 					// index (INSERT and UPDATE that happened in the interim).
-					tbl.Mutations[i].State = descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY
+					tbl.Mutations[m.MutationOrdinal()].State = descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY
 					runStatus = RunningStatusDeleteAndWriteOnly
-
-				case descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY:
-					// The state change has already moved forward.
 				}
-
-			case descpb.DescriptorMutation_DROP:
-				switch mutation.State {
-				case descpb.DescriptorMutation_DELETE_ONLY:
-					// The state change has already moved forward.
-
-				case descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY:
-					tbl.Mutations[i].State = descpb.DescriptorMutation_DELETE_ONLY
+				// else if DELETE_AND_WRITE_ONLY, then the state change has already moved forward.
+			} else if m.Dropped() {
+				if m.WriteAndDeleteOnly() {
+					tbl.Mutations[m.MutationOrdinal()].State = descpb.DescriptorMutation_DELETE_ONLY
 					runStatus = RunningStatusDeleteOnly
 				}
+				// else if DELETE_ONLY, then the state change has already moved forward.
 			}
 			// We might have to update some zone configs for indexes that are
 			// being rewritten. It is important that this is done _before_ the
@@ -948,7 +938,7 @@ func (sc *SchemaChanger) RunStateMachineBeforeBackfill(ctx context.Context) erro
 				txn,
 				dbDesc,
 				tbl,
-				mutation,
+				m,
 				false, // isDone
 				descsCol,
 			); err != nil {
@@ -984,13 +974,13 @@ func (sc *SchemaChanger) RunStateMachineBeforeBackfill(ctx context.Context) erro
 }
 
 func (sc *SchemaChanger) createIndexGCJob(
-	ctx context.Context, index *descpb.IndexDescriptor, txn *kv.Txn, jobDesc string,
+	ctx context.Context, indexID descpb.IndexID, txn *kv.Txn, jobDesc string,
 ) error {
 	dropTime := timeutil.Now().UnixNano()
 	indexGCDetails := jobspb.SchemaChangeGCDetails{
 		Indexes: []jobspb.SchemaChangeGCDetails_DroppedIndex{
 			{
-				IndexID:  index.ID,
+				IndexID:  indexID,
 				DropTime: dropTime,
 			},
 		},
@@ -1081,23 +1071,22 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 
 		var i int           // set to determine whether there is a mutation
 		var isRollback bool // set based on the mutation
-		for _, mutation := range scTable.Mutations {
-			if mutation.MutationID != sc.mutationID {
+		for _, m := range scTable.AllMutations() {
+			if m.MutationID() != sc.mutationID {
 				// Mutations are applied in a FIFO order. Only apply the first set of
 				// mutations if they have the mutation ID we're looking for.
 				break
 			}
-			isRollback = mutation.Rollback
-			if indexDesc := mutation.GetIndex(); mutation.Direction == descpb.DescriptorMutation_DROP &&
-				indexDesc != nil {
-				if canClearRangeForDrop(indexDesc) {
+			isRollback = m.IsRollback()
+			if idx := m.AsIndex(); m.Dropped() && idx != nil {
+				if canClearRangeForDrop(idx.IndexDesc()) {
 					// how we keep track of dropped index names (for, e.g., zone config
 					// lookups), even though in the absence of a GC job there's nothing to
 					// clean them up.
 					scTable.GCMutations = append(
 						scTable.GCMutations,
 						descpb.TableDescriptor_GCDescriptorMutation{
-							IndexID: indexDesc.ID,
+							IndexID: idx.GetID(),
 						})
 
 					description := sc.job.Payload().Description
@@ -1105,24 +1094,22 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 						description = "ROLLBACK of " + description
 					}
 
-					if err := sc.createIndexGCJob(ctx, indexDesc, txn, description); err != nil {
+					if err := sc.createIndexGCJob(ctx, idx.GetID(), txn, description); err != nil {
 						return err
 					}
 				}
 			}
-			if constraint := mutation.GetConstraint(); constraint != nil &&
-				constraint.ConstraintType == descpb.ConstraintToUpdate_FOREIGN_KEY &&
-				mutation.Direction == descpb.DescriptorMutation_ADD &&
-				constraint.ForeignKey.Validity == descpb.ConstraintValidity_Unvalidated {
-				// Add backreference on the referenced table (which could be the same table)
-				backrefTable, err := descsCol.GetMutableTableVersionByID(ctx,
-					constraint.ForeignKey.ReferencedTableID, txn)
-				if err != nil {
-					return err
-				}
-				backrefTable.InboundFKs = append(backrefTable.InboundFKs, constraint.ForeignKey)
-				if err := descsCol.WriteDescToBatch(ctx, kvTrace, backrefTable, b); err != nil {
-					return err
+			if constraint := m.AsConstraint(); constraint != nil && constraint.Adding() {
+				if constraint.IsForeignKey() && constraint.ForeignKey().Validity == descpb.ConstraintValidity_Unvalidated {
+					// Add backreference on the referenced table (which could be the same table)
+					backrefTable, err := descsCol.GetMutableTableVersionByID(ctx, constraint.ForeignKey().ReferencedTableID, txn)
+					if err != nil {
+						return err
+					}
+					backrefTable.InboundFKs = append(backrefTable.InboundFKs, constraint.ForeignKey())
+					if err := descsCol.WriteDescToBatch(ctx, kvTrace, backrefTable, b); err != nil {
+						return err
+					}
 				}
 			}
 
@@ -1134,7 +1121,7 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 				txn,
 				dbDesc,
 				scTable,
-				mutation,
+				m,
 				true, // isDone
 				descsCol,
 			); err != nil {
@@ -1145,7 +1132,7 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 			// of the existing indexes in the view. We do this before the call to
 			// MakeMutationComplete, which swaps out the existing indexes for the
 			// backfilled ones.
-			if refresh := mutation.GetMaterializedViewRefresh(); refresh != nil {
+			if refresh := m.AsMaterializedViewRefresh(); refresh != nil {
 				if fn := sc.testingKnobs.RunBeforeMaterializedViewRefreshCommit; fn != nil {
 					if err := fn(); err != nil {
 						return err
@@ -1153,44 +1140,40 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 				}
 				// If we are mutation is in the ADD state, then start GC jobs for the
 				// existing indexes on the table.
-				if mutation.Direction == descpb.DescriptorMutation_ADD {
+				if m.Adding() {
 					desc := fmt.Sprintf("REFRESH MATERIALIZED VIEW %q cleanup", scTable.Name)
-					if err := sc.createIndexGCJob(ctx, scTable.GetPrimaryIndex().IndexDesc(), txn, desc); err != nil {
-						return err
-					}
-					for _, idx := range scTable.PublicNonPrimaryIndexes() {
-						if err := sc.createIndexGCJob(ctx, idx.IndexDesc(), txn, desc); err != nil {
+					for _, idx := range scTable.ActiveIndexes() {
+						if err := sc.createIndexGCJob(ctx, idx.GetID(), txn, desc); err != nil {
 							return err
 						}
 					}
-				} else if mutation.Direction == descpb.DescriptorMutation_DROP {
+				} else if m.Dropped() {
 					// Otherwise, the refresh job ran into an error and is being rolled
 					// back. So, we need to GC all of the indexes that were going to be
 					// created, in case any data was written to them.
 					desc := fmt.Sprintf("ROLLBACK OF REFRESH MATERIALIZED VIEW %q", scTable.Name)
-					if err := sc.createIndexGCJob(ctx, &refresh.NewPrimaryIndex, txn, desc); err != nil {
+					err = refresh.ForEachIndexID(func(id descpb.IndexID) error {
+						return sc.createIndexGCJob(ctx, id, txn, desc)
+					})
+					if err != nil {
 						return err
-					}
-					for i := range refresh.NewIndexes {
-						if err := sc.createIndexGCJob(ctx, &refresh.NewIndexes[i], txn, desc); err != nil {
-							return err
-						}
 					}
 				}
 			}
 
-			if err := scTable.MakeMutationComplete(mutation); err != nil {
+			if err := scTable.MakeMutationComplete(scTable.Mutations[m.MutationOrdinal()]); err != nil {
 				return err
 			}
 
-			if pkSwap := mutation.GetPrimaryKeySwap(); pkSwap != nil {
+			if pkSwap := m.AsPrimaryKeySwap(); pkSwap != nil {
 				if fn := sc.testingKnobs.RunBeforePrimaryKeySwap; fn != nil {
 					fn()
 				}
 				// For locality swaps, ensure the table descriptor fields are correctly filled.
-				if lcSwap := pkSwap.LocalityConfigSwap; lcSwap != nil {
+				if pkSwap.HasLocalityConfig() {
+					lcSwap := pkSwap.LocalityConfigSwap()
 					localityConfigToSwapTo := lcSwap.NewLocalityConfig
-					if mutation.Direction == descpb.DescriptorMutation_ADD {
+					if m.Adding() {
 						// Sanity check that locality has not been changed during backfill.
 						if !scTable.LocalityConfig.Equal(lcSwap.OldLocalityConfig) {
 							return errors.AssertionFailedf(
@@ -1235,8 +1218,7 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 				// backreference from the parent.
 				// N.B. This logic needs to be kept up to date with the
 				// corresponding piece in runSchemaChangesInTxn.
-				for _, idxID := range append(
-					[]descpb.IndexID{pkSwap.OldPrimaryIndexId}, pkSwap.OldIndexes...) {
+				err := pkSwap.ForEachOldIndexIDs(func(idxID descpb.IndexID) error {
 					oldIndex, err := scTable.FindIndexWithID(idxID)
 					if err != nil {
 						return err
@@ -1269,6 +1251,10 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 							}
 						}
 					}
+					return nil
+				})
+				if err != nil {
+					return err
 				}
 				// If we performed MakeMutationComplete on a PrimaryKeySwap mutation, then we need to start
 				// a job for the index deletion mutations that the primary key swap mutation added, if any.
@@ -1277,7 +1263,7 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 				}
 			}
 
-			if computedColumnSwap := mutation.GetComputedColumnSwap(); computedColumnSwap != nil {
+			if m.AsComputedColumnSwap() != nil {
 				if fn := sc.testingKnobs.RunBeforeComputedColumnSwap; fn != nil {
 					fn()
 				}
@@ -1296,7 +1282,7 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 			// The table descriptor is unchanged, return without writing anything.
 			return nil
 		}
-		committedMutations := scTable.Mutations[:i]
+		committedMutations := scTable.AllMutations()[:i]
 		// Trim the executed mutations from the descriptor.
 		scTable.Mutations = scTable.Mutations[i:]
 
@@ -1573,54 +1559,52 @@ func (sc *SchemaChanger) maybeReverseMutations(ctx context.Context, causingError
 		columns := make(map[string]struct{})
 		droppedMutations = nil
 		b := txn.NewBatch()
-		for i, mutation := range scTable.Mutations {
-			if mutation.MutationID != sc.mutationID {
+		for _, m := range scTable.AllMutations() {
+			if m.MutationID() != sc.mutationID {
 				break
 			}
 
-			if mutation.Rollback {
+			if m.IsRollback() {
 				// Can actually never happen. Since we should have checked for this case
 				// above.
-				return errors.AssertionFailedf("mutation already rolled back: %v", mutation)
+				return errors.AssertionFailedf("mutation already rolled back: %v", scTable.Mutations[m.MutationOrdinal()])
 			}
 
 			// Ignore mutations that would be skipped, nothing
 			// to reverse here.
-			if discarded, _ := isCurrentMutationDiscarded(scTable, mutation, i+1); discarded {
+			if discarded, _ := isCurrentMutationDiscarded(scTable, m, m.MutationOrdinal()+1); discarded {
 				continue
 			}
 
-			log.Warningf(ctx, "reverse schema change mutation: %+v", mutation)
-			scTable.Mutations[i], columns = sc.reverseMutation(mutation, false /*notStarted*/, columns)
+			log.Warningf(ctx, "reverse schema change mutation: %+v", scTable.Mutations[m.MutationOrdinal()])
+			scTable.Mutations[m.MutationOrdinal()], columns = sc.reverseMutation(scTable.Mutations[m.MutationOrdinal()], false /*notStarted*/, columns)
 
 			// If the mutation is for validating a constraint that is being added,
 			// drop the constraint because validation has failed.
-			if constraint := mutation.GetConstraint(); constraint != nil &&
-				mutation.Direction == descpb.DescriptorMutation_ADD {
-				log.Warningf(ctx, "dropping constraint %+v", constraint)
+			if constraint := m.AsConstraint(); constraint != nil && constraint.Adding() {
+				log.Warningf(ctx, "dropping constraint %+v", constraint.ConstraintToUpdateDesc())
 				if err := sc.maybeDropValidatingConstraint(ctx, scTable, constraint); err != nil {
 					return err
 				}
 				// Get the foreign key backreferences to remove.
-				if constraint.ConstraintType == descpb.ConstraintToUpdate_FOREIGN_KEY {
-					fk := &constraint.ForeignKey
-					backrefTable, err := descsCol.GetMutableTableVersionByID(ctx, fk.ReferencedTableID, txn)
+				if constraint.IsForeignKey() {
+					backrefTable, err := descsCol.GetMutableTableVersionByID(ctx, constraint.ForeignKey().ReferencedTableID, txn)
 					if err != nil {
 						return err
 					}
-					if err := removeFKBackReferenceFromTable(backrefTable, fk.Name, scTable); err != nil {
+					if err := removeFKBackReferenceFromTable(backrefTable, constraint.GetName(), scTable); err != nil {
 						// The function being called will return an assertion error if the
 						// backreference was not found, but it may not have been installed
 						// during the incomplete schema change, so we swallow the error.
 						log.Infof(ctx,
-							"error attempting to remove backreference %s during rollback: %s", fk.Name, err)
+							"error attempting to remove backreference %s during rollback: %s", constraint.GetName(), err)
 					}
 					if err := descsCol.WriteDescToBatch(ctx, kvTrace, backrefTable, b); err != nil {
 						return err
 					}
 				}
 			}
-			scTable.Mutations[i].Rollback = true
+			scTable.Mutations[m.MutationOrdinal()].Rollback = true
 		}
 
 		// Delete all mutations that reference any of the reversed columns
@@ -1725,15 +1709,14 @@ func (sc *SchemaChanger) updateJobForRollback(
 }
 
 func (sc *SchemaChanger) maybeDropValidatingConstraint(
-	ctx context.Context, desc *tabledesc.Mutable, constraint *descpb.ConstraintToUpdate,
+	ctx context.Context, desc *tabledesc.Mutable, constraint catalog.ConstraintToUpdate,
 ) error {
-	switch constraint.ConstraintType {
-	case descpb.ConstraintToUpdate_CHECK, descpb.ConstraintToUpdate_NOT_NULL:
-		if constraint.Check.Validity == descpb.ConstraintValidity_Unvalidated {
+	if constraint.IsCheck() || constraint.IsNotNull() {
+		if constraint.Check().Validity == descpb.ConstraintValidity_Unvalidated {
 			return nil
 		}
 		for j, c := range desc.Checks {
-			if c.Name == constraint.Check.Name {
+			if c.Name == constraint.Check().Name {
 				desc.Checks = append(desc.Checks[:j], desc.Checks[j+1:]...)
 				return nil
 			}
@@ -1741,11 +1724,11 @@ func (sc *SchemaChanger) maybeDropValidatingConstraint(
 		log.Infof(
 			ctx,
 			"attempted to drop constraint %s, but it hadn't been added to the table descriptor yet",
-			constraint.Check.Name,
+			constraint.Check().Name,
 		)
-	case descpb.ConstraintToUpdate_FOREIGN_KEY:
+	} else if constraint.IsForeignKey() {
 		for i, fk := range desc.OutboundFKs {
-			if fk.Name == constraint.ForeignKey.Name {
+			if fk.Name == constraint.ForeignKey().Name {
 				desc.OutboundFKs = append(desc.OutboundFKs[:i], desc.OutboundFKs[i+1:]...)
 				return nil
 			}
@@ -1753,14 +1736,14 @@ func (sc *SchemaChanger) maybeDropValidatingConstraint(
 		log.Infof(
 			ctx,
 			"attempted to drop constraint %s, but it hadn't been added to the table descriptor yet",
-			constraint.ForeignKey.Name,
+			constraint.ForeignKey().Name,
 		)
-	case descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX:
-		if constraint.UniqueWithoutIndexConstraint.Validity == descpb.ConstraintValidity_Unvalidated {
+	} else if constraint.IsUniqueWithoutIndex() {
+		if constraint.UniqueWithoutIndex().Validity == descpb.ConstraintValidity_Unvalidated {
 			return nil
 		}
 		for j, c := range desc.UniqueWithoutIndexConstraints {
-			if c.Name == constraint.UniqueWithoutIndexConstraint.Name {
+			if c.Name == constraint.UniqueWithoutIndex().Name {
 				desc.UniqueWithoutIndexConstraints = append(
 					desc.UniqueWithoutIndexConstraints[:j], desc.UniqueWithoutIndexConstraints[j+1:]...,
 				)
@@ -1770,10 +1753,10 @@ func (sc *SchemaChanger) maybeDropValidatingConstraint(
 		log.Infof(
 			ctx,
 			"attempted to drop constraint %s, but it hadn't been added to the table descriptor yet",
-			constraint.UniqueWithoutIndexConstraint.Name,
+			constraint.UniqueWithoutIndex().Name,
 		)
-	default:
-		return errors.AssertionFailedf("unsupported constraint type: %d", errors.Safe(constraint.ConstraintType))
+	} else {
+		return errors.AssertionFailedf("unsupported constraint type: %d", constraint.ConstraintToUpdateDesc().ConstraintType)
 	}
 	return nil
 }
@@ -1818,8 +1801,9 @@ func (sc *SchemaChanger) deleteIndexMutationsWithReversedColumns(
 		}
 		// Drop mutations.
 		newMutations := make([]descpb.DescriptorMutation, 0, len(desc.Mutations))
-		for _, mutation := range desc.Mutations {
-			if _, ok := dropMutations[mutation.MutationID]; ok {
+		for _, m := range desc.AllMutations() {
+			mutation := desc.Mutations[m.MutationOrdinal()]
+			if _, ok := dropMutations[m.MutationID()]; ok {
 				// Reverse mutation. Update columns to reflect additional
 				// columns that have been purged. This mutation doesn't need
 				// a rollback because it was not started.
@@ -2438,21 +2422,22 @@ func (sc *SchemaChanger) applyZoneConfigChangeForMutation(
 	txn *kv.Txn,
 	dbDesc catalog.DatabaseDescriptor,
 	tableDesc *tabledesc.Mutable,
-	mutation descpb.DescriptorMutation,
+	mutation catalog.Mutation,
 	isDone bool,
 	descsCol *descs.Collection,
 ) error {
-	if pkSwap := mutation.GetPrimaryKeySwap(); pkSwap != nil {
-		if lcSwap := pkSwap.LocalityConfigSwap; lcSwap != nil {
+	if pkSwap := mutation.AsPrimaryKeySwap(); pkSwap != nil {
+		if pkSwap.HasLocalityConfig() {
 			// We will add up to three options - one for the table itself,
 			// one for dropping any zone configs for old indexes and one
 			// for all the new indexes associated with the table.
 			opts := make([]applyZoneConfigForMultiRegionTableOption, 0, 3)
+			lcSwap := pkSwap.LocalityConfigSwap()
 
 			// For locality configs, we need to update the zone configs to match
 			// the new multi-region locality configuration, instead of
 			// copying the old zone configs over.
-			if mutation.Direction == descpb.DescriptorMutation_ADD {
+			if mutation.Adding() {
 				// Only apply the zone configuration on the table when the mutation
 				// is complete.
 				if isDone {
@@ -2460,15 +2445,12 @@ func (sc *SchemaChanger) applyZoneConfigChangeForMutation(
 					// us here, but if we're coming from REGIONAL BY ROW, it's also
 					// necessary to drop the zone configurations on the index partitions.
 					if lcSwap.OldLocalityConfig.GetRegionalByRow() != nil {
-						opts = append(
-							opts,
-							dropZoneConfigsForMultiRegionIndexes(
-								append(
-									[]descpb.IndexID{pkSwap.OldPrimaryIndexId},
-									pkSwap.OldIndexes...,
-								)...,
-							),
-						)
+						oldIndexIDs := make([]descpb.IndexID, 0, pkSwap.NumOldIndexes())
+						_ = pkSwap.ForEachOldIndexIDs(func(id descpb.IndexID) error {
+							oldIndexIDs = append(oldIndexIDs, id)
+							return nil
+						})
+						opts = append(opts, dropZoneConfigsForMultiRegionIndexes(oldIndexIDs...))
 					}
 
 					opts = append(
@@ -2483,15 +2465,12 @@ func (sc *SchemaChanger) applyZoneConfigChangeForMutation(
 					*descpb.TableDescriptor_LocalityConfig_RegionalByTable_:
 				case *descpb.TableDescriptor_LocalityConfig_RegionalByRow_:
 					// Apply new zone configurations for all newly partitioned indexes.
-					opts = append(
-						opts,
-						applyZoneConfigForMultiRegionTableOptionNewIndexes(
-							append(
-								[]descpb.IndexID{pkSwap.NewPrimaryIndexId},
-								pkSwap.NewIndexes...,
-							)...,
-						),
-					)
+					newIndexIDs := make([]descpb.IndexID, 0, pkSwap.NumNewIndexes())
+					_ = pkSwap.ForEachNewIndexIDs(func(id descpb.IndexID) error {
+						newIndexIDs = append(newIndexIDs, id)
+						return nil
+					})
+					opts = append(opts, applyZoneConfigForMultiRegionTableOptionNewIndexes(newIndexIDs...))
 				default:
 					return errors.AssertionFailedf(
 						"unknown locality on PK swap: %T",
@@ -2526,7 +2505,7 @@ func (sc *SchemaChanger) applyZoneConfigChangeForMutation(
 		// for any new indexes.
 		// Note this is done even for isDone = true, though not strictly necessary.
 		return maybeUpdateZoneConfigsForPKChange(
-			ctx, txn, sc.execCfg, tableDesc, pkSwap,
+			ctx, txn, sc.execCfg, tableDesc, pkSwap.PrimaryKeySwapDesc(),
 		)
 	}
 	return nil
@@ -2560,7 +2539,7 @@ func DeleteTableDescAndZoneConfig(
 // A will have a unique index, but it later gets dropped. Then for this mutation
 // to be successful the drop column job has to be successful too.
 func (sc *SchemaChanger) getDependentMutationsJobs(
-	ctx context.Context, tableDesc *tabledesc.Mutable, mutations []descpb.DescriptorMutation,
+	ctx context.Context, tableDesc *tabledesc.Mutable, mutations []catalog.Mutation,
 ) ([]jobspb.JobID, error) {
 	dependentJobs := make([]jobspb.JobID, 0, len(tableDesc.MutationJobs))
 	for _, m := range mutations {
@@ -2581,38 +2560,35 @@ func (sc *SchemaChanger) getDependentMutationsJobs(
 // by a later operation. The nextMutationIdx provides the index at which to check for
 // later mutation.
 func isCurrentMutationDiscarded(
-	tableDesc *tabledesc.Mutable, currentMutation descpb.DescriptorMutation, nextMutationIdx int,
+	tableDesc *tabledesc.Mutable, currentMutation catalog.Mutation, nextMutationIdx int,
 ) (bool, descpb.MutationID) {
 	if nextMutationIdx+1 > len(tableDesc.Mutations) {
 		return false, descpb.InvalidMutationID
 	}
-	// Drops will never get canceled out, since we need
-	// clean up.
-	if currentMutation.Direction == descpb.DescriptorMutation_DROP {
+	// Drops will never get canceled out, since we need clean up.
+	if currentMutation.Dropped() {
 		return false, descpb.InvalidMutationID
 	}
 
 	colToCheck := make([]descpb.ColumnID, 0, 1)
 	// Both NOT NULL related updates and check constraint updates
 	// involving this column will get canceled out by a drop column.
-	if constraint := currentMutation.GetConstraint(); constraint != nil {
-		if constraint.ConstraintType == descpb.ConstraintToUpdate_NOT_NULL {
-			colToCheck = append(colToCheck, constraint.NotNullColumn)
-		} else if constraint.ConstraintType == descpb.ConstraintToUpdate_CHECK {
-			colToCheck = constraint.Check.ColumnIDs
+	if constraint := currentMutation.AsConstraint(); constraint != nil {
+		if constraint.IsNotNull() {
+			colToCheck = append(colToCheck, constraint.NotNullColumnID())
+		} else if constraint.IsCheck() {
+			colToCheck = constraint.Check().ColumnIDs
 		}
 	}
 
-	for _, m := range tableDesc.Mutations[nextMutationIdx:] {
-		colDesc := m.GetColumn()
-		if m.Direction == descpb.DescriptorMutation_DROP &&
-			colDesc != nil &&
-			!m.Rollback {
+	for _, m := range tableDesc.AllMutations()[nextMutationIdx:] {
+		col := m.AsColumn()
+		if col != nil && col.Dropped() && !col.IsRollback() {
 			// Column was dropped later on, so this operation
 			// should be a no-op.
-			for _, col := range colToCheck {
-				if colDesc.ID == col {
-					return true, m.MutationID
+			for _, id := range colToCheck {
+				if col.GetID() == id {
+					return true, m.MutationID()
 				}
 			}
 		}

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -360,19 +360,14 @@ func checkTableForDisallowedMutationsWithTruncate(desc *tabledesc.Mutable) error
 						"dropped which depends on another object", desc.GetName(), col.GetName())
 			}
 		} else if c := m.AsConstraint(); c != nil {
-			switch ct := c.ConstraintToUpdateDesc().ConstraintType; ct {
-			case descpb.ConstraintToUpdate_CHECK,
-				descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX,
-				descpb.ConstraintToUpdate_NOT_NULL,
-				descpb.ConstraintToUpdate_FOREIGN_KEY:
+			if c.IsCheck() || c.IsNotNull() || c.IsForeignKey() || c.IsUniqueWithoutIndex() {
 				return unimplemented.Newf(
 					"TRUNCATE concurrent with ongoing schema change",
 					"cannot perform TRUNCATE on %q which has an ongoing %s "+
-						"constraint change", desc.GetName(), ct)
-			default:
-				return errors.AssertionFailedf("cannot perform TRUNCATE due to "+
-					"unknown constraint type %v on mutation %d in %v", ct, i, desc)
+						"constraint change", desc.GetName(), c.ConstraintToUpdateDesc().ConstraintType)
 			}
+			return errors.AssertionFailedf("cannot perform TRUNCATE due to "+
+				"unknown constraint type %v on mutation %d in %v", c.ConstraintToUpdateDesc().ConstraintType, i, desc)
 		} else if s := m.AsPrimaryKeySwap(); s != nil {
 			return unimplemented.Newf(
 				"TRUNCATE concurrent with ongoing schema change",


### PR DESCRIPTION
This commit is a refactor which introduces catalog.Mutation wherever
possible, in an effort to avoid using the descpb.DescriptorMutation
type directly.

Release note: None