### PR TITLE
server: skip TestTelemetrySQLStatsIndependence

### DIFF
--- a/pkg/server/stats_test.go
+++ b/pkg/server/stats_test.go
@@ -37,6 +37,7 @@ import (
 
 func TestTelemetrySQLStatsIndependence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 63844, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	// This test fails if the central reporting server from CRL


### PR DESCRIPTION
Refs: #63844

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None