### PR TITLE
sql: support spilling to disk for bufferNode

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "authorization.go",
         "backfill.go",
         "buffer.go",
+        "buffer_util.go",
         "cancel_queries.go",
         "cancel_sessions.go",
         "check.go",

--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -16,8 +16,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
-	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
@@ -43,10 +43,10 @@ type applyJoinNode struct {
 	// columns contains the metadata for the results of this node.
 	columns colinfo.ResultColumns
 
-	// rightCols contains the metadata for the result of the right side of this
-	// apply join, as built in the optimization phase. Later on, every re-planning
-	// of the right side will emit these same columns.
-	rightCols colinfo.ResultColumns
+	// rightTypes is the schema of the rows produced by the right side of the
+	// join, as built in the optimization phase. Later on, every re-planning of
+	// the right side will emit these same columns.
+	rightTypes []*types.T
 
 	planRightSideFn exec.ApplyJoinPlanRightSideFn
 
@@ -61,10 +61,9 @@ type applyJoinNode struct {
 		leftRowFoundAMatch bool
 		// rightRows will be populated with the result of the right side of the join
 		// each time it's run.
-		rightRows *rowcontainer.RowContainer
-		// curRightRow is the index into rightRows of the current right row being
-		// processed.
-		curRightRow int
+		rightRows rowContainerHelper
+		// rightRowsIterator, if non-nil, is the iterator into rightRows.
+		rightRowsIterator *rowContainerIterator
 		// out is the full result row, populated on each call to Next.
 		out tree.Datums
 		// done is true if the left side has been exhausted.
@@ -72,7 +71,6 @@ type applyJoinNode struct {
 	}
 }
 
-// Set to true to enable ultra verbose debug logging.
 func newApplyJoinNode(
 	joinType descpb.JoinType,
 	left planDataSource,
@@ -93,7 +91,7 @@ func newApplyJoinNode(
 		joinType:        joinType,
 		input:           left,
 		pred:            pred,
-		rightCols:       rightCols,
+		rightTypes:      getTypesFromResultColumns(rightCols),
 		planRightSideFn: planRightSideFn,
 		columns:         pred.cols,
 	}, nil
@@ -103,15 +101,13 @@ func (a *applyJoinNode) startExec(params runParams) error {
 	// If needed, pre-allocate a right row of NULL tuples for when the
 	// join predicate fails to match.
 	if a.joinType == descpb.LeftOuterJoin {
-		a.run.emptyRight = make(tree.Datums, len(a.rightCols))
+		a.run.emptyRight = make(tree.Datums, len(a.rightTypes))
 		for i := range a.run.emptyRight {
 			a.run.emptyRight[i] = tree.DNull
 		}
 	}
 	a.run.out = make(tree.Datums, len(a.columns))
-	ci := colinfo.ColTypeInfoFromResCols(a.rightCols)
-	acc := params.EvalContext().Mon.MakeBoundAccount()
-	a.run.rightRows = rowcontainer.NewRowContainer(acc, ci)
+	a.run.rightRows.init(a.rightTypes, params.extendedEvalCtx, "apply-join" /* opName */)
 	return nil
 }
 
@@ -121,37 +117,42 @@ func (a *applyJoinNode) Next(params runParams) (bool, error) {
 	}
 
 	for {
-		for a.run.curRightRow < a.run.rightRows.Len() {
+		if a.run.rightRowsIterator != nil {
 			// We have right rows set up - check the next one for a match.
-			var rrow tree.Datums
-			if len(a.rightCols) != 0 {
-				rrow = a.run.rightRows.At(a.run.curRightRow)
-			}
-			a.run.curRightRow++
-			// Compute join.
-			predMatched, err := a.pred.eval(params.EvalContext(), a.run.leftRow, rrow)
-			if err != nil {
-				return false, err
-			}
-			if !predMatched {
-				// Didn't match? Try with the next right-side row.
-				continue
-			}
+			for {
+				// Note that if a.rightTypes has zero length, non-nil rrow is
+				// returned the correct number of times.
+				rrow, err := a.run.rightRowsIterator.next()
+				if err != nil {
+					return false, err
+				}
+				if rrow == nil {
+					// We have exhausted all rows from the right side.
+					break
+				}
+				// Compute join.
+				predMatched, err := a.pred.eval(params.EvalContext(), a.run.leftRow, rrow)
+				if err != nil {
+					return false, err
+				}
+				if !predMatched {
+					// Didn't match? Try with the next right-side row.
+					continue
+				}
 
-			a.run.leftRowFoundAMatch = true
-			if a.joinType == descpb.LeftAntiJoin ||
-				a.joinType == descpb.LeftSemiJoin {
-				// We found a match, but we're doing an anti or semi join, so we're
-				// done with this left row.
-				break
+				a.run.leftRowFoundAMatch = true
+				if a.joinType == descpb.LeftAntiJoin ||
+					a.joinType == descpb.LeftSemiJoin {
+					// We found a match, but we're doing an anti or semi join,
+					// so we're done with this left row.
+					break
+				}
+				// We're doing an ordinary join, so prep the row and emit it.
+				a.pred.prepareRow(a.run.out, a.run.leftRow, rrow)
+				return true, nil
 			}
-			// We're doing an ordinary join, so prep the row and emit it.
-			a.pred.prepareRow(a.run.out, a.run.leftRow, rrow)
-			return true, nil
 		}
-		// We're out of right side rows. Clear them, and reset the match state for
-		// next time.
-		a.run.rightRows.Clear(params.ctx)
+		// We're out of right side rows. Reset the match state for next time.
 		foundAMatch := a.run.leftRowFoundAMatch
 		a.run.leftRowFoundAMatch = false
 
@@ -222,15 +223,25 @@ func (a *applyJoinNode) Next(params runParams) (bool, error) {
 // wrong during execution of the right hand side of the join, and that we should
 // completely give up on the outer join.
 func (a *applyJoinNode) runRightSidePlan(params runParams, plan *planComponents) error {
-	a.run.curRightRow = 0
-	a.run.rightRows.Clear(params.ctx)
-	return runPlanInsidePlan(params, plan, a.run.rightRows)
+	// Prepare rightRows state for reuse.
+	if err := a.run.rightRows.clear(params.ctx); err != nil {
+		return err
+	}
+	if a.run.rightRowsIterator != nil {
+		a.run.rightRowsIterator.close()
+		a.run.rightRowsIterator = nil
+	}
+	if err := runPlanInsidePlan(params, plan, &a.run.rightRows); err != nil {
+		return err
+	}
+	a.run.rightRowsIterator = newRowContainerIterator(params.ctx, a.run.rightRows, a.rightTypes)
+	return nil
 }
 
 // runPlanInsidePlan is used to run a plan and gather the results in a row
 // container, as part of the execution of an "outer" plan.
 func runPlanInsidePlan(
-	params runParams, plan *planComponents, rowContainer *rowcontainer.RowContainer,
+	params runParams, plan *planComponents, rowContainer *rowContainerHelper,
 ) error {
 	rowResultWriter := NewRowResultWriter(rowContainer)
 	recv := MakeDistSQLReceiver(
@@ -279,7 +290,9 @@ func (a *applyJoinNode) Values() tree.Datums {
 
 func (a *applyJoinNode) Close(ctx context.Context) {
 	a.input.plan.Close(ctx)
-	if a.run.rightRows != nil {
-		a.run.rightRows.Close(ctx)
+	a.run.rightRows.close(ctx)
+	if a.run.rightRowsIterator != nil {
+		a.run.rightRowsIterator.close()
+		a.run.rightRowsIterator = nil
 	}
 }

--- a/pkg/sql/buffer_util.go
+++ b/pkg/sql/buffer_util.go
@@ -1,0 +1,128 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+)
+
+// rowContainerHelper is a wrapper around a disk-backed row container that
+// should be used by planNodes (or similar components) whenever they need to
+// buffer data. init must be called before the first use.
+type rowContainerHelper struct {
+	rows        *rowcontainer.DiskBackedRowContainer
+	scratch     rowenc.EncDatumRow
+	memMonitor  *mon.BytesMonitor
+	diskMonitor *mon.BytesMonitor
+}
+
+func (c *rowContainerHelper) init(
+	typs []*types.T, evalContext *extendedEvalContext, opName string,
+) {
+	distSQLCfg := &evalContext.DistSQLPlanner.distSQLSrv.ServerConfig
+	c.memMonitor = execinfra.NewLimitedMonitor(evalContext.Context, evalContext.Mon, distSQLCfg, fmt.Sprintf("%s-limited", opName))
+	c.diskMonitor = execinfra.NewMonitor(evalContext.Context, distSQLCfg.ParentDiskMonitor, fmt.Sprintf("%s-disk", opName))
+	c.rows = &rowcontainer.DiskBackedRowContainer{}
+	c.rows.Init(
+		colinfo.NoOrdering, typs, &evalContext.EvalContext,
+		distSQLCfg.TempStorage, c.memMonitor, c.diskMonitor,
+	)
+	c.scratch = make(rowenc.EncDatumRow, len(typs))
+}
+
+// addRow adds a given row to the helper and returns any error it encounters.
+func (c *rowContainerHelper) addRow(ctx context.Context, row tree.Datums) error {
+	for i := range row {
+		c.scratch[i].Datum = row[i]
+	}
+	return c.rows.AddRow(ctx, c.scratch)
+}
+
+// len returns the number of rows buffered so far.
+func (c *rowContainerHelper) len() int {
+	return c.rows.Len()
+}
+
+// clear prepares the helper for reuse (it resets the underlying container which
+// will delete all buffered data; also, the container will be using the
+// in-memory variant even if it spilled on the previous usage).
+func (c *rowContainerHelper) clear(ctx context.Context) error {
+	return c.rows.UnsafeReset(ctx)
+}
+
+// close must be called once the helper is no longer needed to clean up any
+// resources.
+func (c *rowContainerHelper) close(ctx context.Context) {
+	if c.rows != nil {
+		c.rows.Close(ctx)
+		c.memMonitor.Stop(ctx)
+		c.diskMonitor.Stop(ctx)
+		c.rows = nil
+	}
+}
+
+// rowContainerIterator is a wrapper around rowcontainer.RowIterator that takes
+// care of advancing the underlying iterator and converting the rows to
+// tree.Datums.
+type rowContainerIterator struct {
+	iter rowcontainer.RowIterator
+
+	typs   []*types.T
+	datums tree.Datums
+	da     rowenc.DatumAlloc
+}
+
+// newRowContainerIterator returns a new rowContainerIterator that must be
+// closed once no longer needed.
+func newRowContainerIterator(
+	ctx context.Context, c rowContainerHelper, typs []*types.T,
+) *rowContainerIterator {
+	i := &rowContainerIterator{
+		iter:   c.rows.NewIterator(ctx),
+		typs:   typs,
+		datums: make(tree.Datums, len(typs)),
+	}
+	i.iter.Rewind()
+	return i
+}
+
+// next returns the next row of the iterator or an error if encountered. It
+// returns nil, nil when the iterator has been exhausted.
+func (i *rowContainerIterator) next() (tree.Datums, error) {
+	defer i.iter.Next()
+	if valid, err := i.iter.Valid(); err != nil {
+		return nil, err
+	} else if !valid {
+		// All rows have been exhausted.
+		return nil, nil
+	}
+	row, err := i.iter.Row()
+	if err != nil {
+		return nil, err
+	}
+	if err = rowenc.EncDatumRowToDatums(i.typs, i.datums, row, &i.da); err != nil {
+		return nil, err
+	}
+	return i.datums, nil
+}
+
+func (i *rowContainerIterator) close() {
+	i.iter.Close()
+}

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
-	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
@@ -506,14 +505,6 @@ func (r *createStatsResumer) Resume(ctx context.Context, execCtx interface{}) er
 	r.tableID = details.Table.ID
 	evalCtx := p.ExtendedEvalContext()
 
-	ci := colinfo.ColTypeInfoFromColTypes([]*types.T{})
-	rows := rowcontainer.NewRowContainer(evalCtx.Mon.MakeBoundAccount(), ci)
-	defer func() {
-		if rows != nil {
-			rows.Close(ctx)
-		}
-	}()
-
 	dsp := p.DistSQLPlanner()
 	if err := p.ExecCfg().DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		// Set the transaction on the EvalContext to this txn. This allows for
@@ -527,8 +518,11 @@ func (r *createStatsResumer) Resume(ctx context.Context, execCtx interface{}) er
 		}
 
 		planCtx := dsp.NewPlanningCtx(ctx, evalCtx, nil /* planner */, txn, true /* distribute */)
+		// CREATE STATS flow doesn't produce any rows and only emits the
+		// metadata, so we can use a nil rowContainerHelper.
+		resultWriter := NewRowResultWriter(nil /* rowContainer */)
 		if err := dsp.planAndRunCreateStats(
-			ctx, evalCtx, planCtx, txn, r.job, NewRowResultWriter(rows),
+			ctx, evalCtx, planCtx, txn, r.job, resultWriter,
 		); err != nil {
 			// Check if this was a context canceled error and restart if it was.
 			if grpcutil.IsContextCanceled(err) {

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -259,7 +259,7 @@ func (dsp *DistSQLPlanner) planAndRunCreateStats(
 	planCtx *PlanningCtx,
 	txn *kv.Txn,
 	job *jobs.Job,
-	resultRows *RowResultWriter,
+	resultWriter *RowResultWriter,
 ) error {
 	ctx = logtags.AddTag(ctx, "create-stats-distsql", nil)
 
@@ -272,7 +272,7 @@ func (dsp *DistSQLPlanner) planAndRunCreateStats(
 
 	recv := MakeDistSQLReceiver(
 		ctx,
-		resultRows,
+		resultWriter,
 		tree.DDL,
 		evalCtx.ExecCfg.RangeDescriptorCache,
 		txn,
@@ -284,5 +284,5 @@ func (dsp *DistSQLPlanner) planAndRunCreateStats(
 	defer recv.Release()
 
 	dsp.Run(planCtx, txn, physPlan, recv, evalCtx, nil /* finishedSetupFn */)()
-	return resultRows.Err()
+	return resultWriter.Err()
 }

--- a/pkg/sql/logictest/testdata/logic_test/apply_join
+++ b/pkg/sql/logictest/testdata/logic_test/apply_join
@@ -36,6 +36,32 @@ EXECUTE a
 4  four   4  four
 5  five   5  five
 
+# A test case when the right side produces no columns.
+statement ok
+PREPARE right_no_cols AS OPT PLAN '
+(Root
+  (InnerJoinApply
+    (Scan [(Table "t") (Cols "k,str") ])
+    (Select
+      (Scan [(Table "u") (Cols "") ])
+      [ (Eq (Var "k") (Const 2 "int") )]
+     )
+    []
+    []
+  )
+  (Presentation "k,str")
+  (NoOrdering)
+)'
+
+query IT
+EXECUTE right_no_cols
+----
+2  two
+2  two
+2  two
+2  two
+2  two
+
 # LeftJoinApply tests.
 
 statement ok

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -10,7 +10,10 @@
 
 package sql
 
-import "github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+)
 
 var noColumns = make(colinfo.ResultColumns, 0)
 
@@ -158,6 +161,17 @@ func getPlanColumns(plan planNode, mut bool) colinfo.ResultColumns {
 
 	// Every other node has no columns in their results.
 	return noColumns
+}
+
+// planTypes returns the types schema of the rows produced by this planNode. See
+// comments on planColumns for more details.
+func planTypes(plan planNode) []*types.T {
+	columns := planColumns(plan)
+	typs := make([]*types.T, len(columns))
+	for i := range typs {
+		typs[i] = columns[i].Typ
+	}
+	return typs
 }
 
 // optColumnsSlot is a helper struct for nodes with a static signature.

--- a/pkg/sql/recursive_cte.go
+++ b/pkg/sql/recursive_cte.go
@@ -13,10 +13,9 @@ package sql
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
-	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
 
 // recursiveCTENode implements the logic for a recursive CTE:
@@ -40,23 +39,21 @@ type recursiveCTENode struct {
 }
 
 type recursiveCTERun struct {
+	// typs is the schema of the rows produced by this CTE.
+	typs []*types.T
 	// workingRows contains the rows produced by the current iteration (aka the
 	// "working" table).
-	workingRows *rowcontainer.RowContainer
-	// nextRowIdx is the index inside workingRows of the next row to be returned
-	// by the operator.
-	nextRowIdx int
+	workingRows rowContainerHelper
+	iterator    *rowContainerIterator
+	currentRow  tree.Datums
 
 	initialDone bool
 	done        bool
 }
 
 func (n *recursiveCTENode) startExec(params runParams) error {
-	n.workingRows = rowcontainer.NewRowContainer(
-		params.EvalContext().Mon.MakeBoundAccount(),
-		colinfo.ColTypeInfoFromResCols(getPlanColumns(n.initial, false /* mut */)),
-	)
-	n.nextRowIdx = 0
+	n.typs = planTypes(n.initial)
+	n.workingRows.init(n.typs, params.extendedEvalCtx, "cte" /* opName */)
 	return nil
 }
 
@@ -65,19 +62,23 @@ func (n *recursiveCTENode) Next(params runParams) (bool, error) {
 		return false, err
 	}
 
-	n.nextRowIdx++
-
 	if !n.initialDone {
-		ok, err := n.initial.Next(params)
-		if err != nil {
-			return false, err
-		}
-		if ok {
-			if _, err = n.workingRows.AddRow(params.ctx, n.initial.Values()); err != nil {
+		// Fully consume the initial rows (we could have read the initial rows
+		// one at a time and return it in the same fashion, but that would
+		// require special-case behavior).
+		for {
+			ok, err := n.initial.Next(params)
+			if err != nil {
 				return false, err
 			}
-			return true, nil
+			if !ok {
+				break
+			}
+			if err = n.workingRows.addRow(params.ctx, n.initial.Values()); err != nil {
+				return false, err
+			}
 		}
+		n.iterator = newRowContainerIterator(params.ctx, n.workingRows, n.typs)
 		n.initialDone = true
 	}
 
@@ -85,52 +86,67 @@ func (n *recursiveCTENode) Next(params runParams) (bool, error) {
 		return false, nil
 	}
 
-	if n.workingRows.Len() == 0 {
+	if n.workingRows.len() == 0 {
 		// Last iteration returned no rows.
 		n.done = true
 		return false, nil
 	}
 
-	// There are more rows to return from the last iteration.
-	if n.nextRowIdx <= n.workingRows.Len() {
+	var err error
+	n.currentRow, err = n.iterator.next()
+	if err != nil {
+		return false, err
+	}
+	if n.currentRow != nil {
+		// There are more rows to return from the last iteration.
 		return true, nil
 	}
 
 	// Let's run another iteration.
 
+	n.iterator.close()
+	n.iterator = nil
 	lastWorkingRows := n.workingRows
-	defer lastWorkingRows.Close(params.ctx)
+	defer lastWorkingRows.close(params.ctx)
 
-	n.workingRows = rowcontainer.NewRowContainer(
-		params.EvalContext().Mon.MakeBoundAccount(),
-		colinfo.ColTypeInfoFromResCols(getPlanColumns(n.initial, false /* mut */)),
-	)
+	n.workingRows = rowContainerHelper{}
+	n.workingRows.init(n.typs, params.extendedEvalCtx, "cte" /* opName */)
 
 	// Set up a bufferNode that can be used as a reference for a scanBufferNode.
 	buf := &bufferNode{
 		// The plan here is only useful for planColumns, so it's ok to always use
 		// the initial plan.
-		plan:         n.initial,
-		bufferedRows: lastWorkingRows,
-		label:        n.label,
+		plan:  n.initial,
+		typs:  n.typs,
+		rows:  lastWorkingRows,
+		label: n.label,
 	}
 	newPlan, err := n.genIterationFn(newExecFactory(params.p), buf)
 	if err != nil {
 		return false, err
 	}
 
-	if err := runPlanInsidePlan(params, newPlan.(*planComponents), n.workingRows); err != nil {
+	if err := runPlanInsidePlan(params, newPlan.(*planComponents), &n.workingRows); err != nil {
 		return false, err
 	}
-	n.nextRowIdx = 1
-	return n.workingRows.Len() > 0, nil
+
+	n.iterator = newRowContainerIterator(params.ctx, n.workingRows, n.typs)
+	n.currentRow, err = n.iterator.next()
+	if err != nil {
+		return false, err
+	}
+	return n.currentRow != nil, nil
 }
 
 func (n *recursiveCTENode) Values() tree.Datums {
-	return n.workingRows.At(n.nextRowIdx - 1)
+	return n.currentRow
 }
 
 func (n *recursiveCTENode) Close(ctx context.Context) {
 	n.initial.Close(ctx)
-	n.workingRows.Close(ctx)
+	n.workingRows.close(ctx)
+	if n.iterator != nil {
+		n.iterator.close()
+		n.iterator = nil
+	}
 }

--- a/pkg/sql/rowcontainer/datum_row_container.go
+++ b/pkg/sql/rowcontainer/datum_row_container.go
@@ -145,10 +145,14 @@ func (c *RowContainer) Init(acc mon.BoundAccount, ti colinfo.ColTypeInfo, rowCap
 		}
 	}
 
-	// Precalculate the memory used for a chunk, specifically by the Datums in the
-	// chunk and the slice pointing at the chunk.
-	c.chunkMemSize = tree.SizeOfDatum * int64(c.rowsPerChunk*c.numCols)
-	c.chunkMemSize += tree.SizeOfDatums
+	if nCols > 0 {
+		// Precalculate the memory used for a chunk, specifically by the Datums
+		// in the chunk and the slice pointing at the chunk.
+		// Note that when there are no columns, we simply track the number of
+		// rows added in c.numRows and don't allocate any memory.
+		c.chunkMemSize = tree.SizeOfDatum * int64(c.rowsPerChunk*c.numCols)
+		c.chunkMemSize += tree.SizeOfDatums
+	}
 }
 
 // Clear resets the container and releases the associated memory. This allows


### PR DESCRIPTION
This commit refactors several `planNode`s that need to buffer rows to
use a disk-backed row container instead of pure in-memory one. In order
to achieve that a couple of light wrappers are introduced on top of the
corresponding container and an iterator over it.

Still, one - probably important - case is not fixed properly: namely, if
a subquery is executed in AllRows or AllRowsNormalized mode, then we
first buffer the rows into the disk-backed container only to materialize
it later into a single tuple. Addressing this is left as a TODO.

Fixes: #62301.
Fixes: #62674.

Release note (sql change): CockroachDB now should be more stable when
executing queries with subqueries producing many rows (previously we
could OOM crash and now we will use the temporary disk storage).