### PR TITLE
release-20.2: geo: fix st_segmentize to not panic when passed NaN as param

### DIFF
--- a/pkg/geo/geogfn/segmentize.go
+++ b/pkg/geo/geogfn/segmentize.go
@@ -25,6 +25,9 @@ import (
 // This works by dividing each segment by a power of 2 to find the
 // smallest power less than or equal to the segmentMaxLength.
 func Segmentize(geography geo.Geography, segmentMaxLength float64) (geo.Geography, error) {
+	if math.IsNaN(segmentMaxLength) || math.IsInf(segmentMaxLength, 1 /* sign */) {
+		return geography, nil
+	}
 	geometry, err := geography.AsGeomT()
 	if err != nil {
 		return geo.Geography{}, err

--- a/pkg/geo/geogfn/segmentize_test.go
+++ b/pkg/geo/geogfn/segmentize_test.go
@@ -12,6 +12,7 @@ package geogfn
 
 import (
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/geo"
@@ -94,6 +95,16 @@ func TestSegmentize(t *testing.T) {
 			wkt:              "MULTIPOINT((0 0), (1 1))",
 			maxSegmentLength: -1,
 			expectedWKT:      "MULTIPOINT((0 0), (1 1))",
+		},
+		{
+			wkt:              "LINESTRING(0 0, 1 1)",
+			maxSegmentLength: math.NaN(),
+			expectedWKT:      "LINESTRING(0 0, 1 1)",
+		},
+		{
+			wkt:              "LINESTRING(0 0, 1 1)",
+			maxSegmentLength: math.Inf(1),
+			expectedWKT:      "LINESTRING(0 0, 1 1)",
 		},
 	}
 	for _, test := range segmentizeTestCases {

--- a/pkg/geo/geomfn/segmentize.go
+++ b/pkg/geo/geomfn/segmentize.go
@@ -26,6 +26,9 @@ import (
 // between given two-points such that each segment has length less
 // than or equal to given maximum segment length.
 func Segmentize(g geo.Geometry, segmentMaxLength float64) (geo.Geometry, error) {
+	if math.IsNaN(segmentMaxLength) || math.IsInf(segmentMaxLength, 1 /* sign */) {
+		return g, nil
+	}
 	geometry, err := g.AsGeomT()
 	if err != nil {
 		return geo.Geometry{}, err

--- a/pkg/geo/geomfn/segmentize_test.go
+++ b/pkg/geo/geomfn/segmentize_test.go
@@ -12,6 +12,7 @@ package geomfn
 
 import (
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/geo"
@@ -104,6 +105,16 @@ func TestSegmentize(t *testing.T) {
 			wkt:              "MULTIPOINT ((0.0 0.0), (1.0 1.0))",
 			maxSegmentLength: -1,
 			expectedWKT:      "MULTIPOINT ((0.0 0.0), (1.0 1.0))",
+		},
+		{
+			wkt:              "LINESTRING(0 0, 1 1)",
+			maxSegmentLength: math.NaN(),
+			expectedWKT:      "LINESTRING(0 0, 1 1)",
+		},
+		{
+			wkt:              "LINESTRING(0 0, 1 1)",
+			maxSegmentLength: math.Inf(1),
+			expectedWKT:      "LINESTRING(0 0, 1 1)",
 		},
 	}
 	for _, test := range segmentizeTestCases {


### PR DESCRIPTION
Backport 1/1 commits from #62828.

/cc @cockroachdb/release

fixes #63943

---

Fixes #62741.

Release note: None
