### PR TITLE
colbuilder: support 'CASE expr WHEN exprs' form

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -1964,10 +1964,6 @@ func planProjectionOperators(
 		typs = appendOneType(typs, outputType)
 		return op, resultIdx, typs, err
 	case *tree.CaseExpr:
-		if t.Expr != nil {
-			return nil, resultIdx, typs, errors.New("CASE <expr> WHEN expressions unsupported")
-		}
-
 		allocator := colmem.NewAllocator(ctx, acc, factory)
 		caseOutputType := t.ResolvedType()
 		if typeconv.TypeFamilyToCanonicalTypeFamily(caseOutputType.Family()) == types.BytesFamily {
@@ -2010,6 +2006,25 @@ func planProjectionOperators(
 			)
 			if err != nil {
 				return nil, resultIdx, typs, err
+			}
+			if t.Expr != nil {
+				// If we have 'CASE <expr> WHEN ...' form, then we need to
+				// evaluate the equality between '<expr>' and whatever has been
+				// projected by this WHEN arm. We do so by constructing the
+				// corresponding comparison expr and letting the planning do its
+				// job.
+				left := t.Expr.(tree.TypedExpr)
+				// The result of evaluation of this WHEN arm is put at position
+				// resultIdx, so we simply create an ordinal referencing that
+				// column.
+				right := tree.NewTypedOrdinalReference(resultIdx, whenTyped.ResolvedType())
+				cmpExpr := tree.NewTypedComparisonExpr(tree.EQ, left, right)
+				caseOps[i], resultIdx, typs, err = planProjectionOperators(
+					ctx, evalCtx, cmpExpr, typs, caseOps[i], acc, factory,
+				)
+				if err != nil {
+					return nil, resultIdx, typs, err
+				}
 			}
 			caseOps[i], err = colexecutils.BoolOrUnknownToSelOp(caseOps[i], typs, resultIdx)
 			if err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize
@@ -32,6 +32,16 @@ SELECT a, CASE WHEN a = 0 THEN 0 WHEN a = 1 THEN 3 ELSE 5 END FROM a ORDER BY 1,
 2  5
 2  5
 
+query II
+SELECT a, CASE a WHEN 0 THEN 0 WHEN 1 THEN 3 ELSE 5 END FROM a ORDER BY 1, 2 LIMIT 6
+----
+0  0
+0  0
+1  3
+1  3
+2  5
+2  5
+
 # Regression test for 40574.
 statement ok
 CREATE TABLE t40574(pk INTEGER PRIMARY KEY, col0 INTEGER, col1 FLOAT, col2 TEXT, col3 INTEGER, col4 FLOAT, col5 TEXT);
@@ -774,12 +784,27 @@ SELECT CASE WHEN x = 0 THEN 0 ELSE NULL END FROM t_case_null
 0
 
 query I
+SELECT CASE x WHEN 0 THEN 0 ELSE NULL END FROM t_case_null
+----
+0
+
+query I
 SELECT CASE WHEN x = 0 THEN NULL ELSE 0 END FROM t_case_null
 ----
 NULL
 
 query I
+SELECT CASE x WHEN 0 THEN NULL ELSE 0 END FROM t_case_null
+----
+NULL
+
+query I
 SELECT CASE WHEN x = 1 THEN 1 ELSE NULL END FROM t_case_null
+----
+NULL
+
+query I
+SELECT CASE x WHEN 1 THEN 1 ELSE NULL END FROM t_case_null
 ----
 NULL
 
@@ -944,12 +969,21 @@ SELECT CASE WHEN a = 0 THEN a ELSE 1:::INT8 END FROM t43550
 ----
 1
 
+query I
+SELECT CASE a WHEN 0 THEN a ELSE 1:::INT8 END FROM t43550
+----
+1
+
 # Regression test for #43855.
 statement ok
 CREATE TABLE t43855(o OID, r REGPROCEDURE);
 
 query i
 SELECT CASE WHEN o = 0 THEN 0:::OID ELSE r END FROM t43855
+----
+
+query i
+SELECT CASE o WHEN 0 THEN 0:::OID ELSE r END FROM t43855
 ----
 
 # Regression test for an aggregate that has output type different from its


### PR DESCRIPTION
Previously, we didn't support `CASE expr WHEN exprs` form of CASE
expression and had to fallback to row-by-row engine. This form requires
just another step of performing an equality comparison of `expr`
against the projection of the current WHEN arm to decide whether this
arm matched. This commit does so.

Release note: None