### PR TITLE
testutils: retry GetStatusClient in testcluster setup

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -3110,9 +3110,11 @@ func TestDecommission(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 
 	k := tc.ScratchRange(t)
-	admin := tc.GetAdminClient(ctx, t, 0)
+	admin, err := tc.GetAdminClient(ctx, t, 0)
+	require.NoError(t, err)
+
 	// Decommission the first node, which holds most of the leases.
-	_, err := admin.Decommission(
+	_, err = admin.Decommission(
 		ctx, &serverpb.DecommissionRequest{
 			NodeIDs:          []roachpb.NodeID{1},
 			TargetMembership: livenesspb.MembershipStatus_DECOMMISSIONING,

--- a/pkg/kv/kvserver/liveness/client_test.go
+++ b/pkg/kv/kvserver/liveness/client_test.go
@@ -220,7 +220,10 @@ func TestNodeLivenessStatusMap(t *testing.T) {
 	log.Infof(ctx, "checking status map")
 
 	// See what comes up in the status.
-	admin := tc.GetAdminClient(ctx, t, 0)
+	admin, err := tc.GetAdminClient(ctx, t, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	type testCase struct {
 		nodeID         roachpb.NodeID


### PR DESCRIPTION
I recently saw the following spurious test failure in CI:

```
=== CONT
TestCCLLogic/multiregion-9node-3region-3azs/multi_region_zone_configs
testcluster.go:1493: failed to create a status client because of
initial connection heartbeat failed: rpc error: code = Unavailable
desc = connection error: desc = "transport: authentication handshake
failed: context deadline exceeded"
```

I haven't reproduced this locally, but since all other errors in
WaitForNodeStatus are retried, perhaps retrying this error as well
would have worked and avoided the test failure.

Previous to a4d5facc142976d4bd46596c1dc116cc59f0eb62 errors attempting
to connect to the node would have been retried. This restores the
retry behavior.

Release note: None