### PR TITLE
workload/tpcc: store extra columns in order@order_idx to avoid index join

### DIFF
--- a/pkg/sql/opt/testutils/opttester/testfixtures/tpcc_schema
+++ b/pkg/sql/opt/testutils/opttester/testfixtures/tpcc_schema
@@ -92,7 +92,7 @@ CREATE TABLE "order"
     o_ol_cnt     integer,
     o_all_local  integer,
     primary key (o_w_id, o_d_id, o_id DESC),
-    unique index order_idx (o_w_id, o_d_id, o_c_id, o_id DESC) storing (o_entry_d, o_carrier_id),
+    unique index order_idx (o_w_id, o_d_id, o_c_id, o_id DESC) storing (o_entry_d, o_carrier_id, o_ol_cnt, o_all_local),
     foreign key (o_w_id, o_d_id, o_c_id) references customer (c_w_id, c_d_id, c_id)
 ) interleave in parent district (o_w_id, o_d_id)
 ----

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -1147,7 +1147,7 @@ group-by
  ├── key: (2,3)
  ├── fd: (2,3)-->(10)
  ├── ordering: +3,+2
- ├── scan order@order_idx
+ ├── scan order
  │    ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null
  │    ├── key: (1-3)
  │    └── ordering: +3,+2
@@ -1253,7 +1253,7 @@ except-all
            ├── columns: o_id:5!null o_d_id:6!null o_w_id:7!null o_carrier_id:10
            ├── key: (5-7)
            ├── fd: ()-->(10)
-           ├── scan order@order_idx
+           ├── scan order
            │    ├── columns: o_id:5!null o_d_id:6!null o_w_id:7!null o_carrier_id:10
            │    ├── key: (5-7)
            │    └── fd: (5-7)-->(10)
@@ -1276,7 +1276,7 @@ except-all
  │         ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null o_carrier_id:6
  │         ├── key: (1-3)
  │         ├── fd: ()-->(6)
- │         ├── scan order@order_idx
+ │         ├── scan order
  │         │    ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null o_carrier_id:6
  │         │    ├── key: (1-3)
  │         │    └── fd: (1-3)-->(6)

--- a/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
@@ -1149,7 +1149,7 @@ group-by
  ├── key: (2,3)
  ├── fd: (2,3)-->(10)
  ├── ordering: +3,+2
- ├── scan order@order_idx
+ ├── scan order
  │    ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null
  │    ├── key: (1-3)
  │    └── ordering: +3,+2
@@ -1255,7 +1255,7 @@ except-all
            ├── columns: o_id:5!null o_d_id:6!null o_w_id:7!null o_carrier_id:10
            ├── key: (5-7)
            ├── fd: ()-->(10)
-           ├── scan order@order_idx
+           ├── scan order
            │    ├── columns: o_id:5!null o_d_id:6!null o_w_id:7!null o_carrier_id:10
            │    ├── key: (5-7)
            │    └── fd: (5-7)-->(10)
@@ -1278,7 +1278,7 @@ except-all
  │         ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null o_carrier_id:6
  │         ├── key: (1-3)
  │         ├── fd: ()-->(6)
- │         ├── scan order@order_idx
+ │         ├── scan order
  │         │    ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null o_carrier_id:6
  │         │    ├── key: (1-3)
  │         │    └── fd: (1-3)-->(6)
@@ -1380,35 +1380,39 @@ scalar-group-by
  ├── fd: ()-->(21)
  ├── select
  │    ├── columns: o_id:1 o_d_id:2 o_w_id:3 ol_o_id:10 ol_d_id:11 ol_w_id:12
- │    ├── full-join (hash)
+ │    ├── full-join (merge)
  │    │    ├── columns: o_id:1 o_d_id:2 o_w_id:3 ol_o_id:10 ol_d_id:11 ol_w_id:12
- │    │    ├── multiplicity: left-rows(exactly-one), right-rows(one-or-more)
- │    │    ├── project
- │    │    │    ├── columns: ol_o_id:10!null ol_d_id:11!null ol_w_id:12!null
- │    │    │    └── select
- │    │    │         ├── columns: ol_o_id:10!null ol_d_id:11!null ol_w_id:12!null ol_delivery_d:16
- │    │    │         ├── fd: ()-->(16)
- │    │    │         ├── scan order_line
- │    │    │         │    └── columns: ol_o_id:10!null ol_d_id:11!null ol_w_id:12!null ol_delivery_d:16
- │    │    │         └── filters
- │    │    │              └── ol_delivery_d:16 IS NULL [outer=(16), constraints=(/16: [/NULL - /NULL]; tight), fd=()-->(16)]
+ │    │    ├── left ordering: +3,+2,-1
+ │    │    ├── right ordering: +12,+11,-10
  │    │    ├── project
  │    │    │    ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null
  │    │    │    ├── key: (1-3)
+ │    │    │    ├── ordering: +3,+2,-1
  │    │    │    └── select
  │    │    │         ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null o_carrier_id:6
  │    │    │         ├── key: (1-3)
  │    │    │         ├── fd: ()-->(6)
- │    │    │         ├── scan order@order_idx
+ │    │    │         ├── ordering: +3,+2,-1 opt(6) [actual: +3,+2,-1]
+ │    │    │         ├── scan order
  │    │    │         │    ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null o_carrier_id:6
  │    │    │         │    ├── key: (1-3)
- │    │    │         │    └── fd: (1-3)-->(6)
+ │    │    │         │    ├── fd: (1-3)-->(6)
+ │    │    │         │    └── ordering: +3,+2,-1 opt(6) [actual: +3,+2,-1]
  │    │    │         └── filters
  │    │    │              └── o_carrier_id:6 IS NULL [outer=(6), constraints=(/6: [/NULL - /NULL]; tight), fd=()-->(6)]
- │    │    └── filters
- │    │         ├── ol_w_id:12 = o_w_id:3 [outer=(3,12), constraints=(/3: (/NULL - ]; /12: (/NULL - ]), fd=(3)==(12), (12)==(3)]
- │    │         ├── ol_d_id:11 = o_d_id:2 [outer=(2,11), constraints=(/2: (/NULL - ]; /11: (/NULL - ]), fd=(2)==(11), (11)==(2)]
- │    │         └── ol_o_id:10 = o_id:1 [outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+ │    │    ├── project
+ │    │    │    ├── columns: ol_o_id:10!null ol_d_id:11!null ol_w_id:12!null
+ │    │    │    ├── ordering: +12,+11,-10
+ │    │    │    └── select
+ │    │    │         ├── columns: ol_o_id:10!null ol_d_id:11!null ol_w_id:12!null ol_delivery_d:16
+ │    │    │         ├── fd: ()-->(16)
+ │    │    │         ├── ordering: +12,+11,-10 opt(16) [actual: +12,+11,-10]
+ │    │    │         ├── scan order_line
+ │    │    │         │    ├── columns: ol_o_id:10!null ol_d_id:11!null ol_w_id:12!null ol_delivery_d:16
+ │    │    │         │    └── ordering: +12,+11,-10 opt(16) [actual: +12,+11,-10]
+ │    │    │         └── filters
+ │    │    │              └── ol_delivery_d:16 IS NULL [outer=(16), constraints=(/16: [/NULL - /NULL]; tight), fd=()-->(16)]
+ │    │    └── filters (true)
  │    └── filters
  │         └── (ol_o_id:10 IS NULL) OR (o_id:1 IS NULL) [outer=(1,10)]
  └── aggregations

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -829,23 +829,18 @@ project
            ├── cardinality: [0 - 10]
            ├── key: (11)
            ├── fd: ()-->(10,12,19), (11)-->(13-17)
-           ├── index-join order
+           ├── select
            │    ├── columns: o_id:10!null o_d_id:11!null o_w_id:12!null o_c_id:13 o_entry_d:14 o_carrier_id:15 o_ol_cnt:16 o_all_local:17
            │    ├── cardinality: [0 - 10]
            │    ├── key: (11)
            │    ├── fd: ()-->(10,12), (11)-->(13-17)
-           │    └── select
-           │         ├── columns: o_id:10!null o_d_id:11!null o_w_id:12!null o_c_id:13 o_entry_d:14 o_carrier_id:15
-           │         ├── cardinality: [0 - 10]
-           │         ├── key: (11)
-           │         ├── fd: ()-->(10,12), (11)-->(13-15)
-           │         ├── scan order@order_idx
-           │         │    ├── columns: o_id:10!null o_d_id:11!null o_w_id:12!null o_c_id:13 o_entry_d:14 o_carrier_id:15
-           │         │    ├── constraint: /12/11/13/-10: [/10/1 - /10/10]
-           │         │    ├── key: (10,11)
-           │         │    └── fd: ()-->(12), (10,11)-->(13-15)
-           │         └── filters
-           │              └── (o_d_id:11, o_id:10) IN ((10, 2167), (5, 2167), (6, 2167), (9, 2167), (4, 2167), (7, 2167), (8, 2167), (1, 2167), (2, 2167), (3, 2167)) [outer=(10,11), constraints=(/10: [/2167 - /2167]; /11/10: [/1/2167 - /1/2167] [/2/2167 - /2/2167] [/3/2167 - /3/2167] [/4/2167 - /4/2167] [/5/2167 - /5/2167] [/6/2167 - /6/2167] [/7/2167 - /7/2167] [/8/2167 - /8/2167] [/9/2167 - /9/2167] [/10/2167 - /10/2167]; tight), fd=()-->(10)]
+           │    ├── scan order@order_idx
+           │    │    ├── columns: o_id:10!null o_d_id:11!null o_w_id:12!null o_c_id:13 o_entry_d:14 o_carrier_id:15 o_ol_cnt:16 o_all_local:17
+           │    │    ├── constraint: /12/11/13/-10: [/10/1 - /10/10]
+           │    │    ├── key: (10,11)
+           │    │    └── fd: ()-->(12), (10,11)-->(13-17)
+           │    └── filters
+           │         └── (o_d_id:11, o_id:10) IN ((10, 2167), (5, 2167), (6, 2167), (9, 2167), (4, 2167), (7, 2167), (8, 2167), (1, 2167), (2, 2167), (3, 2167)) [outer=(10,11), constraints=(/10: [/2167 - /2167]; /11/10: [/1/2167 - /1/2167] [/2/2167 - /2/2167] [/3/2167 - /3/2167] [/4/2167 - /4/2167] [/5/2167 - /5/2167] [/6/2167 - /6/2167] [/7/2167 - /7/2167] [/8/2167 - /8/2167] [/9/2167 - /9/2167] [/10/2167 - /10/2167]; tight), fd=()-->(10)]
            └── projections
                 └── 10 [as=o_carrier_id_new:19]
 
@@ -1143,7 +1138,7 @@ group-by
  ├── key: (2,3)
  ├── fd: (2,3)-->(10)
  ├── ordering: +3,+2
- ├── scan order@order_idx
+ ├── scan order
  │    ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null
  │    ├── key: (1-3)
  │    └── ordering: +3,+2
@@ -1249,7 +1244,7 @@ except-all
            ├── columns: o_id:5!null o_d_id:6!null o_w_id:7!null o_carrier_id:10
            ├── key: (5-7)
            ├── fd: ()-->(10)
-           ├── scan order@order_idx
+           ├── scan order
            │    ├── columns: o_id:5!null o_d_id:6!null o_w_id:7!null o_carrier_id:10
            │    ├── key: (5-7)
            │    └── fd: (5-7)-->(10)
@@ -1272,7 +1267,7 @@ except-all
  │         ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null o_carrier_id:6
  │         ├── key: (1-3)
  │         ├── fd: ()-->(6)
- │         ├── scan order@order_idx
+ │         ├── scan order
  │         │    ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null o_carrier_id:6
  │         │    ├── key: (1-3)
  │         │    └── fd: (1-3)-->(6)
@@ -1374,35 +1369,39 @@ scalar-group-by
  ├── fd: ()-->(21)
  ├── select
  │    ├── columns: o_id:1 o_d_id:2 o_w_id:3 ol_o_id:10 ol_d_id:11 ol_w_id:12
- │    ├── full-join (hash)
+ │    ├── full-join (merge)
  │    │    ├── columns: o_id:1 o_d_id:2 o_w_id:3 ol_o_id:10 ol_d_id:11 ol_w_id:12
- │    │    ├── multiplicity: left-rows(one-or-more), right-rows(exactly-one)
+ │    │    ├── left ordering: +3,+2,-1
+ │    │    ├── right ordering: +12,+11,-10
  │    │    ├── project
  │    │    │    ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null
  │    │    │    ├── key: (1-3)
+ │    │    │    ├── ordering: +3,+2,-1
  │    │    │    └── select
  │    │    │         ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null o_carrier_id:6
  │    │    │         ├── key: (1-3)
  │    │    │         ├── fd: ()-->(6)
- │    │    │         ├── scan order@order_idx
+ │    │    │         ├── ordering: +3,+2,-1 opt(6) [actual: +3,+2,-1]
+ │    │    │         ├── scan order
  │    │    │         │    ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null o_carrier_id:6
  │    │    │         │    ├── key: (1-3)
- │    │    │         │    └── fd: (1-3)-->(6)
+ │    │    │         │    ├── fd: (1-3)-->(6)
+ │    │    │         │    └── ordering: +3,+2,-1 opt(6) [actual: +3,+2,-1]
  │    │    │         └── filters
  │    │    │              └── o_carrier_id:6 IS NULL [outer=(6), constraints=(/6: [/NULL - /NULL]; tight), fd=()-->(6)]
  │    │    ├── project
  │    │    │    ├── columns: ol_o_id:10!null ol_d_id:11!null ol_w_id:12!null
+ │    │    │    ├── ordering: +12,+11,-10
  │    │    │    └── select
  │    │    │         ├── columns: ol_o_id:10!null ol_d_id:11!null ol_w_id:12!null ol_delivery_d:16
  │    │    │         ├── fd: ()-->(16)
+ │    │    │         ├── ordering: +12,+11,-10 opt(16) [actual: +12,+11,-10]
  │    │    │         ├── scan order_line
- │    │    │         │    └── columns: ol_o_id:10!null ol_d_id:11!null ol_w_id:12!null ol_delivery_d:16
+ │    │    │         │    ├── columns: ol_o_id:10!null ol_d_id:11!null ol_w_id:12!null ol_delivery_d:16
+ │    │    │         │    └── ordering: +12,+11,-10 opt(16) [actual: +12,+11,-10]
  │    │    │         └── filters
  │    │    │              └── ol_delivery_d:16 IS NULL [outer=(16), constraints=(/16: [/NULL - /NULL]; tight), fd=()-->(16)]
- │    │    └── filters
- │    │         ├── ol_w_id:12 = o_w_id:3 [outer=(3,12), constraints=(/3: (/NULL - ]; /12: (/NULL - ]), fd=(3)==(12), (12)==(3)]
- │    │         ├── ol_d_id:11 = o_d_id:2 [outer=(2,11), constraints=(/2: (/NULL - ]; /11: (/NULL - ]), fd=(2)==(11), (11)==(2)]
- │    │         └── ol_o_id:10 = o_id:1 [outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+ │    │    └── filters (true)
  │    └── filters
  │         └── (ol_o_id:10 IS NULL) OR (o_id:1 IS NULL) [outer=(1,10)]
  └── aggregations

--- a/pkg/workload/tpcc/ddls.go
+++ b/pkg/workload/tpcc/ddls.go
@@ -116,7 +116,7 @@ const (
 		o_ol_cnt     integer,
 		o_all_local  integer,
 		primary key  (o_w_id, o_d_id, o_id DESC),
-		unique index order_idx (o_w_id, o_d_id, o_c_id, o_id DESC) storing (o_entry_d, o_carrier_id)
+		unique index order_idx (o_w_id, o_d_id, o_c_id, o_id DESC) storing (o_entry_d, o_carrier_id, o_ol_cnt, o_all_local)
 	)`
 	tpccOrderSchemaInterleaveSuffix = `
 		interleave in parent district (o_w_id, o_d_id)`


### PR DESCRIPTION
This commit stores two new columns in the `order@order_idx` index so that [the UPDATE](https://github.com/cockroachdb/cockroach/blob/df253ab1e1faef67e13f0883229e05f189ab9c44/pkg/workload/tpcc/delivery.go#L158) performed by the Delivery transaction does not need to perform an index join.

This was discovered while exploring #63735.