### PR TITLE
roachtest: use default closed_timestamp.target_duration in more test

### DIFF
--- a/pkg/cmd/roachtest/cdc.go
+++ b/pkg/cmd/roachtest/cdc.go
@@ -151,17 +151,6 @@ func cdcBasicTest(ctx context.Context, t *test, c *cluster, args cdcTestArgs) {
 	defer verifier.maybeLogLatencyHist()
 
 	m.Go(func(ctx context.Context) error {
-		// Some of the tests have a tight enough bound on targetSteadyLatency
-		// that the default for kv.closed_timestamp.target_duration means the
-		// changefeed is never considered sufficiently caught up. We could
-		// instead make targetSteadyLatency less aggressive, but it'd be nice to
-		// keep it where it is.
-		if _, err := db.Exec(
-			`SET CLUSTER SETTING kv.closed_timestamp.target_duration='10s'`,
-		); err != nil {
-			t.Fatal(err)
-		}
-
 		var targets string
 		if args.workloadType == tpccWorkloadType {
 			targets = `tpcc.warehouse, tpcc.district, tpcc.customer, tpcc.history,


### PR DESCRIPTION
The target duration in these tests were set to 10s in 25298629fca when
the default was 30s. The default was changed to 3s in 797819b35f5.

Ideally we wouldn't do this until we understand why the cdc/ledger and 
cdc/cloud-sink-gcs tests have been flakey over the last couple of weeks.
