### PR TITLE
sql: use exec cluster settings in schemachange

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1748,7 +1748,7 @@ func revalidateIndexes(
 	// since our table is offline.
 	var runner sql.HistoricalInternalExecTxnRunner = func(ctx context.Context, fn sql.InternalExecFn) error {
 		return execCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-			ie := job.MakeSessionBoundInternalExecutor(ctx, sql.NewFakeSessionData()).(*sql.InternalExecutor)
+			ie := job.MakeSessionBoundInternalExecutor(ctx, sql.NewFakeSessionData(execCfg.SV())).(*sql.InternalExecutor)
 			return fn(ctx, txn, ie)
 		})
 	}

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangecache"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
@@ -1995,7 +1996,7 @@ func (sc *SchemaChanger) txn(
 func (sc *SchemaChanger) txnWithModified(
 	ctx context.Context, f func(context.Context, *kv.Txn, *descs.Collection) error,
 ) (descsWithNewVersions []lease.IDVersion, _ error) {
-	ie := sc.ieFactory(ctx, NewFakeSessionData())
+	ie := sc.ieFactory(ctx, NewFakeSessionData(sc.execCfg.SV()))
 	if err := descs.Txn(ctx, sc.settings, sc.leaseMgr, ie, sc.db, func(
 		ctx context.Context, txn *kv.Txn, descsCol *descs.Collection,
 	) error {
@@ -2024,7 +2025,7 @@ func createSchemaChangeEvalCtx(
 	ieFactory sqlutil.SessionBoundInternalExecutorFactory,
 ) extendedEvalContext {
 
-	sd := NewFakeSessionData()
+	sd := NewFakeSessionData(execCfg.SV())
 
 	evalCtx := extendedEvalContext{
 		// Make a session tracing object on-the-fly. This is OK
@@ -2070,7 +2071,7 @@ func createSchemaChangeEvalCtx(
 // NewFakeSessionData returns "fake" session data for use in internal queries
 // that are not run on behalf of a user session, such as those run during the
 // steps of background jobs and schema changes.
-func NewFakeSessionData() *sessiondata.SessionData {
+func NewFakeSessionData(sv *settings.Values) *sessiondata.SessionData {
 	sd := &sessiondata.SessionData{
 		SessionData: sessiondatapb.SessionData{
 			// The database is not supposed to be needed in schema changes, as there
@@ -2081,13 +2082,18 @@ func NewFakeSessionData() *sessiondata.SessionData {
 			// And in fact it is used by `current_schemas()`, which, although is a pure
 			// function, takes arguments which might be impure (so it can't always be
 			// pre-evaluated).
-			Database:  "",
-			UserProto: security.NodeUserName().EncodeProto(),
+			Database:      "",
+			UserProto:     security.NodeUserName().EncodeProto(),
+			VectorizeMode: sessiondatapb.VectorizeExecMode(VectorizeClusterMode.Get(sv)),
+		},
+		LocalOnlySessionData: sessiondata.LocalOnlySessionData{
+			DistSQLMode: sessiondata.DistSQLExecMode(DistSQLClusterExecMode.Get(sv)),
 		},
 		SearchPath:    sessiondata.DefaultSearchPathForUser(security.NodeUserName()),
 		SequenceState: sessiondata.NewSequenceState(),
 		Location:      time.UTC,
 	}
+
 	return sd
 }
 


### PR DESCRIPTION
Previously, any internal executor work spawned by schema changes for
validation queries would never use the vectorized engine or use distsql
distribution. This is unfortunate because the validation queries are
OLAP by nature and benefit from vectorized and distribution
significantly.

Now, these queries will decide whether to use the vectorized engine and
distsql distribution by consulting the cluster setting.

Release note (sql change): validation queries run on behalf of schema
changes, such as foreign key validations, unique constraint validations,
and check constraint validations, will now use the vectorized engine and
DistSQL distribution based on the defaults set in the cluster
settings. This may speed up validation queries.