### PR TITLE
roachtest: remove misplaced skip

### DIFF
--- a/pkg/cmd/roachtest/election.go
+++ b/pkg/cmd/roachtest/election.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
@@ -25,8 +24,6 @@ func registerElectionAfterRestart(r *testRegistry) {
 		Skip:    "https://github.com/cockroachdb/cockroach/issues/54246",
 		Cluster: makeClusterSpec(3),
 		Run: func(ctx context.Context, t *test, c *cluster) {
-			skip.UnderRace(t, "race builds make this test exceed its timeout")
-
 			t.Status("starting up")
 			c.Put(ctx, cockroach, "./cockroach")
 			c.Start(ctx, t)


### PR DESCRIPTION
This wasn't having any effect, as roachtest is never invoked with the
race tag.

Release note: None
