### PR TITLE
sql: use catalog.Mutation, catalog.Column and catalog.Index where possible

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1755,14 +1755,14 @@ func revalidateIndexes(
 		}
 		tableDesc := tabledesc.NewBuilder(tbl).BuildExistingMutableTable()
 
-		var forward, inverted []*descpb.IndexDescriptor
+		var forward, inverted []catalog.Index
 		for _, idx := range tableDesc.AllIndexes() {
 			if _, ok := indexes[idx.GetID()]; ok {
 				switch idx.GetType() {
 				case descpb.IndexDescriptor_FORWARD:
-					forward = append(forward, idx.IndexDesc())
+					forward = append(forward, idx)
 				case descpb.IndexDescriptor_INVERTED:
-					inverted = append(inverted, idx.IndexDesc())
+					inverted = append(inverted, idx)
 				}
 			}
 		}
@@ -1901,9 +1901,9 @@ func (r *restoreResumer) publishDescriptors(
 			if err != nil {
 				return err
 			}
-			newIdx := protoutil.Clone(found.IndexDesc()).(*descpb.IndexDescriptor)
+			newIdx := found.IndexDescDeepCopy()
 			mutTable.RemovePublicNonPrimaryIndex(found.Ordinal())
-			if err := mutTable.AddIndexMutation(newIdx, descpb.DescriptorMutation_ADD); err != nil {
+			if err := mutTable.AddIndexMutation(&newIdx, descpb.DescriptorMutation_ADD); err != nil {
 				return err
 			}
 		}

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -116,7 +116,7 @@ func parseAvroSchema(j string) (*avroDataRecord, error) {
 	for _, f := range s.Fields {
 		// s.Fields[idx] has `Name` and `SchemaType` set but nothing else.
 		// They're needed for serialization/deserialization, so fake out a
-		// column descriptor so that we can reuse columnDescToAvroSchema to get
+		// column descriptor so that we can reuse columnToAvroSchema to get
 		// all the various fields of avroSchemaField populated for free.
 		colDesc, err := avroFieldMetadataToColDesc(f.Metadata)
 		if err != nil {
@@ -286,7 +286,7 @@ func TestAvroSchema(t *testing.T) {
 				`{"type":["null","long"],"name":"_u0001f366_","default":null,`+
 				`"__crdb__":"🍦 INT8 NOT NULL"}]}`,
 			tableSchema.codec.Schema())
-		indexSchema, err := indexToAvroSchema(tableDesc, tableDesc.GetPrimaryIndex().IndexDesc(), tableDesc.GetName(), "")
+		indexSchema, err := indexToAvroSchema(tableDesc, tableDesc.GetPrimaryIndex(), tableDesc.GetName(), "")
 		require.NoError(t, err)
 		require.Equal(t,
 			`{"type":"record","name":"_u2603_","fields":[`+
@@ -329,7 +329,7 @@ func TestAvroSchema(t *testing.T) {
 			colType := typ.SQLString()
 			tableDesc, err := parseTableDesc(`CREATE TABLE foo (pk INT PRIMARY KEY, a ` + colType + `)`)
 			require.NoError(t, err)
-			field, err := columnDescToAvroSchema(tableDesc.PublicColumns()[1].ColumnDesc())
+			field, err := columnToAvroSchema(tableDesc.PublicColumns()[1])
 			require.NoError(t, err)
 			schema, err := json.Marshal(field.SchemaType)
 			require.NoError(t, err)

--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -360,7 +360,7 @@ func (e *confluentAvroEncoder) EncodeKey(ctx context.Context, row encodeRow) ([]
 	if !ok {
 		var err error
 		tableName := e.rawTableName(row.tableDesc)
-		registered.schema, err = indexToAvroSchema(row.tableDesc, row.tableDesc.GetPrimaryIndex().IndexDesc(), tableName, e.schemaPrefix)
+		registered.schema, err = indexToAvroSchema(row.tableDesc, row.tableDesc.GetPrimaryIndex(), tableName, e.schemaPrefix)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ccl/changefeedccl/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/rowfetcher_cache.go
@@ -163,14 +163,11 @@ func (c *rowFetcherCache) RowFetcherForTableDesc(
 	rfArgs := row.FetcherTableArgs{
 		Spans:            tableDesc.AllIndexSpans(c.codec),
 		Desc:             tableDesc,
-		Index:            tableDesc.GetPrimaryIndex().IndexDesc(),
+		Index:            tableDesc.GetPrimaryIndex(),
 		ColIdxMap:        colIdxMap,
 		IsSecondaryIndex: false,
-		Cols:             make([]descpb.ColumnDescriptor, len(tableDesc.PublicColumns())),
+		Cols:             tableDesc.PublicColumns(),
 		ValNeededForCol:  valNeededForCol,
-	}
-	for i, col := range tableDesc.PublicColumns() {
-		rfArgs.Cols[i] = *col.ColumnDesc()
 	}
 	if err := rf.Init(
 		context.TODO(),

--- a/pkg/ccl/cliccl/load.go
+++ b/pkg/ccl/cliccl/load.go
@@ -483,19 +483,17 @@ func makeRowFetcher(
 ) (row.Fetcher, error) {
 	var colIdxMap catalog.TableColMap
 	var valNeededForCol util.FastIntSet
-	colDescs := make([]descpb.ColumnDescriptor, len(entry.Desc.PublicColumns()))
 	for i, col := range entry.Desc.PublicColumns() {
 		colIdxMap.Set(col.GetID(), i)
 		valNeededForCol.Add(i)
-		colDescs[i] = *col.ColumnDesc()
 	}
 	table := row.FetcherTableArgs{
 		Spans:            []roachpb.Span{entry.Span},
 		Desc:             entry.Desc,
-		Index:            entry.Desc.GetPrimaryIndex().IndexDesc(),
+		Index:            entry.Desc.GetPrimaryIndex(),
 		ColIdxMap:        colIdxMap,
 		IsSecondaryIndex: false,
-		Cols:             colDescs,
+		Cols:             entry.Desc.PublicColumns(),
 		ValNeededForCol:  valNeededForCol,
 	}
 

--- a/pkg/ccl/importccl/read_import_avro.go
+++ b/pkg/ccl/importccl/read_import_avro.go
@@ -187,7 +187,7 @@ func (a *avroConsumer) convertNative(x interface{}, conv *row.DatumRowConverter)
 		typ := conv.VisibleColTypes[idx]
 		avroT, ok := familyToAvroT[typ.Family()]
 		if !ok {
-			return fmt.Errorf("cannot convert avro value %v to col %s", v, conv.VisibleCols[idx].Type.Name())
+			return fmt.Errorf("cannot convert avro value %v to col %s", v, conv.VisibleCols[idx].GetType().Name())
 		}
 
 		datum, err := nativeToDatum(v, typ, avroT, conv.EvalCtx)
@@ -212,7 +212,7 @@ func (a *avroConsumer) FillDatums(
 	for i := range conv.Datums {
 		if conv.TargetColOrds.Contains(i) && conv.Datums[i] == nil {
 			if a.strict {
-				return fmt.Errorf("field %s was not set in the avro import", conv.VisibleCols[i].Name)
+				return fmt.Errorf("field %s was not set in the avro import", conv.VisibleCols[i].GetName())
 			}
 			conv.Datums[i] = tree.DNull
 		}

--- a/pkg/ccl/importccl/read_import_csv.go
+++ b/pkg/ccl/importccl/read_import_csv.go
@@ -196,7 +196,7 @@ func (c *csvRowConsumer) FillDatums(
 			if err != nil {
 				col := conv.VisibleCols[i]
 				return newImportRowError(
-					errors.Wrapf(err, "parse %q as %s", col.Name, col.Type.SQLString()),
+					errors.Wrapf(err, "parse %q as %s", col.GetName(), col.GetType().SQLString()),
 					strRecord(record, c.opts.Comma),
 					rowNum)
 			}

--- a/pkg/ccl/importccl/read_import_mysql_test.go
+++ b/pkg/ccl/importccl/read_import_mysql_test.go
@@ -224,13 +224,13 @@ func compareTables(t *testing.T, expected, got *descpb.TableDescriptor) {
 		expectedDesc := tabledesc.NewBuilder(expected).BuildImmutableTable()
 		gotDesc := tabledesc.NewBuilder(got).BuildImmutableTable()
 		e, err := catformat.IndexForDisplay(
-			ctx, expectedDesc, tableName, &expected.Indexes[i], "" /* partition */, "" /* interleave */, &semaCtx,
+			ctx, expectedDesc, tableName, expectedDesc.PublicNonPrimaryIndexes()[i], "" /* partition */, "" /* interleave */, &semaCtx,
 		)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
 		g, err := catformat.IndexForDisplay(
-			ctx, gotDesc, tableName, &got.Indexes[i], "" /* partition */, "" /* interleave */, &semaCtx,
+			ctx, gotDesc, tableName, gotDesc.PublicNonPrimaryIndexes()[i], "" /* partition */, "" /* interleave */, &semaCtx,
 		)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)

--- a/pkg/ccl/importccl/read_import_mysqlout.go
+++ b/pkg/ccl/importccl/read_import_mysqlout.go
@@ -252,7 +252,7 @@ func (d *delimitedConsumer) FillDatums(
 			if err != nil {
 				col := conv.VisibleCols[datumIdx]
 				return newImportRowError(
-					fmt.Errorf("error %s while parse %q as %s", err, col.Name, col.Type.SQLString()),
+					fmt.Errorf("error %s while parse %q as %s", err, col.GetName(), col.GetType().SQLString()),
 					string(data), rowNum)
 			}
 		}

--- a/pkg/ccl/importccl/read_import_pgcopy.go
+++ b/pkg/ccl/importccl/read_import_pgcopy.go
@@ -333,7 +333,7 @@ func (p *pgCopyConsumer) FillDatums(
 				col := conv.VisibleCols[i]
 				return newImportRowError(fmt.Errorf(
 					"encountered error %s when attempting to parse %q as %s",
-					err.Error(), col.Name, col.Type.SQLString()), data.String(), rowNum)
+					err.Error(), col.GetName(), col.GetType().SQLString()), data.String(), rowNum)
 			}
 		}
 	}

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -1149,7 +1149,7 @@ func (m *pgDumpReader) readFile(
 							if err != nil {
 								col := conv.VisibleCols[idx]
 								return wrapRowErr(err, "", count, pgcode.Syntax,
-									"parse %q as %s", col.Name, col.Type.SQLString())
+									"parse %q as %s", col.GetName(), col.GetType().SQLString())
 							}
 						}
 					}

--- a/pkg/ccl/partitionccl/partition.go
+++ b/pkg/ccl/partitionccl/partition.go
@@ -39,10 +39,7 @@ import (
 // TODO(dan): The typechecking here should be run during plan construction, so
 // we can support placeholders.
 func valueEncodePartitionTuple(
-	typ tree.PartitionByType,
-	evalCtx *tree.EvalContext,
-	maybeTuple tree.Expr,
-	cols []descpb.ColumnDescriptor,
+	typ tree.PartitionByType, evalCtx *tree.EvalContext, maybeTuple tree.Expr, cols []catalog.Column,
 ) ([]byte, error) {
 	// Replace any occurrences of the MINVALUE/MAXVALUE pseudo-names
 	// into MinVal and MaxVal, to be recognized below.
@@ -98,7 +95,7 @@ func valueEncodePartitionTuple(
 		}
 
 		var semaCtx tree.SemaContext
-		typedExpr, err := schemaexpr.SanitizeVarFreeExpr(evalCtx.Context, expr, cols[i].Type, "partition",
+		typedExpr, err := schemaexpr.SanitizeVarFreeExpr(evalCtx.Context, expr, cols[i].GetType(), "partition",
 			&semaCtx,
 			tree.VolatilityImmutable,
 		)
@@ -113,7 +110,7 @@ func valueEncodePartitionTuple(
 		if err != nil {
 			return nil, errors.Wrapf(err, "evaluating %s", typedExpr)
 		}
-		if err := colinfo.CheckDatumTypeFitsColumnType(&cols[i], datum.ResolvedType()); err != nil {
+		if err := colinfo.CheckDatumTypeFitsColumnType(cols[i], datum.ResolvedType()); err != nil {
 			return nil, err
 		}
 		value, err = rowenc.EncodeTableValue(
@@ -176,7 +173,7 @@ func createPartitioningImpl(
 		return strings.Join(partCols, ", ")
 	}
 
-	var cols []descpb.ColumnDescriptor
+	var cols []catalog.Column
 	for i := 0; i < len(partBy.Fields); i++ {
 		if colOffset+i >= len(indexDesc.ColumnNames) {
 			return partDesc, pgerror.Newf(pgcode.Syntax,
@@ -193,7 +190,7 @@ func createPartitioningImpl(
 		if err != nil {
 			return partDesc, err
 		}
-		cols = append(cols, *col.ColumnDesc())
+		cols = append(cols, col)
 		if string(partBy.Fields[i]) != col.GetName() {
 			// This used to print the first `colOffset + len(partBy.Fields)` fields
 			// but there might not be this many columns in the index. See #37682.
@@ -437,7 +434,7 @@ func selectPartitionExprs(
 		AddMutations: true,
 	}, func(idx catalog.Index) error {
 		return selectPartitionExprsByName(
-			a, evalCtx, tableDesc, idx.IndexDesc(), &idx.IndexDesc().Partitioning, prefixDatums, exprsByPartName, true /* genExpr */)
+			a, evalCtx, tableDesc, idx, &idx.IndexDesc().Partitioning, prefixDatums, exprsByPartName, true /* genExpr */)
 	}); err != nil {
 		return nil, err
 	}
@@ -490,7 +487,7 @@ func selectPartitionExprsByName(
 	a *rowenc.DatumAlloc,
 	evalCtx *tree.EvalContext,
 	tableDesc catalog.TableDescriptor,
-	idxDesc *descpb.IndexDescriptor,
+	idx catalog.Index,
 	partDesc *descpb.PartitioningDescriptor,
 	prefixDatums tree.Datums,
 	exprsByPartName map[string]tree.TypedExpr,
@@ -507,7 +504,7 @@ func selectPartitionExprsByName(
 			exprsByPartName[l.Name] = tree.DBoolFalse
 			var fakeDatums tree.Datums
 			if err := selectPartitionExprsByName(
-				a, evalCtx, tableDesc, idxDesc, &l.Subpartitioning, fakeDatums, exprsByPartName, genExpr,
+				a, evalCtx, tableDesc, idx, &l.Subpartitioning, fakeDatums, exprsByPartName, genExpr,
 			); err != nil {
 				return err
 			}
@@ -524,7 +521,7 @@ func selectPartitionExprsByName(
 		// the column ordinal references, so reconstruct them here.
 		colVars = make(tree.Exprs, len(prefixDatums)+int(partDesc.NumColumns))
 		for i := range colVars {
-			col, err := tabledesc.FindPublicColumnWithID(tableDesc, idxDesc.ColumnIDs[i])
+			col, err := tabledesc.FindPublicColumnWithID(tableDesc, idx.GetColumnID(i))
 			if err != nil {
 				return err
 			}
@@ -547,7 +544,7 @@ func selectPartitionExprsByName(
 		for _, l := range partDesc.List {
 			for _, valueEncBuf := range l.Values {
 				t, _, err := rowenc.DecodePartitionTuple(
-					a, evalCtx.Codec, tableDesc, idxDesc, partDesc, valueEncBuf, prefixDatums)
+					a, evalCtx.Codec, tableDesc, idx, partDesc, valueEncBuf, prefixDatums)
 				if err != nil {
 					return err
 				}
@@ -581,7 +578,7 @@ func selectPartitionExprsByName(
 					genExpr = false
 				}
 				if err := selectPartitionExprsByName(
-					a, evalCtx, tableDesc, idxDesc, &l.Subpartitioning, allDatums, exprsByPartName, genExpr,
+					a, evalCtx, tableDesc, idx, &l.Subpartitioning, allDatums, exprsByPartName, genExpr,
 				); err != nil {
 					return err
 				}

--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -1346,7 +1346,7 @@ func TestRepartitioning(t *testing.T) {
 					repartition.WriteString(`PARTITION BY NOTHING`)
 				} else {
 					if err := sql.ShowCreatePartitioning(
-						&rowenc.DatumAlloc{}, keys.SystemSQLCodec, test.new.parsed.tableDesc, testIndex.IndexDesc(),
+						&rowenc.DatumAlloc{}, keys.SystemSQLCodec, test.new.parsed.tableDesc, testIndex,
 						&testIndex.IndexDesc().Partitioning, &repartition, 0 /* indent */, 0, /* colOffset */
 					); err != nil {
 						t.Fatalf("%+v", err)

--- a/pkg/ccl/storageccl/key_rewriter.go
+++ b/pkg/ccl/storageccl/key_rewriter.go
@@ -241,7 +241,7 @@ func (kr *KeyRewriter) rewriteTableKey(key []byte, isFromSpan bool) ([]byte, boo
 	if !idx.Primary() {
 		return nil, false, errors.New("restoring interleaved secondary indexes not supported")
 	}
-	colIDs, _ := idx.IndexDesc().FullColumnIDs()
+	colIDs, _ := catalog.FullIndexColumnIDs(idx)
 	var skipCols int
 	for i := 0; i < idx.NumInterleaveAncestors(); i++ {
 		skipCols += int(idx.GetInterleaveAncestor(i).SharedPrefixLen)

--- a/pkg/ccl/streamingccl/streamingtest/encoding.go
+++ b/pkg/ccl/streamingccl/streamingtest/encoding.go
@@ -26,8 +26,8 @@ func EncodeKV(
 	t *testing.T, codec keys.SQLCodec, descr catalog.TableDescriptor, pkeyVals ...interface{},
 ) roachpb.KeyValue {
 	require.Equal(t, 1, descr.NumFamilies(), "there can be only one")
-	primary := descr.GetPrimaryIndex().IndexDesc()
-	require.LessOrEqual(t, len(primary.ColumnIDs), len(pkeyVals))
+	primary := descr.GetPrimaryIndex()
+	require.LessOrEqual(t, primary.NumColumns(), len(pkeyVals))
 
 	var datums tree.Datums
 	var colMap catalog.TableColMap

--- a/pkg/server/settingswatcher/row_decoder.go
+++ b/pkg/server/settingswatcher/row_decoder.go
@@ -36,7 +36,7 @@ func MakeRowDecoder(codec keys.SQLCodec) RowDecoder {
 	return RowDecoder{
 		codec: codec,
 		colIdxMap: row.ColIDtoRowIndexFromCols(
-			systemschema.SettingsTable.TableDesc().Columns,
+			systemschema.SettingsTable.PublicColumns(),
 		),
 	}
 }
@@ -52,7 +52,7 @@ func (d *RowDecoder) DecodeRow(
 	{
 		types := []*types.T{tbl.PublicColumns()[0].GetType()}
 		nameRow := make([]rowenc.EncDatum, 1)
-		_, matches, _, err := rowenc.DecodeIndexKey(d.codec, tbl, tbl.GetPrimaryIndex().IndexDesc(), types, nameRow, nil, kv.Key)
+		_, matches, _, err := rowenc.DecodeIndexKey(d.codec, tbl, tbl.GetPrimaryIndex(), types, nameRow, nil, kv.Key)
 		if err != nil {
 			return "", "", "", false, errors.Wrap(err, "failed to decode key")
 		}

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -532,6 +532,7 @@ go_test(
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/lease",
         "//pkg/sql/catalog/multiregion",
+        "//pkg/sql/catalog/systemschema",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/catalog/typedesc",
         "//pkg/sql/distsql",

--- a/pkg/sql/alter_index.go
+++ b/pkg/sql/alter_index.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -29,7 +30,7 @@ import (
 type alterIndexNode struct {
 	n         *tree.AlterIndex
 	tableDesc *tabledesc.Mutable
-	indexDesc *descpb.IndexDescriptor
+	index     catalog.Index
 }
 
 // AlterIndex applies a schema change on an index.
@@ -43,19 +44,11 @@ func (p *planner) AlterIndex(ctx context.Context, n *tree.AlterIndex) (planNode,
 		return nil, err
 	}
 
-	tableDesc, indexDesc, err := p.getTableAndIndex(ctx, &n.Index, privilege.CREATE)
+	tableDesc, index, err := p.getTableAndIndex(ctx, &n.Index, privilege.CREATE)
 	if err != nil {
 		return nil, err
 	}
-	// As an artifact of finding the index by name, we get a pointer to a
-	// different copy than the one in the tableDesc. To make it easier for the
-	// code below, get a pointer to the index descriptor that's actually in
-	// tableDesc.
-	index, err := tableDesc.FindIndexWithID(indexDesc.ID)
-	if err != nil {
-		return nil, err
-	}
-	return &alterIndexNode{n: n, tableDesc: tableDesc, indexDesc: index.IndexDesc()}, nil
+	return &alterIndexNode{n: n, tableDesc: tableDesc, index: index}, nil
 }
 
 // ReadingOwnWrites implements the planNodeReadingOwnWrites interface.
@@ -86,7 +79,8 @@ func (n *alterIndexNode) startExec(params runParams) error {
 					"cannot change the partitioning of an index if the table has PARTITION ALL BY defined",
 				)
 			}
-			if n.indexDesc.Partitioning.NumImplicitColumns > 0 {
+			existingIndexDesc := n.index.IndexDescDeepCopy()
+			if existingIndexDesc.Partitioning.NumImplicitColumns > 0 {
 				return unimplemented.New(
 					"ALTER INDEX PARTITION BY",
 					"cannot ALTER INDEX PARTITION BY on an index which already has implicit column partitioning",
@@ -99,7 +93,7 @@ func (n *alterIndexNode) startExec(params runParams) error {
 				params.extendedEvalCtx.Settings,
 				params.EvalContext(),
 				n.tableDesc,
-				*n.indexDesc,
+				existingIndexDesc,
 				t.PartitionBy,
 				nil, /* allowedNewColumnNames */
 				allowImplicitPartitioning,
@@ -113,19 +107,21 @@ func (n *alterIndexNode) startExec(params runParams) error {
 					"cannot ALTER INDEX and change the partitioning to contain implicit columns",
 				)
 			}
-			descriptorChanged = !n.indexDesc.Equal(&newIndexDesc)
+			descriptorChanged = !existingIndexDesc.Equal(&newIndexDesc)
 			if err = deleteRemovedPartitionZoneConfigs(
 				params.ctx,
 				params.p.txn,
 				n.tableDesc,
-				n.indexDesc,
-				&n.indexDesc.Partitioning,
+				n.index.GetID(),
+				&existingIndexDesc.Partitioning,
 				&newIndexDesc.Partitioning,
 				params.extendedEvalCtx.ExecCfg,
 			); err != nil {
 				return err
 			}
-			*n.indexDesc = newIndexDesc
+			// Update value to make sure it doesn't become stale.
+			n.index = n.tableDesc.AllIndexes()[n.index.Ordinal()]
+			*n.index.IndexDesc() = newIndexDesc
 		default:
 			return errors.AssertionFailedf(
 				"unsupported alter command: %T", cmd)
@@ -158,7 +154,7 @@ func (n *alterIndexNode) startExec(params runParams) error {
 		n.tableDesc.ID,
 		&eventpb.AlterIndex{
 			TableName:  n.n.Index.Table.FQString(),
-			IndexName:  n.indexDesc.Name,
+			IndexName:  n.index.GetName(),
 			MutationID: uint32(mutationID),
 		})
 }

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -192,11 +192,11 @@ func (sc *SchemaChanger) runBackfill(ctx context.Context) error {
 	var addedIndexSpans []roachpb.Span
 	var addedIndexes []descpb.IndexID
 
-	var constraintsToDrop []descpb.ConstraintToUpdate
-	var constraintsToAddBeforeValidation []descpb.ConstraintToUpdate
-	var constraintsToValidate []descpb.ConstraintToUpdate
+	var constraintsToDrop []catalog.ConstraintToUpdate
+	var constraintsToAddBeforeValidation []catalog.ConstraintToUpdate
+	var constraintsToValidate []catalog.ConstraintToUpdate
 
-	var viewToRefresh *descpb.MaterializedViewRefresh
+	var viewToRefresh catalog.MaterializedViewRefresh
 
 	// Note that this descriptor is intentionally not leased. If the schema change
 	// held the lease, certain non-mutation related schema changes would not be
@@ -229,76 +229,59 @@ func (sc *SchemaChanger) runBackfill(ctx context.Context) error {
 	log.Infof(ctx, "running backfill for %q, v=%d", tableDesc.Name, tableDesc.Version)
 
 	needColumnBackfill := false
-	for mutationIdx, m := range tableDesc.Mutations {
-		if m.MutationID != sc.mutationID {
+	for _, m := range tableDesc.AllMutations() {
+		if m.MutationID() != sc.mutationID {
 			break
 		}
 		// If the current mutation is discarded, then
 		// skip over processing.
-		if discarded, _ := isCurrentMutationDiscarded(tableDesc, m, mutationIdx+1); discarded {
+		if discarded, _ := isCurrentMutationDiscarded(tableDesc, m, m.MutationOrdinal()+1); discarded {
 			continue
 		}
 
-		switch m.Direction {
-		case descpb.DescriptorMutation_ADD:
-			switch t := m.Descriptor_.(type) {
-			case *descpb.DescriptorMutation_Column:
-				if tabledesc.ColumnNeedsBackfill(m.Direction, m.GetColumn()) {
-					needColumnBackfill = true
-				}
-			case *descpb.DescriptorMutation_Index:
-				addedIndexSpans = append(addedIndexSpans, tableDesc.IndexSpan(sc.execCfg.Codec, t.Index.ID))
-				addedIndexes = append(addedIndexes, t.Index.ID)
-			case *descpb.DescriptorMutation_Constraint:
-				switch t.Constraint.ConstraintType {
-				case descpb.ConstraintToUpdate_CHECK:
-					if t.Constraint.Check.Validity == descpb.ConstraintValidity_Validating {
-						constraintsToAddBeforeValidation = append(constraintsToAddBeforeValidation, *t.Constraint)
-						constraintsToValidate = append(constraintsToValidate, *t.Constraint)
-					}
-				case descpb.ConstraintToUpdate_FOREIGN_KEY:
-					if t.Constraint.ForeignKey.Validity == descpb.ConstraintValidity_Validating {
-						constraintsToAddBeforeValidation = append(constraintsToAddBeforeValidation, *t.Constraint)
-						constraintsToValidate = append(constraintsToValidate, *t.Constraint)
-					}
-				case descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX:
-					if t.Constraint.UniqueWithoutIndexConstraint.Validity == descpb.ConstraintValidity_Validating {
-						constraintsToAddBeforeValidation = append(constraintsToAddBeforeValidation, *t.Constraint)
-						constraintsToValidate = append(constraintsToValidate, *t.Constraint)
-					}
-				case descpb.ConstraintToUpdate_NOT_NULL:
+		if m.Adding() {
+			if col := m.AsColumn(); col != nil {
+				needColumnBackfill = catalog.ColumnNeedsBackfill(col)
+			} else if idx := m.AsIndex(); idx != nil {
+				addedIndexSpans = append(addedIndexSpans, tableDesc.IndexSpan(sc.execCfg.Codec, idx.GetID()))
+				addedIndexes = append(addedIndexes, idx.GetID())
+			} else if c := m.AsConstraint(); c != nil {
+				isValidating := false
+				if c.IsCheck() {
+					isValidating = c.Check().Validity == descpb.ConstraintValidity_Validating
+				} else if c.IsForeignKey() {
+					isValidating = c.ForeignKey().Validity == descpb.ConstraintValidity_Validating
+				} else if c.IsUniqueWithoutIndex() {
+					isValidating = c.UniqueWithoutIndex().Validity == descpb.ConstraintValidity_Validating
+				} else if c.IsNotNull() {
 					// NOT NULL constraints are always validated before they can be added
-					constraintsToAddBeforeValidation = append(constraintsToAddBeforeValidation, *t.Constraint)
-					constraintsToValidate = append(constraintsToValidate, *t.Constraint)
+					isValidating = true
 				}
-			case *descpb.DescriptorMutation_PrimaryKeySwap, *descpb.DescriptorMutation_ComputedColumnSwap:
+				if isValidating {
+					constraintsToAddBeforeValidation = append(constraintsToAddBeforeValidation, c)
+					constraintsToValidate = append(constraintsToValidate, c)
+				}
+			} else if mvRefresh := m.AsMaterializedViewRefresh(); mvRefresh != nil {
+				viewToRefresh = mvRefresh
+			} else if m.AsPrimaryKeySwap() != nil || m.AsComputedColumnSwap() != nil {
 				// The backfiller doesn't need to do anything here.
-			case *descpb.DescriptorMutation_MaterializedViewRefresh:
-				viewToRefresh = t.MaterializedViewRefresh
-			default:
-				return errors.AssertionFailedf(
-					"unsupported mutation: %+v", m)
+			} else {
+				return errors.AssertionFailedf("unsupported mutation: %+v", m)
 			}
 
-		case descpb.DescriptorMutation_DROP:
-			switch t := m.Descriptor_.(type) {
-			case *descpb.DescriptorMutation_Column:
-				if tabledesc.ColumnNeedsBackfill(m.Direction, m.GetColumn()) {
-					needColumnBackfill = true
+		} else if m.Dropped() {
+			if col := m.AsColumn(); col != nil {
+				needColumnBackfill = catalog.ColumnNeedsBackfill(col)
+			} else if idx := m.AsIndex(); idx != nil {
+				if !canClearRangeForDrop(idx.IndexDesc()) {
+					droppedIndexDescs = append(droppedIndexDescs, *idx.IndexDesc())
 				}
-			case *descpb.DescriptorMutation_Index:
-				if !canClearRangeForDrop(t.Index) {
-					droppedIndexDescs = append(droppedIndexDescs, *t.Index)
-				}
-			case *descpb.DescriptorMutation_Constraint:
-				constraintsToDrop = append(constraintsToDrop, *t.Constraint)
-			case *descpb.DescriptorMutation_PrimaryKeySwap,
-				*descpb.DescriptorMutation_ComputedColumnSwap,
-				*descpb.DescriptorMutation_MaterializedViewRefresh:
+			} else if c := m.AsConstraint(); c != nil {
+				constraintsToDrop = append(constraintsToDrop, c)
+			} else if m.AsPrimaryKeySwap() != nil || m.AsComputedColumnSwap() != nil || m.AsMaterializedViewRefresh() != nil {
 				// The backfiller doesn't need to do anything here.
-			default:
-				return errors.AssertionFailedf(
-					"unsupported mutation: %+v", m)
+			} else {
+				return errors.AssertionFailedf("unsupported mutation: %+v", m)
 			}
 		}
 	}
@@ -381,16 +364,17 @@ func (sc *SchemaChanger) runBackfill(ctx context.Context) error {
 // the given constraint removed from it, and waits until the entire cluster is
 // on the new version of the table descriptor. It returns the new table descs.
 func (sc *SchemaChanger) dropConstraints(
-	ctx context.Context, constraints []descpb.ConstraintToUpdate,
+	ctx context.Context, constraints []catalog.ConstraintToUpdate,
 ) (map[descpb.ID]catalog.TableDescriptor, error) {
 	log.Infof(ctx, "dropping %d constraints", len(constraints))
 
-	fksByBackrefTable := make(map[descpb.ID][]*descpb.ConstraintToUpdate)
-	for i := range constraints {
-		c := &constraints[i]
-		if c.ConstraintType == descpb.ConstraintToUpdate_FOREIGN_KEY &&
-			c.ForeignKey.ReferencedTableID != sc.descID {
-			fksByBackrefTable[c.ForeignKey.ReferencedTableID] = append(fksByBackrefTable[c.ForeignKey.ReferencedTableID], c)
+	fksByBackrefTable := make(map[descpb.ID][]catalog.ConstraintToUpdate)
+	for _, c := range constraints {
+		if c.IsForeignKey() {
+			id := c.ForeignKey().ReferencedTableID
+			if id != sc.descID {
+				fksByBackrefTable[id] = append(fksByBackrefTable[id], c)
+			}
 		}
 	}
 
@@ -401,13 +385,11 @@ func (sc *SchemaChanger) dropConstraints(
 			return err
 		}
 		b := txn.NewBatch()
-		for i := range constraints {
-			constraint := &constraints[i]
-			switch constraint.ConstraintType {
-			case descpb.ConstraintToUpdate_CHECK, descpb.ConstraintToUpdate_NOT_NULL:
+		for _, constraint := range constraints {
+			if constraint.IsCheck() || constraint.IsNotNull() {
 				found := false
 				for j, c := range scTable.Checks {
-					if c.Name == constraint.Name {
+					if c.Name == constraint.GetName() {
 						scTable.Checks = append(scTable.Checks[:j], scTable.Checks[j+1:]...)
 						found = true
 						break
@@ -418,18 +400,18 @@ func (sc *SchemaChanger) dropConstraints(
 						ctx, 2,
 						"backfiller tried to drop constraint %+v but it was not found, "+
 							"presumably due to a retry or rollback",
-						constraint,
+						constraint.ConstraintToUpdateDesc(),
 					)
 				}
-			case descpb.ConstraintToUpdate_FOREIGN_KEY:
+			} else if constraint.IsForeignKey() {
 				var foundExisting bool
 				for j := range scTable.OutboundFKs {
 					def := &scTable.OutboundFKs[j]
-					if def.Name != constraint.Name {
+					if def.Name != constraint.GetName() {
 						continue
 					}
 					backrefTable, err := descsCol.GetMutableTableVersionByID(ctx,
-						constraint.ForeignKey.ReferencedTableID, txn)
+						constraint.ForeignKey().ReferencedTableID, txn)
 					if err != nil {
 						return err
 					}
@@ -452,13 +434,13 @@ func (sc *SchemaChanger) dropConstraints(
 						ctx, 2,
 						"backfiller tried to drop constraint %+v but it was not found, "+
 							"presumably due to a retry or rollback",
-						constraint,
+						constraint.ConstraintToUpdateDesc(),
 					)
 				}
-			case descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX:
+			} else if constraint.IsUniqueWithoutIndex() {
 				found := false
 				for j, c := range scTable.UniqueWithoutIndexConstraints {
-					if c.Name == constraint.Name {
+					if c.Name == constraint.GetName() {
 						scTable.UniqueWithoutIndexConstraints = append(
 							scTable.UniqueWithoutIndexConstraints[:j],
 							scTable.UniqueWithoutIndexConstraints[j+1:]...,
@@ -472,7 +454,7 @@ func (sc *SchemaChanger) dropConstraints(
 						ctx, 2,
 						"backfiller tried to drop constraint %+v but it was not found, "+
 							"presumably due to a retry or rollback",
-						constraint,
+						constraint.ConstraintToUpdateDesc(),
 					)
 				}
 			}
@@ -524,16 +506,17 @@ func (sc *SchemaChanger) dropConstraints(
 // given constraint added to it, and waits until the entire cluster is on
 // the new version of the table descriptor.
 func (sc *SchemaChanger) addConstraints(
-	ctx context.Context, constraints []descpb.ConstraintToUpdate,
+	ctx context.Context, constraints []catalog.ConstraintToUpdate,
 ) error {
 	log.Infof(ctx, "adding %d constraints", len(constraints))
 
-	fksByBackrefTable := make(map[descpb.ID][]*descpb.ConstraintToUpdate)
-	for i := range constraints {
-		c := &constraints[i]
-		if c.ConstraintType == descpb.ConstraintToUpdate_FOREIGN_KEY &&
-			c.ForeignKey.ReferencedTableID != sc.descID {
-			fksByBackrefTable[c.ForeignKey.ReferencedTableID] = append(fksByBackrefTable[c.ForeignKey.ReferencedTableID], c)
+	fksByBackrefTable := make(map[descpb.ID][]catalog.ConstraintToUpdate)
+	for _, c := range constraints {
+		if c.IsForeignKey() {
+			id := c.ForeignKey().ReferencedTableID
+			if id != sc.descID {
+				fksByBackrefTable[id] = append(fksByBackrefTable[id], c)
+			}
 		}
 	}
 
@@ -547,13 +530,11 @@ func (sc *SchemaChanger) addConstraints(
 		}
 
 		b := txn.NewBatch()
-		for i := range constraints {
-			constraint := &constraints[i]
-			switch constraint.ConstraintType {
-			case descpb.ConstraintToUpdate_CHECK, descpb.ConstraintToUpdate_NOT_NULL:
+		for _, constraint := range constraints {
+			if constraint.IsCheck() || constraint.IsNotNull() {
 				found := false
 				for _, c := range scTable.Checks {
-					if c.Name == constraint.Name {
+					if c.Name == constraint.GetName() {
 						log.VEventf(
 							ctx, 2,
 							"backfiller tried to add constraint %+v but found existing constraint %+v, "+
@@ -568,19 +549,19 @@ func (sc *SchemaChanger) addConstraints(
 					}
 				}
 				if !found {
-					scTable.Checks = append(scTable.Checks, &constraints[i].Check)
+					scTable.Checks = append(scTable.Checks, &constraint.ConstraintToUpdateDesc().Check)
 				}
-			case descpb.ConstraintToUpdate_FOREIGN_KEY:
+			} else if constraint.IsForeignKey() {
 				var foundExisting bool
 				for j := range scTable.OutboundFKs {
 					def := &scTable.OutboundFKs[j]
-					if def.Name == constraint.Name {
+					if def.Name == constraint.GetName() {
 						if log.V(2) {
 							log.VEventf(
 								ctx, 2,
 								"backfiller tried to add constraint %+v but found existing constraint %+v, "+
 									"presumably due to a retry or rollback",
-								constraint, def,
+								constraint.ConstraintToUpdateDesc(), def,
 							)
 						}
 						// Ensure the constraint on the descriptor is set to Validating, in
@@ -591,8 +572,8 @@ func (sc *SchemaChanger) addConstraints(
 					}
 				}
 				if !foundExisting {
-					scTable.OutboundFKs = append(scTable.OutboundFKs, constraint.ForeignKey)
-					backrefTable, err := descsCol.GetMutableTableVersionByID(ctx, constraint.ForeignKey.ReferencedTableID, txn)
+					scTable.OutboundFKs = append(scTable.OutboundFKs, constraint.ForeignKey())
+					backrefTable, err := descsCol.GetMutableTableVersionByID(ctx, constraint.ForeignKey().ReferencedTableID, txn)
 					if err != nil {
 						return err
 					}
@@ -600,11 +581,11 @@ func (sc *SchemaChanger) addConstraints(
 					// referenced table. It's possible for the unique index found during
 					// planning to have been dropped in the meantime, since only the
 					// presence of the backreference prevents it.
-					_, err = tabledesc.FindFKReferencedUniqueConstraint(backrefTable, constraint.ForeignKey.ReferencedColumnIDs)
+					_, err = tabledesc.FindFKReferencedUniqueConstraint(backrefTable, constraint.ForeignKey().ReferencedColumnIDs)
 					if err != nil {
 						return err
 					}
-					backrefTable.InboundFKs = append(backrefTable.InboundFKs, constraint.ForeignKey)
+					backrefTable.InboundFKs = append(backrefTable.InboundFKs, constraint.ForeignKey())
 
 					// Note that this code may add the same descriptor to the batch
 					// multiple times if it is referenced multiple times. That's fine as
@@ -618,15 +599,15 @@ func (sc *SchemaChanger) addConstraints(
 						}
 					}
 				}
-			case descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX:
+			} else if constraint.IsUniqueWithoutIndex() {
 				found := false
 				for _, c := range scTable.UniqueWithoutIndexConstraints {
-					if c.Name == constraint.Name {
+					if c.Name == constraint.GetName() {
 						log.VEventf(
 							ctx, 2,
 							"backfiller tried to add constraint %+v but found existing constraint %+v, "+
 								"presumably due to a retry or rollback",
-							constraint, c,
+							constraint.ConstraintToUpdateDesc(), c,
 						)
 						// Ensure the constraint on the descriptor is set to Validating, in
 						// case we're in the middle of rolling back DROP CONSTRAINT
@@ -636,9 +617,8 @@ func (sc *SchemaChanger) addConstraints(
 					}
 				}
 				if !found {
-					scTable.UniqueWithoutIndexConstraints = append(
-						scTable.UniqueWithoutIndexConstraints, constraints[i].UniqueWithoutIndexConstraint,
-					)
+					scTable.UniqueWithoutIndexConstraints = append(scTable.UniqueWithoutIndexConstraints,
+						constraint.UniqueWithoutIndex())
 				}
 			}
 		}
@@ -670,7 +650,7 @@ func (sc *SchemaChanger) addConstraints(
 // This operates over multiple goroutines concurrently and is thus not
 // able to reuse the original kv.Txn safely, so it makes its own.
 func (sc *SchemaChanger) validateConstraints(
-	ctx context.Context, constraints []descpb.ConstraintToUpdate,
+	ctx context.Context, constraints []catalog.ConstraintToUpdate,
 ) error {
 	if lease.TestingTableLeasesAreDisabled() {
 		return nil
@@ -731,28 +711,27 @@ func (sc *SchemaChanger) validateConstraints(
 				// TODO (rohany): When to release this? As of now this is only going to get released
 				//  after the check is validated.
 				defer func() { collection.ReleaseAll(ctx) }()
-				switch c.ConstraintType {
-				case descpb.ConstraintToUpdate_CHECK:
-					if err := validateCheckInTxn(ctx, sc.leaseMgr, &semaCtx, &evalCtx.EvalContext, desc, txn, c.Check.Expr); err != nil {
+				if c.IsCheck() {
+					if err := validateCheckInTxn(ctx, sc.leaseMgr, &semaCtx, &evalCtx.EvalContext, desc, txn, c.Check().Expr); err != nil {
 						return err
 					}
-				case descpb.ConstraintToUpdate_FOREIGN_KEY:
-					if err := validateFkInTxn(ctx, sc.leaseMgr, &evalCtx.EvalContext, desc, txn, c.Name); err != nil {
+				} else if c.IsForeignKey() {
+					if err := validateFkInTxn(ctx, sc.leaseMgr, &evalCtx.EvalContext, desc, txn, c.GetName()); err != nil {
 						return err
 					}
-				case descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX:
-					if err := validateUniqueWithoutIndexConstraintInTxn(ctx, &evalCtx.EvalContext, desc, txn, c.Name); err != nil {
+				} else if c.IsUniqueWithoutIndex() {
+					if err := validateUniqueWithoutIndexConstraintInTxn(ctx, &evalCtx.EvalContext, desc, txn, c.GetName()); err != nil {
 						return err
 					}
-				case descpb.ConstraintToUpdate_NOT_NULL:
-					if err := validateCheckInTxn(ctx, sc.leaseMgr, &semaCtx, &evalCtx.EvalContext, desc, txn, c.Check.Expr); err != nil {
+				} else if c.IsNotNull() {
+					if err := validateCheckInTxn(ctx, sc.leaseMgr, &semaCtx, &evalCtx.EvalContext, desc, txn, c.Check().Expr); err != nil {
 						// TODO (lucy): This should distinguish between constraint
 						// validation errors and other types of unexpected errors, and
 						// return a different error code in the former case
 						return errors.Wrap(err, "validation of NOT NULL constraint failed")
 					}
-				default:
-					return errors.Errorf("unsupported constraint type: %d", c.ConstraintType)
+				} else {
+					return errors.Errorf("unsupported constraint type: %d", c.ConstraintToUpdateDesc().ConstraintType)
 				}
 				return nil
 			})
@@ -1975,85 +1954,72 @@ func runSchemaChangesInTxn(
 	// in the world of transactional schema changes.
 
 	// Collect constraint mutations to process later.
-	var constraintAdditionMutations []descpb.DescriptorMutation
+	var constraintAdditionMutations []catalog.ConstraintToUpdate
 
 	// We use a range loop here as the processing of some mutations
 	// such as the primary key swap mutations result in queueing more
 	// mutations that need to be processed.
-	for i := 0; i < len(tableDesc.Mutations); i++ {
-		m := tableDesc.Mutations[i]
+	for _, m := range tableDesc.AllMutations() {
 		// Skip mutations that get canceled by later operations
-		if discarded, _ := isCurrentMutationDiscarded(tableDesc, m, i+1); discarded {
+		if discarded, _ := isCurrentMutationDiscarded(tableDesc, m, m.MutationOrdinal()+1); discarded {
 			continue
 		}
 
 		immutDesc := tabledesc.NewBuilder(tableDesc.TableDesc()).BuildImmutableTable()
-		switch m.Direction {
-		case descpb.DescriptorMutation_ADD:
-			switch m.Descriptor_.(type) {
-			case *descpb.DescriptorMutation_PrimaryKeySwap:
+
+		if m.Adding() {
+			if m.AsPrimaryKeySwap() != nil {
 				// Don't need to do anything here, as the call to MakeMutationComplete
 				// will perform the steps for this operation.
-			case *descpb.DescriptorMutation_ComputedColumnSwap:
+			} else if m.AsComputedColumnSwap() != nil {
 				return AlterColTypeInTxnNotSupportedErr
-			case *descpb.DescriptorMutation_Column:
-				if doneColumnBackfill || !tabledesc.ColumnNeedsBackfill(m.Direction, m.GetColumn()) {
-					break
+			} else if col := m.AsColumn(); col != nil {
+				if !doneColumnBackfill && catalog.ColumnNeedsBackfill(col) {
+					if err := columnBackfillInTxn(ctx, planner.Txn(), planner.EvalContext(), planner.SemaCtx(), immutDesc, traceKV); err != nil {
+						return err
+					}
+					doneColumnBackfill = true
 				}
-				if err := columnBackfillInTxn(ctx, planner.Txn(), planner.EvalContext(), planner.SemaCtx(), immutDesc, traceKV); err != nil {
-					return err
-				}
-				doneColumnBackfill = true
-
-			case *descpb.DescriptorMutation_Index:
+			} else if idx := m.AsIndex(); idx != nil {
 				if err := indexBackfillInTxn(ctx, planner.Txn(), planner.EvalContext(), planner.SemaCtx(), immutDesc, traceKV); err != nil {
 					return err
 				}
-
-			case *descpb.DescriptorMutation_Constraint:
+			} else if c := m.AsConstraint(); c != nil {
 				// This is processed later. Do not proceed to MakeMutationComplete.
-				constraintAdditionMutations = append(constraintAdditionMutations, m)
+				constraintAdditionMutations = append(constraintAdditionMutations, c)
 				continue
-
-			default:
-				return errors.AssertionFailedf(
-					"unsupported mutation: %+v", m)
+			} else {
+				return errors.AssertionFailedf("unsupported mutation: %+v", m)
 			}
-
-		case descpb.DescriptorMutation_DROP:
+		} else if m.Dropped() {
 			// Drop the name and drop the associated data later.
-			switch t := m.Descriptor_.(type) {
-			case *descpb.DescriptorMutation_Column:
-				if doneColumnBackfill || !tabledesc.ColumnNeedsBackfill(m.Direction, m.GetColumn()) {
-					break
+			if col := m.AsColumn(); col != nil {
+				if !doneColumnBackfill && catalog.ColumnNeedsBackfill(col) {
+					if err := columnBackfillInTxn(
+						ctx, planner.Txn(), planner.EvalContext(), planner.SemaCtx(), immutDesc, traceKV,
+					); err != nil {
+						return err
+					}
+					doneColumnBackfill = true
 				}
-				if err := columnBackfillInTxn(
-					ctx, planner.Txn(), planner.EvalContext(), planner.SemaCtx(), immutDesc, traceKV,
-				); err != nil {
-					return err
-				}
-				doneColumnBackfill = true
-
-			case *descpb.DescriptorMutation_Index:
+			} else if idx := m.AsIndex(); idx != nil {
 				if err := indexTruncateInTxn(
-					ctx, planner.Txn(), planner.ExecCfg(), planner.EvalContext(), immutDesc, t.Index, traceKV,
+					ctx, planner.Txn(), planner.ExecCfg(), planner.EvalContext(), immutDesc, idx.IndexDesc(), traceKV,
 				); err != nil {
 					return err
 				}
-
-			case *descpb.DescriptorMutation_Constraint:
-				switch t.Constraint.ConstraintType {
-				case descpb.ConstraintToUpdate_CHECK, descpb.ConstraintToUpdate_NOT_NULL:
+			} else if c := m.AsConstraint(); c != nil {
+				if c.IsCheck() || c.IsNotNull() {
 					for i := range tableDesc.Checks {
-						if tableDesc.Checks[i].Name == t.Constraint.Name {
+						if tableDesc.Checks[i].Name == c.GetName() {
 							tableDesc.Checks = append(tableDesc.Checks[:i], tableDesc.Checks[i+1:]...)
 							break
 						}
 					}
-				case descpb.ConstraintToUpdate_FOREIGN_KEY:
+				} else if c.IsForeignKey() {
 					for i := range tableDesc.OutboundFKs {
 						fk := &tableDesc.OutboundFKs[i]
-						if fk.Name == t.Constraint.Name {
+						if fk.Name == c.GetName() {
 							if err := planner.removeFKBackReference(ctx, tableDesc, fk); err != nil {
 								return err
 							}
@@ -2061,9 +2027,9 @@ func runSchemaChangesInTxn(
 							break
 						}
 					}
-				case descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX:
+				} else if c.IsUniqueWithoutIndex() {
 					for i := range tableDesc.UniqueWithoutIndexConstraints {
-						if tableDesc.UniqueWithoutIndexConstraints[i].Name == t.Constraint.Name {
+						if tableDesc.UniqueWithoutIndexConstraints[i].Name == c.GetName() {
 							tableDesc.UniqueWithoutIndexConstraints = append(
 								tableDesc.UniqueWithoutIndexConstraints[:i],
 								tableDesc.UniqueWithoutIndexConstraints[i+1:]...,
@@ -2071,17 +2037,13 @@ func runSchemaChangesInTxn(
 							break
 						}
 					}
-				default:
-					return errors.AssertionFailedf(
-						"unsupported constraint type: %d", errors.Safe(t.Constraint.ConstraintType))
+				} else {
+					return errors.AssertionFailedf("unsupported constraint type: %d", c.ConstraintToUpdateDesc().ConstraintType)
 				}
-
-			default:
-				return errors.AssertionFailedf("unsupported mutation: %+v", m)
 			}
-
 		}
-		if err := tableDesc.MakeMutationComplete(m); err != nil {
+
+		if err := tableDesc.MakeMutationComplete(tableDesc.Mutations[m.MutationOrdinal()]); err != nil {
 			return err
 		}
 
@@ -2089,15 +2051,14 @@ func runSchemaChangesInTxn(
 		// extra work that needs to be done. Note that we don't need to create
 		// a job to clean up the dropped indexes because those mutations can
 		// get processed in this txn on the new table.
-		if pkSwap := m.GetPrimaryKeySwap(); pkSwap != nil {
+		if pkSwap := m.AsPrimaryKeySwap(); pkSwap != nil {
 			// If any old index had an interleaved parent, remove the
 			// backreference from the parent.
 			// N.B. This logic needs to be kept up to date with the
 			// corresponding piece in (*SchemaChanger).done. It is slightly
 			// different because of how it access tables and how it needs to
 			// write the modified table descriptors explicitly.
-			for _, idxID := range append(
-				[]descpb.IndexID{pkSwap.OldPrimaryIndexId}, pkSwap.OldIndexes...) {
+			err := pkSwap.ForEachOldIndexIDs(func(idxID descpb.IndexID) error {
 				oldIndex, err := tableDesc.FindIndexWithID(idxID)
 				if err != nil {
 					return err
@@ -2134,27 +2095,42 @@ func runSchemaChangesInTxn(
 						}
 					}
 				}
+				return nil
+			})
+			if err != nil {
+				return err
 			}
 		}
 	}
 	// Clear all the mutations except for adding constraints.
-	tableDesc.Mutations = constraintAdditionMutations
+	tableDesc.Mutations = make([]descpb.DescriptorMutation, len(constraintAdditionMutations))
+	for i, c := range constraintAdditionMutations {
+		tableDesc.Mutations[i] = descpb.DescriptorMutation{
+			Descriptor_: &descpb.DescriptorMutation_Constraint{Constraint: c.ConstraintToUpdateDesc()},
+			Direction:   descpb.DescriptorMutation_ADD,
+			MutationID:  c.MutationID(),
+		}
+		if c.DeleteOnly() {
+			tableDesc.Mutations[i].State = descpb.DescriptorMutation_DELETE_ONLY
+		} else if c.WriteAndDeleteOnly() {
+			tableDesc.Mutations[i].State = descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY
+		}
+	}
 
 	// Now that the table descriptor is in a valid state with all column and index
 	// mutations applied, it can be used for validating check/FK constraints.
-	for _, m := range constraintAdditionMutations {
-		constraint := m.GetConstraint()
-		switch constraint.ConstraintType {
-		case descpb.ConstraintToUpdate_CHECK, descpb.ConstraintToUpdate_NOT_NULL:
-			if constraint.Check.Validity == descpb.ConstraintValidity_Validating {
+	for _, c := range constraintAdditionMutations {
+		if c.IsCheck() || c.IsNotNull() {
+			check := &c.ConstraintToUpdateDesc().Check
+			if check.Validity == descpb.ConstraintValidity_Validating {
 				if err := validateCheckInTxn(
-					ctx, planner.Descriptors().LeaseManager(), &planner.semaCtx, planner.EvalContext(), tableDesc, planner.txn, constraint.Check.Expr,
+					ctx, planner.Descriptors().LeaseManager(), &planner.semaCtx, planner.EvalContext(), tableDesc, planner.txn, check.Expr,
 				); err != nil {
 					return err
 				}
-				constraint.Check.Validity = descpb.ConstraintValidity_Validated
+				check.Validity = descpb.ConstraintValidity_Validated
 			}
-		case descpb.ConstraintToUpdate_FOREIGN_KEY:
+		} else if c.IsForeignKey() {
 			// We can't support adding a validated foreign key constraint in the same
 			// transaction as the CREATE TABLE statement. This would require adding
 			// the backreference to the other table and then validating the constraint
@@ -2167,32 +2143,31 @@ func runSchemaChangesInTxn(
 			// schema change framework eventually.
 			//
 			// For now, just always add the FK as unvalidated.
-			constraint.ForeignKey.Validity = descpb.ConstraintValidity_Unvalidated
-		case descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX:
-			if constraint.UniqueWithoutIndexConstraint.Validity == descpb.ConstraintValidity_Validating {
+			c.ConstraintToUpdateDesc().ForeignKey.Validity = descpb.ConstraintValidity_Unvalidated
+		} else if c.IsUniqueWithoutIndex() {
+			uwi := &c.ConstraintToUpdateDesc().UniqueWithoutIndexConstraint
+			if uwi.Validity == descpb.ConstraintValidity_Validating {
 				if err := validateUniqueWithoutIndexConstraintInTxn(
-					ctx, planner.EvalContext(), tableDesc, planner.txn, constraint.Name,
+					ctx, planner.EvalContext(), tableDesc, planner.txn, c.GetName(),
 				); err != nil {
 					return err
 				}
-				constraint.UniqueWithoutIndexConstraint.Validity = descpb.ConstraintValidity_Validated
+				uwi.Validity = descpb.ConstraintValidity_Validated
 			}
-		default:
-			return errors.AssertionFailedf(
-				"unsupported constraint type: %d", errors.Safe(constraint.ConstraintType))
+		} else {
+			return errors.AssertionFailedf("unsupported constraint type: %d", c.ConstraintToUpdateDesc().ConstraintType)
 		}
+
 	}
 
 	// Finally, add the constraints. We bypass MakeMutationsComplete (which makes
 	// certain assumptions about the state in the usual schema changer) and just
 	// update the table descriptor directly.
-	for _, m := range constraintAdditionMutations {
-		constraint := m.GetConstraint()
-		switch constraint.ConstraintType {
-		case descpb.ConstraintToUpdate_CHECK, descpb.ConstraintToUpdate_NOT_NULL:
-			tableDesc.Checks = append(tableDesc.Checks, &constraint.Check)
-		case descpb.ConstraintToUpdate_FOREIGN_KEY:
-			fk := constraint.ForeignKey
+	for _, c := range constraintAdditionMutations {
+		if c.IsCheck() || c.IsNotNull() {
+			tableDesc.Checks = append(tableDesc.Checks, &c.ConstraintToUpdateDesc().Check)
+		} else if c.IsForeignKey() {
+			fk := c.ConstraintToUpdateDesc().ForeignKey
 			var referencedTableDesc *tabledesc.Mutable
 			// We don't want to lookup/edit a second copy of the same table.
 			selfReference := tableDesc.ID == fk.ReferencedTableID
@@ -2219,13 +2194,12 @@ func runSchemaChangesInTxn(
 					return err
 				}
 			}
-		case descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX:
+		} else if c.IsUniqueWithoutIndex() {
 			tableDesc.UniqueWithoutIndexConstraints = append(
-				tableDesc.UniqueWithoutIndexConstraints, constraint.UniqueWithoutIndexConstraint,
+				tableDesc.UniqueWithoutIndexConstraints, c.ConstraintToUpdateDesc().UniqueWithoutIndexConstraint,
 			)
-		default:
-			return errors.AssertionFailedf(
-				"unsupported constraint type: %d", errors.Safe(constraint.ConstraintType))
+		} else {
+			return errors.AssertionFailedf("unsupported constraint type: %d", c.ConstraintToUpdateDesc().ConstraintType)
 		}
 	}
 	tableDesc.Mutations = nil

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -188,7 +188,7 @@ func (sc *SchemaChanger) runBackfill(ctx context.Context) error {
 
 	// Mutations are applied in a FIFO order. Only apply the first set of
 	// mutations. Collect the elements that are part of the mutation.
-	var droppedIndexDescs []descpb.IndexDescriptor
+	var droppedIndexes []catalog.Index
 	var addedIndexSpans []roachpb.Span
 	var addedIndexes []descpb.IndexID
 
@@ -268,13 +268,12 @@ func (sc *SchemaChanger) runBackfill(ctx context.Context) error {
 			} else {
 				return errors.AssertionFailedf("unsupported mutation: %+v", m)
 			}
-
 		} else if m.Dropped() {
 			if col := m.AsColumn(); col != nil {
 				needColumnBackfill = catalog.ColumnNeedsBackfill(col)
 			} else if idx := m.AsIndex(); idx != nil {
-				if !canClearRangeForDrop(idx.IndexDesc()) {
-					droppedIndexDescs = append(droppedIndexDescs, *idx.IndexDesc())
+				if !canClearRangeForDrop(idx) {
+					droppedIndexes = append(droppedIndexes, idx)
 				}
 			} else if c := m.AsConstraint(); c != nil {
 				constraintsToDrop = append(constraintsToDrop, c)
@@ -306,8 +305,8 @@ func (sc *SchemaChanger) runBackfill(ctx context.Context) error {
 	}
 
 	// Drop indexes not to be removed by `ClearRange`.
-	if len(droppedIndexDescs) > 0 {
-		if err := sc.truncateIndexes(ctx, version, droppedIndexDescs); err != nil {
+	if len(droppedIndexes) > 0 {
+		if err := sc.truncateIndexes(ctx, version, droppedIndexes); err != nil {
 			return err
 		}
 	}
@@ -774,13 +773,21 @@ func TruncateInterleavedIndexes(
 	ctx context.Context,
 	execCfg *ExecutorConfig,
 	table catalog.TableDescriptor,
-	indexes []descpb.IndexDescriptor,
+	indexIDs []descpb.IndexID,
 ) error {
-	log.Infof(ctx, "truncating %d interleaved indexes", len(indexes))
+	log.Infof(ctx, "truncating %d interleaved indexes", len(indexIDs))
 	chunkSize := int64(indexTruncateChunkSize)
 	alloc := &rowenc.DatumAlloc{}
 	codec, db := execCfg.Codec, execCfg.DB
-	for _, desc := range indexes {
+	zoneConfigIndexIDList := make([]uint32, len(indexIDs))
+	for i, id := range indexIDs {
+		zoneConfigIndexIDList[i] = uint32(id)
+	}
+	for _, id := range indexIDs {
+		idx, err := table.FindIndexWithID(id)
+		if err != nil {
+			return err
+		}
 		var resume roachpb.Span
 		for rowIdx, done := int64(0), false; !done; rowIdx += chunkSize {
 			log.VEventf(ctx, 2, "truncate interleaved index (%d) at row: %d, span: %s", table.GetID(), rowIdx, resume)
@@ -794,7 +801,7 @@ func TruncateInterleavedIndexes(
 				}
 				resume, err := td.deleteIndex(
 					ctx,
-					&desc,
+					idx,
 					resumeAt,
 					chunkSize,
 					false, /* traceKV */
@@ -812,7 +819,7 @@ func TruncateInterleavedIndexes(
 			if err != nil {
 				return err
 			}
-			return RemoveIndexZoneConfigs(ctx, txn, execCfg, freshTableDesc, indexes)
+			return RemoveIndexZoneConfigs(ctx, txn, execCfg, freshTableDesc, zoneConfigIndexIDList)
 		}); err != nil {
 			return err
 		}
@@ -826,7 +833,7 @@ func TruncateInterleavedIndexes(
 // The indexes are dropped chunk by chunk, each chunk being deleted in
 // its own txn.
 func (sc *SchemaChanger) truncateIndexes(
-	ctx context.Context, version descpb.DescriptorVersion, dropped []descpb.IndexDescriptor,
+	ctx context.Context, version descpb.DescriptorVersion, dropped []catalog.Index,
 ) error {
 	log.Infof(ctx, "clearing data for %d indexes", len(dropped))
 
@@ -835,7 +842,11 @@ func (sc *SchemaChanger) truncateIndexes(
 		chunkSize = sc.testingKnobs.BackfillChunkSize
 	}
 	alloc := &rowenc.DatumAlloc{}
-	for _, desc := range dropped {
+	droppedIndexIDs := make([]uint32, len(dropped))
+	for i, idx := range dropped {
+		droppedIndexIDs[i] = uint32(idx.GetID())
+	}
+	for _, idx := range dropped {
 		var resume roachpb.Span
 		for rowIdx, done := int64(0), false; !done; rowIdx += chunkSize {
 			resumeAt := resume
@@ -867,10 +878,10 @@ func (sc *SchemaChanger) truncateIndexes(
 				if err := td.init(ctx, txn, nil /* *tree.EvalContext */); err != nil {
 					return err
 				}
-				if !canClearRangeForDrop(&desc) {
+				if !canClearRangeForDrop(idx) {
 					resume, err = td.deleteIndex(
 						ctx,
-						&desc,
+						idx,
 						resumeAt,
 						chunkSize,
 						false, /* traceKV */
@@ -879,7 +890,7 @@ func (sc *SchemaChanger) truncateIndexes(
 					return err
 				}
 				done = true
-				return td.clearIndex(ctx, &desc)
+				return td.clearIndex(ctx, idx)
 			}); err != nil {
 				return err
 			}
@@ -892,7 +903,7 @@ func (sc *SchemaChanger) truncateIndexes(
 			if err != nil {
 				return err
 			}
-			return RemoveIndexZoneConfigs(ctx, txn, sc.execCfg, table, dropped)
+			return RemoveIndexZoneConfigs(ctx, txn, sc.execCfg, table, droppedIndexIDs)
 		}); err != nil {
 			return err
 		}
@@ -1433,8 +1444,7 @@ func (sc *SchemaChanger) validateIndexes(ctx context.Context) error {
 		return err
 	}
 
-	var forwardIndexes []*descpb.IndexDescriptor
-	var invertedIndexes []*descpb.IndexDescriptor
+	var forwardIndexes, invertedIndexes []catalog.Index
 
 	for _, m := range tableDesc.AllMutations() {
 		if sc.mutationID != m.MutationID() {
@@ -1446,9 +1456,9 @@ func (sc *SchemaChanger) validateIndexes(ctx context.Context) error {
 		}
 		switch idx.GetType() {
 		case descpb.IndexDescriptor_FORWARD:
-			forwardIndexes = append(forwardIndexes, idx.IndexDesc())
+			forwardIndexes = append(forwardIndexes, idx)
 		case descpb.IndexDescriptor_INVERTED:
-			invertedIndexes = append(invertedIndexes, idx.IndexDesc())
+			invertedIndexes = append(invertedIndexes, idx)
 		}
 	}
 	if len(forwardIndexes) == 0 && len(invertedIndexes) == 0 {
@@ -1495,7 +1505,7 @@ func ValidateInvertedIndexes(
 	ctx context.Context,
 	codec keys.SQLCodec,
 	tableDesc catalog.TableDescriptor,
-	indexes []*descpb.IndexDescriptor,
+	indexes []catalog.Index,
 	runHistoricalTxn HistoricalInternalExecTxnRunner,
 	gatherAllInvalid bool,
 ) error {
@@ -1518,7 +1528,7 @@ func ValidateInvertedIndexes(
 			// distributed execution and avoid bypassing the SQL decoding
 			start := timeutil.Now()
 			var idxLen int64
-			span := tableDesc.IndexSpan(codec, idx.ID)
+			span := tableDesc.IndexSpan(codec, idx.GetID())
 			key := span.Key
 			endKey := span.EndKey
 			if err := runHistoricalTxn(ctx, func(ctx context.Context, txn *kv.Txn, _ *InternalExecutor) error {
@@ -1538,12 +1548,12 @@ func ValidateInvertedIndexes(
 				return err
 			}
 			log.Infof(ctx, "inverted index %s/%s count = %d, took %s",
-				tableDesc.GetName(), idx.Name, idxLen, timeutil.Since(start))
+				tableDesc.GetName(), idx.GetName(), idxLen, timeutil.Since(start))
 			select {
 			case <-countReady[i]:
 				if idxLen != expectedCount[i] {
 					if gatherAllInvalid {
-						invalid <- idx.ID
+						invalid <- idx.GetID()
 						return nil
 					}
 					// JSON columns cannot have unique indexes, so if the expected and
@@ -1551,7 +1561,7 @@ func ValidateInvertedIndexes(
 					// uniqueness violation.
 					return errors.AssertionFailedf(
 						"validation of index %s failed: expected %d rows, found %d",
-						idx.Name, errors.Safe(expectedCount[i]), errors.Safe(idxLen))
+						idx.GetName(), errors.Safe(expectedCount[i]), errors.Safe(idxLen))
 				}
 			case <-ctx.Done():
 				return ctx.Err()
@@ -1567,21 +1577,22 @@ func ValidateInvertedIndexes(
 
 			if err := runHistoricalTxn(ctx, func(ctx context.Context, txn *kv.Txn, ie *InternalExecutor) error {
 				var stmt string
-				if geoindex.IsEmptyConfig(&idx.GeoConfig) {
+				geoConfig := idx.GetGeoConfig()
+				if geoindex.IsEmptyConfig(&geoConfig) {
 					stmt = fmt.Sprintf(
 						`SELECT coalesce(sum_int(crdb_internal.num_inverted_index_entries(%q, %d)), 0) FROM [%d AS t]`,
-						col, idx.Version, tableDesc.GetID(),
+						col, idx.GetVersion(), tableDesc.GetID(),
 					)
 				} else {
 					stmt = fmt.Sprintf(
 						`SELECT coalesce(sum_int(crdb_internal.num_geo_inverted_index_entries(%d, %d, %q)), 0) FROM [%d AS t]`,
-						tableDesc.GetID(), idx.ID, col, tableDesc.GetID(),
+						tableDesc.GetID(), idx.GetID(), col, tableDesc.GetID(),
 					)
 				}
 				// If the index is a partial index the predicate must be added
 				// as a filter to the query.
 				if idx.IsPartial() {
-					stmt = fmt.Sprintf(`%s WHERE %s`, stmt, idx.Predicate)
+					stmt = fmt.Sprintf(`%s WHERE %s`, stmt, idx.GetPredicate())
 				}
 				return ie.WithSyntheticDescriptors([]catalog.Descriptor{tableDesc}, func() error {
 					row, err := ie.QueryRowEx(ctx, "verify-inverted-idx-count", txn, sessiondata.InternalExecutorOverride{}, stmt)
@@ -1632,7 +1643,7 @@ func ValidateInvertedIndexes(
 func ValidateForwardIndexes(
 	ctx context.Context,
 	tableDesc catalog.TableDescriptor,
-	indexes []*descpb.IndexDescriptor,
+	indexes []catalog.Index,
 	runHistoricalTxn HistoricalInternalExecTxnRunner,
 	withFirstMutationPublic bool,
 	gatherAllInvalid bool,
@@ -1698,11 +1709,11 @@ func ValidateForwardIndexes(
 			// Retrieve the row count in the index.
 			var idxLen int64
 			if err := runHistoricalTxn(ctx, func(ctx context.Context, txn *kv.Txn, ie *InternalExecutor) error {
-				query := fmt.Sprintf(`SELECT count(1) FROM [%d AS t]@[%d]`, desc.GetID(), idx.ID)
+				query := fmt.Sprintf(`SELECT count(1) FROM [%d AS t]@[%d]`, desc.GetID(), idx.GetID())
 				// If the index is a partial index the predicate must be added
 				// as a filter to the query to force scanning the index.
 				if idx.IsPartial() {
-					query = fmt.Sprintf(`%s WHERE %s`, query, idx.Predicate)
+					query = fmt.Sprintf(`%s WHERE %s`, query, idx.GetPredicate())
 				}
 
 				return ie.WithSyntheticDescriptors([]catalog.Descriptor{desc}, func() error {
@@ -1717,13 +1728,13 @@ func ValidateForwardIndexes(
 
 					// For implicitly partitioned unique indexes, we need to independently
 					// validate that the non-implicitly partitioned columns are unique.
-					if idx.Unique && idx.Partitioning.NumImplicitColumns > 0 && !skipUniquenessChecks {
+					if idx.IsUnique() && idx.GetPartitioning().NumImplicitColumns > 0 && !skipUniquenessChecks {
 						if err := validateUniqueConstraint(
 							ctx,
 							tableDesc,
 							idx.GetName(),
-							idx.ColumnIDs[idx.Partitioning.NumImplicitColumns:],
-							idx.Predicate,
+							idx.IndexDesc().ColumnIDs[idx.GetPartitioning().NumImplicitColumns:],
+							idx.GetPredicate(),
 							ie,
 							txn,
 						); err != nil {
@@ -1737,7 +1748,7 @@ func ValidateForwardIndexes(
 			}
 
 			log.Infof(ctx, "validation: index %s/%s row count = %d, time so far %s",
-				tableDesc.GetName(), idx.Name, idxLen, timeutil.Since(start))
+				tableDesc.GetName(), idx.GetName(), idxLen, timeutil.Since(start))
 
 			// Now compare with the row count in the table.
 			select {
@@ -1746,19 +1757,19 @@ func ValidateForwardIndexes(
 				// If the index is a partial index, the expected number of rows
 				// is different than the total number of rows in the table.
 				if idx.IsPartial() {
-					expectedCount = partialIndexExpectedCounts[idx.ID]
+					expectedCount = partialIndexExpectedCounts[idx.GetID()]
 				}
 
 				if idxLen != expectedCount {
 					if gatherAllInvalid {
-						invalid <- idx.ID
+						invalid <- idx.GetID()
 						return nil
 					}
 					// TODO(vivek): find the offending row and include it in the error.
 					return pgerror.WithConstraintName(pgerror.Newf(pgcode.UniqueViolation,
 						"duplicate key value violates unique constraint %q",
-						idx.Name),
-						idx.Name)
+						idx.GetName()),
+						idx.GetName())
 
 				}
 
@@ -1795,7 +1806,7 @@ func ValidateForwardIndexes(
 				// For partial indexes, count the number of rows in the table
 				// for which the predicate expression evaluates to true.
 				if idx.IsPartial() {
-					s.WriteString(fmt.Sprintf(`, count(1) FILTER (WHERE %s)`, idx.Predicate))
+					s.WriteString(fmt.Sprintf(`, count(1) FILTER (WHERE %s)`, idx.GetPredicate()))
 				}
 			}
 			partialIndexCounts := s.String()
@@ -1817,7 +1828,7 @@ func ValidateForwardIndexes(
 				cntIdx := 1
 				for _, idx := range indexes {
 					if idx.IsPartial() {
-						partialIndexExpectedCounts[idx.ID] = int64(tree.MustBeDInt(cnt[cntIdx]))
+						partialIndexExpectedCounts[idx.GetID()] = int64(tree.MustBeDInt(cnt[cntIdx]))
 						cntIdx++
 					}
 				}
@@ -2004,7 +2015,7 @@ func runSchemaChangesInTxn(
 				}
 			} else if idx := m.AsIndex(); idx != nil {
 				if err := indexTruncateInTxn(
-					ctx, planner.Txn(), planner.ExecCfg(), planner.EvalContext(), immutDesc, idx.IndexDesc(), traceKV,
+					ctx, planner.Txn(), planner.ExecCfg(), planner.EvalContext(), immutDesc, idx, traceKV,
 				); err != nil {
 					return err
 				}
@@ -2410,7 +2421,7 @@ func indexTruncateInTxn(
 	execCfg *ExecutorConfig,
 	evalCtx *tree.EvalContext,
 	tableDesc catalog.TableDescriptor,
-	idx *descpb.IndexDescriptor,
+	idx catalog.Index,
 	traceKV bool,
 ) error {
 	alloc := &rowenc.DatumAlloc{}
@@ -2430,5 +2441,5 @@ func indexTruncateInTxn(
 		}
 	}
 	// Remove index zone configs.
-	return RemoveIndexZoneConfigs(ctx, txn, execCfg, tableDesc, []descpb.IndexDescriptor{*idx})
+	return RemoveIndexZoneConfigs(ctx, txn, execCfg, tableDesc, []uint32{uint32(idx.GetID())})
 }

--- a/pkg/sql/catalog/catalogkeys/BUILD.bazel
+++ b/pkg/sql/catalog/catalogkeys/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/keys",
         "//pkg/roachpb",
+        "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/systemschema",
         "//pkg/sql/sem/tree",

--- a/pkg/sql/catalog/catalogkeys/keys.go
+++ b/pkg/sql/catalog/catalogkeys/keys.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -64,19 +65,20 @@ func IsDefaultCreatedDescriptor(descID descpb.ID) bool {
 //    /51/1/42/#/51/2/1337
 // which would return the slice
 //    {ASC, ASC, ASC, 0, ASC, ASC, DESC}
-func IndexKeyValDirs(index *descpb.IndexDescriptor) []encoding.Direction {
+func IndexKeyValDirs(index catalog.Index) []encoding.Direction {
 	if index == nil {
 		return nil
 	}
 
-	dirs := make([]encoding.Direction, 0, (len(index.Interleave.Ancestors)+1)*2+len(index.ColumnDirections))
+	dirs := make([]encoding.Direction, 0, (index.NumInterleaveAncestors()+1)*2+index.NumColumns())
 
 	colIdx := 0
-	for _, ancs := range index.Interleave.Ancestors {
+	for i := 0; i < index.NumInterleaveAncestors(); i++ {
+		ancs := index.GetInterleaveAncestor(i)
 		// Table/Index IDs are always encoded ascending.
 		dirs = append(dirs, encoding.Ascending, encoding.Ascending)
 		for i := 0; i < int(ancs.SharedPrefixLen); i++ {
-			d, err := index.ColumnDirections[colIdx].ToEncodingDirection()
+			d, err := index.GetColumnDirection(colIdx).ToEncodingDirection()
 			if err != nil {
 				panic(err)
 			}
@@ -93,8 +95,8 @@ func IndexKeyValDirs(index *descpb.IndexDescriptor) []encoding.Direction {
 	// The index's table/index ID.
 	dirs = append(dirs, encoding.Ascending, encoding.Ascending)
 
-	for colIdx < len(index.ColumnDirections) {
-		d, err := index.ColumnDirections[colIdx].ToEncodingDirection()
+	for colIdx < index.NumColumns() {
+		d, err := index.GetColumnDirection(colIdx).ToEncodingDirection()
 		if err != nil {
 			panic(err)
 		}
@@ -140,7 +142,7 @@ func PrettySpan(valDirs []encoding.Direction, span roachpb.Span, skip int) strin
 // PrettySpans returns a human-readable description of the spans.
 // If index is nil, then pretty print subroutines will use their default
 // settings.
-func PrettySpans(index *descpb.IndexDescriptor, spans []roachpb.Span, skip int) string {
+func PrettySpans(index catalog.Index, spans []roachpb.Span, skip int) string {
 	if len(spans) == 0 {
 		return ""
 	}

--- a/pkg/sql/catalog/catformat/index.go
+++ b/pkg/sql/catalog/catformat/index.go
@@ -40,6 +40,18 @@ func IndexForDisplay(
 	ctx context.Context,
 	table catalog.TableDescriptor,
 	tableName *tree.TableName,
+	index catalog.Index,
+	partition string,
+	interleave string,
+	semaCtx *tree.SemaContext,
+) (string, error) {
+	return indexForDisplay(ctx, table, tableName, index.IndexDesc(), partition, interleave, semaCtx)
+}
+
+func indexForDisplay(
+	ctx context.Context,
+	table catalog.TableDescriptor,
+	tableName *tree.TableName,
 	index *descpb.IndexDescriptor,
 	partition string,
 	interleave string,

--- a/pkg/sql/catalog/catformat/index_test.go
+++ b/pkg/sql/catalog/catformat/index_test.go
@@ -94,7 +94,7 @@ func TestIndexForDisplay(t *testing.T) {
 
 	for testIdx, tc := range testData {
 		t.Run(strconv.Itoa(testIdx), func(t *testing.T) {
-			got, err := IndexForDisplay(
+			got, err := indexForDisplay(
 				ctx, tableDesc, &tc.tableName, &tc.index, tc.partition, tc.interleave, &semaCtx,
 			)
 			if err != nil {

--- a/pkg/sql/catalog/colinfo/col_type_info.go
+++ b/pkg/sql/catalog/colinfo/col_type_info.go
@@ -41,11 +41,11 @@ func ColTypeInfoFromColTypes(colTypes []*types.T) ColTypeInfo {
 	return ColTypeInfo{colTypes: colTypes}
 }
 
-// ColTypeInfoFromColDescs creates a ColTypeInfo from []ColumnDescriptor.
-func ColTypeInfoFromColDescs(colDescs []descpb.ColumnDescriptor) ColTypeInfo {
-	colTypes := make([]*types.T, len(colDescs))
-	for i, colDesc := range colDescs {
-		colTypes[i] = colDesc.Type
+// ColTypeInfoFromColumns creates a ColTypeInfo from []catalog.Column.
+func ColTypeInfoFromColumns(columns []catalog.Column) ColTypeInfo {
+	colTypes := make([]*types.T, len(columns))
+	for i, col := range columns {
+		colTypes[i] = col.GetType()
 	}
 	return ColTypeInfoFromColTypes(colTypes)
 }
@@ -171,7 +171,7 @@ func GetColumnTypes(
 // IDs into the outTypes slice, returning it. You must use the returned slice,
 // as this function might allocate a new slice.
 func GetColumnTypesFromColDescs(
-	cols []descpb.ColumnDescriptor, columnIDs []descpb.ColumnID, outTypes []*types.T,
+	cols []catalog.Column, columnIDs []descpb.ColumnID, outTypes []*types.T,
 ) []*types.T {
 	if cap(outTypes) < len(columnIDs) {
 		outTypes = make([]*types.T, len(columnIDs))
@@ -180,8 +180,8 @@ func GetColumnTypesFromColDescs(
 	}
 	for i, id := range columnIDs {
 		for j := range cols {
-			if id == cols[j].ID {
-				outTypes[i] = cols[j].Type
+			if id == cols[j].GetID() {
+				outTypes[i] = cols[j].GetType()
 				break
 			}
 		}

--- a/pkg/sql/catalog/colinfo/column_type_properties.go
+++ b/pkg/sql/catalog/colinfo/column_type_properties.go
@@ -11,7 +11,7 @@
 package colinfo
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -26,14 +26,14 @@ import (
 // scalar type String).
 //
 // This is used by the UPDATE, INSERT and UPSERT code.
-func CheckDatumTypeFitsColumnType(col *descpb.ColumnDescriptor, typ *types.T) error {
+func CheckDatumTypeFitsColumnType(col catalog.Column, typ *types.T) error {
 	if typ.Family() == types.UnknownFamily {
 		return nil
 	}
-	if !typ.Equivalent(col.Type) {
+	if !typ.Equivalent(col.GetType()) {
 		return pgerror.Newf(pgcode.DatatypeMismatch,
 			"value type %s doesn't match type %s of column %q",
-			typ.String(), col.Type.String(), tree.ErrNameString(col.Name))
+			typ.String(), col.GetType().String(), tree.ErrNameString(col.GetName()))
 	}
 	return nil
 }

--- a/pkg/sql/catalog/colinfo/result_columns.go
+++ b/pkg/sql/catalog/colinfo/result_columns.go
@@ -37,32 +37,15 @@ type ResultColumn struct {
 // describe the column types of a table.
 type ResultColumns []ResultColumn
 
-// ResultColumnsFromColDescs converts []descpb.ColumnDescriptor to []ResultColumn.
-func ResultColumnsFromColDescs(
-	tableID descpb.ID, colDescs []descpb.ColumnDescriptor,
-) ResultColumns {
-	return resultColumnsFromColDescs(tableID, len(colDescs), func(i int) *descpb.ColumnDescriptor {
-		return &colDescs[i]
-	})
-}
-
-// ResultColumnsFromColDescPtrs converts []*descpb.ColumnDescriptor to []ResultColumn.
-func ResultColumnsFromColDescPtrs(
-	tableID descpb.ID, colDescs []*descpb.ColumnDescriptor,
-) ResultColumns {
-	return resultColumnsFromColDescs(tableID, len(colDescs), func(i int) *descpb.ColumnDescriptor {
-		return colDescs[i]
-	})
-}
-
 // ResultColumnsFromColumns converts []catalog.Column to []ResultColumn.
 func ResultColumnsFromColumns(tableID descpb.ID, columns []catalog.Column) ResultColumns {
-	return resultColumnsFromColDescs(tableID, len(columns), func(i int) *descpb.ColumnDescriptor {
+	return ResultColumnsFromColDescs(tableID, len(columns), func(i int) *descpb.ColumnDescriptor {
 		return columns[i].ColumnDesc()
 	})
 }
 
-func resultColumnsFromColDescs(
+// ResultColumnsFromColDescs is used by ResultColumnsFromColumns and by tests.
+func ResultColumnsFromColDescs(
 	tableID descpb.ID, numCols int, getColDesc func(int) *descpb.ColumnDescriptor,
 ) ResultColumns {
 	cols := make(ResultColumns, numCols)

--- a/pkg/sql/catalog/schemaexpr/check_constraint.go
+++ b/pkg/sql/catalog/schemaexpr/check_constraint.go
@@ -161,9 +161,9 @@ func (b *CheckConstraintBuilder) DefaultName(expr tree.Expr) (string, error) {
 	var nameBuf bytes.Buffer
 	nameBuf.WriteString("check")
 
-	err := iterColDescriptors(b.desc, expr, func(c *descpb.ColumnDescriptor) error {
+	err := iterColDescriptors(b.desc, expr, func(c catalog.Column) error {
 		nameBuf.WriteByte('_')
-		nameBuf.WriteString(c.Name)
+		nameBuf.WriteString(c.GetName())
 		return nil
 	})
 	if err != nil {

--- a/pkg/sql/catalog/schemaexpr/column_test.go
+++ b/pkg/sql/catalog/schemaexpr/column_test.go
@@ -62,7 +62,10 @@ func TestDequalifyColumnRefs(t *testing.T) {
 			source := colinfo.NewSourceInfoForSingleTable(
 				tn, colinfo.ResultColumnsFromColDescs(
 					descpb.ID(1),
-					cols,
+					len(cols),
+					func(i int) *descpb.ColumnDescriptor {
+						return &cols[i]
+					},
 				),
 			)
 

--- a/pkg/sql/catalog/schemaexpr/computed_exprs.go
+++ b/pkg/sql/catalog/schemaexpr/computed_exprs.go
@@ -12,7 +12,6 @@ package schemaexpr
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -26,7 +25,7 @@ type RowIndexedVarContainer struct {
 	// Because the rows we have might not be permuted in the same way as the
 	// original table, we need to store a mapping between them.
 
-	Cols    []descpb.ColumnDescriptor
+	Cols    []catalog.Column
 	Mapping catalog.TableColMap
 }
 
@@ -36,7 +35,7 @@ var _ tree.IndexedVarContainer = &RowIndexedVarContainer{}
 func (r *RowIndexedVarContainer) IndexedVarEval(
 	idx int, ctx *tree.EvalContext,
 ) (tree.Datum, error) {
-	rowIdx, ok := r.Mapping.Get(r.Cols[idx].ID)
+	rowIdx, ok := r.Mapping.Get(r.Cols[idx].GetID())
 	if !ok {
 		return tree.DNull, nil
 	}

--- a/pkg/sql/catalog/schemaexpr/default_exprs.go
+++ b/pkg/sql/catalog/schemaexpr/default_exprs.go
@@ -14,7 +14,6 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -28,7 +27,7 @@ import (
 // as default.
 func MakeDefaultExprs(
 	ctx context.Context,
-	cols []descpb.ColumnDescriptor,
+	cols []catalog.Column,
 	txCtx *transform.ExprTransformContext,
 	evalCtx *tree.EvalContext,
 	semaCtx *tree.SemaContext,
@@ -37,8 +36,8 @@ func MakeDefaultExprs(
 	// are no DEFAULT expressions, we don't bother with constructing the
 	// defaults map as the defaults are all NULL.
 	haveDefaults := false
-	for i := range cols {
-		if cols[i].DefaultExpr != nil {
+	for _, col := range cols {
+		if col.HasDefault() {
 			haveDefaults = true
 			break
 		}
@@ -50,10 +49,9 @@ func MakeDefaultExprs(
 	// Build the default expressions map from the parsed SELECT statement.
 	defaultExprs := make([]tree.TypedExpr, 0, len(cols))
 	exprStrings := make([]string, 0, len(cols))
-	for i := range cols {
-		col := &cols[i]
-		if col.DefaultExpr != nil {
-			exprStrings = append(exprStrings, *col.DefaultExpr)
+	for _, col := range cols {
+		if col.HasDefault() {
+			exprStrings = append(exprStrings, col.GetDefaultExpr())
 		}
 	}
 	exprs, err := parser.ParseExprs(exprStrings)
@@ -62,14 +60,13 @@ func MakeDefaultExprs(
 	}
 
 	defExprIdx := 0
-	for i := range cols {
-		col := &cols[i]
-		if col.DefaultExpr == nil {
+	for _, col := range cols {
+		if !col.HasDefault() {
 			defaultExprs = append(defaultExprs, tree.DNull)
 			continue
 		}
 		expr := exprs[defExprIdx]
-		typedExpr, err := tree.TypeCheck(ctx, expr, semaCtx, col.Type)
+		typedExpr, err := tree.TypeCheck(ctx, expr, semaCtx, col.GetType())
 		if err != nil {
 			return nil, err
 		}
@@ -85,22 +82,20 @@ func MakeDefaultExprs(
 // ProcessColumnSet returns columns in cols, and other writable
 // columns in tableDesc that fulfills a given criteria in inSet.
 func ProcessColumnSet(
-	cols []descpb.ColumnDescriptor,
-	tableDesc catalog.TableDescriptor,
-	inSet func(*descpb.ColumnDescriptor) bool,
-) []descpb.ColumnDescriptor {
+	cols []catalog.Column, tableDesc catalog.TableDescriptor, inSet func(column catalog.Column) bool,
+) []catalog.Column {
 	var colIDSet catalog.TableColSet
 	for i := range cols {
-		colIDSet.Add(cols[i].ID)
+		colIDSet.Add(cols[i].GetID())
 	}
 
 	// Add all public or columns in DELETE_AND_WRITE_ONLY state
 	// that satisfy the condition.
 	for _, col := range tableDesc.WritableColumns() {
-		if inSet(col.ColumnDesc()) {
+		if inSet(col) {
 			if !colIDSet.Contains(col.GetID()) {
 				colIDSet.Add(col.GetID())
-				cols = append(cols, *col.ColumnDesc())
+				cols = append(cols, col)
 			}
 		}
 	}

--- a/pkg/sql/catalog/table_elements.go
+++ b/pkg/sql/catalog/table_elements.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 )
 
@@ -272,6 +273,35 @@ type ConstraintToUpdate interface {
 
 	// ConstraintToUpdateDesc returns the underlying protobuf descriptor.
 	ConstraintToUpdateDesc() *descpb.ConstraintToUpdate
+
+	// GetName returns the name of this constraint update mutation.
+	GetName() string
+
+	// IsCheck returns true iff this is an update for a check constraint.
+	IsCheck() bool
+
+	// IsForeignKey returns true iff this is an update for a fk constraint.
+	IsForeignKey() bool
+
+	// IsNotNull returns true iff this is an update for a not-null constraint.
+	IsNotNull() bool
+
+	// IsUniqueWithoutIndex returns true iff this is an update for a unique
+	// without index constraint.
+	IsUniqueWithoutIndex() bool
+
+	// Check returns the underlying check constraint, if there is one.
+	Check() descpb.TableDescriptor_CheckConstraint
+
+	// ForeignKey returns the underlying fk constraint, if there is one.
+	ForeignKey() descpb.ForeignKeyConstraint
+
+	// NotNullColumnID returns the underlying not-null column ID, if there is one.
+	NotNullColumnID() descpb.ColumnID
+
+	// UniqueWithoutIndex returns the underlying unique without index constraint, if
+	// there is one.
+	UniqueWithoutIndex() descpb.UniqueWithoutIndexConstraint
 }
 
 // PrimaryKeySwap is an interface around a primary key swap mutation.
@@ -280,6 +310,26 @@ type PrimaryKeySwap interface {
 
 	// PrimaryKeySwapDesc returns the underlying protobuf descriptor.
 	PrimaryKeySwapDesc() *descpb.PrimaryKeySwap
+
+	// NumOldIndexes returns the number of old active indexes to swap out.
+	NumOldIndexes() int
+
+	// ForEachOldIndexIDs iterates through each of the old index IDs.
+	// iterutil.Done is supported.
+	ForEachOldIndexIDs(fn func(id descpb.IndexID) error) error
+
+	// NumNewIndexes returns the number of new active indexes to swap in.
+	NumNewIndexes() int
+
+	// ForEachNewIndexIDs iterates through each of the new index IDs.
+	// iterutil.Done is supported.
+	ForEachNewIndexIDs(fn func(id descpb.IndexID) error) error
+
+	// HasLocalityConfig returns true iff the locality config is swapped also.
+	HasLocalityConfig() bool
+
+	// LocalityConfigSwap returns the locality config swap, if there is one.
+	LocalityConfigSwap() descpb.PrimaryKeySwap_LocalityConfigSwap
 }
 
 // ComputedColumnSwap is an interface around a computed column swap mutation.
@@ -297,6 +347,21 @@ type MaterializedViewRefresh interface {
 
 	// MaterializedViewRefreshDesc returns the underlying protobuf descriptor.
 	MaterializedViewRefreshDesc() *descpb.MaterializedViewRefresh
+
+	// ShouldBackfill returns true iff the query should be backfilled into the
+	// indexes.
+	ShouldBackfill() bool
+
+	// AsOf returns the timestamp at which the query should be run.
+	AsOf() hlc.Timestamp
+
+	// ForEachIndexID iterates through each of the index IDs.
+	// iterutil.Done is supported.
+	ForEachIndexID(func(id descpb.IndexID) error) error
+
+	// TableWithNewIndexes returns a new TableDescriptor based on the old one
+	// but with the refreshed indexes put in.
+	TableWithNewIndexes(tbl TableDescriptor) TableDescriptor
 }
 
 func isIndexInSearchSet(desc TableDescriptor, opts IndexOpts, idx Index) bool {
@@ -489,4 +554,27 @@ func ColumnTypesWithVirtualCol(columns []Column, virtualCol Column) []*types.T {
 		}
 	}
 	return t
+}
+
+// ColumnNeedsBackfill returns true if adding or dropping (according to
+// the direction) the given column requires backfill.
+func ColumnNeedsBackfill(col Column) bool {
+	if col.IsVirtual() {
+		// Virtual columns are not stored in the primary index, so they do not need
+		// backfill.
+		return false
+	}
+	if col.Dropped() {
+		// In all other cases, DROP requires backfill.
+		return true
+	}
+	// ADD requires backfill for:
+	//  - columns with non-NULL default value
+	//  - computed columns
+	//  - non-nullable columns (note: if a non-nullable column doesn't have a
+	//    default value, the backfill will fail unless the table is empty).
+	if col.ColumnDesc().HasNullDefault() {
+		return false
+	}
+	return col.HasDefault() || !col.IsNullable() || col.IsComputed()
 }

--- a/pkg/sql/catalog/table_elements.go
+++ b/pkg/sql/catalog/table_elements.go
@@ -512,6 +512,32 @@ func FindDeleteOnlyNonPrimaryIndex(desc TableDescriptor, test func(idx Index) bo
 	return findIndex(desc.DeleteOnlyNonPrimaryIndexes(), test)
 }
 
+// FullIndexColumnIDs returns the index column IDs including any extra (implicit or
+// stored (old STORING encoding)) column IDs for non-unique indexes. It also
+// returns the direction with which each column was encoded.
+func FullIndexColumnIDs(idx Index) ([]descpb.ColumnID, []descpb.IndexDescriptor_Direction) {
+	n := idx.NumColumns()
+	if !idx.IsUnique() {
+		n += idx.NumExtraColumns()
+	}
+	ids := make([]descpb.ColumnID, 0, n)
+	dirs := make([]descpb.IndexDescriptor_Direction, 0, n)
+	for i := 0; i < idx.NumColumns(); i++ {
+		ids = append(ids, idx.GetColumnID(i))
+		dirs = append(dirs, idx.GetColumnDirection(i))
+	}
+	// Non-unique indexes have some of the primary-key columns appended to
+	// their key.
+	if !idx.IsUnique() {
+		for i := 0; i < idx.NumExtraColumns(); i++ {
+			// Extra columns are encoded in ascending order.
+			ids = append(ids, idx.GetExtraColumnID(i))
+			dirs = append(dirs, descpb.IndexDescriptor_ASC)
+		}
+	}
+	return ids, dirs
+}
+
 // UserDefinedTypeColsHaveSameVersion returns whether one table descriptor's
 // columns with user defined type metadata have the same versions of metadata
 // as in the other descriptor. Note that this function is only valid on two

--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//pkg/util/errorutil/unimplemented",
         "//pkg/util/hlc",
         "//pkg/util/interval",
+        "//pkg/util/iterutil",
         "//pkg/util/log",
         "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/catalog/tabledesc/helpers_test.go
+++ b/pkg/sql/catalog/tabledesc/helpers_test.go
@@ -12,6 +12,7 @@ package tabledesc
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/errors"
 )
 
@@ -34,3 +35,13 @@ func GetPostDeserializationChanges(
 }
 
 var FitColumnToFamily = fitColumnToFamily
+
+func TestingMakeColumn(
+	direction descpb.DescriptorMutation_Direction, desc *descpb.ColumnDescriptor,
+) catalog.Column {
+	return &column{
+		maybeMutation: maybeMutation{mutationDirection: direction},
+		desc:          desc,
+		ordinal:       0,
+	}
+}

--- a/pkg/sql/catalog/tabledesc/mutation.go
+++ b/pkg/sql/catalog/tabledesc/mutation.go
@@ -13,6 +13,8 @@ package tabledesc
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 )
 
 var _ catalog.TableElementMaybeMutation = maybeMutation{}
@@ -71,6 +73,7 @@ func (mm maybeMutation) Dropped() bool {
 }
 
 // constraintToUpdate implements the catalog.ConstraintToUpdate interface.
+// It also
 type constraintToUpdate struct {
 	maybeMutation
 	desc *descpb.ConstraintToUpdate
@@ -79,6 +82,53 @@ type constraintToUpdate struct {
 // ConstraintToUpdateDesc returns the underlying protobuf descriptor.
 func (c constraintToUpdate) ConstraintToUpdateDesc() *descpb.ConstraintToUpdate {
 	return c.desc
+}
+
+// GetName returns the name of this constraint update mutation.
+func (c constraintToUpdate) GetName() string {
+	return c.desc.Name
+}
+
+// IsCheck returns true iff this is an update for a check constraint.
+func (c constraintToUpdate) IsCheck() bool {
+	return c.desc.ConstraintType == descpb.ConstraintToUpdate_CHECK
+}
+
+// Check returns the underlying check constraint, if there is one.
+func (c constraintToUpdate) Check() descpb.TableDescriptor_CheckConstraint {
+	return c.desc.Check
+}
+
+// IsForeignKey returns true iff this is an update for a fk constraint.
+func (c constraintToUpdate) IsForeignKey() bool {
+	return c.desc.ConstraintType == descpb.ConstraintToUpdate_FOREIGN_KEY
+}
+
+// ForeignKey returns the underlying fk constraint, if there is one.
+func (c constraintToUpdate) ForeignKey() descpb.ForeignKeyConstraint {
+	return c.desc.ForeignKey
+}
+
+// IsNotNull returns true iff this is an update for a not-null constraint.
+func (c constraintToUpdate) IsNotNull() bool {
+	return c.desc.ConstraintType == descpb.ConstraintToUpdate_NOT_NULL
+}
+
+// NotNullColumnID returns the underlying not-null column ID, if there is one.
+func (c constraintToUpdate) NotNullColumnID() descpb.ColumnID {
+	return c.desc.NotNullColumn
+}
+
+// IsUniqueWithoutIndex returns true iff this is an update for a unique without
+// index constraint.
+func (c constraintToUpdate) IsUniqueWithoutIndex() bool {
+	return c.desc.ConstraintType == descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX
+}
+
+// UniqueWithoutIndex returns the underlying unique without index constraint, if
+// there is one.
+func (c constraintToUpdate) UniqueWithoutIndex() descpb.UniqueWithoutIndexConstraint {
+	return c.desc.UniqueWithoutIndexConstraint
 }
 
 // primaryKeySwap implements the catalog.PrimaryKeySwap interface.
@@ -90,6 +140,60 @@ type primaryKeySwap struct {
 // PrimaryKeySwapDesc returns the underlying protobuf descriptor.
 func (c primaryKeySwap) PrimaryKeySwapDesc() *descpb.PrimaryKeySwap {
 	return c.desc
+}
+
+// NumOldIndexes returns the number of old active indexes to swap out.
+func (c primaryKeySwap) NumOldIndexes() int {
+	return 1 + len(c.desc.OldIndexes)
+}
+
+// ForEachOldIndexIDs iterates through each of the old index IDs.
+// iterutil.Done is supported.
+func (c primaryKeySwap) ForEachOldIndexIDs(fn func(id descpb.IndexID) error) error {
+	return c.forEachIndexIDs(c.desc.OldPrimaryIndexId, c.desc.OldIndexes, fn)
+}
+
+// NumNewIndexes returns the number of new active indexes to swap in.
+func (c primaryKeySwap) NumNewIndexes() int {
+	return 1 + len(c.desc.NewIndexes)
+}
+
+// ForEachNewIndexIDs iterates through each of the new index IDs.
+// iterutil.Done is supported.
+func (c primaryKeySwap) ForEachNewIndexIDs(fn func(id descpb.IndexID) error) error {
+	return c.forEachIndexIDs(c.desc.NewPrimaryIndexId, c.desc.NewIndexes, fn)
+}
+
+func (c primaryKeySwap) forEachIndexIDs(
+	pkID descpb.IndexID, secIDs []descpb.IndexID, fn func(id descpb.IndexID) error,
+) error {
+	err := fn(pkID)
+	if err != nil {
+		if iterutil.Done(err) {
+			return nil
+		}
+		return err
+	}
+	for _, id := range secIDs {
+		err = fn(id)
+		if err != nil {
+			if iterutil.Done(err) {
+				return nil
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+// HasLocalityConfig returns true iff the locality config is swapped also.
+func (c primaryKeySwap) HasLocalityConfig() bool {
+	return c.desc.LocalityConfigSwap != nil
+}
+
+// LocalityConfigSwap returns the locality config swap, if there is one.
+func (c primaryKeySwap) LocalityConfigSwap() descpb.PrimaryKeySwap_LocalityConfigSwap {
+	return *c.desc.LocalityConfigSwap
 }
 
 // computedColumnSwap implements the catalog.ComputedColumnSwap interface.
@@ -112,6 +216,50 @@ type materializedViewRefresh struct {
 // MaterializedViewRefreshDesc returns the underlying protobuf descriptor.
 func (c materializedViewRefresh) MaterializedViewRefreshDesc() *descpb.MaterializedViewRefresh {
 	return c.desc
+}
+
+// ShouldBackfill returns true iff the query should be backfilled into the
+// indexes.
+func (c materializedViewRefresh) ShouldBackfill() bool {
+	return c.desc.ShouldBackfill
+}
+
+// AsOf returns the timestamp at which the query should be run.
+func (c materializedViewRefresh) AsOf() hlc.Timestamp {
+	return c.desc.AsOf
+}
+
+// ForEachIndexID iterates through each of the index IDs.
+// iterutil.Done is supported.
+func (c materializedViewRefresh) ForEachIndexID(fn func(id descpb.IndexID) error) error {
+	err := fn(c.desc.NewPrimaryIndex.ID)
+	if err != nil {
+		if iterutil.Done(err) {
+			return nil
+		}
+		return err
+	}
+	for i := range c.desc.NewIndexes {
+		err = fn(c.desc.NewIndexes[i].ID)
+		if err != nil {
+			if iterutil.Done(err) {
+				return nil
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+// TableWithNewIndexes returns a new TableDescriptor based on the old one
+// but with the refreshed indexes put in.
+func (c materializedViewRefresh) TableWithNewIndexes(
+	tbl catalog.TableDescriptor,
+) catalog.TableDescriptor {
+	deepCopy := NewBuilder(tbl.TableDesc()).BuildCreatedMutableTable().TableDesc()
+	deepCopy.PrimaryIndex = c.desc.NewPrimaryIndex
+	deepCopy.Indexes = c.desc.NewIndexes
+	return NewBuilder(deepCopy).BuildImmutableTable()
 }
 
 // mutation implements the

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -87,10 +87,8 @@ type PostDeserializationTableDescriptorChanges struct {
 
 // FindIndexPartitionByName searches this index descriptor for a partition whose name
 // is the input and returns it, or nil if no match is found.
-func FindIndexPartitionByName(
-	desc *descpb.IndexDescriptor, name string,
-) *descpb.PartitioningDescriptor {
-	return desc.Partitioning.FindPartitionByName(name)
+func FindIndexPartitionByName(idx catalog.Index, name string) *descpb.PartitioningDescriptor {
+	return idx.IndexDesc().Partitioning.FindPartitionByName(name)
 }
 
 // DescriptorType returns the type of this descriptor.
@@ -1140,9 +1138,9 @@ func (desc *Mutable) RemoveColumnFromFamily(colID descpb.ColumnID) {
 
 // RenameColumnDescriptor updates all references to a column name in
 // a table descriptor including indexes and families.
-func (desc *Mutable) RenameColumnDescriptor(column *descpb.ColumnDescriptor, newColName string) {
-	colID := column.ID
-	column.Name = newColName
+func (desc *Mutable) RenameColumnDescriptor(column catalog.Column, newColName string) {
+	colID := column.GetID()
+	column.ColumnDesc().Name = newColName
 
 	for i := range desc.Families {
 		for j := range desc.Families[i].ColumnIDs {
@@ -1211,31 +1209,6 @@ func (desc *wrapper) NamesForColumnIDs(ids descpb.ColumnIDs) ([]string, error) {
 		names[i] = col.GetName()
 	}
 	return names, nil
-}
-
-// RenameIndexDescriptor renames an index descriptor.
-func (desc *Mutable) RenameIndexDescriptor(index *descpb.IndexDescriptor, name string) error {
-	id := index.ID
-	if id == desc.PrimaryIndex.ID {
-		idx := desc.PrimaryIndex
-		idx.Name = name
-		desc.SetPrimaryIndex(idx)
-		return nil
-	}
-	for i, idx := range desc.Indexes {
-		if idx.ID == id {
-			idx.Name = name
-			desc.SetPublicNonPrimaryIndex(i+1, idx)
-			return nil
-		}
-	}
-	for _, m := range desc.Mutations {
-		if idx := m.GetIndex(); idx != nil && idx.ID == id {
-			idx.Name = name
-			return nil
-		}
-	}
-	return fmt.Errorf("index with id = %d does not exist", id)
 }
 
 // DropConstraint drops a constraint, either by removing it from the table
@@ -1393,7 +1366,12 @@ func (desc *Mutable) RenameConstraint(
 			}
 			return dependentViewRenameError("index", tableRef.ID)
 		}
-		return desc.RenameIndexDescriptor(detail.Index, newName)
+		idx, err := desc.FindIndexWithID(detail.Index.ID)
+		if err != nil {
+			return err
+		}
+		idx.IndexDesc().Name = newName
+		return nil
 
 	case descpb.ConstraintTypeUnique:
 		if detail.Index != nil {
@@ -1403,9 +1381,11 @@ func (desc *Mutable) RenameConstraint(
 				}
 				return dependentViewRenameError("index", tableRef.ID)
 			}
-			if err := desc.RenameIndexDescriptor(detail.Index, newName); err != nil {
+			idx, err := desc.FindIndexWithID(detail.Index.ID)
+			if err != nil {
 				return err
 			}
+			idx.IndexDesc().Name = newName
 		} else if detail.UniqueWithoutIndexConstraint != nil {
 			if detail.UniqueWithoutIndexConstraint.Validity == descpb.ConstraintValidity_Validating {
 				return unimplemented.NewWithIssueDetailf(42844,
@@ -1745,8 +1725,8 @@ func (desc *Mutable) performComputedColumnSwap(swap *descpb.ComputedColumnSwap) 
 	oldColName := oldCol.GetName()
 
 	// Rename old column to this new name, and rename newCol to oldCol's name.
-	desc.RenameColumnDescriptor(oldCol.ColumnDesc(), uniqueName)
-	desc.RenameColumnDescriptor(newCol.ColumnDesc(), oldColName)
+	desc.RenameColumnDescriptor(oldCol, uniqueName)
+	desc.RenameColumnDescriptor(newCol, oldColName)
 
 	// Swap Column Family ordering for oldCol and newCol.
 	// Both columns must be in the same family since the new column is
@@ -2283,9 +2263,9 @@ func (desc *immutable) ActiveChecks() []descpb.TableDescriptor_CheckConstraint {
 
 // IsShardColumn returns true if col corresponds to a non-dropped hash sharded
 // index. This method assumes that col is currently a member of desc.
-func (desc *Mutable) IsShardColumn(col *descpb.ColumnDescriptor) bool {
+func (desc *Mutable) IsShardColumn(col catalog.Column) bool {
 	return nil != catalog.FindNonDropIndex(desc, func(idx catalog.Index) bool {
-		return idx.IsSharded() && idx.GetShardColumnName() == col.Name
+		return idx.IsSharded() && idx.GetShardColumnName() == col.GetName()
 	})
 }
 

--- a/pkg/sql/catalog/tabledesc/structured_test.go
+++ b/pkg/sql/catalog/tabledesc/structured_test.go
@@ -446,10 +446,10 @@ func TestColumnNeedsBackfill(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		if ColumnNeedsBackfill(descpb.DescriptorMutation_ADD, &tc.desc) != tc.add {
+		if catalog.ColumnNeedsBackfill(TestingMakeColumn(descpb.DescriptorMutation_ADD, &tc.desc)) != tc.add {
 			t.Errorf("expected ColumnNeedsBackfill to be %v for adding %s", tc.add, tc.info)
 		}
-		if ColumnNeedsBackfill(descpb.DescriptorMutation_DROP, &tc.desc) != tc.drop {
+		if catalog.ColumnNeedsBackfill(TestingMakeColumn(descpb.DescriptorMutation_DROP, &tc.desc)) != tc.drop {
 			t.Errorf("expected ColumnNeedsBackfill to be %v for dropping %s", tc.drop, tc.info)
 		}
 	}

--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -1020,7 +1020,7 @@ func (desc *wrapper) ensureShardedIndexNotComputed(index *descpb.IndexDescriptor
 // indicates how many index columns to skip over.
 func (desc *wrapper) validatePartitioningDescriptor(
 	a *rowenc.DatumAlloc,
-	idxDesc *descpb.IndexDescriptor,
+	idx catalog.Index,
 	partDesc *descpb.PartitioningDescriptor,
 	colOffset int,
 	partitionNames map[string]string,
@@ -1041,9 +1041,9 @@ func (desc *wrapper) validatePartitioningDescriptor(
 	// InterleavedBy is fine, so using the root of the interleave hierarchy will
 	// work. It is expected that this is sufficient for real-world use cases.
 	// Revisit this restriction if that expectation is wrong.
-	if len(idxDesc.Interleave.Ancestors) > 0 {
+	if idx.NumInterleaveAncestors() > 0 {
 		return errors.Errorf("cannot set a zone config for interleaved index %s; "+
-			"set it on the root of the interleaved hierarchy instead", idxDesc.Name)
+			"set it on the root of the interleaved hierarchy instead", idx.GetName())
 	}
 
 	// We don't need real prefixes in the DecodePartitionTuple calls because we're
@@ -1071,10 +1071,10 @@ func (desc *wrapper) validatePartitioningDescriptor(
 			// The partitioning descriptor may be invalid and refer to columns
 			// not stored in the index. In that case, skip this check as the
 			// validation will fail later.
-			if i >= len(idxDesc.ColumnIDs) {
+			if i >= idx.NumColumns() {
 				continue
 			}
-			col, err := desc.FindColumnWithID(idxDesc.ColumnIDs[i])
+			col, err := desc.FindColumnWithID(idx.GetColumnID(i))
 			if err != nil {
 				return err
 			}
@@ -1089,12 +1089,12 @@ func (desc *wrapper) validatePartitioningDescriptor(
 			return fmt.Errorf("PARTITION name must be non-empty")
 		}
 		if indexName, exists := partitionNames[name]; exists {
-			if indexName == idxDesc.Name {
+			if indexName == idx.GetName() {
 				return fmt.Errorf("PARTITION %s: name must be unique (used twice in index %q)",
 					name, indexName)
 			}
 		}
-		partitionNames[name] = idxDesc.Name
+		partitionNames[name] = idx.GetName()
 		return nil
 	}
 
@@ -1117,7 +1117,7 @@ func (desc *wrapper) validatePartitioningDescriptor(
 			// to match the behavior of the value when indexed.
 			for _, valueEncBuf := range p.Values {
 				tuple, keyPrefix, err := rowenc.DecodePartitionTuple(
-					a, codec, desc, idxDesc, partDesc, valueEncBuf, fakePrefixDatums)
+					a, codec, desc, idx, partDesc, valueEncBuf, fakePrefixDatums)
 				if err != nil {
 					return fmt.Errorf("PARTITION %s: %v", p.Name, err)
 				}
@@ -1129,7 +1129,7 @@ func (desc *wrapper) validatePartitioningDescriptor(
 
 			newColOffset := colOffset + int(partDesc.NumColumns)
 			if err := desc.validatePartitioningDescriptor(
-				a, idxDesc, &p.Subpartitioning, newColOffset, partitionNames,
+				a, idx, &p.Subpartitioning, newColOffset, partitionNames,
 			); err != nil {
 				return err
 			}
@@ -1146,12 +1146,12 @@ func (desc *wrapper) validatePartitioningDescriptor(
 			// NB: key encoding is used to check uniqueness because it has to match
 			// the behavior of the value when indexed.
 			fromDatums, fromKey, err := rowenc.DecodePartitionTuple(
-				a, codec, desc, idxDesc, partDesc, p.FromInclusive, fakePrefixDatums)
+				a, codec, desc, idx, partDesc, p.FromInclusive, fakePrefixDatums)
 			if err != nil {
 				return fmt.Errorf("PARTITION %s: %v", p.Name, err)
 			}
 			toDatums, toKey, err := rowenc.DecodePartitionTuple(
-				a, codec, desc, idxDesc, partDesc, p.ToExclusive, fakePrefixDatums)
+				a, codec, desc, idx, partDesc, p.ToExclusive, fakePrefixDatums)
 			if err != nil {
 				return fmt.Errorf("PARTITION %s: %v", p.Name, err)
 			}
@@ -1198,9 +1198,8 @@ func (desc *wrapper) validatePartitioning() error {
 
 	a := &rowenc.DatumAlloc{}
 	return catalog.ForEachNonDropIndex(desc, func(idx catalog.Index) error {
-		idxDesc := idx.IndexDesc()
 		return desc.validatePartitioningDescriptor(
-			a, idxDesc, &idxDesc.Partitioning, 0 /* colOffset */, partitionNames,
+			a, idx, &idx.IndexDesc().Partitioning, 0 /* colOffset */, partitionNames,
 		)
 	})
 }

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -50,13 +50,13 @@ type cTableInfo struct {
 	// want to scan.
 	spans            roachpb.Spans
 	desc             catalog.TableDescriptor
-	index            *descpb.IndexDescriptor
+	index            catalog.Index
 	isSecondaryIndex bool
 	indexColumnDirs  []descpb.IndexDescriptor_Direction
 
 	// The table columns to use for fetching, possibly including ones currently in
 	// schema changes.
-	cols []descpb.ColumnDescriptor
+	cols []catalog.Column
 
 	// The ordered list of ColumnIDs that are required.
 	neededColsList []int
@@ -392,7 +392,7 @@ func (rf *cFetcher) Init(
 	colDescriptors := tableArgs.Cols
 	for i := range colDescriptors {
 		//gcassert:bce
-		id := colDescriptors[i].ID
+		id := colDescriptors[i].GetID()
 		table.colIdxMap.vals = append(table.colIdxMap.vals, id)
 		table.colIdxMap.ords = append(table.colIdxMap.ords, tableArgs.ColIdxMap.GetDefault(id))
 	}
@@ -422,7 +422,7 @@ func (rf *cFetcher) Init(
 	_ = typs[len(colDescriptors)-1]
 	for i := range colDescriptors {
 		//gcassert:bce
-		typs[i] = colDescriptors[i].Type
+		typs[i] = colDescriptors[i].GetType()
 	}
 
 	var err error
@@ -435,7 +435,7 @@ func (rf *cFetcher) Init(
 	}
 	for i := range colDescriptors {
 		//gcassert:bce
-		col := colDescriptors[i].ID
+		col := colDescriptors[i].GetID()
 		idx := tableArgs.ColIdxMap.GetDefault(col)
 		if tableArgs.ValNeededForCol.Contains(idx) {
 			// The idx-th column is required.
@@ -453,13 +453,14 @@ func (rf *cFetcher) Init(
 	}
 	sort.Ints(table.neededColsList)
 
-	table.knownPrefixLength = len(rowenc.MakeIndexKeyPrefix(codec, table.desc, table.index.ID))
+	table.knownPrefixLength = len(rowenc.MakeIndexKeyPrefix(codec, table.desc, table.index.GetID()))
 
 	var indexColumnIDs []descpb.ColumnID
-	indexColumnIDs, table.indexColumnDirs = table.index.FullColumnIDs()
+	indexColumnIDs, table.indexColumnDirs = catalog.FullIndexColumnIDs(table.index)
 
 	compositeColumnIDs := util.MakeFastIntSet()
-	for _, id := range table.index.CompositeColumnIDs {
+	for i := 0; i < table.index.NumCompositeColumns(); i++ {
+		id := table.index.GetCompositeColumnID(i)
 		compositeColumnIDs.Add(int(id))
 	}
 
@@ -516,7 +517,7 @@ func (rf *cFetcher) Init(
 		}
 	}
 	table.invertedColOrdinal = -1
-	if table.index.Type == descpb.IndexDescriptor_INVERTED {
+	if table.index.GetType() == descpb.IndexDescriptor_INVERTED {
 		id := table.index.InvertedColumnID()
 		colIdx, ok := tableArgs.ColIdxMap.Get(id)
 		if ok && neededCols.Contains(int(id)) {
@@ -528,8 +529,9 @@ func (rf *cFetcher) Init(
 	// Unique secondary indexes contain the extra column IDs as part of
 	// the value component. We process these separately, so we need to know
 	// what extra columns are composite or not.
-	if table.isSecondaryIndex && table.index.Unique {
-		for _, id := range table.index.ExtraColumnIDs {
+	if table.isSecondaryIndex && table.index.IsUnique() {
+		for i := 0; i < table.index.NumExtraColumns(); i++ {
+			id := table.index.GetExtraColumnID(i)
 			colIdx, ok := tableArgs.ColIdxMap.Get(id)
 			if ok && neededCols.Contains(int(id)) {
 				if compositeColumnIDs.Contains(int(id)) {
@@ -546,16 +548,16 @@ func (rf *cFetcher) Init(
 	// - If there are needed columns from the index key, we need to read it.
 	//
 	// Otherwise, we can completely avoid decoding the index key.
-	if neededIndexCols > 0 || len(table.index.InterleavedBy) > 0 || len(table.index.Interleave.Ancestors) > 0 {
+	if neededIndexCols > 0 || table.index.NumInterleavedBy() > 0 || table.index.NumInterleaveAncestors() > 0 {
 		rf.mustDecodeIndexKey = true
 	}
 
 	if table.isSecondaryIndex {
 		for i := range colDescriptors {
 			//gcassert:bce
-			id := colDescriptors[i].ID
+			id := colDescriptors[i].GetID()
 			if neededCols.Contains(int(id)) && !table.index.ContainsColumnID(id) {
-				return errors.Errorf("requested column %s not in index", colDescriptors[i].Name)
+				return errors.Errorf("requested column %s not in index", colDescriptors[i].GetName())
 			}
 		}
 	}
@@ -564,17 +566,16 @@ func (rf *cFetcher) Init(
 	table.keyValTypes = colinfo.GetColumnTypesFromColDescs(
 		colDescriptors, indexColumnIDs, table.keyValTypes,
 	)
-	if len(table.index.ExtraColumnIDs) > 0 {
+	if table.index.NumExtraColumns() > 0 {
 		// Unique secondary indexes have a value that is the
 		// primary index key.
 		// Primary indexes only contain ascendingly-encoded
 		// values. If this ever changes, we'll probably have to
 		// figure out the directions here too.
-		extraColumnIDs := table.index.ExtraColumnIDs
 		table.extraTypes = colinfo.GetColumnTypesFromColDescs(
-			colDescriptors, extraColumnIDs, table.extraTypes,
+			colDescriptors, table.index.IndexDesc().ExtraColumnIDs, table.extraTypes,
 		)
-		nExtraColumns := len(extraColumnIDs)
+		nExtraColumns := table.index.NumExtraColumns()
 		if cap(table.extraValColOrdinals) >= nExtraColumns {
 			table.extraValColOrdinals = table.extraValColOrdinals[:nExtraColumns]
 		} else {
@@ -588,10 +589,11 @@ func (rf *cFetcher) Init(
 		}
 
 		extraValColOrdinals := table.extraValColOrdinals
-		_ = extraValColOrdinals[len(extraColumnIDs)-1]
+		_ = extraValColOrdinals[nExtraColumns-1]
 		allExtraValColOrdinals := table.allExtraValColOrdinals
-		_ = allExtraValColOrdinals[len(extraColumnIDs)-1]
-		for i, id := range extraColumnIDs {
+		_ = allExtraValColOrdinals[nExtraColumns-1]
+		for i := 0; i < nExtraColumns; i++ {
+			id := table.index.GetExtraColumnID(i)
 			idx := tableArgs.ColIdxMap.GetDefault(id)
 			//gcassert:bce
 			allExtraValColOrdinals[i] = idx
@@ -607,7 +609,7 @@ func (rf *cFetcher) Init(
 
 	// Keep track of the maximum keys per row to accommodate a
 	// limitHint when StartScan is invoked.
-	keysPerRow, err := table.desc.KeysPerRow(table.index.ID)
+	keysPerRow, err := table.desc.KeysPerRow(table.index.GetID())
 	if err != nil {
 		return err
 	}
@@ -912,7 +914,7 @@ func (rf *cFetcher) nextBatch(ctx context.Context) (coldata.Batch, error) {
 			// them when processing the index. The difference with unique secondary indexes
 			// is that the extra columns are not always there, and are used to unique-ify
 			// the index key, rather than provide the primary key column values.
-			if foundNull && rf.table.isSecondaryIndex && rf.table.index.Unique && rf.table.desc.NumFamilies() != 1 {
+			if foundNull && rf.table.isSecondaryIndex && rf.table.index.IsUnique() && rf.table.desc.NumFamilies() != 1 {
 				// We get the remaining bytes after the computed prefix, and then
 				// slice off the extra encoded columns from those bytes. We calculate
 				// how many bytes were sliced away, and then extend lastRowPrefix
@@ -920,7 +922,7 @@ func (rf *cFetcher) nextBatch(ctx context.Context) (coldata.Batch, error) {
 				prefixLen := len(rf.machine.lastRowPrefix)
 				remainingBytes := rf.machine.nextKV.Key[prefixLen:]
 				origRemainingBytesLen := len(remainingBytes)
-				for range rf.table.index.ExtraColumnIDs {
+				for i := 0; i < rf.table.index.NumExtraColumns(); i++ {
 					var err error
 					// Slice off an extra encoded column from remainingBytes.
 					remainingBytes, err = rowenc.SkipTableKey(remainingBytes)
@@ -1143,7 +1145,7 @@ func (rf *cFetcher) processValue(
 		buf.WriteByte('/')
 		buf.WriteString(rf.table.desc.GetName())
 		buf.WriteByte('/')
-		buf.WriteString(rf.table.index.Name)
+		buf.WriteString(rf.table.index.GetName())
 		for _, idx := range rf.table.allIndexColOrdinals {
 			buf.WriteByte('/')
 			if idx != -1 {
@@ -1164,7 +1166,7 @@ func (rf *cFetcher) processValue(
 	}
 
 	val := rf.machine.nextKV.Value
-	if !table.isSecondaryIndex || table.index.EncodingType == descpb.PrimaryIndexEncoding {
+	if !table.isSecondaryIndex || table.index.GetEncodingType() == descpb.PrimaryIndexEncoding {
 		// If familyID is 0, kv.Value contains values for composite key columns.
 		// These columns already have a table.row value assigned above, but that value
 		// (obtained from the key encoding) might not be correct (e.g. for decimals,
@@ -1216,7 +1218,7 @@ func (rf *cFetcher) processValue(
 				return "", "", scrub.WrapError(scrub.IndexValueDecodingError, err)
 			}
 
-			if table.isSecondaryIndex && table.index.Unique {
+			if table.isSecondaryIndex && table.index.IsUnique() {
 				// This is a unique secondary index; decode the extra
 				// column values from the value.
 				var err error
@@ -1314,7 +1316,7 @@ func (rf *cFetcher) processValueSingle(
 			if len(val.RawBytes) == 0 {
 				return prettyKey, "", nil
 			}
-			typ := table.cols[idx].Type
+			typ := table.cols[idx].GetType()
 			err := colencoding.UnmarshalColumnValueToCol(
 				&table.da, rf.machine.colvecs[idx], rf.machine.rowIdx, typ, val,
 			)
@@ -1414,7 +1416,7 @@ func (rf *cFetcher) processValueBytes(
 
 		vec := rf.machine.colvecs[idx]
 
-		valTyp := table.cols[idx].Type
+		valTyp := table.cols[idx].GetType()
 		valueBytes, err = colencoding.DecodeTableValueToCol(
 			&table.da, vec, rf.machine.rowIdx, typ, dataOffset, valTyp, valueBytes,
 		)
@@ -1454,7 +1456,7 @@ func (rf *cFetcher) fillNulls() error {
 		if table.compositeIndexColOrdinals.Contains(i) {
 			continue
 		}
-		if !table.cols[i].Nullable {
+		if !table.cols[i].IsNullable() {
 			var indexColValues []string
 			for _, idx := range table.indexColOrdinals {
 				if idx != -1 {
@@ -1464,8 +1466,8 @@ func (rf *cFetcher) fillNulls() error {
 				}
 				return scrub.WrapError(scrub.UnexpectedNullValueError, errors.Errorf(
 					"non-nullable column \"%s:%s\" with no value! Index scanned was %q with the index key columns (%s) and the values (%s)",
-					table.desc.GetName(), table.cols[i].Name, table.index.Name,
-					strings.Join(table.index.ColumnNames, ","), strings.Join(indexColValues, ",")))
+					table.desc.GetName(), table.cols[i].GetName(), table.index.GetName(),
+					strings.Join(table.index.IndexDesc().ColumnNames, ","), strings.Join(indexColValues, ",")))
 			}
 		}
 		rf.machine.colvecs[i].Nulls().SetNull(rf.machine.rowIdx)
@@ -1509,7 +1511,7 @@ func (rf *cFetcher) KeyToDesc(key roachpb.Key) (catalog.TableDescriptor, bool) {
 	if len(key) < rf.table.knownPrefixLength {
 		return nil, false
 	}
-	nIndexCols := len(rf.table.index.ColumnIDs) + len(rf.table.index.ExtraColumnIDs)
+	nIndexCols := rf.table.index.NumColumns() + rf.table.index.NumExtraColumns()
 	tableKeyVals := make([]rowenc.EncDatum, nIndexCols)
 	_, ok, _, err := rowenc.DecodeIndexKeyWithoutTableIDIndexIDPrefix(
 		rf.table.desc,

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
@@ -303,14 +302,13 @@ func initCRowFetcher(
 	valNeededForCol util.FastIntSet,
 	spec *execinfrapb.TableReaderSpec,
 	withSystemColumns bool,
-) (index *descpb.IndexDescriptor, isSecondaryIndex bool, err error) {
+) (index catalog.Index, isSecondaryIndex bool, err error) {
 	indexIdx := int(spec.IndexIdx)
 	if indexIdx >= len(desc.ActiveIndexes()) {
 		return nil, false, errors.Errorf("invalid indexIdx %d", indexIdx)
 	}
-	indexI := desc.ActiveIndexes()[indexIdx]
-	index = indexI.IndexDesc()
-	isSecondaryIndex = !indexI.Primary()
+	index = desc.ActiveIndexes()[indexIdx]
+	isSecondaryIndex = !index.Primary()
 
 	tableArgs := row.FetcherTableArgs{
 		Desc:             desc,

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
@@ -89,7 +90,7 @@ func (p *planner) CreateIndex(ctx context.Context, n *tree.CreateIndex) (planNod
 func (p *planner) setupFamilyAndConstraintForShard(
 	ctx context.Context,
 	tableDesc *tabledesc.Mutable,
-	shardCol *descpb.ColumnDescriptor,
+	shardCol catalog.Column,
 	idxColumns []string,
 	buckets int32,
 ) error {
@@ -99,7 +100,7 @@ func (p *planner) setupFamilyAndConstraintForShard(
 	}
 	// Assign shard column to the family of the first column in its index set, and do it
 	// before `AllocateIDs()` assigns it to the primary column family.
-	if err := tableDesc.AddColumnToFamilyMaybeCreate(shardCol.Name, family, false, false); err != nil {
+	if err := tableDesc.AddColumnToFamilyMaybeCreate(shardCol.GetName(), family, false, false); err != nil {
 		return err
 	}
 	// Assign an ID to the newly-added shard column, which is needed for the creation
@@ -108,7 +109,7 @@ func (p *planner) setupFamilyAndConstraintForShard(
 		return err
 	}
 
-	ckDef, err := makeShardCheckConstraintDef(tableDesc, int(buckets), shardCol)
+	ckDef, err := makeShardCheckConstraintDef(int(buckets), shardCol)
 	if err != nil {
 		return err
 	}
@@ -319,7 +320,7 @@ func setupShardedIndex(
 	tableDesc *tabledesc.Mutable,
 	indexDesc *descpb.IndexDescriptor,
 	isNewTable bool,
-) (shard *descpb.ColumnDescriptor, newColumns tree.IndexElemList, newColumn bool, err error) {
+) (shard catalog.Column, newColumns tree.IndexElemList, newColumn bool, err error) {
 	if !shardedIndexEnabled {
 		return nil, nil, false, hashShardedIndexesDisabledError
 	}
@@ -338,13 +339,13 @@ func setupShardedIndex(
 		return nil, nil, false, err
 	}
 	shardIdxElem := tree.IndexElem{
-		Column:    tree.Name(shardCol.Name),
+		Column:    tree.Name(shardCol.GetName()),
 		Direction: tree.Ascending,
 	}
 	newColumns = append(tree.IndexElemList{shardIdxElem}, columns...)
 	indexDesc.Sharded = descpb.ShardedDescriptor{
 		IsSharded:    true,
-		Name:         shardCol.Name,
+		Name:         shardCol.GetName(),
 		ShardBuckets: buckets,
 		ColumnNames:  colNames,
 	}
@@ -356,12 +357,12 @@ func setupShardedIndex(
 // buckets.
 func maybeCreateAndAddShardCol(
 	shardBuckets int, desc *tabledesc.Mutable, colNames []string, isNewTable bool,
-) (col *descpb.ColumnDescriptor, created bool, err error) {
-	shardCol, err := makeShardColumnDesc(colNames, shardBuckets)
+) (col catalog.Column, created bool, err error) {
+	shardColDesc, err := makeShardColumnDesc(colNames, shardBuckets)
 	if err != nil {
 		return nil, false, err
 	}
-	existingShardCol, err := desc.FindColumnWithName(tree.Name(shardCol.Name))
+	existingShardCol, err := desc.FindColumnWithName(tree.Name(shardColDesc.Name))
 	if err == nil && !existingShardCol.Dropped() {
 		// TODO(ajwerner): In what ways is existingShardCol allowed to differ from
 		// the newly made shardCol? Should there be some validation of
@@ -370,9 +371,9 @@ func maybeCreateAndAddShardCol(
 			// The user managed to reverse-engineer our crazy shard column name, so
 			// we'll return an error here rather than try to be tricky.
 			return nil, false, pgerror.Newf(pgcode.DuplicateColumn,
-				"column %s already specified; can't be used for sharding", shardCol.Name)
+				"column %s already specified; can't be used for sharding", shardColDesc.Name)
 		}
-		return existingShardCol.ColumnDesc(), false, nil
+		return existingShardCol, false, nil
 	}
 	columnIsUndefined := sqlerrors.IsUndefinedColumnError(err)
 	if err != nil && !columnIsUndefined {
@@ -380,13 +381,14 @@ func maybeCreateAndAddShardCol(
 	}
 	if columnIsUndefined || existingShardCol.Dropped() {
 		if isNewTable {
-			desc.AddColumn(shardCol)
+			desc.AddColumn(shardColDesc)
 		} else {
-			desc.AddColumnMutation(shardCol, descpb.DescriptorMutation_ADD)
+			desc.AddColumnMutation(shardColDesc, descpb.DescriptorMutation_ADD)
 		}
 		created = true
 	}
-	return shardCol, created, nil
+	shardCol, err := desc.FindColumnWithName(tree.Name(shardColDesc.Name))
+	return shardCol, created, err
 }
 
 var interleavedTableDeprecationError = errors.WithIssueLink(

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -474,7 +474,7 @@ func (n *createTableNode) startExec(params runParams) error {
 				params.p.txn,
 				params.ExecCfg().Codec,
 				desc.ImmutableCopy().(catalog.TableDescriptor),
-				desc.Columns,
+				desc.PublicColumns(),
 				params.p.alloc)
 			if err != nil {
 				return err
@@ -1740,7 +1740,7 @@ func NewTableDesc(
 				if err != nil {
 					return nil, err
 				}
-				checkConstraint, err := makeShardCheckConstraintDef(&desc, int(buckets), shardCol)
+				checkConstraint, err := makeShardCheckConstraintDef(int(buckets), shardCol)
 				if err != nil {
 					return nil, err
 				}
@@ -1825,7 +1825,7 @@ func NewTableDesc(
 	// Now that we've constructed our columns, we pop into any of our computed
 	// columns so that we can dequalify any column references.
 	sourceInfo := colinfo.NewSourceInfoForSingleTable(
-		n.Table, colinfo.ResultColumnsFromColDescs(desc.GetID(), desc.Columns),
+		n.Table, colinfo.ResultColumnsFromColumns(desc.GetID(), desc.PublicColumns()),
 	)
 
 	for i := range desc.Columns {
@@ -1868,7 +1868,7 @@ func NewTableDesc(
 			if err != nil {
 				return nil, err
 			}
-			checkConstraint, err := makeShardCheckConstraintDef(&desc, int(buckets), shardCol)
+			checkConstraint, err := makeShardCheckConstraintDef(int(buckets), shardCol)
 			if err != nil {
 				return nil, err
 			}
@@ -2715,7 +2715,7 @@ func makeHashShardComputeExpr(colNames []string, buckets int) *string {
 }
 
 func makeShardCheckConstraintDef(
-	desc *tabledesc.Mutable, buckets int, shardCol *descpb.ColumnDescriptor,
+	buckets int, shardCol catalog.Column,
 ) (*tree.CheckConstraintTableDef, error) {
 	values := &tree.Tuple{}
 	for i := 0; i < buckets; i++ {
@@ -2729,7 +2729,7 @@ func makeShardCheckConstraintDef(
 		Expr: &tree.ComparisonExpr{
 			Operator: tree.In,
 			Left: &tree.ColumnItem{
-				ColumnName: tree.Name(shardCol.Name),
+				ColumnName: tree.Name(shardCol.GetName()),
 			},
 			Right: values,
 		},

--- a/pkg/sql/database_region_change_finalizer.go
+++ b/pkg/sql/database_region_change_finalizer.go
@@ -174,7 +174,7 @@ func (r *databaseRegionChangeFinalizer) repartitionRegionalByRowTables(
 					ctx,
 					txn,
 					tableDesc,
-					index.IndexDesc(),
+					index.GetID(),
 					&oldPartitioning,
 					&index.IndexDesc().Partitioning,
 					execCfg,

--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -96,13 +96,13 @@ func (d *deleteRangeNode) startExec(params runParams) error {
 	allTables := make([]row.FetcherTableArgs, len(d.interleavedDesc)+1)
 	allTables[0] = row.FetcherTableArgs{
 		Desc:  d.desc,
-		Index: d.desc.GetPrimaryIndex().IndexDesc(),
+		Index: d.desc.GetPrimaryIndex(),
 		Spans: d.spans,
 	}
 	for i, interleaved := range d.interleavedDesc {
 		allTables[i+1] = row.FetcherTableArgs{
 			Desc:  interleaved,
-			Index: interleaved.GetPrimaryIndex().IndexDesc(),
+			Index: interleaved.GetPrimaryIndex(),
 			Spans: d.spans,
 		}
 	}

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1025,10 +1025,9 @@ func (dsp *DistSQLPlanner) nodeVersionIsCompatible(nodeID roachpb.NodeID) bool {
 	return distsql.FlowVerIsCompatible(dsp.planVersion, v.MinAcceptedVersion, v.Version)
 }
 
-func getIndexIdx(index *descpb.IndexDescriptor, desc catalog.TableDescriptor) (uint32, error) {
-	foundIndex, _ := desc.FindIndexWithID(index.ID)
-	if foundIndex != nil && foundIndex.Public() {
-		return uint32(foundIndex.Ordinal()), nil
+func getIndexIdx(index catalog.Index, desc catalog.TableDescriptor) (uint32, error) {
+	if index.Public() {
+		return uint32(index.Ordinal()), nil
 	}
 	return 0, errors.Errorf("invalid index %v (table %s)", index, desc.GetName())
 }
@@ -2047,7 +2046,7 @@ func (dsp *DistSQLPlanner) createPlanForIndexJoin(
 	plan.PlanToStreamColMap = identityMap(plan.PlanToStreamColMap, len(n.cols))
 
 	for i := range n.cols {
-		ord := tableOrdinal(n.table.desc, n.cols[i].ID, n.table.colCfg.visibility)
+		ord := tableOrdinal(n.table.desc, n.cols[i].GetID(), n.table.colCfg.visibility)
 		post.OutputColumns[i] = uint32(ord)
 	}
 

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -184,10 +184,10 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 	// Phase 1: set up all necessary infrastructure for table reader planning
 	// below. This phase is equivalent to what execFactory.ConstructScan does.
 	tabDesc := table.(*optTable).desc
-	indexDesc := index.(*optIndex).desc
+	idx := index.(*optIndex).idx
 	colCfg := makeScanColumnsConfig(table, params.NeededCols)
 
-	sb := span.MakeBuilder(e.planner.EvalContext(), e.planner.ExecCfg().Codec, tabDesc, indexDesc)
+	sb := span.MakeBuilder(e.planner.EvalContext(), e.planner.ExecCfg().Codec, tabDesc, idx)
 
 	// Note that initColsForScan and setting ResultColumns below are equivalent
 	// to what scan.initTable call does in execFactory.ConstructScan.
@@ -215,7 +215,7 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 	}
 
 	isFullTableOrIndexScan := len(spans) == 1 && spans[0].EqualValue(
-		tabDesc.IndexSpan(e.planner.ExecCfg().Codec, indexDesc.ID),
+		tabDesc.IndexSpan(e.planner.ExecCfg().Codec, idx.GetID()),
 	)
 	if err = colCfg.assertValidReqOrdering(reqOrdering); err != nil {
 		return nil, err
@@ -244,7 +244,7 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 		trSpec.VirtualColumn = vc.ColumnDesc()
 	}
 
-	trSpec.IndexIdx, err = getIndexIdx(indexDesc, tabDesc)
+	trSpec.IndexIdx, err = getIndexIdx(idx, tabDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -144,11 +144,11 @@ func (n *dropIndexNode) startExec(params runParams) error {
 // dropShardColumnAndConstraint drops the given shard column and its associated check
 // constraint.
 func (n *dropIndexNode) dropShardColumnAndConstraint(
-	params runParams, tableDesc *tabledesc.Mutable, shardColDesc *descpb.ColumnDescriptor,
+	params runParams, tableDesc *tabledesc.Mutable, shardCol catalog.Column,
 ) error {
 	validChecks := tableDesc.Checks[:0]
 	for _, check := range tableDesc.AllActiveAndInactiveChecks() {
-		if used, err := tableDesc.CheckConstraintUsesColumn(check, shardColDesc.ID); err != nil {
+		if used, err := tableDesc.CheckConstraintUsesColumn(check, shardCol.GetID()); err != nil {
 			return err
 		} else if used {
 			if check.Validity == descpb.ConstraintValidity_Validating {
@@ -164,9 +164,9 @@ func (n *dropIndexNode) dropShardColumnAndConstraint(
 		tableDesc.Checks = validChecks
 	}
 
-	tableDesc.AddColumnMutation(shardColDesc, descpb.DescriptorMutation_DROP)
+	tableDesc.AddColumnMutation(shardCol.ColumnDesc(), descpb.DescriptorMutation_DROP)
 	for i := range tableDesc.Columns {
-		if tableDesc.Columns[i].ID == shardColDesc.ID {
+		if tableDesc.Columns[i].ID == shardCol.GetID() {
 			// Note the third slice parameter which will force a copy of the backing
 			// array if the column being removed is not the last column.
 			tableDesc.Columns = append(tableDesc.Columns[:i:i],
@@ -206,7 +206,7 @@ func (n *dropIndexNode) maybeDropShardColumn(
 	}) != nil {
 		return nil
 	}
-	return n.dropShardColumnAndConstraint(params, tableDesc, shardColDesc.ColumnDesc())
+	return n.dropShardColumnAndConstraint(params, tableDesc, shardColDesc)
 }
 
 func (*dropIndexNode) Next(runParams) (bool, error) { return false, nil }
@@ -240,7 +240,7 @@ func (p *planner) dropIndexByName(
 	constraintBehavior dropIndexConstraintBehavior,
 	jobDesc string,
 ) error {
-	idxI, err := tableDesc.FindIndexWithName(string(idxName))
+	idx, err := tableDesc.FindIndexWithName(string(idxName))
 	if err != nil {
 		// Only index names of the form "table@idx" throw an error here if they
 		// don't exist.
@@ -251,15 +251,14 @@ func (p *planner) dropIndexByName(
 		// Index does not exist, but we want it to: error out.
 		return pgerror.WithCandidateCode(err, pgcode.UndefinedObject)
 	}
-	if idxI.Dropped() {
+	if idx.Dropped() {
 		return nil
 	}
 
-	idx := idxI.IndexDesc()
-	if idx.Unique && behavior != tree.DropCascade && constraintBehavior != ignoreIdxConstraint && !idx.CreatedExplicitly {
+	if idx.IsUnique() && behavior != tree.DropCascade && constraintBehavior != ignoreIdxConstraint && !idx.IsCreatedExplicitly() {
 		return errors.WithHint(
 			pgerror.Newf(pgcode.DependentObjectsStillExist,
-				"index %q is in use as unique constraint", idx.Name),
+				"index %q is in use as unique constraint", idx.GetName()),
 			"use CASCADE if you really want to drop it.",
 		)
 	}
@@ -268,13 +267,13 @@ func (p *planner) dropIndexByName(
 	// necessary for the system tenant, because secondary tenants do not have
 	// zone configs for individual objects.
 	if p.ExecCfg().Codec.ForSystemTenant() {
-		_, zone, _, err := GetZoneConfigInTxn(ctx, p.txn, config.SystemTenantObjectID(tableDesc.ID), nil, "", false)
+		_, zone, _, err := GetZoneConfigInTxn(ctx, p.txn, config.SystemTenantObjectID(tableDesc.ID), nil /* index */, "", false)
 		if err != nil {
 			return err
 		}
 
 		for _, s := range zone.Subzones {
-			if s.IndexID != uint32(idx.ID) {
+			if s.IndexID != uint32(idx.GetID()) {
 				_, err = GenerateSubzoneSpans(
 					p.ExecCfg().Settings,
 					p.ExecCfg().ClusterID(),
@@ -311,17 +310,17 @@ func (p *planner) dropIndexByName(
 	// Construct a list of all the remaining indexes, so that we can see if there
 	// is another index that could replace the one we are deleting for a given
 	// foreign key constraint.
-	remainingIndexes := make([]*descpb.IndexDescriptor, 1, len(tableDesc.ActiveIndexes()))
-	remainingIndexes[0] = tableDesc.GetPrimaryIndex().IndexDesc()
+	remainingIndexes := make([]catalog.Index, 1, len(tableDesc.ActiveIndexes()))
+	remainingIndexes[0] = tableDesc.GetPrimaryIndex()
 	for _, index := range tableDesc.PublicNonPrimaryIndexes() {
-		if index.GetID() != idx.ID {
-			remainingIndexes = append(remainingIndexes, index.IndexDesc())
+		if index.GetID() != idx.GetID() {
+			remainingIndexes = append(remainingIndexes, index)
 		}
 	}
 
 	// indexHasReplacementCandidate runs isValidIndex on each index in remainingIndexes and returns
 	// true if at least one index satisfies isValidIndex.
-	indexHasReplacementCandidate := func(isValidIndex func(*descpb.IndexDescriptor) bool) bool {
+	indexHasReplacementCandidate := func(isValidIndex func(index catalog.Index) bool) bool {
 		foundReplacement := false
 		for _, index := range remainingIndexes {
 			if isValidIndex(index) {
@@ -340,7 +339,7 @@ func (p *planner) dropIndexByName(
 			// foreign key mutation, then make sure that we have another index that
 			// could be used for this mutation.
 			idx.IsValidOriginIndex(c.ForeignKey.OriginColumnIDs) &&
-			!indexHasReplacementCandidate(func(idx *descpb.IndexDescriptor) bool {
+			!indexHasReplacementCandidate(func(idx catalog.Index) bool {
 				return idx.IsValidOriginIndex(c.ForeignKey.OriginColumnIDs)
 			}) {
 			return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
@@ -361,13 +360,13 @@ func (p *planner) dropIndexByName(
 			tableDesc.OutboundFKs[sliceIdx] = tableDesc.OutboundFKs[i]
 			sliceIdx++
 			fk := &tableDesc.OutboundFKs[i]
-			canReplace := func(idx *descpb.IndexDescriptor) bool {
+			canReplace := func(idx catalog.Index) bool {
 				return idx.IsValidOriginIndex(fk.OriginColumnIDs)
 			}
 			// The index being deleted could be used as the origin index for this foreign key.
 			if idx.IsValidOriginIndex(fk.OriginColumnIDs) && !indexHasReplacementCandidate(canReplace) {
 				if behavior != tree.DropCascade && constraintBehavior != ignoreIdxConstraint {
-					return errors.Errorf("index %q is in use as a foreign key constraint", idx.Name)
+					return errors.Errorf("index %q is in use as a foreign key constraint", idx.GetName())
 				}
 				sliceIdx--
 				if err := p.removeFKBackReference(ctx, tableDesc, fk); err != nil {
@@ -391,34 +390,34 @@ func (p *planner) dropIndexByName(
 		return err
 	}
 
-	if len(idx.Interleave.Ancestors) > 0 {
+	if idx.NumInterleaveAncestors() > 0 {
 		if err := p.removeInterleaveBackReference(ctx, tableDesc, idx); err != nil {
 			return err
 		}
 	}
-	for _, ref := range idx.InterleavedBy {
-		if err := p.removeInterleave(ctx, ref); err != nil {
+	for i := 0; i < idx.NumInterleavedBy(); i++ {
+		if err := p.removeInterleave(ctx, idx.GetInterleavedBy(i)); err != nil {
 			return err
 		}
 	}
 
 	var droppedViews []string
 	for _, tableRef := range tableDesc.DependedOnBy {
-		if tableRef.IndexID == idx.ID {
+		if tableRef.IndexID == idx.GetID() {
 			// Ensure that we have DROP privilege on all dependent views
 			err := p.canRemoveDependentViewGeneric(
-				ctx, "index", idx.Name, tableDesc.ParentID, tableRef, behavior)
+				ctx, "index", idx.GetName(), tableDesc.ParentID, tableRef, behavior)
 			if err != nil {
 				return err
 			}
 			viewDesc, err := p.getViewDescForCascade(
-				ctx, "index", idx.Name, tableDesc.ParentID, tableRef.ID, behavior,
+				ctx, "index", idx.GetName(), tableDesc.ParentID, tableRef.ID, behavior,
 			)
 			if err != nil {
 				return err
 			}
 			viewJobDesc := fmt.Sprintf("removing view %q dependent on index %q which is being dropped",
-				viewDesc.Name, idx.Name)
+				viewDesc.Name, idx.GetName())
 			cascadedViews, err := p.removeDependentView(ctx, tableDesc, viewDesc, viewJobDesc)
 			if err != nil {
 				return err
@@ -435,12 +434,12 @@ func (p *planner) dropIndexByName(
 	}
 
 	// Overwriting tableDesc.Index may mess up with the idx object we collected above. Make a copy.
-	idxCopy := *idx
-	idx = &idxCopy
+	idxCopy := *idx.IndexDesc()
+	idxDesc := &idxCopy
 
 	// Currently, a replacement primary index must be specified when dropping the primary index,
 	// and this cannot be done with DROP INDEX.
-	if idx.ID == tableDesc.GetPrimaryIndexID() {
+	if idxDesc.ID == tableDesc.GetPrimaryIndexID() {
 		return errors.WithHint(
 			pgerror.Newf(pgcode.FeatureNotSupported, "cannot drop the primary index of a table using DROP INDEX"),
 			"instead, use ALTER TABLE ... ALTER PRIMARY KEY or"+
@@ -449,7 +448,7 @@ func (p *planner) dropIndexByName(
 	}
 
 	foundIndex := catalog.FindPublicNonPrimaryIndex(tableDesc, func(idxEntry catalog.Index) bool {
-		return idxEntry.GetID() == idx.ID
+		return idxEntry.GetID() == idxDesc.ID
 	})
 
 	if foundIndex == nil {
@@ -501,7 +500,7 @@ func (p *planner) dropIndexByName(
 	}
 	tableDesc.RemovePublicNonPrimaryIndex(idxOrdinal)
 
-	if err := p.removeIndexComment(ctx, tableDesc.ID, idx.ID); err != nil {
+	if err := p.removeIndexComment(ctx, tableDesc.ID, idxDesc.ID); err != nil {
 		return err
 	}
 

--- a/pkg/sql/drop_sequence.go
+++ b/pkg/sql/drop_sequence.go
@@ -143,8 +143,8 @@ func (p *planner) sequenceDependencyError(
 func (p *planner) canRemoveAllTableOwnedSequences(
 	ctx context.Context, desc *tabledesc.Mutable, behavior tree.DropBehavior,
 ) error {
-	for _, col := range desc.Columns {
-		err := p.canRemoveOwnedSequencesImpl(ctx, desc, &col, behavior, false /* isColumnDrop */)
+	for _, col := range desc.PublicColumns() {
+		err := p.canRemoveOwnedSequencesImpl(ctx, desc, col, behavior, false /* isColumnDrop */)
 		if err != nil {
 			return err
 		}
@@ -153,10 +153,7 @@ func (p *planner) canRemoveAllTableOwnedSequences(
 }
 
 func (p *planner) canRemoveAllColumnOwnedSequences(
-	ctx context.Context,
-	desc *tabledesc.Mutable,
-	col *descpb.ColumnDescriptor,
-	behavior tree.DropBehavior,
+	ctx context.Context, desc *tabledesc.Mutable, col catalog.Column, behavior tree.DropBehavior,
 ) error {
 	return p.canRemoveOwnedSequencesImpl(ctx, desc, col, behavior, true /* isColumnDrop */)
 }
@@ -164,11 +161,12 @@ func (p *planner) canRemoveAllColumnOwnedSequences(
 func (p *planner) canRemoveOwnedSequencesImpl(
 	ctx context.Context,
 	desc *tabledesc.Mutable,
-	col *descpb.ColumnDescriptor,
+	col catalog.Column,
 	behavior tree.DropBehavior,
 	isColumnDrop bool,
 ) error {
-	for _, sequenceID := range col.OwnsSequenceIds {
+	for i := 0; i < col.NumOwnsSequences(); i++ {
+		sequenceID := col.GetOwnsSequenceID(i)
 		seqDesc, err := p.LookupTableByID(ctx, sequenceID)
 		if err != nil {
 			// Special case error swallowing for #50711 and #50781, which can cause a
@@ -203,7 +201,7 @@ func (p *planner) canRemoveOwnedSequencesImpl(
 				continue
 			}
 			// ...or we're dropping a column in the table of interest.
-			if len(firstDep.ColumnIDs) == 1 && firstDep.ColumnIDs[0] == col.ID {
+			if len(firstDep.ColumnIDs) == 1 && firstDep.ColumnIDs[0] == col.GetID() {
 				// The sequence is safe to remove iff it's not depended on by any other
 				// columns in the table other than that one.
 				continue
@@ -264,10 +262,9 @@ func dropDependentOnSequence(ctx context.Context, p *planner, seqDesc *tabledesc
 
 		// Iterate over all columns in the table, drop affected columns' default values
 		// and update back references.
-		for idx := range tblDesc.Columns {
-			column := &tblDesc.Columns[idx]
-			if _, ok := colsToDropDefault[column.ID]; ok {
-				column.DefaultExpr = nil
+		for _, column := range tblDesc.PublicColumns() {
+			if _, ok := colsToDropDefault[column.GetID()]; ok {
+				column.ColumnDesc().DefaultExpr = nil
 				if err := p.removeSequenceDependencies(ctx, tblDesc, column); err != nil {
 					return err
 				}

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -307,7 +307,7 @@ func (p *planner) dropTableImpl(
 	// Remove interleave relationships.
 	for _, idx := range tableDesc.NonDropIndexes() {
 		if idx.NumInterleaveAncestors() > 0 {
-			if err := p.removeInterleaveBackReference(ctx, tableDesc, idx.IndexDesc()); err != nil {
+			if err := p.removeInterleaveBackReference(ctx, tableDesc, idx); err != nil {
 				return droppedViews, err
 			}
 		}
@@ -320,15 +320,15 @@ func (p *planner) dropTableImpl(
 	}
 
 	// Remove sequence dependencies.
-	for i := range tableDesc.Columns {
-		if err := p.removeSequenceDependencies(ctx, tableDesc, &tableDesc.Columns[i]); err != nil {
+	for _, col := range tableDesc.PublicColumns() {
+		if err := p.removeSequenceDependencies(ctx, tableDesc, col); err != nil {
 			return droppedViews, err
 		}
 	}
 
 	// Drop sequences that the columns of the table own.
-	for _, col := range tableDesc.Columns {
-		if err := p.dropSequencesOwnedByCol(ctx, &col, !droppingParent, behavior); err != nil {
+	for _, col := range tableDesc.PublicColumns() {
+		if err := p.dropSequencesOwnedByCol(ctx, col, !droppingParent, behavior); err != nil {
 			return droppedViews, err
 		}
 	}
@@ -639,12 +639,12 @@ func removeFKBackReferenceFromTable(
 }
 
 func (p *planner) removeInterleaveBackReference(
-	ctx context.Context, tableDesc *tabledesc.Mutable, idx *descpb.IndexDescriptor,
+	ctx context.Context, tableDesc *tabledesc.Mutable, idx catalog.Index,
 ) error {
-	if len(idx.Interleave.Ancestors) == 0 {
+	if idx.NumInterleaveAncestors() == 0 {
 		return nil
 	}
-	ancestor := idx.Interleave.Ancestors[len(idx.Interleave.Ancestors)-1]
+	ancestor := idx.GetInterleaveAncestor(idx.NumInterleaveAncestors() - 1)
 	var t *tabledesc.Mutable
 	if ancestor.TableID == tableDesc.ID {
 		t = tableDesc
@@ -666,10 +666,10 @@ func (p *planner) removeInterleaveBackReference(
 	targetIdx := targetIdxI.IndexDesc()
 	foundAncestor := false
 	for k, ref := range targetIdx.InterleavedBy {
-		if ref.Table == tableDesc.ID && ref.Index == idx.ID {
+		if ref.Table == tableDesc.ID && ref.Index == idx.GetID() {
 			if foundAncestor {
 				return errors.AssertionFailedf(
-					"ancestor entry in %s for %s@%s found more than once", t.Name, tableDesc.Name, idx.Name)
+					"ancestor entry in %s for %s@%s found more than once", t.Name, tableDesc.Name, idx.GetName())
 			}
 			targetIdx.InterleavedBy = append(targetIdx.InterleavedBy[:k], targetIdx.InterleavedBy[k+1:]...)
 			foundAncestor = true

--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -225,10 +225,10 @@ func constructVirtualScan(
 	if !canQueryVirtualTable(p.EvalContext(), virtual) {
 		return nil, newUnimplementedVirtualTableError(tn.Schema(), tn.Table())
 	}
-	indexDesc := index.(*optVirtualIndex).desc
+	idx := index.(*optVirtualIndex).idx
 	columns, constructor := virtual.getPlanInfo(
 		table.(*optVirtualTable).desc,
-		indexDesc, params.IndexConstraint, p.execCfg.DistSQLPlanner.stopper)
+		idx, params.IndexConstraint, p.execCfg.DistSQLPlanner.stopper)
 
 	n, err := delayedNodeCallback(&delayedNode{
 		name:            fmt.Sprintf("%s@%s", table.Name(), index.Name()),

--- a/pkg/sql/execinfrapb/flow_diagram.go
+++ b/pkg/sql/execinfrapb/flow_diagram.go
@@ -149,7 +149,7 @@ func (tr *TableReaderSpec) summary() (string, []string) {
 		tbl := tr.BuildTableDescriptor()
 		// only show the first span
 		idx := tbl.ActiveIndexes()[int(tr.IndexIdx)]
-		valDirs := catalogkeys.IndexKeyValDirs(idx.IndexDesc())
+		valDirs := catalogkeys.IndexKeyValDirs(idx)
 
 		var spanStr strings.Builder
 		spanStr.WriteString("Spans: ")

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -175,8 +175,8 @@ func emitExplain(
 			return "<virtual table spans>"
 		}
 		tabDesc := table.(*optTable).desc
-		idxDesc := index.(*optIndex).desc
-		spans, err := generateScanSpans(evalCtx, codec, tabDesc, idxDesc, scanParams)
+		idx := index.(*optIndex).idx
+		spans, err := generateScanSpans(evalCtx, codec, tabDesc, idx, scanParams)
 		if err != nil {
 			return err.Error()
 		}
@@ -192,7 +192,7 @@ func emitExplain(
 		if !codec.ForSystemTenant() {
 			skip = 4
 		}
-		return catalogkeys.PrettySpans(idxDesc, spans, skip)
+		return catalogkeys.PrettySpans(idx, spans, skip)
 	}
 
 	return explain.Emit(explainPlan, ob, spanFormatFn)

--- a/pkg/sql/gcjob/gc_job.go
+++ b/pkg/sql/gcjob/gc_job.go
@@ -102,11 +102,15 @@ func (r schemaChangeGCResumer) Resume(ctx context.Context, execCtx interface{}) 
 		if err := sql.WaitToUpdateLeases(ctx, execCfg.LeaseManager, details.InterleavedTable.ID); err != nil {
 			return err
 		}
+		interleavedIndexIDs := make([]descpb.IndexID, len(details.InterleavedIndexes))
+		for i := range details.InterleavedIndexes {
+			interleavedIndexIDs[i] = details.InterleavedIndexes[i].ID
+		}
 		if err := sql.TruncateInterleavedIndexes(
 			ctx,
 			execCfg,
 			tabledesc.NewBuilder(details.InterleavedTable).BuildImmutableTable(),
-			details.InterleavedIndexes,
+			interleavedIndexIDs,
 		); err != nil {
 			return err
 		}

--- a/pkg/sql/index_join.go
+++ b/pkg/sql/index_join.go
@@ -13,8 +13,8 @@ package sql
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -31,7 +31,7 @@ type indexJoinNode struct {
 	table *scanNode
 
 	// The columns returned by this node.
-	cols []descpb.ColumnDescriptor
+	cols []catalog.Column
 	// There is a 1-1 correspondence between cols and resultColumns.
 	resultColumns colinfo.ResultColumns
 

--- a/pkg/sql/indexbackfiller_test.go
+++ b/pkg/sql/indexbackfiller_test.go
@@ -387,9 +387,9 @@ INSERT INTO foo VALUES (1), (10), (100);
 			row.FetcherTableArgs{
 				Spans:            spans,
 				Desc:             table,
-				Index:            idx.IndexDesc(),
+				Index:            idx,
 				ColIdxMap:        colIdxMap,
-				Cols:             table.Columns,
+				Cols:             table.PublicColumns(),
 				ValNeededForCol:  valsNeeded,
 				IsSecondaryIndex: !idx.Primary(),
 			},

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1297,16 +1297,16 @@ CREATE TABLE information_schema.statistics (
 				scNameStr := tree.NewDString(scName)
 				tbNameStr := tree.NewDString(table.GetName())
 
-				appendRow := func(index *descpb.IndexDescriptor, colName string, sequence int,
+				appendRow := func(index catalog.Index, colName string, sequence int,
 					direction tree.Datum, isStored, isImplicit bool,
 				) error {
 					return addRow(
 						dbNameStr,                         // table_catalog
 						scNameStr,                         // table_schema
 						tbNameStr,                         // table_name
-						yesOrNoDatum(!index.Unique),       // non_unique
+						yesOrNoDatum(!index.IsUnique()),   // non_unique
 						scNameStr,                         // index_schema
-						tree.NewDString(index.Name),       // index_name
+						tree.NewDString(index.GetName()),  // index_name
 						tree.NewDInt(tree.DInt(sequence)), // seq_in_index
 						tree.NewDString(colName),          // column_name
 						tree.DNull,                        // collation
@@ -1344,7 +1344,7 @@ CREATE TABLE information_schema.statistics (
 						// We add a row for each column of index.
 						dir := dStringForIndexDirection(index.GetColumnDirection(i))
 						if err := appendRow(
-							index.IndexDesc(),
+							index,
 							col,
 							sequence,
 							dir,
@@ -1359,7 +1359,7 @@ CREATE TABLE information_schema.statistics (
 					for i := 0; i < index.NumStoredColumns(); i++ {
 						col := index.GetStoredColumnName(i)
 						// We add a row for each stored column of index.
-						if err := appendRow(index.IndexDesc(), col, sequence,
+						if err := appendRow(index, col, sequence,
 							indexDirectionNA, true, false); err != nil {
 							return err
 						}
@@ -1377,7 +1377,7 @@ CREATE TABLE information_schema.statistics (
 							col := table.GetPrimaryIndex().GetColumnName(i)
 							if _, isImplicit := implicitCols[col]; isImplicit {
 								// We add a row for each implicit column of index.
-								if err := appendRow(index.IndexDesc(), col, sequence,
+								if err := appendRow(index, col, sequence,
 									indexDirectionAsc, false, true); err != nil {
 									return err
 								}

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -53,7 +52,7 @@ type insertRun struct {
 	checkOrds checkSet
 
 	// insertCols are the columns being inserted into.
-	insertCols []descpb.ColumnDescriptor
+	insertCols []catalog.Column
 
 	// done informs a new call to BatchedNext() that the previous call to
 	// BatchedNext() has completed the work already.
@@ -110,7 +109,7 @@ func (r *insertRun) initRowContainer(params runParams, columns colinfo.ResultCol
 	colIDToRetIndex := catalog.ColumnIDToOrdinalMap(r.ti.tableDesc().PublicColumns())
 	r.rowIdxToTabColIdx = make([]int, len(r.insertCols))
 	for i, col := range r.insertCols {
-		if idx, ok := colIDToRetIndex.Get(col.ID); !ok {
+		if idx, ok := colIDToRetIndex.Get(col.GetID()); !ok {
 			// Column must be write only and not public.
 			r.rowIdxToTabColIdx[i] = -1
 		} else {

--- a/pkg/sql/insert_fast_path.go
+++ b/pkg/sql/insert_fast_path.go
@@ -87,7 +87,7 @@ type insertFastPathFKCheck struct {
 	exec.InsertFastPathFKCheck
 
 	tabDesc     catalog.TableDescriptor
-	idxDesc     *descpb.IndexDescriptor
+	idx         catalog.Index
 	keyPrefix   []byte
 	colMap      catalog.TableColMap
 	spanBuilder *span.Builder
@@ -96,11 +96,11 @@ type insertFastPathFKCheck struct {
 func (c *insertFastPathFKCheck) init(params runParams) error {
 	idx := c.ReferencedIndex.(*optIndex)
 	c.tabDesc = c.ReferencedTable.(*optTable).desc
-	c.idxDesc = idx.desc
+	c.idx = idx.idx
 
 	codec := params.ExecCfg().Codec
-	c.keyPrefix = rowenc.MakeIndexKeyPrefix(codec, c.tabDesc, c.idxDesc.ID)
-	c.spanBuilder = span.MakeBuilder(params.EvalContext(), codec, c.tabDesc, c.idxDesc)
+	c.keyPrefix = rowenc.MakeIndexKeyPrefix(codec, c.tabDesc, c.idx.GetID())
+	c.spanBuilder = span.MakeBuilder(params.EvalContext(), codec, c.tabDesc, c.idx)
 
 	if len(c.InsertCols) > idx.numLaxKeyCols {
 		return errors.AssertionFailedf(
@@ -109,10 +109,10 @@ func (c *insertFastPathFKCheck) init(params runParams) error {
 	}
 	for i, ord := range c.InsertCols {
 		var colID descpb.ColumnID
-		if i < len(c.idxDesc.ColumnIDs) {
-			colID = c.idxDesc.ColumnIDs[i]
+		if i < c.idx.NumColumns() {
+			colID = c.idx.GetColumnID(i)
 		} else {
-			colID = c.idxDesc.ExtraColumnIDs[i-len(c.idxDesc.ColumnIDs)]
+			colID = c.idx.GetExtraColumnID(i - c.idx.NumColumns())
 		}
 
 		c.colMap.Set(colID, int(ord))
@@ -336,23 +336,21 @@ func (n *insertFastPathNode) enableAutoCommit() {
 // If colNum is not -1, only the colNum'th column in insertCols will be checked
 // for AlterColumnTypeInProgress, otherwise every column in insertCols will
 // be checked.
-func interceptAlterColumnTypeParseError(
-	insertCols []descpb.ColumnDescriptor, colNum int, err error,
-) error {
+func interceptAlterColumnTypeParseError(insertCols []catalog.Column, colNum int, err error) error {
 	// Only intercept the error if the column being inserted into
 	// is an actual column. This is to avoid checking on values that don't
 	// correspond to an actual column, for example a check constraint.
 	if colNum >= len(insertCols) {
 		return err
 	}
-	var insertCol descpb.ColumnDescriptor
+	var insertCol catalog.Column
 
 	// wrapParseError is a helper function that checks if an insertCol has the
 	// AlterColumnTypeInProgress flag and wraps the parse error msg stating
 	// that the error may be because the column is being altered.
 	// Returns if the error msg has been wrapped and the wrapped error msg.
-	wrapParseError := func(insertCol descpb.ColumnDescriptor, colNum int, err error) (bool, error) {
-		if insertCol.AlterColumnTypeInProgress {
+	wrapParseError := func(insertCol catalog.Column, colNum int, err error) (bool, error) {
+		if insertCol.ColumnDesc().AlterColumnTypeInProgress {
 			code := pgerror.GetPGCode(err)
 			if code == pgcode.InvalidTextRepresentation {
 				if colNum != -1 {

--- a/pkg/sql/opt/invertedidx/BUILD.bazel
+++ b/pkg/sql/opt/invertedidx/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/geo/geoindex",
         "//pkg/geo/geopb",
         "//pkg/geo/geoprojbase",
+        "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/inverted",
         "//pkg/sql/opt",

--- a/pkg/sql/opt/invertedidx/inverted_index_expr.go
+++ b/pkg/sql/opt/invertedidx/inverted_index_expr.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/inverted"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
@@ -32,10 +32,11 @@ import (
 // NewDatumsToInvertedExpr returns a new DatumsToInvertedExpr. Currently there
 // is only one possible implementation returned, geoDatumsToInvertedExpr.
 func NewDatumsToInvertedExpr(
-	evalCtx *tree.EvalContext, colTypes []*types.T, expr tree.TypedExpr, desc *descpb.IndexDescriptor,
+	evalCtx *tree.EvalContext, colTypes []*types.T, expr tree.TypedExpr, idx catalog.Index,
 ) (invertedexpr.DatumsToInvertedExpr, error) {
-	if !geoindex.IsEmptyConfig(&desc.GeoConfig) {
-		return NewGeoDatumsToInvertedExpr(evalCtx, colTypes, expr, &desc.GeoConfig)
+	geoConfig := idx.GetGeoConfig()
+	if !geoindex.IsEmptyConfig(&geoConfig) {
+		return NewGeoDatumsToInvertedExpr(evalCtx, colTypes, expr, &geoConfig)
 	}
 
 	return NewJSONOrArrayDatumsToInvertedExpr(evalCtx, colTypes, expr)

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -84,7 +84,7 @@ func (ef *execFactory) ConstructScan(
 	}
 
 	tabDesc := table.(*optTable).desc
-	indexDesc := index.(*optIndex).desc
+	idx := index.(*optIndex).idx
 	// Create a scanNode.
 	scan := ef.planner.Scan()
 	colCfg := makeScanColumnsConfig(table, params.NeededCols)
@@ -104,20 +104,20 @@ func (ef *execFactory) ConstructScan(
 		return newZeroNode(scan.resultColumns), nil
 	}
 
-	scan.index = indexDesc
+	scan.index = idx
 	scan.hardLimit = params.HardLimit
 	scan.softLimit = params.SoftLimit
 
 	scan.reverse = params.Reverse
 	scan.parallelize = params.Parallelize
 	var err error
-	scan.spans, err = generateScanSpans(ef.planner.EvalContext(), ef.planner.ExecCfg().Codec, tabDesc, indexDesc, params)
+	scan.spans, err = generateScanSpans(ef.planner.EvalContext(), ef.planner.ExecCfg().Codec, tabDesc, idx, params)
 	if err != nil {
 		return nil, err
 	}
 
 	scan.isFull = len(scan.spans) == 1 && scan.spans[0].EqualValue(
-		scan.desc.IndexSpan(ef.planner.ExecCfg().Codec, scan.index.ID),
+		scan.desc.IndexSpan(ef.planner.ExecCfg().Codec, scan.index.GetID()),
 	)
 	if err = colCfg.assertValidReqOrdering(reqOrdering); err != nil {
 		return nil, err
@@ -136,10 +136,10 @@ func generateScanSpans(
 	evalCtx *tree.EvalContext,
 	codec keys.SQLCodec,
 	tabDesc catalog.TableDescriptor,
-	indexDesc *descpb.IndexDescriptor,
+	index catalog.Index,
 	params exec.ScanParams,
 ) (roachpb.Spans, error) {
-	sb := span.MakeBuilder(evalCtx, codec, tabDesc, indexDesc)
+	sb := span.MakeBuilder(evalCtx, codec, tabDesc, index)
 	if params.InvertedConstraint != nil {
 		return sb.SpansFromInvertedSpans(params.InvertedConstraint, params.IndexConstraint)
 	}
@@ -547,7 +547,7 @@ func (ef *execFactory) ConstructIndexJoin(
 ) (exec.Node, error) {
 	tabDesc := table.(*optTable).desc
 	colCfg := makeScanColumnsConfig(table, tableCols)
-	colDescs := makeColDescList(table, tableCols)
+	cols := makeColList(table, tableCols)
 
 	tableScan := ef.planner.Scan()
 
@@ -555,15 +555,14 @@ func (ef *execFactory) ConstructIndexJoin(
 		return nil, err
 	}
 
-	primaryIndex := tabDesc.GetPrimaryIndex()
-	tableScan.index = primaryIndex.IndexDesc()
+	tableScan.index = tabDesc.GetPrimaryIndex()
 	tableScan.disableBatchLimit()
 
 	n := &indexJoinNode{
 		input:         input.(planNode),
 		table:         tableScan,
-		cols:          colDescs,
-		resultColumns: colinfo.ResultColumnsFromColDescs(tabDesc.GetID(), colDescs),
+		cols:          cols,
+		resultColumns: colinfo.ResultColumnsFromColumns(tabDesc.GetID(), cols),
 		reqOrdering:   ReqOrdering(reqOrdering),
 	}
 
@@ -594,7 +593,7 @@ func (ef *execFactory) ConstructLookupJoin(
 		return ef.constructVirtualTableLookupJoin(joinType, input, table, index, eqCols, lookupCols, onCond)
 	}
 	tabDesc := table.(*optTable).desc
-	indexDesc := index.(*optIndex).desc
+	idx := index.(*optIndex).idx
 	colCfg := makeScanColumnsConfig(table, lookupCols)
 	tableScan := ef.planner.Scan()
 
@@ -602,7 +601,7 @@ func (ef *execFactory) ConstructLookupJoin(
 		return nil, err
 	}
 
-	tableScan.index = indexDesc
+	tableScan.index = idx
 	if locking != nil {
 		tableScan.lockingStrength = descpb.ToScanLockingStrength(locking.Strength)
 		tableScan.lockingWaitPolicy = descpb.ToScanLockingWaitPolicy(locking.WaitPolicy)
@@ -656,7 +655,7 @@ func (ef *execFactory) constructVirtualTableLookupJoin(
 	if lookupCols.Contains(0) {
 		return nil, errors.Errorf("use of %s column not allowed.", table.Column(0).ColName())
 	}
-	indexDesc := index.(*optVirtualIndex).desc
+	idx := index.(*optVirtualIndex).idx
 	tableDesc := table.(*optVirtualTable).desc
 	// Build the result columns.
 	inputCols := planColumns(input.(planNode))
@@ -672,12 +671,8 @@ func (ef *execFactory) constructVirtualTableLookupJoin(
 	if err := tableScan.initTable(context.TODO(), ef.planner, tableDesc, nil, colCfg); err != nil {
 		return nil, err
 	}
-	tableScan.index = indexDesc
-	publicColDescs := make([]descpb.ColumnDescriptor, len(tableDesc.PublicColumns()))
-	for i, col := range tableDesc.PublicColumns() {
-		publicColDescs[i] = *col.ColumnDesc()
-	}
-	vtableCols := colinfo.ResultColumnsFromColDescs(tableDesc.GetID(), publicColDescs)
+	tableScan.index = idx
+	vtableCols := colinfo.ResultColumnsFromColumns(tableDesc.GetID(), tableDesc.PublicColumns())
 	projectedVtableCols := planColumns(&tableScan)
 	outputCols := make(colinfo.ResultColumns, 0, len(inputCols)+len(projectedVtableCols))
 	outputCols = append(outputCols, inputCols...)
@@ -691,7 +686,7 @@ func (ef *execFactory) constructVirtualTableLookupJoin(
 		virtualTableEntry: virtual,
 		dbName:            tn.Catalog(),
 		table:             tableDesc,
-		index:             indexDesc,
+		index:             idx,
 		eqCol:             int(eqCols[0]),
 		inputCols:         inputCols,
 		vtableCols:        vtableCols,
@@ -715,7 +710,7 @@ func (ef *execFactory) ConstructInvertedJoin(
 	reqOrdering exec.OutputOrdering,
 ) (exec.Node, error) {
 	tabDesc := table.(*optTable).desc
-	indexDesc := index.(*optIndex).desc
+	idx := index.(*optIndex).idx
 	// NB: lookupCols does not include the inverted column, which is only a partial
 	// representation of the original table column. This scan configuration does not
 	// affect what the invertedJoiner implementation retrieves from the inverted
@@ -727,7 +722,7 @@ func (ef *execFactory) ConstructInvertedJoin(
 	if err := tableScan.initTable(context.TODO(), ef.planner, tabDesc, nil, colCfg); err != nil {
 		return nil, err
 	}
-	tableScan.index = indexDesc
+	tableScan.index = idx
 
 	n := &invertedJoinNode{
 		input:                     input.(planNode),
@@ -768,9 +763,7 @@ func (ef *execFactory) ConstructInvertedJoin(
 // Helper function to create a scanNode from just a table / index descriptor
 // and requested cols.
 func (ef *execFactory) constructScanForZigzag(
-	indexDesc *descpb.IndexDescriptor,
-	tableDesc catalog.TableDescriptor,
-	cols exec.TableColumnOrdinalSet,
+	index catalog.Index, tableDesc catalog.TableDescriptor, cols exec.TableColumnOrdinalSet,
 ) (*scanNode, error) {
 
 	colCfg := scanColumnsConfig{
@@ -786,7 +779,7 @@ func (ef *execFactory) constructScanForZigzag(
 		return nil, err
 	}
 
-	scan.index = indexDesc
+	scan.index = index
 
 	return scan, nil
 }
@@ -806,16 +799,16 @@ func (ef *execFactory) ConstructZigzagJoin(
 	onCond tree.TypedExpr,
 	reqOrdering exec.OutputOrdering,
 ) (exec.Node, error) {
-	leftIndexDesc := leftIndex.(*optIndex).desc
+	leftIdx := leftIndex.(*optIndex).idx
 	leftTabDesc := leftTable.(*optTable).desc
-	rightIndexDesc := rightIndex.(*optIndex).desc
+	rightIdx := rightIndex.(*optIndex).idx
 	rightTabDesc := rightTable.(*optTable).desc
 
-	leftScan, err := ef.constructScanForZigzag(leftIndexDesc, leftTabDesc, leftCols)
+	leftScan, err := ef.constructScanForZigzag(leftIdx, leftTabDesc, leftCols)
 	if err != nil {
 		return nil, err
 	}
-	rightScan, err := ef.constructScanForZigzag(rightIndexDesc, rightTabDesc, rightCols)
+	rightScan, err := ef.constructScanForZigzag(rightIdx, rightTabDesc, rightCols)
 	if err != nil {
 		return nil, err
 	}
@@ -1181,7 +1174,7 @@ func (ef *execFactory) ConstructInsert(
 	// Derive insert table and column descriptors.
 	rowsNeeded := !returnColOrdSet.Empty()
 	tabDesc := table.(*optTable).desc
-	colDescs := makeColDescList(table, insertColOrdSet)
+	cols := makeColList(table, insertColOrdSet)
 
 	if err := ef.planner.maybeSetSystemConfig(tabDesc.GetID()); err != nil {
 		return nil, err
@@ -1189,7 +1182,7 @@ func (ef *execFactory) ConstructInsert(
 
 	// Create the table inserter, which does the bulk of the work.
 	ri, err := row.MakeInserter(
-		ctx, ef.planner.txn, ef.planner.ExecCfg().Codec, tabDesc, colDescs, ef.planner.alloc,
+		ctx, ef.planner.txn, ef.planner.ExecCfg().Codec, tabDesc, cols, ef.planner.alloc,
 	)
 	if err != nil {
 		return nil, err
@@ -1208,12 +1201,12 @@ func (ef *execFactory) ConstructInsert(
 
 	// If rows are not needed, no columns are returned.
 	if rowsNeeded {
-		returnColDescs := makeColDescList(table, returnColOrdSet)
-		ins.columns = colinfo.ResultColumnsFromColDescs(tabDesc.GetID(), returnColDescs)
+		returnCols := makeColList(table, returnColOrdSet)
+		ins.columns = colinfo.ResultColumnsFromColumns(tabDesc.GetID(), returnCols)
 
 		// Set the tabColIdxToRetIdx for the mutation. Insert always returns
 		// non-mutation columns in the same order they are defined in the table.
-		ins.run.tabColIdxToRetIdx = makePublicToReturnColumnIndexMapping(tabDesc, returnColDescs)
+		ins.run.tabColIdxToRetIdx = makePublicToReturnColumnIndexMapping(tabDesc, returnCols)
 		ins.run.rowsNeeded = true
 	}
 
@@ -1247,7 +1240,7 @@ func (ef *execFactory) ConstructInsertFastPath(
 	// Derive insert table and column descriptors.
 	rowsNeeded := !returnColOrdSet.Empty()
 	tabDesc := table.(*optTable).desc
-	colDescs := makeColDescList(table, insertColOrdSet)
+	cols := makeColList(table, insertColOrdSet)
 
 	if err := ef.planner.maybeSetSystemConfig(tabDesc.GetID()); err != nil {
 		return nil, err
@@ -1255,7 +1248,7 @@ func (ef *execFactory) ConstructInsertFastPath(
 
 	// Create the table inserter, which does the bulk of the work.
 	ri, err := row.MakeInserter(
-		ctx, ef.planner.txn, ef.planner.ExecCfg().Codec, tabDesc, colDescs, ef.planner.alloc,
+		ctx, ef.planner.txn, ef.planner.ExecCfg().Codec, tabDesc, cols, ef.planner.alloc,
 	)
 	if err != nil {
 		return nil, err
@@ -1283,12 +1276,12 @@ func (ef *execFactory) ConstructInsertFastPath(
 
 	// If rows are not needed, no columns are returned.
 	if rowsNeeded {
-		returnColDescs := makeColDescList(table, returnColOrdSet)
-		ins.columns = colinfo.ResultColumnsFromColDescs(tabDesc.GetID(), returnColDescs)
+		returnCols := makeColList(table, returnColOrdSet)
+		ins.columns = colinfo.ResultColumnsFromColumns(tabDesc.GetID(), returnCols)
 
 		// Set the tabColIdxToRetIdx for the mutation. Insert always returns
 		// non-mutation columns in the same order they are defined in the table.
-		ins.run.tabColIdxToRetIdx = makePublicToReturnColumnIndexMapping(tabDesc, returnColDescs)
+		ins.run.tabColIdxToRetIdx = makePublicToReturnColumnIndexMapping(tabDesc, returnCols)
 		ins.run.rowsNeeded = true
 	}
 
@@ -1335,7 +1328,7 @@ func (ef *execFactory) ConstructUpdate(
 	// Derive table and column descriptors.
 	rowsNeeded := !returnColOrdSet.Empty()
 	tabDesc := table.(*optTable).desc
-	fetchColDescs := makeColDescList(table, fetchColOrdSet)
+	fetchCols := makeColList(table, fetchColOrdSet)
 
 	if err := ef.planner.maybeSetSystemConfig(tabDesc.GetID()); err != nil {
 		return nil, err
@@ -1344,10 +1337,10 @@ func (ef *execFactory) ConstructUpdate(
 	// Add each column to update as a sourceSlot. The CBO only uses scalarSlot,
 	// since it compiles tuples and subqueries into a simple sequence of target
 	// columns.
-	updateColDescs := makeColDescList(table, updateColOrdSet)
-	sourceSlots := make([]sourceSlot, len(updateColDescs))
+	updateCols := makeColList(table, updateColOrdSet)
+	sourceSlots := make([]sourceSlot, len(updateCols))
 	for i := range sourceSlots {
-		sourceSlots[i] = scalarSlot{column: updateColDescs[i], sourceIndex: len(fetchColDescs) + i}
+		sourceSlots[i] = scalarSlot{column: updateCols[i], sourceIndex: len(fetchCols) + i}
 	}
 
 	// Create the table updater, which does the bulk of the work.
@@ -1356,8 +1349,8 @@ func (ef *execFactory) ConstructUpdate(
 		ef.planner.txn,
 		ef.planner.ExecCfg().Codec,
 		tabDesc,
-		updateColDescs,
-		fetchColDescs,
+		updateCols,
+		fetchCols,
 		row.UpdaterDefault,
 		ef.planner.alloc,
 	)
@@ -1369,7 +1362,7 @@ func (ef *execFactory) ConstructUpdate(
 	// the explanatory comments in updateRun.
 	var updateColsIdx catalog.TableColMap
 	for i := range ru.UpdateCols {
-		id := ru.UpdateCols[i].ID
+		id := ru.UpdateCols[i].GetID()
 		updateColsIdx.Set(id, i)
 	}
 
@@ -1393,9 +1386,9 @@ func (ef *execFactory) ConstructUpdate(
 
 	// If rows are not needed, no columns are returned.
 	if rowsNeeded {
-		returnColDescs := makeColDescList(table, returnColOrdSet)
+		returnCols := makeColList(table, returnColOrdSet)
 
-		upd.columns = colinfo.ResultColumnsFromColDescs(tabDesc.GetID(), returnColDescs)
+		upd.columns = colinfo.ResultColumnsFromColumns(tabDesc.GetID(), returnCols)
 		// Add the passthrough columns to the returning columns.
 		upd.columns = append(upd.columns, passthrough...)
 
@@ -1406,7 +1399,7 @@ func (ef *execFactory) ConstructUpdate(
 		// since the return columns are always a subset of the fetch columns,
 		// we can use use the fetch columns to generate the mapping for the
 		// returned rows.
-		upd.run.rowIdxToRetIdx = row.ColMapping(ru.FetchCols, returnColDescs)
+		upd.run.rowIdxToRetIdx = row.ColMapping(ru.FetchCols, returnCols)
 		upd.run.rowsNeeded = true
 	}
 
@@ -1444,9 +1437,9 @@ func (ef *execFactory) ConstructUpsert(
 	// Derive table and column descriptors.
 	rowsNeeded := !returnColOrdSet.Empty()
 	tabDesc := table.(*optTable).desc
-	insertColDescs := makeColDescList(table, insertColOrdSet)
-	fetchColDescs := makeColDescList(table, fetchColOrdSet)
-	updateColDescs := makeColDescList(table, updateColOrdSet)
+	insertCols := makeColList(table, insertColOrdSet)
+	fetchCols := makeColList(table, fetchColOrdSet)
+	updateCols := makeColList(table, updateColOrdSet)
 
 	if err := ef.planner.maybeSetSystemConfig(tabDesc.GetID()); err != nil {
 		return nil, err
@@ -1458,7 +1451,7 @@ func (ef *execFactory) ConstructUpsert(
 		ef.planner.txn,
 		ef.planner.ExecCfg().Codec,
 		tabDesc,
-		insertColDescs,
+		insertCols,
 		ef.planner.alloc,
 	)
 	if err != nil {
@@ -1471,8 +1464,8 @@ func (ef *execFactory) ConstructUpsert(
 		ef.planner.txn,
 		ef.planner.ExecCfg().Codec,
 		tabDesc,
-		updateColDescs,
-		fetchColDescs,
+		updateCols,
+		fetchCols,
 		row.UpdaterDefault,
 		ef.planner.alloc,
 	)
@@ -1490,8 +1483,8 @@ func (ef *execFactory) ConstructUpsert(
 			tw: optTableUpserter{
 				ri:            ri,
 				canaryOrdinal: int(canaryCol),
-				fetchCols:     fetchColDescs,
-				updateCols:    updateColDescs,
+				fetchCols:     fetchCols,
+				updateCols:    updateCols,
 				ru:            ru,
 			},
 		},
@@ -1499,14 +1492,14 @@ func (ef *execFactory) ConstructUpsert(
 
 	// If rows are not needed, no columns are returned.
 	if rowsNeeded {
-		returnColDescs := makeColDescList(table, returnColOrdSet)
-		ups.columns = colinfo.ResultColumnsFromColDescs(tabDesc.GetID(), returnColDescs)
+		returnCols := makeColList(table, returnColOrdSet)
+		ups.columns = colinfo.ResultColumnsFromColumns(tabDesc.GetID(), returnCols)
 
 		// Update the tabColIdxToRetIdx for the mutation. Upsert returns
 		// non-mutation columns specified, in the same order they are defined
 		// in the table.
-		ups.run.tw.tabColIdxToRetIdx = makePublicToReturnColumnIndexMapping(tabDesc, returnColDescs)
-		ups.run.tw.returnCols = returnColDescs
+		ups.run.tw.tabColIdxToRetIdx = makePublicToReturnColumnIndexMapping(tabDesc, returnCols)
+		ups.run.tw.returnCols = returnCols
 		ups.run.tw.rowsNeeded = true
 	}
 
@@ -1536,7 +1529,7 @@ func (ef *execFactory) ConstructDelete(
 	// Derive table and column descriptors.
 	rowsNeeded := !returnColOrdSet.Empty()
 	tabDesc := table.(*optTable).desc
-	fetchColDescs := makeColDescList(table, fetchColOrdSet)
+	fetchCols := makeColList(table, fetchColOrdSet)
 
 	if err := ef.planner.maybeSetSystemConfig(tabDesc.GetID()); err != nil {
 		return nil, err
@@ -1546,7 +1539,7 @@ func (ef *execFactory) ConstructDelete(
 	// the deleter derives the columns that need to be fetched. By contrast, the
 	// CBO will have already determined the set of fetch columns, and passes
 	// those sets into the deleter (which will basically be a no-op).
-	rd := row.MakeDeleter(ef.planner.ExecCfg().Codec, tabDesc, fetchColDescs)
+	rd := row.MakeDeleter(ef.planner.ExecCfg().Codec, tabDesc, fetchCols)
 
 	// Now make a delete node. We use a pool.
 	del := deleteNodePool.Get().(*deleteNode)
@@ -1560,12 +1553,12 @@ func (ef *execFactory) ConstructDelete(
 
 	// If rows are not needed, no columns are returned.
 	if rowsNeeded {
-		returnColDescs := makeColDescList(table, returnColOrdSet)
+		returnCols := makeColList(table, returnColOrdSet)
 		// Delete returns the non-mutation columns specified, in the same
 		// order they are defined in the table.
-		del.columns = colinfo.ResultColumnsFromColDescs(tabDesc.GetID(), returnColDescs)
+		del.columns = colinfo.ResultColumnsFromColumns(tabDesc.GetID(), returnCols)
 
-		del.run.rowIdxToRetIdx = row.ColMapping(rd.FetchCols, returnColDescs)
+		del.run.rowIdxToRetIdx = row.ColMapping(rd.FetchCols, returnCols)
 		del.run.rowsNeeded = true
 	}
 
@@ -1593,8 +1586,7 @@ func (ef *execFactory) ConstructDeleteRange(
 	autoCommit bool,
 ) (exec.Node, error) {
 	tabDesc := table.(*optTable).desc
-	indexDesc := tabDesc.GetPrimaryIndex().IndexDesc()
-	sb := span.MakeBuilder(ef.planner.EvalContext(), ef.planner.ExecCfg().Codec, tabDesc, indexDesc)
+	sb := span.MakeBuilder(ef.planner.EvalContext(), ef.planner.ExecCfg().Codec, tabDesc, tabDesc.GetPrimaryIndex())
 
 	if err := ef.planner.maybeSetSystemConfig(tabDesc.GetID()); err != nil {
 		return nil, err
@@ -1691,7 +1683,7 @@ func (ef *execFactory) ConstructCreateView(
 		var ref descpb.TableDescriptor_Reference
 		if d.SpecificIndex {
 			idx := d.DataSource.(cat.Table).Index(d.Index)
-			ref.IndexID = idx.(*optIndex).desc.ID
+			ref.IndexID = idx.(*optIndex).idx.GetID()
 		}
 		if !d.ColumnOrdinals.Empty() {
 			ref.ColumnIDs = make([]descpb.ColumnID, 0, d.ColumnOrdinals.Len())
@@ -1774,7 +1766,7 @@ func (ef *execFactory) ConstructAlterTableSplit(
 
 	return &splitNode{
 		tableDesc:      index.Table().(*optTable).desc,
-		index:          index.(*optIndex).desc,
+		index:          index.(*optIndex).idx,
 		rows:           input.(planNode),
 		expirationTime: expirationTime,
 	}, nil
@@ -1798,7 +1790,7 @@ func (ef *execFactory) ConstructAlterTableUnsplit(
 
 	return &unsplitNode{
 		tableDesc: index.Table().(*optTable).desc,
-		index:     index.(*optIndex).desc,
+		index:     index.(*optIndex).idx,
 		rows:      input.(planNode),
 	}, nil
 }
@@ -1819,7 +1811,7 @@ func (ef *execFactory) ConstructAlterTableUnsplitAll(index cat.Index) (exec.Node
 
 	return &unsplitAllNode{
 		tableDesc: index.Table().(*optTable).desc,
-		index:     index.(*optIndex).desc,
+		index:     index.(*optIndex).idx,
 	}, nil
 }
 
@@ -1835,7 +1827,7 @@ func (ef *execFactory) ConstructAlterTableRelocate(
 		relocateLease:     relocateLease,
 		relocateNonVoters: relocateNonVoters,
 		tableDesc:         index.Table().(*optTable).desc,
-		index:             index.(*optIndex).desc,
+		index:             index.(*optIndex).idx,
 		rows:              input.(planNode),
 	}, nil
 }
@@ -1975,18 +1967,18 @@ func (rb *renderBuilder) setOutput(exprs tree.TypedExprs, columns colinfo.Result
 	rb.r.columns = columns
 }
 
-// makeColDescList returns a list of table column descriptors. Columns are
+// makeColList returns a list of table column interfaces. Columns are
 // included if their ordinal position in the table schema is in the cols set.
-func makeColDescList(table cat.Table, cols exec.TableColumnOrdinalSet) []descpb.ColumnDescriptor {
+func makeColList(table cat.Table, cols exec.TableColumnOrdinalSet) []catalog.Column {
 	tab := table.(optCatalogTableInterface)
-	colDescs := make([]descpb.ColumnDescriptor, 0, cols.Len())
+	ret := make([]catalog.Column, 0, cols.Len())
 	for i, n := 0, table.ColumnCount(); i < n; i++ {
 		if !cols.Contains(i) {
 			continue
 		}
-		colDescs = append(colDescs, *tab.getCol(i).ColumnDesc())
+		ret = append(ret, tab.getCol(i))
 	}
-	return colDescs
+	return ret
 }
 
 // makePublicToReturnColumnIndexMapping returns a map from the ordinals
@@ -1996,12 +1988,7 @@ func makeColDescList(table cat.Table, cols exec.TableColumnOrdinalSet) []descpb.
 //                   the i'th public column, or
 //              -1 if the i'th public column is not found in returnColDescs.
 func makePublicToReturnColumnIndexMapping(
-	tableDesc catalog.TableDescriptor, returnColDescs []descpb.ColumnDescriptor,
+	tableDesc catalog.TableDescriptor, returnCols []catalog.Column,
 ) []int {
-	publicCols := tableDesc.PublicColumns()
-	publicColDescs := make([]descpb.ColumnDescriptor, len(publicCols))
-	for i, col := range publicCols {
-		publicColDescs[i] = *col.ColumnDesc()
-	}
-	return row.ColMapping(publicColDescs, returnColDescs)
+	return row.ColMapping(tableDesc.PublicColumns(), returnCols)
 }

--- a/pkg/sql/partition_utils.go
+++ b/pkg/sql/partition_utils.go
@@ -125,7 +125,7 @@ func GenerateSubzoneSpans(
 
 		var emptyPrefix []tree.Datum
 		indexPartitionCoverings, err := indexCoveringsForPartitioning(
-			a, codec, tableDesc, idx.IndexDesc(), &idx.IndexDesc().Partitioning, subzoneIndexByPartition, emptyPrefix)
+			a, codec, tableDesc, idx, &idx.IndexDesc().Partitioning, subzoneIndexByPartition, emptyPrefix)
 		if err != nil {
 			return err
 		}
@@ -185,7 +185,7 @@ func indexCoveringsForPartitioning(
 	a *rowenc.DatumAlloc,
 	codec keys.SQLCodec,
 	tableDesc catalog.TableDescriptor,
-	idxDesc *descpb.IndexDescriptor,
+	idx catalog.Index,
 	partDesc *descpb.PartitioningDescriptor,
 	relevantPartitions map[string]int32,
 	prefixDatums []tree.Datum,
@@ -209,7 +209,7 @@ func indexCoveringsForPartitioning(
 		for _, p := range partDesc.List {
 			for _, valueEncBuf := range p.Values {
 				t, keyPrefix, err := rowenc.DecodePartitionTuple(
-					a, codec, tableDesc, idxDesc, partDesc, valueEncBuf, prefixDatums)
+					a, codec, tableDesc, idx, partDesc, valueEncBuf, prefixDatums)
 				if err != nil {
 					return nil, err
 				}
@@ -221,7 +221,7 @@ func indexCoveringsForPartitioning(
 				}
 				newPrefixDatums := append(prefixDatums, t.Datums...)
 				subpartitionCoverings, err := indexCoveringsForPartitioning(
-					a, codec, tableDesc, idxDesc, &p.Subpartitioning, relevantPartitions, newPrefixDatums)
+					a, codec, tableDesc, idx, &p.Subpartitioning, relevantPartitions, newPrefixDatums)
 				if err != nil {
 					return nil, err
 				}
@@ -241,12 +241,12 @@ func indexCoveringsForPartitioning(
 				continue
 			}
 			_, fromKey, err := rowenc.DecodePartitionTuple(
-				a, codec, tableDesc, idxDesc, partDesc, p.FromInclusive, prefixDatums)
+				a, codec, tableDesc, idx, partDesc, p.FromInclusive, prefixDatums)
 			if err != nil {
 				return nil, err
 			}
 			_, toKey, err := rowenc.DecodePartitionTuple(
-				a, codec, tableDesc, idxDesc, partDesc, p.ToExclusive, prefixDatums)
+				a, codec, tableDesc, idx, partDesc, p.ToExclusive, prefixDatums)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -55,7 +55,7 @@ Query {"String": "DROP INDEX t_x_idx"}
 until crdb_only
 CommandComplete
 ----
-{"Severity":"NOTICE","SeverityUnlocalized":"","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":519,"Routine":"dropIndexByName","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":518,"Routine":"dropIndexByName","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 
 until noncrdb_only

--- a/pkg/sql/physicalplan/fake_span_resolver_test.go
+++ b/pkg/sql/physicalplan/fake_span_resolver_test.go
@@ -57,7 +57,7 @@ func TestFakeSpanResolver(t *testing.T) {
 	it := resolver.NewSpanResolverIterator(txn)
 
 	tableDesc := catalogkv.TestingGetTableDescriptor(db, keys.SystemSQLCodec, "test", "t")
-	primIdxValDirs := catalogkeys.IndexKeyValDirs(tableDesc.GetPrimaryIndex().IndexDesc())
+	primIdxValDirs := catalogkeys.IndexKeyValDirs(tableDesc.GetPrimaryIndex())
 
 	span := tableDesc.PrimaryIndexSpan(keys.SystemSQLCodec)
 

--- a/pkg/sql/randgen/mutator.go
+++ b/pkg/sql/randgen/mutator.go
@@ -357,15 +357,9 @@ func encodeInvertedIndexHistogramUpperBounds(colType *types.T, val tree.Datum) (
 	var err error
 	switch colType.Family() {
 	case types.GeometryFamily:
-		tempIdx := descpb.IndexDescriptor{
-			GeoConfig: *geoindex.DefaultGeometryIndexConfig(),
-		}
-		keys, err = rowenc.EncodeGeoInvertedIndexTableKeys(val, nil, &tempIdx)
+		keys, err = rowenc.EncodeGeoInvertedIndexTableKeys(val, nil, *geoindex.DefaultGeometryIndexConfig())
 	case types.GeographyFamily:
-		tempIdx := descpb.IndexDescriptor{
-			GeoConfig: *geoindex.DefaultGeographyIndexConfig(),
-		}
-		keys, err = rowenc.EncodeGeoInvertedIndexTableKeys(val, nil, &tempIdx)
+		keys, err = rowenc.EncodeGeoInvertedIndexTableKeys(val, nil, *geoindex.DefaultGeographyIndexConfig())
 	default:
 		keys, err = rowenc.EncodeInvertedIndexTableKeys(val, nil, descpb.EmptyArraysInInvertedIndexesVersion)
 	}

--- a/pkg/sql/randgen/schema.go
+++ b/pkg/sql/randgen/schema.go
@@ -569,7 +569,7 @@ func TestingMakePrimaryIndexKeyForTenant(
 	}
 
 	keyPrefix := rowenc.MakeIndexKeyPrefix(codec, desc, index.GetID())
-	key, _, err := rowenc.EncodeIndexKey(desc, index.IndexDesc(), colIDToRowIndex, datums, keyPrefix)
+	key, _, err := rowenc.EncodeIndexKey(desc, index, colIDToRowIndex, datums, keyPrefix)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -1481,12 +1481,11 @@ func (p *planner) validateZoneConfigForMultiRegionTable(
 	regionalByRowNewIndexes := make(map[uint32]struct{})
 	for _, mut := range desc.AllMutations() {
 		if pkSwap := mut.AsPrimaryKeySwap(); pkSwap != nil {
-			swapDesc := pkSwap.PrimaryKeySwapDesc()
-			if swapDesc.LocalityConfigSwap != nil {
-				for _, id := range swapDesc.NewIndexes {
+			if pkSwap.HasLocalityConfig() {
+				_ = pkSwap.ForEachNewIndexIDs(func(id descpb.IndexID) error {
 					regionalByRowNewIndexes[uint32(id)] = struct{}{}
-				}
-				regionalByRowNewIndexes[uint32(swapDesc.NewPrimaryIndexId)] = struct{}{}
+					return nil
+				})
 			}
 			// There can only be one pkSwap at a time, so break now.
 			break

--- a/pkg/sql/relocate.go
+++ b/pkg/sql/relocate.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -32,7 +31,7 @@ type relocateNode struct {
 	relocateLease     bool
 	relocateNonVoters bool
 	tableDesc         catalog.TableDescriptor
-	index             *descpb.IndexDescriptor
+	index             catalog.Index
 	rows              planNode
 
 	run relocateRun

--- a/pkg/sql/rename_column.go
+++ b/pkg/sql/rename_column.go
@@ -122,7 +122,7 @@ func (p *planner) renameColumn(
 		// Noop.
 		return false, nil
 	}
-	isShardColumn := tableDesc.IsShardColumn(col.ColumnDesc())
+	isShardColumn := tableDesc.IsShardColumn(col)
 	if isShardColumn && !allowRenameOfShardColumn {
 		return false, pgerror.Newf(pgcode.ReservedName, "cannot rename shard column")
 	}
@@ -161,9 +161,7 @@ func (p *planner) renameColumn(
 			if err != nil {
 				return false, err
 			}
-			indexDesc := *index.IndexDesc()
-			indexDesc.Predicate = newExpr
-			tableDesc.SetPublicNonPrimaryIndex(index.Ordinal(), indexDesc)
+			index.IndexDesc().Predicate = newExpr
 		}
 	}
 
@@ -232,7 +230,7 @@ func (p *planner) renameColumn(
 	}
 
 	// Rename the column in the indexes.
-	tableDesc.RenameColumnDescriptor(col.ColumnDesc(), string(*newName))
+	tableDesc.RenameColumnDescriptor(col, string(*newName))
 
 	// Rename any shard columns which need to be renamed because their name was
 	// based on this column.

--- a/pkg/sql/rename_index.go
+++ b/pkg/sql/rename_index.go
@@ -13,6 +13,7 @@ package sql
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -26,7 +27,7 @@ var errEmptyIndexName = pgerror.New(pgcode.Syntax, "empty index name")
 type renameIndexNode struct {
 	n         *tree.RenameIndex
 	tableDesc *tabledesc.Mutable
-	idx       *descpb.IndexDescriptor
+	idx       catalog.Index
 }
 
 // RenameIndex renames the index.
@@ -65,7 +66,7 @@ func (p *planner) RenameIndex(ctx context.Context, n *tree.RenameIndex) (planNod
 		return nil, err
 	}
 
-	return &renameIndexNode{n: n, idx: idx.IndexDesc(), tableDesc: tableDesc}, nil
+	return &renameIndexNode{n: n, idx: idx, tableDesc: tableDesc}, nil
 }
 
 // ReadingOwnWrites implements the planNodeReadingOwnWrites interface.
@@ -80,7 +81,7 @@ func (n *renameIndexNode) startExec(params runParams) error {
 	idx := n.idx
 
 	for _, tableRef := range tableDesc.DependedOnBy {
-		if tableRef.IndexID != idx.ID {
+		if tableRef.IndexID != idx.GetID() {
 			continue
 		}
 		return p.dependentViewError(
@@ -97,13 +98,11 @@ func (n *renameIndexNode) startExec(params runParams) error {
 		return nil
 	}
 
-	if _, err := tableDesc.FindIndexWithName(string(n.n.NewName)); err == nil {
+	if foundIndex, _ := tableDesc.FindIndexWithName(string(n.n.NewName)); foundIndex != nil {
 		return pgerror.Newf(pgcode.DuplicateRelation, "index name %q already exists", string(n.n.NewName))
 	}
 
-	if err := tableDesc.RenameIndexDescriptor(idx, string(n.n.NewName)); err != nil {
-		return err
-	}
+	idx.IndexDesc().Name = string(n.n.NewName)
 
 	if err := validateDescriptor(ctx, p, tableDesc); err != nil {
 		return err

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -752,7 +752,7 @@ func expandIndexName(
 // It can return indexes that are being rolled out.
 func (p *planner) getTableAndIndex(
 	ctx context.Context, tableWithIndex *tree.TableIndexName, privilege privilege.Kind,
-) (*tabledesc.Mutable, *descpb.IndexDescriptor, error) {
+) (*tabledesc.Mutable, catalog.Index, error) {
 	var catalog optCatalog
 	catalog.init(p)
 	catalog.reset()
@@ -774,7 +774,7 @@ func (p *planner) getTableAndIndex(
 		tableWithIndex.Table = tree.MakeTableNameFromPrefix(qualifiedName.ObjectNamePrefix, qualifiedName.ObjectName)
 	}
 
-	return tabledesc.NewBuilder(optIdx.tab.desc.TableDesc()).BuildExistingMutableTable(), optIdx.desc, nil
+	return tabledesc.NewBuilder(optIdx.tab.desc.TableDesc()).BuildExistingMutableTable(), optIdx.idx, nil
 }
 
 // expandTableGlob expands pattern into a list of objects represented

--- a/pkg/sql/row/deleter.go
+++ b/pkg/sql/row/deleter.go
@@ -26,7 +26,7 @@ import (
 // Deleter abstracts the key/value operations for deleting table rows.
 type Deleter struct {
 	Helper    rowHelper
-	FetchCols []descpb.ColumnDescriptor
+	FetchCols []catalog.Column
 	// FetchColIDtoRowIndex must be kept in sync with FetchCols.
 	FetchColIDtoRowIndex catalog.TableColMap
 	// For allocation avoidance.
@@ -41,15 +41,11 @@ type Deleter struct {
 // FetchCols; otherwise, all columns that are part of the key of any index
 // (either primary or secondary) are included in FetchCols.
 func MakeDeleter(
-	codec keys.SQLCodec, tableDesc catalog.TableDescriptor, requestedCols []descpb.ColumnDescriptor,
+	codec keys.SQLCodec, tableDesc catalog.TableDescriptor, requestedCols []catalog.Column,
 ) Deleter {
 	indexes := tableDesc.DeletableNonPrimaryIndexes()
-	indexDescs := make([]descpb.IndexDescriptor, len(indexes))
-	for i, index := range indexes {
-		indexDescs[i] = *index.IndexDesc()
-	}
 
-	var fetchCols []descpb.ColumnDescriptor
+	var fetchCols []catalog.Column
 	var fetchColIDtoRowIndex catalog.TableColMap
 	if requestedCols != nil {
 		fetchCols = requestedCols[:len(requestedCols):len(requestedCols)]
@@ -62,7 +58,7 @@ func MakeDeleter(
 					return err
 				}
 				fetchColIDtoRowIndex.Set(col.GetID(), len(fetchCols))
-				fetchCols = append(fetchCols, *col.ColumnDesc())
+				fetchCols = append(fetchCols, col)
 			}
 			return nil
 		}
@@ -90,7 +86,7 @@ func MakeDeleter(
 	}
 
 	rd := Deleter{
-		Helper:               newRowHelper(codec, tableDesc, indexDescs),
+		Helper:               newRowHelper(codec, tableDesc, indexes),
 		FetchCols:            fetchCols,
 		FetchColIDtoRowIndex: fetchColIDtoRowIndex,
 	}
@@ -110,7 +106,7 @@ func (rd *Deleter) DeleteRow(
 	for i := range rd.Helper.Indexes {
 		// If the index ID exists in the set of indexes to ignore, do not
 		// attempt to delete from the index.
-		if pm.IgnoreForDel.Contains(int(rd.Helper.Indexes[i].ID)) {
+		if pm.IgnoreForDel.Contains(int(rd.Helper.Indexes[i].GetID())) {
 			continue
 		}
 
@@ -118,7 +114,7 @@ func (rd *Deleter) DeleteRow(
 		entries, err := rowenc.EncodeSecondaryIndex(
 			rd.Helper.Codec,
 			rd.Helper.TableDesc,
-			&rd.Helper.Indexes[i],
+			rd.Helper.Indexes[i],
 			rd.FetchColIDtoRowIndex,
 			values,
 			true, /* includeEmpty */
@@ -164,7 +160,7 @@ func (rd *Deleter) DeleteRow(
 // DeleteIndexRow adds to the batch the kv operations necessary to delete a
 // table row from the given index.
 func (rd *Deleter) DeleteIndexRow(
-	ctx context.Context, b *kv.Batch, idx *descpb.IndexDescriptor, values []tree.Datum, traceKV bool,
+	ctx context.Context, b *kv.Batch, idx catalog.Index, values []tree.Datum, traceKV bool,
 ) error {
 	// We want to include empty k/v pairs because we want
 	// to delete all k/v's for this row. By setting includeEmpty

--- a/pkg/sql/row/errors.go
+++ b/pkg/sql/row/errors.go
@@ -101,8 +101,8 @@ func NewUniquenessConstraintViolationError(
 	skipCols := index.ExplicitColumnStartIdx()
 	return errors.WithDetail(
 		pgerror.WithConstraintName(pgerror.Newf(pgcode.UniqueViolation,
-			"duplicate key value violates unique constraint %q", index.Name,
-		), index.Name),
+			"duplicate key value violates unique constraint %q", index.GetName(),
+		), index.GetName()),
 		fmt.Sprintf(
 			"Key (%s)=(%s) already exists.",
 			strings.Join(names[skipCols:], ","),
@@ -134,7 +134,7 @@ func NewLockNotAvailableError(
 		strings.Join(colNames, ","),
 		strings.Join(values, ","),
 		tableDesc.GetName(),
-		index.Name)
+		index.GetName())
 }
 
 // DecodeRowInfo takes a table descriptor, a key, and an optional value and
@@ -146,7 +146,7 @@ func DecodeRowInfo(
 	key roachpb.Key,
 	value *roachpb.Value,
 	allColumns bool,
-) (_ *descpb.IndexDescriptor, columnNames []string, columnValues []string, _ error) {
+) (_ catalog.Index, columnNames []string, columnValues []string, _ error) {
 	// Strip the tenant prefix and pretend to use the system tenant's SQL codec
 	// for the rest of this function. This is safe because the key is just used
 	// to decode the corresponding datums and never escapes this function.
@@ -188,19 +188,19 @@ func DecodeRowInfo(
 	valNeededForCol.AddRange(0, len(colIDs)-1)
 
 	var colIdxMap catalog.TableColMap
-	cols := make([]descpb.ColumnDescriptor, len(colIDs))
+	cols := make([]catalog.Column, len(colIDs))
 	for i, colID := range colIDs {
 		colIdxMap.Set(colID, i)
 		col, err := tableDesc.FindColumnWithID(colID)
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		cols[i] = *col.ColumnDesc()
+		cols[i] = col
 	}
 
 	tableArgs := FetcherTableArgs{
 		Desc:             tableDesc,
-		Index:            index.IndexDesc(),
+		Index:            index,
 		ColIdxMap:        colIdxMap,
 		IsSecondaryIndex: indexID != tableDesc.GetPrimaryIndexID(),
 		Cols:             cols,
@@ -237,13 +237,13 @@ func DecodeRowInfo(
 	names := make([]string, len(cols))
 	values := make([]string, len(cols))
 	for i := range cols {
-		names[i] = cols[i].Name
+		names[i] = cols[i].GetName()
 		if datums[i] == tree.DNull {
 			continue
 		}
 		values[i] = datums[i].String()
 	}
-	return index.IndexDesc(), names, values, nil
+	return index, names, values, nil
 }
 
 func (f *singleKVFetcher) close(context.Context) {}

--- a/pkg/sql/row/fetcher_mvcc_test.go
+++ b/pkg/sql/row/fetcher_mvcc_test.go
@@ -92,19 +92,17 @@ func TestRowFetcherMVCCMetadata(t *testing.T) {
 	for _, desc := range []catalog.TableDescriptor{parentDesc, childDesc} {
 		var colIdxMap catalog.TableColMap
 		var valNeededForCol util.FastIntSet
-		colDescs := make([]descpb.ColumnDescriptor, len(desc.PublicColumns()))
 		for i, col := range desc.PublicColumns() {
 			colIdxMap.Set(col.GetID(), i)
 			valNeededForCol.Add(i)
-			colDescs[i] = *col.ColumnDesc()
 		}
 		args = append(args, row.FetcherTableArgs{
 			Spans:            desc.AllIndexSpans(keys.SystemSQLCodec),
 			Desc:             desc,
-			Index:            desc.GetPrimaryIndex().IndexDesc(),
+			Index:            desc.GetPrimaryIndex(),
 			ColIdxMap:        colIdxMap,
 			IsSecondaryIndex: false,
-			Cols:             colDescs,
+			Cols:             desc.PublicColumns(),
 			ValNeededForCol:  valNeededForCol,
 		})
 	}

--- a/pkg/sql/row/fetcher_test.go
+++ b/pkg/sql/row/fetcher_test.go
@@ -53,14 +53,11 @@ func makeFetcherArgs(entries []initFetcherArgs) []FetcherTableArgs {
 		fetcherArgs[i] = FetcherTableArgs{
 			Spans:            entry.spans,
 			Desc:             entry.tableDesc,
-			Index:            index.IndexDesc(),
+			Index:            index,
 			ColIdxMap:        catalog.ColumnIDToOrdinalMap(entry.tableDesc.PublicColumns()),
 			IsSecondaryIndex: !index.Primary(),
-			Cols:             make([]descpb.ColumnDescriptor, len(entry.tableDesc.PublicColumns())),
+			Cols:             entry.tableDesc.PublicColumns(),
 			ValNeededForCol:  entry.valNeededForCol,
-		}
-		for j, col := range entry.tableDesc.PublicColumns() {
-			fetcherArgs[i].Cols[j] = *col.ColumnDesc()
 		}
 	}
 	return fetcherArgs
@@ -195,11 +192,11 @@ func TestNextRowSingle(t *testing.T) {
 
 				count++
 
-				if desc.GetID() != tableDesc.GetID() || index.ID != tableDesc.GetPrimaryIndexID() {
+				if desc.GetID() != tableDesc.GetID() || index.GetID() != tableDesc.GetPrimaryIndexID() {
 					t.Fatalf(
 						"unexpected row retrieved from fetcher.\nnexpected:  table %s - index %s\nactual: table %s - index %s",
 						tableDesc.GetName(), tableDesc.GetPrimaryIndex().GetName(),
-						desc.GetName(), index.Name,
+						desc.GetName(), index.GetName(),
 					)
 				}
 
@@ -316,11 +313,11 @@ func TestNextRowBatchLimiting(t *testing.T) {
 
 				count++
 
-				if desc.GetID() != tableDesc.GetID() || index.ID != tableDesc.GetPrimaryIndexID() {
+				if desc.GetID() != tableDesc.GetID() || index.GetID() != tableDesc.GetPrimaryIndexID() {
 					t.Fatalf(
 						"unexpected row retrieved from fetcher.\nnexpected:  table %s - index %s\nactual: table %s - index %s",
 						tableDesc.GetName(), tableDesc.GetPrimaryIndex().GetName(),
-						desc.GetName(), index.Name,
+						desc.GetName(), index.GetName(),
 					)
 				}
 
@@ -676,11 +673,11 @@ func TestNextRowSecondaryIndex(t *testing.T) {
 
 				count++
 
-				if desc.GetID() != tableDesc.GetID() || index.ID != tableDesc.PublicNonPrimaryIndexes()[0].GetID() {
+				if desc.GetID() != tableDesc.GetID() || index.GetID() != tableDesc.PublicNonPrimaryIndexes()[0].GetID() {
 					t.Fatalf(
 						"unexpected row retrieved from fetcher.\nnexpected:  table %s - index %s\nactual: table %s - index %s",
 						tableDesc.GetName(), tableDesc.PublicNonPrimaryIndexes()[0].GetName(),
-						desc.GetName(), index.Name,
+						desc.GetName(), index.GetName(),
 					)
 				}
 
@@ -1032,11 +1029,11 @@ func TestNextRowInterleaved(t *testing.T) {
 					break
 				}
 
-				entry, found := idLookups[idLookupKey(desc.GetID(), index.ID)]
+				entry, found := idLookups[idLookupKey(desc.GetID(), index.GetID())]
 				if !found {
 					t.Fatalf(
 						"unexpected row from table %s - index %s",
-						desc.GetName(), index.Name,
+						desc.GetName(), index.GetName(),
 					)
 				}
 

--- a/pkg/sql/row/inserter.go
+++ b/pkg/sql/row/inserter.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -28,7 +27,7 @@ import (
 // Inserter abstracts the key/value operations for inserting table rows.
 type Inserter struct {
 	Helper                rowHelper
-	InsertCols            []descpb.ColumnDescriptor
+	InsertCols            []catalog.Column
 	InsertColIDtoRowIndex catalog.TableColMap
 
 	// For allocation avoidance.
@@ -47,17 +46,11 @@ func MakeInserter(
 	txn *kv.Txn,
 	codec keys.SQLCodec,
 	tableDesc catalog.TableDescriptor,
-	insertCols []descpb.ColumnDescriptor,
+	insertCols []catalog.Column,
 	alloc *rowenc.DatumAlloc,
 ) (Inserter, error) {
-	writableIndexes := tableDesc.WritableNonPrimaryIndexes()
-	writableIndexDescs := make([]descpb.IndexDescriptor, len(writableIndexes))
-	for i, index := range writableIndexes {
-		writableIndexDescs[i] = *index.IndexDesc()
-	}
-
 	ri := Inserter{
-		Helper:                newRowHelper(codec, tableDesc, writableIndexDescs),
+		Helper:                newRowHelper(codec, tableDesc, tableDesc.WritableNonPrimaryIndexes()),
 		InsertCols:            insertCols,
 		InsertColIDtoRowIndex: ColIDtoRowIndexFromCols(insertCols),
 		marshaled:             make([]roachpb.Value, len(insertCols)),
@@ -146,7 +139,7 @@ func (ri *Inserter) InsertRow(
 	for i, val := range values {
 		// Make sure the value can be written to the column before proceeding.
 		var err error
-		if ri.marshaled[i], err = rowenc.MarshalColumnValue(&ri.InsertCols[i], val); err != nil {
+		if ri.marshaled[i], err = rowenc.MarshalColumnValue(ri.InsertCols[i], val); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/row/writer.go
+++ b/pkg/sql/row/writer.go
@@ -29,10 +29,10 @@ import (
 // ColIDtoRowIndexFromCols groups a slice of ColumnDescriptors by their ID
 // field, returning a map from ID to the index of the column in the input slice.
 // It assumes there are no duplicate descriptors in the input.
-func ColIDtoRowIndexFromCols(cols []descpb.ColumnDescriptor) catalog.TableColMap {
+func ColIDtoRowIndexFromCols(cols []catalog.Column) catalog.TableColMap {
 	var colIDtoRowIndex catalog.TableColMap
 	for i := range cols {
-		colIDtoRowIndex.Set(cols[i].ID, i)
+		colIDtoRowIndex.Set(cols[i].GetID(), i)
 	}
 	return colIDtoRowIndex
 }
@@ -42,11 +42,11 @@ func ColIDtoRowIndexFromCols(cols []descpb.ColumnDescriptor) catalog.TableColMap
 //
 //   result[i] = j such that fromCols[i].ID == toCols[j].ID, or
 //                -1 if the column is not part of toCols.
-func ColMapping(fromCols, toCols []descpb.ColumnDescriptor) []int {
+func ColMapping(fromCols, toCols []catalog.Column) []int {
 	// colMap is a map from ColumnID to ordinal into fromCols.
 	var colMap util.FastIntMap
 	for i := range fromCols {
-		colMap.Set(int(fromCols[i].ID), i)
+		colMap.Set(int(fromCols[i].GetID()), i)
 	}
 
 	result := make([]int, len(fromCols))
@@ -57,7 +57,7 @@ func ColMapping(fromCols, toCols []descpb.ColumnDescriptor) []int {
 
 	// Set the appropriate index values for the returning columns.
 	for toOrd := range toCols {
-		if fromOrd, ok := colMap.Get(int(toCols[toOrd].ID)); ok {
+		if fromOrd, ok := colMap.Get(int(toCols[toOrd].GetID())); ok {
 			result[fromOrd] = toOrd
 		}
 	}
@@ -94,7 +94,7 @@ func prepareInsertOrUpdateBatch(
 	batch putter,
 	helper *rowHelper,
 	primaryIndexKey []byte,
-	fetchedCols []descpb.ColumnDescriptor,
+	fetchedCols []catalog.Column,
 	values []tree.Datum,
 	valColIDMapping catalog.TableColMap,
 	marshaledValues []roachpb.Value,
@@ -180,12 +180,12 @@ func prepareInsertOrUpdateBatch(
 				continue
 			}
 
-			col := &fetchedCols[idx]
-			if lastColID > col.ID {
-				return nil, errors.AssertionFailedf("cannot write column id %d after %d", col.ID, lastColID)
+			col := fetchedCols[idx]
+			if lastColID > col.GetID() {
+				return nil, errors.AssertionFailedf("cannot write column id %d after %d", col.GetID(), lastColID)
 			}
-			colIDDiff := col.ID - lastColID
-			lastColID = col.ID
+			colIDDiff := col.GetID() - lastColID
+			lastColID = col.GetID()
 			var err error
 			rawValueBuf, err = rowenc.EncodeTableValue(rawValueBuf, colIDDiff, values[idx], nil)
 			if err != nil {

--- a/pkg/sql/rowenc/client_index_encoding_test.go
+++ b/pkg/sql/rowenc/client_index_encoding_test.go
@@ -230,7 +230,7 @@ func TestAdjustStartKeyForInterleave(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			codec := keys.SystemSQLCodec
 			actual := EncodeTestKey(t, kvDB, codec, ShortToLongKeyFmt(tc.input))
-			actual, err := rowenc.AdjustStartKeyForInterleave(codec, tc.index.IndexDesc(), actual)
+			actual, err := rowenc.AdjustStartKeyForInterleave(codec, tc.index, actual)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -652,7 +652,7 @@ func TestAdjustEndKeyForInterleave(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			codec := keys.SystemSQLCodec
 			actual := EncodeTestKey(t, kvDB, codec, ShortToLongKeyFmt(tc.input))
-			actual, err := rowenc.AdjustEndKeyForInterleave(codec, tc.table, tc.index.IndexDesc(), actual, tc.inclusive)
+			actual, err := rowenc.AdjustEndKeyForInterleave(codec, tc.table, tc.index, actual, tc.inclusive)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/rowenc/column_type_encoding_test.go
+++ b/pkg/sql/rowenc/column_type_encoding_test.go
@@ -280,10 +280,7 @@ func TestMarshalColumnValueRoundtrip(t *testing.T) {
 					return "error generating datum"
 				}
 				datum := d.(tree.Datum)
-				desc := descpb.ColumnDescriptor{
-					Type: typ,
-				}
-				value, err := rowenc.MarshalColumnValue(&desc, datum)
+				value, err := rowenc.MarshalColumnTypeValue("testcol", typ, datum)
 				if err != nil {
 					return "error marshaling: " + err.Error()
 				}

--- a/pkg/sql/rowenc/index_encoding_test.go
+++ b/pkg/sql/rowenc/index_encoding_test.go
@@ -112,14 +112,14 @@ func makeTableDescForTest(test indexKeyTest) (catalog.TableDescriptor, catalog.T
 }
 
 func decodeIndex(
-	codec keys.SQLCodec, tableDesc catalog.TableDescriptor, index *descpb.IndexDescriptor, key []byte,
+	codec keys.SQLCodec, tableDesc catalog.TableDescriptor, index catalog.Index, key []byte,
 ) ([]tree.Datum, error) {
-	types, err := colinfo.GetColumnTypes(tableDesc, index.ColumnIDs, nil)
+	types, err := colinfo.GetColumnTypes(tableDesc, index.IndexDesc().ColumnIDs, nil)
 	if err != nil {
 		return nil, err
 	}
-	values := make([]EncDatum, len(index.ColumnIDs))
-	colDirs := index.ColumnDirections
+	values := make([]EncDatum, index.NumColumns())
+	colDirs := index.IndexDesc().ColumnDirections
 	_, ok, _, err := DecodeIndexKey(codec, tableDesc, index, types, values, colDirs, key)
 	if err != nil {
 		return nil, err
@@ -227,7 +227,7 @@ func TestIndexKey(t *testing.T) {
 
 		codec := keys.SystemSQLCodec
 		primaryKeyPrefix := MakeIndexKeyPrefix(codec, tableDesc, tableDesc.GetPrimaryIndexID())
-		primaryKey, _, err := EncodeIndexKey(tableDesc, tableDesc.GetPrimaryIndex().IndexDesc(), colMap, testValues, primaryKeyPrefix)
+		primaryKey, _, err := EncodeIndexKey(tableDesc, tableDesc.GetPrimaryIndex(), colMap, testValues, primaryKeyPrefix)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -235,7 +235,7 @@ func TestIndexKey(t *testing.T) {
 		primaryIndexKV := kv.KeyValue{Key: primaryKey, Value: &primaryValue}
 
 		secondaryIndexEntry, err := EncodeSecondaryIndex(
-			codec, tableDesc, tableDesc.PublicNonPrimaryIndexes()[0].IndexDesc(), colMap, testValues, true /* includeEmpty */)
+			codec, tableDesc, tableDesc.PublicNonPrimaryIndexes()[0], colMap, testValues, true /* includeEmpty */)
 		if len(secondaryIndexEntry) != 1 {
 			t.Fatalf("expected 1 index entry, got %d. got %#v", len(secondaryIndexEntry), secondaryIndexEntry)
 		}
@@ -247,14 +247,14 @@ func TestIndexKey(t *testing.T) {
 			Value: &secondaryIndexEntry[0].Value,
 		}
 
-		checkEntry := func(index *descpb.IndexDescriptor, entry kv.KeyValue) {
+		checkEntry := func(index catalog.Index, entry kv.KeyValue) {
 			values, err := decodeIndex(codec, tableDesc, index, entry.Key)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			for j, value := range values {
-				testValue := testValues[colMap.GetDefault(index.ColumnIDs[j])]
+				testValue := testValues[colMap.GetDefault(index.GetColumnID(j))]
 				if value.Compare(evalCtx, testValue) != 0 {
 					t.Fatalf("%d: value %d got %q but expected %q", i, j, value, testValue)
 				}
@@ -264,7 +264,7 @@ func TestIndexKey(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if indexID != index.ID {
+			if indexID != index.GetID() {
 				t.Errorf("%d", i)
 			}
 
@@ -277,8 +277,8 @@ func TestIndexKey(t *testing.T) {
 			}
 		}
 
-		checkEntry(tableDesc.GetPrimaryIndex().IndexDesc(), primaryIndexKV)
-		checkEntry(tableDesc.PublicNonPrimaryIndexes()[0].IndexDesc(), secondaryIndexKV)
+		checkEntry(tableDesc.GetPrimaryIndex(), primaryIndexKV)
+		checkEntry(tableDesc.PublicNonPrimaryIndexes()[0], secondaryIndexKV)
 	}
 }
 
@@ -388,7 +388,7 @@ func TestInvertedIndexKey(t *testing.T) {
 		codec := keys.SystemSQLCodec
 
 		secondaryIndexEntries, err := EncodeSecondaryIndex(
-			codec, tableDesc, tableDesc.PublicNonPrimaryIndexes()[0].IndexDesc(), colMap, testValues, true /* includeEmpty */)
+			codec, tableDesc, tableDesc.PublicNonPrimaryIndexes()[0], colMap, testValues, true /* includeEmpty */)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -943,9 +943,7 @@ func TestMarshalColumnValue(t *testing.T) {
 
 	for i, testCase := range tests {
 		typ := testCase.typ
-		col := descpb.ColumnDescriptor{ID: descpb.ColumnID(typ.Family() + 1), Type: typ}
-
-		if actual, err := MarshalColumnValue(&col, testCase.datum); err != nil {
+		if actual, err := MarshalColumnTypeValue("testcol", typ, testCase.datum); err != nil {
 			t.Errorf("%d: unexpected error with column type %v: %v", i, typ, err)
 		} else if !reflect.DeepEqual(actual, testCase.exp) {
 			t.Errorf("%d: MarshalColumnValue() got %v, expected %v", i, actual, testCase.exp)
@@ -1070,7 +1068,7 @@ func TestIndexKeyEquivSignature(t *testing.T) {
 			desc, colMap := makeTableDescForTest(tc.table.indexKeyArgs)
 			primaryKeyPrefix := MakeIndexKeyPrefix(keys.SystemSQLCodec, desc, desc.GetPrimaryIndexID())
 			primaryKey, _, err := EncodeIndexKey(
-				desc, desc.GetPrimaryIndex().IndexDesc(), colMap, tc.table.values, primaryKeyPrefix)
+				desc, desc.GetPrimaryIndex(), colMap, tc.table.values, primaryKeyPrefix)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1127,7 +1125,7 @@ func TestTableEquivSignatures(t *testing.T) {
 			tc.table.indexKeyArgs.primaryValues = tc.table.values
 			// Setup descriptors and form an index key.
 			desc, _ := makeTableDescForTest(tc.table.indexKeyArgs)
-			equivSigs, err := TableEquivSignatures(desc.TableDesc(), desc.GetPrimaryIndex().IndexDesc())
+			equivSigs, err := TableEquivSignatures(desc, desc.GetPrimaryIndex())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1212,13 +1210,13 @@ func TestEquivSignature(t *testing.T) {
 				desc, colMap := makeTableDescForTest(table.indexKeyArgs)
 				primaryKeyPrefix := MakeIndexKeyPrefix(keys.SystemSQLCodec, desc, desc.GetPrimaryIndexID())
 				primaryKey, _, err := EncodeIndexKey(
-					desc, desc.GetPrimaryIndex().IndexDesc(), colMap, table.values, primaryKeyPrefix)
+					desc, desc.GetPrimaryIndex(), colMap, table.values, primaryKeyPrefix)
 				if err != nil {
 					t.Fatal(err)
 				}
 
 				// Extract out the table's equivalence signature.
-				tempEquivSigs, err := TableEquivSignatures(desc.TableDesc(), desc.GetPrimaryIndex().IndexDesc())
+				tempEquivSigs, err := TableEquivSignatures(desc, desc.GetPrimaryIndex())
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -1371,20 +1369,19 @@ func ExtractIndexKey(
 		return entry.Key, nil
 	}
 
-	indexI, err := tableDesc.FindIndexWithID(indexID)
+	index, err := tableDesc.FindIndexWithID(indexID)
 	if err != nil {
 		return nil, err
 	}
-	index := indexI.IndexDesc()
 
 	// Extract the values for index.ColumnIDs.
-	indexTypes, err := colinfo.GetColumnTypes(tableDesc, index.ColumnIDs, nil)
+	indexTypes, err := colinfo.GetColumnTypes(tableDesc, index.IndexDesc().ColumnIDs, nil)
 	if err != nil {
 		return nil, err
 	}
-	values := make([]EncDatum, len(index.ColumnIDs))
-	dirs := index.ColumnDirections
-	if len(index.Interleave.Ancestors) > 0 {
+	values := make([]EncDatum, index.NumColumns())
+	dirs := index.IndexDesc().ColumnDirections
+	if index.NumInterleaveAncestors() > 0 {
 		// TODO(dan): In the interleaved index case, we parse the key twice; once to
 		// find the index id so we can look up the descriptor, and once to extract
 		// the values. Only parse once.
@@ -1404,18 +1401,18 @@ func ExtractIndexKey(
 	}
 
 	// Extract the values for index.ExtraColumnIDs
-	extraTypes, err := colinfo.GetColumnTypes(tableDesc, index.ExtraColumnIDs, nil)
+	extraTypes, err := colinfo.GetColumnTypes(tableDesc, index.IndexDesc().ExtraColumnIDs, nil)
 	if err != nil {
 		return nil, err
 	}
-	extraValues := make([]EncDatum, len(index.ExtraColumnIDs))
-	dirs = make([]descpb.IndexDescriptor_Direction, len(index.ExtraColumnIDs))
-	for i := range index.ExtraColumnIDs {
+	extraValues := make([]EncDatum, index.NumExtraColumns())
+	dirs = make([]descpb.IndexDescriptor_Direction, index.NumExtraColumns())
+	for i := 0; i < index.NumExtraColumns(); i++ {
 		// Implicit columns are always encoded Ascending.
 		dirs[i] = descpb.IndexDescriptor_ASC
 	}
 	extraKey := key
-	if index.Unique {
+	if index.IsUnique() {
 		extraKey, err = entry.Value.GetBytes()
 		if err != nil {
 			return nil, err
@@ -1428,11 +1425,13 @@ func ExtractIndexKey(
 
 	// Encode the index key from its components.
 	var colMap catalog.TableColMap
-	for i, columnID := range index.ColumnIDs {
+	for i := 0; i < index.NumColumns(); i++ {
+		columnID := index.GetColumnID(i)
 		colMap.Set(columnID, i)
 	}
-	for i, columnID := range index.ExtraColumnIDs {
-		colMap.Set(columnID, i+len(index.ColumnIDs))
+	for i := 0; i < index.NumExtraColumns(); i++ {
+		columnID := index.GetExtraColumnID(i)
+		colMap.Set(columnID, i+index.NumColumns())
 	}
 	indexKeyPrefix := MakeIndexKeyPrefix(codec, tableDesc, tableDesc.GetPrimaryIndexID())
 
@@ -1452,6 +1451,6 @@ func ExtractIndexKey(
 		decodedValues[len(values)+i] = value.Datum
 	}
 	indexKey, _, err := EncodeIndexKey(
-		tableDesc, tableDesc.GetPrimaryIndex().IndexDesc(), colMap, decodedValues, indexKeyPrefix)
+		tableDesc, tableDesc.GetPrimaryIndex(), colMap, decodedValues, indexKeyPrefix)
 	return indexKey, err
 }

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -66,7 +66,7 @@ type invertedJoiner struct {
 	desc         catalog.TableDescriptor
 	// The map from ColumnIDs in the table to the column position.
 	colIdxMap catalog.TableColMap
-	index     *descpb.IndexDescriptor
+	index     catalog.Index
 	// The ColumnID of the inverted column. Confusingly, this is also the id of
 	// the table column that was indexed.
 	invertedColID descpb.ColumnID
@@ -200,12 +200,12 @@ func newInvertedJoiner(
 	if indexIdx >= len(ij.desc.ActiveIndexes()) {
 		return nil, errors.Errorf("invalid indexIdx %d", indexIdx)
 	}
-	ij.index = ij.desc.ActiveIndexes()[indexIdx].IndexDesc()
+	ij.index = ij.desc.ActiveIndexes()[indexIdx]
 	ij.invertedColID = ij.index.InvertedColumnID()
 
 	// Initialize tableRow, indexRow, indexRowTypes, and indexRowToTableRowMap,
 	// a mapping from indexRow column ordinal to tableRow column ordinals.
-	indexColumnIDs, _ := ij.index.FullColumnIDs()
+	indexColumnIDs, _ := catalog.FullIndexColumnIDs(ij.index)
 	// Inverted joins are not used for mutations.
 	ij.tableRow = make(rowenc.EncDatumRow, len(ij.desc.PublicColumns()))
 	ij.indexRow = make(rowenc.EncDatumRow, len(indexColumnIDs)-1)
@@ -446,7 +446,7 @@ func (ij *invertedJoiner) readInput() (invertedJoinerState, *execinfrapb.Produce
 				prefixKey, _, _, err := rowenc.MakeKeyFromEncDatums(
 					ij.indexRow[:len(ij.prefixEqualityCols)],
 					ij.indexRowTypes[:len(ij.prefixEqualityCols)],
-					ij.index.ColumnDirections,
+					ij.index.IndexDesc().ColumnDirections,
 					ij.desc,
 					ij.index,
 					&ij.alloc,
@@ -540,7 +540,7 @@ func (ij *invertedJoiner) performScan() (invertedJoinerState, *execinfrapb.Produ
 			prefixKey, _, _, err := rowenc.MakeKeyFromEncDatums(
 				ij.indexRow[:len(ij.prefixEqualityCols)],
 				ij.indexRowTypes[:len(ij.prefixEqualityCols)],
-				ij.index.ColumnDirections,
+				ij.index.IndexDesc().ColumnDirections,
 				ij.desc,
 				ij.index,
 				&ij.alloc,

--- a/pkg/sql/rowexec/rowfetcher.go
+++ b/pkg/sql/rowexec/rowfetcher.go
@@ -48,7 +48,7 @@ type rowFetcher interface {
 	) error
 
 	NextRow(ctx context.Context) (
-		rowenc.EncDatumRow, catalog.TableDescriptor, *descpb.IndexDescriptor, error)
+		rowenc.EncDatumRow, catalog.TableDescriptor, catalog.Index, error)
 
 	// PartialKey is not stat-related but needs to be supported.
 	PartialKey(int) (roachpb.Key, error)
@@ -76,13 +76,12 @@ func initRowFetcher(
 	lockWaitPolicy descpb.ScanLockingWaitPolicy,
 	withSystemColumns bool,
 	virtualColumn catalog.Column,
-) (index *descpb.IndexDescriptor, isSecondaryIndex bool, err error) {
+) (index catalog.Index, isSecondaryIndex bool, err error) {
 	if indexIdx >= len(desc.ActiveIndexes()) {
 		return nil, false, errors.Errorf("invalid indexIdx %d", indexIdx)
 	}
-	indexI := desc.ActiveIndexes()[indexIdx]
-	index = indexI.IndexDesc()
-	isSecondaryIndex = !indexI.Primary()
+	index = desc.ActiveIndexes()[indexIdx]
+	isSecondaryIndex = !index.Primary()
 
 	tableArgs := row.FetcherTableArgs{
 		Desc:             desc,

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -342,7 +342,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 			}
 			switch s.outTypes[col].Family() {
 			case types.GeographyFamily, types.GeometryFamily:
-				invKeys, err = rowenc.EncodeGeoInvertedIndexTableKeys(row[col].Datum, nil /* inKey */, index)
+				invKeys, err = rowenc.EncodeGeoInvertedIndexTableKeys(row[col].Datum, nil /* inKey */, index.GeoConfig)
 			default:
 				invKeys, err = rowenc.EncodeInvertedIndexTableKeys(row[col].Datum, nil /* inKey */, index.Version)
 			}

--- a/pkg/sql/rowexec/stats.go
+++ b/pkg/sql/rowexec/stats.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
@@ -94,7 +93,7 @@ func newRowFetcherStatCollector(f *row.Fetcher) *rowFetcherStatCollector {
 // NextRow is part of the rowFetcher interface.
 func (c *rowFetcherStatCollector) NextRow(
 	ctx context.Context,
-) (rowenc.EncDatumRow, catalog.TableDescriptor, *descpb.IndexDescriptor, error) {
+) (rowenc.EncDatumRow, catalog.TableDescriptor, catalog.Index, error) {
 	start := timeutil.Now()
 	row, t, i, err := c.Fetcher.NextRow(ctx)
 	if row != nil {

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -382,7 +382,7 @@ type zigzagJoinerInfo struct {
 	rowsRead   int64
 	alloc      *rowenc.DatumAlloc
 	table      catalog.TableDescriptor
-	index      *descpb.IndexDescriptor
+	index      catalog.Index
 	indexTypes []*types.T
 	indexDirs  []descpb.IndexDescriptor_Direction
 
@@ -428,15 +428,15 @@ func (z *zigzagJoiner) setupInfo(
 	info.table = tables[side]
 	info.eqColumns = spec.EqColumns[side].Columns
 	indexOrdinal := spec.IndexOrdinals[side]
-	info.index = info.table.ActiveIndexes()[indexOrdinal].IndexDesc()
+	info.index = info.table.ActiveIndexes()[indexOrdinal]
 
 	var columnIDs []descpb.ColumnID
-	columnIDs, info.indexDirs = info.index.FullColumnIDs()
+	columnIDs, info.indexDirs = catalog.FullIndexColumnIDs(info.index)
 	info.indexTypes = make([]*types.T, len(columnIDs))
 	columnTypes := catalog.ColumnTypes(info.table.PublicColumns())
 	colIdxMap := catalog.ColumnIDToOrdinalMap(info.table.PublicColumns())
 	for i, columnID := range columnIDs {
-		if info.index.Type == descpb.IndexDescriptor_INVERTED &&
+		if info.index.GetType() == descpb.IndexDescriptor_INVERTED &&
 			columnID == info.index.InvertedColumnID() {
 			// Inverted key columns have type Bytes.
 			info.indexTypes[i] = types.Bytes
@@ -499,7 +499,7 @@ func (z *zigzagJoiner) setupInfo(
 		info.fetcher = &fetcher
 	}
 
-	info.prefix = rowenc.MakeIndexKeyPrefix(flowCtx.Codec(), info.table, info.index.ID)
+	info.prefix = rowenc.MakeIndexKeyPrefix(flowCtx.Codec(), info.table, info.index.GetID())
 	span, err := z.produceSpanFromBaseRow()
 
 	if err != nil {
@@ -519,9 +519,9 @@ func (z *zigzagJoiner) close() {
 	}
 }
 
-func findColumnID(s []descpb.ColumnID, t descpb.ColumnID) int {
-	for i := range s {
-		if s[i] == t {
+func findColumnOrdinalInIndex(index catalog.Index, t descpb.ColumnID) int {
+	for i := 0; i < index.NumColumns(); i++ {
+		if index.GetColumnID(i) == t {
 			return i
 		}
 	}
@@ -592,12 +592,12 @@ func (z *zigzagJoiner) produceInvertedIndexKey(
 		}
 
 		decodedDatums[i] = encDatum.Datum
-		if i < len(info.index.ColumnIDs) {
-			colMap.Set(info.index.ColumnIDs[i], i)
+		if i < info.index.NumColumns() {
+			colMap.Set(info.index.GetColumnID(i), i)
 		} else {
 			// This column's value will be encoded in the second part (i.e.
 			// EncodeColumns).
-			colMap.Set(info.index.ExtraColumnIDs[i-len(info.index.ColumnIDs)], i)
+			colMap.Set(info.index.GetExtraColumnID(i-info.index.NumColumns()), i)
 		}
 	}
 
@@ -625,7 +625,7 @@ func (z *zigzagJoiner) produceInvertedIndexKey(
 
 	// Append remaining (non-JSON) datums to the key.
 	keyBytes, _, err := rowenc.EncodeColumns(
-		info.index.ExtraColumnIDs[:len(datums)-1],
+		info.index.IndexDesc().ExtraColumnIDs[:len(datums)-1],
 		info.indexDirs[1:],
 		colMap,
 		decodedDatums,
@@ -647,7 +647,7 @@ func (z *zigzagJoiner) produceSpanFromBaseRow() (roachpb.Span, error) {
 
 	// Construct correct row by concatenating right fixed datums with
 	// primary key extracted from `row`.
-	if info.index.Type == descpb.IndexDescriptor_INVERTED {
+	if info.index.GetType() == descpb.IndexDescriptor_INVERTED {
 		return z.produceInvertedIndexKey(info, neededDatums)
 	}
 
@@ -674,12 +674,12 @@ func (zi *zigzagJoinerInfo) eqOrdering() (colinfo.ColumnOrdering, error) {
 		// the current column, 'colID'.
 		var direction encoding.Direction
 		var err error
-		if idx := findColumnID(zi.index.ColumnIDs, colID); idx != -1 {
-			direction, err = zi.index.ColumnDirections[idx].ToEncodingDirection()
+		if idx := findColumnOrdinalInIndex(zi.index, colID); idx != -1 {
+			direction, err = zi.index.GetColumnDirection(idx).ToEncodingDirection()
 			if err != nil {
 				return nil, err
 			}
-		} else if idx := findColumnID(zi.table.GetPrimaryIndex().IndexDesc().ColumnIDs, colID); idx != -1 {
+		} else if idx := findColumnOrdinalInIndex(zi.table.GetPrimaryIndex(), colID); idx != -1 {
 			direction, err = zi.table.GetPrimaryIndex().GetColumnDirection(idx).ToEncodingDirection()
 			if err != nil {
 				return nil, err

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -46,10 +46,10 @@ type scanNode struct {
 	_ util.NoCopy
 
 	desc  catalog.TableDescriptor
-	index *descpb.IndexDescriptor
+	index catalog.Index
 
 	// Set if an index was explicitly specified.
-	specifiedIndex *descpb.IndexDescriptor
+	specifiedIndex catalog.Index
 	// Set if the NO_INDEX_JOIN hint was given.
 	noIndexJoin bool
 
@@ -231,14 +231,14 @@ func (n *scanNode) lookupSpecifiedIndex(indexFlags *tree.IndexFlags) error {
 		if foundIndex == nil || !foundIndex.Public() {
 			return errors.Errorf("index %q not found", tree.ErrString(&indexFlags.Index))
 		}
-		n.specifiedIndex = foundIndex.IndexDesc()
+		n.specifiedIndex = foundIndex
 	} else if indexFlags.IndexID != 0 {
 		// Search index by ID.
 		foundIndex, _ := n.desc.FindIndexWithID(descpb.IndexID(indexFlags.IndexID))
 		if foundIndex == nil || !foundIndex.Public() {
 			return errors.Errorf("index [%d] not found", indexFlags.IndexID)
 		}
-		n.specifiedIndex = foundIndex.IndexDesc()
+		n.specifiedIndex = foundIndex
 	}
 	return nil
 }
@@ -301,7 +301,7 @@ func initColsForScan(
 // Initializes the column structures.
 func (n *scanNode) initDescDefaults(colCfg scanColumnsConfig) error {
 	n.colCfg = colCfg
-	n.index = n.desc.GetPrimaryIndex().IndexDesc()
+	n.index = n.desc.GetPrimaryIndex()
 
 	var err error
 	n.cols, err = initColsForScan(n.desc, n.colCfg)

--- a/pkg/sql/scatter.go
+++ b/pkg/sql/scatter.go
@@ -45,24 +45,25 @@ func (p *planner) Scatter(ctx context.Context, n *tree.Scatter) (planNode, error
 	var span roachpb.Span
 	if n.From == nil {
 		// No FROM/TO specified; the span is the entire table/index.
-		span = tableDesc.IndexSpan(p.ExecCfg().Codec, index.ID)
+		span = tableDesc.IndexSpan(p.ExecCfg().Codec, index.GetID())
 	} else {
 		switch {
 		case len(n.From) == 0:
 			return nil, errors.Errorf("no columns in SCATTER FROM expression")
-		case len(n.From) > len(index.ColumnIDs):
+		case len(n.From) > index.NumColumns():
 			return nil, errors.Errorf("too many columns in SCATTER FROM expression")
 		case len(n.To) == 0:
 			return nil, errors.Errorf("no columns in SCATTER TO expression")
-		case len(n.To) > len(index.ColumnIDs):
+		case len(n.To) > index.NumColumns():
 			return nil, errors.Errorf("too many columns in SCATTER TO expression")
 		}
 
 		// Calculate the desired types for the select statement:
 		//  - column values; it is OK if the select statement returns fewer columns
 		//  (the relevant prefix is used).
-		desiredTypes := make([]*types.T, len(index.ColumnIDs))
-		for i, colID := range index.ColumnIDs {
+		desiredTypes := make([]*types.T, index.NumColumns())
+		for i := 0; i < index.NumColumns(); i++ {
+			colID := index.GetColumnID(i)
 			c, err := tableDesc.FindColumnWithID(colID)
 			if err != nil {
 				return nil, err

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -220,10 +220,10 @@ func (e errTableVersionMismatch) Error() string {
 
 // refreshMaterializedView updates the physical data for a materialized view.
 func (sc *SchemaChanger) refreshMaterializedView(
-	ctx context.Context, table *tabledesc.Mutable, refresh *descpb.MaterializedViewRefresh,
+	ctx context.Context, table *tabledesc.Mutable, refresh catalog.MaterializedViewRefresh,
 ) error {
 	// If we aren't requested to backfill any data, then return immediately.
-	if !refresh.ShouldBackfill {
+	if !refresh.ShouldBackfill() {
 		return nil
 	}
 	// The data for the materialized view is stored under the current set of
@@ -233,14 +233,12 @@ func (sc *SchemaChanger) refreshMaterializedView(
 	// set of indexes. We then backfill into this modified table, which writes
 	// data only to the new desired indexes. In SchemaChanger.done(), we'll swap
 	// the indexes from the old versions into the new ones.
-	tableToRefresh := protoutil.Clone(table.TableDesc()).(*descpb.TableDescriptor)
-	tableToRefresh.PrimaryIndex = refresh.NewPrimaryIndex
-	tableToRefresh.Indexes = refresh.NewIndexes
-	return sc.backfillQueryIntoTable(ctx, tableToRefresh, table.ViewQuery, refresh.AsOf, "refreshView")
+	tableToRefresh := refresh.TableWithNewIndexes(table)
+	return sc.backfillQueryIntoTable(ctx, tableToRefresh, table.ViewQuery, refresh.AsOf(), "refreshView")
 }
 
 func (sc *SchemaChanger) backfillQueryIntoTable(
-	ctx context.Context, table *descpb.TableDescriptor, query string, ts hlc.Timestamp, desc string,
+	ctx context.Context, table catalog.TableDescriptor, query string, ts hlc.Timestamp, desc string,
 ) error {
 	if fn := sc.testingKnobs.RunBeforeQueryBackfill; fn != nil {
 		if err := fn(); err != nil {
@@ -329,7 +327,7 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 				localPlanner.curPlan.main,
 			).WillDistribute()
 			out := execinfrapb.ProcessorCoreUnion{BulkRowWriter: &execinfrapb.BulkRowWriterSpec{
-				Table: *table,
+				Table: *table.TableDesc(),
 			}}
 
 			PlanAndRunCTAS(ctx, sc.distSQLPlanner, localPlanner,
@@ -358,7 +356,7 @@ func (sc *SchemaChanger) maybeBackfillCreateTableAs(
 	}
 	log.Infof(ctx, "starting backfill for CREATE TABLE AS with query %q", table.GetCreateQuery())
 
-	return sc.backfillQueryIntoTable(ctx, table.TableDesc(), table.GetCreateQuery(), table.GetCreateAsOfTime(), "ctasBackfill")
+	return sc.backfillQueryIntoTable(ctx, table, table.GetCreateQuery(), table.GetCreateAsOfTime(), "ctasBackfill")
 }
 
 func (sc *SchemaChanger) maybeBackfillMaterializedView(
@@ -369,7 +367,7 @@ func (sc *SchemaChanger) maybeBackfillMaterializedView(
 	}
 	log.Infof(ctx, "starting backfill for CREATE MATERIALIZED VIEW with query %q", table.GetViewQuery())
 
-	return sc.backfillQueryIntoTable(ctx, table.TableDesc(), table.GetViewQuery(), table.GetCreateAsOfTime(), "materializedViewBackfill")
+	return sc.backfillQueryIntoTable(ctx, table, table.GetViewQuery(), table.GetCreateAsOfTime(), "materializedViewBackfill")
 }
 
 // maybe make a table PUBLIC if it's in the ADD state.
@@ -905,38 +903,30 @@ func (sc *SchemaChanger) RunStateMachineBeforeBackfill(ctx context.Context) erro
 		}
 		runStatus = ""
 		// Apply mutations belonging to the same version.
-		for i, mutation := range tbl.Mutations {
-			if mutation.MutationID != sc.mutationID {
+		for _, m := range tbl.AllMutations() {
+			if m.MutationID() != sc.mutationID {
 				// Mutations are applied in a FIFO order. Only apply the first set of
 				// mutations if they have the mutation ID we're looking for.
 				break
 			}
-			switch mutation.Direction {
-			case descpb.DescriptorMutation_ADD:
-				switch mutation.State {
-				case descpb.DescriptorMutation_DELETE_ONLY:
+			if m.Adding() {
+				if m.DeleteOnly() {
 					// TODO(vivek): while moving up the state is appropriate,
 					// it will be better to run the backfill of a unique index
 					// twice: once in the DELETE_ONLY state to confirm that
 					// the index can indeed be created, and subsequently in the
 					// DELETE_AND_WRITE_ONLY state to fill in the missing elements of the
 					// index (INSERT and UPDATE that happened in the interim).
-					tbl.Mutations[i].State = descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY
+					tbl.Mutations[m.MutationOrdinal()].State = descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY
 					runStatus = RunningStatusDeleteAndWriteOnly
-
-				case descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY:
-					// The state change has already moved forward.
 				}
-
-			case descpb.DescriptorMutation_DROP:
-				switch mutation.State {
-				case descpb.DescriptorMutation_DELETE_ONLY:
-					// The state change has already moved forward.
-
-				case descpb.DescriptorMutation_DELETE_AND_WRITE_ONLY:
-					tbl.Mutations[i].State = descpb.DescriptorMutation_DELETE_ONLY
+				// else if DELETE_AND_WRITE_ONLY, then the state change has already moved forward.
+			} else if m.Dropped() {
+				if m.WriteAndDeleteOnly() {
+					tbl.Mutations[m.MutationOrdinal()].State = descpb.DescriptorMutation_DELETE_ONLY
 					runStatus = RunningStatusDeleteOnly
 				}
+				// else if DELETE_ONLY, then the state change has already moved forward.
 			}
 			// We might have to update some zone configs for indexes that are
 			// being rewritten. It is important that this is done _before_ the
@@ -948,7 +938,7 @@ func (sc *SchemaChanger) RunStateMachineBeforeBackfill(ctx context.Context) erro
 				txn,
 				dbDesc,
 				tbl,
-				mutation,
+				m,
 				false, // isDone
 				descsCol,
 			); err != nil {
@@ -984,13 +974,13 @@ func (sc *SchemaChanger) RunStateMachineBeforeBackfill(ctx context.Context) erro
 }
 
 func (sc *SchemaChanger) createIndexGCJob(
-	ctx context.Context, index *descpb.IndexDescriptor, txn *kv.Txn, jobDesc string,
+	ctx context.Context, indexID descpb.IndexID, txn *kv.Txn, jobDesc string,
 ) error {
 	dropTime := timeutil.Now().UnixNano()
 	indexGCDetails := jobspb.SchemaChangeGCDetails{
 		Indexes: []jobspb.SchemaChangeGCDetails_DroppedIndex{
 			{
-				IndexID:  index.ID,
+				IndexID:  indexID,
 				DropTime: dropTime,
 			},
 		},
@@ -1081,23 +1071,22 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 
 		var i int           // set to determine whether there is a mutation
 		var isRollback bool // set based on the mutation
-		for _, mutation := range scTable.Mutations {
-			if mutation.MutationID != sc.mutationID {
+		for _, m := range scTable.AllMutations() {
+			if m.MutationID() != sc.mutationID {
 				// Mutations are applied in a FIFO order. Only apply the first set of
 				// mutations if they have the mutation ID we're looking for.
 				break
 			}
-			isRollback = mutation.Rollback
-			if indexDesc := mutation.GetIndex(); mutation.Direction == descpb.DescriptorMutation_DROP &&
-				indexDesc != nil {
-				if canClearRangeForDrop(indexDesc) {
+			isRollback = m.IsRollback()
+			if idx := m.AsIndex(); m.Dropped() && idx != nil {
+				if canClearRangeForDrop(idx.IndexDesc()) {
 					// how we keep track of dropped index names (for, e.g., zone config
 					// lookups), even though in the absence of a GC job there's nothing to
 					// clean them up.
 					scTable.GCMutations = append(
 						scTable.GCMutations,
 						descpb.TableDescriptor_GCDescriptorMutation{
-							IndexID: indexDesc.ID,
+							IndexID: idx.GetID(),
 						})
 
 					description := sc.job.Payload().Description
@@ -1105,24 +1094,22 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 						description = "ROLLBACK of " + description
 					}
 
-					if err := sc.createIndexGCJob(ctx, indexDesc, txn, description); err != nil {
+					if err := sc.createIndexGCJob(ctx, idx.GetID(), txn, description); err != nil {
 						return err
 					}
 				}
 			}
-			if constraint := mutation.GetConstraint(); constraint != nil &&
-				constraint.ConstraintType == descpb.ConstraintToUpdate_FOREIGN_KEY &&
-				mutation.Direction == descpb.DescriptorMutation_ADD &&
-				constraint.ForeignKey.Validity == descpb.ConstraintValidity_Unvalidated {
-				// Add backreference on the referenced table (which could be the same table)
-				backrefTable, err := descsCol.GetMutableTableVersionByID(ctx,
-					constraint.ForeignKey.ReferencedTableID, txn)
-				if err != nil {
-					return err
-				}
-				backrefTable.InboundFKs = append(backrefTable.InboundFKs, constraint.ForeignKey)
-				if err := descsCol.WriteDescToBatch(ctx, kvTrace, backrefTable, b); err != nil {
-					return err
+			if constraint := m.AsConstraint(); constraint != nil && constraint.Adding() {
+				if constraint.IsForeignKey() && constraint.ForeignKey().Validity == descpb.ConstraintValidity_Unvalidated {
+					// Add backreference on the referenced table (which could be the same table)
+					backrefTable, err := descsCol.GetMutableTableVersionByID(ctx, constraint.ForeignKey().ReferencedTableID, txn)
+					if err != nil {
+						return err
+					}
+					backrefTable.InboundFKs = append(backrefTable.InboundFKs, constraint.ForeignKey())
+					if err := descsCol.WriteDescToBatch(ctx, kvTrace, backrefTable, b); err != nil {
+						return err
+					}
 				}
 			}
 
@@ -1134,7 +1121,7 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 				txn,
 				dbDesc,
 				scTable,
-				mutation,
+				m,
 				true, // isDone
 				descsCol,
 			); err != nil {
@@ -1145,7 +1132,7 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 			// of the existing indexes in the view. We do this before the call to
 			// MakeMutationComplete, which swaps out the existing indexes for the
 			// backfilled ones.
-			if refresh := mutation.GetMaterializedViewRefresh(); refresh != nil {
+			if refresh := m.AsMaterializedViewRefresh(); refresh != nil {
 				if fn := sc.testingKnobs.RunBeforeMaterializedViewRefreshCommit; fn != nil {
 					if err := fn(); err != nil {
 						return err
@@ -1153,44 +1140,40 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 				}
 				// If we are mutation is in the ADD state, then start GC jobs for the
 				// existing indexes on the table.
-				if mutation.Direction == descpb.DescriptorMutation_ADD {
+				if m.Adding() {
 					desc := fmt.Sprintf("REFRESH MATERIALIZED VIEW %q cleanup", scTable.Name)
-					if err := sc.createIndexGCJob(ctx, scTable.GetPrimaryIndex().IndexDesc(), txn, desc); err != nil {
-						return err
-					}
-					for _, idx := range scTable.PublicNonPrimaryIndexes() {
-						if err := sc.createIndexGCJob(ctx, idx.IndexDesc(), txn, desc); err != nil {
+					for _, idx := range scTable.ActiveIndexes() {
+						if err := sc.createIndexGCJob(ctx, idx.GetID(), txn, desc); err != nil {
 							return err
 						}
 					}
-				} else if mutation.Direction == descpb.DescriptorMutation_DROP {
+				} else if m.Dropped() {
 					// Otherwise, the refresh job ran into an error and is being rolled
 					// back. So, we need to GC all of the indexes that were going to be
 					// created, in case any data was written to them.
 					desc := fmt.Sprintf("ROLLBACK OF REFRESH MATERIALIZED VIEW %q", scTable.Name)
-					if err := sc.createIndexGCJob(ctx, &refresh.NewPrimaryIndex, txn, desc); err != nil {
+					err = refresh.ForEachIndexID(func(id descpb.IndexID) error {
+						return sc.createIndexGCJob(ctx, id, txn, desc)
+					})
+					if err != nil {
 						return err
-					}
-					for i := range refresh.NewIndexes {
-						if err := sc.createIndexGCJob(ctx, &refresh.NewIndexes[i], txn, desc); err != nil {
-							return err
-						}
 					}
 				}
 			}
 
-			if err := scTable.MakeMutationComplete(mutation); err != nil {
+			if err := scTable.MakeMutationComplete(scTable.Mutations[m.MutationOrdinal()]); err != nil {
 				return err
 			}
 
-			if pkSwap := mutation.GetPrimaryKeySwap(); pkSwap != nil {
+			if pkSwap := m.AsPrimaryKeySwap(); pkSwap != nil {
 				if fn := sc.testingKnobs.RunBeforePrimaryKeySwap; fn != nil {
 					fn()
 				}
 				// For locality swaps, ensure the table descriptor fields are correctly filled.
-				if lcSwap := pkSwap.LocalityConfigSwap; lcSwap != nil {
+				if pkSwap.HasLocalityConfig() {
+					lcSwap := pkSwap.LocalityConfigSwap()
 					localityConfigToSwapTo := lcSwap.NewLocalityConfig
-					if mutation.Direction == descpb.DescriptorMutation_ADD {
+					if m.Adding() {
 						// Sanity check that locality has not been changed during backfill.
 						if !scTable.LocalityConfig.Equal(lcSwap.OldLocalityConfig) {
 							return errors.AssertionFailedf(
@@ -1235,8 +1218,7 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 				// backreference from the parent.
 				// N.B. This logic needs to be kept up to date with the
 				// corresponding piece in runSchemaChangesInTxn.
-				for _, idxID := range append(
-					[]descpb.IndexID{pkSwap.OldPrimaryIndexId}, pkSwap.OldIndexes...) {
+				err := pkSwap.ForEachOldIndexIDs(func(idxID descpb.IndexID) error {
 					oldIndex, err := scTable.FindIndexWithID(idxID)
 					if err != nil {
 						return err
@@ -1269,6 +1251,10 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 							}
 						}
 					}
+					return nil
+				})
+				if err != nil {
+					return err
 				}
 				// If we performed MakeMutationComplete on a PrimaryKeySwap mutation, then we need to start
 				// a job for the index deletion mutations that the primary key swap mutation added, if any.
@@ -1277,7 +1263,7 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 				}
 			}
 
-			if computedColumnSwap := mutation.GetComputedColumnSwap(); computedColumnSwap != nil {
+			if m.AsComputedColumnSwap() != nil {
 				if fn := sc.testingKnobs.RunBeforeComputedColumnSwap; fn != nil {
 					fn()
 				}
@@ -1296,7 +1282,7 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 			// The table descriptor is unchanged, return without writing anything.
 			return nil
 		}
-		committedMutations := scTable.Mutations[:i]
+		committedMutations := scTable.AllMutations()[:i]
 		// Trim the executed mutations from the descriptor.
 		scTable.Mutations = scTable.Mutations[i:]
 
@@ -1573,54 +1559,52 @@ func (sc *SchemaChanger) maybeReverseMutations(ctx context.Context, causingError
 		columns := make(map[string]struct{})
 		droppedMutations = nil
 		b := txn.NewBatch()
-		for i, mutation := range scTable.Mutations {
-			if mutation.MutationID != sc.mutationID {
+		for _, m := range scTable.AllMutations() {
+			if m.MutationID() != sc.mutationID {
 				break
 			}
 
-			if mutation.Rollback {
+			if m.IsRollback() {
 				// Can actually never happen. Since we should have checked for this case
 				// above.
-				return errors.AssertionFailedf("mutation already rolled back: %v", mutation)
+				return errors.AssertionFailedf("mutation already rolled back: %v", scTable.Mutations[m.MutationOrdinal()])
 			}
 
 			// Ignore mutations that would be skipped, nothing
 			// to reverse here.
-			if discarded, _ := isCurrentMutationDiscarded(scTable, mutation, i+1); discarded {
+			if discarded, _ := isCurrentMutationDiscarded(scTable, m, m.MutationOrdinal()+1); discarded {
 				continue
 			}
 
-			log.Warningf(ctx, "reverse schema change mutation: %+v", mutation)
-			scTable.Mutations[i], columns = sc.reverseMutation(mutation, false /*notStarted*/, columns)
+			log.Warningf(ctx, "reverse schema change mutation: %+v", scTable.Mutations[m.MutationOrdinal()])
+			scTable.Mutations[m.MutationOrdinal()], columns = sc.reverseMutation(scTable.Mutations[m.MutationOrdinal()], false /*notStarted*/, columns)
 
 			// If the mutation is for validating a constraint that is being added,
 			// drop the constraint because validation has failed.
-			if constraint := mutation.GetConstraint(); constraint != nil &&
-				mutation.Direction == descpb.DescriptorMutation_ADD {
-				log.Warningf(ctx, "dropping constraint %+v", constraint)
+			if constraint := m.AsConstraint(); constraint != nil && constraint.Adding() {
+				log.Warningf(ctx, "dropping constraint %+v", constraint.ConstraintToUpdateDesc())
 				if err := sc.maybeDropValidatingConstraint(ctx, scTable, constraint); err != nil {
 					return err
 				}
 				// Get the foreign key backreferences to remove.
-				if constraint.ConstraintType == descpb.ConstraintToUpdate_FOREIGN_KEY {
-					fk := &constraint.ForeignKey
-					backrefTable, err := descsCol.GetMutableTableVersionByID(ctx, fk.ReferencedTableID, txn)
+				if constraint.IsForeignKey() {
+					backrefTable, err := descsCol.GetMutableTableVersionByID(ctx, constraint.ForeignKey().ReferencedTableID, txn)
 					if err != nil {
 						return err
 					}
-					if err := removeFKBackReferenceFromTable(backrefTable, fk.Name, scTable); err != nil {
+					if err := removeFKBackReferenceFromTable(backrefTable, constraint.GetName(), scTable); err != nil {
 						// The function being called will return an assertion error if the
 						// backreference was not found, but it may not have been installed
 						// during the incomplete schema change, so we swallow the error.
 						log.Infof(ctx,
-							"error attempting to remove backreference %s during rollback: %s", fk.Name, err)
+							"error attempting to remove backreference %s during rollback: %s", constraint.GetName(), err)
 					}
 					if err := descsCol.WriteDescToBatch(ctx, kvTrace, backrefTable, b); err != nil {
 						return err
 					}
 				}
 			}
-			scTable.Mutations[i].Rollback = true
+			scTable.Mutations[m.MutationOrdinal()].Rollback = true
 		}
 
 		// Delete all mutations that reference any of the reversed columns
@@ -1725,15 +1709,14 @@ func (sc *SchemaChanger) updateJobForRollback(
 }
 
 func (sc *SchemaChanger) maybeDropValidatingConstraint(
-	ctx context.Context, desc *tabledesc.Mutable, constraint *descpb.ConstraintToUpdate,
+	ctx context.Context, desc *tabledesc.Mutable, constraint catalog.ConstraintToUpdate,
 ) error {
-	switch constraint.ConstraintType {
-	case descpb.ConstraintToUpdate_CHECK, descpb.ConstraintToUpdate_NOT_NULL:
-		if constraint.Check.Validity == descpb.ConstraintValidity_Unvalidated {
+	if constraint.IsCheck() || constraint.IsNotNull() {
+		if constraint.Check().Validity == descpb.ConstraintValidity_Unvalidated {
 			return nil
 		}
 		for j, c := range desc.Checks {
-			if c.Name == constraint.Check.Name {
+			if c.Name == constraint.Check().Name {
 				desc.Checks = append(desc.Checks[:j], desc.Checks[j+1:]...)
 				return nil
 			}
@@ -1741,11 +1724,11 @@ func (sc *SchemaChanger) maybeDropValidatingConstraint(
 		log.Infof(
 			ctx,
 			"attempted to drop constraint %s, but it hadn't been added to the table descriptor yet",
-			constraint.Check.Name,
+			constraint.Check().Name,
 		)
-	case descpb.ConstraintToUpdate_FOREIGN_KEY:
+	} else if constraint.IsForeignKey() {
 		for i, fk := range desc.OutboundFKs {
-			if fk.Name == constraint.ForeignKey.Name {
+			if fk.Name == constraint.ForeignKey().Name {
 				desc.OutboundFKs = append(desc.OutboundFKs[:i], desc.OutboundFKs[i+1:]...)
 				return nil
 			}
@@ -1753,14 +1736,14 @@ func (sc *SchemaChanger) maybeDropValidatingConstraint(
 		log.Infof(
 			ctx,
 			"attempted to drop constraint %s, but it hadn't been added to the table descriptor yet",
-			constraint.ForeignKey.Name,
+			constraint.ForeignKey().Name,
 		)
-	case descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX:
-		if constraint.UniqueWithoutIndexConstraint.Validity == descpb.ConstraintValidity_Unvalidated {
+	} else if constraint.IsUniqueWithoutIndex() {
+		if constraint.UniqueWithoutIndex().Validity == descpb.ConstraintValidity_Unvalidated {
 			return nil
 		}
 		for j, c := range desc.UniqueWithoutIndexConstraints {
-			if c.Name == constraint.UniqueWithoutIndexConstraint.Name {
+			if c.Name == constraint.UniqueWithoutIndex().Name {
 				desc.UniqueWithoutIndexConstraints = append(
 					desc.UniqueWithoutIndexConstraints[:j], desc.UniqueWithoutIndexConstraints[j+1:]...,
 				)
@@ -1770,10 +1753,10 @@ func (sc *SchemaChanger) maybeDropValidatingConstraint(
 		log.Infof(
 			ctx,
 			"attempted to drop constraint %s, but it hadn't been added to the table descriptor yet",
-			constraint.UniqueWithoutIndexConstraint.Name,
+			constraint.UniqueWithoutIndex().Name,
 		)
-	default:
-		return errors.AssertionFailedf("unsupported constraint type: %d", errors.Safe(constraint.ConstraintType))
+	} else {
+		return errors.AssertionFailedf("unsupported constraint type: %d", constraint.ConstraintToUpdateDesc().ConstraintType)
 	}
 	return nil
 }
@@ -1818,8 +1801,9 @@ func (sc *SchemaChanger) deleteIndexMutationsWithReversedColumns(
 		}
 		// Drop mutations.
 		newMutations := make([]descpb.DescriptorMutation, 0, len(desc.Mutations))
-		for _, mutation := range desc.Mutations {
-			if _, ok := dropMutations[mutation.MutationID]; ok {
+		for _, m := range desc.AllMutations() {
+			mutation := desc.Mutations[m.MutationOrdinal()]
+			if _, ok := dropMutations[m.MutationID()]; ok {
 				// Reverse mutation. Update columns to reflect additional
 				// columns that have been purged. This mutation doesn't need
 				// a rollback because it was not started.
@@ -2438,21 +2422,22 @@ func (sc *SchemaChanger) applyZoneConfigChangeForMutation(
 	txn *kv.Txn,
 	dbDesc catalog.DatabaseDescriptor,
 	tableDesc *tabledesc.Mutable,
-	mutation descpb.DescriptorMutation,
+	mutation catalog.Mutation,
 	isDone bool,
 	descsCol *descs.Collection,
 ) error {
-	if pkSwap := mutation.GetPrimaryKeySwap(); pkSwap != nil {
-		if lcSwap := pkSwap.LocalityConfigSwap; lcSwap != nil {
+	if pkSwap := mutation.AsPrimaryKeySwap(); pkSwap != nil {
+		if pkSwap.HasLocalityConfig() {
 			// We will add up to three options - one for the table itself,
 			// one for dropping any zone configs for old indexes and one
 			// for all the new indexes associated with the table.
 			opts := make([]applyZoneConfigForMultiRegionTableOption, 0, 3)
+			lcSwap := pkSwap.LocalityConfigSwap()
 
 			// For locality configs, we need to update the zone configs to match
 			// the new multi-region locality configuration, instead of
 			// copying the old zone configs over.
-			if mutation.Direction == descpb.DescriptorMutation_ADD {
+			if mutation.Adding() {
 				// Only apply the zone configuration on the table when the mutation
 				// is complete.
 				if isDone {
@@ -2460,15 +2445,12 @@ func (sc *SchemaChanger) applyZoneConfigChangeForMutation(
 					// us here, but if we're coming from REGIONAL BY ROW, it's also
 					// necessary to drop the zone configurations on the index partitions.
 					if lcSwap.OldLocalityConfig.GetRegionalByRow() != nil {
-						opts = append(
-							opts,
-							dropZoneConfigsForMultiRegionIndexes(
-								append(
-									[]descpb.IndexID{pkSwap.OldPrimaryIndexId},
-									pkSwap.OldIndexes...,
-								)...,
-							),
-						)
+						oldIndexIDs := make([]descpb.IndexID, 0, pkSwap.NumOldIndexes())
+						_ = pkSwap.ForEachOldIndexIDs(func(id descpb.IndexID) error {
+							oldIndexIDs = append(oldIndexIDs, id)
+							return nil
+						})
+						opts = append(opts, dropZoneConfigsForMultiRegionIndexes(oldIndexIDs...))
 					}
 
 					opts = append(
@@ -2483,15 +2465,12 @@ func (sc *SchemaChanger) applyZoneConfigChangeForMutation(
 					*descpb.TableDescriptor_LocalityConfig_RegionalByTable_:
 				case *descpb.TableDescriptor_LocalityConfig_RegionalByRow_:
 					// Apply new zone configurations for all newly partitioned indexes.
-					opts = append(
-						opts,
-						applyZoneConfigForMultiRegionTableOptionNewIndexes(
-							append(
-								[]descpb.IndexID{pkSwap.NewPrimaryIndexId},
-								pkSwap.NewIndexes...,
-							)...,
-						),
-					)
+					newIndexIDs := make([]descpb.IndexID, 0, pkSwap.NumNewIndexes())
+					_ = pkSwap.ForEachNewIndexIDs(func(id descpb.IndexID) error {
+						newIndexIDs = append(newIndexIDs, id)
+						return nil
+					})
+					opts = append(opts, applyZoneConfigForMultiRegionTableOptionNewIndexes(newIndexIDs...))
 				default:
 					return errors.AssertionFailedf(
 						"unknown locality on PK swap: %T",
@@ -2526,7 +2505,7 @@ func (sc *SchemaChanger) applyZoneConfigChangeForMutation(
 		// for any new indexes.
 		// Note this is done even for isDone = true, though not strictly necessary.
 		return maybeUpdateZoneConfigsForPKChange(
-			ctx, txn, sc.execCfg, tableDesc, pkSwap,
+			ctx, txn, sc.execCfg, tableDesc, pkSwap.PrimaryKeySwapDesc(),
 		)
 	}
 	return nil
@@ -2560,7 +2539,7 @@ func DeleteTableDescAndZoneConfig(
 // A will have a unique index, but it later gets dropped. Then for this mutation
 // to be successful the drop column job has to be successful too.
 func (sc *SchemaChanger) getDependentMutationsJobs(
-	ctx context.Context, tableDesc *tabledesc.Mutable, mutations []descpb.DescriptorMutation,
+	ctx context.Context, tableDesc *tabledesc.Mutable, mutations []catalog.Mutation,
 ) ([]jobspb.JobID, error) {
 	dependentJobs := make([]jobspb.JobID, 0, len(tableDesc.MutationJobs))
 	for _, m := range mutations {
@@ -2581,38 +2560,35 @@ func (sc *SchemaChanger) getDependentMutationsJobs(
 // by a later operation. The nextMutationIdx provides the index at which to check for
 // later mutation.
 func isCurrentMutationDiscarded(
-	tableDesc *tabledesc.Mutable, currentMutation descpb.DescriptorMutation, nextMutationIdx int,
+	tableDesc *tabledesc.Mutable, currentMutation catalog.Mutation, nextMutationIdx int,
 ) (bool, descpb.MutationID) {
 	if nextMutationIdx+1 > len(tableDesc.Mutations) {
 		return false, descpb.InvalidMutationID
 	}
-	// Drops will never get canceled out, since we need
-	// clean up.
-	if currentMutation.Direction == descpb.DescriptorMutation_DROP {
+	// Drops will never get canceled out, since we need clean up.
+	if currentMutation.Dropped() {
 		return false, descpb.InvalidMutationID
 	}
 
 	colToCheck := make([]descpb.ColumnID, 0, 1)
 	// Both NOT NULL related updates and check constraint updates
 	// involving this column will get canceled out by a drop column.
-	if constraint := currentMutation.GetConstraint(); constraint != nil {
-		if constraint.ConstraintType == descpb.ConstraintToUpdate_NOT_NULL {
-			colToCheck = append(colToCheck, constraint.NotNullColumn)
-		} else if constraint.ConstraintType == descpb.ConstraintToUpdate_CHECK {
-			colToCheck = constraint.Check.ColumnIDs
+	if constraint := currentMutation.AsConstraint(); constraint != nil {
+		if constraint.IsNotNull() {
+			colToCheck = append(colToCheck, constraint.NotNullColumnID())
+		} else if constraint.IsCheck() {
+			colToCheck = constraint.Check().ColumnIDs
 		}
 	}
 
-	for _, m := range tableDesc.Mutations[nextMutationIdx:] {
-		colDesc := m.GetColumn()
-		if m.Direction == descpb.DescriptorMutation_DROP &&
-			colDesc != nil &&
-			!m.Rollback {
+	for _, m := range tableDesc.AllMutations()[nextMutationIdx:] {
+		col := m.AsColumn()
+		if col != nil && col.Dropped() && !col.IsRollback() {
 			// Column was dropped later on, so this operation
 			// should be a no-op.
-			for _, col := range colToCheck {
-				if colDesc.ID == col {
-					return true, m.MutationID
+			for _, id := range colToCheck {
+				if col.GetID() == id {
+					return true, m.MutationID()
 				}
 			}
 		}

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1079,7 +1079,7 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 			}
 			isRollback = m.IsRollback()
 			if idx := m.AsIndex(); m.Dropped() && idx != nil {
-				if canClearRangeForDrop(idx.IndexDesc()) {
+				if canClearRangeForDrop(idx) {
 					// how we keep track of dropped index names (for, e.g., zone config
 					// lookups), even though in the absence of a GC job there's nothing to
 					// clean them up.

--- a/pkg/sql/schemachanger/scbuild/builder.go
+++ b/pkg/sql/schemachanger/scbuild/builder.go
@@ -484,7 +484,7 @@ func (b *Builder) addOrUpdatePrimaryIndexTargetsForAddColumn(
 	// Create a new primary index, identical to the existing one except for its
 	// ID and name.
 	idxID = b.nextIndexID(table)
-	newIdx := protoutil.Clone(table.GetPrimaryIndex().IndexDesc()).(*descpb.IndexDescriptor)
+	newIdx := table.GetPrimaryIndex().IndexDescDeepCopy()
 	newIdx.Name = tabledesc.GenerateUniqueConstraintName(
 		"new_primary_key",
 		func(name string) bool {
@@ -513,7 +513,7 @@ func (b *Builder) addOrUpdatePrimaryIndexTargetsForAddColumn(
 
 	b.addNode(scpb.Target_ADD, &scpb.PrimaryIndex{
 		TableID:             table.GetID(),
-		Index:               *newIdx,
+		Index:               newIdx,
 		OtherPrimaryIndexID: table.GetPrimaryIndexID(),
 		StoreColumnIDs:      append(storeColIDs, colID),
 		StoreColumnNames:    append(storeColNames, colName),
@@ -522,7 +522,7 @@ func (b *Builder) addOrUpdatePrimaryIndexTargetsForAddColumn(
 	// Drop the existing primary index.
 	b.addNode(scpb.Target_DROP, &scpb.PrimaryIndex{
 		TableID:             table.GetID(),
-		Index:               *(protoutil.Clone(table.GetPrimaryIndex().IndexDesc()).(*descpb.IndexDescriptor)),
+		Index:               table.GetPrimaryIndex().IndexDescDeepCopy(),
 		OtherPrimaryIndexID: newIdx.ID,
 		StoreColumnIDs:      storeColIDs,
 		StoreColumnNames:    storeColNames,

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -284,13 +284,13 @@ func (n *scrubNode) startScrubTable(
 // getPrimaryColIdxs returns a list of the primary index columns and
 // their corresponding index in the columns list.
 func getPrimaryColIdxs(
-	tableDesc catalog.TableDescriptor, columns []*descpb.ColumnDescriptor,
+	tableDesc catalog.TableDescriptor, columns []catalog.Column,
 ) (primaryColIdxs []int, err error) {
 	for i := 0; i < tableDesc.GetPrimaryIndex().NumColumns(); i++ {
 		colID := tableDesc.GetPrimaryIndex().GetColumnID(i)
 		rowIdx := -1
 		for idx, col := range columns {
-			if col.ID == colID {
+			if col.GetID() == colID {
 				rowIdx = idx
 				break
 			}
@@ -347,7 +347,7 @@ func createPhysicalCheckOperations(
 	tableDesc catalog.TableDescriptor, tableName *tree.TableName,
 ) (checks []checkOperation) {
 	for _, idx := range tableDesc.ActiveIndexes() {
-		checks = append(checks, newPhysicalCheckOperation(tableName, tableDesc, idx.IndexDesc()))
+		checks = append(checks, newPhysicalCheckOperation(tableName, tableDesc, idx))
 	}
 	return checks
 }
@@ -371,7 +371,7 @@ func createIndexCheckOperations(
 			results = append(results, newIndexCheckOperation(
 				tableName,
 				tableDesc,
-				idx.IndexDesc(),
+				idx,
 				asOf,
 			))
 		}
@@ -388,7 +388,7 @@ func createIndexCheckOperations(
 			results = append(results, newIndexCheckOperation(
 				tableName,
 				tableDesc,
-				idx.IndexDesc(),
+				idx,
 				asOf,
 			))
 			delete(names, idx.GetName())

--- a/pkg/sql/scrub_constraint.go
+++ b/pkg/sql/scrub_constraint.go
@@ -34,7 +34,7 @@ type sqlCheckConstraintCheckOperation struct {
 
 	// columns is a list of the columns returned in the query result
 	// tree.Datums.
-	columns []*descpb.ColumnDescriptor
+	columns []catalog.Column
 	// primaryColIdxs maps PrimaryIndex.Columns to the row
 	// indexes in the query result tree.Datums.
 	primaryColIdxs []int
@@ -107,11 +107,8 @@ func (o *sqlCheckConstraintCheckOperation) Start(params runParams) error {
 
 	o.run.started = true
 	o.run.rows = rows
-
 	// Collect all the columns.
-	for _, c := range o.tableDesc.PublicColumns() {
-		o.columns = append(o.columns, c.ColumnDesc())
-	}
+	o.columns = o.tableDesc.PublicColumns()
 	// Find the row indexes for all of the primary index columns.
 	o.primaryColIdxs, err = getPrimaryColIdxs(o.tableDesc, o.columns)
 	return err
@@ -140,7 +137,7 @@ func (o *sqlCheckConstraintCheckOperation) Next(params runParams) (tree.Datums, 
 	details["constraint_name"] = o.checkDesc.Name
 	for rowIdx, col := range o.columns {
 		// TODO(joey): We should maybe try to get the underlying type.
-		rowDetails[col.Name] = row[rowIdx].String()
+		rowDetails[col.GetName()] = row[rowIdx].String()
 	}
 	detailsJSON, err := tree.MakeDJSON(details)
 	if err != nil {

--- a/pkg/sql/scrub_fk.go
+++ b/pkg/sql/scrub_fk.go
@@ -102,15 +102,6 @@ func (o *sqlForeignKeyCheckOperation) Start(params runParams) error {
 		o.run.rows = append(o.run.rows, rows...)
 	}
 
-	// Collect the expected types for the query results. This is all
-	// columns and extra columns in the secondary index used for foreign
-	// key referencing. This also implicitly includes all primary index
-	// columns.
-	columnsByID := make(map[descpb.ColumnID]*descpb.ColumnDescriptor, len(o.tableDesc.PublicColumns()))
-	for _, c := range o.tableDesc.PublicColumns() {
-		columnsByID[c.GetID()] = c.ColumnDesc()
-	}
-
 	// Get primary key columns not included in the FK.
 	var colIDs []descpb.ColumnID
 	colIDs = append(colIDs, o.constraint.FK.OriginColumnIDs...)

--- a/pkg/sql/scrub_index.go
+++ b/pkg/sql/scrub_index.go
@@ -33,13 +33,13 @@ import (
 type indexCheckOperation struct {
 	tableName *tree.TableName
 	tableDesc catalog.TableDescriptor
-	indexDesc *descpb.IndexDescriptor
+	index     catalog.Index
 	asOf      hlc.Timestamp
 
 	// columns is a list of the columns returned by one side of the
 	// queries join. The actual resulting rows from the RowContainer is
 	// twice this.
-	columns []*descpb.ColumnDescriptor
+	columns []catalog.Column
 	// primaryColIdxs maps PrimaryIndex.Columns to the row
 	// indexes in the query result tree.Datums.
 	primaryColIdxs []int
@@ -58,13 +58,13 @@ type indexCheckRun struct {
 func newIndexCheckOperation(
 	tableName *tree.TableName,
 	tableDesc catalog.TableDescriptor,
-	indexDesc *descpb.IndexDescriptor,
+	index catalog.Index,
 	asOf hlc.Timestamp,
 ) *indexCheckOperation {
 	return &indexCheckOperation{
 		tableName: tableName,
 		tableDesc: tableDesc,
-		indexDesc: indexDesc,
+		index:     index,
 		asOf:      asOf,
 	}
 }
@@ -79,48 +79,41 @@ func (o *indexCheckOperation) Start(params runParams) error {
 		colToIdx.Set(c.GetID(), c.Ordinal())
 	}
 
-	var pkColumns, otherColumns []*descpb.ColumnDescriptor
+	var pkColumns, otherColumns []catalog.Column
 
 	for i := 0; i < o.tableDesc.GetPrimaryIndex().NumColumns(); i++ {
 		colID := o.tableDesc.GetPrimaryIndex().GetColumnID(i)
 		col := o.tableDesc.PublicColumns()[colToIdx.GetDefault(colID)]
-		pkColumns = append(pkColumns, col.ColumnDesc())
+		pkColumns = append(pkColumns, col)
 		colToIdx.Set(colID, -1)
 	}
 
-	maybeAddOtherCol := func(colID descpb.ColumnID) {
+	maybeAddOtherCol := func(colID descpb.ColumnID) error {
 		pos := colToIdx.GetDefault(colID)
 		if pos == -1 {
 			// Skip PK column.
-			return
+			return nil
 		}
 		col := o.tableDesc.PublicColumns()[pos]
-		otherColumns = append(otherColumns, col.ColumnDesc())
+		otherColumns = append(otherColumns, col)
+		return nil
 	}
 
 	// Collect all of the columns we are fetching from the index. This
 	// includes the columns involved in the index: columns, extra columns,
 	// and store columns.
-	for _, colID := range o.indexDesc.ColumnIDs {
-		maybeAddOtherCol(colID)
-	}
-	for _, colID := range o.indexDesc.ExtraColumnIDs {
-		maybeAddOtherCol(colID)
-	}
-	for _, colID := range o.indexDesc.StoreColumnIDs {
-		maybeAddOtherCol(colID)
-	}
+	_ = o.index.ForEachColumnID(maybeAddOtherCol)
 
-	colNames := func(cols []*descpb.ColumnDescriptor) []string {
+	colNames := func(cols []catalog.Column) []string {
 		res := make([]string, len(cols))
 		for i := range cols {
-			res[i] = cols[i].Name
+			res[i] = cols[i].GetName()
 		}
 		return res
 	}
 
 	checkQuery := createIndexCheckQuery(
-		colNames(pkColumns), colNames(otherColumns), o.tableDesc.GetID(), o.indexDesc.ID,
+		colNames(pkColumns), colNames(otherColumns), o.tableDesc.GetID(), o.index.GetID(),
 	)
 
 	rows, err := params.extendedEvalCtx.ExecCfg.InternalExecutor.QueryBuffered(
@@ -181,12 +174,12 @@ func (o *indexCheckOperation) Next(params runParams) (tree.Datums, error) {
 	details := make(map[string]interface{})
 	rowDetails := make(map[string]interface{})
 	details["row_data"] = rowDetails
-	details["index_name"] = o.indexDesc.Name
+	details["index_name"] = o.index.GetName()
 	if isMissingIndexReferenceError {
 		// Fetch the primary index values from the primary index row data.
 		for rowIdx, col := range o.columns {
 			// TODO(joey): We should maybe try to get the underlying type.
-			rowDetails[col.Name] = row[rowIdx].String()
+			rowDetails[col.GetName()] = row[rowIdx].String()
 		}
 	} else {
 		// Fetch the primary index values from the secondary index row data,
@@ -195,7 +188,7 @@ func (o *indexCheckOperation) Next(params runParams) (tree.Datums, error) {
 		// set of columns is for the primary index.
 		for rowIdx, col := range o.columns {
 			// TODO(joey): We should maybe try to get the underlying type.
-			rowDetails[col.Name] = row[rowIdx+colLen].String()
+			rowDetails[col.GetName()] = row[rowIdx+colLen].String()
 		}
 	}
 

--- a/pkg/sql/scrub_physical.go
+++ b/pkg/sql/scrub_physical.go
@@ -29,11 +29,11 @@ var _ checkOperation = &physicalCheckOperation{}
 type physicalCheckOperation struct {
 	tableName *tree.TableName
 	tableDesc catalog.TableDescriptor
-	indexDesc *descpb.IndexDescriptor
+	index     catalog.Index
 
 	// columns is a list of the columns returned in the query result
 	// tree.Datums.
-	columns []*descpb.ColumnDescriptor
+	columns []catalog.Column
 	// primaryColIdxs maps PrimaryIndex.Columns to the row
 	// indexes in the query result tree.Datums.
 	primaryColIdxs []int
@@ -50,12 +50,12 @@ type physicalCheckRun struct {
 }
 
 func newPhysicalCheckOperation(
-	tableName *tree.TableName, tableDesc catalog.TableDescriptor, indexDesc *descpb.IndexDescriptor,
+	tableName *tree.TableName, tableDesc catalog.TableDescriptor, index catalog.Index,
 ) *physicalCheckOperation {
 	return &physicalCheckOperation{
 		tableName: tableName,
 		tableDesc: tableDesc,
-		indexDesc: indexDesc,
+		index:     index,
 	}
 }
 
@@ -67,28 +67,31 @@ func (o *physicalCheckOperation) Start(params runParams) error {
 	// Collect all of the columns, their types, and their IDs.
 	var columnIDs []tree.ColumnID
 	colIDToIdx := catalog.ColumnIDToOrdinalMap(o.tableDesc.PublicColumns())
-	columns := make([]*descpb.ColumnDescriptor, len(columnIDs))
+	columns := make([]catalog.Column, len(columnIDs))
 
 	// Collect all of the columns being scanned.
-	if o.indexDesc.ID == o.tableDesc.GetPrimaryIndexID() {
+	if o.index.GetID() == o.tableDesc.GetPrimaryIndexID() {
 		for _, c := range o.tableDesc.PublicColumns() {
 			columnIDs = append(columnIDs, tree.ColumnID(c.GetID()))
 		}
 	} else {
-		for _, id := range o.indexDesc.ColumnIDs {
+		for i := 0; i < o.index.NumColumns(); i++ {
+			id := o.index.GetColumnID(i)
 			columnIDs = append(columnIDs, tree.ColumnID(id))
 		}
-		for _, id := range o.indexDesc.ExtraColumnIDs {
+		for i := 0; i < o.index.NumExtraColumns(); i++ {
+			id := o.index.GetExtraColumnID(i)
 			columnIDs = append(columnIDs, tree.ColumnID(id))
 		}
-		for _, id := range o.indexDesc.StoreColumnIDs {
+		for i := 0; i < o.index.NumStoredColumns(); i++ {
+			id := o.index.GetStoredColumnID(i)
 			columnIDs = append(columnIDs, tree.ColumnID(id))
 		}
 	}
 
 	for i := range columnIDs {
 		idx := colIDToIdx.GetDefault(descpb.ColumnID(columnIDs[i]))
-		columns = append(columns, o.tableDesc.PublicColumns()[idx].ColumnDesc())
+		columns = append(columns, o.tableDesc.PublicColumns()[idx])
 	}
 
 	// Find the row indexes for all of the primary index columns.
@@ -98,7 +101,7 @@ func (o *physicalCheckOperation) Start(params runParams) error {
 	}
 
 	indexFlags := &tree.IndexFlags{
-		IndexID:     tree.IndexID(o.indexDesc.ID),
+		IndexID:     tree.IndexID(o.index.GetID()),
 		NoIndexJoin: true,
 	}
 	scan := params.p.Scan()
@@ -108,7 +111,7 @@ func (o *physicalCheckOperation) Start(params runParams) error {
 		return err
 	}
 	scan.index = scan.specifiedIndex
-	sb := span.MakeBuilder(params.EvalContext(), params.ExecCfg().Codec, o.tableDesc, o.indexDesc)
+	sb := span.MakeBuilder(params.EvalContext(), params.ExecCfg().Codec, o.tableDesc, o.index)
 	scan.spans, err = sb.UnconstrainedSpans()
 	if err != nil {
 		return err

--- a/pkg/sql/scrub_test.go
+++ b/pkg/sql/scrub_test.go
@@ -69,7 +69,7 @@ INSERT INTO t."tEst" VALUES (10, 20);
 	// Construct the secondary index key that is currently in the
 	// database.
 	secondaryIndexKey, err := rowenc.EncodeSecondaryIndex(
-		keys.SystemSQLCodec, tableDesc, secondaryIndex.IndexDesc(), colIDtoRowIndex, values, true /* includeEmpty */)
+		keys.SystemSQLCodec, tableDesc, secondaryIndex, colIDtoRowIndex, values, true /* includeEmpty */)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -138,7 +138,7 @@ CREATE INDEX secondary ON t.test (v);
 	// Construct datums and secondary k/v for our row values (k, v).
 	values := []tree.Datum{tree.NewDInt(10), tree.NewDInt(314)}
 	secondaryIndexKey, err := rowenc.EncodeSecondaryIndex(
-		keys.SystemSQLCodec, tableDesc, secondaryIndex.IndexDesc(), colIDtoRowIndex, values, true /* includeEmpty */)
+		keys.SystemSQLCodec, tableDesc, secondaryIndex, colIDtoRowIndex, values, true /* includeEmpty */)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -233,7 +233,7 @@ INSERT INTO t.test VALUES (10, 20, 1337);
 	// Generate the existing secondary index key.
 	values := []tree.Datum{tree.NewDInt(10), tree.NewDInt(20), tree.NewDInt(1337)}
 	secondaryIndexKey, err := rowenc.EncodeSecondaryIndex(
-		keys.SystemSQLCodec, tableDesc, secondaryIndex.IndexDesc(), colIDtoRowIndex, values, true /* includeEmpty */)
+		keys.SystemSQLCodec, tableDesc, secondaryIndex, colIDtoRowIndex, values, true /* includeEmpty */)
 
 	if len(secondaryIndexKey) != 1 {
 		t.Fatalf("expected 1 index entry, got %d. got %#v", len(secondaryIndexKey), secondaryIndexKey)
@@ -250,7 +250,7 @@ INSERT INTO t.test VALUES (10, 20, 1337);
 	// Generate a secondary index k/v that has a different value.
 	values = []tree.Datum{tree.NewDInt(10), tree.NewDInt(20), tree.NewDInt(314)}
 	secondaryIndexKey, err = rowenc.EncodeSecondaryIndex(
-		keys.SystemSQLCodec, tableDesc, secondaryIndex.IndexDesc(), colIDtoRowIndex, values, true /* includeEmpty */)
+		keys.SystemSQLCodec, tableDesc, secondaryIndex, colIDtoRowIndex, values, true /* includeEmpty */)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -353,7 +353,7 @@ INSERT INTO t.test VALUES (10, 2);
 	primaryIndexKeyPrefix := rowenc.MakeIndexKeyPrefix(
 		keys.SystemSQLCodec, tableDesc, tableDesc.GetPrimaryIndexID())
 	primaryIndexKey, _, err := rowenc.EncodeIndexKey(
-		tableDesc, tableDesc.GetPrimaryIndex().IndexDesc(), colIDtoRowIndex, values, primaryIndexKeyPrefix)
+		tableDesc, tableDesc.GetPrimaryIndex(), colIDtoRowIndex, values, primaryIndexKeyPrefix)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -454,7 +454,7 @@ func TestScrubFKConstraintFKMissing(t *testing.T) {
 	// Construct the secondary index key entry as it exists in the
 	// database.
 	secondaryIndexKey, err := rowenc.EncodeSecondaryIndex(
-		keys.SystemSQLCodec, tableDesc, secondaryIndex.IndexDesc(), colIDtoRowIndex, values, true /* includeEmpty */)
+		keys.SystemSQLCodec, tableDesc, secondaryIndex, colIDtoRowIndex, values, true /* includeEmpty */)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -474,7 +474,7 @@ func TestScrubFKConstraintFKMissing(t *testing.T) {
 
 	// Construct the new secondary index key that will be inserted.
 	secondaryIndexKey, err = rowenc.EncodeSecondaryIndex(
-		keys.SystemSQLCodec, tableDesc, secondaryIndex.IndexDesc(), colIDtoRowIndex, values, true /* includeEmpty */)
+		keys.SystemSQLCodec, tableDesc, secondaryIndex, colIDtoRowIndex, values, true /* includeEmpty */)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -593,7 +593,7 @@ INSERT INTO t.test VALUES (217, 314);
 	primaryIndexKeyPrefix := rowenc.MakeIndexKeyPrefix(
 		keys.SystemSQLCodec, tableDesc, tableDesc.GetPrimaryIndexID())
 	primaryIndexKey, _, err := rowenc.EncodeIndexKey(
-		tableDesc, tableDesc.GetPrimaryIndex().IndexDesc(), colIDtoRowIndex, values, primaryIndexKeyPrefix)
+		tableDesc, tableDesc.GetPrimaryIndex(), colIDtoRowIndex, values, primaryIndexKeyPrefix)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -676,7 +676,7 @@ INSERT INTO t.test VALUES (217, 314, 1337);
 	primaryIndexKeyPrefix := rowenc.MakeIndexKeyPrefix(
 		keys.SystemSQLCodec, tableDesc, tableDesc.GetPrimaryIndexID())
 	primaryIndexKey, _, err := rowenc.EncodeIndexKey(
-		tableDesc, tableDesc.GetPrimaryIndex().IndexDesc(), colIDtoRowIndex, values, primaryIndexKeyPrefix)
+		tableDesc, tableDesc.GetPrimaryIndex(), colIDtoRowIndex, values, primaryIndexKeyPrefix)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -781,7 +781,7 @@ CREATE TABLE t.test (
 	primaryIndexKeyPrefix := rowenc.MakeIndexKeyPrefix(
 		keys.SystemSQLCodec, tableDesc, tableDesc.GetPrimaryIndexID())
 	primaryIndexKey, _, err := rowenc.EncodeIndexKey(
-		tableDesc, tableDesc.GetPrimaryIndex().IndexDesc(), colIDtoRowIndex, values, primaryIndexKeyPrefix)
+		tableDesc, tableDesc.GetPrimaryIndex(), colIDtoRowIndex, values, primaryIndexKeyPrefix)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -886,7 +886,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v1 INT, v2 INT);
 	primaryIndexKeyPrefix := rowenc.MakeIndexKeyPrefix(
 		keys.SystemSQLCodec, tableDesc, tableDesc.GetPrimaryIndexID())
 	primaryIndexKey, _, err := rowenc.EncodeIndexKey(
-		tableDesc, tableDesc.GetPrimaryIndex().IndexDesc(), colIDtoRowIndex, values, primaryIndexKeyPrefix)
+		tableDesc, tableDesc.GetPrimaryIndex(), colIDtoRowIndex, values, primaryIndexKeyPrefix)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -495,7 +495,7 @@ func assignSequenceOptions(
 				// We only want to trigger schema changes if the owner is not what we
 				// want it to be.
 				if opts.SequenceOwner.OwnerTableID != tableDesc.ID ||
-					opts.SequenceOwner.OwnerColumnID != col.ID {
+					opts.SequenceOwner.OwnerColumnID != col.GetID() {
 					if err := removeSequenceOwnerIfExists(params.ctx, params.p, sequenceID, opts); err != nil {
 						return err
 					}
@@ -559,17 +559,17 @@ func removeSequenceOwnerIfExists(
 		return err
 	}
 	// Find an item in colDesc.OwnsSequenceIds which references SequenceID.
-	refIdx := -1
+	newOwnsSequenceIDs := make([]descpb.ID, 0, col.NumOwnsSequences())
 	for i := 0; i < col.NumOwnsSequences(); i++ {
 		id := col.GetOwnsSequenceID(i)
-		if id == sequenceID {
-			refIdx = i
+		if id != sequenceID {
+			newOwnsSequenceIDs = append(newOwnsSequenceIDs, id)
 		}
 	}
-	if refIdx == -1 {
+	if len(newOwnsSequenceIDs) == col.NumOwnsSequences() {
 		return errors.AssertionFailedf("couldn't find reference from column to this sequence")
 	}
-	col.ColumnDesc().OwnsSequenceIds = append(col.ColumnDesc().OwnsSequenceIds[:refIdx], col.ColumnDesc().OwnsSequenceIds[refIdx+1:]...)
+	col.ColumnDesc().OwnsSequenceIds = newOwnsSequenceIDs
 	if err := p.writeSchemaChange(
 		ctx, tableDesc, descpb.InvalidMutationID,
 		fmt.Sprintf("removing sequence owner %s(%d) for sequence %d",
@@ -585,7 +585,7 @@ func removeSequenceOwnerIfExists(
 
 func resolveColumnItemToDescriptors(
 	ctx context.Context, p *planner, columnItem *tree.ColumnItem,
-) (*tabledesc.Mutable, *descpb.ColumnDescriptor, error) {
+) (*tabledesc.Mutable, catalog.Column, error) {
 	if columnItem.TableName == nil {
 		err := pgerror.New(pgcode.Syntax, "invalid OWNED BY option")
 		return nil, nil, errors.WithHint(err, "Specify OWNED BY table.column or OWNED BY NONE.")
@@ -599,7 +599,7 @@ func resolveColumnItemToDescriptors(
 	if err != nil {
 		return nil, nil, err
 	}
-	return tableDesc, col.ColumnDesc(), nil
+	return tableDesc, col, nil
 }
 
 func addSequenceOwner(
@@ -614,9 +614,9 @@ func addSequenceOwner(
 		return err
 	}
 
-	col.OwnsSequenceIds = append(col.OwnsSequenceIds, sequenceID)
+	col.ColumnDesc().OwnsSequenceIds = append(col.ColumnDesc().OwnsSequenceIds, sequenceID)
 
-	opts.SequenceOwner.OwnerColumnID = col.ID
+	opts.SequenceOwner.OwnerColumnID = col.GetID()
 	opts.SequenceOwner.OwnerTableID = tableDesc.GetID()
 	return p.writeSchemaChange(
 		ctx, tableDesc, descpb.InvalidMutationID, fmt.Sprintf(
@@ -736,12 +736,16 @@ func GetSequenceDescFromIdentifier(
 // dropSequencesOwnedByCol drops all the sequences from col.OwnsSequenceIDs.
 // Called when the respective column (or the whole table) is being dropped.
 func (p *planner) dropSequencesOwnedByCol(
-	ctx context.Context, col *descpb.ColumnDescriptor, queueJob bool, behavior tree.DropBehavior,
+	ctx context.Context, col catalog.Column, queueJob bool, behavior tree.DropBehavior,
 ) error {
 	// Copy out the sequence IDs as the code to drop the sequence will reach
 	// back around and update the descriptor from underneath us.
-	ownsSequenceIDs := append([]descpb.ID(nil), col.OwnsSequenceIds...)
-	for _, sequenceID := range ownsSequenceIDs {
+	colOwnsSequenceIDs := make([]descpb.ID, col.NumOwnsSequences())
+	for i := 0; i < col.NumOwnsSequences(); i++ {
+		colOwnsSequenceIDs[i] = col.GetOwnsSequenceID(i)
+	}
+
+	for _, sequenceID := range colOwnsSequenceIDs {
 		seqDesc, err := p.Descriptors().GetMutableTableVersionByID(ctx, sequenceID, p.txn)
 		// Special case error swallowing for #50781, which can cause a
 		// column to own sequences that do not exist.
@@ -776,9 +780,10 @@ func (p *planner) dropSequencesOwnedByCol(
 //   - writes the sequence descriptor and notifies a schema change.
 // The column descriptor is mutated but not saved to persistent storage; the caller must save it.
 func (p *planner) removeSequenceDependencies(
-	ctx context.Context, tableDesc *tabledesc.Mutable, col *descpb.ColumnDescriptor,
+	ctx context.Context, tableDesc *tabledesc.Mutable, col catalog.Column,
 ) error {
-	for _, sequenceID := range col.UsesSequenceIds {
+	for i := 0; i < col.NumUsesSequences(); i++ {
+		sequenceID := col.GetUsesSequenceID(i)
 		// Get the sequence descriptor so we can remove the reference from it.
 		seqDesc, err := p.Descriptors().GetMutableTableVersionByID(ctx, sequenceID, p.txn)
 		if err != nil {
@@ -803,7 +808,7 @@ func (p *planner) removeSequenceDependencies(
 			if reference.ID == tableDesc.ID {
 				refTableIdx = i
 				for j, colRefID := range seqDesc.DependedOnBy[i].ColumnIDs {
-					if colRefID == col.ID {
+					if colRefID == col.GetID() {
 						refColIdx = j
 						break found
 					}
@@ -842,6 +847,6 @@ func (p *planner) removeSequenceDependencies(
 		}
 	}
 	// Remove the reference from the column descriptor to the sequence descriptor.
-	col.UsesSequenceIds = []descpb.ID{}
+	col.ColumnDesc().UsesSequenceIds = []descpb.ID{}
 	return nil
 }

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -87,7 +87,7 @@ func ShowCreateTable(
 			f.WriteString(",")
 		}
 		f.WriteString("\n\t")
-		colstr, err := schemaexpr.FormatColumnForDisplay(ctx, desc, col.ColumnDesc(), &p.RunParams(ctx).p.semaCtx)
+		colstr, err := schemaexpr.FormatColumnForDisplay(ctx, desc, col, &p.RunParams(ctx).p.semaCtx)
 		if err != nil {
 			return "", err
 		}
@@ -155,7 +155,7 @@ func ShowCreateTable(
 			// Build the PARTITION BY clause.
 			var partitionBuf bytes.Buffer
 			if err := ShowCreatePartitioning(
-				a, p.ExecCfg().Codec, desc, idx.IndexDesc(), &idx.IndexDesc().Partitioning, &partitionBuf, 1 /* indent */, 0, /* colOffset */
+				a, p.ExecCfg().Codec, desc, idx, &idx.IndexDesc().Partitioning, &partitionBuf, 1 /* indent */, 0, /* colOffset */
 			); err != nil {
 				return "", err
 			}
@@ -166,7 +166,7 @@ func ShowCreateTable(
 			if includeInterleaveClause {
 				// TODO(mgartner): The logic in showCreateInterleave can be
 				// moved to catformat.IndexForDisplay.
-				if err := showCreateInterleave(idx.IndexDesc(), &interleaveBuf, dbPrefix, lCtx); err != nil {
+				if err := showCreateInterleave(idx, &interleaveBuf, dbPrefix, lCtx); err != nil {
 					return "", err
 				}
 			}
@@ -176,7 +176,7 @@ func ShowCreateTable(
 				ctx,
 				desc,
 				&descpb.AnonymousTable,
-				idx.IndexDesc(),
+				idx,
 				partitionBuf.String(),
 				interleaveBuf.String(),
 				p.RunParams(ctx).p.SemaCtx(),
@@ -195,11 +195,11 @@ func ShowCreateTable(
 		return "", err
 	}
 
-	if err := showCreateInterleave(desc.GetPrimaryIndex().IndexDesc(), &f.Buffer, dbPrefix, lCtx); err != nil {
+	if err := showCreateInterleave(desc.GetPrimaryIndex(), &f.Buffer, dbPrefix, lCtx); err != nil {
 		return "", err
 	}
 	if err := ShowCreatePartitioning(
-		a, p.ExecCfg().Codec, desc, desc.GetPrimaryIndex().IndexDesc(), &desc.GetPrimaryIndex().IndexDesc().Partitioning, &f.Buffer, 0 /* indent */, 0, /* colOffset */
+		a, p.ExecCfg().Codec, desc, desc.GetPrimaryIndex(), &desc.GetPrimaryIndex().IndexDesc().Partitioning, &f.Buffer, 0 /* indent */, 0, /* colOffset */
 	); err != nil {
 		return "", err
 	}

--- a/pkg/sql/show_fingerprints.go
+++ b/pkg/sql/show_fingerprints.go
@@ -29,7 +29,7 @@ type showFingerprintsNode struct {
 	optColumnsSlot
 
 	tableDesc catalog.TableDescriptor
-	indexes   []*descpb.IndexDescriptor
+	indexes   []catalog.Index
 
 	run showFingerprintsRun
 }
@@ -65,15 +65,9 @@ func (p *planner) ShowFingerprints(
 		return nil, err
 	}
 
-	indexes := tableDesc.NonDropIndexes()
-	indexDescs := make([]*descpb.IndexDescriptor, len(indexes))
-	for i, index := range indexes {
-		indexDescs[i] = index.IndexDesc()
-	}
-
 	return &showFingerprintsNode{
 		tableDesc: tableDesc,
-		indexes:   indexDescs,
+		indexes:   tableDesc.NonDropIndexes(),
 	}, nil
 }
 
@@ -97,30 +91,34 @@ func (n *showFingerprintsNode) Next(params runParams) (bool, error) {
 	index := n.indexes[n.run.rowIdx]
 
 	cols := make([]string, 0, len(n.tableDesc.PublicColumns()))
-	addColumn := func(col *descpb.ColumnDescriptor) {
+	addColumn := func(col catalog.Column) {
 		// TODO(dan): This is known to be a flawed way to fingerprint. Any datum
 		// with the same string representation is fingerprinted the same, even
 		// if they're different types.
-		switch col.Type.Family() {
+		name := col.GetName()
+		switch col.GetType().Family() {
 		case types.BytesFamily:
-			cols = append(cols, fmt.Sprintf("%s:::bytes", tree.NameStringP(&col.Name)))
+			cols = append(cols, fmt.Sprintf("%s:::bytes", tree.NameStringP(&name)))
 		default:
-			cols = append(cols, fmt.Sprintf("%s::string::bytes", tree.NameStringP(&col.Name)))
+			cols = append(cols, fmt.Sprintf("%s::string::bytes", tree.NameStringP(&name)))
 		}
 	}
 
-	if index.ID == n.tableDesc.GetPrimaryIndexID() {
+	if index.GetID() == n.tableDesc.GetPrimaryIndexID() {
 		for _, col := range n.tableDesc.PublicColumns() {
-			addColumn(col.ColumnDesc())
+			addColumn(col)
 		}
 	} else {
-		colsByID := make(map[descpb.ColumnID]*descpb.ColumnDescriptor)
-		for _, col := range n.tableDesc.PublicColumns() {
-			colsByID[col.GetID()] = col.ColumnDesc()
-		}
-		colIDs := append(append(index.ColumnIDs, index.ExtraColumnIDs...), index.StoreColumnIDs...)
-		for _, colID := range colIDs {
-			addColumn(colsByID[colID])
+		err := index.ForEachColumnID(func(id descpb.ColumnID) error {
+			col, err := n.tableDesc.FindColumnWithID(id)
+			if err != nil {
+				return err
+			}
+			addColumn(col)
+			return nil
+		})
+		if err != nil {
+			return false, err
 		}
 	}
 
@@ -139,7 +137,7 @@ func (n *showFingerprintsNode) Next(params runParams) (bool, error) {
 	sql := fmt.Sprintf(`SELECT
 	  xor_agg(fnv64(%s))::string AS fingerprint
 	  FROM [%d AS t]@{FORCE_INDEX=[%d]}
-	`, strings.Join(cols, `,`), n.tableDesc.GetID(), index.ID)
+	`, strings.Join(cols, `,`), n.tableDesc.GetID(), index.GetID())
 	// If were'in in an AOST context, propagate it to the inner statement so that
 	// the inner statement gets planned with planner.avoidCachedDescriptors set,
 	// like the outter one.
@@ -165,7 +163,7 @@ func (n *showFingerprintsNode) Next(params runParams) (bool, error) {
 	}
 	fingerprint := fingerprintCols[0]
 
-	n.run.values[0] = tree.NewDString(index.Name)
+	n.run.values[0] = tree.NewDString(index.GetName())
 	n.run.values[1] = fingerprint
 	n.run.rowIdx++
 	return true, nil

--- a/pkg/sql/span/span_builder_test.go
+++ b/pkg/sql/span/span_builder_test.go
@@ -23,7 +23,7 @@ func TestSpanBuilderDoesNotSplitSystemTableFamilySpans(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)
 	builder := MakeBuilder(&evalCtx, keys.SystemSQLCodec, systemschema.DescriptorTable,
-		systemschema.DescriptorTable.GetPrimaryIndex().IndexDesc())
+		systemschema.DescriptorTable.GetPrimaryIndex())
 
 	if res := builder.CanSplitSpanIntoFamilySpans(
 		1, 1, false); res {

--- a/pkg/sql/span_builder_test.go
+++ b/pkg/sql/span_builder_test.go
@@ -107,7 +107,7 @@ func TestSpanBuilderCanSplitSpan(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			builder := span.MakeBuilder(evalCtx, execCfg.Codec, desc, idx.IndexDesc())
+			builder := span.MakeBuilder(evalCtx, execCfg.Codec, desc, idx)
 			if res := builder.CanSplitSpanIntoFamilySpans(
 				tc.numNeededFamilies, tc.prefixLen, tc.containsNull); res != tc.canSplit {
 				t.Errorf("expected result to be %v, but found %v", tc.canSplit, res)

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -186,7 +186,7 @@ func decodeTableStatisticsKV(
 	dirs := []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC, descpb.IndexDescriptor_ASC}
 	keyVals := make([]rowenc.EncDatum, 2)
 	_, matches, _, err := rowenc.DecodeIndexKey(
-		codec, tbl, tbl.GetPrimaryIndex().IndexDesc(), types, keyVals, dirs, kv.Key,
+		codec, tbl, tbl.GetPrimaryIndex(), types, keyVals, dirs, kv.Key,
 	)
 	if err != nil {
 		return 0, err

--- a/pkg/sql/tablewriter_upsert_opt.go
+++ b/pkg/sql/tablewriter_upsert_opt.go
@@ -64,13 +64,13 @@ type optTableUpserter struct {
 	// fetchCols indicate which columns need to be fetched from the target table,
 	// in order to detect whether a conflict has occurred, as well as to provide
 	// existing values for updates.
-	fetchCols []descpb.ColumnDescriptor
+	fetchCols []catalog.Column
 
 	// updateCols indicate which columns need an update during a conflict.
-	updateCols []descpb.ColumnDescriptor
+	updateCols []catalog.Column
 
 	// returnCols indicate which columns need to be returned by the Upsert.
-	returnCols []descpb.ColumnDescriptor
+	returnCols []catalog.Column
 
 	// canaryOrdinal is the ordinal position of the column within the input row
 	// that is used to decide whether to execute an insert or update operation.
@@ -107,7 +107,7 @@ func (tu *optTableUpserter) init(
 		tu.resultRow = make(tree.Datums, len(tu.returnCols))
 		tu.rows = rowcontainer.NewRowContainer(
 			evalCtx.Mon.MakeBoundAccount(),
-			colinfo.ColTypeInfoFromColDescs(tu.returnCols),
+			colinfo.ColTypeInfoFromColumns(tu.returnCols),
 		)
 
 		// Create the map from colIds to the expected columns.
@@ -117,7 +117,7 @@ func (tu *optTableUpserter) init(
 		tu.colIDToReturnIndex = catalog.ColumnIDToOrdinalMap(tu.tableDesc().PublicColumns())
 		if tu.ri.InsertColIDtoRowIndex.Len() == tu.colIDToReturnIndex.Len() {
 			for i := range tu.ri.InsertCols {
-				colID := tu.ri.InsertCols[i].ID
+				colID := tu.ri.InsertCols[i].GetID()
 				resultIndex, ok := tu.colIDToReturnIndex.Get(colID)
 				if !ok || resultIndex != tu.ri.InsertColIDtoRowIndex.GetDefault(colID) {
 					tu.insertReorderingRequired = true

--- a/pkg/sql/tests/hash_sharded_test.go
+++ b/pkg/sql/tests/hash_sharded_test.go
@@ -118,7 +118,8 @@ func TestBasicHashShardedIndexes(t *testing.T) {
 			t.Fatal(err)
 		}
 		foundShardColumn := false
-		for _, colID := range foo.IndexDesc().ExtraColumnIDs {
+		for i := 0; i < foo.NumExtraColumns(); i++ {
+			colID := foo.GetExtraColumnID(i)
 			if colID == shardColID {
 				foundShardColumn = true
 				break

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -531,6 +531,6 @@ func (p *planner) reassignIndexComments(
 // key from a single span.
 // This determines whether an index is dropped during a schema change, or if
 // it is only deleted upon GC.
-func canClearRangeForDrop(index *descpb.IndexDescriptor) bool {
+func canClearRangeForDrop(index catalog.Index) bool {
 	return !index.IsInterleaved()
 }

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -360,19 +360,14 @@ func checkTableForDisallowedMutationsWithTruncate(desc *tabledesc.Mutable) error
 						"dropped which depends on another object", desc.GetName(), col.GetName())
 			}
 		} else if c := m.AsConstraint(); c != nil {
-			switch ct := c.ConstraintToUpdateDesc().ConstraintType; ct {
-			case descpb.ConstraintToUpdate_CHECK,
-				descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX,
-				descpb.ConstraintToUpdate_NOT_NULL,
-				descpb.ConstraintToUpdate_FOREIGN_KEY:
+			if c.IsCheck() || c.IsNotNull() || c.IsForeignKey() || c.IsUniqueWithoutIndex() {
 				return unimplemented.Newf(
 					"TRUNCATE concurrent with ongoing schema change",
 					"cannot perform TRUNCATE on %q which has an ongoing %s "+
-						"constraint change", desc.GetName(), ct)
-			default:
-				return errors.AssertionFailedf("cannot perform TRUNCATE due to "+
-					"unknown constraint type %v on mutation %d in %v", ct, i, desc)
+						"constraint change", desc.GetName(), c.ConstraintToUpdateDesc().ConstraintType)
 			}
+			return errors.AssertionFailedf("cannot perform TRUNCATE due to "+
+				"unknown constraint type %v on mutation %d in %v", c.ConstraintToUpdateDesc().ConstraintType, i, desc)
 		} else if s := m.AsPrimaryKeySwap(); s != nil {
 			return unimplemented.Newf(
 				"TRUNCATE concurrent with ongoing schema change",

--- a/pkg/sql/unsplit.go
+++ b/pkg/sql/unsplit.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/errors"
@@ -26,7 +25,7 @@ type unsplitNode struct {
 	optColumnsSlot
 
 	tableDesc catalog.TableDescriptor
-	index     *descpb.IndexDescriptor
+	index     catalog.Index
 	run       unsplitRun
 	rows      planNode
 }
@@ -77,7 +76,7 @@ type unsplitAllNode struct {
 	optColumnsSlot
 
 	tableDesc catalog.TableDescriptor
-	index     *descpb.IndexDescriptor
+	index     catalog.Index
 	run       unsplitAllRun
 }
 
@@ -104,8 +103,8 @@ func (n *unsplitAllNode) startExec(params runParams) error {
 		return err
 	}
 	indexName := ""
-	if n.index.ID != n.tableDesc.GetPrimaryIndexID() {
-		indexName = n.index.Name
+	if n.index.GetID() != n.tableDesc.GetPrimaryIndexID() {
+		indexName = n.index.GetName()
 	}
 	it, err := params.p.ExtendedEvalContext().InternalExecutor.(*InternalExecutor).QueryIteratorEx(
 		params.ctx, "split points query", params.p.txn, sessiondata.InternalExecutorOverride{},

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -14,8 +14,8 @@ import (
 	"context"
 	"sync"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
@@ -43,7 +43,7 @@ type upsertRun struct {
 	checkOrds checkSet
 
 	// insertCols are the columns being inserted/upserted into.
-	insertCols []descpb.ColumnDescriptor
+	insertCols []catalog.Column
 
 	// done informs a new call to BatchedNext() that the previous call to
 	// BatchedNext() has completed the work already.

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -478,7 +478,7 @@ func (e *virtualDefEntry) validateRow(datums tree.Datums, columns colinfo.Result
 // where we can't guarantee it will be Close()d in case of error.
 func (e *virtualDefEntry) getPlanInfo(
 	table catalog.TableDescriptor,
-	index *descpb.IndexDescriptor,
+	index catalog.Index,
 	idxConstraint *constraint.Constraint,
 	stopper *stop.Stopper,
 ) (colinfo.ResultColumns, virtualTableConstructor) {
@@ -541,14 +541,14 @@ func (e *virtualDefEntry) getPlanInfo(
 
 			// We are now dealing with a constrained virtual index scan.
 
-			if index.ID == 1 {
+			if index.GetID() == 1 {
 				return nil, errors.AssertionFailedf(
 					"programming error: can't constrain scan on primary virtual index of table %s", e.desc.GetName())
 			}
 
 			// Figure out the ordinal position of the column that we're filtering on.
 			columnIdxMap := catalog.ColumnIDToOrdinalMap(table.PublicColumns())
-			indexKeyDatums := make([]tree.Datum, len(index.ColumnIDs))
+			indexKeyDatums := make([]tree.Datum, index.NumColumns())
 
 			generator, cleanup, setupError := setupGenerator(ctx, e.makeConstrainedRowsGenerator(
 				ctx, p, dbDesc, index, indexKeyDatums, columnIdxMap, idxConstraint, columns), stopper)
@@ -572,7 +572,7 @@ func (e *virtualDefEntry) makeConstrainedRowsGenerator(
 	ctx context.Context,
 	p *planner,
 	dbDesc catalog.DatabaseDescriptor,
-	index *descpb.IndexDescriptor,
+	index catalog.Index,
 	indexKeyDatums []tree.Datum,
 	columnIdxMap catalog.TableColMap,
 	idxConstraint *constraint.Constraint,
@@ -583,7 +583,8 @@ func (e *virtualDefEntry) makeConstrainedRowsGenerator(
 		var span constraint.Span
 		addRowIfPassesFilter := func(idxConstraint *constraint.Constraint) func(datums ...tree.Datum) error {
 			return func(datums ...tree.Datum) error {
-				for i, id := range index.ColumnIDs {
+				for i := 0; i < index.NumColumns(); i++ {
+					id := index.GetColumnID(i)
 					indexKeyDatums[i] = datums[columnIdxMap.GetDefault(id)]
 				}
 				// Construct a single key span out of the current row, so that
@@ -620,7 +621,7 @@ func (e *virtualDefEntry) makeConstrainedRowsGenerator(
 				break
 			}
 			constraintDatum := span.StartKey().Value(0)
-			virtualIndex := def.getIndex(index.ID)
+			virtualIndex := def.getIndex(index.GetID())
 
 			// For each span, run the index's populate method, constrained to the
 			// constraint span's value.

--- a/pkg/sql/virtual_table.go
+++ b/pkg/sql/virtual_table.go
@@ -206,7 +206,7 @@ type vTableLookupJoinNode struct {
 	dbName string
 	db     catalog.DatabaseDescriptor
 	table  catalog.TableDescriptor
-	index  *descpb.IndexDescriptor
+	index  catalog.Index
 	// eqCol is the single equality column ordinal into the lookup table. Virtual
 	// indexes only support a single indexed column currently.
 	eqCol             int

--- a/pkg/sql/zone_config_test.go
+++ b/pkg/sql/zone_config_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -136,9 +137,10 @@ func TestGetZoneConfig(t *testing.T) {
 			}
 
 			// Verify sql.GetZoneConfigInTxn.
+			dummyIndex := systemschema.CommentsTable.GetPrimaryIndex()
 			if err := s.DB().Txn(context.Background(), func(ctx context.Context, txn *kv.Txn) error {
 				_, zoneCfg, subzone, err := sql.GetZoneConfigInTxn(
-					ctx, txn, config.SystemTenantObjectID(tc.objectID), &descpb.IndexDescriptor{}, tc.partitionName, false,
+					ctx, txn, config.SystemTenantObjectID(tc.objectID), dummyIndex, tc.partitionName, false,
 				)
 				if err != nil {
 					return err
@@ -259,8 +261,8 @@ func TestGetZoneConfig(t *testing.T) {
 	tb21Cfg.NumReplicas = proto.Int32(1)
 	tb21Cfg.Constraints = []zonepb.ConstraintsConjunction{{Constraints: []zonepb.Constraint{{Value: "db2.tb1"}}}}
 	tb21Cfg.Subzones = []zonepb.Subzone{
-		{PartitionName: "p0", Config: p211Cfg},
-		{PartitionName: "p1", Config: p212Cfg},
+		{IndexID: 1, PartitionName: "p0", Config: p211Cfg},
+		{IndexID: 1, PartitionName: "p1", Config: p212Cfg},
 	}
 	tb21Cfg.SubzoneSpans = []zonepb.SubzoneSpan{
 		{SubzoneIndex: 0, Key: []byte{1}},
@@ -275,7 +277,7 @@ func TestGetZoneConfig(t *testing.T) {
 	// Subzone Placeholder
 	tb22Cfg := *zonepb.NewZoneConfig()
 	tb22Cfg.NumReplicas = proto.Int32(0)
-	tb22Cfg.Subzones = []zonepb.Subzone{{PartitionName: "p0", Config: p221Cfg}}
+	tb22Cfg.Subzones = []zonepb.Subzone{{IndexID: 1, PartitionName: "p0", Config: p221Cfg}}
 	tb22Cfg.SubzoneSpans = []zonepb.SubzoneSpan{
 		{SubzoneIndex: 0, Key: []byte{1}, EndKey: []byte{255}},
 	}
@@ -374,9 +376,10 @@ func TestCascadingZoneConfig(t *testing.T) {
 			}
 
 			// Verify sql.GetZoneConfigInTxn.
+			dummyIndex := systemschema.CommentsTable.GetPrimaryIndex()
 			if err := s.DB().Txn(context.Background(), func(ctx context.Context, txn *kv.Txn) error {
 				_, zoneCfg, subzone, err := sql.GetZoneConfigInTxn(
-					ctx, txn, config.SystemTenantObjectID(tc.objectID), &descpb.IndexDescriptor{}, tc.partitionName, false,
+					ctx, txn, config.SystemTenantObjectID(tc.objectID), dummyIndex, tc.partitionName, false,
 				)
 				if err != nil {
 					return err
@@ -516,8 +519,8 @@ func TestCascadingZoneConfig(t *testing.T) {
 	tb21Cfg.Constraints = []zonepb.ConstraintsConjunction{{Constraints: []zonepb.Constraint{{Value: "db2.tb1"}}}}
 	tb21Cfg.InheritedConstraints = false
 	tb21Cfg.Subzones = []zonepb.Subzone{
-		{PartitionName: "p0", Config: p211Cfg},
-		{PartitionName: "p1", Config: p212Cfg},
+		{IndexID: 1, PartitionName: "p0", Config: p211Cfg},
+		{IndexID: 1, PartitionName: "p1", Config: p212Cfg},
 	}
 	tb21Cfg.SubzoneSpans = []zonepb.SubzoneSpan{
 		{SubzoneIndex: 0, Key: []byte{1}},
@@ -529,8 +532,8 @@ func TestCascadingZoneConfig(t *testing.T) {
 	expectedTb21Cfg := defaultZoneConfig
 	expectedTb21Cfg.Constraints = []zonepb.ConstraintsConjunction{{Constraints: []zonepb.Constraint{{Value: "db2.tb1"}}}}
 	expectedTb21Cfg.Subzones = []zonepb.Subzone{
-		{PartitionName: "p0", Config: p211Cfg},
-		{PartitionName: "p1", Config: p212Cfg},
+		{IndexID: 1, PartitionName: "p0", Config: p211Cfg},
+		{IndexID: 1, PartitionName: "p1", Config: p212Cfg},
 	}
 	expectedTb21Cfg.SubzoneSpans = []zonepb.SubzoneSpan{
 		{SubzoneIndex: 0, Key: []byte{1}},
@@ -549,7 +552,7 @@ func TestCascadingZoneConfig(t *testing.T) {
 	// Subzone Placeholder
 	tb22Cfg := *zonepb.NewZoneConfig()
 	tb22Cfg.NumReplicas = proto.Int32(0)
-	tb22Cfg.Subzones = []zonepb.Subzone{{PartitionName: "p0", Config: p221Cfg}}
+	tb22Cfg.Subzones = []zonepb.Subzone{{IndexID: 1, PartitionName: "p0", Config: p221Cfg}}
 	tb22Cfg.SubzoneSpans = []zonepb.SubzoneSpan{
 		{SubzoneIndex: 0, Key: []byte{1}, EndKey: []byte{255}},
 	}


### PR DESCRIPTION
    sql: use catalog.Mutation where possible
    
    This commit is a refactor which introduces catalog.Mutation wherever
    possible, in an effort to avoid using the descpb.DescriptorMutation
    type directly.
    
    Release note: None


    sql: use catalog.Column and catalog.Index where possible
    
    This commit is a refactor which introduces the catalog.Column and
    catalog.Index interfaces wherever possible. These had recently been
    added in an effort to avoid using the descpb.ColumnDescriptor and
    descpb.IndexDescriptor types directly. This commit generalizes their
    usage throughout the sql packages.
    
    Fixes #63755.
    
    Release note: None

