### PR TITLE
opt: introduce placeholder fast path

### DIFF
--- a/docs/generated/sql/bnf/explain_analyze_stmt.bnf
+++ b/docs/generated/sql/bnf/explain_analyze_stmt.bnf
@@ -1,7 +1,7 @@
 explain_stmt ::=
-	'EXPLAIN' preparable_stmt
-	| 'EXPLAIN' '(' ( 'PLAN' | 'DISTSQL' | 'DEBUG' ) ( ( ',' ( 'PLAN' | 'DISTSQL' | 'DEBUG' ) ) )* ')' preparable_stmt
-	| 'EXPLAIN' 'ANALYZE' preparable_stmt
-	| 'EXPLAIN' 'ANALYSE' preparable_stmt
-	| 'EXPLAIN' 'ANALYZE' '(' ( 'PLAN' | 'DISTSQL' | 'DEBUG' ) ( ( ',' ( 'PLAN' | 'DISTSQL' | 'DEBUG' ) ) )* ')' preparable_stmt
-	| 'EXPLAIN' 'ANALYSE' '(' ( 'PLAN' | 'DISTSQL' | 'DEBUG' ) ( ( ',' ( 'PLAN' | 'DISTSQL' | 'DEBUG' ) ) )* ')' preparable_stmt
+	'EXPLAIN' explainable_stmt
+	| 'EXPLAIN' '(' ( 'PLAN' | 'DISTSQL' | 'DEBUG' ) ( ( ',' ( 'PLAN' | 'DISTSQL' | 'DEBUG' ) ) )* ')' explainable_stmt
+	| 'EXPLAIN' 'ANALYZE' explainable_stmt
+	| 'EXPLAIN' 'ANALYSE' explainable_stmt
+	| 'EXPLAIN' 'ANALYZE' '(' ( 'PLAN' | 'DISTSQL' | 'DEBUG' ) ( ( ',' ( 'PLAN' | 'DISTSQL' | 'DEBUG' ) ) )* ')' explainable_stmt
+	| 'EXPLAIN' 'ANALYSE' '(' ( 'PLAN' | 'DISTSQL' | 'DEBUG' ) ( ( ',' ( 'PLAN' | 'DISTSQL' | 'DEBUG' ) ) )* ')' explainable_stmt

--- a/docs/generated/sql/bnf/explain_stmt.bnf
+++ b/docs/generated/sql/bnf/explain_stmt.bnf
@@ -1,3 +1,3 @@
 explain_stmt ::=
-	'EXPLAIN' preparable_stmt
-	| 'EXPLAIN' '(' ( 'VERBOSE' | 'TYPES' | 'OPT' | 'DISTSQL' | 'VEC' ) ( ( ',' ( 'VERBOSE' | 'TYPES' | 'OPT' | 'DISTSQL' | 'VEC' ) ) )* ')' preparable_stmt
+	'EXPLAIN' explainable_stmt
+	| 'EXPLAIN' '(' ( 'VERBOSE' | 'TYPES' | 'OPT' | 'DISTSQL' | 'VEC' ) ( ( ',' ( 'VERBOSE' | 'TYPES' | 'OPT' | 'DISTSQL' | 'VEC' ) ) )* ')' explainable_stmt

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -148,12 +148,12 @@ drop_stmt ::=
 	| drop_schedule_stmt
 
 explain_stmt ::=
-	'EXPLAIN' preparable_stmt
-	| 'EXPLAIN' '(' explain_option_list ')' preparable_stmt
-	| 'EXPLAIN' 'ANALYZE' preparable_stmt
-	| 'EXPLAIN' 'ANALYSE' preparable_stmt
-	| 'EXPLAIN' 'ANALYZE' '(' explain_option_list ')' preparable_stmt
-	| 'EXPLAIN' 'ANALYSE' '(' explain_option_list ')' preparable_stmt
+	'EXPLAIN' explainable_stmt
+	| 'EXPLAIN' '(' explain_option_list ')' explainable_stmt
+	| 'EXPLAIN' 'ANALYZE' explainable_stmt
+	| 'EXPLAIN' 'ANALYSE' explainable_stmt
+	| 'EXPLAIN' 'ANALYZE' '(' explain_option_list ')' explainable_stmt
+	| 'EXPLAIN' 'ANALYSE' '(' explain_option_list ')' explainable_stmt
 
 import_stmt ::=
 	'IMPORT' import_format string_or_placeholder opt_with_options
@@ -491,6 +491,10 @@ drop_role_stmt ::=
 drop_schedule_stmt ::=
 	'DROP' 'SCHEDULE' a_expr
 	| 'DROP' 'SCHEDULES' select_stmt
+
+explainable_stmt ::=
+	preparable_stmt
+	| execute_stmt
 
 explain_option_list ::=
 	( explain_option_name ) ( ( ',' explain_option_name ) )*

--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/sql/mutations",
         "//pkg/sql/opt",
         "//pkg/sql/opt/cat",
+        "//pkg/sql/opt/constraint",
         "//pkg/sql/opt/exec",
         "//pkg/sql/opt/memo",
         "//pkg/sql/opt/norm",

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -719,7 +719,7 @@ func (b *Builder) buildDeleteRange(
 		// We can't calculate the maximum number of keys if there are interleaved
 		// children, as we don't know how many children rows may be in range.
 		if len(interleavedTables) == 0 {
-			if maxRows, ok := b.indexConstraintMaxResults(scan); ok {
+			if maxRows, ok := b.indexConstraintMaxResults(&scan.ScanPrivate, scan.Relational()); ok {
 				if maxKeys := maxRows * uint64(tab.FamilyCount()); maxKeys <= row.TableTruncateChunkSize {
 					// Other mutations only allow auto-commit if there are no FK checks or
 					// cascades. In this case, we won't actually execute anything for the

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -21,10 +21,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/ordering"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -191,6 +193,9 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 
 	case *memo.ScanExpr:
 		ep, err = b.buildScan(t)
+
+	case *memo.PlaceholderScanExpr:
+		ep, err = b.buildPlaceholderScan(t)
 
 	case *memo.SelectExpr:
 		ep, err = b.buildSelect(t)
@@ -468,7 +473,9 @@ func (b *Builder) getColumns(
 // indexConstraintMaxResults returns the maximum number of results for a scan;
 // if successful (ok=true), the scan is guaranteed never to return more results
 // than maxRows.
-func (b *Builder) indexConstraintMaxResults(scan *memo.ScanExpr) (maxRows uint64, ok bool) {
+func (b *Builder) indexConstraintMaxResults(
+	scan *memo.ScanPrivate, relProps *props.Relational,
+) (maxRows uint64, ok bool) {
 	c := scan.Constraint
 	if c == nil || c.IsContradiction() || c.IsUnconstrained() {
 		return 0, false
@@ -479,16 +486,16 @@ func (b *Builder) indexConstraintMaxResults(scan *memo.ScanExpr) (maxRows uint64
 	for i := 0; i < numCols; i++ {
 		indexCols.Add(c.Columns.Get(i).ID())
 	}
-	rel := scan.Relational()
-	if !rel.FuncDeps.ColsAreLaxKey(indexCols) {
+	if !relProps.FuncDeps.ColsAreLaxKey(indexCols) {
 		return 0, false
 	}
 
-	return c.CalculateMaxResults(b.evalCtx, indexCols, rel.NotNullCols)
+	return c.CalculateMaxResults(b.evalCtx, indexCols, relProps.NotNullCols)
 }
 
+// scanParams populates ScanParams and the output column mapping.
 func (b *Builder) scanParams(
-	tab cat.Table, scan *memo.ScanExpr,
+	tab cat.Table, scan *memo.ScanPrivate, relProps *props.Relational, reqProps *physical.Required,
 ) (exec.ScanParams, opt.ColMap, error) {
 	// Check if we tried to force a specific index but there was no Scan with that
 	// index in the memo.
@@ -535,28 +542,29 @@ func (b *Builder) scanParams(
 
 	needed, outputMap := b.getColumns(scan.Cols, scan.Table)
 
-	// Get the estimated row count from the statistics.
+	// Get the estimated row count from the statistics. When there are no
+	// statistics available, we construct a scan node with
+	// the estimated row count of zero rows.
+	//
 	// Note: if this memo was originally created as part of a PREPARE
 	// statement or was stored in the query cache, the column stats would have
 	// been removed by DetachMemo. Update that function if the column stats are
 	// needed here in the future.
-	rowCount := scan.Relational().Stats.RowCount
-	if !scan.Relational().Stats.Available {
-		// When there are no statistics available, we construct a scan node with
-		// the estimated row count of zero rows.
-		rowCount = 0
+	var rowCount float64
+	if relProps.Stats.Available {
+		rowCount = relProps.Stats.RowCount
 	}
 
 	if scan.PartitionConstrainedScan {
 		sqltelemetry.IncrementPartitioningCounter(sqltelemetry.PartitionConstrainedScan)
 	}
 
-	softLimit := int64(math.Ceil(scan.RequiredPhysical().LimitHint))
+	softLimit := int64(math.Ceil(reqProps.LimitHint))
 	hardLimit := scan.HardLimit.RowCount()
 
 	parallelize := false
 	if hardLimit == 0 && softLimit == 0 {
-		maxResults, ok := b.indexConstraintMaxResults(scan)
+		maxResults, ok := b.indexConstraintMaxResults(scan, relProps)
 		if ok && maxResults < ParallelScanResultThreshold {
 			// Don't set the flag when we have a single span which returns a single
 			// row: it does nothing in this case except litter EXPLAINs.
@@ -568,18 +576,28 @@ func (b *Builder) scanParams(
 		}
 	}
 
+	// Figure out if we need to scan in reverse (ScanPrivateCanProvide takes
+	// HardLimit.Reverse() into account).
+	ok, reverse := ordering.ScanPrivateCanProvide(
+		b.mem.Metadata(),
+		scan,
+		&reqProps.Ordering,
+	)
+	if !ok {
+		return exec.ScanParams{}, opt.ColMap{}, errors.AssertionFailedf("scan can't provide required ordering")
+	}
+
 	return exec.ScanParams{
 		NeededCols:         needed,
 		IndexConstraint:    scan.Constraint,
 		InvertedConstraint: scan.InvertedConstraint,
 		HardLimit:          hardLimit,
 		SoftLimit:          softLimit,
-		// HardLimit.Reverse() is taken into account by ScanIsReverse.
-		Reverse:           ordering.ScanIsReverse(scan, &scan.RequiredPhysical().Ordering),
-		Parallelize:       parallelize,
-		Locking:           locking,
-		EstimatedRowCount: rowCount,
-		LocalityOptimized: scan.LocalityOptimized,
+		Reverse:            reverse,
+		Parallelize:        parallelize,
+		Locking:            locking,
+		EstimatedRowCount:  rowCount,
+		LocalityOptimized:  scan.LocalityOptimized,
 	}, outputMap, nil
 }
 
@@ -591,7 +609,7 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 		telemetry.Inc(sqltelemetry.PartialIndexScanUseCounter)
 	}
 
-	params, outputCols, err := b.scanParams(tab, scan)
+	params, outputCols, err := b.scanParams(tab, &scan.ScanPrivate, scan.Relational(), scan.RequiredPhysical())
 	if err != nil {
 		return execPlan{}, err
 	}
@@ -614,6 +632,72 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 		} else {
 			b.ContainsFullIndexScan = true
 		}
+	}
+
+	res.root = root
+	return res, nil
+}
+
+func (b *Builder) buildPlaceholderScan(scan *memo.PlaceholderScanExpr) (execPlan, error) {
+	if scan.Constraint != nil || scan.InvertedConstraint != nil {
+		return execPlan{}, errors.AssertionFailedf("PlaceholderScan cannot have constraints")
+	}
+
+	md := b.mem.Metadata()
+	tab := md.Table(scan.Table)
+	idx := tab.Index(scan.Index)
+
+	// Build the index constraint.
+	spanColumns := make([]opt.OrderingColumn, len(scan.Span))
+	for i := range spanColumns {
+		col := idx.Column(i)
+		ordinal := col.Ordinal()
+		colID := scan.Table.ColumnID(ordinal)
+		spanColumns[i] = opt.MakeOrderingColumn(colID, col.Descending)
+	}
+	var columns constraint.Columns
+	columns.Init(spanColumns)
+	keyCtx := constraint.MakeKeyContext(&columns, b.evalCtx)
+
+	values := make([]tree.Datum, len(scan.Span))
+	for i, expr := range scan.Span {
+		// The expression is either a placeholder or a constant.
+		if p, ok := expr.(*memo.PlaceholderExpr); ok {
+			val, err := p.Value.(*tree.Placeholder).Eval(b.evalCtx)
+			if err != nil {
+				return execPlan{}, err
+			}
+			values[i] = val
+		} else {
+			values[i] = memo.ExtractConstDatum(expr)
+		}
+	}
+
+	key := constraint.MakeCompositeKey(values...)
+	var span constraint.Span
+	span.Init(key, constraint.IncludeBoundary, key, constraint.IncludeBoundary)
+	var spans constraint.Spans
+	spans.InitSingleSpan(&span)
+
+	var c constraint.Constraint
+	c.Init(&keyCtx, &spans)
+
+	private := scan.ScanPrivate
+	private.Constraint = &c
+
+	params, outputCols, err := b.scanParams(tab, &private, scan.Relational(), scan.RequiredPhysical())
+	if err != nil {
+		return execPlan{}, err
+	}
+	res := execPlan{outputCols: outputCols}
+	root, err := b.factory.ConstructScan(
+		tab,
+		tab.Index(scan.Index),
+		params,
+		res.reqOrdering(scan),
+	)
+	if err != nil {
+		return execPlan{}, err
 	}
 
 	res.root = root

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -454,7 +454,7 @@ vectorized: true
 │ order: +grantee,+privilege_type
 │
 └── • filter
-    │ filter: (table_catalog, table_schema, table_name) IN (('test', 'public', 'foo'),)
+    │ filter: ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')
     │
     └── • virtual table
           table: table_privileges@primary

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -1567,3 +1567,27 @@ vectorized: true
 • insert fast path
   into: t2(x)
   auto commit
+
+statement ok
+PREPARE prep AS SELECT $1 + 1
+
+statement error EXPLAIN EXECUTE is not supported
+EXPLAIN EXECUTE prep(1)
+
+statement error EXPLAIN EXECUTE is not supported
+SELECT 1 FROM [ EXPLAIN EXECUTE prep(1) ]
+
+query T
+EXPLAIN ANALYZE EXECUTE prep(1)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+maximum memory usage: <hidden>
+network usage: <hidden>
+·
+• values
+  cluster nodes: <hidden>
+  actual row count: 1
+  size: 1 column, 1 row

--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare
@@ -102,3 +102,47 @@ vectorized: true
       estimated row count: 1 (100% of the table; stats collected <hidden> ago)
       table: ab@primary
       spans: FULL SCAN
+
+# Verify the plan of a very simple query which should be using the placeholder
+# fast path.
+statement ok
+PREPARE pklookup AS SELECT b FROM ab WHERE a = $1
+
+query T
+EXPLAIN ANALYZE EXECUTE pklookup(1)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+rows read from KV: 1 (8 B)
+maximum memory usage: <hidden>
+network usage: <hidden>
+·
+• scan
+  cluster nodes: <hidden>
+  actual row count: 1
+  KV rows read: 1
+  KV bytes read: 8 B
+  estimated row count: 0
+  table: ab@primary
+  spans: [/1 - /1]
+
+query T
+EXPLAIN ANALYZE EXECUTE pklookup(2)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+maximum memory usage: <hidden>
+network usage: <hidden>
+·
+• scan
+  cluster nodes: <hidden>
+  actual row count: 0
+  KV rows read: 0
+  KV bytes read: 0 B
+  estimated row count: 0
+  table: ab@primary
+  spans: [/2 - /2]

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -1201,7 +1201,7 @@ vectorized: true
 • filter
 │ columns: (c0)
 │ estimated row count: 333 (missing stats)
-│ filter: CASE WHEN c0 IN (c0,) THEN ARRAY[NULL] ELSE ARRAY[] END IS NULL
+│ filter: CASE WHEN (c0 IS DISTINCT FROM CAST(NULL AS DECIMAL)) OR CAST(NULL AS BOOL) THEN ARRAY[NULL] ELSE ARRAY[] END IS NULL
 │
 └── • scan
       columns: (c0)

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -823,7 +823,7 @@ vectorized: true
 └── • filter
     │ columns: (k, a, b)
     │ estimated row count: 333 (missing stats)
-    │ filter: ((a IN (6,)) AND (a > 6)) OR (b >= 4)
+    │ filter: ((a = 6) AND (a > 6)) OR (b >= 4)
     │
     └── • scan
           columns: (k, a, b)

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual
@@ -139,7 +139,7 @@ vectorized: true
         │ equality: (oid) = (connamespace)
         │
         ├── • filter
-        │   │ filter: nspname IN ('public',)
+        │   │ filter: nspname = 'public'
         │   │
         │   └── • virtual table
         │         table: pg_namespace@primary

--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -40,7 +40,7 @@ func (m *Memo) CheckExpr(e opt.Expr) {
 		// If the expression was added to an existing group, cross-check its
 		// properties against the properties of the group. Skip this check if the
 		// operator is known to not have code for building logical props.
-		if t != t.FirstExpr() && t.Op() != opt.MergeJoinOp {
+		if t != t.FirstExpr() && t.Op() != opt.MergeJoinOp && t.Op() != opt.PlaceholderScanOp {
 			var relProps props.Relational
 			// Don't build stats when verifying logical props - unintentionally
 			// building stats for non-normalized expressions could add extra colStats

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -172,6 +172,12 @@ func (b *logicalPropsBuilder) buildScanProps(scan *ScanExpr, rel *props.Relation
 	}
 }
 
+func (b *logicalPropsBuilder) buildPlaceholderScanProps(
+	scan *PlaceholderScanExpr, rel *props.Relational,
+) {
+	panic(errors.AssertionFailedf("not implemented"))
+}
+
 func (b *logicalPropsBuilder) buildSequenceSelectProps(
 	seq *SequenceSelectExpr, rel *props.Relational,
 ) {

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -537,18 +537,20 @@ project
  │    ├── project
  │    │    ├── columns: col1:27(bool)
  │    │    ├── immutable
- │    │    ├── stats: [rows=333333.333, distinct(27)=333333.333, null(27)=0]
- │    │    ├── inner-join (cross)
+ │    │    ├── stats: [rows=10000, distinct(27)=10000, null(27)=0]
+ │    │    ├── inner-join (hash)
  │    │    │    ├── columns: tab0.e:5(varchar) tab0.f:6("char") tab0.h:8(varchar) tab0.j:10(float!null) tab1.e:17(varchar) tab1.f:18("char") tab1.j:22(float!null)
- │    │    │    ├── stats: [rows=333333.333, distinct(5,6,8,17,18)=333333.333, null(5,6,8,17,18)=3.33333333e-05]
+ │    │    │    ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
+ │    │    │    ├── stats: [rows=10000, distinct(10)=100, null(10)=0, distinct(22)=100, null(22)=0, distinct(5,6,8,17,18)=10000, null(5,6,8,17,18)=1e-06]
+ │    │    │    ├── fd: (10)==(22), (22)==(10)
  │    │    │    ├── scan t37953 [as=tab0]
  │    │    │    │    ├── columns: tab0.e:5(varchar) tab0.f:6("char") tab0.h:8(varchar) tab0.j:10(float!null)
- │    │    │    │    └── stats: [rows=1000, distinct(5,6,8)=1000, null(5,6,8)=0.001]
+ │    │    │    │    └── stats: [rows=1000, distinct(10)=100, null(10)=0, distinct(5,6,8)=1000, null(5,6,8)=0.001]
  │    │    │    ├── scan t37953 [as=tab1]
  │    │    │    │    ├── columns: tab1.e:17(varchar) tab1.f:18("char") tab1.j:22(float!null)
- │    │    │    │    └── stats: [rows=1000, distinct(17,18)=1000, null(17,18)=0.1]
+ │    │    │    │    └── stats: [rows=1000, distinct(22)=100, null(22)=0, distinct(17,18)=1000, null(17,18)=0.1]
  │    │    │    └── filters
- │    │    │         └── tab0.j:10 IN (tab1.j:22,) [type=bool, outer=(10,22)]
+ │    │    │         └── tab0.j:10 = tab1.j:22 [type=bool, outer=(10,22), constraints=(/10: (/NULL - ]; /22: (/NULL - ]), fd=(10)==(22), (22)==(10)]
  │    │    └── projections
  │    │         └── CASE WHEN ilike_escape(regexp_replace(tab0.h:8, tab1.e:17, tab0.f:6, tab0.e:5::STRING), tab1.f:18, '') THEN true ELSE false END [as=col1:27, type=bool, outer=(5,6,8,17,18), immutable]
  │    └── filters

--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -86,6 +86,16 @@ $input
 =>
 (Null (BoolType))
 
+[SimplifyInSingleElement, Normalize]
+(In $left:* (Tuple [ $right:* ]))
+=>
+(Eq $left $right)
+
+[SimplifyNotInSingleElement, Normalize]
+(NotIn $left:* (Tuple [ $right:* ]))
+=>
+(Ne $left $right)
+
 # UnifyComparisonTypes takes a mixed-type comparison between a non-constant and
 # a constant and, if appropriate, converts the constant to the type of the
 # non-constant to allow constraints to be generated.

--- a/pkg/sql/opt/norm/testdata/rules/assign_placeholders
+++ b/pkg/sql/opt/norm/testdata/rules/assign_placeholders
@@ -58,7 +58,8 @@ select
  │    ├── key: (1-3)
  │    └── fd: (1-3)-->(4)
  └── filters
-      └── (a:1, b:2) IN ((1, 2),) [outer=(1,2), constraints=(/1/2: [/1/2 - /1/2]; /2: [/2 - /2]; tight), fd=()-->(1,2)]
+      ├── a:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+      └── b:2 = 2 [outer=(2), constraints=(/2: [/2 - /2]; tight), fd=()-->(2)]
 
 # The normalized expression above can be explored into a constrained scan.
 opt

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -239,7 +239,7 @@ project
  ├── scan a
  │    └── columns: s:4
  └── projections
-      └── s:4 NOT IN ('foo',) [as=r:7, outer=(4)]
+      └── s:4 != 'foo' [as=r:7, outer=(4)]
 
 # Don't sort, since the list is not constant.
 norm expect-not=NormalizeInConst
@@ -274,6 +274,111 @@ values
  ├── key: ()
  ├── fd: ()-->(1)
  └── (true IN (NULL, NULL, ('201.249.149.90/18' & '97a7:3650:3dd8:d4e9:35fe:6cfb:a714:1c17/61') << 'e22f:2067:2ed2:7b07:b167:206f:f17b:5b7d/82'),)
+
+# --------------------------------------------------
+# SimplifyInSingleElement
+# --------------------------------------------------
+norm expect=SimplifyInSingleElement
+SELECT * FROM a WHERE k IN (1)
+----
+select
+ ├── columns: k:1!null i:2 f:3 s:4 arr:5
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 arr:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── k:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+
+norm expect=SimplifyInSingleElement
+SELECT 1 IN (k) FROM a
+----
+project
+ ├── columns: "?column?":7!null
+ ├── scan a
+ │    ├── columns: k:1!null
+ │    └── key: (1)
+ └── projections
+      └── k:1 = 1 [as="?column?":7, outer=(1)]
+
+norm expect=SimplifyInSingleElement
+SELECT k+1 IN (i*2) FROM a
+----
+project
+ ├── columns: "?column?":7
+ ├── immutable
+ ├── scan a
+ │    ├── columns: k:1!null i:2
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ └── projections
+      └── (k:1 + 1) = (i:2 * 2) [as="?column?":7, outer=(1,2), immutable]
+
+norm expect-not=SimplifyInSingleElement
+SELECT k IN (1,2) FROM a
+----
+project
+ ├── columns: "?column?":7!null
+ ├── scan a
+ │    ├── columns: k:1!null
+ │    └── key: (1)
+ └── projections
+      └── k:1 IN (1, 2) [as="?column?":7, outer=(1)]
+
+# --------------------------------------------------
+# SimplifyNotInSingleElement
+# --------------------------------------------------
+norm expect=SimplifyNotInSingleElement
+SELECT * FROM a WHERE k NOT IN (1)
+----
+select
+ ├── columns: k:1!null i:2 f:3 s:4 arr:5
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 arr:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── k:1 != 1 [outer=(1), constraints=(/1: (/NULL - /0] [/2 - ]; tight)]
+
+norm expect=SimplifyNotInSingleElement
+SELECT 1 NOT IN (k) FROM a
+----
+project
+ ├── columns: "?column?":7!null
+ ├── scan a
+ │    ├── columns: k:1!null
+ │    └── key: (1)
+ └── projections
+      └── k:1 != 1 [as="?column?":7, outer=(1)]
+
+norm expect=SimplifyNotInSingleElement
+SELECT k+1 NOT IN (i*2) FROM a
+----
+project
+ ├── columns: "?column?":7
+ ├── immutable
+ ├── scan a
+ │    ├── columns: k:1!null i:2
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ └── projections
+      └── (k:1 + 1) != (i:2 * 2) [as="?column?":7, outer=(1,2), immutable]
+
+norm expect-not=SimplifyNotInSingleElement
+SELECT k NOT IN (1,2) FROM a
+----
+project
+ ├── columns: "?column?":7!null
+ ├── scan a
+ │    ├── columns: k:1!null
+ │    └── key: (1)
+ └── projections
+      └── k:1 NOT IN (1, 2) [as="?column?":7, outer=(1)]
 
 # --------------------------------------------------
 # EliminateExistsZeroRows

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -94,6 +94,21 @@ define ScanPrivate {
     PartitionConstrainedScan bool
 }
 
+# PlaceholderScan is a special variant of Scan. It scans exactly one span of a
+# non-inverted index, and the span has the same start and end key. The values
+# for the span key are child scalar operators which are either constants or
+# placeholders. This operator evaluates the placeholders at execbuild time.
+#
+# PlaceholderScan cannot have a Constraint or InvertedConstraint.
+[Relational]
+define PlaceholderScan {
+    # Span contains the values for a constraint span key; they map 1-1 to a
+    # prefix of the index columns. They are either constant values or
+    # placeholders.
+    Span ScalarListExpr
+    _ ScanPrivate
+}
+
 # SequenceSelect represents a read from a sequence as a data source. It always returns
 # three columns, last_value, log_cnt, and is_called, with a single row. last_value is
 # the most recent value returned from the sequence and log_cnt and is_called are

--- a/pkg/sql/opt/optbuilder/explain.go
+++ b/pkg/sql/opt/optbuilder/explain.go
@@ -14,12 +14,20 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/errors"
 )
 
 func (b *Builder) buildExplain(explain *tree.Explain, inScope *scope) (outScope *scope) {
+	if _, ok := explain.Statement.(*tree.Execute); ok {
+		panic(pgerror.New(
+			pgcode.FeatureNotSupported, "EXPLAIN EXECUTE is not supported; use EXPLAIN ANALYZE",
+		))
+	}
+
 	stmtScope := b.buildStmtAtRoot(explain.Statement, nil /* desiredTypes */)
 
 	outScope = inScope.push()

--- a/pkg/sql/opt/partialidx/testdata/implicator/or-expr
+++ b/pkg/sql/opt/partialidx/testdata/implicator/or-expr
@@ -55,7 +55,7 @@ a IN (1)
 a = 1 OR a = 2
 ----
 true
-└── remaining filters: a IN (1,)
+└── remaining filters: a = 1
 
 predtest vars=(a int)
 a IN (1, 2, 3)
@@ -146,7 +146,7 @@ a IN (1) OR a IN (2)
 a = 1 OR a = 2
 ----
 true
-└── remaining filters: (a IN (1,)) OR (a IN (2,))
+└── remaining filters: none
 
 predtest vars=(a int, b int)
 a IN (1, 2)

--- a/pkg/sql/opt/xform/BUILD.bazel
+++ b/pkg/sql/opt/xform/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "memo_format.go",
         "optimizer.go",
         "physical_props.go",
+        "placeholder_fast_path.go",
         "scan_funcs.go",
         "scan_index_iter.go",
         "select_funcs.go",

--- a/pkg/sql/opt/xform/optimizer_test.go
+++ b/pkg/sql/opt/xform/optimizer_test.go
@@ -218,6 +218,17 @@ func TestExternal(t *testing.T) {
 	)
 }
 
+func TestPlaceholderFastPath(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	runDataDrivenTest(
+		t,
+		"testdata/placeholder-fast-path",
+		memo.ExprFmtHideStats|memo.ExprFmtHideCost|memo.ExprFmtHideRuleProps|
+			memo.ExprFmtHideQualifications|memo.ExprFmtHideScalars|memo.ExprFmtHideTypes,
+	)
+}
+
 // runDataDrivenTest runs data-driven testcases of the form
 //   <command>
 //   <SQL statement>

--- a/pkg/sql/opt/xform/placeholder_fast_path.go
+++ b/pkg/sql/opt/xform/placeholder_fast_path.go
@@ -1,0 +1,209 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package xform
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
+	"github.com/cockroachdb/errors"
+)
+
+// TryPlaceholderFastPath attempts to produce a fully optimized memo with
+// placeholders. This is only possible in very simple cases and involves special
+// operators (PlaceholderScan) which use placeholders and resolve them at
+// execbuild time.
+//
+// Currently we support cases where we can convert the entire tree to a single
+// PlaceholderScan.
+//
+// If this function succeeds, the memo will be considered fully optimized.
+func (o *Optimizer) TryPlaceholderFastPath() (_ opt.Expr, ok bool, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			// This code allows us to propagate internal errors without having to add
+			// error checks everywhere throughout the code. This is only possible
+			// because the code does not update shared state and does not manipulate
+			// locks.
+			if shouldCatch, e := errorutil.ShouldCatch(r); shouldCatch {
+				err = e
+			} else {
+				// Other panic objects can't be considered "safe" and thus are
+				// propagated as crashes that terminate the session.
+				panic(r)
+			}
+		}
+	}()
+
+	root := o.mem.RootExpr().(memo.RelExpr)
+	rootProps := o.mem.RootProps()
+
+	if !rootProps.Ordering.Any() {
+		return nil, false, nil
+	}
+
+	rootColumns := root.Relational().OutputCols
+
+	// TODO(radu): if we want to support more cases, we should use optgen to write
+	// the rules.
+
+	// Ignore any top-level Project that only passes through columns. It's safe to
+	// remove it because the presentation property still enforces the final result
+	// columns.
+	expr := root
+	if proj, isProject := expr.(*memo.ProjectExpr); isProject {
+		if len(proj.Projections) != 0 {
+			return nil, false, nil
+		}
+		expr = proj.Input
+	}
+
+	sel, isSelect := expr.(*memo.SelectExpr)
+	if !isSelect {
+		return nil, false, nil
+	}
+	scan, isScan := sel.Input.(*memo.ScanExpr)
+	if !isScan {
+		return nil, false, nil
+	}
+
+	var constrainedCols opt.ColSet
+	for i := range sel.Filters {
+		// Each condition must be an equality between a variable and a constant
+		// value or a placeholder.
+		cond := sel.Filters[i].Condition
+		eq, isEq := cond.(*memo.EqExpr)
+		if !isEq {
+			return nil, false, nil
+		}
+		v, isVar := eq.Left.(*memo.VariableExpr)
+		if !isVar {
+			return nil, false, nil
+		}
+		if !opt.IsConstValueOp(eq.Right) && eq.Right.Op() != opt.PlaceholderOp {
+			return nil, false, nil
+		}
+		if constrainedCols.Contains(v.Col) {
+			// The same variable is part of multiple equalities.
+			return nil, false, nil
+		}
+		constrainedCols.Add(v.Col)
+	}
+	numConstrained := len(sel.Filters)
+
+	// Check if there is exactly one covering, non-partial index with a prefix
+	// matching constrainedCols, and there are no partial indexes that could be
+	// used by the query. If these conditions are satisfied, using this index is
+	// always the optimal plan.
+
+	md := o.mem.Metadata()
+	tabMeta := md.TableMeta(scan.Table)
+	var foundIndex cat.Index
+	for ord, n := 0, tabMeta.Table.IndexCount(); ord < n; ord++ {
+		index := tabMeta.Table.Index(ord)
+		if index.IsInverted() {
+			continue
+		}
+
+		if pred, isPartialIndex := tabMeta.PartialIndexPredicate(ord); isPartialIndex {
+			// We are not equipped to handle partial indexes.
+			//
+			// If it is a pseudo-partial index (true predicate), treat it as a regular
+			// index.
+			//
+			// Otherwise, check if the predicate has any columns in common with our
+			// filters; if it does, bail. If it doesn't, we can safely ignore the
+			// index.
+			predFilters := pred.(*memo.FiltersExpr)
+			for i := range *predFilters {
+				if (*predFilters)[i].ScalarProps().OuterCols.Intersects(constrainedCols) {
+					return nil, false, nil
+				}
+			}
+			if !predFilters.IsTrue() {
+				continue
+			}
+		}
+
+		idxColCount := index.ColumnCount()
+		if idxColCount < numConstrained {
+			continue
+		}
+
+		var prefixCols opt.ColSet
+		for i := 0; i < numConstrained; i++ {
+			ord := index.Column(i).Ordinal()
+			prefixCols.Add(tabMeta.MetaID.ColumnID(ord))
+		}
+		if !prefixCols.Equals(constrainedCols) {
+			// The index columns don't match the filters.
+			continue
+		}
+
+		// Check if the index is covering.
+		indexCols := prefixCols.Copy()
+		for i := numConstrained; i < idxColCount; i++ {
+			ord := index.Column(i).Ordinal()
+			indexCols.Add(tabMeta.MetaID.ColumnID(ord))
+		}
+		if isCovering := scan.ScanPrivate.Cols.SubsetOf(indexCols); !isCovering {
+			continue
+		}
+
+		if foundIndex != nil {
+			// We found multiple candidate indexes. Choosing the best index (e.g.
+			// fewer columns) requires costing.
+			return nil, false, nil
+		}
+		foundIndex = index
+	}
+
+	if foundIndex == nil {
+		return nil, false, nil
+	}
+
+	// Success!
+	newPrivate := scan.ScanPrivate
+	newPrivate.Cols = rootColumns
+	newPrivate.Index = foundIndex.Ordinal()
+
+	span := make(memo.ScalarListExpr, numConstrained)
+	for i := range span {
+		col := tabMeta.MetaID.ColumnID(foundIndex.Column(i).Ordinal())
+		for j := range sel.Filters {
+			eq := sel.Filters[j].Condition.(*memo.EqExpr)
+			if v := eq.Left.(*memo.VariableExpr); v.Col == col {
+				span[i] = eq.Right
+				break
+			}
+		}
+		if span[i] == nil {
+			// We checked above that the constrained columns match the index prefix.
+			return nil, false, errors.AssertionFailedf("no span value")
+		}
+	}
+	placeholderScan := &memo.PlaceholderScanExpr{
+		Span:        span,
+		ScanPrivate: newPrivate,
+	}
+	placeholderScan = o.mem.AddPlaceholderScanToGroup(placeholderScan, root)
+	o.mem.SetBestProps(placeholderScan, rootProps, &physical.Provided{}, 1.0 /* cost */)
+	o.mem.SetRoot(placeholderScan, rootProps)
+
+	if util.CrdbTestBuild && !o.mem.IsOptimized() {
+		return nil, false, errors.AssertionFailedf("IsOptimized() should be true")
+	}
+
+	return placeholderScan, true, nil
+}

--- a/pkg/sql/opt/xform/testdata/placeholder-fast-path/scan
+++ b/pkg/sql/opt/xform/testdata/placeholder-fast-path/scan
@@ -1,0 +1,230 @@
+exec-ddl
+CREATE TABLE kv (k INT PRIMARY KEY, v INT)
+----
+
+exec-ddl
+CREATE TABLE abcd (
+  a INT,
+  b INT,
+  c INT,
+  d INT,
+  INDEX (a,b) STORING (c),
+  INDEX (c,b,a) STORING (d),
+  INDEX (d,c,a),
+  INDEX (d,c,b)
+)
+----
+
+placeholder-fast-path
+SELECT * FROM kv WHERE k = $1
+----
+placeholder-scan kv
+ ├── columns: k:1!null v:2
+ ├── has-placeholder
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ └── span
+      └── $1
+
+placeholder-fast-path
+SELECT * FROM kv WHERE k = $1 FOR UPDATE
+----
+placeholder-scan kv
+ ├── columns: k:1!null v:2
+ ├── locking: for-update
+ ├── volatile, has-placeholder
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ └── span
+      └── $1
+
+placeholder-fast-path
+SELECT k FROM kv WHERE k = $1
+----
+placeholder-scan kv
+ ├── columns: k:1!null
+ ├── has-placeholder
+ ├── key: (1)
+ └── span
+      └── $1
+
+placeholder-fast-path
+SELECT k FROM kv WHERE k IN ($1)
+----
+placeholder-scan kv
+ ├── columns: k:1!null
+ ├── has-placeholder
+ ├── key: (1)
+ └── span
+      └── $1
+
+placeholder-fast-path
+SELECT v FROM kv WHERE k = $1
+----
+placeholder-scan kv
+ ├── columns: v:2
+ ├── has-placeholder
+ └── span
+      └── $1
+
+# Fast path not available when we're projecting a new expression.
+placeholder-fast-path
+SELECT v+1 FROM kv WHERE k = $1
+----
+no fast path
+
+placeholder-fast-path
+SELECT a, b, c FROM abcd WHERE a=$1 AND b=$2
+----
+placeholder-scan abcd@secondary
+ ├── columns: a:1!null b:2!null c:3
+ ├── has-placeholder
+ └── span
+      ├── $1
+      └── $2
+
+placeholder-fast-path
+SELECT a, b, c FROM abcd WHERE b=$1 AND a=$2
+----
+placeholder-scan abcd@secondary
+ ├── columns: a:1!null b:2!null c:3
+ ├── has-placeholder
+ └── span
+      ├── $2
+      └── $1
+
+# One constant value, one placeholder.
+placeholder-fast-path
+SELECT a, b, c FROM abcd WHERE a=0 AND b=$1
+----
+placeholder-scan abcd@secondary
+ ├── columns: a:1!null b:2!null c:3
+ ├── has-placeholder
+ ├── fd: ()-->(1)
+ └── span
+      ├── 0
+      └── $1
+
+placeholder-fast-path
+SELECT a, b, c FROM abcd WHERE a=$1 AND b=0
+----
+placeholder-scan abcd@secondary
+ ├── columns: a:1!null b:2!null c:3
+ ├── has-placeholder
+ ├── fd: ()-->(2)
+ └── span
+      ├── $1
+      └── 0
+
+# Constant folding is allowed (for immutable operators).
+placeholder-fast-path
+SELECT a, b, c FROM abcd WHERE a=1+2 AND b=$1
+----
+placeholder-scan abcd@secondary
+ ├── columns: a:1!null b:2!null c:3
+ ├── has-placeholder
+ ├── fd: ()-->(1)
+ └── span
+      ├── 3
+      └── $1
+
+placeholder-fast-path
+SELECT a, b, c FROM abcd WHERE a=fnv32a('foo') AND b=$1
+----
+placeholder-scan abcd@secondary
+ ├── columns: a:1!null b:2!null c:3
+ ├── has-placeholder
+ ├── fd: ()-->(1)
+ └── span
+      ├── 2851307223
+      └── $1
+
+# Fast path not available when value is not constant-foldable.
+placeholder-fast-path
+SELECT a, b, c FROM abcd WHERE a=now()::string::int AND b=$1
+----
+no fast path
+
+placeholder-fast-path
+SELECT a, b, c FROM abcd WHERE a=0 AND b=$1+1
+----
+no fast path
+
+# Fast path not available when we have an ordering requirement.
+placeholder-fast-path
+SELECT a, b, c FROM abcd WHERE a=$1 AND b=$2 ORDER BY c
+----
+no fast path
+
+# Fast path not available when we have a limit.
+placeholder-fast-path
+SELECT a, b, c FROM abcd WHERE a=$1 AND b=$2 LIMIT 1
+----
+no fast path
+
+# Fast path not available when index is not covering.
+placeholder-fast-path
+SELECT a, b, c, d FROM abcd WHERE a=$1 AND b=$2
+----
+no fast path
+
+# Fast path not available when two indexes are possible.
+placeholder-fast-path
+SELECT d FROM abcd WHERE d=$1 AND c=$2
+----
+no fast path
+
+# Now we have only one covering index.
+placeholder-fast-path
+SELECT a, d FROM abcd WHERE d=$1 AND c=$2
+----
+placeholder-scan abcd@secondary
+ ├── columns: a:1 d:4!null
+ ├── has-placeholder
+ └── span
+      ├── $1
+      └── $2
+
+exec-ddl
+CREATE TABLE kj (
+  k INT PRIMARY KEY,
+  j JSON,
+  INVERTED INDEX(j)
+)
+----
+
+# Verify that we don't incorrectly use an inverted index.
+placeholder-fast-path
+SELECT j FROM kj WHERE j = '{"foo": "bar"}'::JSON
+----
+no fast path
+
+exec-ddl
+CREATE TABLE partial1 (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT,
+  c INT,
+  INDEX partial_ab(a, b) WHERE (c = 0),
+  INDEX cab(c, a, b),
+  INDEX pseudo_ab(a, b) WHERE (1 = 1)
+)
+----
+
+# Make sure the fast path doesn't choose the cab index, getting in the way of
+# using partial_ab (which might be the better index when the placeholder is 0).
+placeholder-fast-path
+SELECT a, b FROM partial1 WHERE c = $1
+----
+no fast path
+
+# Ok to ignore the partial index when the filters don't involve predicate
+# columns; and, ok to use a pseudo-partial index.
+placeholder-fast-path
+SELECT a, b FROM partial1 WHERE a = $1
+----
+placeholder-scan partial1@pseudo_ab,partial
+ ├── columns: a:2!null b:3
+ ├── has-placeholder
+ └── span
+      └── $1

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -854,6 +854,7 @@ func (u *sqlSymUnion) objectNamePrefixList() tree.ObjectNamePrefixList {
 %type <tree.Statement> explain_stmt
 %type <tree.Statement> prepare_stmt
 %type <tree.Statement> preparable_stmt
+%type <tree.Statement> explainable_stmt
 %type <tree.Statement> row_source_extension_stmt
 %type <tree.Statement> export_stmt
 %type <tree.Statement> execute_stmt
@@ -3801,7 +3802,7 @@ analyze_target:
 //
 // %SeeAlso: WEBDOCS/explain.html
 explain_stmt:
-  EXPLAIN preparable_stmt
+  EXPLAIN explainable_stmt
   {
     var err error
     $$.val, err = tree.MakeExplain(nil /* options */, $2.stmt())
@@ -3810,7 +3811,7 @@ explain_stmt:
     }
   }
 | EXPLAIN error // SHOW HELP: EXPLAIN
-| EXPLAIN '(' explain_option_list ')' preparable_stmt
+| EXPLAIN '(' explain_option_list ')' explainable_stmt
   {
     var err error
     $$.val, err = tree.MakeExplain($3.strs(), $5.stmt())
@@ -3818,7 +3819,7 @@ explain_stmt:
       return setErr(sqllex, err)
     }
   }
-| EXPLAIN ANALYZE preparable_stmt
+| EXPLAIN ANALYZE explainable_stmt
   {
     var err error
     $$.val, err = tree.MakeExplain([]string{"ANALYZE"}, $3.stmt())
@@ -3826,7 +3827,7 @@ explain_stmt:
       return setErr(sqllex, err)
     }
   }
-| EXPLAIN ANALYSE preparable_stmt
+| EXPLAIN ANALYSE explainable_stmt
   {
     var err error
     $$.val, err = tree.MakeExplain([]string{"ANALYZE"}, $3.stmt())
@@ -3834,7 +3835,7 @@ explain_stmt:
       return setErr(sqllex, err)
     }
   }
-| EXPLAIN ANALYZE '(' explain_option_list ')' preparable_stmt
+| EXPLAIN ANALYZE '(' explain_option_list ')' explainable_stmt
   {
     var err error
     $$.val, err = tree.MakeExplain(append($4.strs(), "ANALYZE"), $6.stmt())
@@ -3842,7 +3843,7 @@ explain_stmt:
       return setErr(sqllex, err)
     }
   }
-| EXPLAIN ANALYSE '(' explain_option_list ')' preparable_stmt
+| EXPLAIN ANALYSE '(' explain_option_list ')' explainable_stmt
   {
     var err error
     $$.val, err = tree.MakeExplain(append($4.strs(), "ANALYZE"), $6.stmt())
@@ -3855,6 +3856,10 @@ explain_stmt:
 // cause a help text for the select clause, which will be confusing in
 // the context of EXPLAIN.
 | EXPLAIN '(' error // SHOW HELP: EXPLAIN
+
+explainable_stmt:
+  preparable_stmt
+| execute_stmt
 
 preparable_stmt:
   alter_stmt     // help texts in sub-rule

--- a/pkg/sql/parser/testdata/errors
+++ b/pkg/sql/parser/testdata/errors
@@ -516,15 +516,6 @@ e'\xad'::string
 ^
 
 error
-EXPLAIN EXECUTE a
-----
-at or near "execute": syntax error
-DETAIL: source SQL:
-EXPLAIN EXECUTE a
-        ^
-HINT: try \h EXPLAIN
-
-error
 EXPLAIN (ANALYZE, PLAN) SELECT 1
 ----
 at or near "analyze": syntax error


### PR DESCRIPTION
#### sql: support EXPLAIN ANALYZE EXECUTE

We currently cannot EXPLAIN an EXECUTE statement (the syntax doesn't
even allow it). EXECUTE is handled with special code at the top-level,
so it's tricky to make it work with EXPLAIN. However, EXPLAIN ANALYZE
Is also handled at the top level, before the EXECUTE handling, so that
should just work.

This change allows the parsing of such statements so we can use
EXPLAIN ANALYZE EXECUTE. If EXPLAIN EXECUTE is attempted, we get a
"not supported" error (this is less cryptic than the parsing error
anyway).

Release note: None

#### opt: normalize In with single-element list to Eq

This commit adds a rule that normalizes `a IN (b)` to `a = b` (and
similarly `NOT IN` to `!=`).

This query confirms the equivalency holds even when NULLs are
involved:

```
WITH
  vals (v) AS (VALUES (1), (2), (NULL))
SELECT
  v1.v, v2.v, v1.v NOT IN (v2.v,) AS in, v1.v != v2.v AS eq
FROM
  vals AS v1, vals AS v2

   v   |  v   |  in   |  eq
-------+------+-------+--------
     1 |    1 | false | false
     1 |    2 | true  | true
     1 | NULL | NULL  | NULL
     2 |    1 | true  | true
     2 |    2 | false | false
     2 | NULL | NULL  | NULL
  NULL |    1 | NULL  | NULL
  NULL |    2 | NULL  | NULL
  NULL | NULL | NULL  | NULL
```

Release note: None

#### opt: introduce placeholder fast path

Currently running a query with placeholders happens as follows:
 - at preparation time, we build a memo with the normalized expression
   *with* placeholders.
 - at execution time, we copy the expression into a new memo,
   replacing placeholders with their value (AssignPlaceholders).
 - then we run exploration which performs the actual optimization.

For trivial queries like KV reads, we do too much work during
execution (profiles show it is 10-20% of the runtime for KV workloads
with high read rates).

This commit introduces the concept of a "placeholder fast path". The
idea is that we can make specific checks for simple expressions and
produce (at preparation time) a fully optimized expression (which
still depends on placeholders). For this, we introduce a new operator,
PlaceholderScan which is similar to a Scan except that it always scans
one span with the same start and end key, and the key values are child
scalar expressions (either constants or placeholders).

We use this new operator only for simple SELECTs where the filters
constrain a prefix of an index to constant values; in addition, the
index must be covering and there must be only one such index. With
these conditions, we know the optimal plan upfront.

For now, the placeholder fast path transformation is Go code; if it
gets more complicated, it should be switched to use optgen rules.

A benchmark on my machine shows a kv95 workload going from 34kiops to
38kiops with this change.

Release note: None

Informs #57223.