### PR TITLE
scripts/gceworker.sh: always populate username

### DIFF
--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -8,7 +8,7 @@ source build/shlib.sh
 export CLOUDSDK_CORE_PROJECT=${CLOUDSDK_CORE_PROJECT-${GCEWORKER_PROJECT-cockroach-workers}}
 export CLOUDSDK_COMPUTE_ZONE=${GCEWORKER_ZONE-${CLOUDSDK_COMPUTE_ZONE-us-east1-b}}
 INSTANCE=${GCEWORKER_NAME-gceworker-$(id -un)}
-SSH_USER=${GCEWORKER_USER:-""}
+SSH_USER=${GCEWORKER_USER:-"$(id -un)"}
 
 cmd=${1-}
 if [[ "${cmd}" ]]; then


### PR DESCRIPTION
In the previous change (#63645) to this file we were to allow injecting a username.
The code before this commit, the code would populate the username as "" leading
to a leading `@` in the address. The `ssh` family of commands are happy enough
with this but the unison command is not. Before this change, we'd see:

```
Fatal error: ill-formed root specification ssh://@gceworker-ajwerner.us-east1-b.cockroach-workers/go/src/github.com/cockroachdb/cockroach
```

I'm content doing something different here like detecting whether we have
a username injected instead. I don't have a strong reason to do that but
maybe by explicitly making the user the output of `whoami` I'm preventing
some other customization.

Release note: None