### PR TITLE
release-20.1: roachtest: update libpq blocklist to ignore TestCopyInBinaryError

### DIFF
--- a/pkg/cmd/roachtest/libpq.go
+++ b/pkg/cmd/roachtest/libpq.go
@@ -14,6 +14,9 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
+
+	"github.com/stretchr/testify/require"
 )
 
 var libPQReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
@@ -28,19 +31,14 @@ func registerLibPQ(r *testRegistry) {
 		c.Put(ctx, cockroach, "./cockroach", c.All())
 		c.Start(ctx, t, c.All())
 		version, err := fetchCockroachVersion(ctx, c, node[0])
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := alterZoneConfigAndClusterSettings(ctx, version, c, node[0]); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		err = alterZoneConfigAndClusterSettings(ctx, version, c, node[0])
+		require.NoError(t, err)
 
 		t.Status("cloning lib/pq and installing prerequisites")
 		latestTag, err := repeatGetLatestTag(
 			ctx, c, "lib", "pq", libPQReleaseTagRegex)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		c.l.Printf("Latest lib/pq release is %s.", latestTag)
 
 		installLatestGolang(ctx, t, c, node)
@@ -53,21 +51,19 @@ func registerLibPQ(r *testRegistry) {
 		)
 
 		// Remove any old lib/pq installations
-		if err := repeatRunE(
+		err = repeatRunE(
 			ctx, c, node, "remove old lib/pq", fmt.Sprintf("rm -rf %s", libPQPath),
-		); err != nil {
-			t.Fatal(err)
-		}
+		)
+		require.NoError(t, err)
 
 		// Install go-junit-report to convert test results to .xml format we know
 		// how to work with.
-		if err := repeatRunE(
-			ctx, c, node, "install go-junit-report", fmt.Sprintf("GOPATH=%s go get -u github.com/jstemmer/go-junit-report", goPath),
-		); err != nil {
-			t.Fatal(err)
-		}
+		err = repeatRunE(ctx, c, node, "install go-junit-report",
+			fmt.Sprintf("GOPATH=%s go get -u github.com/jstemmer/go-junit-report", goPath),
+		)
+		require.NoError(t, err)
 
-		if err := repeatGitCloneE(
+		err = repeatGitCloneE(
 			ctx,
 			t.l,
 			c,
@@ -75,13 +71,11 @@ func registerLibPQ(r *testRegistry) {
 			libPQPath,
 			latestTag,
 			node,
-		); err != nil {
-			t.Fatal(err)
-		}
-
+		)
+		require.NoError(t, err)
 		_ = c.RunE(ctx, node, fmt.Sprintf("mkdir -p %s", resultsDir))
 
-		blocklistName, expectedFailures, ignorelistName, ignoredFailures := libPQBlocklists.getLists(version)
+		blocklistName, expectedFailures, ignorelistName, ignoreList := libPQBlocklists.getLists(version)
 		if expectedFailures == nil {
 			t.Fatalf("No lib/pq blocklist defined for cockroach version %s", version)
 		}
@@ -89,23 +83,54 @@ func registerLibPQ(r *testRegistry) {
 
 		t.Status("running lib/pq test suite and collecting results")
 
+		// List all the tests that start with Test or Example.
+		testListRegex := "^(Test|Example)"
+		buf, err := c.RunWithBuffer(
+			ctx,
+			t.l,
+			node,
+			fmt.Sprintf(`cd %s && PGPORT=26257 PGUSER=root PGSSLMODE=disable PGDATABASE=postgres go test -list "%s"`, libPQPath, testListRegex),
+		)
+		require.NoError(t, err)
+
+		// Convert the output of go test -list into an list.
+		tests := strings.Fields(string(buf))
+		var allowedTests []string
+
+		compiledTestListRegex, err := regexp.Compile(testListRegex)
+		require.NoError(t, err)
+		for _, testName := range tests {
+			// Ignore tests that do not match the test regex pattern.
+			matched := compiledTestListRegex.MatchString(testName)
+			if !matched {
+				continue
+			}
+			// If the test is part of ignoreList, do not run the test.
+			if _, ok := ignoreList[testName]; !ok {
+				allowedTests = append(allowedTests, testName)
+			}
+		}
+
+		allowedTestsRegExp := fmt.Sprintf(`"^(%s)$"`, strings.Join(allowedTests, "|"))
+
 		// Ignore the error as there will be failing tests.
 		_ = c.RunE(
 			ctx,
 			node,
-			fmt.Sprintf("cd %s && PGPORT=26257 PGUSER=root PGSSLMODE=disable PGDATABASE=postgres go test -v 2>&1 | %s/bin/go-junit-report > %s", libPQPath, goPath, resultsPath),
+			fmt.Sprintf("cd %s && PGPORT=26257 PGUSER=root PGSSLMODE=disable PGDATABASE=postgres go test -run %s -v 2>&1 | %s/bin/go-junit-report > %s",
+				libPQPath, allowedTestsRegExp, goPath, resultsPath),
 		)
 
 		parseAndSummarizeJavaORMTestsResults(
 			ctx, t, c, node, "lib/pq" /* ormName */, []byte(resultsPath),
-			blocklistName, expectedFailures, ignoredFailures, version, latestTag,
+			blocklistName, expectedFailures, ignoreList, version, latestTag,
 		)
 	}
 
 	r.Add(testSpec{
 		Name:       "lib/pq",
 		Owner:      OwnerAppDev,
-		MinVersion: "v19.2.0",
+		MinVersion: "v20.1.0",
 		Cluster:    makeClusterSpec(1),
 		Tags:       []string{`default`, `driver`},
 		Run:        runLibPQ,

--- a/pkg/cmd/roachtest/libpq_blocklist.go
+++ b/pkg/cmd/roachtest/libpq_blocklist.go
@@ -11,7 +11,6 @@
 package main
 
 var libPQBlocklists = blocklistsForVersion{
-	{"v19.2", "libPQBlocklist19_2", libPQBlocklist19_2, "libPQIgnorelist19_2", libPQIgnorelist19_2},
 	{"v20.1", "libPQBlocklist20_1", libPQBlocklist20_1, "libPQIgnorelist20_1", libPQIgnorelist20_1},
 	{"v20.2", "libPQBlocklist20_2", libPQBlocklist20_2, "libPQIgnorelist20_2", libPQIgnorelist20_2},
 }
@@ -30,7 +29,6 @@ var libPQBlocklist20_2 = blocklist{
 	"pq.TestContextCancelExec":                       "41335",
 	"pq.TestContextCancelQuery":                      "41335",
 	"pq.TestCopyFromError":                           "5807",
-	"pq.TestCopyInBinaryError":                       "5807",
 	"pq.TestCopyInRaiseStmtTrigger":                  "5807",
 	"pq.TestCopyInTypes":                             "5807",
 	"pq.TestCopyRespLoopConnectionError":             "5807",
@@ -68,7 +66,6 @@ var libPQBlocklist20_1 = blocklist{
 	"pq.TestContextCancelExec":                                 "41335",
 	"pq.TestContextCancelQuery":                                "41335",
 	"pq.TestCopyFromError":                                     "5807",
-	"pq.TestCopyInBinaryError":                                 "5807",
 	"pq.TestCopyInRaiseStmtTrigger":                            "5807",
 	"pq.TestCopyInTypes":                                       "5807",
 	"pq.TestCopyRespLoopConnectionError":                       "5807",
@@ -104,79 +101,19 @@ var libPQBlocklist20_1 = blocklist{
 	"pq.TestTimeWithoutTimezone/24:00_=>_0000-01-02T00:00:00Z":           "44548",
 }
 
-var libPQBlocklist19_2 = blocklist{
-	"pq.ExampleConnectorWithNoticeHandler":           "unknown",
-	"pq.TestBinaryByteSliceToInt":                    "41547",
-	"pq.TestBinaryByteSlicetoUUID":                   "41547",
-	"pq.TestBindError":                               "5807",
-	"pq.TestByteaOutputFormats":                      "26947",
-	"pq.TestCommit":                                  "5807",
-	"pq.TestConnListen":                              "41522",
-	"pq.TestConnUnlisten":                            "41522",
-	"pq.TestConnUnlistenAll":                         "41522",
-	"pq.TestConnectorWithNoticeHandler_Simple":       "unknown",
-	"pq.TestConnectorWithNotificationHandler_Simple": "unknown",
-	"pq.TestContextCancelBegin":                      "41335",
-	"pq.TestContextCancelExec":                       "41335",
-	"pq.TestContextCancelQuery":                      "41335",
-	"pq.TestCopyFromError":                           "5807",
-	"pq.TestCopyInBinaryError":                       "5807",
-	"pq.TestCopyInMultipleValues":                    "5807",
-	"pq.TestCopyInRaiseStmtTrigger":                  "5807",
-	"pq.TestCopyInStmtAffectedRows":                  "5807",
-	"pq.TestCopyInTypes":                             "5807",
-	"pq.TestCopyInWrongType":                         "5807",
-	"pq.TestCopyRespLoopConnectionError":             "5807",
-	"pq.TestEncodeAndParseTs":                        "41563",
-	"pq.TestErrorDuringStartup":                      "41551",
-	"pq.TestErrorOnExec":                             "5807",
-	"pq.TestErrorOnQuery":                            "5807",
-	"pq.TestErrorOnQueryRowSimpleQuery":              "5807",
-	"pq.TestExec":                                    "5807",
-	"pq.TestInfinityTimestamp":                       "41564",
-	"pq.TestIssue186":                                "41558",
-	"pq.TestIssue196":                                "41689",
-	"pq.TestIssue282":                                "12137",
-	"pq.TestIssue494":                                "5807",
-	"pq.TestListenerFailedQuery":                     "41522",
-	"pq.TestListenerListen":                          "41522",
-	"pq.TestListenerReconnect":                       "41522",
-	"pq.TestListenerUnlisten":                        "41522",
-	"pq.TestListenerUnlistenAll":                     "41522",
-	"pq.TestNotifyExtra":                             "41522",
-	"pq.TestPing":                                    "35897",
-	"pq.TestQueryRowBugWorkaround":                   "5807",
-	"pq.TestReconnect":                               "35897",
-	"pq.TestReturning":                               "5807",
-	"pq.TestRowsColumnTypes":                         "41688",
-	"pq.TestRowsResultTag":                           "5807",
-	"pq.TestRuntimeParameters":                       "12137",
-	"pq.TestStringWithNul":                           "26366",
-	"pq.TestTimeWithTimezone":                        "44548",
-	"pq.TestTimeWithTimezone/11:59:59+00:00_=>_0000-01-01T11:59:59Z":      "44548",
-	"pq.TestTimeWithTimezone/11:59:59+04:00_=>_0000-01-01T11:59:59+04:00": "44548",
-	"pq.TestTimeWithTimezone/24:00+00_=>_0000-01-02T00:00:00Z":            "44548",
-	"pq.TestTimeWithTimezone/24:00-04:00_=>_0000-01-02T00:00:00-04:00":    "44548",
-	"pq.TestTimeWithTimezone/24:00:00+00_=>_0000-01-02T00:00:00Z":         "44548",
-	"pq.TestTimeWithTimezone/24:00:00.0+00_=>_0000-01-02T00:00:00Z":       "44548",
-	"pq.TestTimeWithTimezone/24:00:00.000000+00_=>_0000-01-02T00:00:00Z":  "44548",
-	"pq.TestTimeWithTimezone/24:00Z_=>_0000-01-02T00:00:00Z":              "44548",
-	"pq.TestTimeWithoutTimezone":                                          "44548",
-	"pq.TestTimeWithoutTimezone/24:00:00.000000_=>_0000-01-02T00:00:00Z":  "44548",
-	"pq.TestTimeWithoutTimezone/24:00:00.0_=>_0000-01-02T00:00:00Z":       "44548",
-	"pq.TestTimeWithoutTimezone/24:00:00_=>_0000-01-02T00:00:00Z":         "44548",
-	"pq.TestTimeWithoutTimezone/24:00_=>_0000-01-02T00:00:00Z":            "44548",
-	"pq.TestTimestampWithTimeZone":                                        "41565",
-}
-
 var libPQIgnorelist20_2 = libPQIgnorelist20_1
 
-var libPQIgnorelist20_1 = libPQIgnorelist19_2
-
-var libPQIgnorelist19_2 = blocklist{
+// The test names here do not include "pq." since `go test -list` returns
+// the test name without "pq.". We use the name returned from `go test -list`
+// to ignore the test.
+var libPQIgnorelist20_1 = blocklist{
 	// TestFormatTsBacked fails due to not returning an error for accepting a
 	// timestamp format that postgres does not.
-	"pq.TestFormatTsBackend": "41690",
+	"TestFormatTsBackend": "41690",
 	// TestTxOptions fails because it attempts to change isolation levels.
-	"pq.TestTxOptions": "41690",
+	"TestTxOptions": "41690",
+	// TestCopyInBinaryError is expected to error with:
+	// pq: only text format supported for COPY, however no error is returned
+	// for CRDB.
+	"TestCopyInBinaryError": "63235",
 }


### PR DESCRIPTION
Backport 1/1 commits from #63238.

/cc @cockroachdb/release

---

roachtest: update libpq blocklist to ignore TestCopyInBinaryError

TestCopyInBinary's behaviour was incorrect in the test since we were not receiving an expected error (`pq: only text format supported for COPY`). 
Furthermore the test would sporadically panic causing the following tests to fail.

Release note: None

Resolves #57855 
