### PR TITLE
release-21.1: sql: gate new schema changer behind testing knob

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1286,7 +1286,8 @@ func (ns *prepStmtNamespace) resetTo(
 func (ex *connExecutor) resetExtraTxnState(ctx context.Context, ev txnEvent) error {
 	ex.extraTxnState.jobs = nil
 	ex.extraTxnState.hasAdminRoleCache = HasAdminRoleCache{}
-	if ex.server.cfg.Settings.Version.IsActive(ctx, clusterversion.NewSchemaChanger) {
+	if ex.server.cfg.Settings.Version.IsActive(ctx, clusterversion.NewSchemaChanger) &&
+		ex.server.cfg.TestingKnobs.AllowNewSchemaChanger {
 		ex.extraTxnState.schemaChangerState = SchemaChangerState{
 			mode: ex.sessionData.NewSchemaChangerMode,
 		}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -992,6 +992,10 @@ type ExecutorTestingKnobs struct {
 	// return, possibly nil, a callback that will be called every time
 	// DistSQLReceiver.Push is called.
 	DistSQLReceiverPushCallbackFactory func(query string) func(rowenc.EncDatumRow, *execinfrapb.ProducerMetadata)
+
+	// AllowNewSchemaChanger is used to allow enabling the new schema changer.
+	// It cannot be enabled without this testing knob in 21.1.
+	AllowNewSchemaChanger bool
 }
 
 // PGWireTestingKnobs contains knobs for the pgwire module.

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1333,7 +1333,8 @@ func (t *logicTest) newCluster(serverArgs TestServerArgs) {
 					ForceProductionBatchSizes:       serverArgs.forceProductionBatchSizes,
 				},
 				SQLExecutor: &sql.ExecutorTestingKnobs{
-					DeterministicExplain: true,
+					DeterministicExplain:  true,
+					AllowNewSchemaChanger: true,
 				},
 			},
 			ClusterName:   "testclustername",

--- a/pkg/sql/schemachanger/scbuild/builder_test.go
+++ b/pkg/sql/schemachanger/scbuild/builder_test.go
@@ -45,7 +45,13 @@ func TestBuilderAlterTable(t *testing.T) {
 	ctx := context.Background()
 
 	datadriven.Walk(t, filepath.Join("testdata"), func(t *testing.T, path string) {
-		s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+		s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				SQLExecutor: &sql.ExecutorTestingKnobs{
+					AllowNewSchemaChanger: true,
+				},
+			},
+		})
 		defer s.Stopper().Stop(ctx)
 
 		tdb := sqlutils.MakeSQLRunner(sqlDB)

--- a/pkg/sql/schemachanger/scexec/executor_external_test.go
+++ b/pkg/sql/schemachanger/scexec/executor_external_test.go
@@ -52,7 +52,16 @@ type testInfra struct {
 }
 
 func setupTestInfra(t testing.TB) *testInfra {
-	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	knobs := base.TestingKnobs{
+		SQLExecutor: &sql.ExecutorTestingKnobs{
+			AllowNewSchemaChanger: true,
+		},
+	}
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: knobs,
+		},
+	})
 	return &testInfra{
 		tc:       tc,
 		settings: tc.Server(0).ClusterSettings(),

--- a/pkg/sql/tests/BUILD.bazel
+++ b/pkg/sql/tests/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
         "kv_test.go",
         "main_test.go",
         "monotonic_insert_test.go",
+        "new_schema_changer_knob_test.go",
         "random_schema_test.go",
         "rename_column_test.go",
         "repair_test.go",

--- a/pkg/sql/tests/new_schema_changer_knob_test.go
+++ b/pkg/sql/tests/new_schema_changer_knob_test.go
@@ -1,0 +1,55 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewSchemaChangerKnob ensures that the new schema changer cannot be
+// enabled without a testing knob being set.
+func TestNewSchemaChangerKnob(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testutils.RunTrueAndFalse(t, "knob", func(t *testing.T, enabled bool) {
+		ctx := context.Background()
+		s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				SQLExecutor: &sql.ExecutorTestingKnobs{
+					AllowNewSchemaChanger: enabled,
+				},
+			},
+		})
+		defer s.Stopper().Stop(ctx)
+		tdb := sqlutils.MakeSQLRunner(sqlDB)
+
+		tdb.Exec(t, "CREATE TABLE t (i INT PRIMARY KEY, j INT)")
+		// The session variable is allowed but requires the knob to do anything.
+		tdb.Exec(t, "SET experimental_use_new_schema_changer = 'unsafe_always'")
+
+		_, err := sqlDB.Exec("ALTER TABLE t DROP COLUMN j")
+		if enabled {
+			require.Regexp(t,
+				`pq: \*tree.AlterTableDropColumn not implemented in the new schema changer`,
+				err)
+		} else {
+			require.NoError(t, err)
+		}
+	})
+}


### PR DESCRIPTION
There's no reason for us to support code that we really don't want an end-user
to enable. This gate is cheap and effective.

Fixes #63986.

Release note: None