### PR TITLE
Rename ExtraOptions fields to EncryptionOptions.

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -507,9 +507,10 @@ type StorageConfig struct {
 	// UseFileRegistry is true if the file registry is needed (eg: encryption-at-rest).
 	// This may force the store version to versionFileRegistry if currently lower.
 	UseFileRegistry bool
-	// ExtraOptions is a serialized protobuf set by Go CCL code and passed through
-	// to C CCL code.
-	ExtraOptions []byte
+	// EncryptionOptions is a serialized protobuf set by Go CCL code and passed
+	// through to C CCL code to set up encryption-at-rest.  Must be set if and
+	// only if encryption is enabled, otherwise left empty.
+	EncryptionOptions []byte
 }
 
 const (

--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -513,6 +513,11 @@ type StorageConfig struct {
 	EncryptionOptions []byte
 }
 
+// IsEncrypted returns whether the StorageConfig has encryption enabled.
+func (sc StorageConfig) IsEncrypted() bool {
+	return len(sc.EncryptionOptions) > 0
+}
+
 const (
 	// DefaultTempStorageMaxSizeBytes is the default maximum budget
 	// for temp storage.

--- a/pkg/base/store_spec.go
+++ b/pkg/base/store_spec.go
@@ -226,6 +226,11 @@ func (ss StoreSpec) String() string {
 	return buffer.String()
 }
 
+// IsEncrypted returns whether the StoreSpec has encryption enabled.
+func (ss StoreSpec) IsEncrypted() bool {
+	return len(ss.EncryptionOptions) > 0
+}
+
 // fractionRegex is the regular expression that recognizes whether
 // the specified size is a fraction of the total available space.
 // Proportional sizes can be expressed as fractional numbers, either

--- a/pkg/base/store_spec.go
+++ b/pkg/base/store_spec.go
@@ -182,9 +182,10 @@ type StoreSpec struct {
 	// Pebble OPTIONS file but treating any whitespace as a newline:
 	// (Eg, "[Options] delete_range_flush_delay=2s flush_split_bytes=4096")
 	PebbleOptions string
-	// ExtraOptions is a serialized protobuf set by Go CCL code and passed through
-	// to C CCL code.
-	ExtraOptions []byte
+	// EncryptionOptions is a serialized protobuf set by Go CCL code and passed
+	// through to C CCL code to set up encryption-at-rest.  Must be set if and
+	// only if encryption is enabled, otherwise left empty.
+	EncryptionOptions []byte
 }
 
 // String returns a fully parsable version of the store spec.

--- a/pkg/ccl/baseccl/encryption_spec.go
+++ b/pkg/ccl/baseccl/encryption_spec.go
@@ -210,7 +210,7 @@ func PopulateStoreSpecWithEncryption(
 			if err != nil {
 				return err
 			}
-			storeSpecs.Specs[i].ExtraOptions = opts
+			storeSpecs.Specs[i].EncryptionOptions = opts
 			found = true
 			break
 		}
@@ -221,7 +221,7 @@ func PopulateStoreSpecWithEncryption(
 	return nil
 }
 
-// EncryptionOptionsForStore takes a store directory and returns its ExtraOptions
+// EncryptionOptionsForStore takes a store directory and returns its EncryptionOptions
 // if a matching entry if found in the StoreEncryptionSpecList.
 // The caller should appropriately set UseFileRegistry on a non-nil result.
 func EncryptionOptionsForStore(

--- a/pkg/ccl/cliccl/debug.go
+++ b/pkg/ccl/cliccl/debug.go
@@ -107,7 +107,7 @@ func fillEncryptionOptionsForStore(cfg *base.StorageConfig) error {
 	}
 
 	if opts != nil {
-		cfg.ExtraOptions = opts
+		cfg.EncryptionOptions = opts
 		cfg.UseFileRegistry = true
 	}
 	return nil

--- a/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
+++ b/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
@@ -211,10 +211,10 @@ func TestPebbleEncryption(t *testing.T) {
 		context.Background(),
 		storage.PebbleConfig{
 			StorageConfig: base.StorageConfig{
-				Attrs:           roachpb.Attributes{},
-				MaxSize:         512 << 20,
-				UseFileRegistry: true,
-				ExtraOptions:    encOptionsBytes,
+				Attrs:             roachpb.Attributes{},
+				MaxSize:           512 << 20,
+				UseFileRegistry:   true,
+				EncryptionOptions: encOptionsBytes,
 			},
 			Opts: opts,
 		})
@@ -258,10 +258,10 @@ func TestPebbleEncryption(t *testing.T) {
 		context.Background(),
 		storage.PebbleConfig{
 			StorageConfig: base.StorageConfig{
-				Attrs:           roachpb.Attributes{},
-				MaxSize:         512 << 20,
-				UseFileRegistry: true,
-				ExtraOptions:    encOptionsBytes,
+				Attrs:             roachpb.Attributes{},
+				MaxSize:           512 << 20,
+				UseFileRegistry:   true,
+				EncryptionOptions: encOptionsBytes,
 			},
 			Opts: opts2,
 		})

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -391,7 +391,7 @@ func runStart(cmd *cobra.Command, args []string, startSingleNode bool) (returnEr
 	// If we can't find one, we use the first StoreSpec in the list.
 	var specIdx = 0
 	for i := range serverCfg.Stores.Specs {
-		if serverCfg.Stores.Specs[i].ExtraOptions != nil {
+		if serverCfg.Stores.Specs[i].EncryptionOptions != nil {
 			specIdx = i
 		}
 	}

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -390,8 +390,8 @@ func runStart(cmd *cobra.Command, args []string, startSingleNode bool) (returnEr
 	// the first encrypted store as temp dir target, if any.
 	// If we can't find one, we use the first StoreSpec in the list.
 	var specIdx = 0
-	for i := range serverCfg.Stores.Specs {
-		if serverCfg.Stores.Specs[i].EncryptionOptions != nil {
+	for i, spec := range serverCfg.Stores.Specs {
+		if spec.IsEncrypted() {
 			specIdx = i
 		}
 	}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -530,12 +530,12 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 				i, humanizeutil.IBytes(sizeInBytes), openFileLimitPerStore))
 
 			storageConfig := base.StorageConfig{
-				Attrs:           spec.Attributes,
-				Dir:             spec.Path,
-				MaxSize:         sizeInBytes,
-				Settings:        cfg.Settings,
-				UseFileRegistry: spec.UseFileRegistry,
-				ExtraOptions:    spec.ExtraOptions,
+				Attrs:             spec.Attributes,
+				Dir:               spec.Path,
+				MaxSize:           sizeInBytes,
+				Settings:          cfg.Settings,
+				UseFileRegistry:   spec.UseFileRegistry,
+				EncryptionOptions: spec.EncryptionOptions,
 			}
 			pebbleConfig := storage.PebbleConfig{
 				StorageConfig: storageConfig,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1410,7 +1410,7 @@ func (s *Server) PreStart(ctx context.Context) error {
 		if storeSpec.InMemory {
 			continue
 		}
-		if len(storeSpec.ExtraOptions) > 0 {
+		if len(storeSpec.EncryptionOptions) > 0 {
 			encryptedStore = true
 		}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1410,7 +1410,7 @@ func (s *Server) PreStart(ctx context.Context) error {
 		if storeSpec.InMemory {
 			continue
 		}
-		if len(storeSpec.EncryptionOptions) > 0 {
+		if storeSpec.IsEncrypted() {
 			encryptedStore = true
 		}
 

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -484,7 +484,7 @@ func ResolveEncryptedEnvOptions(
 	}
 
 	var statsHandler EncryptionStatsHandler
-	if len(cfg.EncryptionOptions) > 0 {
+	if cfg.IsEncrypted() {
 		// Encryption is enabled.
 		if !cfg.UseFileRegistry {
 			return nil, nil, fmt.Errorf("file registry is needed to support encryption")

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -484,7 +484,7 @@ func ResolveEncryptedEnvOptions(
 	}
 
 	var statsHandler EncryptionStatsHandler
-	if len(cfg.ExtraOptions) > 0 {
+	if len(cfg.EncryptionOptions) > 0 {
 		// Encryption is enabled.
 		if !cfg.UseFileRegistry {
 			return nil, nil, fmt.Errorf("file registry is needed to support encryption")
@@ -494,7 +494,7 @@ func ResolveEncryptedEnvOptions(
 		}
 		var err error
 		cfg.Opts.FS, statsHandler, err =
-			NewEncryptedEnvFunc(cfg.Opts.FS, fileRegistry, cfg.Dir, cfg.Opts.ReadOnly, cfg.ExtraOptions)
+			NewEncryptedEnvFunc(cfg.Opts.FS, fileRegistry, cfg.Dir, cfg.Opts.ReadOnly, cfg.EncryptionOptions)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/storage/temp_engine.go
+++ b/pkg/storage/temp_engine.go
@@ -36,13 +36,12 @@ func storageConfigFromTempStorageConfigAndStoreSpec(
 	config base.TempStorageConfig, spec base.StoreSpec,
 ) base.StorageConfig {
 	return base.StorageConfig{
-		Attrs: roachpb.Attributes{},
-		Dir:   config.Path,
-		// MaxSize doesn't matter for temp storage - it's not enforced in any way.
-		MaxSize:         0,
-		Settings:        config.Settings,
-		UseFileRegistry: spec.UseFileRegistry,
-		ExtraOptions:    spec.ExtraOptions,
+		Attrs:             roachpb.Attributes{},
+		Dir:               config.Path,
+		MaxSize:           0, // doesn't matter for temp storage - it's not enforced in any way.
+		Settings:          config.Settings,
+		UseFileRegistry:   spec.UseFileRegistry,
+		EncryptionOptions: spec.EncryptionOptions,
 	}
 }
 


### PR DESCRIPTION
In practice, this field only encodes encryption keys.
There are several places in the code base where this field being
non-empty is used as an indicator that encryption is enabled, so using
it for other purposes at this point could easily lead to bugs.

Fixes #62358.