### PR TITLE
backupccl: add backup_type to SHOW BACKUP

### DIFF
--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -109,6 +109,10 @@ func (r BackupFileDescriptors) Less(i, j int) bool {
 	return bytes.Compare(r[i].Span.EndKey, r[j].Span.EndKey) < 0
 }
 
+func (m *BackupManifest) isIncremental() bool {
+	return !m.StartTime.IsEmpty()
+}
+
 // ReadBackupManifestFromURI creates an export store from the given URI, then
 // reads and unmarshalls a BackupManifest at the standard location in the
 // export storage.


### PR DESCRIPTION
Previously, SHOW BACKUP users had to rely on the NULLness of
start_time to distinguish between full and incremental backups.
This commit makes it explicit by adding a 'backup_type' column,
whose value can be one of 'full' or 'incremental'.

Informs:  #63832

Release note (enterprise change): SHOW BACKUP now shows whether
the backup is full or incremental under the 'backup_type' column.