### PR TITLE
release-20.2: sql: make column backfill batch size a setting

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -53,13 +53,6 @@ import (
 )
 
 const (
-	// TODO(vivek): Replace these constants with a runtime budget for the
-	// operation chunk involved.
-
-	// columnTruncateAndBackfillChunkSize is the maximum number of columns
-	// processed per chunk during column truncate or backfill.
-	columnTruncateAndBackfillChunkSize = 200
-
 	// indexTruncateChunkSize is the maximum number of index entries truncated
 	// per chunk during an index truncation. This value is larger than the
 	// other chunk constants because the operation involves only running a
@@ -83,6 +76,14 @@ var indexBulkBackfillChunkSize = settings.RegisterIntSetting(
 	"schemachanger.bulk_index_backfill.batch_size",
 	"number of rows to process at a time during bulk index backfill",
 	50000,
+)
+
+// columnBackfillBatchSize is the maximum number of rows we update at once when
+// adding or removing columns.
+var columnBackfillBatchSize = settings.RegisterNonNegativeIntSetting(
+	"bulkio.column_backfill.batch_size",
+	"the number of rows updated at a time to add/remove columns",
+	200,
 )
 
 var _ sort.Interface = columnsByID{}
@@ -1648,7 +1649,7 @@ func (sc *SchemaChanger) truncateAndBackfillColumns(
 	log.Infof(ctx, "clearing and backfilling columns")
 
 	if err := sc.distBackfill(
-		ctx, version, columnBackfill, columnTruncateAndBackfillChunkSize,
+		ctx, version, columnBackfill, columnBackfillBatchSize.Get(&sc.settings.SV),
 		backfill.ColumnMutationFilter, nil); err != nil {
 		return err
 	}
@@ -2050,7 +2051,7 @@ func columnBackfillInTxn(
 	for sp.Key != nil {
 		var err error
 		sp.Key, err = backfiller.RunColumnBackfillChunk(ctx,
-			txn, tableDesc, sp, columnTruncateAndBackfillChunkSize,
+			txn, tableDesc, sp, columnBackfillBatchSize.Get(&evalCtx.Settings.SV),
 			false /*alsoCommit*/, traceKV)
 		if err != nil {
 			return err


### PR DESCRIPTION
Backport 1/1 commits from #63936.

/cc @cockroachdb/release

---

Release note: none.
