### PR TITLE
release-20.2: remove decommission/mixed-versions

### DIFF
--- a/pkg/cmd/roachtest/decommission.go
+++ b/pkg/cmd/roachtest/decommission.go
@@ -62,18 +62,6 @@ func registerDecommission(r *testRegistry) {
 			},
 		})
 	}
-	{
-		numNodes := 4
-		r.Add(testSpec{
-			Name:       "decommission/mixed-versions",
-			Owner:      OwnerKV,
-			MinVersion: "v20.2.0",
-			Cluster:    makeClusterSpec(numNodes),
-			Run: func(ctx context.Context, t *test, c *cluster) {
-				runDecommissionMixedVersions(ctx, t, c, r.buildVersion)
-			},
-		})
-	}
 }
 
 // runDecommission decommissions and wipes nodes in a cluster repeatedly,


### PR DESCRIPTION
It has issues that come from its use of the v20.1 binary, and it is
unlikely that we will introduce any mixed-version issues related to
decommissioning that this test would catch.

Closes #58058.

Release note: None
