### PR TITLE
backupccl: fix CheckEmittedEvents

### DIFF
--- a/pkg/ccl/backupccl/testutils.go
+++ b/pkg/ccl/backupccl/testutils.go
@@ -56,6 +56,9 @@ func CheckEmittedEvents(
 			}
 			require.Equal(t, expectedJobType, ev.JobType)
 			require.Equal(t, jobID, ev.JobID)
+			if i >= len(expectedStatus) {
+				return errors.New("more events fround in log than expected")
+			}
 			require.Equal(t, expectedStatus[i], ev.Status)
 		}
 		if !foundEntry {


### PR DESCRIPTION
Found while working on #63812.

This ensures the test does not panic if there are more entries in the
log than expected.

Release note: None