### PR TITLE
roachprod: destroy clusters in parallel

### DIFF
--- a/pkg/cmd/roachprod/BUILD.bazel
+++ b/pkg/cmd/roachprod/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/cmd/roachprod/vm/azure",
         "//pkg/cmd/roachprod/vm/gce",
         "//pkg/cmd/roachprod/vm/local",
+        "//pkg/util/ctxgroup",
         "//pkg/util/flagutil",
         "//pkg/util/httputil",
         "//pkg/util/syncutil",


### PR DESCRIPTION
Destroying a cluster is slow, and often when one waits
for it to finish it's because one wants to spin up new
clusters. I wrote this in bash more than a dozen times
and this commit makes sure nobody ever has to again.

cc @cockroachdb/kv

Release note: None
