### PR TITLE
kv: properly handle intent pushes to synthetic timestamps

### DIFF
--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
@@ -124,6 +124,73 @@ reset namespace
 ----
 
 # -------------------------------------------------------------
+# Same situation as above, only here, the read-only transaction
+# has a timestamp that is synthetic, meaning that if it succeeds
+# in pushing the intent, the intent will be left with a
+# synthetic timestamp. Even though the transaction's uncertainty
+# interval extends past present time, the transaction pushes all
+# the way to its uncertainty limit and marks the pushTo
+# timestamp as "synthetic". See lockTableWaiterImpl.pushHeader.
+# -------------------------------------------------------------
+
+debug-set-clock ts=135
+----
+
+new-txn name=txn1 ts=100,1 epoch=0
+----
+
+new-txn name=txn2 ts=120,1? epoch=0 uncertainty-limit=150,1
+----
+
+new-request name=req1 txn=txn2 ts=120,1?
+  get key=k
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+handle-write-intent-error req=req1 lease-seq=1
+  intent txn=txn1 key=k
+----
+[2] handle write intent error req1: handled conflicting intents on "k", released latches
+
+debug-lock-table
+----
+global: num=1
+ lock: "k"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 100.000000000,1, info: repl epoch: 0, seqs: [0]
+local: num=0
+
+sequence req=req1
+----
+[3] sequence req1: re-sequencing request
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: waiting in lock wait-queues
+[3] sequence req1: pushing timestamp of txn 00000001 above 150.000000000,1?
+[3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+on-txn-updated txn=txn1 status=pending ts=150,2?
+----
+[-] update txn: increasing timestamp of txn1
+[3] sequence req1: resolving intent "k" for txn 00000001 with PENDING status
+[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.23s
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: sequencing complete, returned guard
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+reset namespace
+----
+
+# -------------------------------------------------------------
 # A transactional (txn2) read-only request runs into a replicated
 # intent below its read timestamp and informs the lock table.
 #

--- a/pkg/sql/opt/props/func_dep.go
+++ b/pkg/sql/opt/props/func_dep.go
@@ -324,7 +324,7 @@ import (
 // to have redundant columns that can be functionally determined from other
 // columns in the key. Of more value is the set of "candidate keys", which are
 // keys that contain no redundant columns. Removing any column from such a key
-// causes it to longer be a key. It is possible to enumerate the set of
+// causes it to no longer be a key. It is possible to enumerate the set of
 // candidate keys in polynomial rather than exponential time (see Wikipedia
 // "Candidate key" entry).
 //


### PR DESCRIPTION
This commit reworks the timestamp that pushers use when pushing intents
to synthetic timestamps. Usually, as of #59086, a pusher limits the
timestamp that it pushes conflicting intents to using the local HLC
clock. This is based on the assumption that it will be able to ignore
any intent above the local HLC clock's reading using observed timestamps
and a local uncertainty limit.

However, this argument only holds if we expect to be able to use a local
uncertainty limit when we return to read the pushed intent. Notably,
local uncertainty limits can not be used to ignore intents with
synthetic timestamps that would otherwise be in a reader's uncertainty
interval. This is because observed timestamps do not apply to
intents/values with synthetic timestamps. So if we know that we will be
pushing an intent to a synthetic timestamp, we don't limit the value to
a clock reading from the local clock.

This came out of some exploration of kvnemesis. I don't think this was
actually causing an issue, but it seemed like a potential source of an
infinite push + conflict loop.

Release note (bug fix): Read-write contention on GLOBAL tables no longer
has a potential to thrash without making progress.