### PR TITLE
rowenc: add value encoding for arrays of tuples

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -1745,3 +1745,39 @@ INSERT INTO t VALUES (
   '{192.168.100.128, ::ffff:10.4.3.2}',
   '{0101, 11}',
   '{12.34, 45.67}');
+
+# Test for #32715: able to distribute queries with arrays of tuples.
+
+statement ok
+CREATE TABLE kv (
+  k INT PRIMARY KEY,
+  v STRING
+);
+INSERT INTO kv VALUES (1, 'one'), (2, 'two'), (3, 'three'), (4, 'four'), (5, null)
+
+query T rowsort
+SELECT ARRAY[(k, k)] FROM kv
+----
+{"(1,1)"}
+{"(2,2)"}
+{"(3,3)"}
+{"(4,4)"}
+{"(5,5)"}
+
+query T rowsort
+SELECT ARRAY[(k, k), (1, 2)] FROM kv
+----
+{"(1,1)","(1,2)"}
+{"(2,2)","(1,2)"}
+{"(3,3)","(1,2)"}
+{"(4,4)","(1,2)"}
+{"(5,5)","(1,2)"}
+
+query T rowsort
+SELECT ARRAY[(k, 'foo'), (1, v)] FROM kv
+----
+{"(1,foo)","(1,one)"}
+{"(2,foo)","(1,two)"}
+{"(3,foo)","(1,three)"}
+{"(4,foo)","(1,four)"}
+{"(5,foo)","(1,)"}

--- a/pkg/sql/rowenc/column_type_encoding.go
+++ b/pkg/sql/rowenc/column_type_encoding.go
@@ -1040,6 +1040,13 @@ func UnmarshalColumnValue(a *DatumAlloc, typ *types.T, value roachpb.Value) (tre
 // encodeTuple produces the value encoding for a tuple.
 func encodeTuple(t *tree.DTuple, appendTo []byte, colID uint32, scratch []byte) ([]byte, error) {
 	appendTo = encoding.EncodeValueTag(appendTo, colID, encoding.Tuple)
+	return encodeUntaggedTuple(t, appendTo, colID, scratch)
+}
+
+// encodeUntaggedTuple produces the value encoding for a tuple without a value tag.
+func encodeUntaggedTuple(
+	t *tree.DTuple, appendTo []byte, colID uint32, scratch []byte,
+) ([]byte, error) {
 	appendTo = encoding.EncodeNonsortingUvarint(appendTo, uint64(len(t.D)))
 
 	var err error
@@ -1358,6 +1365,8 @@ func DatumTypeToArrayElementEncodingType(t *types.T) (encoding.Type, error) {
 		return encoding.IPAddr, nil
 	case types.JsonFamily:
 		return encoding.JSON, nil
+	case types.TupleFamily:
+		return encoding.Tuple, nil
 	default:
 		return 0, errors.AssertionFailedf("no known encoding type for %s", t)
 	}
@@ -1435,6 +1444,8 @@ func encodeArrayElement(b []byte, d tree.Datum) ([]byte, error) {
 			return nil, err
 		}
 		return encoding.EncodeUntaggedBytesValue(b, encoded), nil
+	case *tree.DTuple:
+		return encodeUntaggedTuple(t, b, encoding.NoColumnID, nil)
 	default:
 		return nil, errors.Errorf("don't know how to encode %s (%T)", d, d)
 	}

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -4071,9 +4071,10 @@ var errNonHomogeneousArray = pgerror.New(pgcode.ArraySubscript, "multidimensiona
 // Append appends a Datum to the array, whose parameterized type must be
 // consistent with the type of the Datum.
 func (d *DArray) Append(v Datum) error {
-	if v != DNull && !d.ParamTyp.Equivalent(v.ResolvedType()) {
-		return errors.AssertionFailedf("cannot append %s to array containing %s", d.ParamTyp,
-			v.ResolvedType())
+	// v.ResolvedType() must be the left-hand side because EquivalentOrNull
+	// only allows null tuple elements on the left-hand side.
+	if !v.ResolvedType().EquivalentOrNull(d.ParamTyp, true /* allowNullTupleEquivalence */) {
+		return errors.AssertionFailedf("cannot append %s to array containing %s", v.ResolvedType(), d.ParamTyp)
 	}
 	if d.Len() >= maxArrayLength {
 		return errors.WithStack(errArrayTooLongError)

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1974,7 +1974,7 @@ func typeCheckSubqueryWithIn(left, right *types.T) error {
 			return pgerror.Newf(pgcode.InvalidParameterValue,
 				unsupportedCompErrFmt, fmt.Sprintf(compSignatureFmt, left, In, right))
 		}
-		if !left.EquivalentOrNull(right.TupleContents()[0]) {
+		if !left.EquivalentOrNull(right.TupleContents()[0], false /* allowNullTupleEquivalence */) {
 			return pgerror.Newf(pgcode.InvalidParameterValue,
 				unsupportedCompErrFmt, fmt.Sprintf(compSignatureFmt, left, In, right))
 		}

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -1813,9 +1813,9 @@ func (t *T) Equivalent(other *T) bool {
 }
 
 // EquivalentOrNull is the same as Equivalent, except it returns true if:
-// * `t` is Unknown (i.e., NULL) and `other` is not a tuple,
+// * `t` is Unknown (i.e., NULL) AND (allowNullTupleEquivalence OR `other` is not a tuple),
 // * `t` is a tuple with all non-Unknown elements matching the types in `other`.
-func (t *T) EquivalentOrNull(other *T) bool {
+func (t *T) EquivalentOrNull(other *T, allowNullTupleEquivalence bool) bool {
 	// Check normal equivalency first, then check for Null
 	normalEquivalency := t.Equivalent(other)
 	if normalEquivalency {
@@ -1824,7 +1824,7 @@ func (t *T) EquivalentOrNull(other *T) bool {
 
 	switch t.Family() {
 	case UnknownFamily:
-		return other.Family() != TupleFamily
+		return allowNullTupleEquivalence || other.Family() != TupleFamily
 
 	case TupleFamily:
 		if other.Family() != TupleFamily {
@@ -1840,7 +1840,7 @@ func (t *T) EquivalentOrNull(other *T) bool {
 			return false
 		}
 		for i := range t.TupleContents() {
-			if !t.TupleContents()[i].EquivalentOrNull(other.TupleContents()[i]) {
+			if !t.TupleContents()[i].EquivalentOrNull(other.TupleContents()[i], allowNullTupleEquivalence) {
 				return false
 			}
 		}


### PR DESCRIPTION
fixes #32715
resurrecting an old PR #32871

Previously, queries that required an array of tuples to be encoded would
fail. This could only happen if a distsql query required such a datum to
be sent over the wire. This commit adds an encoding so such queries can
succeed.

A good followup task to do after this is #63995

Release note (bug fix): queries involving arrays of tuples will no
longer spuriously fail due to an encoding error.