### PR TITLE
backupccl: fix a bug in routing scattered ranges

### DIFF
--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -186,7 +186,11 @@ func distRestore(
 
 	for _, srcProc := range splitAndScatterProcs {
 		slot := 0
-		for _, destProc := range restoreDataProcs {
+		for _, destNode := range nodes {
+			// Streams were added to the range router in the same order that the
+			// nodes appeared in `nodes`. Make sure that the `slot`s here are
+			// ordered the same way.
+			destProc := restoreDataProcs[destNode]
 			p.Streams = append(p.Streams, physicalplan.Stream{
 				SourceProcessor:  srcProc,
 				SourceRouterSlot: slot,


### PR DESCRIPTION
This change fixes a bug in the planning of the restore DistSQL flow. The
ordering of the source router slots did not match the order that the
streams were added to the range router. This meant that the range router
could mis-direct rows in the flow to the incorrect node.

Ever after this change, it appears that a lot of AddSSTables are not
handled locally and so the release note does not indicate any
performance improvement.

Release note: None