### PR TITLE
colexecagg: clean up the constructors of several aggregate funcs

### DIFF
--- a/pkg/sql/colexec/colexecagg/avg_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/avg_agg_tmpl.go
@@ -64,27 +64,24 @@ func newAvg_AGGKINDAggAlloc(
 ) (aggregateFuncAlloc, error) {
 	allocBase := aggAllocBase{allocator: allocator, allocSize: allocSize}
 	switch t.Family() {
-	case types.IntFamily:
+	// {{range .}}
+	case _TYPE_FAMILY:
 		switch t.Width() {
-		case 16:
-			return &avgInt16_AGGKINDAggAlloc{aggAllocBase: allocBase}, nil
-		case 32:
-			return &avgInt32_AGGKINDAggAlloc{aggAllocBase: allocBase}, nil
-		default:
-			return &avgInt64_AGGKINDAggAlloc{aggAllocBase: allocBase}, nil
+		// {{range .WidthOverloads}}
+		case _TYPE_WIDTH:
+			// {{with .Overload}}
+			return &avg_TYPE_AGGKINDAggAlloc{aggAllocBase: allocBase}, nil
+			// {{end}}
+			// {{end}}
 		}
-	case types.DecimalFamily:
-		return &avgDecimal_AGGKINDAggAlloc{aggAllocBase: allocBase}, nil
-	case types.FloatFamily:
-		return &avgFloat64_AGGKINDAggAlloc{aggAllocBase: allocBase}, nil
-	case types.IntervalFamily:
-		return &avgInterval_AGGKINDAggAlloc{aggAllocBase: allocBase}, nil
-	default:
-		return nil, errors.Errorf("unsupported avg agg type %s", t.Name())
+		// {{end}}
 	}
+	return nil, errors.Errorf("unsupported avg agg type %s", t.Name())
 }
 
 // {{range .}}
+// {{range .WidthOverloads}}
+// {{with .Overload}}
 
 type avg_TYPE_AGGKINDAgg struct {
 	// {{if eq "_AGGKIND" "Ordered"}}
@@ -233,6 +230,8 @@ func (a *avg_TYPE_AGGKINDAggAlloc) newAggFunc() AggregateFunc {
 	return f
 }
 
+// {{end}}
+// {{end}}
 // {{end}}
 
 // {{/*

--- a/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
@@ -42,18 +42,30 @@ func newAvgHashAggAlloc(
 			return &avgInt16HashAggAlloc{aggAllocBase: allocBase}, nil
 		case 32:
 			return &avgInt32HashAggAlloc{aggAllocBase: allocBase}, nil
+		case -1:
 		default:
 			return &avgInt64HashAggAlloc{aggAllocBase: allocBase}, nil
 		}
 	case types.DecimalFamily:
-		return &avgDecimalHashAggAlloc{aggAllocBase: allocBase}, nil
+		switch t.Width() {
+		case -1:
+		default:
+			return &avgDecimalHashAggAlloc{aggAllocBase: allocBase}, nil
+		}
 	case types.FloatFamily:
-		return &avgFloat64HashAggAlloc{aggAllocBase: allocBase}, nil
+		switch t.Width() {
+		case -1:
+		default:
+			return &avgFloat64HashAggAlloc{aggAllocBase: allocBase}, nil
+		}
 	case types.IntervalFamily:
-		return &avgIntervalHashAggAlloc{aggAllocBase: allocBase}, nil
-	default:
-		return nil, errors.Errorf("unsupported avg agg type %s", t.Name())
+		switch t.Width() {
+		case -1:
+		default:
+			return &avgIntervalHashAggAlloc{aggAllocBase: allocBase}, nil
+		}
 	}
+	return nil, errors.Errorf("unsupported avg agg type %s", t.Name())
 }
 
 type avgInt16HashAgg struct {

--- a/pkg/sql/colexec/colexecagg/hash_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_sum_agg.eg.go
@@ -10,7 +10,6 @@
 package colexecagg
 
 import (
-	"strings"
 	"unsafe"
 
 	"github.com/cockroachdb/apd/v2"
@@ -43,18 +42,30 @@ func newSumHashAggAlloc(
 			return &sumInt16HashAggAlloc{aggAllocBase: allocBase}, nil
 		case 32:
 			return &sumInt32HashAggAlloc{aggAllocBase: allocBase}, nil
+		case -1:
 		default:
 			return &sumInt64HashAggAlloc{aggAllocBase: allocBase}, nil
 		}
 	case types.DecimalFamily:
-		return &sumDecimalHashAggAlloc{aggAllocBase: allocBase}, nil
+		switch t.Width() {
+		case -1:
+		default:
+			return &sumDecimalHashAggAlloc{aggAllocBase: allocBase}, nil
+		}
 	case types.FloatFamily:
-		return &sumFloat64HashAggAlloc{aggAllocBase: allocBase}, nil
+		switch t.Width() {
+		case -1:
+		default:
+			return &sumFloat64HashAggAlloc{aggAllocBase: allocBase}, nil
+		}
 	case types.IntervalFamily:
-		return &sumIntervalHashAggAlloc{aggAllocBase: allocBase}, nil
-	default:
-		return nil, errors.Errorf("unsupported sum %s agg type %s", strings.ToLower(""), t.Name())
+		switch t.Width() {
+		case -1:
+		default:
+			return &sumIntervalHashAggAlloc{aggAllocBase: allocBase}, nil
+		}
 	}
+	return nil, errors.Errorf("unsupported sum agg type %s", t.Name())
 }
 
 type sumInt16HashAgg struct {

--- a/pkg/sql/colexec/colexecagg/hash_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_sum_int_agg.eg.go
@@ -10,7 +10,6 @@
 package colexecagg
 
 import (
-	"strings"
 	"unsafe"
 
 	"github.com/cockroachdb/apd/v2"
@@ -42,12 +41,12 @@ func newSumIntHashAggAlloc(
 			return &sumIntInt16HashAggAlloc{aggAllocBase: allocBase}, nil
 		case 32:
 			return &sumIntInt32HashAggAlloc{aggAllocBase: allocBase}, nil
+		case -1:
 		default:
 			return &sumIntInt64HashAggAlloc{aggAllocBase: allocBase}, nil
 		}
-	default:
-		return nil, errors.Errorf("unsupported sum %s agg type %s", strings.ToLower("Int"), t.Name())
 	}
+	return nil, errors.Errorf("unsupported sum agg type %s", t.Name())
 }
 
 type sumIntInt16HashAgg struct {

--- a/pkg/sql/colexec/colexecagg/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/min_max_agg_tmpl.go
@@ -58,70 +58,29 @@ func _ASSIGN_CMP(_, _, _, _, _, _ string) bool {
 
 // */}}
 
-func newMin_AGGKINDAggAlloc(
-	allocator *colmem.Allocator, t *types.T, allocSize int64,
-) aggregateFuncAlloc {
-	allocBase := aggAllocBase{allocator: allocator, allocSize: allocSize}
-	switch typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()) {
-	case types.BoolFamily:
-		return &minBool_AGGKINDAggAlloc{aggAllocBase: allocBase}
-	case types.BytesFamily:
-		return &minBytes_AGGKINDAggAlloc{aggAllocBase: allocBase}
-	case types.DecimalFamily:
-		return &minDecimal_AGGKINDAggAlloc{aggAllocBase: allocBase}
-	case types.IntFamily:
-		switch t.Width() {
-		case 16:
-			return &minInt16_AGGKINDAggAlloc{aggAllocBase: allocBase}
-		case 32:
-			return &minInt32_AGGKINDAggAlloc{aggAllocBase: allocBase}
-		default:
-			return &minInt64_AGGKINDAggAlloc{aggAllocBase: allocBase}
-		}
-	case types.FloatFamily:
-		return &minFloat64_AGGKINDAggAlloc{aggAllocBase: allocBase}
-	case types.TimestampTZFamily:
-		return &minTimestamp_AGGKINDAggAlloc{aggAllocBase: allocBase}
-	case types.IntervalFamily:
-		return &minInterval_AGGKINDAggAlloc{aggAllocBase: allocBase}
-	default:
-		return &minDatum_AGGKINDAggAlloc{aggAllocBase: allocBase}
-	}
-}
-
-func newMax_AGGKINDAggAlloc(
-	allocator *colmem.Allocator, t *types.T, allocSize int64,
-) aggregateFuncAlloc {
-	allocBase := aggAllocBase{allocator: allocator, allocSize: allocSize}
-	switch typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()) {
-	case types.BoolFamily:
-		return &maxBool_AGGKINDAggAlloc{aggAllocBase: allocBase}
-	case types.BytesFamily:
-		return &maxBytes_AGGKINDAggAlloc{aggAllocBase: allocBase}
-	case types.DecimalFamily:
-		return &maxDecimal_AGGKINDAggAlloc{aggAllocBase: allocBase}
-	case types.IntFamily:
-		switch t.Width() {
-		case 16:
-			return &maxInt16_AGGKINDAggAlloc{aggAllocBase: allocBase}
-		case 32:
-			return &maxInt32_AGGKINDAggAlloc{aggAllocBase: allocBase}
-		default:
-			return &maxInt64_AGGKINDAggAlloc{aggAllocBase: allocBase}
-		}
-	case types.FloatFamily:
-		return &maxFloat64_AGGKINDAggAlloc{aggAllocBase: allocBase}
-	case types.TimestampTZFamily:
-		return &maxTimestamp_AGGKINDAggAlloc{aggAllocBase: allocBase}
-	case types.IntervalFamily:
-		return &maxInterval_AGGKINDAggAlloc{aggAllocBase: allocBase}
-	default:
-		return &maxDatum_AGGKINDAggAlloc{aggAllocBase: allocBase}
-	}
-}
-
 // {{range .}}
 // {{$agg := .Agg}}
+
+func new_AGG_TITLE_AGGKINDAggAlloc(
+	allocator *colmem.Allocator, t *types.T, allocSize int64,
+) aggregateFuncAlloc {
+	allocBase := aggAllocBase{allocator: allocator, allocSize: allocSize}
+	switch typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()) {
+	// {{range .Overloads}}
+	case _CANONICAL_TYPE_FAMILY:
+		switch t.Width() {
+		// {{range .WidthOverloads}}
+		case _TYPE_WIDTH:
+			return &_AGG_TYPE_AGGKINDAggAlloc{aggAllocBase: allocBase}
+			// {{end}}
+		}
+		// {{end}}
+	}
+	colexecerror.InternalError(errors.AssertionFailedf("unexpectedly didn't find _AGG overload for %s type family", t.Name()))
+	// This code is unreachable, but the compiler cannot infer that.
+	return nil
+}
+
 // {{range .Overloads}}
 // {{range .WidthOverloads}}
 

--- a/pkg/sql/colexec/colexecagg/ordered_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_avg_agg.eg.go
@@ -42,18 +42,30 @@ func newAvgOrderedAggAlloc(
 			return &avgInt16OrderedAggAlloc{aggAllocBase: allocBase}, nil
 		case 32:
 			return &avgInt32OrderedAggAlloc{aggAllocBase: allocBase}, nil
+		case -1:
 		default:
 			return &avgInt64OrderedAggAlloc{aggAllocBase: allocBase}, nil
 		}
 	case types.DecimalFamily:
-		return &avgDecimalOrderedAggAlloc{aggAllocBase: allocBase}, nil
+		switch t.Width() {
+		case -1:
+		default:
+			return &avgDecimalOrderedAggAlloc{aggAllocBase: allocBase}, nil
+		}
 	case types.FloatFamily:
-		return &avgFloat64OrderedAggAlloc{aggAllocBase: allocBase}, nil
+		switch t.Width() {
+		case -1:
+		default:
+			return &avgFloat64OrderedAggAlloc{aggAllocBase: allocBase}, nil
+		}
 	case types.IntervalFamily:
-		return &avgIntervalOrderedAggAlloc{aggAllocBase: allocBase}, nil
-	default:
-		return nil, errors.Errorf("unsupported avg agg type %s", t.Name())
+		switch t.Width() {
+		case -1:
+		default:
+			return &avgIntervalOrderedAggAlloc{aggAllocBase: allocBase}, nil
+		}
 	}
+	return nil, errors.Errorf("unsupported avg agg type %s", t.Name())
 }
 
 type avgInt16OrderedAgg struct {

--- a/pkg/sql/colexec/colexecagg/ordered_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_sum_agg.eg.go
@@ -10,7 +10,6 @@
 package colexecagg
 
 import (
-	"strings"
 	"unsafe"
 
 	"github.com/cockroachdb/apd/v2"
@@ -43,18 +42,30 @@ func newSumOrderedAggAlloc(
 			return &sumInt16OrderedAggAlloc{aggAllocBase: allocBase}, nil
 		case 32:
 			return &sumInt32OrderedAggAlloc{aggAllocBase: allocBase}, nil
+		case -1:
 		default:
 			return &sumInt64OrderedAggAlloc{aggAllocBase: allocBase}, nil
 		}
 	case types.DecimalFamily:
-		return &sumDecimalOrderedAggAlloc{aggAllocBase: allocBase}, nil
+		switch t.Width() {
+		case -1:
+		default:
+			return &sumDecimalOrderedAggAlloc{aggAllocBase: allocBase}, nil
+		}
 	case types.FloatFamily:
-		return &sumFloat64OrderedAggAlloc{aggAllocBase: allocBase}, nil
+		switch t.Width() {
+		case -1:
+		default:
+			return &sumFloat64OrderedAggAlloc{aggAllocBase: allocBase}, nil
+		}
 	case types.IntervalFamily:
-		return &sumIntervalOrderedAggAlloc{aggAllocBase: allocBase}, nil
-	default:
-		return nil, errors.Errorf("unsupported sum %s agg type %s", strings.ToLower(""), t.Name())
+		switch t.Width() {
+		case -1:
+		default:
+			return &sumIntervalOrderedAggAlloc{aggAllocBase: allocBase}, nil
+		}
 	}
+	return nil, errors.Errorf("unsupported sum agg type %s", t.Name())
 }
 
 type sumInt16OrderedAgg struct {

--- a/pkg/sql/colexec/colexecagg/ordered_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_sum_int_agg.eg.go
@@ -10,7 +10,6 @@
 package colexecagg
 
 import (
-	"strings"
 	"unsafe"
 
 	"github.com/cockroachdb/apd/v2"
@@ -42,12 +41,12 @@ func newSumIntOrderedAggAlloc(
 			return &sumIntInt16OrderedAggAlloc{aggAllocBase: allocBase}, nil
 		case 32:
 			return &sumIntInt32OrderedAggAlloc{aggAllocBase: allocBase}, nil
+		case -1:
 		default:
 			return &sumIntInt64OrderedAggAlloc{aggAllocBase: allocBase}, nil
 		}
-	default:
-		return nil, errors.Errorf("unsupported sum %s agg type %s", strings.ToLower("Int"), t.Name())
 	}
+	return nil, errors.Errorf("unsupported sum agg type %s", t.Name())
 }
 
 type sumIntInt16OrderedAgg struct {

--- a/pkg/sql/colexec/colexecagg/sum_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/sum_agg_tmpl.go
@@ -20,7 +20,6 @@
 package colexecagg
 
 import (
-	"strings"
 	"unsafe"
 
 	"github.com/cockroachdb/apd/v2"
@@ -58,29 +57,24 @@ func newSum_SUMKIND_AGGKINDAggAlloc(
 ) (aggregateFuncAlloc, error) {
 	allocBase := aggAllocBase{allocator: allocator, allocSize: allocSize}
 	switch t.Family() {
-	case types.IntFamily:
+	// {{range .Infos}}
+	case _TYPE_FAMILY:
 		switch t.Width() {
-		case 16:
-			return &sum_SUMKINDInt16_AGGKINDAggAlloc{aggAllocBase: allocBase}, nil
-		case 32:
-			return &sum_SUMKINDInt32_AGGKINDAggAlloc{aggAllocBase: allocBase}, nil
-		default:
-			return &sum_SUMKINDInt64_AGGKINDAggAlloc{aggAllocBase: allocBase}, nil
+		// {{range .WidthOverloads}}
+		case _TYPE_WIDTH:
+			// {{with .Overload}}
+			return &sum_SUMKIND_TYPE_AGGKINDAggAlloc{aggAllocBase: allocBase}, nil
+			// {{end}}
+			// {{end}}
 		}
-	// {{if eq .SumKind ""}}
-	case types.DecimalFamily:
-		return &sumDecimal_AGGKINDAggAlloc{aggAllocBase: allocBase}, nil
-	case types.FloatFamily:
-		return &sumFloat64_AGGKINDAggAlloc{aggAllocBase: allocBase}, nil
-	case types.IntervalFamily:
-		return &sumInterval_AGGKINDAggAlloc{aggAllocBase: allocBase}, nil
-	// {{end}}
-	default:
-		return nil, errors.Errorf("unsupported sum %s agg type %s", strings.ToLower("_SUMKIND"), t.Name())
+		// {{end}}
 	}
+	return nil, errors.Errorf("unsupported sum agg type %s", t.Name())
 }
 
 // {{range .Infos}}
+// {{range .WidthOverloads}}
+// {{with .Overload}}
 
 type sum_SUMKIND_TYPE_AGGKINDAgg struct {
 	// {{if eq "_AGGKIND" "Ordered"}}
@@ -226,6 +220,8 @@ func (a *sum_SUMKIND_TYPE_AGGKINDAggAlloc) newAggFunc() AggregateFunc {
 	return f
 }
 
+// {{end}}
+// {{end}}
 // {{end}}
 
 // {{/*

--- a/pkg/sql/colexec/execgen/cmd/execgen/min_max_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/min_max_agg_gen.go
@@ -22,6 +22,9 @@ const minMaxAggTmpl = "pkg/sql/colexec/colexecagg/min_max_agg_tmpl.go"
 
 func genMinMaxAgg(inputFileContents string, wr io.Writer) error {
 	r := strings.NewReplacer(
+		"_CANONICAL_TYPE_FAMILY", "{{.CanonicalTypeFamilyStr}}",
+		"_TYPE_WIDTH", typeWidthReplacement,
+		"_AGG_TITLE", "{{.AggTitle}}",
 		"_AGG", "{{$agg}}",
 		"_GOTYPESLICE", "{{.GoTypeSliceName}}",
 		"_GOTYPE", "{{.GoType}}",
@@ -44,14 +47,17 @@ func genMinMaxAgg(inputFileContents string, wr io.Writer) error {
 	}
 	return tmpl.Execute(wr, []struct {
 		Agg       string
+		AggTitle  string
 		Overloads []*oneArgOverload
 	}{
 		{
 			Agg:       "min",
+			AggTitle:  "Min",
 			Overloads: sameTypeComparisonOpToOverloads[tree.LT],
 		},
 		{
 			Agg:       "max",
+			AggTitle:  "Max",
 			Overloads: sameTypeComparisonOpToOverloads[tree.GT],
 		},
 	})


### PR DESCRIPTION
Previously, the type switch in constructors of AVG, MIN, MAX, and SUM
aggregate functions was hard-coded in the templates. This makes it a bit
annoying, so this commit cleans the situation up.

Release note: None