### PR TITLE
release-21.1: sql: make column backfill batch size a setting

### DIFF
--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -20,7 +20,7 @@ import (
 
 // MaxSettings is the maximum number of settings that the system supports.
 // Exported for tests.
-const MaxSettings = 256
+const MaxSettings = 512
 
 // Values is a container that stores values for all registered settings.
 // Each setting is assigned a unique slot (up to MaxSettings).

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -51,13 +51,6 @@ import (
 )
 
 const (
-	// TODO(vivek): Replace these constants with a runtime budget for the
-	// operation chunk involved.
-
-	// columnTruncateAndBackfillChunkSize is the maximum number of rows
-	// processed per chunk during column truncate or backfill.
-	columnTruncateAndBackfillChunkSize = 200
-
 	// indexTruncateChunkSize is the maximum number of index entries truncated
 	// per chunk during an index truncation. This value is larger than the
 	// other chunk constants because the operation involves only running a
@@ -84,6 +77,15 @@ var indexBackfillBatchSize = settings.RegisterIntSetting(
 	"bulkio.index_backfill.batch_size",
 	"the number of rows for which we construct index entries in a single batch",
 	50000,
+	settings.NonNegativeInt, /* validateFn */
+)
+
+// columnBackfillBatchSize is the maximum number of rows we update at once when
+// adding or removing columns.
+var columnBackfillBatchSize = settings.RegisterIntSetting(
+	"bulkio.column_backfill.batch_size",
+	"the number of rows updated at a time to add/remove columns",
+	200,
 	settings.NonNegativeInt, /* validateFn */
 )
 
@@ -1886,7 +1888,7 @@ func (sc *SchemaChanger) truncateAndBackfillColumns(
 	log.Infof(ctx, "clearing and backfilling columns")
 
 	if err := sc.distBackfill(
-		ctx, version, columnBackfill, columnTruncateAndBackfillChunkSize,
+		ctx, version, columnBackfill, columnBackfillBatchSize.Get(&sc.settings.SV),
 		backfill.ColumnMutationFilter, nil); err != nil {
 		return err
 	}
@@ -2347,7 +2349,7 @@ func columnBackfillInTxn(
 	for sp.Key != nil {
 		var err error
 		sp.Key, err = backfiller.RunColumnBackfillChunk(ctx,
-			txn, tableDesc, sp, columnTruncateAndBackfillChunkSize,
+			txn, tableDesc, sp, columnBackfillBatchSize.Get(&evalCtx.Settings.SV),
 			false /*alsoCommit*/, traceKV)
 		if err != nil {
 			return err


### PR DESCRIPTION
Backport 1/1 commits from #63936.

/cc @cockroachdb/release

---

Release note: none.
