### PR TITLE
release-20.2: builtins: fix crdb_internal.encode_key for user defined types

### DIFF
--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -204,3 +204,17 @@ func (p *planner) createDescriptorWithID(
 	}
 	return nil
 }
+
+// GetImmutableTableInterfaceByID is part of the EvalPlanner interface.
+func (p *planner) GetImmutableTableInterfaceByID(ctx context.Context, id int) (interface{}, error) {
+	desc, err := p.Descriptors().GetTableVersionByID(
+		ctx,
+		p.txn,
+		descpb.ID(id),
+		tree.ObjectLookupFlagsWithRequired(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return desc, nil
+}

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -101,6 +101,13 @@ func (ep *DummyEvalPlanner) UnsafeUpsertDescriptor(
 	return errors.WithStack(errEvalPlanner)
 }
 
+// GetImmutableTableInterfaceByID is part of the EvalPlanner interface.
+func (ep *DummyEvalPlanner) GetImmutableTableInterfaceByID(
+	ctx context.Context, id int,
+) (interface{}, error) {
+	return nil, errors.WithStack(errEvalPlanner)
+}
+
 // UnsafeDeleteDescriptor is part of the EvalPlanner interface.
 func (ep *DummyEvalPlanner) UnsafeDeleteDescriptor(
 	ctx context.Context, descID int64, force bool,

--- a/pkg/sql/logictest/testdata/logic_test/ranges
+++ b/pkg/sql/logictest/testdata/logic_test/ranges
@@ -564,3 +564,21 @@ ALTER INDEX i59011 SPLIT AT VALUES (2, '6cf22b39-a1eb-43ee-8edf-0da8543c5c38'::U
 
 statement error excessive number of values provided: expected 1, got 2
 ALTER INDEX i59011 UNSPLIT AT VALUES (2, '6cf22b39-a1eb-43ee-8edf-0da8543c5c38'::UUID);
+
+# Regression for #63646
+
+statement ok
+CREATE TYPE e63646 AS ENUM ('a', 'b');
+CREATE TABLE t63646 (e e63646 PRIMARY KEY);
+INSERT INTO t63646 VALUES ('a'), ('b');
+ALTER TABLE t63646 SPLIT AT VALUES ('a'), ('b')
+
+query TT
+SELECT start_key, end_key FROM [SHOW RANGE FROM TABLE t63646 FOR ROW ('a')]
+----
+/"@"  /"\x80"
+
+query TT
+SELECT start_key, end_key FROM [SHOW RANGE FROM TABLE t63646 FOR ROW ('b')]
+----
+/"\x80"  NULL

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2986,6 +2986,10 @@ type EvalPlanner interface {
 	EvalDatabase
 	TypeReferenceResolver
 
+	// GetImmutableTableInterfaceByID returns an interface{} with
+	// catalog.TableDescriptor to avoid a circular dependency.
+	GetImmutableTableInterfaceByID(ctx context.Context, id int) (interface{}, error)
+
 	// GetTypeFromValidSQLSyntax parses a column type when the input
 	// string uses the parseable SQL representation of a type name, e.g.
 	// `INT(13)`, `mytype`, `"mytype"`, `pg_catalog.int4` or `"public".mytype`.


### PR DESCRIPTION
Backport 1/1 commits from #63716.

/cc @cockroachdb/release

---

Resolves #63646

Release note (bug fix): Fix crdb_internal.encode_key for user defined
types. This would previously error.
