### PR TITLE
roachtest/tpcc: pass correct warehouse count in multi-region tpccbench

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -436,10 +436,8 @@ func registerTPCC(r *testRegistry) {
 		Distribution: multiRegion,
 		LoadConfig:   multiLoadgen,
 
-		LoadWarehouses: 5000,
-		EstimatedMax:   3000,
-
-		MinVersion: "v20.1.0",
+		LoadWarehouses: 3000,
+		EstimatedMax:   2000,
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes:      9,
@@ -449,8 +447,6 @@ func registerTPCC(r *testRegistry) {
 
 		LoadWarehouses: 2000,
 		EstimatedMax:   900,
-
-		MinVersion: "v20.1.0",
 	})
 }
 
@@ -883,7 +879,6 @@ func runTPCCBench(ctx context.Context, t *test, c *cluster, b tpccBenchSpec) {
 				}
 
 				extraFlags := ""
-				activeWarehouses := warehouses
 				switch b.LoadConfig {
 				case singleLoadgen:
 					// Nothing.
@@ -892,7 +887,6 @@ func runTPCCBench(ctx context.Context, t *test, c *cluster, b tpccBenchSpec) {
 				case multiLoadgen:
 					extraFlags = fmt.Sprintf(` --partitions=%d --partition-affinity=%d`,
 						b.partitions(), groupIdx)
-					activeWarehouses = warehouses / numLoadGroups
 				default:
 					// Abort the whole test.
 					t.Fatalf("unimplemented LoadConfig %v", b.LoadConfig)
@@ -903,10 +897,10 @@ func runTPCCBench(ctx context.Context, t *test, c *cluster, b tpccBenchSpec) {
 					extraFlags += " --method=simple"
 				}
 				t.Status(fmt.Sprintf("running benchmark, warehouses=%d", warehouses))
-				histogramsPath := fmt.Sprintf("%s/warehouses=%d/stats.json", perfArtifactsDir, activeWarehouses)
+				histogramsPath := fmt.Sprintf("%s/warehouses=%d/stats.json", perfArtifactsDir, warehouses)
 				cmd := fmt.Sprintf("./cockroach workload run tpcc --warehouses=%d --active-warehouses=%d "+
 					"--tolerate-errors --ramp=%s --duration=%s%s --histograms=%s {pgurl%s}",
-					b.LoadWarehouses, activeWarehouses, rampDur,
+					b.LoadWarehouses, warehouses, rampDur,
 					loadDur, extraFlags, histogramsPath, sqlGateways)
 				err := c.RunE(ctx, group.loadNodes, cmd)
 				loadDone <- timeutil.Now()
@@ -930,7 +924,7 @@ func runTPCCBench(ctx context.Context, t *test, c *cluster, b tpccBenchSpec) {
 					// overload but something that deserves failing the whole test.
 					t.Fatal(err)
 				}
-				result := tpcc.NewResultWithSnapshots(activeWarehouses, 0, snapshots)
+				result := tpcc.NewResultWithSnapshots(warehouses, 0, snapshots)
 				resultChan <- result
 				return nil
 			})


### PR DESCRIPTION
This commit fixes an unfortunate bug where we were fooling ourselves into thinking that we supported 3x the number of warehouses in this configuration than we actually do. This is because we were dividing the number of warehouses by the number of regions before passing the count to the `--active-warehouses` flag. However, the load generator already takes into account the number of partitions to split the load across when provided with the `--partitions` flag.

So for instance, if tpccbench's line searcher was instructing us to test 3000 warehouses, we would divide this by 3 to arrive at 1000 warehouses, then we would pass this to each workload (`--partitions=3 --active-warehouses=1000`), which would each run over 333 warehouses.

As a sanity check, `tpccbench/nodes=9/cpu=4/multi-region` uses a total of `9*4=36 vCPUs`. `tpccbench/nodes=3/cpu=16` uses a total of `3*16=48 vCPUs`. On GCE, `tpccbench/nodes=3/cpu=16` typically maxes out at about 2200 warehouses. Last time `tpccbench/nodes=9/cpu=4/multi-region` ran, it (allegedly) maxed out at the full 4999 warehouses.