### PR TITLE
release-21.1: opt: rework opt/bench

### DIFF
--- a/pkg/sql/opt/bench/BUILD.bazel
+++ b/pkg/sql/opt/bench/BUILD.bazel
@@ -31,10 +31,8 @@ go_test(
         "//pkg/sql/parser",
         "//pkg/sql/sem/tree",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/util/log",
         "//pkg/util/randutil",
-        "//pkg/util/timeutil",
     ],
 )

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -13,13 +13,8 @@ package bench
 import (
 	"bytes"
 	"context"
-	gosql "database/sql"
-	"flag"
 	"fmt"
-	"os"
-	"runtime/pprof"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security"
@@ -36,56 +31,87 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
-type BenchmarkType int
+// A query can be issued using the "simple protocol" or the "prepare protocol".
+//
+// With the simple protocol, all arguments are inlined in the SQL string; the
+// query goes through all phases of planning on each execution. Only these
+// phases are valid with the simple protocol:
+//   - Parse
+//   - OptBuildNoNorm
+//   - OptBuildNorm
+//   - Explore
+//   - ExecBuild
+//
+// With the prepare protocol, the query is built at prepare time (with
+// normalization rules turned on) and the resulting memo is saved and reused. On
+// each execution, placeholders are assigned before exploration. Only these
+// phases are valid with the prepare protocol:
+//  - AssignPlaceholdersNoNorm
+//  - AssignPlaceholdersNorm
+//  - Explore
+//  - ExecBuild
+type Phase int
 
 const (
-	// Parse creates the AST.
-	Parse BenchmarkType = iota
+	// Parse creates the AST from the SQL string.
+	Parse Phase = iota
 
-	// OptBuild constructs the Memo from the AST. It runs no normalization or
-	// exploration rules. OptBuild does not include the time to Parse.
-	OptBuild
+	// OptBuildNoNorm constructs the Memo from the AST, with normalization rules
+	// disabled. OptBuildNoNorm includes the time to Parse.
+	OptBuildNoNorm
 
-	// Normalize constructs the Memo from the AST, but enables all normalization
-	// rules, unlike OptBuild. No Explore rules are enabled. Normalize includes
-	// the time to OptBuild.
-	Normalize
+	// OptBuildNorm constructs the Memo from the AST, with normalization rules
+	// enabled. OptBuildNorm includes the time to Parse.
+	OptBuildNorm
 
-	// Explore constructs the Memo from the AST and enables all normalization
+	// AssignPlaceholdersNoNorm uses a prepared Memo and assigns placeholders,
+	// with normalization rules disabled.
+	AssignPlaceholdersNoNorm
+
+	// AssignPlaceholdersNorm uses a prepared Memo and assigns placeholders, with
+	// normalization rules enabled.
+	AssignPlaceholdersNorm
+
+	// Explore constructs the Memo (either by building it from the statement or by
+	// assigning placeholders to a prepared Memo) and enables all normalization
 	// and exploration rules. The Memo is fully optimized. Explore includes the
-	// time to OptBuild and Normalize.
+	// time to OptBuildNorm or AssignPlaceholdersNorm.
 	Explore
 
 	// ExecBuild calls a stub factory to construct a dummy plan from the optimized
 	// Memo. Since the factory is not creating a real plan, only a part of the
-	// execbuild time is captured.
+	// execbuild time is captured. ExecBuild includes the time to Explore.
 	ExecBuild
-
-	// EndToEnd executes the query end-to-end using the cost-based optimizer.
-	EndToEnd
 )
 
-var benchmarkTypeStrings = [...]string{
-	Parse:     "Parse",
-	OptBuild:  "OptBuild",
-	Normalize: "Normalize",
-	Explore:   "Explore",
-	ExecBuild: "ExecBuild",
-	EndToEnd:  "EndToEnd",
+// SimplePhases are the legal phases when running a query that was not prepared.
+var SimplePhases = []Phase{Parse, OptBuildNoNorm, OptBuildNorm, Explore, ExecBuild}
+
+// PreparedPhases are the legal phases when running a query that was prepared.
+var PreparedPhases = []Phase{AssignPlaceholdersNoNorm, AssignPlaceholdersNorm, Explore, ExecBuild}
+
+func (bt Phase) String() string {
+	var strTab = [...]string{
+		Parse:                    "Parse",
+		OptBuildNoNorm:           "OptBuildNoNorm",
+		OptBuildNorm:             "OptBuildNorm",
+		AssignPlaceholdersNoNorm: "AssignPlaceholdersNoNorm",
+		AssignPlaceholdersNorm:   "AssignPlaceholdersNorm",
+		Explore:                  "Explore",
+		ExecBuild:                "ExecBuild",
+	}
+	return strTab[bt]
 }
 
 type benchQuery struct {
-	name    string
-	query   string
-	args    []interface{}
-	prepare bool
+	name  string
+	query string
+	args  []interface{}
 }
 
 var schemas = [...]string{
@@ -183,26 +209,16 @@ var queries = [...]benchQuery{
 	// 2. Table with no indexes.
 	// 3. Very simple query that returns single row based on key filter.
 	{
-		name:    "kv-read",
-		query:   `SELECT k, v FROM kv WHERE k IN ($1)`,
-		args:    []interface{}{1},
-		prepare: true,
-	},
-
-	// 1. No PREPARE phase, only EXECUTE.
-	{
-		name:    "kv-read-no-prep",
-		query:   `SELECT k, v FROM kv WHERE k IN ($1)`,
-		args:    []interface{}{1},
-		prepare: false,
+		name:  "kv-read",
+		query: `SELECT k, v FROM kv WHERE k IN ($1)`,
+		args:  []interface{}{1},
 	},
 
 	// 1. PREPARE with constant filter value (no placeholders).
 	{
-		name:    "kv-read-const",
-		query:   `SELECT k, v FROM kv WHERE k IN (1)`,
-		args:    []interface{}{},
-		prepare: true,
+		name:  "kv-read-const",
+		query: `SELECT k, v FROM kv WHERE k IN (1)`,
+		args:  []interface{}{},
 	},
 
 	// 1. Table with many columns.
@@ -216,8 +232,7 @@ var queries = [...]benchQuery{
 			FROM customer
 			WHERE c_w_id = $1 AND c_d_id = $2 AND c_id = $3
 		`,
-		args:    []interface{}{10, 100, 50},
-		prepare: true,
+		args: []interface{}{10, 100, 50},
 	},
 
 	// 1. ORDER BY clause.
@@ -232,8 +247,7 @@ var queries = [...]benchQuery{
 			ORDER BY no_o_id ASC
 			LIMIT 1
 		`,
-		args:    []interface{}{10, 100},
-		prepare: true,
+		args: []interface{}{10, 100},
 	},
 
 	// 1. Count and Distinct aggregate functions.
@@ -252,8 +266,7 @@ var queries = [...]benchQuery{
 				AND ol_o_id BETWEEN $3 - 20 AND $3 - 1
 				AND s_quantity < $4
 		`,
-		args:    []interface{}{10, 100, 1000, 15},
-		prepare: true,
+		args: []interface{}{10, 100, 1000, 15},
 	},
 }
 
@@ -263,70 +276,38 @@ func init() {
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 }
 
-var profileTime = flag.Duration("profile-time", 10*time.Second, "duration of profiling run")
-var profileType = flag.String("profile-type", "ExecBuild", "Parse, OptBuild, Normalize, Explore, ExecBuild, EndToEnd")
-var profileQuery = flag.String("profile-query", "kv-read", "name of query to run")
-
-// TestCPUProfile executes the configured profileQuery in a loop in order to
-// profile its CPU usage. Rather than allow the Go testing infrastructure to
-// start profiling, TestCPUProfile triggers startup, so that it has control over
-// when profiling starts. In particular, profiling is only started once the
-// server or API has been initialized, so that the profiles don't include
-// startup activities.
-//
-// TestCPUProfile writes the output profile to a cpu.out file in the current
-// directory. See the profile flags for ways to configure what is profiled.
-func TestCPUProfile(t *testing.T) {
-	skip.IgnoreLint(t,
-		"Remove this when profiling. Use profile flags above to configure. Sample command line: \n"+
-			"GOMAXPROCS=1 go test -run TestCPUProfile && go tool pprof cpu.out",
-	)
-
-	h := newHarness()
-	defer h.close()
-
-	var query benchQuery
-	for _, query = range queries {
-		if query.name == *profileQuery {
-			break
-		}
-	}
-
-	var bmType BenchmarkType
-	for i, s := range benchmarkTypeStrings {
-		if s == *profileType {
-			bmType = BenchmarkType(i)
-		}
-	}
-
-	h.runForProfiling(t, bmType, query, *profileTime)
-}
-
 // BenchmarkPhases measures the time that each of the optimization phases takes
-// to run. See the comments for the BenchmarkType enumeration for more details
+// to run. See the comments for the Phase enumeration for more details
 // on what each phase includes.
 func BenchmarkPhases(b *testing.B) {
-	bm := newHarness()
-	defer bm.close()
-
 	for _, query := range queries {
-		bm.runForBenchmark(b, Parse, query)
-		bm.runForBenchmark(b, OptBuild, query)
-		bm.runForBenchmark(b, Normalize, query)
-		bm.runForBenchmark(b, Explore, query)
-		bm.runForBenchmark(b, ExecBuild, query)
-	}
-}
-
-// BenchmarkEndToEnd measures the time to execute a query end-to-end.
-func BenchmarkEndToEnd(b *testing.B) {
-	defer log.Scope(b).Close(b)
-
-	h := newHarness()
-	defer h.close()
-
-	for _, query := range queries {
-		h.runForBenchmark(b, EndToEnd, query)
+		h := newHarness(b, query)
+		b.Run(query.name, func(b *testing.B) {
+			b.Run("Simple", func(b *testing.B) {
+				for _, phase := range SimplePhases {
+					b.Run(phase.String(), func(b *testing.B) {
+						for i := 0; i < b.N; i++ {
+							h.runSimple(b, query, phase)
+						}
+					})
+				}
+			})
+			b.Run("Prepared", func(b *testing.B) {
+				phases := PreparedPhases
+				if !h.prepMemo.HasPlaceholders() {
+					// If the query has no placeholders, the only phase which does
+					// something is ExecBuild.
+					phases = []Phase{ExecBuild}
+				}
+				for _, phase := range phases {
+					b.Run(phase.String(), func(b *testing.B) {
+						for i := 0; i < b.N; i++ {
+							h.runPrepared(b, phase)
+						}
+					})
+				}
+			})
+		})
 	}
 }
 
@@ -335,173 +316,55 @@ type harness struct {
 	semaCtx   tree.SemaContext
 	evalCtx   tree.EvalContext
 	prepMemo  *memo.Memo
-	cat       *testcat.Catalog
+	testCat   *testcat.Catalog
 	optimizer xform.Optimizer
-
-	s  serverutils.TestServerInterface
-	db *gosql.DB
-	sr *sqlutils.SQLRunner
-
-	bmType   BenchmarkType
-	query    benchQuery
-	prepared *gosql.Stmt
-	ready    bool
 }
 
-func newHarness() *harness {
-	return &harness{}
-}
-
-func (h *harness) close() {
-	if h.s != nil {
-		h.s.Stopper().Stop(context.Background())
-	}
-}
-
-func (h *harness) runForProfiling(
-	t *testing.T, bmType BenchmarkType, query benchQuery, duration time.Duration,
-) {
-	h.bmType = bmType
-	h.query = query
-	h.prepare(t)
-
-	f, err := os.Create("cpu.out")
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	defer f.Close()
-
-	err = pprof.StartCPUProfile(f)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	defer pprof.StopCPUProfile()
-
-	start := timeutil.Now()
-	for {
-		now := timeutil.Now()
-		if now.Sub(start) > duration {
-			break
-		}
-
-		// Minimize overhead of getting timings by iterating 1000 times before
-		// checking if done.
-		for i := 0; i < 1000; i++ {
-			switch bmType {
-			case EndToEnd:
-				h.runUsingServer(t)
-
-			default:
-				h.runUsingAPI(t, bmType, query.prepare)
-			}
-		}
-	}
-}
-
-func (h *harness) runForBenchmark(b *testing.B, bmType BenchmarkType, query benchQuery) {
-	h.bmType = bmType
-	h.query = query
-	h.prepare(b)
-
-	b.Run(fmt.Sprintf("%s/%s", query.name, benchmarkTypeStrings[bmType]), func(b *testing.B) {
-		switch bmType {
-		case EndToEnd:
-			for i := 0; i < b.N; i++ {
-				h.runUsingServer(b)
-			}
-
-		default:
-			for i := 0; i < b.N; i++ {
-				h.runUsingAPI(b, bmType, query.prepare)
-			}
-		}
-	})
-}
-
-func (h *harness) prepare(tb testing.TB) {
-	switch h.bmType {
-	case EndToEnd:
-		h.prepareUsingServer(tb)
-
-	default:
-		h.prepareUsingAPI(tb)
-	}
-}
-
-func (h *harness) prepareUsingServer(tb testing.TB) {
-	if !h.ready {
-		// Set up database.
-		h.s, h.db, _ = serverutils.StartServer(tb, base.TestServerArgs{UseDatabase: "bench"})
-		h.sr = sqlutils.MakeSQLRunner(h.db)
-		h.sr.Exec(tb, `CREATE DATABASE bench`)
-		for _, schema := range schemas {
-			h.sr.Exec(tb, schema)
-		}
-		h.ready = true
+func newHarness(tb testing.TB, query benchQuery) *harness {
+	h := &harness{
+		ctx:     context.Background(),
+		semaCtx: tree.MakeSemaContext(),
+		evalCtx: tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings()),
 	}
 
-	if h.query.prepare {
-		var err error
-		h.prepared, err = h.db.Prepare(h.query.query)
-		if err != nil {
-			tb.Fatalf("%v", err)
-		}
-	} else {
-		h.prepared = nil
-	}
-}
-
-func (h *harness) runUsingServer(tb testing.TB) {
-	var err error
-	if h.prepared != nil {
-		_, err = h.prepared.Exec(h.query.args...)
-		if err != nil {
-			tb.Fatalf("%v", err)
-		}
-	} else {
-		h.sr.Exec(tb, h.query.query, h.query.args...)
-	}
-}
-
-func (h *harness) prepareUsingAPI(tb testing.TB) {
-	// Clear any state from previous usage of this harness instance.
-	h.ctx = context.Background()
-	h.semaCtx = tree.MakeSemaContext()
-	h.evalCtx = tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
-	h.prepMemo = nil
-	h.cat = nil
-	h.optimizer = xform.Optimizer{}
-
-	// Set up the catalog.
-	h.cat = testcat.New()
+	// Set up the test catalog.
+	h.testCat = testcat.New()
 	for _, schema := range schemas {
-		_, err := h.cat.ExecuteDDL(schema)
+		_, err := h.testCat.ExecuteDDL(schema)
 		if err != nil {
 			tb.Fatalf("%v", err)
 		}
 	}
 
-	if err := h.semaCtx.Placeholders.Init(len(h.query.args), nil /* typeHints */); err != nil {
+	if err := h.semaCtx.Placeholders.Init(len(query.args), nil /* typeHints */); err != nil {
 		tb.Fatal(err)
 	}
-	if h.query.prepare {
-		// Prepare the query by normalizing it (if it has placeholders) or exploring
-		// it (if it doesn't have placeholders), and cache the resulting memo so that
-		// it can be used during execution.
-		if len(h.query.args) > 0 {
-			h.runUsingAPI(tb, Normalize, false /* usePrepared */)
-		} else {
-			h.runUsingAPI(tb, Explore, false /* usePrepared */)
-		}
-		h.prepMemo = h.optimizer.DetachMemo()
-	} else {
-		// Run optbuilder to infer any placeholder types.
-		h.runUsingAPI(tb, OptBuild, false /* usePrepared */)
+	// Run optbuilder to build the memo for Prepare. Even if we will not be using
+	// the Prepare method, we still want to run the optbuilder to infer any
+	// placeholder types.
+	stmt, err := parser.ParseOne(query.query)
+	if err != nil {
+		tb.Fatalf("%v", err)
+	}
+	h.optimizer.Init(&h.evalCtx, h.testCat)
+	bld := optbuilder.New(h.ctx, &h.semaCtx, &h.evalCtx, h.testCat, h.optimizer.Factory(), stmt.AST)
+	bld.KeepPlaceholders = true
+	if err := bld.Build(); err != nil {
+		tb.Fatalf("%v", err)
 	}
 
+	// If there are no placeholders, we explore during PREPARE.
+	if len(query.args) == 0 {
+		if _, err := h.optimizer.Optimize(); err != nil {
+			tb.Fatalf("%v", err)
+		}
+	}
+	h.prepMemo = h.optimizer.DetachMemo()
+	h.optimizer = xform.Optimizer{}
+
 	// Construct placeholder values.
-	h.semaCtx.Placeholders.Values = make(tree.QueryArguments, len(h.query.args))
-	for i, arg := range h.query.args {
+	h.semaCtx.Placeholders.Values = make(tree.QueryArguments, len(query.args))
+	for i, arg := range query.args {
 		var parg tree.Expr
 		parg, err := parser.ParseExpr(fmt.Sprintf("%v", arg))
 		if err != nil {
@@ -526,52 +389,49 @@ func (h *harness) prepareUsingAPI(tb testing.TB) {
 	}
 	h.evalCtx.Placeholders = &h.semaCtx.Placeholders
 	h.evalCtx.Annotations = &h.semaCtx.Annotations
+	return h
 }
 
-func (h *harness) runUsingAPI(tb testing.TB, bmType BenchmarkType, usePrepared bool) {
-	var stmt parser.Statement
-	var err error
-	if !usePrepared {
-		stmt, err = parser.ParseOne(h.query.query)
-		if err != nil {
-			tb.Fatalf("%v", err)
-		}
+// runSimple simulates running a query through the "simple protocol" (no prepare
+// step). The placeholders are replaced with their values automatically when we
+// build the memo.
+func (h *harness) runSimple(tb testing.TB, query benchQuery, phase Phase) {
+	stmt, err := parser.ParseOne(query.query)
+	if err != nil {
+		tb.Fatalf("%v", err)
 	}
 
-	if bmType == Parse {
+	if phase == Parse {
 		return
 	}
 
-	h.optimizer.Init(&h.evalCtx, h.cat)
-	if bmType == OptBuild {
+	h.optimizer.Init(&h.evalCtx, h.testCat)
+	if phase == OptBuildNoNorm {
 		h.optimizer.DisableOptimizations()
 	}
 
-	if !usePrepared {
-		bld := optbuilder.New(h.ctx, &h.semaCtx, &h.evalCtx, h.cat, h.optimizer.Factory(), stmt.AST)
-		if err = bld.Build(); err != nil {
-			tb.Fatalf("%v", err)
-		}
-	} else if h.prepMemo.HasPlaceholders() {
-		_ = h.optimizer.Factory().AssignPlaceholders(h.prepMemo)
+	bld := optbuilder.New(h.ctx, &h.semaCtx, &h.evalCtx, h.testCat, h.optimizer.Factory(), stmt.AST)
+	// Note that KeepPlaceholders is false and we have placeholder values in the
+	// evalCtx, so the optbuilder will replace all placeholders with their values.
+	if err = bld.Build(); err != nil {
+		tb.Fatalf("%v", err)
 	}
 
-	if bmType == OptBuild || bmType == Normalize {
+	if phase == OptBuildNoNorm || phase == OptBuildNorm {
 		return
 	}
 
-	var execMemo *memo.Memo
-	if usePrepared && !h.prepMemo.HasPlaceholders() {
-		execMemo = h.prepMemo
-	} else {
-		if _, err := h.optimizer.Optimize(); err != nil {
-			panic(err)
-		}
-		execMemo = h.optimizer.Memo()
+	if _, err := h.optimizer.Optimize(); err != nil {
+		panic(err)
+	}
+	execMemo := h.optimizer.Memo()
+
+	if phase == Explore {
+		return
 	}
 
-	if bmType == Explore {
-		return
+	if phase != ExecBuild {
+		tb.Fatalf("invalid phase %s for Simple", phase)
 	}
 
 	root := execMemo.RootExpr()
@@ -579,6 +439,52 @@ func (h *harness) runUsingAPI(tb testing.TB, bmType BenchmarkType, usePrepared b
 		exec.StubFactory{}, execMemo, nil /* catalog */, root, &h.evalCtx, true, /* allowAutoCommit */
 	)
 	if _, err = eb.Build(); err != nil {
+		tb.Fatalf("%v", err)
+	}
+}
+
+// runPrepared simulates running the query after it was prepared.
+func (h *harness) runPrepared(tb testing.TB, phase Phase) {
+	h.optimizer.Init(&h.evalCtx, h.testCat)
+
+	if h.prepMemo.HasPlaceholders() {
+		if phase == AssignPlaceholdersNoNorm {
+			h.optimizer.DisableOptimizations()
+		}
+		err := h.optimizer.Factory().AssignPlaceholders(h.prepMemo)
+		if err != nil {
+			tb.Fatalf("%v", err)
+		}
+	}
+
+	if phase == AssignPlaceholdersNoNorm || phase == AssignPlaceholdersNorm {
+		return
+	}
+
+	var execMemo *memo.Memo
+	if !h.prepMemo.HasPlaceholders() {
+		// No placeholders, we already did the exploration at prepare time.
+		execMemo = h.prepMemo
+	} else {
+		if _, err := h.optimizer.Optimize(); err != nil {
+			tb.Fatalf("%v", err)
+		}
+		execMemo = h.optimizer.Memo()
+	}
+
+	if phase == Explore {
+		return
+	}
+
+	if phase != ExecBuild {
+		tb.Fatalf("invalid phase %s for Prepared", phase)
+	}
+
+	root := execMemo.RootExpr()
+	eb := execbuilder.New(
+		exec.StubFactory{}, execMemo, nil /* catalog */, root, &h.evalCtx, true, /* allowAutoCommit */
+	)
+	if _, err := eb.Build(); err != nil {
 		tb.Fatalf("%v", err)
 	}
 }
@@ -624,13 +530,49 @@ func makeChain(size int) benchQuery {
 //     AND d.x = e.y
 //
 func BenchmarkChain(b *testing.B) {
-	h := newHarness()
-	defer h.close()
-
 	for i := 1; i < 20; i++ {
 		q := makeChain(i)
-		for i := 0; i < b.N; i++ {
-			h.runForBenchmark(b, Explore, q)
-		}
+		h := newHarness(b, q)
+		b.Run(q.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				h.runSimple(b, q, Explore)
+			}
+		})
+	}
+}
+
+// BenchmarkEndToEnd measures the time to execute a query end-to-end (against a
+// test server).
+func BenchmarkEndToEnd(b *testing.B) {
+	defer log.Scope(b).Close(b)
+
+	// Set up database.
+	srv, db, _ := serverutils.StartServer(b, base.TestServerArgs{UseDatabase: "bench"})
+	defer srv.Stopper().Stop(context.Background())
+	sr := sqlutils.MakeSQLRunner(db)
+	sr.Exec(b, `CREATE DATABASE bench`)
+	for _, schema := range schemas {
+		sr.Exec(b, schema)
+	}
+
+	for _, query := range queries {
+		b.Run(query.name, func(b *testing.B) {
+			b.Run("Simple", func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					sr.Exec(b, query.query, query.args...)
+				}
+			})
+			b.Run("Prepared", func(b *testing.B) {
+				prepared, err := db.Prepare(query.query)
+				if err != nil {
+					b.Fatalf("%v", err)
+				}
+				for i := 0; i < b.N; i++ {
+					if _, err = prepared.Exec(query.args...); err != nil {
+						b.Fatalf("%v", err)
+					}
+				}
+			})
+		})
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #63618.

/cc @cockroachdb/release

---
opt: rework opt/bench

This commit reworks opt/bench to make it easier to understand. We run
every query in both "simple" and "prepared" mode, and we are more
explicit about what the phases are. The old phases were problematic in
prepared mode, where Parse wasn't measuring anything and
OptBuild/Normalize was measuring AssignPlaceholders.

The special test to profile queries is removed, since it makes the
code more complicated and it has marginal benefits compared to running
the benchmark with `-cpuprofile`.

Sample results:

```
Phases/kv-read/Simple/Parse                                13.5µs ± 1%
Phases/kv-read/Simple/OptBuildNoNorm                       31.4µs ± 1%
Phases/kv-read/Simple/OptBuildNorm                         35.0µs ± 1%
Phases/kv-read/Simple/Explore                              41.8µs ± 1%
Phases/kv-read/Simple/ExecBuild                            43.2µs ± 1%
Phases/kv-read/Prepared/AssignPlaceholdersNoNorm           7.93µs ± 0%
Phases/kv-read/Prepared/AssignPlaceholdersNorm             7.87µs ± 1%
Phases/kv-read/Prepared/Explore                            12.6µs ± 1%
Phases/kv-read/Prepared/ExecBuild                          13.5µs ± 2%
Phases/kv-read-const/Simple/Parse                          13.6µs ± 1%
Phases/kv-read-const/Simple/OptBuildNoNorm                 31.7µs ± 1%
Phases/kv-read-const/Simple/OptBuildNorm                   35.3µs ± 1%
Phases/kv-read-const/Simple/Explore                        42.4µs ± 1%
Phases/kv-read-const/Simple/ExecBuild                      43.7µs ± 0%
Phases/kv-read-const/Prepared/ExecBuild                     964ns ± 3%
Phases/tpcc-new-order/Simple/Parse                         26.9µs ± 1%
Phases/tpcc-new-order/Simple/OptBuildNoNorm                67.4µs ± 4%
Phases/tpcc-new-order/Simple/OptBuildNorm                  79.7µs ± 2%
Phases/tpcc-new-order/Simple/Explore                        106µs ± 4%
Phases/tpcc-new-order/Simple/ExecBuild                      107µs ± 3%
Phases/tpcc-new-order/Prepared/AssignPlaceholdersNoNorm    15.1µs ± 1%
Phases/tpcc-new-order/Prepared/AssignPlaceholdersNorm      15.1µs ± 1%
Phases/tpcc-new-order/Prepared/Explore                     39.7µs ± 1%
Phases/tpcc-new-order/Prepared/ExecBuild                   41.2µs ± 1%
Phases/tpcc-delivery/Simple/Parse                          22.4µs ± 0%
Phases/tpcc-delivery/Simple/OptBuildNoNorm                 55.0µs ± 1%
Phases/tpcc-delivery/Simple/OptBuildNorm                   67.6µs ± 2%
Phases/tpcc-delivery/Simple/Explore                        86.0µs ± 2%
Phases/tpcc-delivery/Simple/ExecBuild                      87.5µs ± 2%
Phases/tpcc-delivery/Prepared/AssignPlaceholdersNoNorm     13.7µs ± 1%
Phases/tpcc-delivery/Prepared/AssignPlaceholdersNorm       13.9µs ± 1%
Phases/tpcc-delivery/Prepared/Explore                      28.2µs ± 1%
Phases/tpcc-delivery/Prepared/ExecBuild                    29.2µs ± 1%
Phases/tpcc-stock-level/Simple/Parse                       46.6µs ± 1%
Phases/tpcc-stock-level/Simple/OptBuildNoNorm               177µs ± 1%
Phases/tpcc-stock-level/Simple/OptBuildNorm                 309µs ± 3%
Phases/tpcc-stock-level/Simple/Explore                      389µs ± 1%
Phases/tpcc-stock-level/Simple/ExecBuild                    397µs ± 0%
Phases/tpcc-stock-level/Prepared/AssignPlaceholdersNoNorm  59.0µs ± 0%
Phases/tpcc-stock-level/Prepared/AssignPlaceholdersNorm    59.7µs ± 1%
Phases/tpcc-stock-level/Prepared/Explore                    127µs ± 1%
Phases/tpcc-stock-level/Prepared/ExecBuild                  136µs ± 1%
Chain/chain-1                                              16.5µs ± 1%
Chain/chain-2                                              93.9µs ± 2%
Chain/chain-3                                               184µs ± 2%
Chain/chain-4                                               271µs ± 1%
Chain/chain-5                                               370µs ± 1%
Chain/chain-6                                               477µs ± 0%
Chain/chain-7                                               599µs ± 1%
Chain/chain-8                                               723µs ± 0%
Chain/chain-9                                               892µs ± 1%
Chain/chain-10                                             1.05ms ± 1%
Chain/chain-11                                             1.21ms ± 1%
Chain/chain-12                                             1.39ms ± 1%
Chain/chain-13                                             1.58ms ± 1%
Chain/chain-14                                             1.85ms ± 1%
Chain/chain-15                                             2.08ms ± 1%
Chain/chain-16                                             2.33ms ± 1%
Chain/chain-17                                             2.59ms ± 0%
Chain/chain-18                                             2.86ms ± 0%
Chain/chain-19                                             3.15ms ± 2%
EndToEnd/kv-read/Simple                                     226µs ± 1%
EndToEnd/kv-read/Prepared                                   163µs ± 3%
EndToEnd/kv-read-const/Simple                               150µs ± 1%
EndToEnd/kv-read-const/Prepared                             127µs ± 2%
EndToEnd/tpcc-new-order/Simple                              303µs ± 2%
EndToEnd/tpcc-new-order/Prepared                            234µs ± 2%
EndToEnd/tpcc-delivery/Simple                               270µs ± 1%
EndToEnd/tpcc-delivery/Prepared                             201µs ± 2%
EndToEnd/tpcc-stock-level/Simple                            592µs ± 3%
EndToEnd/tpcc-stock-level/Prepared                          481µs ± 2%
FKInsert/SingleRow/None                                     566µs ± 5%
FKInsert/SingleRow/NoFastPath                               743µs ± 4%
FKInsert/SingleRow/FastPath                                 372µs ± 3%
FKInsert/MultiRowSingleParent/None                         1.27ms ± 3%
FKInsert/MultiRowSingleParent/NoFastPath                   1.29ms ± 3%
FKInsert/MultiRowSingleParent/FastPath                      556µs ± 4%
FKInsert/MultiRowMultiParent/None                          1.39ms ± 2%
FKInsert/MultiRowMultiParent/NoFastPath                    1.42ms ± 5%
FKInsert/MultiRowMultiParent/FastPath                       698µs ± 2%
```

Release note: None
