### PR TITLE
sql: disallow RBR transforms if transitioning indexes are incompatible

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
+++ b/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
@@ -2625,7 +2625,7 @@ CREATE TABLE hash_sharded_idx_table (
   pk INT PRIMARY KEY USING HASH WITH BUCKET_COUNT = 8
 )
 
-statement error cannot convert a table to REGIONAL BY ROW if table table contains hash sharded indexes
+statement error cannot convert hash_sharded_idx_table to REGIONAL BY ROW as the table contains hash sharded indexes
 ALTER TABLE hash_sharded_idx_table SET LOCALITY REGIONAL BY ROW
 
 statement ok

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -746,7 +746,7 @@ func checkCanConvertTableToMultiRegion(
 			tableDesc.GetName(),
 		)
 	}
-	for _, idx := range tableDesc.NonDropIndexes() {
+	for _, idx := range tableDesc.AllIndexes() {
 		if idx.GetPartitioning().NumColumns > 0 {
 			return errors.WithDetailf(
 				pgerror.Newf(

--- a/pkg/sql/alter_table_locality.go
+++ b/pkg/sql/alter_table_locality.go
@@ -240,9 +240,13 @@ func (n *alterTableSetLocalityNode) alterTableLocalityToRegionalByRow(
 		return interleaveOnRegionalByRowError()
 	}
 
-	for _, idx := range n.tableDesc.NonDropIndexes() {
+	for _, idx := range n.tableDesc.AllIndexes() {
 		if idx.IsSharded() {
-			return pgerror.New(pgcode.FeatureNotSupported, "cannot convert a table to REGIONAL BY ROW if table table contains hash sharded indexes")
+			return pgerror.Newf(
+				pgcode.FeatureNotSupported,
+				"cannot convert %s to REGIONAL BY ROW as the table contains hash sharded indexes",
+				tree.Name(n.tableDesc.GetName()),
+			)
 		}
 	}
 


### PR DESCRIPTION
Release note (bug fix): Previously, if a DROP INDEX failed during a
REGIONAL BY ROW transition, the index may be re-inserted back into the
REGIONAL BY ROW table but would be invalid if it was sharded or
partitioned. This is now rectified.