### PR TITLE
roachtest: exit 10 when tests failed

### DIFF
--- a/build/teamcity-nightly-roachtest-invoke.sh
+++ b/build/teamcity-nightly-roachtest-invoke.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+set +e
 bin/roachtest run \
   --cloud="${CLOUD}" \
   --artifacts="${ARTIFACTS}" \
@@ -17,3 +18,16 @@ bin/roachtest run \
   --slack-token="${SLACK_TOKEN}" \
   --cluster-id="${TC_BUILD_ID}" \
   "${TESTS}"
+code=$?
+set -e
+
+if [[ ${code} -eq 10 ]]; then
+  # Exit code 10 indicates that some tests failed, but that roachtest
+  # as a whole passed. We want to exit zero in this case so that we
+  # can let TeamCity report failing tests without also failing the
+  # build. That way, build failures can be used to notify about serious
+  # problems that prevent tests from being invoked in the first place.
+  code=0
+fi
+
+exit ${code}

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -21,8 +21,14 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
 )
+
+// ExitCodeTestsFailed is the exit code that results from a run of
+// roachtest in which the infrastructure worked, but at least one
+// test failed.
+const ExitCodeTestsFailed = 10
 
 // runnerLogsDir is the dir under the artifacts root where the test runner log
 // and other runner-related logs (i.e. cluster creation logs) will be written.
@@ -146,6 +152,10 @@ Examples:
 roachtest run takes a list of regex patterns and runs all the matching tests.
 If no pattern is given, all tests are run. See "help list" for more details on
 the test tags.
+
+If all invoked tests passed, the exit status is zero. If at least one test
+failed, it is 10. Any other exit status reports a problem with the test
+runner itself.
 `,
 		RunE: func(_ *cobra.Command, args []string) error {
 			return runTests(registerTests, cliCfg{
@@ -244,8 +254,12 @@ the test tags.
 	rootCmd.AddCommand(benchCmd)
 
 	if err := rootCmd.Execute(); err != nil {
+		code := 1
+		if errors.Is(err, errTestsFailed) {
+			code = ExitCodeTestsFailed
+		}
 		// Cobra has already printed the error message.
-		os.Exit(1)
+		os.Exit(code)
 	}
 }
 

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -42,6 +42,8 @@ import (
 	"github.com/petermattis/goid"
 )
 
+var errTestsFailed = fmt.Errorf("some tests failed")
+
 // testRunner runs tests.
 type testRunner struct {
 	// buildVersion is the version of the Cockroach binary that tests will run against.
@@ -328,7 +330,7 @@ func (r *testRunner) Run(
 	passFailLine := r.generateReport()
 	shout(ctx, l, lopt.stdout, passFailLine)
 	if len(r.status.fail) > 0 {
-		return fmt.Errorf("some tests failed")
+		return errTestsFailed
 	}
 	return nil
 }

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -23,7 +23,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
+	"github.com/cockroachdb/errors"
 	"github.com/kr/pretty"
+	"github.com/stretchr/testify/require"
 )
 
 const OwnerUnitTest Owner = `unittest`
@@ -330,4 +332,38 @@ func TestRegistryMinVersion(t *testing.T) {
 			}
 		})
 	}
+}
+
+func runExitCodeTest(t *testing.T, injectedError error) error {
+	ctx := context.Background()
+	t.Helper()
+	cr := newClusterRegistry()
+	runner := newTestRunner(cr, version.Version{})
+	r, err := makeTestRegistry()
+	require.NoError(t, err)
+	r.Add(testSpec{
+		Name:    "boom",
+		Owner:   OwnerUnitTest,
+		Cluster: makeClusterSpec(0),
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			if injectedError != nil {
+				t.Fatal(injectedError)
+			}
+		},
+	})
+	tests := testsToRun(ctx, r, newFilter(nil))
+	lopt := loggingOpt{
+		l:            nilLogger(),
+		tee:          noTee,
+		stdout:       ioutil.Discard,
+		stderr:       ioutil.Discard,
+		artifactsDir: "",
+	}
+	return runner.Run(ctx, tests, 1, 1, clustersOpt{}, testOpts{}, lopt)
+}
+
+func TestExitCode(t *testing.T) {
+	require.NoError(t, runExitCodeTest(t, nil /* test passes */))
+	err := runExitCodeTest(t, errors.New("boom"))
+	require.True(t, errors.Is(err, errTestsFailed))
 }


### PR DESCRIPTION
Prior to this commit, `roachtest run` would always exit with code 1 if
it encountered ny problems. In practice, most of the time the reason it
would do that is because one of its tests failed; the exit status in
nightlies is always nonzero.

We want to distinguish that common case from that of roachtest itself
failing to run all of the tests. This commit adds a dedicated exit
status (10) which is used if some tests failed, but roachtest itself
did not encounter any problems.

In follow-up work, we will treat this exit status as a success, which
will allow us to configure notifications for the roachtest nightlies,
so that they can sound the alarm whenever seeing a truly unexpected
exit status (i.e. not zero or ten). For inspiration, see #63825 for
a recent roachtest breakage that this work should alert us to more
proactively in the future once the above plan is carried out.

Test failures continue to be emitted just the same (and issues are
still posted).

Independently roachtest also needs to be hardened against being taken
down by tests. This will require more invasive changes.

Release note: None