### PR TITLE
release-20.2: sql: use read ts as batch ts to send index backfill SSTs

### DIFF
--- a/pkg/ccl/importccl/bench_test.go
+++ b/pkg/ccl/importccl/bench_test.go
@@ -137,7 +137,7 @@ func benchmarkAddSSTable(b *testing.B, dir string, tables []tableSSTable) {
 		for _, t := range tables {
 			totalBytes += int64(len(t.sstData))
 			require.NoError(b, kvDB.AddSSTable(
-				ctx, t.span.Key, t.span.EndKey, t.sstData, true /* disallowShadowing */, nil /* stats */, false, /*ingestAsWrites */
+				ctx, t.span.Key, t.span.EndKey, t.sstData, true /* disallowShadowing */, nil /* stats */, false /*ingestAsWrites */, hlc.Timestamp{},
 			))
 		}
 		b.StopTimer()

--- a/pkg/kv/bulk/buffering_adder.go
+++ b/pkg/kv/bulk/buffering_adder.go
@@ -106,6 +106,7 @@ func MakeBulkAdder(
 			skipDuplicates:    opts.SkipDuplicates,
 			disallowShadowing: opts.DisallowShadowing,
 			splitAfter:        opts.SplitAndScatterAfter,
+			batchTS:           opts.BatchTimestamp,
 		},
 		timestamp:           timestamp,
 		curBufferSize:       opts.MinBufferSize,

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -72,6 +72,10 @@ type SSTBatcher struct {
 	// will not raise a DuplicateKeyError.
 	skipDuplicates bool
 
+	// batchTS is the timestamp that will be set on batch requests used to send
+	// produced SSTs.
+	batchTS hlc.Timestamp
+
 	// The rest of the fields accumulated state as opposed to configuration. Some,
 	// like totalRows, are accumulated _across_ batches and are not reset between
 	// batches when Reset() is called.
@@ -296,7 +300,7 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int, nextKey roachpb.Ke
 	}
 
 	beforeSend := timeutil.Now()
-	files, err := AddSSTable(ctx, b.db, start, end, b.sstFile.Data(), b.disallowShadowing, b.ms, b.settings)
+	files, err := AddSSTable(ctx, b.db, start, end, b.sstFile.Data(), b.disallowShadowing, b.ms, b.settings, b.batchTS)
 	if err != nil {
 		return err
 	}
@@ -353,7 +357,13 @@ func (b *SSTBatcher) GetSummary() roachpb.BulkOpSummary {
 // SSTSender is an interface to send SST data to an engine.
 type SSTSender interface {
 	AddSSTable(
-		ctx context.Context, begin, end interface{}, data []byte, disallowShadowing bool, stats *enginepb.MVCCStats, ingestAsWrites bool,
+		ctx context.Context,
+		begin, end interface{},
+		data []byte,
+		disallowShadowing bool,
+		stats *enginepb.MVCCStats,
+		ingestAsWrites bool,
+		batchTs hlc.Timestamp,
 	) error
 	SplitAndScatter(ctx context.Context, key roachpb.Key, expirationTime hlc.Timestamp) error
 }
@@ -376,6 +386,7 @@ func AddSSTable(
 	disallowShadowing bool,
 	ms enginepb.MVCCStats,
 	settings *cluster.Settings,
+	batchTs hlc.Timestamp,
 ) (int, error) {
 	var files int
 	now := timeutil.Now()
@@ -421,7 +432,7 @@ func AddSSTable(
 					ingestAsWriteBatch = true
 				}
 				// This will fail if the range has split but we'll check for that below.
-				err = db.AddSSTable(ctx, item.start, item.end, item.sstBytes, item.disallowShadowing, &item.stats, ingestAsWriteBatch)
+				err = db.AddSSTable(ctx, item.start, item.end, item.sstBytes, item.disallowShadowing, &item.stats, ingestAsWriteBatch, batchTs)
 				if err == nil {
 					log.VEventf(ctx, 3, "adding %s AddSSTable [%s,%s) took %v", sz(len(item.sstBytes)), item.start, item.end, timeutil.Since(before))
 					return nil

--- a/pkg/kv/bulk/sst_batcher_test.go
+++ b/pkg/kv/bulk/sst_batcher_test.go
@@ -270,6 +270,7 @@ func (m mockSender) AddSSTable(
 	disallowShadowing bool,
 	_ *enginepb.MVCCStats,
 	ingestAsWrites bool,
+	batchTS hlc.Timestamp,
 ) error {
 	return m(roachpb.Span{Key: begin.(roachpb.Key), EndKey: end.(roachpb.Key)})
 }
@@ -333,7 +334,7 @@ func TestAddBigSpanningSSTWithSplits(t *testing.T) {
 
 	t.Logf("Adding %dkb sst spanning %d splits from %v to %v", len(sst)/kb, len(splits), start, end)
 	if _, err := bulk.AddSSTable(
-		ctx, mock, start, end, sst, false /* disallowShadowing */, enginepb.MVCCStats{}, cluster.MakeTestingClusterSettings(),
+		ctx, mock, start, end, sst, false /* disallowShadowing */, enginepb.MVCCStats{}, cluster.MakeTestingClusterSettings(), hlc.Timestamp{},
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -633,8 +633,9 @@ func (db *DB) AddSSTable(
 	disallowShadowing bool,
 	stats *enginepb.MVCCStats,
 	ingestAsWrites bool,
+	batchTs hlc.Timestamp,
 ) error {
-	b := &Batch{}
+	b := &Batch{Header: roachpb.Header{Timestamp: batchTs}}
 	b.addSSTable(begin, end, data, disallowShadowing, stats, ingestAsWrites)
 	return getOneErr(db.Run(ctx, b), b)
 }

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -101,6 +101,10 @@ func TestDBAddSSTable(t *testing.T) {
 	})
 }
 
+const ingestAsWrites, ingestAsSST = true, false
+
+var nilStats *enginepb.MVCCStats
+
 // if store != nil, assume it is on-disk and check ingestion semantics.
 func runTestDBAddSSTable(ctx context.Context, t *testing.T, db *kv.DB, store *kvserver.Store) {
 	{
@@ -112,13 +116,13 @@ func runTestDBAddSSTable(ctx context.Context, t *testing.T, db *kv.DB, store *kv
 
 		// Key is before the range in the request span.
 		if err := db.AddSSTable(
-			ctx, "d", "e", data, false /* disallowShadowing */, nil /* stats */, false, /* ingestAsWrites */
+			ctx, "d", "e", data, false /* disallowShadowing */, nilStats, ingestAsSST, hlc.Timestamp{},
 		); !testutils.IsError(err, "not in request range") {
 			t.Fatalf("expected request range error got: %+v", err)
 		}
 		// Key is after the range in the request span.
 		if err := db.AddSSTable(
-			ctx, "a", "b", data, false /* disallowShadowing */, nil /* stats */, false, /* ingestAsWrites */
+			ctx, "a", "b", data, false /* disallowShadowing */, nilStats, ingestAsSST, hlc.Timestamp{},
 		); !testutils.IsError(err, "not in request range") {
 			t.Fatalf("expected request range error got: %+v", err)
 		}
@@ -127,7 +131,7 @@ func runTestDBAddSSTable(ctx context.Context, t *testing.T, db *kv.DB, store *kv
 		ingestCtx, collect, cancel := tracing.ContextWithRecordingSpan(ctx, "test-recording")
 		defer cancel()
 		if err := db.AddSSTable(
-			ingestCtx, "b", "c", data, false /* disallowShadowing */, nil /* stats */, false, /* ingestAsWrites */
+			ingestCtx, "b", "c", data, false /* disallowShadowing */, nilStats, ingestAsSST, hlc.Timestamp{},
 		); err != nil {
 			t.Fatalf("%+v", err)
 		}
@@ -170,7 +174,7 @@ func runTestDBAddSSTable(ctx context.Context, t *testing.T, db *kv.DB, store *kv
 		}
 
 		if err := db.AddSSTable(
-			ctx, "b", "c", data, false /* disallowShadowing */, nil /* stats */, false, /* ingestAsWrites */
+			ctx, "b", "c", data, false /* disallowShadowing */, nilStats, ingestAsSST, hlc.Timestamp{},
 		); err != nil {
 			t.Fatalf("%+v", err)
 		}
@@ -207,7 +211,7 @@ func runTestDBAddSSTable(ctx context.Context, t *testing.T, db *kv.DB, store *kv
 			defer cancel()
 
 			if err := db.AddSSTable(
-				ingestCtx, "b", "c", data, false /* disallowShadowing */, nil /* stats */, false, /* ingestAsWrites */
+				ingestCtx, "b", "c", data, false /* disallowShadowing */, nilStats, ingestAsSST, hlc.Timestamp{},
 			); err != nil {
 				t.Fatalf("%+v", err)
 			}
@@ -262,7 +266,7 @@ func runTestDBAddSSTable(ctx context.Context, t *testing.T, db *kv.DB, store *kv
 			defer cancel()
 
 			if err := db.AddSSTable(
-				ingestCtx, "b", "c", data, false /* disallowShadowing */, nil /* stats */, true, /* ingestAsWrites */
+				ingestCtx, "b", "c", data, false /* disallowShadowing */, nilStats, ingestAsWrites, hlc.Timestamp{},
 			); err != nil {
 				t.Fatalf("%+v", err)
 			}
@@ -302,7 +306,7 @@ func runTestDBAddSSTable(ctx context.Context, t *testing.T, db *kv.DB, store *kv
 		}
 
 		if err := db.AddSSTable(
-			ctx, "b", "c", data, false /* disallowShadowing */, nil /* stats */, false, /* ingestAsWrites */
+			ctx, "b", "c", data, false /* disallowShadowing */, nilStats, ingestAsSST, hlc.Timestamp{},
 		); !testutils.IsError(err, "invalid checksum") {
 			t.Fatalf("expected 'invalid checksum' error got: %+v", err)
 		}

--- a/pkg/kv/kvserver/kvserverbase/bulk_adder.go
+++ b/pkg/kv/kvserver/kvserverbase/bulk_adder.go
@@ -57,6 +57,11 @@ type BulkAdderOptions struct {
 	// DisallowShadowing controls whether shadowing of existing keys is permitted
 	// when the SSTables produced by this adder are ingested.
 	DisallowShadowing bool
+
+	// BatchTimestamp is the timestamp to use on AddSSTable requests (which can be
+	// different from the timestamp used to construct the adder which is what is
+	// actually applied to each key).
+	BatchTimestamp hlc.Timestamp
 }
 
 // BulkAdderFactory describes a factory function for BulkAdders.

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -104,6 +104,7 @@ func (ib *indexBackfiller) prepare(ctx context.Context) error {
 		MaxBufferSize:  maxBufferSize,
 		StepBufferSize: stepSize,
 		SkipDuplicates: ib.ContainsInvertedIndex(),
+		BatchTimestamp: ib.spec.ReadAsOf,
 	}
 	adder, err := ib.flowCtx.Cfg.BulkAdder(ctx, ib.flowCtx.Cfg.DB, ib.spec.ReadAsOf, opts)
 	if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #64023.

/cc @cockroachdb/release

---

This changes SSTs sent by index backfills to be sent with a batch
timestamp equal to the timestamp that was used to read the rows from
which the index entries in that SST were generated.

This is done to ensure that if the index span has already GCed any
keys related to more recent SQL writes the SST will be rejected. Adding
the SST generated from older writes could otherwise accidentally re-add
an entry after a later SQL delete's tombstone had been GC'ed, as described
in #64014.

Release note (bug fix): fix a theoretical issue in index backfills that could result in stale entries that would likely fail validation (#64014).
