### PR TITLE
opt: include NULL first column values in spans between partitions

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_index
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_index
@@ -224,3 +224,58 @@ statement error interleaved indexes cannot be partitioned
 CREATE INDEX i ON t60699_b (a) INTERLEAVE IN PARENT t60699_a (a) PARTITION BY LIST (a) (
   partition part1 VALUES IN (1)
 )
+
+# Regression test for #63733. Scanning a partitioned index should produce rows
+# where the first index column is NULL.
+statement ok
+CREATE TABLE t63733 (
+  k INT PRIMARY KEY,
+  region STRING,
+  INDEX idx (region) PARTITION BY LIST (region) (
+     PARTITION us_west VALUES IN (('us-west'))
+  )
+);
+INSERT INTO t63733 VALUES (1, NULL)
+
+query IT
+SELECT * FROM t63733@idx WHERE k = 1
+----
+1  NULL
+
+statement ok
+CREATE TABLE t63733_multi (
+  a INT,
+  b INT,
+  c INT,
+  INDEX idx (a,b,c) PARTITION BY LIST (a, b) (
+    PARTITION x VALUES IN ((10, 10)),
+    PARTITION y VALUES IN ((20, 20))
+  )
+)
+
+statement ok
+INSERT INTO t63733_multi VALUES
+  (10, 10, 1),
+  (10, 10, 1),
+  (20, 20, 1),
+  (NULL, NULL, 1),
+  (NULL, 10, 1),
+  (5, NULL, 1),
+  (10, NULL, 1),
+  (15, NULL, 1),
+  (20, NULL, 1),
+  (25, NULL, 1)
+
+query III rowsort
+SELECT * FROM t63733_multi@idx WHERE c = 1
+----
+NULL  NULL  1
+NULL  10    1
+5     NULL  1
+10    NULL  1
+10    10    1
+10    10    1
+15    NULL  1
+20    NULL  1
+20    20    1
+25    NULL  1

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -438,6 +438,28 @@ func (c *CustomFuncs) tryFoldComputedCol(
 // correctness reasons; although values are unlikely to exist between defined
 // partitions, they may exist and so the constraints of the scan must incorporate
 // these spans.
+//
+// For example, if we have:
+//   PARTITION BY LIST (a, b) (
+//     PARTITION a VALUES IN ((1, 10)),
+//     PARTITION b VALUES IN ((2, 20)),
+//   )
+// The in-between filters are:
+//   (a, b) < (1, 10) OR
+//   ((a, b) > (1, 10) AND (a, b) < (2, 20)) OR
+//   (a, b) > (2, 20)
+//
+// When passed as optional filters to index constrains, these filters generate
+// the desired spans:
+//   [ - /1/10), (/1/10 - /2/20), (2/20 - ].
+//
+// TODO(radu,mgartner): technically these filters are not correct with respect
+// to NULL values - we would want the tuple comparisons to treat NULLs as the
+// smallest value. We compensate for this by adding an (a IS NULL) disjunct if
+// column `a` is nullable; in addition, we know that these filters will only be
+// used for span generation, and the span generation currently doesn't exclude
+// NULLs on any columns other than the first in the tuple. This is fragile and
+// would break if we improve the span generation for tuple inequalities.
 func (c *CustomFuncs) inBetweenFilters(
 	tabID opt.TableID, index cat.Index, partitionValues []tree.Datums,
 ) memo.FiltersExpr {
@@ -451,6 +473,31 @@ func (c *CustomFuncs) inBetweenFilters(
 	sort.Slice(partitionValues, func(i, j int) bool {
 		return partitionValues[i].Compare(c.e.evalCtx, partitionValues[j]) < 0
 	})
+
+	// The beginExpr created below will not include NULL values for the first
+	// column. For example, with an index on (a, b) and partition values of
+	// {'foo', 'bar'}, beginExpr would be (a, b) < ('foo', 'bar') which
+	// evaluates to NULL if a is NULL. The index constraint span generated for
+	// beginExpr expression would be (/NULL - /'foo'/'bar'), which excludes NULL
+	// values for a. Any rows where a is NULL would not be scanned, producing
+	// incorrect query results.
+	//
+	// Therefore, if the first column in the index is nullable, we add an IS
+	// NULL expression so that NULL values are included in the index constraint
+	// span generated later on. In the same example above, the constraint span
+	// above becomes [/NULL - /'foo'/'bar'), which includes NULL values for a.
+	//
+	// This is only required for the first column in the index because the index
+	// constraint spans built for tuple inequalities only exclude NULL values
+	// for the first element in the tuple.
+	firstCol := index.Column(0)
+	if firstCol.IsNullable() {
+		nullExpr := c.e.f.ConstructIs(
+			c.e.f.ConstructVariable(tabID.ColumnID(firstCol.Ordinal())),
+			memo.NullSingleton,
+		)
+		inBetween = append(inBetween, nullExpr)
+	}
 
 	// Add the beginning span.
 	beginExpr := c.columnComparison(tabID, index, partitionValues[0], -1)

--- a/pkg/sql/opt/xform/testdata/rules/partitioned
+++ b/pkg/sql/opt/xform/testdata/rules/partitioned
@@ -78,3 +78,93 @@ scan tab42147@id
  ├── cardinality: [0 - 1]
  ├── key: ()
  └── fd: ()-->(1)
+
+# Regression test for #63733. Index spans for in-between values should include
+# NULL values for the first index column if the column is nullable.
+exec-ddl
+CREATE TABLE t63733 (
+    k INT PRIMARY KEY,
+    a STRING,
+    b STRING,
+    INDEX idx (a, b ASC) PARTITION BY LIST (a, b) (
+       PARTITION us_west VALUES IN (('foo', 'bar'))
+    )
+)
+----
+
+opt
+SELECT k FROM t63733@idx WHERE k = 1;
+----
+select
+ ├── columns: k:1!null
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ ├── scan t63733@idx
+ │    ├── columns: k:1!null
+ │    ├── constraint: /2/3/1
+ │    │    ├── [/NULL - /'foo'/'bar')
+ │    │    ├── [/'foo'/'bar'/1 - /'foo'/'bar'/1]
+ │    │    └── [/'foo'/e'bar\x00'/1 - ]
+ │    ├── flags: force-index=idx
+ │    └── key: (1)
+ └── filters
+      └── k:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+
+# Verify the same for multiple nullable columns.
+exec-ddl
+CREATE TABLE t63733_multi (
+  a INT,
+  b INT,
+  c INT,
+  INDEX idx (a,b,c) PARTITION BY LIST (a, b) (
+    PARTITION x VALUES IN ((10, 10)),
+    PARTITION y VALUES IN ((20, 20))
+  )
+)
+----
+
+opt
+SELECT * FROM t63733_multi@idx WHERE c = 1
+----
+select
+ ├── columns: a:1 b:2 c:3!null
+ ├── fd: ()-->(3)
+ ├── scan t63733_multi@idx
+ │    ├── columns: a:1 b:2 c:3
+ │    ├── constraint: /1/2/3/4
+ │    │    ├── [/NULL - /10/9/1]
+ │    │    ├── [/10/10/1 - /10/10/1]
+ │    │    ├── [/10/11/1 - /20/19/1]
+ │    │    ├── [/20/20/1 - /20/20/1]
+ │    │    └── [/20/21/1 - ]
+ │    └── flags: force-index=idx
+ └── filters
+      └── c:3 = 1 [outer=(3), constraints=(/3: [/1 - /1]; tight), fd=()-->(3)]
+
+# Verify that we don't generate incorrect partitioning if the partitioning
+# values have nulls.
+exec-ddl
+CREATE TABLE t63733_nulls (
+  a INT,
+  b INT,
+  c INT,
+  INDEX idx (a,b,c) PARTITION BY LIST (a, b) (
+    PARTITION x VALUES IN ((NULL, NULL)),
+    PARTITION y VALUES IN ((NULL, 10)),
+    PARTITION z VALUES IN ((10, NULL))
+  )
+)
+----
+
+opt
+SELECT * FROM t63733_nulls@idx WHERE c = 1
+----
+select
+ ├── columns: a:1 b:2 c:3!null
+ ├── fd: ()-->(3)
+ ├── scan t63733_nulls@idx
+ │    ├── columns: a:1 b:2 c:3
+ │    └── flags: force-index=idx
+ └── filters
+      └── c:3 = 1 [outer=(3), constraints=(/3: [/1 - /1]; tight), fd=()-->(3)]


### PR DESCRIPTION
Previously, index spans which were meant to include values in-between
index partition values did not include NULL values for the first index
column. As a result, a partitioned index scan did not produce any rows
where the value of the first index column was NULL. This commit fix the
bug by including NULL for the first index column in the index spans if
the column is nullable.

Fixes #63733

Release note (bug fix): A correctness bug, which caused partitioned
index scans to omit rows where the value of the first index column was
NULL, has been fixed. This bug was present since v19.2.0.