### PR TITLE
roachtest: install dependencies used by pgx

### DIFF
--- a/pkg/cmd/roachtest/go_helpers.go
+++ b/pkg/cmd/roachtest/go_helpers.go
@@ -18,6 +18,22 @@ const goPath = `/mnt/data1/go`
 // "node".
 func installGolang(ctx context.Context, t *test, c *cluster, node nodeListOption) {
 	if err := repeatRunE(
+		ctx, c, node, "update apt-get", `sudo apt-get -qq update`,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repeatRunE(
+		ctx,
+		c,
+		node,
+		"install dependencies (go uses C bindings)",
+		`sudo apt-get -qq install build-essential`,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repeatRunE(
 		ctx, c, node, "download go", `curl -fsSL https://dl.google.com/go/go1.15.11.linux-amd64.tar.gz > /tmp/go.tgz`,
 	); err != nil {
 		t.Fatal(err)

--- a/pkg/cmd/roachtest/gopg.go
+++ b/pkg/cmd/roachtest/gopg.go
@@ -66,16 +66,6 @@ func registerGopg(r *testRegistry) {
 		installGolang(ctx, t, c, node)
 
 		if err := repeatRunE(
-			ctx,
-			c,
-			node,
-			"install dependencies",
-			`sudo apt-get -qq install build-essential`,
-		); err != nil {
-			t.Fatal(err)
-		}
-
-		if err := repeatRunE(
 			ctx, c, node, "remove old gopg",
 			fmt.Sprintf(`sudo rm -rf %s`, destPath),
 		); err != nil {

--- a/pkg/cmd/roachtest/pgx_blocklist.go
+++ b/pkg/cmd/roachtest/pgx_blocklist.go
@@ -22,43 +22,7 @@ var pgxBlocklists = blocklistsForVersion{
 // in the test log.
 var pgxBlocklist21_1 = blocklist{}
 
-var pgxBlocklist20_2 = blocklist{
-	"v4.Example_CustomType":                                        "27796",
-	"v4.TestConnBeginBatchDeferredError":                           "31632",
-	"v4.TestConnCopyFromLarge":                                     "52722",
-	"v4.TestConnQueryDeferredError":                                "31632",
-	"v4.TestConnQueryErrorWhileReturningRows":                      "26925",
-	"v4.TestConnQueryReadRowMultipleTimes":                         "26925",
-	"v4.TestConnQueryValues":                                       "26925",
-	"v4.TestConnSendBatch":                                         "44712",
-	"v4.TestConnSendBatchWithPreparedStatement":                    "41558",
-	"v4.TestConnSimpleProtocol":                                    "21286",
-	"v4.TestConnSimpleProtocolRefusesNonStandardConformingStrings": "36215",
-	"v4.TestConnSimpleProtocolRefusesNonUTF8ClientEncoding":        "37129",
-	"v4.TestDomainType":                                            "27796",
-	"v4.TestFatalRxError":                                          "35897",
-	"v4.TestFatalTxError":                                          "35897",
-	"v4.TestInetCIDRArrayTranscodeIP":                              "18846",
-	"v4.TestInetCIDRArrayTranscodeIPNet":                           "18846",
-	"v4.TestInetCIDRTranscodeIP":                                   "18846",
-	"v4.TestInetCIDRTranscodeIPNet":                                "18846",
-	"v4.TestInetCIDRTranscodeWithJustIP":                           "18846",
-	"v4.TestLargeObjects":                                          "26725",
-	"v4.TestLargeObjectsMultipleTransactions":                      "26725",
-	"v4.TestLargeObjectsPreferSimpleProtocol":                      "26725",
-	"v4.TestListenNotify":                                          "41522",
-	"v4.TestListenNotifySelfNotification":                          "41522",
-	"v4.TestListenNotifyWhileBusyIsSafe":                           "41522",
-	"v4.TestQueryContextErrorWhileReceivingRows":                   "26925",
-	"v4.TestRowDecode":                                             "26925",
-	"v4.TestTransactionSuccessfulCommit":                           "31632",
-	"v4.TestTransactionSuccessfulRollback":                         "31632",
-	"v4.TestTxCommitSerializationFailure":                          "12701",
-	"v4.TestTxCommitWhenTxBroken":                                  "31632",
-	"v4.TestTxNestedTransactionCommit":                             "31632",
-	"v4.TestTxNestedTransactionRollback":                           "31632",
-	"v4.TestUnregisteredTypeUsableAsStringArgumentAndBaseResult":   "27796",
-}
+var pgxBlocklist20_2 = blocklist{}
 
 var pgxBlocklist20_1 = blocklist{
 	"v4.Example_CustomType":                                        "27796",


### PR DESCRIPTION
This seems to have changed since roachprod was changed to use a new
image.

Also fix the blocklist for 20.2.

fixes https://github.com/cockroachdb/cockroach/issues/63892

Release note: None