### PR TITLE
release-20.2: sql: use exec cluster settings in schemachange

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1320,7 +1320,7 @@ func revalidateIndexes(
 	// since our table is offline.
 	var runner sql.HistoricalInternalExecTxnRunner = func(ctx context.Context, fn sql.InternalExecFn) error {
 		return execCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-			ie := job.MakeSessionBoundInternalExecutor(ctx, sql.NewFakeSessionData()).(*sql.InternalExecutor)
+			ie := job.MakeSessionBoundInternalExecutor(ctx, sql.NewFakeSessionData(&execCfg.Settings.SV)).(*sql.InternalExecutor)
 			return fn(ctx, txn, ie)
 		})
 	}


### PR DESCRIPTION
Backport 1/1 commits from #64003.

/cc @cockroachdb/release

---

Previously, any internal executor work spawned by schema changes for
validation queries would never use the vectorized engine or use distsql
distribution. This is unfortunate because the validation queries are
OLAP by nature and benefit from vectorized and distribution
significantly.

Now, these queries will decide whether to use the vectorized engine and
distsql distribution by consulting the cluster setting.

Release note (sql change): validation queries run on behalf of schema
changes, such as foreign key validations, unique constraint validations,
and check constraint validations, will now use the vectorized engine and
DistSQL distribution based on the defaults set in the cluster
settings. This may speed up validation queries.
