### PR TITLE
release-21.1: geomfn: fix st_simplify with NaN

### DIFF
--- a/pkg/geo/geomfn/topology_operations.go
+++ b/pkg/geo/geomfn/topology_operations.go
@@ -11,7 +11,10 @@
 package geomfn
 
 import (
+	"math"
+
 	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/geo/geos"
 )
 
@@ -96,6 +99,9 @@ func Difference(a, b geo.Geometry) (geo.Geometry, error) {
 
 // Simplify returns a simplified Geometry.
 func Simplify(g geo.Geometry, tolerance float64) (geo.Geometry, error) {
+	if math.IsNaN(tolerance) || g.ShapeType2D() == geopb.ShapeType_Point || g.ShapeType2D() == geopb.ShapeType_MultiPoint {
+		return g, nil
+	}
 	simplifiedEWKB, err := geos.Simplify(g.EWKB(), tolerance)
 	if err != nil {
 		return geo.Geometry{}, err

--- a/pkg/geo/geomfn/topology_operations_test.go
+++ b/pkg/geo/geomfn/topology_operations_test.go
@@ -216,6 +216,21 @@ func TestSimplify(t *testing.T) {
 			tolerance: 3,
 			expected:  "POLYGON ((5 7, 16 11, 18 7, 2 5, 5 7))",
 		},
+		{
+			wkt:       "POLYGON ((5 7, 2 5, 5 4, 13 4, 18 7, 16 11, 7 9, 11 7, 5 7), (13 8, 13 6, 14 6, 15 9, 13 8))",
+			tolerance: math.NaN(),
+			expected:  "POLYGON ((5 7, 2 5, 5 4, 13 4, 18 7, 16 11, 7 9, 11 7, 5 7), (13 8, 13 6, 14 6, 15 9, 13 8))",
+		},
+		{
+			wkt:       "MULTIPOINT (1 1, 1 1)",
+			tolerance: 2,
+			expected:  "MULTIPOINT (1 1, 1 1)",
+		},
+		{
+			wkt:       "POINT (1 1)",
+			tolerance: 2,
+			expected:  "POINT (1 1)",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Backport 1/1 commits from #63760.

/cc @cockroachdb/release

---

Release note (SQL Change): Earlier st_simplify with NaN caused node to crash.
This fixes the behaviour to align it more to PostGIS.

Fixes: #63620 
