### PR TITLE
kv: commit-wait before running commit triggers and resolving intents

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -1198,7 +1198,7 @@ func TestTxnCommitWait(t *testing.T) {
 		deferredWaitC := make(chan struct{})
 		errC := make(chan error, 1)
 		go func() {
-			var commitWaitFn func(context.Context)
+			var commitWaitFn func(context.Context) error
 			if deferred {
 				// If the test wants the caller to assume responsibility for commit
 				// waiting, we expect the transaction to return immediately after a
@@ -1246,7 +1246,7 @@ func TestTxnCommitWait(t *testing.T) {
 
 			if commitWaitFn != nil {
 				close(deferredWaitC)
-				commitWaitFn(ctx) // NOTE: blocks
+				_ = commitWaitFn(ctx) // NOTE: blocks
 			}
 
 			errC <- err

--- a/pkg/kv/kvclient/kvcoord/txn_metrics.go
+++ b/pkg/kv/kvclient/kvcoord/txn_metrics.go
@@ -75,7 +75,7 @@ var (
 		Measurement: "KV Transactions",
 		Unit:        metric.Unit_COUNT,
 	}
-	metaCommitWaitRates = metric.Metadata{
+	metaCommitWaitCount = metric.Metadata{
 		Name: "txn.commit_waits",
 		Help: "Number of KV transactions that had to commit-wait on commit " +
 			"in order to ensure linearizability. This generally happens to " +
@@ -235,7 +235,7 @@ func MakeTxnMetrics(histogramWindow time.Duration) TxnMetrics {
 		Commits:                       metric.NewCounter(metaCommitsRates),
 		Commits1PC:                    metric.NewCounter(metaCommits1PCRates),
 		ParallelCommits:               metric.NewCounter(metaParallelCommitsRates),
-		CommitWaits:                   metric.NewCounter(metaCommitWaitRates),
+		CommitWaits:                   metric.NewCounter(metaCommitWaitCount),
 		RefreshSuccess:                metric.NewCounter(metaRefreshSuccess),
 		RefreshFail:                   metric.NewCounter(metaRefreshFail),
 		RefreshFailWithCondensedSpans: metric.NewCounter(metaRefreshFailWithCondensedSpans),

--- a/pkg/kv/kvserver/abortspan/abortspan.go
+++ b/pkg/kv/kvserver/abortspan/abortspan.go
@@ -183,7 +183,7 @@ func (sc *AbortSpan) CopyTo(
 			hlc.Timestamp{}, nil, &entry,
 		)
 	}); err != nil {
-		return roachpb.NewReplicaCorruptionError(errors.Wrap(err, "AbortSpan.CopyTo"))
+		return errors.Wrap(err, "AbortSpan.CopyTo")
 	}
 	log.Eventf(ctx, "abort span: copied %d entries, skipped %d", abortSpanCopyCount, abortSpanSkipCount)
 	return nil

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/abortspan"
@@ -1060,6 +1061,98 @@ func TestPartialRollbackOnEndTransaction(t *testing.T) {
 			t.Error("expected txn record remaining after test, found none")
 		} else {
 			require.Equal(t, txn.IgnoredSeqNums, txnRec.IgnoredSeqNums)
+		}
+	})
+}
+
+// TestAssertNoCommitWaitIfCommitTrigger tests that an EndTxn that carries a
+// commit trigger and needs to commit-wait because it has a commit timestamp in
+// the future will return an assertion error. Such situations should trigger a
+// higher-level hook (maybeCommitWaitBeforeCommitTrigger) to perform the commit
+// wait sleep before the request acquires latches and begins evaluating.
+func TestCommitWaitBeforeIntentResolutionIfCommitTrigger(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testutils.RunTrueAndFalse(t, "commitTrigger", func(t *testing.T, commitTrigger bool) {
+		for _, cfg := range []struct {
+			name     string
+			commitTS func(now hlc.Timestamp) hlc.Timestamp
+			expError bool
+		}{
+			{
+				name:     "past",
+				commitTS: func(now hlc.Timestamp) hlc.Timestamp { return now },
+				expError: false,
+			},
+			{
+				name:     "past-syn",
+				commitTS: func(now hlc.Timestamp) hlc.Timestamp { return now.WithSynthetic(true) },
+				expError: false,
+			},
+			{
+				name:     "future-syn",
+				commitTS: func(now hlc.Timestamp) hlc.Timestamp { return now.Add(100, 0).WithSynthetic(true) },
+				// If the EndTxn carried a commit trigger and its transaction will need
+				// to commit-wait because the transaction has a future-time commit
+				// timestamp, evaluating the request should return an error.
+				expError: commitTrigger,
+			},
+		} {
+			t.Run(cfg.name, func(t *testing.T) {
+				ctx := context.Background()
+				db := storage.NewDefaultInMemForTesting()
+				defer db.Close()
+				batch := db.NewBatch()
+				defer batch.Close()
+
+				manual := hlc.NewManualClock(123)
+				clock := hlc.NewClock(manual.UnixNano, time.Nanosecond)
+				desc := roachpb.RangeDescriptor{
+					RangeID:  99,
+					StartKey: roachpb.RKey("a"),
+					EndKey:   roachpb.RKey("z"),
+				}
+
+				now := clock.Now()
+				commitTS := cfg.commitTS(now)
+				txn := roachpb.MakeTransaction("test", desc.StartKey.AsRawKey(), 0, now, 0)
+				txn.ReadTimestamp = commitTS
+				txn.WriteTimestamp = commitTS
+
+				// Issue the end txn command.
+				req := roachpb.EndTxnRequest{
+					RequestHeader: roachpb.RequestHeader{Key: txn.Key},
+					Commit:        true,
+				}
+				if commitTrigger {
+					req.InternalCommitTrigger = &roachpb.InternalCommitTrigger{
+						ModifiedSpanTrigger: &roachpb.ModifiedSpanTrigger{SystemConfigSpan: true},
+					}
+				}
+				var resp roachpb.EndTxnResponse
+				_, err := EndTxn(ctx, batch, CommandArgs{
+					EvalCtx: (&MockEvalCtx{
+						Desc:  &desc,
+						Clock: clock,
+						CanCreateTxn: func() (bool, hlc.Timestamp, roachpb.TransactionAbortedReason) {
+							return true, hlc.Timestamp{}, 0
+						},
+					}).EvalContext(),
+					Args: &req,
+					Header: roachpb.Header{
+						Timestamp: commitTS,
+						Txn:       &txn,
+					},
+				}, &resp)
+
+				if cfg.expError {
+					require.Error(t, err)
+					require.Regexp(t, `txn .* with modified-span \(system-config\) commit trigger needs commit wait`, err)
+				} else {
+					require.NoError(t, err)
+				}
+			})
 		}
 	})
 }

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -294,6 +294,15 @@ var (
 		Unit:        metric.Unit_COUNT,
 	}
 
+	// Server-side transaction metrics.
+	metaCommitWaitBeforeCommitTriggerCount = metric.Metadata{
+		Name: "txn.commit_waits.before_commit_trigger",
+		Help: "Number of KV transactions that had to commit-wait on the server " +
+			"before committing because they had a commit trigger",
+		Measurement: "KV Transactions",
+		Unit:        metric.Unit_COUNT,
+	}
+
 	// RocksDB metrics.
 	metaRdbBlockCacheHits = metric.Metadata{
 		Name:        "rocksdb.block.cache.hits",
@@ -1084,6 +1093,9 @@ type StoreMetrics struct {
 	// Follower read metrics.
 	FollowerReadsCount *metric.Counter
 
+	// Server-side transaction metrics.
+	CommitWaitsBeforeCommitTrigger *metric.Counter
+
 	// RocksDB metrics.
 	RdbBlockCacheHits           *metric.Gauge
 	RdbBlockCacheMisses         *metric.Gauge
@@ -1454,6 +1466,9 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 
 		// Follower reads metrics.
 		FollowerReadsCount: metric.NewCounter(metaFollowerReadsCount),
+
+		// Server-side transaction metrics.
+		CommitWaitsBeforeCommitTrigger: metric.NewCounter(metaCommitWaitBeforeCommitTriggerCount),
 
 		// RocksDB metrics.
 		RdbBlockCacheHits:           metric.NewGauge(metaRdbBlockCacheHits),

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -551,7 +551,7 @@ func (r *Replica) evaluate1PC(
 		if err != nil {
 			return onePCResult{
 				success: onePCFailed,
-				pErr:    roachpb.NewErrorf("failed to run commit trigger: %s", err),
+				pErr:    roachpb.NewError(errors.Wrap(err, "failed to run commit trigger")),
 			}
 		}
 		if err := res.MergeAndDestroy(innerResult); err != nil {

--- a/pkg/kv/mock_transactional_sender.go
+++ b/pkg/kv/mock_transactional_sender.go
@@ -209,7 +209,7 @@ func (m *MockTransactionalSender) ManualRefresh(ctx context.Context) error {
 }
 
 // DeferCommitWait is part of the TxnSender interface.
-func (m *MockTransactionalSender) DeferCommitWait(ctx context.Context) func(context.Context) {
+func (m *MockTransactionalSender) DeferCommitWait(ctx context.Context) func(context.Context) error {
 	panic("unimplemented")
 }
 

--- a/pkg/kv/sender.go
+++ b/pkg/kv/sender.go
@@ -319,7 +319,7 @@ type TxnSender interface {
 	// WARNING: failure to call the returned function could lead to consistency
 	// violations where a future, causally dependent transaction may fail to
 	// observe the writes performed by this transaction.
-	DeferCommitWait(ctx context.Context) func(context.Context)
+	DeferCommitWait(ctx context.Context) func(context.Context) error
 }
 
 // SteppingMode is the argument type to ConfigureStepping.

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -1328,7 +1328,7 @@ func (txn *Txn) ManualRefresh(ctx context.Context) error {
 // WARNING: failure to run the returned function could lead to consistency
 // violations where a future, causally dependent transaction may fail to
 // observe the writes performed by this transaction.
-func (txn *Txn) DeferCommitWait(ctx context.Context) func(context.Context) {
+func (txn *Txn) DeferCommitWait(ctx context.Context) func(context.Context) error {
 	txn.mu.Lock()
 	defer txn.mu.Unlock()
 	return txn.mu.sender.DeferCommitWait(ctx)

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -861,6 +861,31 @@ func (v Value) PrettyPrint() string {
 	return buf.String()
 }
 
+// Kind returns the kind of commit trigger as a string.
+func (ct InternalCommitTrigger) Kind() string {
+	switch {
+	case ct.SplitTrigger != nil:
+		return "split"
+	case ct.MergeTrigger != nil:
+		return "merge"
+	case ct.ChangeReplicasTrigger != nil:
+		return "change-replicas"
+	case ct.ModifiedSpanTrigger != nil:
+		switch {
+		case ct.ModifiedSpanTrigger.SystemConfigSpan:
+			return "modified-span (system-config)"
+		case ct.ModifiedSpanTrigger.NodeLivenessSpan != nil:
+			return "modified-span (node-liveness)"
+		default:
+			panic("unknown modified-span commit trigger kind")
+		}
+	case ct.StickyBitTrigger != nil:
+		return "sticky-bit"
+	default:
+		panic("unknown commit trigger kind")
+	}
+}
+
 // IsFinalized determines whether the transaction status is in a finalized
 // state. A finalized state is terminal, meaning that once a transaction
 // enters one of these states, it will never leave it.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -926,7 +926,7 @@ func ensureClockMonotonicity(
 	clock *hlc.Clock,
 	startTime time.Time,
 	prevHLCUpperBound int64,
-	sleepUntilFn func(t hlc.Timestamp),
+	sleepUntilFn func(context.Context, hlc.Timestamp) error,
 ) {
 	var sleepUntil int64
 	if prevHLCUpperBound != 0 {
@@ -960,7 +960,7 @@ func ensureClockMonotonicity(
 			sleepUntil,
 			delta,
 		)
-		sleepUntilFn(hlc.Timestamp{WallTime: sleepUntil})
+		_ = sleepUntilFn(ctx, hlc.Timestamp{WallTime: sleepUntil})
 	}
 }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -770,11 +770,12 @@ func TestEnsureInitialWallTimeMonotonicity(t *testing.T) {
 			m := hlc.NewManualClock(test.clockStartTime)
 			c := hlc.NewClock(m.UnixNano, maxOffset)
 
-			sleepUntilFn := func(t hlc.Timestamp) {
+			sleepUntilFn := func(ctx context.Context, t hlc.Timestamp) error {
 				delta := t.WallTime - c.Now().WallTime
 				if delta > 0 {
 					m.Increment(delta)
 				}
+				return nil
 			}
 
 			wallTime1 := c.Now().WallTime

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -967,6 +967,7 @@ var charts = []sectionDescription{
 					"txn.commits1PC",
 					"txn.parallelcommits",
 					"txn.commit_waits",
+					"txn.commit_waits.before_commit_trigger",
 				},
 			},
 			{


### PR DESCRIPTION
Fixes a serious bug revealed by #63747.

This commit fixes a bug revealed by kvnemesis where a range-merge watcher on the
right-hand side of a range merge could incorrectly determine that a range merge
txn had succeeded, when in reality, it had failed. The watcher would then put
the RHS leaseholder replica into a stalled state by setting `r.mu.destroyStatus`
to `destroyReasonMergePending`, effectively stalling any operation on the range
indefinitely.

The setup for this bug was that a range was operating with a `global_reads` zone
configuration attribute, so it was pushing all writers into the future. The
range was split and then rapidly merged back together. During the merge txn, a
range-merge watcher (see `maybeWatchForMergeLocked`) began monitoring the state
of the range merge txn. The problem was that at the time that the range merge
txn committed, neither the meta descriptor version written by the merge or even
the meta descriptor version written by the split were visible to the watcher's
follow-up query. Because the watcher read below the split txn's descriptor, it
came to the wrong conclusion about the merge.

It is interesting to think about what is going wrong here, because it's not
immediately obvious who is at fault. If a transaction has a commit timestamp in
the future of present time, it will need to commit-wait before acknowledging the
client. Typically, this is performed in the TxnCoordSender after the transaction
has committed and resolved its intents (see TxnCoordSender.maybeCommitWait). It
is safe to wait after a future-time transaction has committed and resolved
intents without compromising linearizability because the uncertainty interval of
concurrent and later readers ensures atomic visibility of the effects of the
transaction. In other words, all of the transaction's intents will become
visible and will remain visible at once, which is sometimes called "monotonic
reads". This is true even if the resolved intents are at a high enough timestamp
such that they are not visible to concurrent readers immediately after they are
resolved, but only become visible sometime during the writer's commit-wait
sleep. This property is central to the correctness of non-blocking transactions.
See: https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/20200811_non_blocking_txns.md

However, if a transaction has a commit trigger, the side-effects of the trigger
will go into effect immediately upon applying the corresponding Raft log entry.
This poses a problem, because we do not want part of a transaction's effects
(e.g. its commit trigger) to become visible to onlookers before the rest of its
effects do (e.g. its intent writes).

To avoid this problem, this commit adds special server-side logic to perform the
commit-wait stage of a transaction with a commit trigger early, before its
EndTxn evaluates and its commit trigger fires. This results in the transaction
waiting longer to commit, run its commit trigger, and resolve its intents, but
it is otherwise safe and effective.

Interestingly, this is quite similar to how Spanner handles its commit-wait rule:

> Before allowing any coordinator replica to apply the commit record, the
> coordinator leader waits until TT.after(s), so as to obey the commit-wait rule
> described in Section 4.1.2. Because the coordinator leader chose s based on
> TT.now().latest, and now waits until that timestamp is guaranteed to be in the
> past, the expected wait is at least 2 ∗ . This wait is typically overlapped with
> Paxos communication. After commit wait, the coordinator sends the commit
> timestamp to the client and all other participant leaders. Each participant
> leader logs the transaction’s outcome through Paxos. All participants apply at
> the same timestamp and then release locks.

Of course, the whole point of non-blocking transactions is that we release locks
early and use clocks (through uncertainty intervals + a reader-side commit-wait
rule) to enforce consistency, so we don't want to make this change for standard
transactions.

Before this change, I could hit the bug in about 5 minutes of stressing
kvnemesis on a roachprod cluster. After this change, I've been able to run
kvnemesis for a few hours without issue.

Release note (bug fix): Fixed a rare bug present in betas where rapid range
splits and merges on a GLOBAL table could lead to a stuck leaseholder replica.
The situation is no longer possible.

cc. @cockroachdb/kv 