### PR TITLE
release-20.2: sql: fix dropping table in CTAS/materialized view rollback

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -829,45 +829,64 @@ func (sc *SchemaChanger) rollbackSchemaChange(ctx context.Context, err error) er
 	// Check if the target table needs to be cleaned up at all. If the target
 	// table was in the ADD state and the schema change failed, then we need to
 	// clean up the descriptor.
-	desc, err := sc.getTargetDescriptor(ctx)
-	if err != nil {
-		return err
-	}
-	if tblDesc, ok := desc.(catalog.TableDescriptor); ok && tblDesc.GetState() == descpb.DescriptorState_ADD {
-		// Delete the names in use by this descriptor.
-		if err := sc.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-			return catalogkv.RemoveObjectNamespaceEntry(
-				ctx,
-				txn,
-				sc.execCfg.Codec,
-				tblDesc.GetParentID(),
-				tblDesc.GetParentSchemaID(),
-				tblDesc.GetName(),
-				false, /* kvTrace */
-			)
-		}); err != nil {
+	var cleanupJob *jobs.StartableJob
+	if err := sc.txn(ctx, func(ctx context.Context, txn *kv.Txn, descsCol *descs.Collection) error {
+		scTable, err := descsCol.GetMutableTableVersionByID(ctx, sc.descID, txn)
+		if err != nil {
 			return err
 		}
-		// Now start a GC job for the table.
-		if err := startGCJob(
+		if !scTable.Adding() {
+			return nil
+		}
+
+		b := txn.NewBatch()
+		scTable.SetDropped()
+		if err := descsCol.WriteDescToBatch(ctx, false /* kvTrace */, scTable, b); err != nil {
+			return err
+		}
+		catalogkv.WriteObjectNamespaceEntryRemovalToBatch(
 			ctx,
-			sc.db,
-			sc.jobRegistry,
-			sc.job.Payload().Username,
-			"ROLLBACK OF"+sc.job.Payload().Description,
+			b,
+			sc.execCfg.Codec,
+			scTable.GetParentID(),
+			scTable.GetParentSchemaID(),
+			scTable.GetName(),
+			false, /* kvTrace */
+		)
+
+		// Queue a GC job.
+		jobRecord := CreateGCJobRecord(
+			"ROLLBACK OF "+sc.job.Payload().Description,
+			sc.job.Payload().Description,
 			jobspb.SchemaChangeGCDetails{
 				Tables: []jobspb.SchemaChangeGCDetails_DroppedID{
 					{
-						ID:       tblDesc.GetID(),
+						ID:       scTable.GetID(),
 						DropTime: timeutil.Now().UnixNano(),
 					},
 				},
 			},
-		); err != nil {
+		)
+		job, err := sc.jobRegistry.CreateStartableJobWithTxn(ctx, jobRecord, txn, nil /* resultsCh */)
+		if err != nil {
 			return err
 		}
+		cleanupJob = job
+		return txn.Run(ctx, b)
+	}); err != nil {
+		if cleanupJob != nil {
+			if rollbackErr := cleanupJob.CleanupOnRollback(ctx); rollbackErr != nil {
+				log.Warningf(ctx, "failed to clean up job: %v", rollbackErr)
+			}
+		}
+		return err
 	}
-
+	if cleanupJob != nil {
+		if _, err := cleanupJob.Start(ctx); err != nil {
+			log.Warningf(ctx, "starting job %d failed with error: %v", *cleanupJob.ID(), err)
+		}
+		log.VEventf(ctx, 2, "started job %d", *cleanupJob.ID())
+	}
 	return nil
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #55272.

/cc @cockroachdb/release

---

When we were dropping the table while rolling back `CREATE TABLE AS` or
`CREATE MATERIALIZED VIEW`, we neglected to move the table from the ADD
state to the DROP state. This is currently blocking us from using logic
tests for testing `DROP DATABASE CASCADE`, because if the descriptor's
parent database is dropped, we'll produce a spurious error from
validation about a missing parent descriptor. The bug also probably
leads to other subtle problems with draining leases, etc., though the GC
job should be able to handle such descriptors, at least. This PR fixes
the bug.

Fixes #54186.
Touches #53810.

Release note (bug fix): Fixed a bug where upon failure of `CREATE TABLE
AS` or `CREATE MATERIALIZED VIEW` tables would be left in an invalid
non-public state until GC instead of being marked as dropped, possibly
causing spurious validation failures. The bug was introduced in earlier
20.2 prereleases.
