### PR TITLE
release-21.1: sql: use read ts as batch ts to send index backfill SSTs

### DIFF
--- a/pkg/ccl/importccl/bench_test.go
+++ b/pkg/ccl/importccl/bench_test.go
@@ -140,7 +140,7 @@ func benchmarkAddSSTable(b *testing.B, dir string, tables []tableSSTable) {
 		for _, t := range tables {
 			totalBytes += int64(len(t.sstData))
 			require.NoError(b, kvDB.AddSSTable(
-				ctx, t.span.Key, t.span.EndKey, t.sstData, true /* disallowShadowing */, nil /* stats */, false, /*ingestAsWrites */
+				ctx, t.span.Key, t.span.EndKey, t.sstData, true /* disallowShadowing */, nil /* stats */, false /*ingestAsWrites */, hlc.Timestamp{},
 			))
 		}
 		b.StopTimer()

--- a/pkg/kv/bulk/buffering_adder.go
+++ b/pkg/kv/bulk/buffering_adder.go
@@ -108,6 +108,7 @@ func MakeBulkAdder(
 			skipDuplicates:    opts.SkipDuplicates,
 			disallowShadowing: opts.DisallowShadowing,
 			splitAfter:        opts.SplitAndScatterAfter,
+			batchTS:           opts.BatchTimestamp,
 		},
 		timestamp:           timestamp,
 		curBufferSize:       opts.MinBufferSize,

--- a/pkg/kv/bulk/sst_batcher_test.go
+++ b/pkg/kv/bulk/sst_batcher_test.go
@@ -270,6 +270,7 @@ func (m mockSender) AddSSTable(
 	disallowShadowing bool,
 	_ *enginepb.MVCCStats,
 	ingestAsWrites bool,
+	batchTS hlc.Timestamp,
 ) error {
 	return m(roachpb.Span{Key: begin.(roachpb.Key), EndKey: end.(roachpb.Key)})
 }
@@ -333,7 +334,7 @@ func TestAddBigSpanningSSTWithSplits(t *testing.T) {
 
 	t.Logf("Adding %dkb sst spanning %d splits from %v to %v", len(sst)/kb, len(splits), start, end)
 	if _, err := bulk.AddSSTable(
-		ctx, mock, start, end, sst, false /* disallowShadowing */, enginepb.MVCCStats{}, cluster.MakeTestingClusterSettings(),
+		ctx, mock, start, end, sst, false /* disallowShadowing */, enginepb.MVCCStats{}, cluster.MakeTestingClusterSettings(), hlc.Timestamp{},
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -688,8 +688,9 @@ func (db *DB) AddSSTable(
 	disallowShadowing bool,
 	stats *enginepb.MVCCStats,
 	ingestAsWrites bool,
+	batchTs hlc.Timestamp,
 ) error {
-	b := &Batch{}
+	b := &Batch{Header: roachpb.Header{Timestamp: batchTs}}
 	b.addSSTable(begin, end, data, disallowShadowing, stats, ingestAsWrites)
 	return getOneErr(db.Run(ctx, b), b)
 }

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -96,6 +96,10 @@ func TestDBAddSSTable(t *testing.T) {
 	})
 }
 
+const ingestAsWrites, ingestAsSST = true, false
+
+var nilStats *enginepb.MVCCStats
+
 // if store != nil, assume it is on-disk and check ingestion semantics.
 func runTestDBAddSSTable(
 	ctx context.Context, t *testing.T, db *kv.DB, tr *tracing.Tracer, store *kvserver.Store,
@@ -110,13 +114,13 @@ func runTestDBAddSSTable(
 
 		// Key is before the range in the request span.
 		if err := db.AddSSTable(
-			ctx, "d", "e", data, false /* disallowShadowing */, nil /* stats */, false, /* ingestAsWrites */
+			ctx, "d", "e", data, false /* disallowShadowing */, nilStats, ingestAsSST, hlc.Timestamp{},
 		); !testutils.IsError(err, "not in request range") {
 			t.Fatalf("expected request range error got: %+v", err)
 		}
 		// Key is after the range in the request span.
 		if err := db.AddSSTable(
-			ctx, "a", "b", data, false /* disallowShadowing */, nil /* stats */, false, /* ingestAsWrites */
+			ctx, "a", "b", data, false /* disallowShadowing */, nilStats, ingestAsSST, hlc.Timestamp{},
 		); !testutils.IsError(err, "not in request range") {
 			t.Fatalf("expected request range error got: %+v", err)
 		}
@@ -125,7 +129,7 @@ func runTestDBAddSSTable(
 		ingestCtx, collect, cancel := tracing.ContextWithRecordingSpan(ctx, tr, "test-recording")
 		defer cancel()
 		if err := db.AddSSTable(
-			ingestCtx, "b", "c", data, false /* disallowShadowing */, nil /* stats */, false, /* ingestAsWrites */
+			ingestCtx, "b", "c", data, false /* disallowShadowing */, nilStats, ingestAsSST, hlc.Timestamp{},
 		); err != nil {
 			t.Fatalf("%+v", err)
 		}
@@ -168,7 +172,7 @@ func runTestDBAddSSTable(
 		}
 
 		if err := db.AddSSTable(
-			ctx, "b", "c", data, false /* disallowShadowing */, nil /* stats */, false, /* ingestAsWrites */
+			ctx, "b", "c", data, false /* disallowShadowing */, nilStats, ingestAsSST, hlc.Timestamp{},
 		); err != nil {
 			t.Fatalf("%+v", err)
 		}
@@ -205,7 +209,7 @@ func runTestDBAddSSTable(
 			defer cancel()
 
 			if err := db.AddSSTable(
-				ingestCtx, "b", "c", data, false /* disallowShadowing */, nil /* stats */, false, /* ingestAsWrites */
+				ingestCtx, "b", "c", data, false /* disallowShadowing */, nilStats, ingestAsSST, hlc.Timestamp{},
 			); err != nil {
 				t.Fatalf("%+v", err)
 			}
@@ -260,7 +264,7 @@ func runTestDBAddSSTable(
 			defer cancel()
 
 			if err := db.AddSSTable(
-				ingestCtx, "b", "c", data, false /* disallowShadowing */, nil /* stats */, true, /* ingestAsWrites */
+				ingestCtx, "b", "c", data, false /* disallowShadowing */, nilStats, ingestAsWrites, hlc.Timestamp{},
 			); err != nil {
 				t.Fatalf("%+v", err)
 			}
@@ -300,7 +304,7 @@ func runTestDBAddSSTable(
 		}
 
 		if err := db.AddSSTable(
-			ctx, "b", "c", data, false /* disallowShadowing */, nil /* stats */, false, /* ingestAsWrites */
+			ctx, "b", "c", data, false /* disallowShadowing */, nilStats, ingestAsSST, hlc.Timestamp{},
 		); !testutils.IsError(err, "invalid checksum") {
 			t.Fatalf("expected 'invalid checksum' error got: %+v", err)
 		}

--- a/pkg/kv/kvserver/kvserverbase/bulk_adder.go
+++ b/pkg/kv/kvserver/kvserverbase/bulk_adder.go
@@ -58,6 +58,11 @@ type BulkAdderOptions struct {
 	// DisallowShadowing controls whether shadowing of existing keys is permitted
 	// when the SSTables produced by this adder are ingested.
 	DisallowShadowing bool
+
+	// BatchTimestamp is the timestamp to use on AddSSTable requests (which can be
+	// different from the timestamp used to construct the adder which is what is
+	// actually applied to each key).
+	BatchTimestamp hlc.Timestamp
 }
 
 // DisableExplicitSplits can be returned by a SplitAndScatterAfter function to

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -186,6 +186,7 @@ func (ib *indexBackfiller) ingestIndexEntries(
 		MaxBufferSize:  maxBufferSize,
 		StepBufferSize: stepSize,
 		SkipDuplicates: ib.ContainsInvertedIndex(),
+		BatchTimestamp: ib.spec.ReadAsOf,
 	}
 	adder, err := ib.flowCtx.Cfg.BulkAdder(ctx, ib.flowCtx.Cfg.DB, ib.spec.ReadAsOf, opts)
 	if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #64023.

/cc @cockroachdb/release

---

This changes SSTs sent by index backfills to be sent with a batch
timestamp equal to the timestamp that was used to read the rows from
which the index entries in that SST were generated.

This is done to ensure that if the index span has already GCed any
keys related to more recent SQL writes the SST will be rejected. Adding
the SST generated from older writes could otherwise accidentally re-add
an entry after a later SQL delete's tombstone had been GC'ed, as described
in #64014.

Release note (bug fix): fix a theoretical issue in index backfills that could result in stale entries that would likely fail validation (#64014).
