### PR TITLE
release-21.1: sql: fix index out of range error in inverted filterer

### DIFF
--- a/pkg/sql/inverted/testdata/expression
+++ b/pkg/sql/inverted/testdata/expression
@@ -242,7 +242,7 @@ and result=_ left=b right=ac
 ----
 span expression
  ├── tight: true, unique: true
- ├── to read: ["a", "c")
+ ├── to read: ["b", "b"]
  └── union spans: ["b", "b"]
 
 new-span-leaf name=bj tight=true unique=true span=b,j
@@ -265,7 +265,7 @@ and result=_ left=b right=bj
 ----
 span expression
  ├── tight: true, unique: true
- ├── to read: ["b", "j")
+ ├── to read: ["b", "b"]
  └── union spans: ["b", "b"]
 
 # [b, j) or [a, c) = [a, j)

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -880,6 +880,12 @@ SELECT j FROM f@i WHERE j->'a' = '"b"' AND j->'c' = '[{"d": 1}, {"e": 2}]' ORDER
 ----
 {"a": "b", "c": [{"d": 1}, {"e": 2}]}
 
+# Regression test for #63180. This query should not cause an index out of range
+# error in the inverted filterer.
+query T
+SELECT j FROM f@i WHERE j @> '{"a": "c"}' AND (j @> '{"a": "b"}' OR j @> '{"a": "c"}')
+----
+
 subtest arrays
 
 statement ok

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -2998,7 +2998,8 @@ project
       │              ├── inverted constraint: /7/1
       │              │    └── spans
       │              │         ├── ["B\xfdL\x00\x00\x00\x00\x00\x00\x00", "B\xfdL\x00\x00\x00\x00\x00\x00\x00"]
-      │              │         └── ["B\xfdN\x00\x00\x00\x00\x00\x00\x01", "B\xfdP\x00\x00\x00\x00\x00\x00\x01")
+      │              │         ├── ["B\xfdO\x00\x00\x00\x00\x00\x00\x00", "B\xfdO\x00\x00\x00\x00\x00\x00\x00"]
+      │              │         └── ["B\xfdP\x00\x00\x00\x00\x00\x00\x00", "B\xfdP\x00\x00\x00\x00\x00\x00\x00"]
       │              ├── key: (1)
       │              └── fd: (1)-->(7)
       └── filters
@@ -4182,6 +4183,35 @@ select
  │    └── fd: (1)-->(2)
  └── filters
       └── st_intersects(g:2, '0103000020E610000000000000') [outer=(2), immutable, constraints=(/2: (/NULL - ])]
+
+# Regression test for #63180. Ensure that we only scan spans needed by the
+# inverted filter.
+exec-ddl
+CREATE TABLE t63180 (
+  j JSON,
+  INVERTED INDEX j_idx (j)
+)
+----
+
+opt expect=GenerateInvertedIndexScans
+SELECT j FROM t63180@j_idx WHERE j @> '{"a": "c"}' AND (j @> '{"a": "b"}' OR j @> '{"a": "c"}');
+----
+index-join t63180
+ ├── columns: j:1!null
+ ├── immutable
+ └── inverted-filter
+      ├── columns: rowid:2!null
+      ├── inverted expression: /4
+      │    ├── tight: true, unique: false
+      │    └── union spans: ["7a\x00\x01\x12c\x00\x01", "7a\x00\x01\x12c\x00\x01"]
+      ├── key: (2)
+      └── scan t63180@j_idx
+           ├── columns: rowid:2!null j_inverted_key:4!null
+           ├── inverted constraint: /4/2
+           │    └── spans: ["7a\x00\x01\x12c\x00\x01", "7a\x00\x01\x12c\x00\x01"]
+           ├── flags: force-index=j_idx
+           ├── key: (2)
+           └── fd: (2)-->(4)
 
 # --------------------------------------------------
 # GenerateZigzagJoins


### PR DESCRIPTION
Backport 1/1 commits from #63574.

/cc @cockroachdb/release

---

Prior to this commit, it was possible that the `SpansToRead` in
an `inverted.SpanExpression` were a superset of the spans that were
needed to evaluate the span expression. This could result in an index
out of range error in the `invertedFilterer` when a span from the input
didn't exist in its list of needed spans. This commit fixes the
problem by ensuring that `SpansToRead` does not contain spans that are
not needed to evaluate the span expression.

Fixes #63180

Release note (bug fix): Fixed an internal error that could occur
when executing queries using an inverted index. The error was an index
out of range error, and could occur in rare cases when a filter or
join predicate contained at least two JSON, Array, Geometry or
Geography expressions that were combined with AND. This has now been
fixed.
