### PR TITLE
sqlsmith: don't use crdb_internal.create_join_token

### DIFF
--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -481,7 +481,8 @@ var functions = func() map[tree.FunctionClass]map[oid.Oid][]function {
 			continue
 		}
 		if strings.Contains(def.Name, "crdb_internal.force_") ||
-			strings.Contains(def.Name, "crdb_internal.unsafe_") {
+			strings.Contains(def.Name, "crdb_internal.unsafe_") ||
+			strings.Contains(def.Name, "crdb_internal.create_join_token") {
 			continue
 		}
 		if _, ok := m[def.Class]; !ok {


### PR DESCRIPTION
This is an internal builtin, and we probably don't get much when using
it in the sqlsmith. Currently this builtin occasionally leads to an
internal error.

Addresses: #63819.

Release note: None