### PR TITLE
build: retry register.cockrachdb.com requests

### DIFF
--- a/build/teamcity-local-roachtest.sh
+++ b/build/teamcity-local-roachtest.sh
@@ -6,7 +6,7 @@ source "$(dirname "${0}")/teamcity-support.sh"
 
 tc_start_block "Prepare environment"
 # Grab a testing license good for one hour.
-COCKROACH_DEV_LICENSE=$(curl -f "https://register.cockroachdb.com/api/prodtest")
+COCKROACH_DEV_LICENSE=$(curl --retry 3 --retry-connrefused -f "https://register.cockroachdb.com/api/prodtest")
 run mkdir -p artifacts
 maybe_ccache
 tc_end_block "Prepare environment"


### PR DESCRIPTION
Retry transient problems getting a developer license. We may want to
avoid the retries here as a forcing function to make that service more
reliable, but given that we might see timeouts from non-service
related local networking problems, I'd prefer to not fail the test run
because of a single curl failure.

Release note: None