### PR TITLE
cmd/roachtest: fix dependencies for sequelize/typeorm

### DIFF
--- a/pkg/cmd/roachtest/sequelize.go
+++ b/pkg/cmd/roachtest/sequelize.go
@@ -79,7 +79,7 @@ func registerSequelize(r *testRegistry) {
 			node,
 			"install dependencies",
 			`sudo apt-get -qq install make python3 libpq-dev python-dev gcc g++ `+
-				`python-software-properties build-essential`,
+				`software-properties-common build-essential`,
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/typeorm.go
+++ b/pkg/cmd/roachtest/typeorm.go
@@ -64,7 +64,7 @@ func registerTypeORM(r *testRegistry) {
 			node,
 			"install dependencies",
 			`sudo apt-get -qq install make python3 libpq-dev python-dev gcc g++ `+
-				`python-software-properties build-essential`,
+				`software-properties-common build-essential`,
 		); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
The update to the roachtest ubuntu version requires a software package
tweak from python-software-properties to software-properties-common.

Release note: None

Resolves #63895 