### PR TITLE
colexec: remove redundant deep copies in distinct template

### DIFF
--- a/pkg/sql/colexec/colexecbase/distinct.eg.go
+++ b/pkg/sql/colexec/colexecbase/distinct.eg.go
@@ -279,9 +279,8 @@ func (p *distinctBoolOp) Next(ctx context.Context) coldata.Batch {
 						}
 
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
-						lastVal = v
 						{
-							__retval_0 = lastVal
+							__retval_0 = v
 						}
 					}
 					lastVal = __retval_0
@@ -374,9 +373,8 @@ func (p *distinctBoolOp) Next(ctx context.Context) coldata.Batch {
 						}
 
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
-						lastVal = v
 						{
-							__retval_0 = lastVal
+							__retval_0 = v
 						}
 					}
 					lastVal = __retval_0
@@ -385,6 +383,7 @@ func (p *distinctBoolOp) Next(ctx context.Context) coldata.Batch {
 		}
 	}
 
+	// We need to perform a deep copy for the next iteration.
 	p.lastVal = lastVal
 	p.lastValNull = lastValNull
 
@@ -498,7 +497,7 @@ func (p *distinctBytesOp) Next(ctx context.Context) coldata.Batch {
 
 								outputCol[outputIdx] = outputCol[outputIdx] || unique
 							}
-							lastVal = append(lastVal[:0], v...)
+							lastVal = v
 						}
 						{
 							__retval_lastVal = lastVal
@@ -527,9 +526,8 @@ func (p *distinctBytesOp) Next(ctx context.Context) coldata.Batch {
 						}
 
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
-						lastVal = append(lastVal[:0], v...)
 						{
-							__retval_0 = lastVal
+							__retval_0 = v
 						}
 					}
 					lastVal = __retval_0
@@ -577,7 +575,7 @@ func (p *distinctBytesOp) Next(ctx context.Context) coldata.Batch {
 
 								outputCol[outputIdx] = outputCol[outputIdx] || unique
 							}
-							lastVal = append(lastVal[:0], v...)
+							lastVal = v
 						}
 						{
 							__retval_lastVal = lastVal
@@ -606,9 +604,8 @@ func (p *distinctBytesOp) Next(ctx context.Context) coldata.Batch {
 						}
 
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
-						lastVal = append(lastVal[:0], v...)
 						{
-							__retval_0 = lastVal
+							__retval_0 = v
 						}
 					}
 					lastVal = __retval_0
@@ -617,7 +614,8 @@ func (p *distinctBytesOp) Next(ctx context.Context) coldata.Batch {
 		}
 	}
 
-	p.lastVal = lastVal
+	// We need to perform a deep copy for the next iteration.
+	p.lastVal = append(p.lastVal[:0], lastVal...)
 	p.lastValNull = lastValNull
 
 	return batch
@@ -730,7 +728,7 @@ func (p *distinctDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 								outputCol[outputIdx] = outputCol[outputIdx] || unique
 							}
-							lastVal.Set(&v)
+							lastVal = v
 						}
 						{
 							__retval_lastVal = lastVal
@@ -759,9 +757,8 @@ func (p *distinctDecimalOp) Next(ctx context.Context) coldata.Batch {
 						}
 
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
-						lastVal.Set(&v)
 						{
-							__retval_0 = lastVal
+							__retval_0 = v
 						}
 					}
 					lastVal = __retval_0
@@ -809,7 +806,7 @@ func (p *distinctDecimalOp) Next(ctx context.Context) coldata.Batch {
 
 								outputCol[outputIdx] = outputCol[outputIdx] || unique
 							}
-							lastVal.Set(&v)
+							lastVal = v
 						}
 						{
 							__retval_lastVal = lastVal
@@ -838,9 +835,8 @@ func (p *distinctDecimalOp) Next(ctx context.Context) coldata.Batch {
 						}
 
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
-						lastVal.Set(&v)
 						{
-							__retval_0 = lastVal
+							__retval_0 = v
 						}
 					}
 					lastVal = __retval_0
@@ -849,7 +845,8 @@ func (p *distinctDecimalOp) Next(ctx context.Context) coldata.Batch {
 		}
 	}
 
-	p.lastVal = lastVal
+	// We need to perform a deep copy for the next iteration.
+	p.lastVal.Set(&lastVal)
 	p.lastValNull = lastValNull
 
 	return batch
@@ -1013,9 +1010,8 @@ func (p *distinctInt16Op) Next(ctx context.Context) coldata.Batch {
 						}
 
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
-						lastVal = v
 						{
-							__retval_0 = lastVal
+							__retval_0 = v
 						}
 					}
 					lastVal = __retval_0
@@ -1114,9 +1110,8 @@ func (p *distinctInt16Op) Next(ctx context.Context) coldata.Batch {
 						}
 
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
-						lastVal = v
 						{
-							__retval_0 = lastVal
+							__retval_0 = v
 						}
 					}
 					lastVal = __retval_0
@@ -1125,6 +1120,7 @@ func (p *distinctInt16Op) Next(ctx context.Context) coldata.Batch {
 		}
 	}
 
+	// We need to perform a deep copy for the next iteration.
 	p.lastVal = lastVal
 	p.lastValNull = lastValNull
 
@@ -1289,9 +1285,8 @@ func (p *distinctInt32Op) Next(ctx context.Context) coldata.Batch {
 						}
 
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
-						lastVal = v
 						{
-							__retval_0 = lastVal
+							__retval_0 = v
 						}
 					}
 					lastVal = __retval_0
@@ -1390,9 +1385,8 @@ func (p *distinctInt32Op) Next(ctx context.Context) coldata.Batch {
 						}
 
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
-						lastVal = v
 						{
-							__retval_0 = lastVal
+							__retval_0 = v
 						}
 					}
 					lastVal = __retval_0
@@ -1401,6 +1395,7 @@ func (p *distinctInt32Op) Next(ctx context.Context) coldata.Batch {
 		}
 	}
 
+	// We need to perform a deep copy for the next iteration.
 	p.lastVal = lastVal
 	p.lastValNull = lastValNull
 
@@ -1565,9 +1560,8 @@ func (p *distinctInt64Op) Next(ctx context.Context) coldata.Batch {
 						}
 
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
-						lastVal = v
 						{
-							__retval_0 = lastVal
+							__retval_0 = v
 						}
 					}
 					lastVal = __retval_0
@@ -1666,9 +1660,8 @@ func (p *distinctInt64Op) Next(ctx context.Context) coldata.Batch {
 						}
 
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
-						lastVal = v
 						{
-							__retval_0 = lastVal
+							__retval_0 = v
 						}
 					}
 					lastVal = __retval_0
@@ -1677,6 +1670,7 @@ func (p *distinctInt64Op) Next(ctx context.Context) coldata.Batch {
 		}
 	}
 
+	// We need to perform a deep copy for the next iteration.
 	p.lastVal = lastVal
 	p.lastValNull = lastValNull
 
@@ -1857,9 +1851,8 @@ func (p *distinctFloat64Op) Next(ctx context.Context) coldata.Batch {
 						}
 
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
-						lastVal = v
 						{
-							__retval_0 = lastVal
+							__retval_0 = v
 						}
 					}
 					lastVal = __retval_0
@@ -1974,9 +1967,8 @@ func (p *distinctFloat64Op) Next(ctx context.Context) coldata.Batch {
 						}
 
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
-						lastVal = v
 						{
-							__retval_0 = lastVal
+							__retval_0 = v
 						}
 					}
 					lastVal = __retval_0
@@ -1985,6 +1977,7 @@ func (p *distinctFloat64Op) Next(ctx context.Context) coldata.Batch {
 		}
 	}
 
+	// We need to perform a deep copy for the next iteration.
 	p.lastVal = lastVal
 	p.lastValNull = lastValNull
 
@@ -2141,9 +2134,8 @@ func (p *distinctTimestampOp) Next(ctx context.Context) coldata.Batch {
 						}
 
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
-						lastVal = v
 						{
-							__retval_0 = lastVal
+							__retval_0 = v
 						}
 					}
 					lastVal = __retval_0
@@ -2234,9 +2226,8 @@ func (p *distinctTimestampOp) Next(ctx context.Context) coldata.Batch {
 						}
 
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
-						lastVal = v
 						{
-							__retval_0 = lastVal
+							__retval_0 = v
 						}
 					}
 					lastVal = __retval_0
@@ -2245,6 +2236,7 @@ func (p *distinctTimestampOp) Next(ctx context.Context) coldata.Batch {
 		}
 	}
 
+	// We need to perform a deep copy for the next iteration.
 	p.lastVal = lastVal
 	p.lastValNull = lastValNull
 
@@ -2387,9 +2379,8 @@ func (p *distinctIntervalOp) Next(ctx context.Context) coldata.Batch {
 						}
 
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
-						lastVal = v
 						{
-							__retval_0 = lastVal
+							__retval_0 = v
 						}
 					}
 					lastVal = __retval_0
@@ -2466,9 +2457,8 @@ func (p *distinctIntervalOp) Next(ctx context.Context) coldata.Batch {
 						}
 
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
-						lastVal = v
 						{
-							__retval_0 = lastVal
+							__retval_0 = v
 						}
 					}
 					lastVal = __retval_0
@@ -2477,6 +2467,7 @@ func (p *distinctIntervalOp) Next(ctx context.Context) coldata.Batch {
 		}
 	}
 
+	// We need to perform a deep copy for the next iteration.
 	p.lastVal = lastVal
 	p.lastValNull = lastValNull
 
@@ -2623,9 +2614,8 @@ func (p *distinctDatumOp) Next(ctx context.Context) coldata.Batch {
 						}
 
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
-						lastVal = v
 						{
-							__retval_0 = lastVal
+							__retval_0 = v
 						}
 					}
 					lastVal = __retval_0
@@ -2706,9 +2696,8 @@ func (p *distinctDatumOp) Next(ctx context.Context) coldata.Batch {
 						}
 
 						outputCol[outputIdx] = outputCol[outputIdx] || unique
-						lastVal = v
 						{
-							__retval_0 = lastVal
+							__retval_0 = v
 						}
 					}
 					lastVal = __retval_0
@@ -2717,6 +2706,7 @@ func (p *distinctDatumOp) Next(ctx context.Context) coldata.Batch {
 		}
 	}
 
+	// We need to perform a deep copy for the next iteration.
 	p.lastVal = lastVal
 	p.lastValNull = lastValNull
 

--- a/pkg/sql/colexec/colexecbase/distinct_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/distinct_tmpl.go
@@ -230,7 +230,8 @@ func (p *distinct_TYPEOp) Next(ctx context.Context) coldata.Batch {
 		}
 	}
 
-	p.lastVal = lastVal
+	// We need to perform a deep copy for the next iteration.
+	execgen.COPYVAL(p.lastVal, lastVal)
 	p.lastValNull = lastValNull
 
 	return batch
@@ -315,8 +316,7 @@ func checkDistinct(
 	var unique bool
 	_ASSIGN_NE(unique, v, lastVal, _, col, _)
 	outputCol[outputIdx] = outputCol[outputIdx] || unique
-	execgen.COPYVAL(lastVal, v)
-	return lastVal
+	return v
 }
 
 // checkDistinctWithNulls behaves the same as checkDistinct, but it also
@@ -349,7 +349,7 @@ func checkDistinctWithNulls(
 			_ASSIGN_NE(unique, v, lastVal, _, col, _)
 			outputCol[outputIdx] = outputCol[outputIdx] || unique
 		}
-		execgen.COPYVAL(lastVal, v)
+		lastVal = v
 	}
 	return lastVal, null
 }

--- a/pkg/sql/colexec/distinct_test.go
+++ b/pkg/sql/colexec/distinct_test.go
@@ -19,12 +19,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexectestutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/errors"
 )
 
 type distinctTestCase struct {
@@ -271,38 +273,72 @@ func runDistinctBenchmarks(
 	isExternal bool,
 ) {
 	rng, _ := randutil.NewPseudoRand()
+	const nCols = 2
+	const bytesValueLength = 8
+	distinctCols := []uint32{0, 1}
 	nullsOptions := []bool{false, true}
 	nRowsOptions := []int{1, 64, 4 * coldata.BatchSize(), 256 * coldata.BatchSize()}
-	nColsOptions := []int{2, 4}
 	if isExternal {
 		nullsOptions = []bool{false}
 		nRowsOptions = []int{coldata.BatchSize(), 64 * coldata.BatchSize(), 4096 * coldata.BatchSize()}
 	}
 	if testing.Short() {
 		nRowsOptions = []int{coldata.BatchSize()}
-		nColsOptions = []int{2}
+	}
+	setFirstValue := func(vec coldata.Vec) {
+		if typ := vec.Type(); typ == types.Int {
+			vec.Int64()[0] = 0
+		} else if typ == types.Bytes {
+			vec.Bytes().Set(0, make([]byte, bytesValueLength))
+		} else {
+			colexecerror.InternalError(errors.AssertionFailedf("unsupported type %s", typ))
+		}
+	}
+	setIthValue := func(vec coldata.Vec, i int, newValueProbability float64) {
+		if i == 0 {
+			colexecerror.InternalError(errors.New("setIthValue called with i == 0"))
+		}
+		if typ := vec.Type(); typ == types.Int {
+			col := vec.Int64()
+			col[i] = col[i-1]
+			if rng.Float64() < newValueProbability {
+				col[i]++
+			}
+		} else if typ == types.Bytes {
+			v := make([]byte, bytesValueLength)
+			copy(v, vec.Bytes().Get(i-1))
+			if rng.Float64() < newValueProbability {
+				for pos := 0; pos < bytesValueLength; pos++ {
+					v[pos]++
+					// If we have overflowed our current byte, we need to
+					// increment the next one; otherwise, we have a new distinct
+					// value.
+					if v[pos] != 0 {
+						break
+					}
+				}
+			}
+			vec.Bytes().Set(i, v)
+		} else {
+			colexecerror.InternalError(errors.AssertionFailedf("unsupported type %s", typ))
+		}
 	}
 	for _, hasNulls := range nullsOptions {
 		for _, newTupleProbability := range []float64{0.001, 0.1} {
 			for _, nRows := range nRowsOptions {
-				for _, nCols := range nColsOptions {
+				for _, typ := range []*types.T{types.Int, types.Bytes} {
 					typs := make([]*types.T, nCols)
 					cols := make([]coldata.Vec, nCols)
 					for i := range typs {
-						typs[i] = types.Int
+						typs[i] = typ
 						cols[i] = testAllocator.NewMemColumn(typs[i], nRows)
 					}
-					distinctCols := []uint32{0, 1, 2, 3}[:nCols]
 					numOrderedCols := getNumOrderedCols(nCols)
 					newValueProbability := getNewValueProbabilityForDistinct(newTupleProbability, nCols)
 					for i := range distinctCols {
-						col := cols[i].Int64()
-						col[0] = 0
+						setFirstValue(cols[i])
 						for j := 1; j < nRows; j++ {
-							col[j] = col[j-1]
-							if rng.Float64() < newValueProbability {
-								col[j]++
-							}
+							setIthValue(cols[i], j, newValueProbability)
 						}
 						if hasNulls {
 							cols[i].Nulls().SetNull(0)
@@ -313,9 +349,9 @@ func runDistinctBenchmarks(
 						nullsPrefix = fmt.Sprintf("/hasNulls=%t", hasNulls)
 					}
 					b.Run(
-						fmt.Sprintf("%s%s/newTupleProbability=%.3f/rows=%d/cols=%d/ordCols=%d",
+						fmt.Sprintf("%s%s/newTupleProbability=%.3f/rows=%d/ordCols=%d/type=%s",
 							namePrefix, nullsPrefix, newTupleProbability,
-							nRows, nCols, numOrderedCols,
+							nRows, numOrderedCols, typ.Name(),
 						),
 						func(b *testing.B) {
 							b.SetBytes(int64(8 * nRows * nCols))

--- a/pkg/sql/colexec/sort_partitioner.eg.go
+++ b/pkg/sql/colexec/sort_partitioner.eg.go
@@ -197,9 +197,8 @@ func (p partitionerBool) partitionWithOrder(
 					}
 
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
-					lastVal = v
 					{
-						__retval_0 = lastVal
+						__retval_0 = v
 					}
 				}
 				lastVal = __retval_0
@@ -303,9 +302,8 @@ func (p partitionerBool) partition(colVec coldata.Vec, outputCol []bool, n int) 
 					}
 
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
-					lastVal = v
 					{
-						__retval_0 = lastVal
+						__retval_0 = v
 					}
 				}
 				lastVal = __retval_0
@@ -368,7 +366,7 @@ func (p partitionerBytes) partitionWithOrder(
 
 							outputCol[outputIdx] = outputCol[outputIdx] || unique
 						}
-						lastVal = append(lastVal[:0], v...)
+						lastVal = v
 					}
 					{
 						__retval_lastVal = lastVal
@@ -394,9 +392,8 @@ func (p partitionerBytes) partitionWithOrder(
 					}
 
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
-					lastVal = append(lastVal[:0], v...)
 					{
-						__retval_0 = lastVal
+						__retval_0 = v
 					}
 				}
 				lastVal = __retval_0
@@ -455,7 +452,7 @@ func (p partitionerBytes) partition(colVec coldata.Vec, outputCol []bool, n int)
 
 							outputCol[outputIdx] = outputCol[outputIdx] || unique
 						}
-						lastVal = append(lastVal[:0], v...)
+						lastVal = v
 					}
 					{
 						__retval_lastVal = lastVal
@@ -484,9 +481,8 @@ func (p partitionerBytes) partition(colVec coldata.Vec, outputCol []bool, n int)
 					}
 
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
-					lastVal = append(lastVal[:0], v...)
 					{
-						__retval_0 = lastVal
+						__retval_0 = v
 					}
 				}
 				lastVal = __retval_0
@@ -549,7 +545,7 @@ func (p partitionerDecimal) partitionWithOrder(
 
 							outputCol[outputIdx] = outputCol[outputIdx] || unique
 						}
-						lastVal.Set(&v)
+						lastVal = v
 					}
 					{
 						__retval_lastVal = lastVal
@@ -575,9 +571,8 @@ func (p partitionerDecimal) partitionWithOrder(
 					}
 
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
-					lastVal.Set(&v)
 					{
-						__retval_0 = lastVal
+						__retval_0 = v
 					}
 				}
 				lastVal = __retval_0
@@ -636,7 +631,7 @@ func (p partitionerDecimal) partition(colVec coldata.Vec, outputCol []bool, n in
 
 							outputCol[outputIdx] = outputCol[outputIdx] || unique
 						}
-						lastVal.Set(&v)
+						lastVal = v
 					}
 					{
 						__retval_lastVal = lastVal
@@ -665,9 +660,8 @@ func (p partitionerDecimal) partition(colVec coldata.Vec, outputCol []bool, n in
 					}
 
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
-					lastVal.Set(&v)
 					{
-						__retval_0 = lastVal
+						__retval_0 = v
 					}
 				}
 				lastVal = __retval_0
@@ -778,9 +772,8 @@ func (p partitionerInt16) partitionWithOrder(
 					}
 
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
-					lastVal = v
 					{
-						__retval_0 = lastVal
+						__retval_0 = v
 					}
 				}
 				lastVal = __retval_0
@@ -890,9 +883,8 @@ func (p partitionerInt16) partition(colVec coldata.Vec, outputCol []bool, n int)
 					}
 
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
-					lastVal = v
 					{
-						__retval_0 = lastVal
+						__retval_0 = v
 					}
 				}
 				lastVal = __retval_0
@@ -1003,9 +995,8 @@ func (p partitionerInt32) partitionWithOrder(
 					}
 
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
-					lastVal = v
 					{
-						__retval_0 = lastVal
+						__retval_0 = v
 					}
 				}
 				lastVal = __retval_0
@@ -1115,9 +1106,8 @@ func (p partitionerInt32) partition(colVec coldata.Vec, outputCol []bool, n int)
 					}
 
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
-					lastVal = v
 					{
-						__retval_0 = lastVal
+						__retval_0 = v
 					}
 				}
 				lastVal = __retval_0
@@ -1228,9 +1218,8 @@ func (p partitionerInt64) partitionWithOrder(
 					}
 
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
-					lastVal = v
 					{
-						__retval_0 = lastVal
+						__retval_0 = v
 					}
 				}
 				lastVal = __retval_0
@@ -1340,9 +1329,8 @@ func (p partitionerInt64) partition(colVec coldata.Vec, outputCol []bool, n int)
 					}
 
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
-					lastVal = v
 					{
-						__retval_0 = lastVal
+						__retval_0 = v
 					}
 				}
 				lastVal = __retval_0
@@ -1469,9 +1457,8 @@ func (p partitionerFloat64) partitionWithOrder(
 					}
 
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
-					lastVal = v
 					{
-						__retval_0 = lastVal
+						__retval_0 = v
 					}
 				}
 				lastVal = __retval_0
@@ -1597,9 +1584,8 @@ func (p partitionerFloat64) partition(colVec coldata.Vec, outputCol []bool, n in
 					}
 
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
-					lastVal = v
 					{
-						__retval_0 = lastVal
+						__retval_0 = v
 					}
 				}
 				lastVal = __retval_0
@@ -1702,9 +1688,8 @@ func (p partitionerTimestamp) partitionWithOrder(
 					}
 
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
-					lastVal = v
 					{
-						__retval_0 = lastVal
+						__retval_0 = v
 					}
 				}
 				lastVal = __retval_0
@@ -1806,9 +1791,8 @@ func (p partitionerTimestamp) partition(colVec coldata.Vec, outputCol []bool, n 
 					}
 
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
-					lastVal = v
 					{
-						__retval_0 = lastVal
+						__retval_0 = v
 					}
 				}
 				lastVal = __retval_0
@@ -1897,9 +1881,8 @@ func (p partitionerInterval) partitionWithOrder(
 					}
 
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
-					lastVal = v
 					{
-						__retval_0 = lastVal
+						__retval_0 = v
 					}
 				}
 				lastVal = __retval_0
@@ -1987,9 +1970,8 @@ func (p partitionerInterval) partition(colVec coldata.Vec, outputCol []bool, n i
 					}
 
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
-					lastVal = v
 					{
-						__retval_0 = lastVal
+						__retval_0 = v
 					}
 				}
 				lastVal = __retval_0
@@ -2082,9 +2064,8 @@ func (p partitionerDatum) partitionWithOrder(
 					}
 
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
-					lastVal = v
 					{
-						__retval_0 = lastVal
+						__retval_0 = v
 					}
 				}
 				lastVal = __retval_0
@@ -2176,9 +2157,8 @@ func (p partitionerDatum) partition(colVec coldata.Vec, outputCol []bool, n int)
 					}
 
 					outputCol[outputIdx] = outputCol[outputIdx] || unique
-					lastVal = v
 					{
-						__retval_0 = lastVal
+						__retval_0 = v
 					}
 				}
 				lastVal = __retval_0


### PR DESCRIPTION
**colexec: run distinct benchmarks on Bytes columns**

This commit makes it so that we now run all distinct benchmarks on Bytes
columns in addition to Ints. In order to not double the running time, we
now hardcode running only for 2 distinct columns (4 column option is now
removed since it wasn't giving us much additional info anyway).

Release note: None

**colexec: remove redundant deep copies in distinct template**

Previously, we would perform a deep copy of the current value to be
stored as "last value" when running ordered distinct (also reused by the
sorter). The deep copy is only necessary after we have processed the
batch in ordered distinct and not necessary at all for sort partitioners,
yet previously we were doing a deep copy on each value. This commit fixes
the issue which should give a nice speed up for non-trivial types.

Release note: None