### PR TITLE
release-21.1: kvserver: fix tscache read summaries

### DIFF
--- a/pkg/kv/kvserver/replica_closedts.go
+++ b/pkg/kv/kvserver/replica_closedts.go
@@ -208,9 +208,10 @@ type sidetransportReceiver interface {
 	GetClosedTimestamp(
 		ctx context.Context, rangeID roachpb.RangeID, leaseholderNode roachpb.NodeID,
 	) (hlc.Timestamp, ctpb.LAI)
+	HTML() string
 }
 
-func (st *sidetransportAccess) init(receiver *sidetransport.Receiver, rangeID roachpb.RangeID) {
+func (st *sidetransportAccess) init(receiver sidetransportReceiver, rangeID roachpb.RangeID) {
 	if receiver != nil {
 		// Avoid st.receiver becoming a typed nil.
 		st.receiver = receiver

--- a/pkg/kv/kvserver/replica_follower_read.go
+++ b/pkg/kv/kvserver/replica_follower_read.go
@@ -196,6 +196,9 @@ func (r *Replica) ClosedTimestampV2(ctx context.Context) hlc.Timestamp {
 	r.mu.RLock()
 	appliedLAI := ctpb.LAI(r.mu.state.LeaseAppliedIndex)
 	leaseholder := r.mu.state.Lease.Replica.NodeID
+	raftClosed := r.mu.state.RaftClosedTimestamp
 	r.mu.RUnlock()
-	return r.sideTransportClosedTimestamp.get(ctx, leaseholder, appliedLAI, hlc.Timestamp{} /* sufficient */)
+	sideTransportClosed := r.sideTransportClosedTimestamp.get(ctx, leaseholder, appliedLAI, hlc.Timestamp{} /* sufficient */)
+	raftClosed.Forward(sideTransportClosed)
+	return raftClosed
 }

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -652,7 +652,7 @@ type StoreConfig struct {
 
 	ClosedTimestamp         *container.Container
 	ClosedTimestampSender   *sidetransport.Sender
-	ClosedTimestampReceiver *sidetransport.Receiver
+	ClosedTimestampReceiver sidetransportReceiver
 
 	// SQLExecutor is used by the store to execute SQL statements.
 	SQLExecutor sqlutil.InternalExecutor

--- a/pkg/server/debug/server.go
+++ b/pkg/server/debug/server.go
@@ -253,10 +253,15 @@ func (ds *Server) RegisterEngines(specs []base.StoreSpec, engines []storage.Engi
 	return nil
 }
 
+// sidetransportReceiver abstracts *sidetransport.Receiver.
+type sidetransportReceiver interface {
+	HTML() string
+}
+
 // RegisterClosedTimestampSideTransport registers web endpoints for the closed
 // timestamp side transport sender and receiver.
 func (ds *Server) RegisterClosedTimestampSideTransport(
-	sender *sidetransport.Sender, receiver *sidetransport.Receiver,
+	sender *sidetransport.Sender, receiver sidetransportReceiver,
 ) {
 	ds.mux.HandleFunc("/debug/closedts-receiver",
 		func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
Backport 1/1 commits from #64001.

/cc @cockroachdb/release

---

r.ClosedTimestampV2() was recently broken in that it was only
consultingh the side-transport, not the raft closed timestamp. This lead
to read summaries (used by lease transfers and range merges) to not
properly incorporate the closed timestamp.

This broke in https://github.com/cockroachdb/cockroach/pull/63357/commits/edc4b5372bac83d16d8040eea9cdff8b73f081fc

Release note: None
