### PR TITLE
kvserver: assign closed timestamp to lease requests again

### DIFF
--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -876,9 +876,12 @@ func (b *propBuf) EvaluatingRequestsCount() int {
 // tok := propbBuf.TrackEvaluatingRequest()
 // defer tok.DoneIfNotMoved()
 // fn(tok.Move())
+//
+// A zero value TrackedRequestToken acts as a no-op: calling DoneIfNotMoved() on
+// it will not interact with the tracker at all, but will cause stillTracked()
+// to switch from true->false.
 type TrackedRequestToken struct {
 	done bool
-	noop bool
 	tok  tracker.RemovalToken
 	b    *propBuf
 }
@@ -892,28 +895,32 @@ type TrackedRequestToken struct {
 // tokens are expected to be destroyed at once by the propBuf (which calls
 // doneLocked).
 func (t *TrackedRequestToken) DoneIfNotMoved(ctx context.Context) {
-	if t.done || t.noop {
+	if t.done {
 		return
 	}
-	t.b.p.locker().Lock()
+	if t.b != nil {
+		t.b.p.locker().Lock()
+		defer t.b.p.locker().Unlock()
+	}
 	t.doneIfNotMovedLocked(ctx)
-	t.b.p.locker().Unlock()
 }
 
 // doneIfNotMovedLocked untrackes the request. It is idempotent; in particular,
 // this is used when wanting to untrack a proposal that might, in fact, be a
 // reproposal.
 func (t *TrackedRequestToken) doneIfNotMovedLocked(ctx context.Context) {
-	if t.done || t.noop {
+	if t.done {
 		return
 	}
 	t.done = true
-	t.b.evalTracker.Untrack(ctx, t.tok)
+	if t.b != nil {
+		t.b.evalTracker.Untrack(ctx, t.tok)
+	}
 }
 
 // stillTracked returns true if no Done* method has been called.
 func (t *TrackedRequestToken) stillTracked() bool {
-	return !(t.done || t.noop)
+	return !t.done
 }
 
 // Move returns a new token which can untrack the request. The original token is
@@ -922,18 +929,9 @@ func (t *TrackedRequestToken) Move(ctx context.Context) TrackedRequestToken {
 	if t.done {
 		log.Fatalf(ctx, "attempting to Move() after Done() call")
 	}
-	if t.noop {
-		return *t
-	}
 	cpy := *t
 	t.done = true
 	return cpy
-}
-
-// SetNoop marks this token as not actually corresponding to a tracked request.
-// Any operation on the token will be a no-op.
-func (t *TrackedRequestToken) SetNoop() {
-	t.noop = true
 }
 
 // TrackEvaluatingRequest atomically starts tracking an evaluating request and

--- a/pkg/kv/kvserver/replica_proposal_buf_test.go
+++ b/pkg/kv/kvserver/replica_proposal_buf_test.go
@@ -909,12 +909,7 @@ func TestProposalBufferClosedTimestamp(t *testing.T) {
 			default:
 				t.Fatalf("unknown req type %d", tc.reqType)
 			}
-			tok := TrackedRequestToken{
-				done: false,
-				tok:  nil,
-				b:    &b,
-			}
-			_, err := b.Insert(ctx, pd, data, tok)
+			_, err := b.Insert(ctx, pd, data, TrackedRequestToken{})
 			require.NoError(t, err)
 			require.NoError(t, b.flushLocked(ctx))
 			checkClosedTS(t, r, tc.expClosed)

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -106,8 +106,6 @@ func (r *Replica) executeWriteBatch(
 		var minTS2 hlc.Timestamp
 		minTS2, tok = r.mu.proposalBuf.TrackEvaluatingRequest(ctx, ba.WriteTimestamp())
 		minTS.Forward(minTS2)
-	} else {
-		tok.SetNoop()
 	}
 	defer tok.DoneIfNotMoved(ctx)
 


### PR DESCRIPTION
https://github.com/cockroachdb/cockroach/pull/63357/commits/2d5a43e050bf073cc56a9b06252353e5029a3026 broke Raft closed timestamps. That patch aimed to not needlessly track
the evaluation of non-MVCC requests, but it did more than that - it
inadvertently also made these requests not carry closed timestamps,
because the code was mistakingly interpreting a non-mvcc command as a
reproposal. This is a problem for lease requests and lease transfers:
it's important for such commands to carry closed timestamps.

We had a test that was supposed to catch this, but unfortunately the
mocking in that test was diverging from the production code; it was not
making the non-mvcc requests look like reproposal. The test has been
improved.

Fixes #63905

Release note: None