### PR TITLE
release-20.2: sql: properly classify errors for duplicate index names for UNIQUE indexes

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -184,6 +184,12 @@ func (n *alterTableNode) startExec(params runParams) error {
 					}
 					continue
 				}
+
+				// If the index is named, ensure that the name is unique.
+				// Unnamed indexes will be given a unique auto-generated name later on.
+				if d.Name != "" && n.tableDesc.ValidateIndexNameIsUnique(d.Name.String()) != nil {
+					return pgerror.Newf(pgcode.DuplicateRelation, "duplicate index name: %q", d.Name)
+				}
 				idx := descpb.IndexDescriptor{
 					Name:             string(d.Name),
 					Unique:           true,

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1537,6 +1537,11 @@ func NewTableDesc(
 				return nil, unimplemented.NewWithIssue(9148, "use CREATE INDEX to make interleaved indexes")
 			}
 		case *tree.UniqueConstraintTableDef:
+			// If the index is named, ensure that the name is unique.
+			// Unnamed indexes will be given a unique auto-generated name later on.
+			if d.Name != "" && desc.ValidateIndexNameIsUnique(d.Name.String()) != nil {
+				return nil, pgerror.Newf(pgcode.DuplicateRelation, "duplicate index name: %q", d.Name)
+			}
 			idx := descpb.IndexDescriptor{
 				Name:             string(d.Name),
 				Unique:           true,

--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -976,7 +976,7 @@ CREATE TABLE t.test (a STRING PRIMARY KEY, b STRING, c STRING, INDEX foo (c));
 	// "foo" is being added.
 	mt.writeIndexMutation("foo", descpb.DescriptorMutation{Direction: descpb.DescriptorMutation_ADD})
 	if _, err := sqlDB.Exec(`ALTER TABLE t.test ADD CONSTRAINT foo UNIQUE (c)`); !testutils.IsError(err,
-		`duplicate: index "foo" in the middle of being added, not yet public`) {
+		`duplicate index name: "foo"`) {
 		t.Fatal(err)
 	}
 	// Make "foo" live.

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -37,7 +37,7 @@ LIMIT 1
 ----
 SCHEMA CHANGE  ALTER TABLE test.public.t ADD CONSTRAINT foo UNIQUE (b)  root  succeeded  1  ·
 
-statement error duplicate constraint name: "foo"
+statement error pgcode 42P07 duplicate index name: "foo"
 ALTER TABLE t ADD CONSTRAINT foo UNIQUE (b)
 
 statement error pq: multiple primary keys for table "t" are not allowed
@@ -1430,3 +1430,11 @@ ALTER TABLE t60786 DROP CONSTRAINT ck CASCADE
 
 statement ok
 ROLLBACK
+
+subtest unique_index_duplicate_name
+
+statement ok
+CREATE TABLE duplicate_index_test (k INT PRIMARY KEY, v INT, INDEX idx (v));
+
+statement error pgcode 42P07 duplicate index name: \"idx\"
+ALTER TABLE duplicate_index_test ADD CONSTRAINT idx UNIQUE (v)

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -333,3 +333,10 @@ CREATE TABLE ctas AS (SELECT * FROM crdb_internal.node_transaction_statistics);
 
 query error crdb_internal.node_txn_stats cannot be used in this context
 CREATE TABLE ctas AS (SELECT * FROM crdb_internal.node_txn_stats);
+subtest duplicate_index_name_unique_index
+
+statement error pgcode 42P07 duplicate index name: \"idx\"
+CREATE TABLE error (a INT, b INT, INDEX idx (a), UNIQUE INDEX idx (b))
+
+statement error pgcode 42P07 duplicate index name: \"idx\"
+CREATE TABLE error (a INT, b INT, UNIQUE INDEX idx (a), UNIQUE INDEX idx (b))


### PR DESCRIPTION
Backport 2/2 commits from #63934.

/cc @cockroachdb/release

---

Two commits, one for `CREATE TABLE` one for `ALTER TABLE`.

Touches #63026.

Release note (bug fix): Fixed error classification for ALTER TABLE ... ADD
CONSTRAINT ... UNIQUE with the same name as an existing index.

Release note (bug fix): Fixed the error classification for duplicate index
names where the later index was a UNIQUE index.

