### PR TITLE
jobs: skip flakey test that should be removed

### DIFF
--- a/pkg/jobs/registry_external_test.go
+++ b/pkg/jobs/registry_external_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -79,6 +80,11 @@ func TestRegistryResumeExpiredLease(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	defer jobs.ResetConstructors()()
+
+	// This test exercises code that has not been in use since the 20.1->20.2
+	// mixed version state. It is scheduled for removal and thus not worth
+	// de-flaking.
+	skip.WithIssue(t, 63842)
 
 	ctx := context.Background()
 


### PR DESCRIPTION
This tests seems to flake but exercises old code. It is scheduled for
removal in #61417 which didn't make the 21.1 release.

Touches #63842.

Release note: None