### PR TITLE
release-21.1: builtins: fix crdb_internal.encode_key for user defined types

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -636,6 +636,11 @@ RETURNING crdb_region, pk
 ----
 ap-southeast-2  23
 
+query TT
+SELECT start_key, end_key FROM [SHOW RANGE FROM TABLE regional_by_row_table FOR ROW ('ap-southeast-2', 1)]
+----
+NULL  NULL
+
 query TIIII
 SELECT crdb_region, pk, pk2, a, b FROM regional_by_row_table
 ORDER BY pk

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -304,3 +304,17 @@ func (p *planner) maybeInitializeMultiRegionMetadata(
 
 	return regionConfig, nil
 }
+
+// GetImmutableTableInterfaceByID is part of the EvalPlanner interface.
+func (p *planner) GetImmutableTableInterfaceByID(ctx context.Context, id int) (interface{}, error) {
+	desc, err := p.Descriptors().GetImmutableTableByID(
+		ctx,
+		p.txn,
+		descpb.ID(id),
+		tree.ObjectLookupFlagsWithRequired(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return desc, nil
+}

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -146,6 +146,13 @@ func (ep *DummyEvalPlanner) UnsafeUpsertDescriptor(
 	return errors.WithStack(errEvalPlanner)
 }
 
+// GetImmutableTableInterfaceByID is part of the EvalPlanner interface.
+func (ep *DummyEvalPlanner) GetImmutableTableInterfaceByID(
+	ctx context.Context, id int,
+) (interface{}, error) {
+	return nil, errors.WithStack(errEvalPlanner)
+}
+
 // UnsafeDeleteDescriptor is part of the EvalPlanner interface.
 func (ep *DummyEvalPlanner) UnsafeDeleteDescriptor(
 	ctx context.Context, descID int64, force bool,

--- a/pkg/sql/logictest/testdata/logic_test/ranges
+++ b/pkg/sql/logictest/testdata/logic_test/ranges
@@ -566,3 +566,21 @@ ALTER INDEX i59011 SPLIT AT VALUES (2, '6cf22b39-a1eb-43ee-8edf-0da8543c5c38'::U
 
 statement error excessive number of values provided: expected 1, got 2
 ALTER INDEX i59011 UNSPLIT AT VALUES (2, '6cf22b39-a1eb-43ee-8edf-0da8543c5c38'::UUID);
+
+# Regression for #63646
+
+statement ok
+CREATE TYPE e63646 AS ENUM ('a', 'b');
+CREATE TABLE t63646 (e e63646 PRIMARY KEY);
+INSERT INTO t63646 VALUES ('a'), ('b');
+ALTER TABLE t63646 SPLIT AT VALUES ('a'), ('b')
+
+query TT
+SELECT start_key, end_key FROM [SHOW RANGE FROM TABLE t63646 FOR ROW ('a')]
+----
+/"@"  /"\x80"
+
+query TT
+SELECT start_key, end_key FROM [SHOW RANGE FROM TABLE t63646 FOR ROW ('b')]
+----
+/"\x80"  NULL

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -3878,12 +3878,14 @@ may increase either contention or retry errors, or both.`,
 				}
 
 				// Get the referenced table and index.
-				// TODO(ajwerner): This is awful, we should be able to resolve this
-				// thing using the usual tools rather than going through the DB.
-				tableDesc, err := catalogkv.MustGetTableDescByID(ctx.Context, ctx.Txn, ctx.Codec, descpb.ID(tableID))
+				tableDescIntf, err := ctx.Planner.GetImmutableTableInterfaceByID(
+					ctx.Context,
+					tableID,
+				)
 				if err != nil {
 					return nil, err
 				}
+				tableDesc := tableDescIntf.(catalog.TableDescriptor)
 				index, err := tableDesc.FindIndexWithID(descpb.IndexID(indexID))
 				if err != nil {
 					return nil, err

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3056,6 +3056,10 @@ type EvalPlanner interface {
 	EvalDatabase
 	TypeReferenceResolver
 
+	// GetImmutableTableInterfaceByID returns an interface{} with
+	// catalog.TableDescriptor to avoid a circular dependency.
+	GetImmutableTableInterfaceByID(ctx context.Context, id int) (interface{}, error)
+
 	// GetTypeFromValidSQLSyntax parses a column type when the input
 	// string uses the parseable SQL representation of a type name, e.g.
 	// `INT(13)`, `mytype`, `"mytype"`, `pg_catalog.int4` or `"public".mytype`.


### PR DESCRIPTION
Backport 1/1 commits from #63716.

/cc @cockroachdb/release

---

Resolves #63646

Release note (bug fix): Fix crdb_internal.encode_key for user defined
types. This would previously error. This will also fix SHOW RANGE FOR
ROW for tables with user-defined types as their PRIMARY KEY.
