### PR TITLE
sql: mapping postgres unimplemented type into crdb implemented types

### DIFF
--- a/pkg/cmd/generate-postgres-metadata-tables/BUILD.bazel
+++ b/pkg/cmd/generate-postgres-metadata-tables/BUILD.bazel
@@ -7,7 +7,9 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//pkg/sql",
+        "//pkg/sql/types",
         "@com_github_jackc_pgx//:pgx",
+        "@com_github_lib_pq//oid",
     ],
 )
 

--- a/pkg/sql/pg_metadata_diff.go
+++ b/pkg/sql/pg_metadata_diff.go
@@ -37,6 +37,7 @@ const GetPGMetadataSQL = `
 	WHERE n.nspname = $1
 	AND a.attnum > 0
   AND c.relkind != 'i'
+  AND c.relname NOT LIKE 'pg_stat%'
 	ORDER BY 1, 2;
 `
 

--- a/pkg/sql/testdata/information_schema_tables.json
+++ b/pkg/sql/testdata/information_schema_tables.json
@@ -3,8 +3,8 @@
   "pgMetadata": {
     "_pg_foreign_data_wrappers": {
       "authorization_identifier": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -21,20 +21,20 @@
         "expectedDataType": null
       },
       "foreign_data_wrapper_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_data_wrapper_language": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_data_wrapper_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -47,44 +47,44 @@
     },
     "_pg_foreign_servers": {
       "authorization_identifier": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_data_wrapper_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_data_wrapper_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_server_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_server_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_server_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_server_version": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -129,38 +129,38 @@
     },
     "_pg_foreign_tables": {
       "authorization_identifier": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_server_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_server_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_table_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_table_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_table_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -173,20 +173,20 @@
     },
     "_pg_user_mappings": {
       "authorization_identifier": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_server_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_server_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -197,8 +197,8 @@
         "expectedDataType": null
       },
       "srvowner": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -217,3898 +217,3892 @@
     },
     "administrable_role_authorizations": {
       "grantee": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_grantable": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "role_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "applicable_roles": {
       "grantee": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_grantable": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "role_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "attributes": {
       "attribute_default": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "attribute_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "attribute_udt_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "attribute_udt_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "attribute_udt_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_maximum_length": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_octet_length": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_set_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_set_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_set_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "collation_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "collation_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "collation_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "data_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "datetime_precision": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "dtd_identifier": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "interval_precision": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "interval_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_derived_reference_attribute": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_nullable": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "maximum_cardinality": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "numeric_precision": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "numeric_precision_radix": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "numeric_scale": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "ordinal_position": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "scope_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "scope_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "scope_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "character_sets": {
       "character_repertoire": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_set_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_set_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_set_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "default_collate_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "default_collate_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "default_collate_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "form_of_use": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "check_constraint_routine_usage": {
       "constraint_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "constraint_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "constraint_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "specific_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "specific_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "specific_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "check_constraints": {
       "check_clause": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "constraint_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "constraint_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "constraint_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "collation_character_set_applicability": {
       "character_set_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_set_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_set_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "collation_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "collation_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "collation_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "collations": {
       "collation_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "collation_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "collation_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "pad_attribute": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "column_column_usage": {
       "column_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "dependent_column": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "column_domain_usage": {
       "column_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "domain_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "domain_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "domain_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "column_options": {
       "column_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "option_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "option_value": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "column_privileges": {
       "column_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "grantee": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "grantor": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_grantable": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "privilege_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "column_udt_usage": {
       "column_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "columns": {
       "character_maximum_length": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_octet_length": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_set_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_set_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_set_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "collation_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "collation_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "collation_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "column_default": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "column_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "data_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "datetime_precision": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "domain_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "domain_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "domain_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "dtd_identifier": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "generation_expression": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "identity_cycle": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "identity_generation": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "identity_increment": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "identity_maximum": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "identity_minimum": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "identity_start": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "interval_precision": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "interval_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_generated": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_identity": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_nullable": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_self_referencing": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_updatable": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "maximum_cardinality": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "numeric_precision": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "numeric_precision_radix": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "numeric_scale": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "ordinal_position": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "scope_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "scope_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "scope_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "constraint_column_usage": {
       "column_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "constraint_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "constraint_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "constraint_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "constraint_table_usage": {
       "constraint_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "constraint_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "constraint_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "data_type_privileges": {
       "dtd_identifier": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "object_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "object_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "object_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "object_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "domain_constraints": {
       "constraint_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "constraint_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "constraint_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "domain_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "domain_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "domain_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "initially_deferred": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_deferrable": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "domain_udt_usage": {
       "domain_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "domain_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "domain_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "domains": {
       "character_maximum_length": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_octet_length": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_set_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_set_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_set_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "collation_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "collation_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "collation_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "data_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "datetime_precision": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "domain_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "domain_default": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "domain_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "domain_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "dtd_identifier": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "interval_precision": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "interval_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "maximum_cardinality": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "numeric_precision": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "numeric_precision_radix": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "numeric_scale": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "scope_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "scope_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "scope_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "element_types": {
       "character_maximum_length": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_octet_length": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_set_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_set_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_set_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "collation_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "collation_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "collation_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "collection_type_identifier": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "data_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "datetime_precision": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "domain_default": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "dtd_identifier": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "interval_precision": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "interval_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "maximum_cardinality": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "numeric_precision": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "numeric_precision_radix": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "numeric_scale": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "object_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "object_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "object_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "object_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "scope_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "scope_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "scope_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "enabled_roles": {
       "role_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "foreign_data_wrapper_options": {
       "foreign_data_wrapper_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_data_wrapper_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "option_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "option_value": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "foreign_data_wrappers": {
       "authorization_identifier": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_data_wrapper_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_data_wrapper_language": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_data_wrapper_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "library_name": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "foreign_server_options": {
       "foreign_server_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_server_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "option_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "option_value": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "foreign_servers": {
       "authorization_identifier": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_data_wrapper_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_data_wrapper_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_server_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_server_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_server_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_server_version": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "foreign_table_options": {
       "foreign_table_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_table_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_table_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "option_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "option_value": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "foreign_tables": {
       "foreign_server_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_server_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_table_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_table_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_table_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "information_schema_catalog_name": {
       "catalog_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "key_column_usage": {
       "column_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "constraint_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "constraint_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "constraint_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "ordinal_position": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "position_in_unique_constraint": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "parameters": {
       "as_locator": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_maximum_length": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_octet_length": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_set_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_set_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_set_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "collation_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "collation_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "collation_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "data_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "datetime_precision": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "dtd_identifier": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "interval_precision": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "interval_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_result": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "maximum_cardinality": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "numeric_precision": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "numeric_precision_radix": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "numeric_scale": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "ordinal_position": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "parameter_default": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "parameter_mode": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "parameter_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "scope_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "scope_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "scope_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "specific_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "specific_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "specific_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "referential_constraints": {
       "constraint_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "constraint_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "constraint_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "delete_rule": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "match_option": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "unique_constraint_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "unique_constraint_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "unique_constraint_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "update_rule": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "role_column_grants": {
       "column_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "grantee": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "grantor": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_grantable": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "privilege_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "role_routine_grants": {
       "grantee": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "grantor": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_grantable": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "privilege_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "routine_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "routine_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "routine_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "specific_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "specific_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "specific_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "role_table_grants": {
       "grantee": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "grantor": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_grantable": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "privilege_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "with_hierarchy": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "role_udt_grants": {
       "grantee": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "grantor": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_grantable": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "privilege_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "role_usage_grants": {
       "grantee": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "grantor": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_grantable": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "object_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "object_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "object_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "object_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "privilege_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "routine_privileges": {
       "grantee": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "grantor": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_grantable": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "privilege_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "routine_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "routine_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "routine_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "specific_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "specific_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "specific_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "routines": {
       "as_locator": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_maximum_length": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_octet_length": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_set_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_set_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_set_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "collation_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "collation_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "collation_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "created": {
-        "oid": 13448,
-        "dataType": "time_stamp",
+        "oid": 1184,
+        "dataType": "TIMESTAMPTZ",
         "expectedOid": null,
         "expectedDataType": null
       },
       "data_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "datetime_precision": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "dtd_identifier": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "external_language": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "external_name": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "interval_precision": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "interval_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_deterministic": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_implicitly_invocable": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_null_call": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_udt_dependent": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_user_defined_cast": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "last_altered": {
-        "oid": 13448,
-        "dataType": "time_stamp",
+        "oid": 1184,
+        "dataType": "TIMESTAMPTZ",
         "expectedOid": null,
         "expectedDataType": null
       },
       "max_dynamic_result_sets": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "maximum_cardinality": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "module_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "module_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "module_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "new_savepoint_level": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "numeric_precision": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "numeric_precision_radix": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "numeric_scale": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "parameter_style": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "result_cast_as_locator": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "result_cast_char_max_length": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "result_cast_char_octet_length": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "result_cast_char_set_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "result_cast_char_set_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "result_cast_char_set_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "result_cast_collation_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "result_cast_collation_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "result_cast_collation_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "result_cast_datetime_precision": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "result_cast_dtd_identifier": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "result_cast_from_data_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "result_cast_interval_precision": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "result_cast_interval_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "result_cast_maximum_cardinality": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "result_cast_numeric_precision": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "result_cast_numeric_precision_radix": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "result_cast_numeric_scale": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "result_cast_scope_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "result_cast_scope_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "result_cast_scope_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "result_cast_type_udt_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "result_cast_type_udt_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "result_cast_type_udt_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "routine_body": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "routine_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "routine_definition": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "routine_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "routine_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "routine_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "schema_level_routine": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "scope_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "scope_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "scope_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "security_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "specific_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "specific_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "specific_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "sql_data_access": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "sql_path": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "to_sql_specific_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "to_sql_specific_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "to_sql_specific_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "type_udt_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "type_udt_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "type_udt_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "schemata": {
       "catalog_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "default_character_set_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "default_character_set_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "default_character_set_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "schema_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "schema_owner": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "sql_path": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "sequences": {
       "cycle_option": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "data_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "increment": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "maximum_value": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "minimum_value": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "numeric_precision": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "numeric_precision_radix": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "numeric_scale": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "sequence_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "sequence_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "sequence_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "start_value": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "sql_features": {
       "comments": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "feature_id": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "feature_name": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_supported": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_verified_by": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "sub_feature_id": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "sub_feature_name": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "sql_implementation_info": {
       "character_value": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "comments": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "implementation_info_id": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "implementation_info_name": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "integer_value": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "sql_parts": {
       "comments": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "feature_id": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "feature_name": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_supported": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_verified_by": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "sql_sizing": {
       "comments": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "sizing_id": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "sizing_name": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "supported_value": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "table_constraints": {
       "constraint_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "constraint_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "constraint_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "constraint_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "enforced": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "initially_deferred": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_deferrable": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "table_privileges": {
       "grantee": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "grantor": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_grantable": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "privilege_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "with_hierarchy": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "tables": {
       "commit_action": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_insertable_into": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_typed": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "reference_generation": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "self_referencing_column_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "user_defined_type_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "user_defined_type_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "user_defined_type_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "transforms": {
       "group_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "specific_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "specific_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "specific_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "transform_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "triggered_update_columns": {
       "event_object_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "event_object_column": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "event_object_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "event_object_table": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "trigger_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "trigger_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "trigger_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "triggers": {
       "action_condition": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "action_order": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "action_orientation": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "action_reference_new_row": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "action_reference_new_table": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "action_reference_old_row": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "action_reference_old_table": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "action_statement": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "action_timing": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "created": {
-        "oid": 13448,
-        "dataType": "time_stamp",
+        "oid": 1184,
+        "dataType": "TIMESTAMPTZ",
         "expectedOid": null,
         "expectedDataType": null
       },
       "event_manipulation": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "event_object_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "event_object_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "event_object_table": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "trigger_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "trigger_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "trigger_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "udt_privileges": {
       "grantee": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "grantor": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_grantable": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "privilege_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "udt_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "usage_privileges": {
       "grantee": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "grantor": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_grantable": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "object_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "object_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "object_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "object_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "privilege_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "user_defined_types": {
       "character_maximum_length": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_octet_length": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_set_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_set_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "character_set_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "collation_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "collation_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "collation_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "data_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "datetime_precision": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "interval_precision": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "interval_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_final": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_instantiable": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "numeric_precision": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "numeric_precision_radix": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "numeric_scale": {
-        "oid": 13438,
-        "dataType": "cardinal_number",
+        "oid": 23,
+        "dataType": "INT4",
         "expectedOid": null,
         "expectedDataType": null
       },
       "ordering_category": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "ordering_form": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "ordering_routine_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "ordering_routine_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "ordering_routine_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "ref_dtd_identifier": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "reference_type": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "source_dtd_identifier": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "user_defined_type_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "user_defined_type_category": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "user_defined_type_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "user_defined_type_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "user_mapping_options": {
       "authorization_identifier": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_server_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_server_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "option_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "option_value": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "user_mappings": {
       "authorization_identifier": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_server_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "foreign_server_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "view_column_usage": {
       "column_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "view_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "view_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "view_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "view_routine_usage": {
       "specific_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "specific_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "specific_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "view_table_usage": {
       "table_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "view_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "view_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "view_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "views": {
       "check_option": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_insertable_into": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_trigger_deletable": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_trigger_insertable_into": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_trigger_updatable": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "is_updatable": {
-        "oid": 13450,
-        "dataType": "yes_or_no",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_catalog": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_name": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "table_schema": {
-        "oid": 13443,
-        "dataType": "sql_identifier",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "view_definition": {
-        "oid": 13441,
-        "dataType": "character_data",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
     }
   },
-  "unimplementedTypes": {
-    "13438": "cardinal_number",
-    "13441": "character_data",
-    "13443": "sql_identifier",
-    "13448": "time_stamp",
-    "13450": "yes_or_no"
-  }
+  "unimplementedTypes": null
 }

--- a/pkg/sql/testdata/information_schema_test_expected_diffs.json
+++ b/pkg/sql/testdata/information_schema_test_expected_diffs.json
@@ -4,593 +4,65 @@
   "_pg_foreign_table_columns": {},
   "_pg_foreign_tables": {},
   "_pg_user_mappings": {},
-  "administrable_role_authorizations": {
-    "grantee": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "is_grantable": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
-    },
-    "role_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    }
-  },
-  "applicable_roles": {
-    "grantee": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "is_grantable": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
-    },
-    "role_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    }
-  },
   "attributes": {},
-  "character_sets": {
-    "character_repertoire": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "character_set_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "character_set_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "character_set_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "default_collate_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "default_collate_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "default_collate_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "form_of_use": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    }
-  },
   "check_constraint_routine_usage": {},
-  "check_constraints": {
-    "check_clause": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "constraint_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "constraint_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "constraint_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    }
-  },
-  "collation_character_set_applicability": {
-    "character_set_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "character_set_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "character_set_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "collation_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "collation_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "collation_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    }
-  },
-  "collations": {
-    "collation_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "collation_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "collation_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "pad_attribute": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    }
-  },
   "column_column_usage": {},
   "column_domain_usage": {},
   "column_options": {},
-  "column_privileges": {
-    "column_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "grantee": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "grantor": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "is_grantable": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
-    },
-    "privilege_type": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "table_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "table_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "table_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    }
-  },
-  "column_udt_usage": {
-    "column_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "table_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "table_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "table_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "udt_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "udt_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "udt_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    }
-  },
   "columns": {
     "character_maximum_length": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "character_octet_length": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
-    },
-    "character_set_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "character_set_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "character_set_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "collation_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "collation_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "collation_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "column_default": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "column_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "data_type": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "datetime_precision": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
-    },
-    "domain_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "domain_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "domain_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "dtd_identifier": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "generation_expression": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "identity_cycle": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
-    },
-    "identity_generation": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "identity_increment": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "identity_maximum": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "identity_minimum": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "identity_start": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "interval_precision": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
-    },
-    "interval_type": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "is_generated": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "is_identity": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
-    },
-    "is_nullable": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
-    },
-    "is_self_referencing": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
-    },
-    "is_updatable": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "maximum_cardinality": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "numeric_precision": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "numeric_precision_radix": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "numeric_scale": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "ordinal_position": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
-    },
-    "scope_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "scope_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "scope_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "table_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "table_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "table_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "udt_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "udt_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "udt_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    }
-  },
-  "constraint_column_usage": {
-    "column_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "constraint_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "constraint_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "constraint_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "table_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "table_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "table_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     }
   },
   "constraint_table_usage": {},
@@ -599,14 +71,6 @@
   "domain_udt_usage": {},
   "domains": {},
   "element_types": {},
-  "enabled_roles": {
-    "role_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    }
-  },
   "foreign_data_wrapper_options": {},
   "foreign_data_wrappers": {},
   "foreign_server_options": {},
@@ -615,956 +79,208 @@
   "foreign_tables": {},
   "information_schema_catalog_name": {},
   "key_column_usage": {
-    "column_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "constraint_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "constraint_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "constraint_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
     "ordinal_position": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "position_in_unique_constraint": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
-    },
-    "table_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "table_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "table_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     }
   },
   "parameters": {
-    "as_locator": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
-    },
     "character_maximum_length": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "character_octet_length": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
-    },
-    "character_set_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "character_set_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "character_set_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "collation_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "collation_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "collation_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "data_type": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "datetime_precision": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
-    },
-    "dtd_identifier": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "interval_precision": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
-    },
-    "interval_type": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "is_result": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "maximum_cardinality": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "numeric_precision": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "numeric_precision_radix": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "numeric_scale": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "ordinal_position": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
-    },
-    "parameter_default": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "parameter_mode": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "parameter_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "scope_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "scope_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "scope_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "specific_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "specific_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "specific_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "udt_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "udt_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "udt_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    }
-  },
-  "referential_constraints": {
-    "constraint_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "constraint_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "constraint_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "delete_rule": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "match_option": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "unique_constraint_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "unique_constraint_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "unique_constraint_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "update_rule": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     }
   },
   "role_column_grants": {},
   "role_routine_grants": {},
-  "role_table_grants": {
-    "grantee": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "grantor": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "is_grantable": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
-    },
-    "privilege_type": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "table_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "table_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "table_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "with_hierarchy": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
-    }
-  },
   "role_udt_grants": {},
   "role_usage_grants": {},
   "routine_privileges": {},
   "routines": {
-    "as_locator": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
-    },
     "character_maximum_length": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "character_octet_length": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
-    },
-    "character_set_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "character_set_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "character_set_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "collation_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "collation_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "collation_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "created": {
-      "oid": 1184,
-      "dataType": "timestamptz",
-      "expectedOid": 13448,
-      "expectedDataType": "time_stamp"
-    },
-    "data_type": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "datetime_precision": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
-    },
-    "dtd_identifier": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "external_language": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "external_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "interval_precision": {
       "oid": 25,
       "dataType": "text",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
-    },
-    "interval_type": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "is_deterministic": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
-    },
-    "is_implicitly_invocable": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
-    },
-    "is_null_call": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
-    },
-    "is_udt_dependent": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
-    },
-    "is_user_defined_cast": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
-    },
-    "last_altered": {
-      "oid": 1184,
-      "dataType": "timestamptz",
-      "expectedOid": 13448,
-      "expectedDataType": "time_stamp"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "max_dynamic_result_sets": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "maximum_cardinality": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
-    },
-    "module_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "module_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "module_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "new_savepoint_level": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "numeric_precision": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "numeric_precision_radix": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "numeric_scale": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
-    },
-    "parameter_style": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "result_cast_as_locator": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "result_cast_char_max_length": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "result_cast_char_octet_length": {
       "oid": 25,
       "dataType": "text",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
-    },
-    "result_cast_char_set_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "result_cast_char_set_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "result_cast_char_set_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "result_cast_collation_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "result_cast_collation_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "result_cast_collation_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "result_cast_datetime_precision": {
       "oid": 25,
       "dataType": "text",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
-    },
-    "result_cast_dtd_identifier": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "result_cast_from_data_type": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "result_cast_interval_precision": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
-    },
-    "result_cast_interval_type": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "result_cast_maximum_cardinality": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "result_cast_numeric_precision": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "result_cast_numeric_precision_radix": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "result_cast_numeric_scale": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
-    "result_cast_scope_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "result_cast_scope_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "result_cast_scope_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "result_cast_type_udt_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "result_cast_type_udt_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "result_cast_type_udt_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "routine_body": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "routine_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "routine_definition": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "routine_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "routine_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "routine_type": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "schema_level_routine": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
-    },
-    "scope_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "scope_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "scope_schema": null,
-    "security_type": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "specific_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "specific_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "specific_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "sql_data_access": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "sql_path": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "to_sql_specific_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "to_sql_specific_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "to_sql_specific_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "type_udt_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "type_udt_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "type_udt_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "udt_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "udt_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "udt_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    }
+    "scope_schema": null
   },
   "schemata": {
-    "catalog_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
     "default_character_set_catalog": null,
-    "default_character_set_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
     "default_character_set_schema": null,
-    "schema_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "schema_owner": null,
-    "sql_path": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    }
+    "schema_owner": null
   },
   "sequences": {
-    "cycle_option": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
-    },
-    "data_type": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "increment": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "maximum_value": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "minimum_value": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
     "numeric_precision": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "numeric_precision_radix": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     },
     "numeric_scale": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 13438,
-      "expectedDataType": "cardinal_number"
-    },
-    "sequence_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "sequence_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "sequence_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "start_value": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
+      "expectedOid": 23,
+      "expectedDataType": "INT4"
     }
   },
   "sql_features": {},
@@ -1572,147 +288,13 @@
   "sql_parts": {},
   "sql_sizing": {},
   "table_constraints": {
-    "constraint_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "constraint_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "constraint_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "constraint_type": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "enforced": null,
-    "initially_deferred": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
-    },
-    "is_deferrable": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
-    },
-    "table_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "table_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "table_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    }
-  },
-  "table_privileges": {
-    "grantee": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "grantor": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "is_grantable": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
-    },
-    "privilege_type": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "table_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "table_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "table_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "with_hierarchy": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
-    }
+    "enforced": null
   },
   "tables": {
     "commit_action": null,
-    "is_insertable_into": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
-    },
     "is_typed": null,
     "reference_generation": null,
     "self_referencing_column_name": null,
-    "table_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "table_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "table_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "table_type": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
     "user_defined_type_catalog": null,
     "user_defined_type_name": null,
     "user_defined_type_schema": null
@@ -1727,67 +309,5 @@
   "user_mappings": {},
   "view_column_usage": {},
   "view_routine_usage": {},
-  "view_table_usage": {},
-  "views": {
-    "check_option": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    },
-    "is_insertable_into": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
-    },
-    "is_trigger_deletable": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
-    },
-    "is_trigger_insertable_into": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
-    },
-    "is_trigger_updatable": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
-    },
-    "is_updatable": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13450,
-      "expectedDataType": "yes_or_no"
-    },
-    "table_catalog": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "table_name": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "table_schema": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13443,
-      "expectedDataType": "sql_identifier"
-    },
-    "view_definition": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 13441,
-      "expectedDataType": "character_data"
-    }
-  }
+  "view_table_usage": {}
 }

--- a/pkg/sql/testdata/pg_catalog_tables.json
+++ b/pkg/sql/testdata/pg_catalog_tables.json
@@ -257,8 +257,8 @@
     },
     "pg_attrdef": {
       "adbin": {
-        "oid": 194,
-        "dataType": "pg_node_tree",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -283,8 +283,8 @@
     },
     "pg_attribute": {
       "attacl": {
-        "oid": 1034,
-        "dataType": "_aclitem",
+        "oid": 1009,
+        "dataType": "_TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -661,8 +661,8 @@
         "expectedDataType": null
       },
       "relacl": {
-        "oid": 1034,
-        "dataType": "_aclitem",
+        "oid": 1009,
+        "dataType": "_TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -697,8 +697,8 @@
         "expectedDataType": null
       },
       "relfrozenxid": {
-        "oid": 28,
-        "dataType": "xid",
+        "oid": 26,
+        "dataType": "OID",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -751,8 +751,8 @@
         "expectedDataType": null
       },
       "relminmxid": {
-        "oid": 28,
-        "dataType": "xid",
+        "oid": 26,
+        "dataType": "OID",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -799,8 +799,8 @@
         "expectedDataType": null
       },
       "relpartbound": {
-        "oid": 194,
-        "dataType": "pg_node_tree",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -931,8 +931,8 @@
     },
     "pg_constraint": {
       "conbin": {
-        "oid": 194,
-        "dataType": "pg_node_tree",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -1171,8 +1171,8 @@
     },
     "pg_database": {
       "datacl": {
-        "oid": 1034,
-        "dataType": "_aclitem",
+        "oid": 1009,
+        "dataType": "_TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -1207,8 +1207,8 @@
         "expectedDataType": null
       },
       "datfrozenxid": {
-        "oid": 28,
-        "dataType": "xid",
+        "oid": 26,
+        "dataType": "OID",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -1225,8 +1225,8 @@
         "expectedDataType": null
       },
       "datminmxid": {
-        "oid": 28,
-        "dataType": "xid",
+        "oid": 26,
+        "dataType": "OID",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -1277,8 +1277,8 @@
     },
     "pg_default_acl": {
       "defaclacl": {
-        "oid": 1034,
-        "dataType": "_aclitem",
+        "oid": 1009,
+        "dataType": "_TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -1543,8 +1543,8 @@
     },
     "pg_foreign_data_wrapper": {
       "fdwacl": {
-        "oid": 1034,
-        "dataType": "_aclitem",
+        "oid": 1009,
+        "dataType": "_TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -1593,8 +1593,8 @@
         "expectedDataType": null
       },
       "srvacl": {
-        "oid": 1034,
-        "dataType": "_aclitem",
+        "oid": 1009,
+        "dataType": "_TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -1751,8 +1751,8 @@
         "expectedDataType": null
       },
       "indexprs": {
-        "oid": 194,
-        "dataType": "pg_node_tree",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -1841,8 +1841,8 @@
         "expectedDataType": null
       },
       "indpred": {
-        "oid": 194,
-        "dataType": "pg_node_tree",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -1913,8 +1913,8 @@
         "expectedDataType": null
       },
       "initprivs": {
-        "oid": 1034,
-        "dataType": "_aclitem",
+        "oid": 1009,
+        "dataType": "_TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -1939,8 +1939,8 @@
     },
     "pg_language": {
       "lanacl": {
-        "oid": 1034,
-        "dataType": "_aclitem",
+        "oid": 1009,
+        "dataType": "_TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -2015,8 +2015,8 @@
     },
     "pg_largeobject_metadata": {
       "lomacl": {
-        "oid": 1034,
-        "dataType": "_aclitem",
+        "oid": 1009,
+        "dataType": "_TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -2101,8 +2101,8 @@
         "expectedDataType": null
       },
       "transactionid": {
-        "oid": 28,
-        "dataType": "xid",
+        "oid": 26,
+        "dataType": "OID",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -2171,8 +2171,8 @@
     },
     "pg_namespace": {
       "nspacl": {
-        "oid": 1034,
-        "dataType": "_aclitem",
+        "oid": 1009,
+        "dataType": "_TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -2401,8 +2401,8 @@
         "expectedDataType": null
       },
       "partexprs": {
-        "oid": 194,
-        "dataType": "pg_node_tree",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -2501,8 +2501,8 @@
         "expectedDataType": null
       },
       "polqual": {
-        "oid": 194,
-        "dataType": "pg_node_tree",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -2519,8 +2519,8 @@
         "expectedDataType": null
       },
       "polwithcheck": {
-        "oid": 194,
-        "dataType": "pg_node_tree",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
@@ -2583,8 +2583,8 @@
         "expectedDataType": null
       },
       "transaction": {
-        "oid": 28,
-        "dataType": "xid",
+        "oid": 26,
+        "dataType": "OID",
         "expectedOid": null,
         "expectedDataType": null
       }
@@ -2597,8 +2597,8 @@
         "expectedDataType": null
       },
       "proacl": {
-        "oid": 1034,
-        "dataType": "_aclitem",
+        "oid": 1009,
+        "dataType": "_TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -2609,8 +2609,8 @@
         "expectedDataType": null
       },
       "proargdefaults": {
-        "oid": 194,
-        "dataType": "pg_node_tree",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -2927,14 +2927,14 @@
         "expectedDataType": null
       },
       "local_lsn": {
-        "oid": 3220,
-        "dataType": "pg_lsn",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
       "remote_lsn": {
-        "oid": 3220,
-        "dataType": "pg_lsn",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       }
@@ -2953,14 +2953,14 @@
         "expectedDataType": null
       },
       "catalog_xmin": {
-        "oid": 28,
-        "dataType": "xid",
+        "oid": 26,
+        "dataType": "OID",
         "expectedOid": null,
         "expectedDataType": null
       },
       "confirmed_flush_lsn": {
-        "oid": 3220,
-        "dataType": "pg_lsn",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -2983,8 +2983,8 @@
         "expectedDataType": null
       },
       "restart_lsn": {
-        "oid": 3220,
-        "dataType": "pg_lsn",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -3019,16 +3019,16 @@
         "expectedDataType": null
       },
       "xmin": {
-        "oid": 28,
-        "dataType": "xid",
+        "oid": 26,
+        "dataType": "OID",
         "expectedOid": null,
         "expectedDataType": null
       }
     },
     "pg_rewrite": {
       "ev_action": {
-        "oid": 194,
-        "dataType": "pg_node_tree",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -3045,8 +3045,8 @@
         "expectedDataType": null
       },
       "ev_qual": {
-        "oid": 194,
-        "dataType": "pg_node_tree",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -3657,2890 +3657,6 @@
         "expectedDataType": null
       }
     },
-    "pg_stat_activity": {
-      "application_name": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "backend_start": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "backend_type": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "backend_xid": {
-        "oid": 28,
-        "dataType": "xid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "backend_xmin": {
-        "oid": 28,
-        "dataType": "xid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "client_addr": {
-        "oid": 869,
-        "dataType": "inet",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "client_hostname": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "client_port": {
-        "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "datid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "datname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "leader_pid": {
-        "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "pid": {
-        "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "query": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "query_start": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "state": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "state_change": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "usename": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "usesysid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "wait_event": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "wait_event_type": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "xact_start": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_stat_all_indexes": {
-      "idx_scan": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "idx_tup_fetch": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "idx_tup_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "indexrelid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "indexrelname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "schemaname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_stat_all_tables": {
-      "analyze_count": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "autoanalyze_count": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "autovacuum_count": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "idx_scan": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "idx_tup_fetch": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "last_analyze": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "last_autoanalyze": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "last_autovacuum": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "last_vacuum": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_dead_tup": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_ins_since_vacuum": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_live_tup": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_mod_since_analyze": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_tup_del": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_tup_hot_upd": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_tup_ins": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_tup_upd": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "schemaname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "seq_scan": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "seq_tup_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "vacuum_count": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_stat_archiver": {
-      "archived_count": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "failed_count": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "last_archived_time": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "last_archived_wal": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "last_failed_time": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "last_failed_wal": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stats_reset": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_stat_bgwriter": {
-      "buffers_alloc": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "buffers_backend": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "buffers_backend_fsync": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "buffers_checkpoint": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "buffers_clean": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "checkpoint_sync_time": {
-        "oid": 701,
-        "dataType": "float8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "checkpoint_write_time": {
-        "oid": 701,
-        "dataType": "float8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "checkpoints_req": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "checkpoints_timed": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "maxwritten_clean": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stats_reset": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_stat_database": {
-      "blk_read_time": {
-        "oid": 701,
-        "dataType": "float8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "blk_write_time": {
-        "oid": 701,
-        "dataType": "float8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "blks_hit": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "blks_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "checksum_failures": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "checksum_last_failure": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "conflicts": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "datid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "datname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "deadlocks": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "numbackends": {
-        "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stats_reset": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "temp_bytes": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "temp_files": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "tup_deleted": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "tup_fetched": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "tup_inserted": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "tup_returned": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "tup_updated": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "xact_commit": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "xact_rollback": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_stat_database_conflicts": {
-      "confl_bufferpin": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "confl_deadlock": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "confl_lock": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "confl_snapshot": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "confl_tablespace": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "datid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "datname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_stat_gssapi": {
-      "encrypted": {
-        "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "gss_authenticated": {
-        "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "pid": {
-        "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "principal": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_stat_progress_analyze": {
-      "child_tables_done": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "child_tables_total": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "current_child_table_relid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "datid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "datname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "ext_stats_computed": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "ext_stats_total": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "phase": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "pid": {
-        "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "sample_blks_scanned": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "sample_blks_total": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_stat_progress_basebackup": {
-      "backup_streamed": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "backup_total": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "phase": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "pid": {
-        "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "tablespaces_streamed": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "tablespaces_total": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_stat_progress_cluster": {
-      "cluster_index_relid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "command": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "datid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "datname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "heap_blks_scanned": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "heap_blks_total": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "heap_tuples_scanned": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "heap_tuples_written": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "index_rebuild_count": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "phase": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "pid": {
-        "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_stat_progress_create_index": {
-      "blocks_done": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "blocks_total": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "command": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "current_locker_pid": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "datid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "datname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "index_relid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "lockers_done": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "lockers_total": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "partitions_done": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "partitions_total": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "phase": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "pid": {
-        "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "tuples_done": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "tuples_total": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_stat_progress_vacuum": {
-      "datid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "datname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "heap_blks_scanned": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "heap_blks_total": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "heap_blks_vacuumed": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "index_vacuum_count": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "max_dead_tuples": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "num_dead_tuples": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "phase": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "pid": {
-        "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_stat_replication": {
-      "application_name": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "backend_start": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "backend_xmin": {
-        "oid": 28,
-        "dataType": "xid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "client_addr": {
-        "oid": 869,
-        "dataType": "inet",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "client_hostname": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "client_port": {
-        "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "flush_lag": {
-        "oid": 1186,
-        "dataType": "interval",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "flush_lsn": {
-        "oid": 3220,
-        "dataType": "pg_lsn",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "pid": {
-        "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "replay_lag": {
-        "oid": 1186,
-        "dataType": "interval",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "replay_lsn": {
-        "oid": 3220,
-        "dataType": "pg_lsn",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "reply_time": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "sent_lsn": {
-        "oid": 3220,
-        "dataType": "pg_lsn",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "state": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "sync_priority": {
-        "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "sync_state": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "usename": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "usesysid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "write_lag": {
-        "oid": 1186,
-        "dataType": "interval",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "write_lsn": {
-        "oid": 3220,
-        "dataType": "pg_lsn",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_stat_slru": {
-      "blks_exists": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "blks_hit": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "blks_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "blks_written": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "blks_zeroed": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "flushes": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "name": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stats_reset": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "truncates": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_stat_ssl": {
-      "bits": {
-        "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "cipher": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "client_dn": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "client_serial": {
-        "oid": 1700,
-        "dataType": "numeric",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "compression": {
-        "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "issuer_dn": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "pid": {
-        "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "ssl": {
-        "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "version": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_stat_subscription": {
-      "last_msg_receipt_time": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "last_msg_send_time": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "latest_end_lsn": {
-        "oid": 3220,
-        "dataType": "pg_lsn",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "latest_end_time": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "pid": {
-        "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "received_lsn": {
-        "oid": 3220,
-        "dataType": "pg_lsn",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "subid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "subname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_stat_sys_indexes": {
-      "idx_scan": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "idx_tup_fetch": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "idx_tup_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "indexrelid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "indexrelname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "schemaname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_stat_sys_tables": {
-      "analyze_count": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "autoanalyze_count": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "autovacuum_count": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "idx_scan": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "idx_tup_fetch": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "last_analyze": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "last_autoanalyze": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "last_autovacuum": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "last_vacuum": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_dead_tup": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_ins_since_vacuum": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_live_tup": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_mod_since_analyze": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_tup_del": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_tup_hot_upd": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_tup_ins": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_tup_upd": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "schemaname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "seq_scan": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "seq_tup_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "vacuum_count": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_stat_user_functions": {
-      "calls": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "funcid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "funcname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "schemaname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "self_time": {
-        "oid": 701,
-        "dataType": "float8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "total_time": {
-        "oid": 701,
-        "dataType": "float8",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_stat_user_indexes": {
-      "idx_scan": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "idx_tup_fetch": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "idx_tup_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "indexrelid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "indexrelname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "schemaname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_stat_user_tables": {
-      "analyze_count": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "autoanalyze_count": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "autovacuum_count": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "idx_scan": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "idx_tup_fetch": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "last_analyze": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "last_autoanalyze": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "last_autovacuum": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "last_vacuum": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_dead_tup": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_ins_since_vacuum": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_live_tup": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_mod_since_analyze": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_tup_del": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_tup_hot_upd": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_tup_ins": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_tup_upd": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "schemaname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "seq_scan": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "seq_tup_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "vacuum_count": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_stat_wal_receiver": {
-      "conninfo": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "flushed_lsn": {
-        "oid": 3220,
-        "dataType": "pg_lsn",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "last_msg_receipt_time": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "last_msg_send_time": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "latest_end_lsn": {
-        "oid": 3220,
-        "dataType": "pg_lsn",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "latest_end_time": {
-        "oid": 1184,
-        "dataType": "timestamptz",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "pid": {
-        "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "receive_start_lsn": {
-        "oid": 3220,
-        "dataType": "pg_lsn",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "receive_start_tli": {
-        "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "received_tli": {
-        "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "sender_host": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "sender_port": {
-        "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "slot_name": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "status": {
-        "oid": 25,
-        "dataType": "text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "written_lsn": {
-        "oid": 3220,
-        "dataType": "pg_lsn",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_stat_xact_all_tables": {
-      "idx_scan": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "idx_tup_fetch": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_tup_del": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_tup_hot_upd": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_tup_ins": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_tup_upd": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "schemaname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "seq_scan": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "seq_tup_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_stat_xact_sys_tables": {
-      "idx_scan": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "idx_tup_fetch": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_tup_del": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_tup_hot_upd": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_tup_ins": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_tup_upd": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "schemaname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "seq_scan": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "seq_tup_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_stat_xact_user_functions": {
-      "calls": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "funcid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "funcname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "schemaname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "self_time": {
-        "oid": 701,
-        "dataType": "float8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "total_time": {
-        "oid": 701,
-        "dataType": "float8",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_stat_xact_user_tables": {
-      "idx_scan": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "idx_tup_fetch": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_tup_del": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_tup_hot_upd": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_tup_ins": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_tup_upd": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "schemaname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "seq_scan": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "seq_tup_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_statio_all_indexes": {
-      "idx_blks_hit": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "idx_blks_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "indexrelid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "indexrelname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "schemaname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_statio_all_sequences": {
-      "blks_hit": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "blks_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "schemaname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_statio_all_tables": {
-      "heap_blks_hit": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "heap_blks_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "idx_blks_hit": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "idx_blks_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "schemaname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "tidx_blks_hit": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "tidx_blks_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "toast_blks_hit": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "toast_blks_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_statio_sys_indexes": {
-      "idx_blks_hit": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "idx_blks_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "indexrelid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "indexrelname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "schemaname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_statio_sys_sequences": {
-      "blks_hit": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "blks_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "schemaname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_statio_sys_tables": {
-      "heap_blks_hit": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "heap_blks_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "idx_blks_hit": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "idx_blks_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "schemaname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "tidx_blks_hit": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "tidx_blks_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "toast_blks_hit": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "toast_blks_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_statio_user_indexes": {
-      "idx_blks_hit": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "idx_blks_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "indexrelid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "indexrelname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "schemaname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_statio_user_sequences": {
-      "blks_hit": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "blks_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "schemaname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_statio_user_tables": {
-      "heap_blks_hit": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "heap_blks_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "idx_blks_hit": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "idx_blks_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "relname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "schemaname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "tidx_blks_hit": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "tidx_blks_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "toast_blks_hit": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "toast_blks_read": {
-        "oid": 20,
-        "dataType": "int8",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_statistic": {
-      "staattnum": {
-        "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stacoll1": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stacoll2": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stacoll3": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stacoll4": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stacoll5": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stadistinct": {
-        "oid": 700,
-        "dataType": "float4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stainherit": {
-        "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stakind1": {
-        "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stakind2": {
-        "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stakind3": {
-        "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stakind4": {
-        "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stakind5": {
-        "oid": 21,
-        "dataType": "int2",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stanullfrac": {
-        "oid": 700,
-        "dataType": "float4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stanumbers1": {
-        "oid": 1021,
-        "dataType": "_float4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stanumbers2": {
-        "oid": 1021,
-        "dataType": "_float4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stanumbers3": {
-        "oid": 1021,
-        "dataType": "_float4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stanumbers4": {
-        "oid": 1021,
-        "dataType": "_float4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stanumbers5": {
-        "oid": 1021,
-        "dataType": "_float4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "staop1": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "staop2": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "staop3": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "staop4": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "staop5": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "starelid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stavalues1": {
-        "oid": 2277,
-        "dataType": "anyarray",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stavalues2": {
-        "oid": 2277,
-        "dataType": "anyarray",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stavalues3": {
-        "oid": 2277,
-        "dataType": "anyarray",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stavalues4": {
-        "oid": 2277,
-        "dataType": "anyarray",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stavalues5": {
-        "oid": 2277,
-        "dataType": "anyarray",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stawidth": {
-        "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_statistic_ext": {
-      "oid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stxkeys": {
-        "oid": 22,
-        "dataType": "int2vector",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stxkind": {
-        "oid": 1002,
-        "dataType": "_char",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stxname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stxnamespace": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stxowner": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stxrelid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stxstattarget": {
-        "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_statistic_ext_data": {
-      "stxddependencies": {
-        "oid": 3402,
-        "dataType": "pg_dependencies",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stxdmcv": {
-        "oid": 5017,
-        "dataType": "pg_mcv_list",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stxdndistinct": {
-        "oid": 3361,
-        "dataType": "pg_ndistinct",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "stxoid": {
-        "oid": 26,
-        "dataType": "oid",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_stats": {
-      "attname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "avg_width": {
-        "oid": 23,
-        "dataType": "int4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "correlation": {
-        "oid": 700,
-        "dataType": "float4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "elem_count_histogram": {
-        "oid": 1021,
-        "dataType": "_float4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "histogram_bounds": {
-        "oid": 2277,
-        "dataType": "anyarray",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "inherited": {
-        "oid": 16,
-        "dataType": "bool",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "most_common_elem_freqs": {
-        "oid": 1021,
-        "dataType": "_float4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "most_common_elems": {
-        "oid": 2277,
-        "dataType": "anyarray",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "most_common_freqs": {
-        "oid": 1021,
-        "dataType": "_float4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "most_common_vals": {
-        "oid": 2277,
-        "dataType": "anyarray",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_distinct": {
-        "oid": 700,
-        "dataType": "float4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "null_frac": {
-        "oid": 700,
-        "dataType": "float4",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "schemaname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "tablename": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
-    "pg_stats_ext": {
-      "attnames": {
-        "oid": 1003,
-        "dataType": "_name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "dependencies": {
-        "oid": 3402,
-        "dataType": "pg_dependencies",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "kinds": {
-        "oid": 1002,
-        "dataType": "_char",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "most_common_base_freqs": {
-        "oid": 1022,
-        "dataType": "_float8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "most_common_freqs": {
-        "oid": 1022,
-        "dataType": "_float8",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "most_common_val_nulls": {
-        "oid": 1000,
-        "dataType": "_bool",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "most_common_vals": {
-        "oid": 1009,
-        "dataType": "_text",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "n_distinct": {
-        "oid": 3361,
-        "dataType": "pg_ndistinct",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "schemaname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "statistics_name": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "statistics_owner": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "statistics_schemaname": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      },
-      "tablename": {
-        "oid": 19,
-        "dataType": "name",
-        "expectedOid": null,
-        "expectedDataType": null
-      }
-    },
     "pg_subscription": {
       "oid": {
         "oid": 26,
@@ -6611,8 +3727,8 @@
         "expectedDataType": null
       },
       "srsublsn": {
-        "oid": 3220,
-        "dataType": "pg_lsn",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -6681,8 +3797,8 @@
         "expectedDataType": null
       },
       "spcacl": {
-        "oid": 1034,
-        "dataType": "_aclitem",
+        "oid": 1009,
+        "dataType": "_TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -6881,8 +3997,8 @@
         "expectedDataType": null
       },
       "tgqual": {
-        "oid": 194,
-        "dataType": "pg_node_tree",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -7085,8 +4201,8 @@
         "expectedDataType": null
       },
       "typacl": {
-        "oid": 1034,
-        "dataType": "_aclitem",
+        "oid": 1009,
+        "dataType": "_TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -7139,8 +4255,8 @@
         "expectedDataType": null
       },
       "typdefaultbin": {
-        "oid": 194,
-        "dataType": "pg_node_tree",
+        "oid": 25,
+        "dataType": "TEXT",
         "expectedOid": null,
         "expectedDataType": null
       },
@@ -7413,14 +4529,6 @@
     }
   },
   "unimplementedTypes": {
-    "1034": "_aclitem",
-    "194": "pg_node_tree",
-    "2275": "cstring",
-    "2277": "anyarray",
-    "28": "xid",
-    "3220": "pg_lsn",
-    "3361": "pg_ndistinct",
-    "3402": "pg_dependencies",
-    "5017": "pg_mcv_list"
+    "2277": "anyarray"
   }
 }

--- a/pkg/sql/testdata/pg_catalog_test_expected_diffs.json
+++ b/pkg/sql/testdata/pg_catalog_test_expected_diffs.json
@@ -7,43 +7,17 @@
       "expectedDataType": "regproc"
     }
   },
-  "pg_attrdef": {
-    "adbin": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 194,
-      "expectedDataType": "pg_node_tree"
-    }
-  },
   "pg_attribute": {
-    "attacl": {
-      "oid": 1009,
-      "dataType": "_text",
-      "expectedOid": 1034,
-      "expectedDataType": "_aclitem"
-    },
     "attmissingval": null
   },
   "pg_class": {
-    "relacl": {
-      "oid": 1009,
-      "dataType": "_text",
-      "expectedOid": 1034,
-      "expectedDataType": "_aclitem"
-    },
     "relfrozenxid": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 28,
-      "expectedDataType": "xid"
+      "expectedOid": 26,
+      "expectedDataType": "OID"
     },
-    "relminmxid": null,
-    "relpartbound": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 194,
-      "expectedDataType": "pg_node_tree"
-    }
+    "relminmxid": null
   },
   "pg_collation": {
     "collcollate": {
@@ -66,12 +40,6 @@
     }
   },
   "pg_constraint": {
-    "conbin": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 194,
-      "expectedDataType": "pg_node_tree"
-    },
     "confdeltype": {
       "oid": 25,
       "dataType": "text",
@@ -107,12 +75,6 @@
     }
   },
   "pg_database": {
-    "datacl": {
-      "oid": 1009,
-      "dataType": "_text",
-      "expectedOid": 1034,
-      "expectedDataType": "_aclitem"
-    },
     "datcollate": {
       "oid": 25,
       "dataType": "text",
@@ -128,22 +90,14 @@
     "datfrozenxid": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 28,
-      "expectedDataType": "xid"
+      "expectedOid": 26,
+      "expectedDataType": "OID"
     },
     "datminmxid": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 28,
-      "expectedDataType": "xid"
-    }
-  },
-  "pg_default_acl": {
-    "defaclacl": {
-      "oid": 1009,
-      "dataType": "_text",
-      "expectedOid": 1034,
-      "expectedDataType": "_aclitem"
+      "expectedOid": 26,
+      "expectedDataType": "OID"
     }
   },
   "pg_enum": {
@@ -168,60 +122,14 @@
       "expectedDataType": "_oid"
     }
   },
-  "pg_foreign_data_wrapper": {
-    "fdwacl": {
-      "oid": 1009,
-      "dataType": "_text",
-      "expectedOid": 1034,
-      "expectedDataType": "_aclitem"
-    }
-  },
-  "pg_foreign_server": {
-    "srvacl": {
-      "oid": 1009,
-      "dataType": "_text",
-      "expectedOid": 1034,
-      "expectedDataType": "_aclitem"
-    }
-  },
-  "pg_index": {
-    "indexprs": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 194,
-      "expectedDataType": "pg_node_tree"
-    },
-    "indpred": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 194,
-      "expectedDataType": "pg_node_tree"
-    }
-  },
   "pg_init_privs": {},
-  "pg_language": {
-    "lanacl": {
-      "oid": 1009,
-      "dataType": "_text",
-      "expectedOid": 1034,
-      "expectedDataType": "_aclitem"
-    }
-  },
   "pg_largeobject_metadata": {},
   "pg_locks": {
     "transactionid": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 28,
-      "expectedDataType": "xid"
-    }
-  },
-  "pg_namespace": {
-    "nspacl": {
-      "oid": 1009,
-      "dataType": "_text",
-      "expectedOid": 1034,
-      "expectedDataType": "_aclitem"
+      "expectedOid": 26,
+      "expectedDataType": "OID"
     }
   },
   "pg_operator": {
@@ -256,23 +164,11 @@
     "transaction": {
       "oid": 20,
       "dataType": "int8",
-      "expectedOid": 28,
-      "expectedDataType": "xid"
+      "expectedOid": 26,
+      "expectedDataType": "OID"
     }
   },
   "pg_proc": {
-    "proacl": {
-      "oid": 1009,
-      "dataType": "_text",
-      "expectedOid": 1034,
-      "expectedDataType": "_aclitem"
-    },
-    "proargdefaults": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 194,
-      "expectedDataType": "pg_node_tree"
-    },
     "proargmodes": {
       "oid": 1009,
       "dataType": "_text",
@@ -297,23 +193,11 @@
   "pg_replication_origin_status": {},
   "pg_replication_slots": {},
   "pg_rewrite": {
-    "ev_action": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 194,
-      "expectedDataType": "pg_node_tree"
-    },
     "ev_enabled": {
       "oid": 25,
       "dataType": "text",
       "expectedOid": 18,
       "expectedDataType": "char"
-    },
-    "ev_qual": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 194,
-      "expectedDataType": "pg_node_tree"
     },
     "ev_type": {
       "oid": 25,
@@ -339,106 +223,13 @@
       "expectedDataType": "_text"
     }
   },
-  "pg_stat_activity": {
-    "backend_xid": {
-      "oid": 20,
-      "dataType": "int8",
-      "expectedOid": 28,
-      "expectedDataType": "xid"
-    },
-    "backend_xmin": {
-      "oid": 20,
-      "dataType": "int8",
-      "expectedOid": 28,
-      "expectedDataType": "xid"
-    },
-    "client_port": {
-      "oid": 20,
-      "dataType": "int8",
-      "expectedOid": 23,
-      "expectedDataType": "int4"
-    },
-    "pid": {
-      "oid": 20,
-      "dataType": "int8",
-      "expectedOid": 23,
-      "expectedDataType": "int4"
-    }
-  },
-  "pg_stat_all_indexes": {},
-  "pg_stat_all_tables": {},
-  "pg_stat_archiver": {},
-  "pg_stat_bgwriter": {},
-  "pg_stat_database": {},
-  "pg_stat_database_conflicts": {},
-  "pg_stat_gssapi": {},
-  "pg_stat_progress_analyze": {},
-  "pg_stat_progress_basebackup": {},
-  "pg_stat_progress_cluster": {},
-  "pg_stat_progress_create_index": {},
-  "pg_stat_progress_vacuum": {},
-  "pg_stat_replication": {},
-  "pg_stat_slru": {},
-  "pg_stat_ssl": {},
-  "pg_stat_subscription": {},
-  "pg_stat_sys_indexes": {},
-  "pg_stat_sys_tables": {},
-  "pg_stat_user_functions": {},
-  "pg_stat_user_indexes": {},
-  "pg_stat_user_tables": {},
-  "pg_stat_wal_receiver": {},
-  "pg_stat_xact_all_tables": {},
-  "pg_stat_xact_sys_tables": {},
-  "pg_stat_xact_user_functions": {},
-  "pg_stat_xact_user_tables": {},
-  "pg_statio_all_indexes": {},
-  "pg_statio_all_sequences": {},
-  "pg_statio_all_tables": {},
-  "pg_statio_sys_indexes": {},
-  "pg_statio_sys_sequences": {},
-  "pg_statio_sys_tables": {},
-  "pg_statio_user_indexes": {},
-  "pg_statio_user_sequences": {},
-  "pg_statio_user_tables": {},
-  "pg_statistic": {},
-  "pg_statistic_ext_data": {},
-  "pg_stats": {},
-  "pg_stats_ext": {},
   "pg_subscription_rel": {},
-  "pg_tablespace": {
-    "spcacl": {
-      "oid": 1009,
-      "dataType": "_text",
-      "expectedOid": 1034,
-      "expectedDataType": "_aclitem"
-    }
-  },
   "pg_trigger": {
     "tgenabled": {
       "oid": 25,
       "dataType": "text",
       "expectedOid": 18,
       "expectedDataType": "char"
-    },
-    "tgqual": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 194,
-      "expectedDataType": "pg_node_tree"
-    }
-  },
-  "pg_type": {
-    "typacl": {
-      "oid": 1009,
-      "dataType": "_text",
-      "expectedOid": 1034,
-      "expectedDataType": "_aclitem"
-    },
-    "typdefaultbin": {
-      "oid": 25,
-      "dataType": "text",
-      "expectedOid": 194,
-      "expectedDataType": "pg_node_tree"
     }
   },
   "pg_user": {


### PR DESCRIPTION
Previously, diff tool was unable to implement some columns because
its type is unimplemented in cockroach db
This was inadequate because most of these types are synonyms or
are equivalents to other implemented types
To address this, this patch maps unimplemented types into an
equivalent implemented type

Release note: None