### PR TITLE
[WIP] server,sql: make the time-to-first-query observable in telemetry

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -126,8 +126,11 @@ type TestServerArgs struct {
 	// is running in secure mode.
 	DisableWebSessionAuthentication bool
 
-	// IF set, the demo login endpoint will be enabled.
+	// If set, the demo login endpoint will be enabled.
 	EnableDemoLoginEndpoint bool
+
+	// If set, nodes will keep track of the first query timestamp.
+	EnableTrackFirstQueryTimestamp bool
 }
 
 // TestClusterArgs contains the parameters one can set when creating a test

--- a/pkg/cli/demo_cluster.go
+++ b/pkg/cli/demo_cluster.go
@@ -560,16 +560,17 @@ func testServerArgsForTransientCluster(
 	storeSpec.StickyInMemoryEngineID = fmt.Sprintf("demo-node%d", nodeID)
 
 	args := base.TestServerArgs{
-		SocketFile:              sock.filename(),
-		PartOfCluster:           true,
-		Stopper:                 stop.NewStopper(),
-		JoinAddr:                joinAddr,
-		DisableTLSForHTTP:       true,
-		StoreSpecs:              []base.StoreSpec{storeSpec},
-		SQLMemoryPoolSize:       demoCtx.sqlPoolMemorySize,
-		CacheSize:               demoCtx.cacheSize,
-		NoAutoInitializeCluster: true,
-		EnableDemoLoginEndpoint: true,
+		SocketFile:                     sock.filename(),
+		PartOfCluster:                  true,
+		Stopper:                        stop.NewStopper(),
+		JoinAddr:                       joinAddr,
+		DisableTLSForHTTP:              true,
+		StoreSpecs:                     []base.StoreSpec{storeSpec},
+		SQLMemoryPoolSize:              demoCtx.sqlPoolMemorySize,
+		CacheSize:                      demoCtx.cacheSize,
+		NoAutoInitializeCluster:        true,
+		EnableDemoLoginEndpoint:        true,
+		EnableTrackFirstQueryTimestamp: true,
 		// This disables the tenant server. We could enable it but would have to
 		// generate the suitable certs at the caller who wishes to do so.
 		TenantAddr: new(string),

--- a/pkg/cli/mt_start_sql.go
+++ b/pkg/cli/mt_start_sql.go
@@ -69,6 +69,10 @@ func runStartSQL(cmd *cobra.Command, args []string) error {
 	// suitable storage.
 	serverCfg.Stores.Specs = nil
 
+	// Initialize first query tracking.
+	// TODO(knz): We may want a command-line flag to disable this functionality.
+	serverCfg.SQLConfig.EnableTrackFirstQueryTimestamp = true
+
 	stopper, err := setupAndInitializeLoggingAndProfiling(ctx, cmd, false /* isServerCmd */)
 	if err != nil {
 		return err

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -384,6 +384,10 @@ func runStart(cmd *cobra.Command, args []string, startSingleNode bool) (returnEr
 		return err
 	}
 
+	// Initialize first query tracking.
+	// TODO(knz): We may want a command-line flag to disable this functionality.
+	serverCfg.SQLConfig.EnableTrackFirstQueryTimestamp = true
+
 	// Next we initialize the target directory for temporary storage.
 	// If encryption at rest is enabled in any fashion, we'll want temp
 	// storage to be encrypted too. To achieve this, we use

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -337,6 +337,13 @@ type SQLConfig struct {
 	//
 	// Only applies when the SQL server is deployed individually.
 	TenantKVAddrs []string
+
+	// EnableTrackFirstQueryTimestamp, when set,
+	// cause the cluster to remember the timestamp
+	// of the first query. This is set for
+	// servers started from the command line
+	// but not for test servers by default.
+	EnableTrackFirstQueryTimestamp bool
 }
 
 // MakeSQLConfig returns a SQLConfig with default values.

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -197,6 +197,9 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	if params.CacheSize != 0 {
 		cfg.CacheSize = params.CacheSize
 	}
+	if params.EnableTrackFirstQueryTimestamp {
+		cfg.SQLConfig.EnableTrackFirstQueryTimestamp = true
+	}
 
 	if params.JoinAddr != "" {
 		cfg.JoinList = []string{params.JoinAddr}

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -20,7 +20,7 @@ import (
 
 // MaxSettings is the maximum number of settings that the system supports.
 // Exported for tests.
-const MaxSettings = 256
+const MaxSettings = 512
 
 // Values is a container that stores values for all registered settings.
 // Each setting is assigned a unique slot (up to MaxSettings).

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -328,8 +328,13 @@ func Match(rd io.Reader) bool {
 }
 
 // Start makes the Server ready for serving connections.
-func (s *Server) Start(ctx context.Context, stopper *stop.Stopper) {
-	s.SQLServer.Start(ctx, stopper)
+func (s *Server) Start(
+	ctx context.Context,
+	stopper *stop.Stopper,
+	ie *sql.InternalExecutor,
+	trackFirstQueryTimestamp bool,
+) {
+	s.SQLServer.Start(ctx, stopper, ie, trackFirstQueryTimestamp)
 }
 
 // IsDraining returns true if the server is not currently accepting


### PR DESCRIPTION
(inspired from the discussion on #55059  and a request by @vilamurugu )

This change aims to expose “time to first query”, a product
metric that correlates with how easy it is for a user
to start using CockroachDB.

The collection of “time to first query” is made complicated
to collect because of the following:

- we cannot compute this entirely on one node using solely in-memory
  operations: we need to find the first time a query is executed across
  a fleet of nodes, and we need to remember the value when nodes get
  restarted.

- we would like to avoid a read-eval-write cycle with an access to KV
  storage, or disk, or a fan-out across the network, upon every query. The
  collection of this metric should have virtually no performance impact
  on the common case of workloads beyond the first access.

- the metric “time to first query” is different from “time *of* first
  query”: we want to track the *amount of time* between cluster
  creation and the time of first query.

- we wish to avoid taking into account “internal” SQL queries, such
  as those issued internally by CockroachDB itself and those
  issued by helper/orchestration tools.

In order to reach the stated goal, this commit proposes the following
model:

- to avoid “internal” SQL queries, the mechanism described below
  only looks at queries issued when the `application_name` is
  not “internal”, that is, does not start with the special
  prefix `"$ "`.

- nodes keep track of their “time *of* first query” as
  follows:

  - an in-memory only timestamp is maintained and checked upon
    every query execution. Accesses are atomic to avoid
    any performance impact.

  - separately, an asynchronous background process
    (`startSynchronizeFirstQueryTimestamp`) synchronizes
    the in-memory timestamp with a new cluster setting
    `sql.metrics.first_query.timestamp`.

    The choice is made to use a cluster setting because these
    automatically synchronize between nodes and are
    automatically embarked in telemetry already.

- separately and independently, the cluster now remembers its
  initialization time by storing a timestamp inside a new cluster
  setting `sql.metrics.cluster_init.timestamp`. This is set only once,
  upon cluster init.

  Again, the choice is made to use a cluster setting because these are
  automatically embarked in telemetry already.

Note that this change does not compute the time *to* first query,
but instead presents two different timestamp in telemetry
(from the cluster settings) which can be subtracted from each other
to reach the stated goal.

Here is an example use, using `cockroach demo` (nb: by default `demo`
uses an internal `application_name`):

    ```
    $ cockroach demo

    root> show cluster setting sql.metrics.cluster_init.timestamp;
    sql.metrics.cluster_init.timestamp
    --------------------------------------
                     1618666751186151817

    root> show cluster setting sql.metrics.first_query.timestamp;
      sql.metrics.first_query.timestamp
    -------------------------------------
                                      0

    root> set application_name = 'foo';

    root> show cluster setting sql.metrics.first_query.timestamp;
      sql.metrics.first_query.timestamp
    -------------------------------------
                    1618666852579067840

    root> select 1;

    root> -- observe: the first query timestamp does not change!

    root> show cluster setting sql.metrics.first_query.timestamp;
      sql.metrics.first_query.timestamp
    -------------------------------------
                    1618666852579067840
    ```



Note also that the new `first_query.timestamp` value is approximate.
This is explained by the following comment in the source code:

```
// The timestamp of the first query that was not issued by
// an "internal" client (as determined by application_name).
//
// This is set to non-zero by any node receiving a query if the
// value is observed to still be zero.
// Meanwhile, as for every cluster setting, it is possible for this
// value to take a while to propagate to the rest of this cluster.
// Therefore, it is possible for multiple nodes to concurrently
// write to the cluster setting, when they receive their first
// client query within a short time frame (the setting propagation
// delay).
// We find this acceptable because this propagation delay
// is short (seconds) whereas the information we hope to extract
// from this timestamp need only be at minutes/hours granularity.
```

See the release note below for a descriptionof impact.

Release note (sql change): CockroachDB now stores the time at which
the SQL logical layer of a cluster was initialized in the cluster
setting `sql.metrics.cluster_init.timestamp`.It also stores the
approximate time *at* which the first query from a SQL client is
executed in the new cluster setting
`sql.metrics.first_query.timestamp`.

This makes it possible to compute the time *to* first query since
cluster initialization, by subtracting the two values.

Note that the value is approximate because when the initial clients
connect to multiple nodes simultaneously, it is possible for multiple
nodes to concurrently estimate that they received the “first
query”. The uncertainty in this approximation is limited by the
propagation delay of cluster settings, which is typically a dozen of
seconds or less across the entire cluster.