### PR TITLE
release-20.2: sql: ensure "promoted" temporary views are marked as such

### DIFF
--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -176,7 +176,7 @@ func (n *createViewNode) startExec(params runParams) error {
 			privs,
 			&params.p.semaCtx,
 			params.p.EvalContext(),
-			n.persistence,
+			persistence,
 		)
 		if err != nil {
 			return err

--- a/pkg/sql/logictest/testdata/logic_test/temp_table
+++ b/pkg/sql/logictest/testdata/logic_test/temp_table
@@ -285,3 +285,42 @@ grant testuser to root
 
 statement ok
 ALTER TABLE second_db.pg_temp.a OWNER TO testuser
+
+
+# Below is a regression test to deal ensure that views which are "upgraded" to
+# temporary because they reference temporary tables are indeed marked as
+# temporary.
+subtest upgraded_view_marked_temporary
+
+statement ok
+CREATE DATABASE upgraded_view_marked_temporary;
+USE upgraded_view_marked_temporary;
+CREATE TEMPORARY TABLE t (i INT PRIMARY KEY);
+CREATE VIEW v AS SELECT i FROM t;
+
+# Confirm at a low-level that the descriptor for v is marked temporary.
+
+query T
+SELECT crdb_internal.pb_to_json(
+        'cockroach.sql.sqlbase.Descriptor',
+        descriptor
+       )->'table'->>'temporary'
+  FROM system.descriptor
+ WHERE id = 'v'::REGCLASS;
+----
+true
+
+statement ok
+USE test
+
+# Switch to a different user and thus different connection and attempt to
+# drop the database which contains the promoted temporary view. If the view
+# were not properly marked as temporary, this would fail with an opaque error
+# about not being able to find the descriptor.
+
+user root
+
+statement ok
+DROP DATABASE upgraded_view_marked_temporary CASCADE;
+
+user testuser


### PR DESCRIPTION
This commit fixes a bug whereby views which reference temp tables are created
in the temporary schema but are not marked as being temporary. Usually this
doesn't cause a lot of trouble. Problems arise when another session attempts
to drop the database corresponding to the temp schema containing these views
before they have been cleaned up. In that case, the `DROP DATABASE` command
will observe an opaque `descriptor not found` error.

Fixes #62281.

Release note (bug fix): Fixed a bug which could cause errors in DROP DATABASE
CASCADE when the database contains temporary views in other sessions which
were not explicitly marked as TEMPORARY.