### PR TITLE
schemaexpr: fix data race in ProcessColumnSet

### DIFF
--- a/pkg/sql/catalog/schemaexpr/default_exprs.go
+++ b/pkg/sql/catalog/schemaexpr/default_exprs.go
@@ -91,13 +91,15 @@ func ProcessColumnSet(
 
 	// Add all public or columns in DELETE_AND_WRITE_ONLY state
 	// that satisfy the condition.
+	ret := make([]catalog.Column, 0, len(tableDesc.AllColumns()))
+	ret = append(ret, cols...)
 	for _, col := range tableDesc.WritableColumns() {
 		if inSet(col) {
 			if !colIDSet.Contains(col.GetID()) {
 				colIDSet.Add(col.GetID())
-				cols = append(cols, col)
+				ret = append(ret, col)
 			}
 		}
 	}
-	return cols
+	return ret
 }


### PR DESCRIPTION
This commit fixes a data race introduced by my recent changes tracked
under #63755, involving the generalized use of catalog.Column instead of
descpb.ColumnDescriptor.

Fixes #63907

Release note: None