### PR TITLE
release-21.1: sql: fix bad interraction with DROP region rollback and alter to RBR

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -2732,7 +2732,7 @@ func TestBackupRestoreDuringUserDefinedTypeChange(t *testing.T) {
 				ServerArgs: base.TestServerArgs{
 					Knobs: base.TestingKnobs{
 						SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
-							RunBeforeEnumMemberPromotion: func() {
+							RunBeforeEnumMemberPromotion: func() error {
 								mu.Lock()
 								if numTypeChangesStarted < len(tc.queries) {
 									numTypeChangesStarted++
@@ -2744,6 +2744,7 @@ func TestBackupRestoreDuringUserDefinedTypeChange(t *testing.T) {
 								} else {
 									mu.Unlock()
 								}
+								return nil
 							},
 						},
 					},

--- a/pkg/ccl/multiregionccl/region_test.go
+++ b/pkg/ccl/multiregionccl/region_test.go
@@ -117,7 +117,7 @@ func TestConcurrentAddDropRegions(t *testing.T) {
 
 			knobs := base.TestingKnobs{
 				SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
-					RunBeforeEnumMemberPromotion: func() {
+					RunBeforeEnumMemberPromotion: func() error {
 						mu.Lock()
 						if firstOp {
 							firstOp = false
@@ -129,6 +129,7 @@ func TestConcurrentAddDropRegions(t *testing.T) {
 						} else {
 							mu.Unlock()
 						}
+						return nil
 					},
 				},
 			}
@@ -200,6 +201,152 @@ CREATE TABLE db.rbr () LOCALITY REGIONAL BY ROW`)
 	}
 }
 
+// TestRegionAddDropEnclosingRegionalByRowAlters tests adding/dropping regions
+// (expected to fail) with a concurrent alter to a regional by row table. The
+// sketch of the test is as follows:
+// - Client 1 performs an ALTER ADD / DROP REGION. Let the user txn commit.
+// - Block in the type schema changer.
+// - Client 2 alters a REGIONAL / GLOBAL table to a REGIONAL BY ROW table. Let
+// this operation finish.
+// - Force a rollback on the REGION ADD / DROP by injecting an error.
+// - Ensure the partitions on the REGIONAL BY ROW table are sane.
+func TestRegionAddDropFailureEnclosingRegionalByRowAlters(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderRace(t, "times out under race")
+
+	// Decrease the adopt loop interval so that retries happen quickly.
+	defer sqltestutils.SetTestJobsAdoptInterval()()
+
+	regionAlterCmds := []struct {
+		name string
+		cmd  string
+	}{
+		{
+			name: "drop-region",
+			cmd:  `ALTER DATABASE db DROP REGION "us-east3"`,
+		},
+		{
+			name: "add-region",
+			cmd:  `ALTER DATABASE db ADD REGION "us-east4"`,
+		},
+	}
+
+	testCases := []struct {
+		name  string
+		setup string
+	}{
+		{
+			name:  "alter-from-global",
+			setup: `CREATE TABLE db.t () LOCALITY GLOBAL`,
+		},
+		{
+			name:  "alter-from-explicit-regional",
+			setup: `CREATE TABLE db.t () LOCALITY REGIONAL IN "us-east2"`,
+		},
+		{
+			name:  "alter-from-regional",
+			setup: `CREATE TABLE db.t () LOCALITY REGIONAL IN PRIMARY REGION`,
+		},
+		{
+			name:  "alter-from-rbr",
+			setup: `CREATE TABLE db.t (reg db.crdb_internal_region) LOCALITY REGIONAL BY ROW AS reg`,
+		},
+	}
+
+	var mu syncutil.Mutex
+	typeChangeStarted := make(chan struct{}, 1)
+	typeChangeFinished := make(chan struct{}, 1)
+	rbrOpFinished := make(chan struct{}, 1)
+
+	knobs := base.TestingKnobs{
+		SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
+			RunBeforeEnumMemberPromotion: func() error {
+				mu.Lock()
+				defer mu.Unlock()
+				typeChangeStarted <- struct{}{}
+				<-rbrOpFinished
+				// Trigger a roll-back.
+				return errors.New("boom")
+			},
+		},
+	}
+
+	_, sqlDB, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
+		t, 4 /* numServers */, knobs, nil, /* baseDir */
+	)
+	defer cleanup()
+
+	for _, tc := range testCases {
+		for _, regionAlterCmd := range regionAlterCmds {
+			t.Run(regionAlterCmd.name+tc.name, func(t *testing.T) {
+
+				_, err := sqlDB.Exec(`
+DROP DATABASE IF EXISTS db;
+CREATE DATABASE db WITH PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3";
+`)
+				require.NoError(t, err)
+
+				_, err = sqlDB.Exec(tc.setup)
+				require.NoError(t, err)
+
+				go func() {
+					_, err := sqlDB.Exec(regionAlterCmd.cmd)
+					if !testutils.IsError(err, "boom") {
+						t.Errorf("expected error boom, found %v", err)
+					}
+					typeChangeFinished <- struct{}{}
+				}()
+
+				<-typeChangeStarted
+
+				_, err = sqlDB.Exec(`BEGIN; SET TRANSACTION PRIORITY HIGH; ALTER TABLE db.t SET LOCALITY REGIONAL BY ROW; COMMIT;`)
+				rbrOpFinished <- struct{}{}
+				require.NoError(t, err)
+
+				testutils.SucceedsSoon(t, func() error {
+					rows, err := sqlDB.Query("SELECT partition_name FROM [SHOW PARTITIONS FROM TABLE db.t] ORDER BY partition_name")
+					if err != nil {
+						return err
+					}
+					defer rows.Close()
+
+					var partitionNames []string
+					for rows.Next() {
+						var partitionName string
+						if err := rows.Scan(&partitionName); err != nil {
+							return err
+						}
+
+						partitionNames = append(partitionNames, partitionName)
+					}
+
+					expectedPartitions := []string{"us-east1", "us-east2", "us-east3"}
+					if len(partitionNames) != len(expectedPartitions) {
+						return errors.AssertionFailedf(
+							"unexpected number of partitions; expected %d, found %d",
+							len(expectedPartitions),
+							len(partitionNames),
+						)
+					}
+					for i := range expectedPartitions {
+						if expectedPartitions[i] != partitionNames[i] {
+							return errors.AssertionFailedf(
+								"unexpected partitions; expected %v, found %v",
+								expectedPartitions,
+								partitionNames,
+							)
+						}
+					}
+					return nil
+				})
+				<-typeChangeFinished
+			})
+		}
+	}
+}
+
 func TestSettingPrimaryRegionAmidstDrop(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -210,7 +357,7 @@ func TestSettingPrimaryRegionAmidstDrop(t *testing.T) {
 	dropRegionFinished := make(chan struct{})
 	knobs := base.TestingKnobs{
 		SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
-			RunBeforeEnumMemberPromotion: func() {
+			RunBeforeEnumMemberPromotion: func() error {
 				mu.Lock()
 				defer mu.Unlock()
 				if dropRegionStarted != nil {
@@ -218,6 +365,7 @@ func TestSettingPrimaryRegionAmidstDrop(t *testing.T) {
 					<-waitForPrimaryRegionSwitch
 					dropRegionStarted = nil
 				}
+				return nil
 			},
 		},
 	}

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -54,6 +54,7 @@ go_library(
         "create_view.go",
         "data_source.go",
         "database.go",
+        "database_region_change_finalizer.go",
         "deallocate.go",
         "delayed.go",
         "delete.go",

--- a/pkg/sql/database_region_change_finalizer.go
+++ b/pkg/sql/database_region_change_finalizer.go
@@ -1,0 +1,239 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+)
+
+// databaseRegionChangeFinalizer encapsulates the logic and state for finalizing
+// a region metadata operation on a multi-region database. This includes methods
+// to update partitions and zone configurations as well as leases on REGIONAL BY
+// ROW tables.
+type databaseRegionChangeFinalizer struct {
+	dbID                descpb.ID
+	typeID              descpb.ID
+	regionalByRowTables []descpb.ID
+}
+
+// newDatabaseRegionChangeFinalizer returns a databaseRegionChangeFinalizer.
+func newDatabaseRegionChangeFinalizer(
+	dbID descpb.ID, typeID descpb.ID,
+) *databaseRegionChangeFinalizer {
+	return &databaseRegionChangeFinalizer{
+		dbID:   dbID,
+		typeID: typeID,
+	}
+}
+
+// finalize updates the zone configurations of the database and all enclosed
+// REGIONAL BY ROW tables once the region promotion/demotion is complete. The
+// caller must call waitToUpdateLeases once the provided transaction commits.
+func (r *databaseRegionChangeFinalizer) finalize(
+	ctx context.Context, txn *kv.Txn, descsCol *descs.Collection, execCfg *ExecutorConfig,
+) error {
+	if err := r.updateDatabaseZoneConfig(ctx, txn, descsCol, execCfg); err != nil {
+		return err
+	}
+	return r.repartitionRegionalByRowTables(ctx, txn, descsCol, execCfg)
+}
+
+// updateDatabaseZoneConfig updates the zone config of the database that
+// encloses the multi-region enum such that there is an entry for all PUBLIC
+// region values.
+func (r *databaseRegionChangeFinalizer) updateDatabaseZoneConfig(
+	ctx context.Context, txn *kv.Txn, descsCol *descs.Collection, execCfg *ExecutorConfig,
+) error {
+
+	regionConfig, err := SynthesizeRegionConfig(ctx, txn, r.dbID, descsCol)
+	if err != nil {
+		return err
+	}
+	return ApplyZoneConfigFromDatabaseRegionConfig(
+		ctx,
+		r.dbID,
+		regionConfig,
+		txn,
+		execCfg,
+	)
+}
+
+// repartitionRegionalByRowTables re-partitions all REGIONAL BY ROW tables
+// contained in the database. repartitionRegionalByRowTables adds a partition
+// and corresponding zone configuration for all PUBLIC enum members (regions)
+// on the multi-region enum.
+func (r *databaseRegionChangeFinalizer) repartitionRegionalByRowTables(
+	ctx context.Context, txn *kv.Txn, descsCol *descs.Collection, execCfg *ExecutorConfig,
+) error {
+	var repartitionedTableIDs []descpb.ID
+
+	p, cleanup := NewInternalPlanner(
+		"repartition-regional-by-row-tables",
+		txn,
+		security.RootUserName(),
+		&MemoryMetrics{},
+		execCfg,
+		sessiondatapb.SessionData{},
+		WithDescCollection(descsCol),
+	)
+	defer cleanup()
+	localPlanner := p.(*planner)
+
+	_, dbDesc, err := descsCol.GetImmutableDatabaseByID(
+		ctx, txn, r.dbID, tree.DatabaseLookupFlags{
+			Required: true,
+		})
+	if err != nil {
+		return err
+	}
+
+	b := txn.NewBatch()
+	regionConfig, err := SynthesizeRegionConfig(ctx, txn, r.dbID, descsCol)
+	if err != nil {
+		return err
+	}
+
+	err = localPlanner.forEachMutableTableInDatabase(ctx, dbDesc,
+		func(ctx context.Context, tableDesc *tabledesc.Mutable) error {
+			if !tableDesc.IsLocalityRegionalByRow() || tableDesc.Dropped() {
+				// We only need to re-partition REGIONAL BY ROW tables. Even then, we
+				// don't need to (can't) repartition a REGIONAL BY ROW table if it has
+				// been dropped.
+				return nil
+			}
+
+			colName, err := tableDesc.GetRegionalByRowTableRegionColumnName()
+			if err != nil {
+				return err
+			}
+			partitionAllBy := partitionByForRegionalByRow(regionConfig, colName)
+
+			// oldPartitioningDescs saves the old partitioning descriptors for each
+			// index that is repartitioned. This is later used to remove zone
+			// configurations from any partitions that are removed.
+			oldPartitioningDescs := make(map[descpb.IndexID]descpb.PartitioningDescriptor)
+
+			// Update the partitioning on all indexes of the table that aren't being
+			// dropped.
+			for _, index := range tableDesc.NonDropIndexes() {
+				newIdx, err := CreatePartitioning(
+					ctx,
+					localPlanner.extendedEvalCtx.Settings,
+					localPlanner.EvalContext(),
+					tableDesc,
+					*index.IndexDesc(),
+					partitionAllBy,
+					nil,  /* allowedNewColumnName*/
+					true, /* allowImplicitPartitioning */
+				)
+				if err != nil {
+					return err
+				}
+
+				oldPartitioningDescs[index.GetID()] = index.IndexDesc().Partitioning
+
+				// Update the index descriptor proto's partitioning.
+				index.IndexDesc().Partitioning = newIdx.Partitioning
+			}
+
+			// Remove zone configurations that applied to partitions that were removed
+			// in the previous step. This requires all indexes to have been
+			// repartitioned such that there is no partitioning on the removed enum
+			// value. This is because `deleteRemovedPartitionZoneConfigs` generates
+			// subzone spans for the entire table (all indexes) downstream for each
+			// index. Spans can only be generated if partitioning values are present on
+			// the type descriptor (removed enum values obviously aren't), so we must
+			// remove the partition from all indexes before trying to delete zone
+			// configurations.
+			for _, index := range tableDesc.NonDropIndexes() {
+				oldPartitioning := oldPartitioningDescs[index.GetID()]
+
+				// Remove zone configurations that reference partition values we removed
+				// in the previous step.
+				if err = deleteRemovedPartitionZoneConfigs(
+					ctx,
+					txn,
+					tableDesc,
+					index.IndexDesc(),
+					&oldPartitioning,
+					&index.IndexDesc().Partitioning,
+					execCfg,
+				); err != nil {
+					return err
+				}
+			}
+
+			// Update the zone configurations now that the partition's been added.
+			if err := ApplyZoneConfigForMultiRegionTable(
+				ctx,
+				txn,
+				localPlanner.ExecCfg(),
+				regionConfig,
+				tableDesc,
+				ApplyZoneConfigForMultiRegionTableOptionTableAndIndexes,
+			); err != nil {
+				return err
+			}
+
+			if err := localPlanner.Descriptors().WriteDescToBatch(ctx, false /* kvTrace */, tableDesc, b); err != nil {
+				return err
+			}
+
+			repartitionedTableIDs = append(repartitionedTableIDs, tableDesc.GetID())
+			return nil
+		})
+	if err != nil {
+		return err
+	}
+
+	if err := txn.Run(ctx, b); err != nil {
+		return err
+	}
+
+	r.regionalByRowTables = repartitionedTableIDs
+
+	return nil
+}
+
+// waitToUpdateLeases ensures that the entire cluster has been updated to the
+// latest descriptor version for all regional by row tables that were previously
+// repartitioned.
+func (r *databaseRegionChangeFinalizer) waitToUpdateLeases(
+	ctx context.Context, leaseMgr *lease.Manager,
+) error {
+	for _, tbID := range r.regionalByRowTables {
+		if err := WaitToUpdateLeases(ctx, leaseMgr, tbID); err != nil {
+			if !errors.Is(err, catalog.ErrDescriptorNotFound) {
+				return err
+			}
+			// Swallow.
+			log.Infof(ctx,
+				"could not find table %d to be repartitioned when adding/removing regions on "+
+					"enum %d, assuming it was dropped and moving on",
+				tbID,
+				r.typeID,
+			)
+		}
+	}
+	return nil
+}

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -188,7 +188,7 @@ type TypeSchemaChangerTestingKnobs struct {
 	RunBeforeExec func() error
 	// RunBeforeEnumMemberPromotion runs before enum members are promoted from
 	// readable to all permissions in the typeSchemaChanger.
-	RunBeforeEnumMemberPromotion func()
+	RunBeforeEnumMemberPromotion func() error
 	// RunAfterOnFailOrCancel runs after OnFailOrCancel completes, if
 	// OnFailOrCancel is triggered.
 	RunAfterOnFailOrCancel func() error
@@ -278,7 +278,9 @@ func (t *typeSchemaChanger) exec(ctx context.Context) error {
 		typeDesc.Kind == descpb.TypeDescriptor_MULTIREGION_ENUM) &&
 		len(t.transitioningMembers) != 0 {
 		if fn := t.execCfg.TypeSchemaChangerTestingKnobs.RunBeforeEnumMemberPromotion; fn != nil {
-			fn()
+			if err := fn(); err != nil {
+				return err
+			}
 		}
 
 		// First, we check if any of the enum values that are being removed are in
@@ -440,13 +442,13 @@ func applyFilterOnEnumMembers(
 // 2. If an enum value was being removed as part of this txn, we promote
 // it back to writable.
 func (t *typeSchemaChanger) cleanupEnumValues(ctx context.Context) error {
+	var regionChangeFinalizer *databaseRegionChangeFinalizer
 	// Cleanup:
 	cleanup := func(ctx context.Context, txn *kv.Txn, descsCol *descs.Collection) error {
 		typeDesc, err := descsCol.GetMutableTypeVersionByID(ctx, txn, t.typeID)
 		if err != nil {
 			return err
 		}
-		b := txn.NewBatch()
 		// No cleanup required.
 		if !enumHasNonPublic(&typeDesc.Immutable) {
 			return nil
@@ -467,12 +469,19 @@ func (t *typeSchemaChanger) cleanupEnumValues(ctx context.Context) error {
 			return t.isTransitioningInCurrentJob(member) && enumMemberIsAdding(member)
 		})
 
-		if err := descsCol.WriteDescToBatch(
-			ctx, true /* kvTrace */, typeDesc, b,
-		); err != nil {
+		if err := descsCol.WriteDesc(ctx, true /* kvTrace */, typeDesc, txn); err != nil {
 			return err
 		}
-		return txn.Run(ctx, b)
+
+		if typeDesc.Kind == descpb.TypeDescriptor_MULTIREGION_ENUM {
+			regionChangeFinalizer = newDatabaseRegionChangeFinalizer(typeDesc.GetParentID(), typeDesc.GetID())
+
+			if err := regionChangeFinalizer.finalize(ctx, txn, descsCol, t.execCfg); err != nil {
+				return err
+			}
+		}
+
+		return nil
 	}
 	if err := descs.Txn(ctx, t.execCfg.Settings, t.execCfg.LeaseManager, t.execCfg.InternalExecutor,
 		t.execCfg.DB, cleanup); err != nil {
@@ -486,6 +495,13 @@ func (t *typeSchemaChanger) cleanupEnumValues(ctx context.Context) error {
 		}
 		return err
 	}
+
+	if regionChangeFinalizer != nil {
+		if err := regionChangeFinalizer.waitToUpdateLeases(ctx, t.execCfg.LeaseManager); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -29,14 +29,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/multiregion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
-	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/errors"
@@ -307,10 +305,7 @@ func (t *typeSchemaChanger) exec(ctx context.Context) error {
 			return err
 		}
 
-		// A list of multi-region tables that were repartitioned as a result of
-		// promotion/demotion of enum values. This is used to track tables whose
-		// leases need to be invalidated.
-		var repartitionedTables []descpb.ID
+		var regionChangeFinalizer *databaseRegionChangeFinalizer
 
 		// Now that we've ascertained that the enum values can be removed, we can
 		// actually go about modifying the type descriptor.
@@ -362,21 +357,11 @@ func (t *typeSchemaChanger) exec(ctx context.Context) error {
 			// REGIONAL BY ROW tables must be updated to reflect the new region values
 			// available.
 			if typeDesc.Kind == descpb.TypeDescriptor_MULTIREGION_ENUM {
-				immut, err := descsCol.GetImmutableTypeByID(ctx, txn, t.typeID, tree.ObjectLookupFlags{})
-				if err != nil {
-					return err
-				}
 				if fn := t.execCfg.TypeSchemaChangerTestingKnobs.RunBeforeMultiRegionUpdates; fn != nil {
 					return fn()
 				}
-				repartitionedTables, err = performMultiRegionFinalization(
-					ctx,
-					immut,
-					txn,
-					t.execCfg,
-					descsCol,
-				)
-				if err != nil {
+				regionChangeFinalizer = newDatabaseRegionChangeFinalizer(typeDesc.GetParentID(), typeDesc.GetID())
+				if err := regionChangeFinalizer.finalize(ctx, txn, descsCol, t.execCfg); err != nil {
 					return err
 				}
 			}
@@ -392,17 +377,8 @@ func (t *typeSchemaChanger) exec(ctx context.Context) error {
 
 		// If any tables were repartitioned, make sure their leases are updated as
 		// well.
-		for _, tbID := range repartitionedTables {
-			if err := WaitToUpdateLeases(ctx, leaseMgr, tbID); err != nil {
-				if errors.Is(err, catalog.ErrDescriptorNotFound) {
-					// Swallow.
-					log.Infof(ctx,
-						"could not find table %d to be repartitioned when adding/removing regions on "+
-							"enum %d, assuming it was dropped and moving on",
-						tbID,
-						t.typeID,
-					)
-				}
+		if regionChangeFinalizer != nil {
+			if err := regionChangeFinalizer.waitToUpdateLeases(ctx, leaseMgr); err != nil {
 				return err
 			}
 		}
@@ -424,178 +400,6 @@ func (t *typeSchemaChanger) exec(ctx context.Context) error {
 		}
 	}
 	return nil
-}
-
-// performMultiRegionFinalization updates the zone configurations on the
-// database and re-partitions all REGIONAL BY ROW tables after REGION ADD/DROP
-// has completed. A list of re-partitioned tables, if any, is returned.
-func performMultiRegionFinalization(
-	ctx context.Context,
-	typeDesc *typedesc.Immutable,
-	txn *kv.Txn,
-	execCfg *ExecutorConfig,
-	descsCol *descs.Collection,
-) ([]descpb.ID, error) {
-	regionConfig, err := SynthesizeRegionConfig(ctx, txn, typeDesc.ParentID, descsCol)
-	if err != nil {
-		return nil, err
-	}
-	// Once the region promotion/demotion is complete, we update the
-	// zone configuration on the database.
-	if err := ApplyZoneConfigFromDatabaseRegionConfig(
-		ctx,
-		typeDesc.ParentID,
-		regionConfig,
-		txn,
-		execCfg,
-	); err != nil {
-		return nil, err
-	}
-
-	return repartitionRegionalByRowTables(ctx, typeDesc, txn, execCfg, descsCol, regionConfig)
-}
-
-// repartitionRegionalByRowTables takes a multi-region enum and re-partitions
-// all REGIONAL BY ROW tables in the enclosing database such that there is a
-// partition and corresponding zone configuration for all PUBLIC enum members
-// (regions).
-func repartitionRegionalByRowTables(
-	ctx context.Context,
-	typeDesc *typedesc.Immutable,
-	txn *kv.Txn,
-	execCfg *ExecutorConfig,
-	descsCol *descs.Collection,
-	regionConfig multiregion.RegionConfig,
-) ([]descpb.ID, error) {
-	var repartitionedTableIDs []descpb.ID
-	if typeDesc.GetKind() != descpb.TypeDescriptor_MULTIREGION_ENUM {
-		return repartitionedTableIDs, errors.AssertionFailedf(
-			"expected multi-region enum, but found type descriptor of kind: %v", typeDesc.GetKind(),
-		)
-	}
-	p, cleanup := NewInternalPlanner(
-		"repartition-regional-by-row-tables",
-		txn,
-		security.RootUserName(),
-		&MemoryMetrics{},
-		execCfg,
-		sessiondatapb.SessionData{},
-		WithDescCollection(descsCol),
-	)
-	defer cleanup()
-	localPlanner := p.(*planner)
-
-	_, dbDesc, err := descsCol.GetImmutableDatabaseByID(
-		ctx, txn, typeDesc.ParentID, tree.DatabaseLookupFlags{
-			Required: true,
-		})
-	if err != nil {
-		return nil, err
-	}
-
-	b := txn.NewBatch()
-	err = localPlanner.forEachMutableTableInDatabase(ctx, dbDesc,
-		func(ctx context.Context, tableDesc *tabledesc.Mutable) error {
-			if !tableDesc.IsLocalityRegionalByRow() || tableDesc.Dropped() {
-				// We only need to re-partition REGIONAL BY ROW tables. Even then, we
-				// don't need to (can't) repartition a REGIONAL BY ROW table if it has
-				// been dropped.
-				return nil
-			}
-
-			colName, err := tableDesc.GetRegionalByRowTableRegionColumnName()
-			if err != nil {
-				return err
-			}
-			partitionAllBy := partitionByForRegionalByRow(regionConfig, colName)
-
-			// oldPartitioningDescs saves the old partitioning descriptors for each
-			// index that is repartitioned. This is later used to remove zone
-			// configurations from any partitions that are removed.
-			oldPartitioningDescs := make(map[descpb.IndexID]descpb.PartitioningDescriptor)
-
-			// Update the partitioning on all indexes of the table that aren't being
-			// dropped.
-			for _, index := range tableDesc.NonDropIndexes() {
-				newIdx, err := CreatePartitioning(
-					ctx,
-					localPlanner.extendedEvalCtx.Settings,
-					localPlanner.EvalContext(),
-					tableDesc,
-					*index.IndexDesc(),
-					partitionAllBy,
-					nil,  /* allowedNewColumnName*/
-					true, /* allowImplicitPartitioning */
-				)
-				if err != nil {
-					return err
-				}
-
-				oldPartitioningDescs[index.GetID()] = index.IndexDesc().Partitioning
-
-				// Update the index descriptor proto's partitioning.
-				index.IndexDesc().Partitioning = newIdx.Partitioning
-			}
-
-			// Remove zone configurations that applied to partitions that were removed
-			// in the previous step. This requires all indexes to have been
-			// repartitioned such that there is no partitioning on the removed enum
-			// value. This is because `deleteRemovedPartitionZoneConfigs` generates
-			// subzone spans for the entire table (all indexes) downstream for each
-			// index. Spans can only be generated if partitioning values are present on
-			// the type descriptor (removed enum values obviously aren't), so we must
-			// remove the partition from all indexes before trying to delete zone
-			// configurations.
-			for _, index := range tableDesc.NonDropIndexes() {
-				oldPartitioning := oldPartitioningDescs[index.GetID()]
-
-				// Remove zone configurations that reference partition values we removed
-				// in the previous step.
-				if err = deleteRemovedPartitionZoneConfigs(
-					ctx,
-					txn,
-					tableDesc,
-					index.IndexDesc(),
-					&oldPartitioning,
-					&index.IndexDesc().Partitioning,
-					execCfg,
-				); err != nil {
-					return err
-				}
-			}
-
-			// Update the zone configurations now that the partition's been added.
-			regionConfig, err := SynthesizeRegionConfig(ctx, txn, typeDesc.ParentID, descsCol)
-			if err != nil {
-				return err
-			}
-			if err := ApplyZoneConfigForMultiRegionTable(
-				ctx,
-				txn,
-				localPlanner.ExecCfg(),
-				regionConfig,
-				tableDesc,
-				ApplyZoneConfigForMultiRegionTableOptionTableAndIndexes,
-			); err != nil {
-				return err
-			}
-
-			if err := localPlanner.Descriptors().WriteDescToBatch(ctx, false /* kvTrace */, tableDesc, b); err != nil {
-				return err
-			}
-
-			repartitionedTableIDs = append(repartitionedTableIDs, tableDesc.GetID())
-			return nil
-		})
-	if err != nil {
-		return nil, err
-	}
-
-	if err := txn.Run(ctx, b); err != nil {
-		return nil, err
-	}
-
-	return repartitionedTableIDs, nil
 }
 
 // isTransitioningInCurrentJob returns true if the given member is either being

--- a/pkg/sql/type_change_test.go
+++ b/pkg/sql/type_change_test.go
@@ -528,9 +528,10 @@ func TestTypeChangeJobCancelSemantics(t *testing.T) {
 			finishedSchemaChange.Add(1)
 
 			params.Knobs.SQLTypeSchemaChanger = &sql.TypeSchemaChangerTestingKnobs{
-				RunBeforeEnumMemberPromotion: func() {
+				RunBeforeEnumMemberPromotion: func() error {
 					typeSchemaChangeStarted.Done()
 					blockTypeSchemaChange.Wait()
+					return nil
 				},
 			}
 


### PR DESCRIPTION
Backport 2/2 commits from #63525.

/cc @cockroachdb/release

---

See individual commits for details. 
