### PR TITLE
colbuilder: optimize IS DISTINCT FROM NULL when null is casted

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vectorize_local
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_local
@@ -347,3 +347,27 @@ EXPLAIN (VEC) SELECT concat_agg(_bytes), concat_agg(_string) FROM bytes_string
   └ *colexec.orderedAggregator
     └ *colexecbase.distinctChainOps
       └ *colfetcher.ColBatchScan
+
+statement ok
+CREATE TABLE t63792 (c INT);
+INSERT INTO t63792 VALUES (NULL), (1), (2)
+
+# Check that casts of constants are pre-evaluated (which allows us to use
+# colexec.isNullProjOp instead of colexecproj.defaultCmpProjOp).
+query T
+EXPLAIN (VEC) SELECT c = c FROM t63792
+----
+│
+└ Node 1
+  └ *colexec.orProjOp
+    ├ *colfetcher.ColBatchScan
+    ├ *colexec.isNullProjOp
+    └ *colexecbase.castOpNullAny
+      └ *colexecbase.constNullOp
+
+query IB rowsort
+SELECT c, c = c FROM t63792
+----
+NULL  NULL
+1     true
+2     true


### PR DESCRIPTION
We have an optimized operator for `Is{Not}DistinctFrom` operation which
we can plan currently only if the right side is a constant NULL. In some
cases the optimizer might create a cast expression on the right in order
to propagate the type of the null, and previously we would fallback to
the default comparison operator in such scenario. This is suboptimal,
and this commit fixes the issue by special casing the scenario of
casting NULL to some type.

Fixes: #63792.

Release note: None