### PR TITLE
release-20.2: sql: fix version gate for user-defined schemas

### DIFF
--- a/pkg/sql/create_schema.go
+++ b/pkg/sql/create_schema.go
@@ -83,7 +83,10 @@ func (p *planner) createUserDefinedSchema(params runParams, n *tree.CreateSchema
 	}
 
 	// Ensure that the cluster version is high enough to create the schema.
-	if !params.p.ExecCfg().Settings.Version.IsActive(params.ctx, clusterversion.VersionUserDefinedSchemas) {
+	if !params.p.ExecCfg().Settings.Version.IsActive(
+		params.ctx, clusterversion.VersionUserDefinedSchemas,
+	) ||
+		params.p.Descriptors().DatabaseLeasingUnsupported() {
 		return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
 			`creating schemas requires all nodes to be upgraded to %s`,
 			clusterversion.VersionByKey(clusterversion.VersionUserDefinedSchemas))


### PR DESCRIPTION
The cluster version which enables user-defined schemas comes after the
activation of the version which enables leasing database descriptors. However
the usability of leased database descriptors is checked at the beginning of
the transaction to ensure that the use remains stable throughout the life
of the transaction. The use of leased database descriptors is a requirement
to create user-defined schemas. This difference in when the two conditions
are checked leads to a window for a crash whereby we attempt to create a
new-style database due to a `CREATE SCHEMA` statement in a transaction which
does not have those databases enabled.

We fix this by checking both conditions in the `CREATE SCHEMA` execution.

Fixes #58307.

Release note (bug fix): Fixed a rare bug which can cause a crash if CREATE
SCHEMA is run in a transaction which began prior to a cluster version update
which enables that statement.