### PR TITLE
release-21.1: roachtest: skip psycopg password_encryption test

### DIFF
--- a/pkg/cmd/roachtest/psycopg_blocklist.go
+++ b/pkg/cmd/roachtest/psycopg_blocklist.go
@@ -29,8 +29,10 @@ var psycopgBlocklists = blocklistsForVersion{
 // After a failed run, an updated version of this blocklist should be available
 // in the test log.
 var psycopgBlockList21_1 = blocklist{
-	"tests.test_async_keyword.CancelTests.test_async_cancel":    "41335",
-	"tests.test_module.ExceptionsTestCase.test_9_6_diagnostics": "58035",
+	"tests.test_async_keyword.CancelTests.test_async_cancel": "41335",
+	// The following two items can be removed once there is a new psycopg2 release.
+	"tests.test_connection.TestEncryptPassword.test_encrypt_server": "42519",
+	"tests.test_module.ExceptionsTestCase.test_9_6_diagnostics":     "58035",
 }
 
 var psycopgBlockList20_2 = blocklist{


### PR DESCRIPTION
Backport 1/1 commits from #63933.

/cc @cockroachdb/release

---

This is being skipped upstream (https://github.com/psycopg/psycopg2/pull/1263)
but until that is released, we mark it as expected to fail.

fixes https://github.com/cockroachdb/cockroach/issues/63893

Release note: None
