### PR TITLE
schemaexpr: fix data race in name resolver

### DIFF
--- a/pkg/sql/catalog/schemaexpr/expr.go
+++ b/pkg/sql/catalog/schemaexpr/expr.go
@@ -239,7 +239,7 @@ func newNameResolver(
 		*tn,
 		colinfo.ResultColumnsFromColumns(tableID, cols),
 	)
-	nrc := &nameResolverIVarContainer{cols}
+	nrc := &nameResolverIVarContainer{append(make([]catalog.Column, 0, len(cols)), cols...)}
 	ivarHelper := tree.MakeIndexedVarHelper(nrc, len(cols))
 
 	return &nameResolver{


### PR DESCRIPTION
Previously, the name resolver was initialized with a fresh copy of
a slice of column descriptors. Recent work tracked by #63755 replaced
descpb.ColumnDescriptor types with catalog.Column and this copying
behaviour was not maintained, inadvertantly introducing a data race when
the same slice returned by the PublicColumns() method of a
catalog.TableDescriptor was appended to concurrently. This commit fixes
this by making a shallow copy of the slice when initializing the
nameResolver struct.

Fixes #63906.

Release note: None