### PR TITLE
build: update the go version requirement for `make`

### DIFF
--- a/build/go-version-check.sh
+++ b/build/go-version-check.sh
@@ -7,7 +7,8 @@
 
 required_version_major=1
 minimum_version_minor=15
-minimum_version_15_patch=3
+minimum_version_15_patch=10 # update to 11 when issue #63836 is addressed
+minimum_version_16_patch=3
 
 go=${1-go}
 


### PR DESCRIPTION
Fixes #63837.

The builder image already requires go 1.15.10. This patch
modifies the check for a non-builder `make` command to require
at least the same version.

Release note: None