### PR TITLE
release-21.1: multiregionccl: deflake TestIndexCleanupAfterAlterFromRegionalByRow

### DIFF
--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "//pkg/jobs",
         "//pkg/keys",
         "//pkg/kv",
+        "//pkg/kv/kvserver",
         "//pkg/roachpb",
         "//pkg/security",
         "//pkg/security/securitytest",

--- a/pkg/ccl/multiregionccl/regional_by_row_test.go
+++ b/pkg/ccl/multiregionccl/regional_by_row_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
@@ -566,7 +567,20 @@ func TestIndexCleanupAfterAlterFromRegionalByRow(t *testing.T) {
 	} {
 		t.Run(tc.locality, func(t *testing.T) {
 			_, sqlDB, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
-				t, 3 /* numServers */, base.TestingKnobs{}, nil, /* baseDir */
+				t, 3 /* numServers */, base.TestingKnobs{
+					Store: &kvserver.StoreTestingKnobs{
+						// Disable the merge queue because it makes this test flakey
+						// under stress. Consider changing this when admin commands are
+						// better synchronized leading to less thrashing of the range cache.
+						// We may also need to retry ClearRange operations which bump into
+						// the GC threshold. Generally that's not a concern because
+						// generally that threshold isn't super small. The problem with
+						// ranges is that when they merge, as may happen during the parallel
+						// execution of a big ClearRange is that the highest threshold will
+						// be inherited.
+						DisableMergeQueue: true,
+					},
+				}, nil, /* baseDir */
 			)
 			defer cleanup()
 


### PR DESCRIPTION
Backport 1/1 commits from #63635.

/cc @cockroachdb/release

---

Under stress this test could time out. Looking at the failures, you see
a log of goroutines stuck in retry loops either in the DistSender or in
AdminMerge. Disabling the merge queue seems to deflake this behavior.

Resolves #63896 .

Release note: None
