### PR TITLE
changefeed: wire up changefeed.table_metadata_nanos metric

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -249,7 +249,7 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 	ca.sink = &errorWrapperSink{wrapped: ca.sink}
 
 	buf := kvfeed.MakeChanBuffer()
-	schemaFeed := newSchemaFeed(ctx, ca.flowCtx.Cfg, ca.spec)
+	schemaFeed := newSchemaFeed(ctx, ca.flowCtx.Cfg, ca.spec, ca.metrics)
 	kvfeedCfg := makeKVFeedCfg(ca.flowCtx.Cfg, ca.kvFeedMemMon, ca.spec,
 		spans, buf, ca.metrics, schemaFeed)
 	cfg := ca.flowCtx.Cfg
@@ -288,7 +288,10 @@ func (ca *changeAggregator) startKVFeed(ctx context.Context, kvfeedCfg kvfeed.Co
 }
 
 func newSchemaFeed(
-	ctx context.Context, cfg *execinfra.ServerConfig, spec execinfrapb.ChangeAggregatorSpec,
+	ctx context.Context,
+	cfg *execinfra.ServerConfig,
+	spec execinfrapb.ChangeAggregatorSpec,
+	metrics *Metrics,
 ) kvfeed.SchemaFeed {
 	schemaChangePolicy := changefeedbase.SchemaChangePolicy(
 		spec.Feed.Opts[changefeedbase.OptSchemaChangePolicy])
@@ -307,6 +310,7 @@ func newSchemaFeed(
 		InternalExecutor:   cfg.SessionBoundInternalExecutorFactory(ctx, &sessiondata.SessionData{}),
 		SchemaChangeEvents: schemaChangeEvents,
 		InitialHighWater:   initialHighWater,
+		Metrics:            &metrics.SchemaFeedMetrics,
 	})
 }
 

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1658,6 +1658,9 @@ func TestChangefeedMonitoring(t *testing.T) {
 		if c := s.MustGetSQLCounter(`changefeed.buffer_entries.out`); c != 0 {
 			t.Errorf(`expected 0 got %d`, c)
 		}
+		if c := s.MustGetSQLCounter(`changefeed.table_metadata_nanos`); c != 0 {
+			t.Errorf(`expected 0 got %d`, c)
+		}
 
 		beforeEmitRowCh <- struct{}{}
 		foo := feed(t, f, `CREATE CHANGEFEED FOR foo`)
@@ -1690,6 +1693,10 @@ func TestChangefeedMonitoring(t *testing.T) {
 			if c := s.MustGetSQLCounter(`changefeed.buffer_entries.out`); c <= 0 {
 				return errors.Errorf(`expected > 0 got %d`, c)
 			}
+			if c := s.MustGetSQLCounter(`changefeed.table_metadata_nanos`); c <= 0 {
+				t.Errorf(`expected > 0 got %d`, c)
+			}
+
 			return nil
 		})
 

--- a/pkg/ccl/changefeedccl/metrics.go
+++ b/pkg/ccl/changefeedccl/metrics.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvfeed"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/schemafeed"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -135,12 +136,6 @@ var (
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
 	}
-	metaChangefeedTableMetadataNanos = metric.Metadata{
-		Name:        "changefeed.table_metadata_nanos",
-		Help:        "Time blocked while verifying table metadata histories",
-		Measurement: "Nanoseconds",
-		Unit:        metric.Unit_NANOSECONDS,
-	}
 	metaChangefeedEmitNanos = metric.Metadata{
 		Name:        "changefeed.emit_nanos",
 		Help:        "Total time spent emitting all feeds",
@@ -200,17 +195,18 @@ var (
 
 // Metrics are for production monitoring of changefeeds.
 type Metrics struct {
-	KVFeedMetrics   kvfeed.Metrics
+	KVFeedMetrics     kvfeed.Metrics
+	SchemaFeedMetrics schemafeed.Metrics
+
 	EmittedMessages *metric.Counter
 	EmittedBytes    *metric.Counter
 	Flushes         *metric.Counter
 	ErrorRetries    *metric.Counter
 	Failures        *metric.Counter
 
-	ProcessingNanos    *metric.Counter
-	TableMetadataNanos *metric.Counter
-	EmitNanos          *metric.Counter
-	FlushNanos         *metric.Counter
+	ProcessingNanos *metric.Counter
+	EmitNanos       *metric.Counter
+	FlushNanos      *metric.Counter
 
 	CheckpointHistNanos *metric.Histogram
 	EmitHistNanos       *metric.Histogram
@@ -232,17 +228,17 @@ func (*Metrics) MetricStruct() {}
 // MakeMetrics makes the metrics for changefeed monitoring.
 func MakeMetrics(histogramWindow time.Duration) metric.Struct {
 	m := &Metrics{
-		KVFeedMetrics:   kvfeed.MakeMetrics(histogramWindow),
-		EmittedMessages: metric.NewCounter(metaChangefeedEmittedMessages),
-		EmittedBytes:    metric.NewCounter(metaChangefeedEmittedBytes),
-		Flushes:         metric.NewCounter(metaChangefeedFlushes),
-		ErrorRetries:    metric.NewCounter(metaChangefeedErrorRetries),
-		Failures:        metric.NewCounter(metaChangefeedFailures),
+		KVFeedMetrics:     kvfeed.MakeMetrics(histogramWindow),
+		SchemaFeedMetrics: schemafeed.MakeMetrics(histogramWindow),
+		EmittedMessages:   metric.NewCounter(metaChangefeedEmittedMessages),
+		EmittedBytes:      metric.NewCounter(metaChangefeedEmittedBytes),
+		Flushes:           metric.NewCounter(metaChangefeedFlushes),
+		ErrorRetries:      metric.NewCounter(metaChangefeedErrorRetries),
+		Failures:          metric.NewCounter(metaChangefeedFailures),
 
-		ProcessingNanos:    metric.NewCounter(metaChangefeedProcessingNanos),
-		TableMetadataNanos: metric.NewCounter(metaChangefeedTableMetadataNanos),
-		EmitNanos:          metric.NewCounter(metaChangefeedEmitNanos),
-		FlushNanos:         metric.NewCounter(metaChangefeedFlushNanos),
+		ProcessingNanos: metric.NewCounter(metaChangefeedProcessingNanos),
+		EmitNanos:       metric.NewCounter(metaChangefeedEmitNanos),
+		FlushNanos:      metric.NewCounter(metaChangefeedFlushNanos),
 
 		CheckpointHistNanos: metric.NewHistogram(metaChangefeedCheckpointHistNanos, histogramWindow,
 			changefeedCheckpointHistMaxLatency.Nanoseconds(), 2),

--- a/pkg/ccl/changefeedccl/schemafeed/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/schemafeed/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "schemafeed",
     srcs = [
+        "metrics.go",
         "schema_feed.go",
         "table_event_filter.go",
     ],
@@ -27,6 +28,7 @@ go_library(
         "//pkg/util/encoding",
         "//pkg/util/hlc",
         "//pkg/util/log",
+        "//pkg/util/metric",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/ccl/changefeedccl/schemafeed/metrics.go
+++ b/pkg/ccl/changefeedccl/schemafeed/metrics.go
@@ -1,0 +1,39 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package schemafeed
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+)
+
+var metaChangefeedTableMetadataNanos = metric.Metadata{
+	Name:        "changefeed.table_metadata_nanos",
+	Help:        "Time blocked while verifying table metadata histories",
+	Measurement: "Nanoseconds",
+	Unit:        metric.Unit_NANOSECONDS,
+}
+
+// Metrics is a metric.Struct for schemafeed metrics.
+type Metrics struct {
+	TableMetadataNanos *metric.Counter
+}
+
+// MetricStruct implements the metric.Struct interface.
+func (Metrics) MetricStruct() {}
+
+// MakeMetrics constructs a Metrics struct with the provided histogram window.
+func MakeMetrics(histogramWindow time.Duration) Metrics {
+	return Metrics{
+		TableMetadataNanos: metric.NewCounter(metaChangefeedTableMetadataNanos),
+	}
+}
+
+var _ (metric.Struct) = (*Metrics)(nil)


### PR DESCRIPTION
This metric wasn't being used anywhere. Rather than removing it, this
change starts using it to track how long we are waiting in the
schemafeed.

Release note: None