### PR TITLE
changefeedccl: Improve avro encoder performance

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -180,6 +180,7 @@ go_test(
         "//pkg/util/span",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+        "//pkg/util/timeutil/pgdate",
         "//pkg/util/uuid",
         "//pkg/workload",
         "//pkg/workload/bank",

--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -102,7 +102,19 @@ type avroSchemaField struct {
 
 	typ *types.T
 
+	// encodeFn encodes specified tree.Datum as go "native" interface value.
 	encodeFn func(tree.Datum) (interface{}, error)
+
+	// Avro encoder treats every field as optional -- that is, we always
+	// allow null values.  As such, every value returned by encodeFn is an
+	// avro record represented as a map with a single "union" key (see avroUnionKey())
+	// and the value either null or the actual encoded value.
+	// nativeEncoded is a map that's returned by encodeFn.  We allocate
+	// this map once to avoid repeated map allocations.  We simply update
+	// "union key" value.
+	nativeEncoded map[string]interface{}
+
+	// decodeFn decodes specified go "native" value into tree.Datum.
 	decodeFn func(interface{}) (tree.Datum, error)
 }
 
@@ -123,7 +135,10 @@ type avroDataRecord struct {
 
 	colIdxByFieldIdx map[int]int
 	fieldIdxByName   map[string]int
-	alloc            rowenc.DatumAlloc
+	// Allocate Go native representation once, to avoid repeated map allocation
+	// when encoding.
+	native map[string]interface{}
+	alloc  rowenc.DatumAlloc
 }
 
 // avroMetadata is the `avroEnvelopeRecord` metadata.
@@ -154,251 +169,289 @@ func columnToAvroSchema(col catalog.Column) (*avroSchemaField, error) {
 		typ:      col.GetType(),
 	}
 
-	var avroType avroSchemaType
-	switch col.GetType().Family() {
-	case types.IntFamily:
-		avroType = avroSchemaLong
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			return int64(*d.(*tree.DInt)), nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			return tree.NewDInt(tree.DInt(x.(int64))), nil
-		}
-	case types.BoolFamily:
-		avroType = avroSchemaBoolean
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			return bool(*d.(*tree.DBool)), nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			return tree.MakeDBool(tree.DBool(x.(bool))), nil
-		}
-	case types.FloatFamily:
-		avroType = avroSchemaDouble
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			return float64(*d.(*tree.DFloat)), nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			return tree.NewDFloat(tree.DFloat(x.(float64))), nil
-		}
-	case types.Box2DFamily:
-		avroType = avroSchemaString
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			return d.(*tree.DBox2D).CartesianBoundingBox.Repr(), nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			b, err := geo.ParseCartesianBoundingBox(x.(string))
-			if err != nil {
-				return nil, err
-			}
-			return tree.NewDBox2D(b), nil
-		}
-	case types.GeographyFamily:
-		avroType = avroSchemaBytes
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			return []byte(d.(*tree.DGeography).EWKB()), nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			g, err := geo.ParseGeographyFromEWKBUnsafe(geopb.EWKB(x.([]byte)))
-			if err != nil {
-				return nil, err
-			}
-			return &tree.DGeography{Geography: g}, nil
-		}
-	case types.GeometryFamily:
-		avroType = avroSchemaBytes
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			return []byte(d.(*tree.DGeometry).EWKB()), nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			g, err := geo.ParseGeometryFromEWKBUnsafe(geopb.EWKB(x.([]byte)))
-			if err != nil {
-				return nil, err
-			}
-			return &tree.DGeometry{Geometry: g}, nil
-		}
-	case types.StringFamily:
-		avroType = avroSchemaString
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			return string(*d.(*tree.DString)), nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			return tree.NewDString(x.(string)), nil
-		}
-	case types.BytesFamily:
-		avroType = avroSchemaBytes
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			return []byte(*d.(*tree.DBytes)), nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			return tree.NewDBytes(tree.DBytes(x.([]byte))), nil
-		}
-	case types.DateFamily:
-		avroType = avroLogicalType{
-			SchemaType:  avroSchemaInt,
-			LogicalType: `date`,
-		}
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			date := *d.(*tree.DDate)
-			if !date.IsFinite() {
-				return nil, errors.Errorf(
-					`column %s: infinite date not yet supported with avro`, col.GetName())
-			}
-			// The avro library requires us to return this as a time.Time.
-			return date.ToTime()
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			// The avro library hands this back as a time.Time.
-			return tree.NewDDateFromTime(x.(time.Time))
-		}
-	case types.TimeFamily:
-		avroType = avroLogicalType{
-			SchemaType:  avroSchemaLong,
-			LogicalType: `time-micros`,
-		}
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			// The avro library requires us to return this as a time.Duration.
-			duration := time.Duration(*d.(*tree.DTime)) * time.Microsecond
-			return duration, nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			// The avro library hands this back as a time.Duration.
-			micros := x.(time.Duration) / time.Microsecond
-			return tree.MakeDTime(timeofday.TimeOfDay(micros)), nil
-		}
-	case types.TimeTZFamily:
-		avroType = avroSchemaString
-		// We cannot encode this as a long, as it does not encode
-		// timezone correctly.
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			return d.(*tree.DTimeTZ).TimeTZ.String(), nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			d, _, err := tree.ParseDTimeTZ(nil, x.(string), time.Microsecond)
-			return d, err
-		}
-	case types.TimestampFamily:
-		avroType = avroLogicalType{
-			SchemaType:  avroSchemaLong,
-			LogicalType: `timestamp-micros`,
-		}
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			return d.(*tree.DTimestamp).Time, nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			return tree.MakeDTimestamp(x.(time.Time), time.Microsecond)
-		}
-	case types.TimestampTZFamily:
-		avroType = avroLogicalType{
-			SchemaType:  avroSchemaLong,
-			LogicalType: `timestamp-micros`,
-		}
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			return d.(*tree.DTimestampTZ).Time, nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			return tree.MakeDTimestampTZ(x.(time.Time), time.Microsecond)
-		}
-	case types.DecimalFamily:
-		if col.GetType().Precision() == 0 {
-			return nil, errors.Errorf(
-				`column %s: decimal with no precision not yet supported with avro`, col.GetName())
-		}
-		width := int(col.GetType().Width())
-		prec := int(col.GetType().Precision())
-		avroType = avroLogicalType{
-			SchemaType:  avroSchemaBytes,
-			LogicalType: `decimal`,
-			Precision:   prec,
-			Scale:       width,
-		}
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			dec := d.(*tree.DDecimal).Decimal
-
-			// If the decimal happens to fit a smaller width than the
-			// column allows, add trailing zeroes so the scale is constant
-			if col.GetType().Width() > -dec.Exponent {
-				_, err := tree.DecimalCtx.WithPrecision(uint32(prec)).Quantize(&dec, &dec, -int32(width))
-				if err != nil {
-					// This should always be possible without rounding since we're using the column def,
-					// but if it's not, WithPrecision will force it to error.
-					return nil, err
-				}
-			}
-
-			// TODO(dan): For the cases that the avro defined decimal format
-			// would not roundtrip, serialize the decimal as a string. Also
-			// support the unspecified precision/scale case in this branch. We
-			// can't currently do this without surgery to the avro library we're
-			// using and that's too scary leading up to 2.1.0.
-			rat, err := decimalToRat(dec, int32(width))
-			if err != nil {
-				return nil, err
-			}
-			return &rat, nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			return &tree.DDecimal{Decimal: ratToDecimal(*x.(*big.Rat), int32(width))}, nil
-		}
-	case types.UuidFamily:
-		// Should be logical type of "uuid", but the avro library doesn't support
-		// that yet.
-		avroType = avroSchemaString
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			return d.(*tree.DUuid).UUID.String(), nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			return tree.ParseDUuidFromString(x.(string))
-		}
-	case types.INetFamily:
-		avroType = avroSchemaString
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			return d.(*tree.DIPAddr).IPAddr.String(), nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			return tree.ParseDIPAddrFromINetString(x.(string))
-		}
-	case types.JsonFamily:
-		avroType = avroSchemaString
-		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
-			return d.(*tree.DJSON).JSON.String(), nil
-		}
-		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
-			return tree.ParseDJSON(x.(string))
-		}
-	default:
-		return nil, errors.Errorf(`column %s: type %s not yet supported with avro`,
-			col.GetName(), col.GetType().SQLString())
-	}
-	schema.SchemaType = avroType
-
 	// Make every field optional by unioning it with null, so that all schema
 	// evolutions for a table are considered "backward compatible" by avro. This
 	// means that the Avro type doesn't mirror the column's nullability, but it
 	// makes it much easier to work with long histories of table data afterward,
 	// especially for things like loading into analytics databases.
-	{
+	setNullable := func(
+		avroType avroSchemaType,
+		encoder func(datum tree.Datum) (interface{}, error),
+		decoder func(interface{}) (tree.Datum, error),
+	) {
 		// The default for a union type is the default for the first element of
 		// the union.
 		schema.SchemaType = []avroSchemaType{avroSchemaNull, avroType}
-		encodeFn := schema.encodeFn
-		decodeFn := schema.decodeFn
 		unionKey := avroUnionKey(avroType)
+		schema.nativeEncoded = map[string]interface{}{unionKey: nil}
+
 		schema.encodeFn = func(d tree.Datum) (interface{}, error) {
 			if d == tree.DNull {
-				return goavro.Union(avroSchemaNull, nil), nil
+				return nil /* value */, nil
 			}
-			encoded, err := encodeFn(d)
+			encoded, err := encoder(d)
 			if err != nil {
 				return nil, err
 			}
-			return goavro.Union(unionKey, encoded), nil
+			schema.nativeEncoded[unionKey] = encoded
+			return schema.nativeEncoded, nil
 		}
 		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
 			if x == nil {
 				return tree.DNull, nil
 			}
-			return decodeFn(x.(map[string]interface{})[unionKey])
+			return decoder(x.(map[string]interface{})[unionKey])
 		}
+	}
+
+	switch col.GetType().Family() {
+	case types.IntFamily:
+		setNullable(
+			avroSchemaLong,
+			func(d tree.Datum) (interface{}, error) {
+				return int64(*d.(*tree.DInt)), nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				return tree.NewDInt(tree.DInt(x.(int64))), nil
+			},
+		)
+	case types.BoolFamily:
+		setNullable(
+			avroSchemaBoolean,
+			func(d tree.Datum) (interface{}, error) {
+				return bool(*d.(*tree.DBool)), nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				return tree.MakeDBool(tree.DBool(x.(bool))), nil
+			},
+		)
+	case types.FloatFamily:
+		setNullable(
+			avroSchemaDouble,
+			func(d tree.Datum) (interface{}, error) {
+				return float64(*d.(*tree.DFloat)), nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				return tree.NewDFloat(tree.DFloat(x.(float64))), nil
+			},
+		)
+	case types.Box2DFamily:
+		setNullable(
+			avroSchemaString,
+			func(d tree.Datum) (interface{}, error) {
+				return d.(*tree.DBox2D).CartesianBoundingBox.Repr(), nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				b, err := geo.ParseCartesianBoundingBox(x.(string))
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDBox2D(b), nil
+			},
+		)
+	case types.GeographyFamily:
+		setNullable(
+			avroSchemaBytes,
+			func(d tree.Datum) (interface{}, error) {
+				return []byte(d.(*tree.DGeography).EWKB()), nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				g, err := geo.ParseGeographyFromEWKBUnsafe(geopb.EWKB(x.([]byte)))
+				if err != nil {
+					return nil, err
+				}
+				return &tree.DGeography{Geography: g}, nil
+			},
+		)
+	case types.GeometryFamily:
+		setNullable(
+			avroSchemaBytes,
+			func(d tree.Datum) (interface{}, error) {
+				return []byte(d.(*tree.DGeometry).EWKB()), nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				g, err := geo.ParseGeometryFromEWKBUnsafe(geopb.EWKB(x.([]byte)))
+				if err != nil {
+					return nil, err
+				}
+				return &tree.DGeometry{Geometry: g}, nil
+			},
+		)
+	case types.StringFamily:
+		setNullable(
+			avroSchemaString,
+			func(d tree.Datum) (interface{}, error) {
+				return string(*d.(*tree.DString)), nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				return tree.NewDString(x.(string)), nil
+			},
+		)
+	case types.BytesFamily:
+		setNullable(
+			avroSchemaBytes,
+			func(d tree.Datum) (interface{}, error) {
+				return []byte(*d.(*tree.DBytes)), nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				return tree.NewDBytes(tree.DBytes(x.([]byte))), nil
+			},
+		)
+	case types.DateFamily:
+		setNullable(
+			avroLogicalType{
+				SchemaType:  avroSchemaInt,
+				LogicalType: `date`,
+			},
+			func(d tree.Datum) (interface{}, error) {
+				date := *d.(*tree.DDate)
+				if !date.IsFinite() {
+					return nil, errors.Errorf(
+						`column %s: infinite date not yet supported with avro`, col.GetName())
+				}
+				// The avro library requires us to return this as a time.Time.
+				return date.ToTime()
+			},
+			func(x interface{}) (tree.Datum, error) {
+				// The avro library hands this back as a time.Time.
+				return tree.NewDDateFromTime(x.(time.Time))
+			},
+		)
+	case types.TimeFamily:
+		setNullable(
+			avroLogicalType{
+				SchemaType:  avroSchemaLong,
+				LogicalType: `time-micros`,
+			},
+			func(d tree.Datum) (interface{}, error) {
+				// The avro library requires us to return this as a time.Duration.
+				duration := time.Duration(*d.(*tree.DTime)) * time.Microsecond
+				return duration, nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				// The avro library hands this back as a time.Duration.
+				micros := x.(time.Duration) / time.Microsecond
+				return tree.MakeDTime(timeofday.TimeOfDay(micros)), nil
+			},
+		)
+	case types.TimeTZFamily:
+		setNullable(
+			avroSchemaString,
+			// We cannot encode this as a long, as it does not encode
+			// timezone correctly.
+			func(d tree.Datum) (interface{}, error) {
+				return d.(*tree.DTimeTZ).TimeTZ.String(), nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				d, _, err := tree.ParseDTimeTZ(nil, x.(string), time.Microsecond)
+				return d, err
+			},
+		)
+	case types.TimestampFamily:
+		setNullable(
+			avroLogicalType{
+				SchemaType:  avroSchemaLong,
+				LogicalType: `timestamp-micros`,
+			},
+			func(d tree.Datum) (interface{}, error) {
+				return d.(*tree.DTimestamp).Time, nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				return tree.MakeDTimestamp(x.(time.Time), time.Microsecond)
+			},
+		)
+	case types.TimestampTZFamily:
+		setNullable(
+			avroLogicalType{
+				SchemaType:  avroSchemaLong,
+				LogicalType: `timestamp-micros`,
+			},
+			func(d tree.Datum) (interface{}, error) {
+				return d.(*tree.DTimestampTZ).Time, nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				return tree.MakeDTimestampTZ(x.(time.Time), time.Microsecond)
+			},
+		)
+	case types.DecimalFamily:
+		if col.GetType().Precision() == 0 {
+			return nil, errors.Errorf(
+				`column %s: decimal with no precision not yet supported with avro`, col.GetName())
+		}
+
+		width := int(col.GetType().Width())
+		prec := int(col.GetType().Precision())
+		setNullable(
+			avroLogicalType{
+				SchemaType:  avroSchemaBytes,
+				LogicalType: `decimal`,
+				Precision:   prec,
+				Scale:       width,
+			},
+			func(d tree.Datum) (interface{}, error) {
+				dec := d.(*tree.DDecimal).Decimal
+
+				// If the decimal happens to fit a smaller width than the
+				// column allows, add trailing zeroes so the scale is constant
+				if col.GetType().Width() > -dec.Exponent {
+					_, err := tree.DecimalCtx.WithPrecision(uint32(prec)).Quantize(&dec, &dec, -int32(width))
+					if err != nil {
+						// This should always be possible without rounding since we're using the column def,
+						// but if it's not, WithPrecision will force it to error.
+						return nil, err
+					}
+				}
+
+				// TODO(dan): For the cases that the avro defined decimal format
+				// would not roundtrip, serialize the decimal as a string. Also
+				// support the unspecified precision/scale case in this branch. We
+				// can't currently do this without surgery to the avro library we're
+				// using and that's too scary leading up to 2.1.0.
+				rat, err := decimalToRat(dec, int32(width))
+				if err != nil {
+					return nil, err
+				}
+				return &rat, nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				return &tree.DDecimal{Decimal: ratToDecimal(*x.(*big.Rat), int32(width))}, nil
+			},
+		)
+	case types.UuidFamily:
+		// Should be logical type of "uuid", but the avro library doesn't support
+		// that yet.
+		setNullable(
+			avroSchemaString,
+			func(d tree.Datum) (interface{}, error) {
+				return d.(*tree.DUuid).UUID.String(), nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				return tree.ParseDUuidFromString(x.(string))
+			},
+		)
+	case types.INetFamily:
+		setNullable(
+			avroSchemaString,
+			func(d tree.Datum) (interface{}, error) {
+				return d.(*tree.DIPAddr).IPAddr.String(), nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				return tree.ParseDIPAddrFromINetString(x.(string))
+			},
+		)
+	case types.JsonFamily:
+		setNullable(
+			avroSchemaString,
+			func(d tree.Datum) (interface{}, error) {
+				return d.(*tree.DJSON).JSON.String(), nil
+			},
+			func(x interface{}) (tree.Datum, error) {
+				return tree.ParseDJSON(x.(string))
+			},
+		)
+	default:
+		return nil, errors.Errorf(`column %s: type %s not yet supported with avro`,
+			col.GetName(), col.GetType().SQLString())
 	}
 
 	return schema, nil
@@ -535,18 +588,23 @@ func (r *avroDataRecord) RowFromBinary(buf []byte) (rowenc.EncDatumRow, error) {
 }
 
 func (r *avroDataRecord) nativeFromRow(row rowenc.EncDatumRow) (interface{}, error) {
-	avroDatums := make(map[string]interface{}, len(row))
+	if r.native == nil {
+		// Note that it's safe to reuse r.native without clearing it because all records will
+		// contain the same complete set of fields.
+		r.native = make(map[string]interface{}, len(r.Fields))
+	}
+
 	for fieldIdx, field := range r.Fields {
 		d := row[r.colIdxByFieldIdx[fieldIdx]]
 		if err := d.EnsureDecoded(field.typ, &r.alloc); err != nil {
 			return nil, err
 		}
 		var err error
-		if avroDatums[field.Name], err = field.encodeFn(d.Datum); err != nil {
+		if r.native[field.Name], err = field.encodeFn(d.Datum); err != nil {
 			return nil, err
 		}
 	}
-	return avroDatums, nil
+	return r.native, nil
 }
 
 func (r *avroDataRecord) rowFromNative(native interface{}) (rowenc.EncDatumRow, error) {


### PR DESCRIPTION
Avoid expensive allocations (maps) when encoding datums.
Improve encoder performance by ~40%, and significantly reduce
memory allocations per op.

```
BenchmarkEncodeInt-16                    1834214               665.4 ns/op            73 B/op          5 allocs/op
BenchmarkEncodeBool-16                   1975244               597.8 ns/op            33 B/op          3 allocs/op
BenchmarkEncodeFloat-16                  1773226               661.6 ns/op            73 B/op          5 allocs/op                                                  BenchmarkEncodeBox2D-16                   628884              1740 ns/op             579 B/op         18 allocs/op
BenchmarkEncodeGeography-16              1734722               713.3 ns/op           233 B/op          5 allocs/op                                                  BenchmarkEncodeGeometry-16               1495227              1208 ns/op            2737 B/op          5 allocs/op                                                  BenchmarkEncodeBytes-16                  2171725               698.4 ns/op            64 B/op          5 allocs/op                                                  BenchmarkEncodeString-16                 1847884               696.0 ns/op            49 B/op          4 allocs/op
BenchmarkEncodeDate-16                   2159253               701.6 ns/op            64 B/op          5 allocs/op
BenchmarkEncodeTime-16                   1857284               682.9 ns/op            81 B/op          6 allocs/op
BenchmarkEncodeTimeTZ-16                  833163              1405 ns/op             402 B/op         14 allocs/op
BenchmarkEncodeTimestamp-16              1623998               720.5 ns/op            97 B/op          6 allocs/op
BenchmarkEncodeTimestampTZ-16            1614201               719.0 ns/op            97 B/op          6 allocs/op
BenchmarkEncodeDecimal-16                 790902              1473 ns/op             490 B/op         23 allocs/op
BenchmarkEncodeUUID-16                   2216424               783.0 ns/op           176 B/op          6 allocs/op
BenchmarkEncodeINet-16                   1545225               817.6 ns/op           113 B/op          8 allocs/op
BenchmarkEncodeJSON-16                   2146824              1731 ns/op             728 B/op         21 allocs/op
```


Release Notes: None
