### PR TITLE
roachtest: delete tpccbench/nodes=6/cpu=16/multi-az roachtest

### DIFF
--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -382,14 +382,6 @@ func registerTPCC(r *testRegistry) {
 		Tags: []string{`weekly`},
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
-		Nodes:        6,
-		CPUs:         16,
-		Distribution: multiZone,
-
-		LoadWarehouses: 5000,
-		EstimatedMax:   2500,
-	})
-	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes:        9,
 		CPUs:         4,
 		Distribution: multiRegion,


### PR DESCRIPTION
This test has historically failed due to infra flakes, import causing
OOMs, LSM backpressure. A known issue with certain flavors of IMPORT
causing an upside-down LSM was fixed in 20.2 with the adoption of pebble
as our storage engine.

This change deletes the roachtest from 20.1 branch.

Fixes: #59044

Release note: None