### PR TITLE
server: skip TestTelemetrySQLStatsIndependence

### DIFF
--- a/pkg/server/stats_test.go
+++ b/pkg/server/stats_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -37,6 +38,12 @@ import (
 func TestTelemetrySQLStatsIndependence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// This test fails if the central reporting server from CRL
+	// breaks. It should be improved to customize the reporting URL and
+	// mock the registration collector with an in-memory server.
+	skip.WithIssue(t, 63851)
+
 	ctx := context.Background()
 	params, _ := tests.CreateTestServerParams()
 	s, sqlDB, _ := serverutils.StartServer(t, params)


### PR DESCRIPTION
This test flakes if the reg server is temporarily unavailable.

Informs  #63844, #63851,  #63848