### PR TITLE
sql: allow 'experimental_always' for 'vectorize' cluster setting

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -704,7 +704,9 @@ func NewColOperator(
 	resultPreSpecPlanningStateShallowCopy := *r
 
 	if err = supportedNatively(spec); err != nil {
-		if err := canWrap(flowCtx.EvalCtx.SessionData.VectorizeMode, spec); err != nil {
+		if wrapErr := canWrap(flowCtx.EvalCtx.SessionData.VectorizeMode, spec); wrapErr != nil {
+			// Return the original error for why we don't support this spec
+			// natively since it is more interesting.
 			return r, err
 		}
 		if log.V(1) {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -423,8 +423,9 @@ var VectorizeClusterMode = settings.RegisterEnumSetting(
 	"default vectorize mode",
 	"on",
 	map[int64]string{
-		int64(sessiondatapb.VectorizeOff): "off",
-		int64(sessiondatapb.VectorizeOn):  "on",
+		int64(sessiondatapb.VectorizeOff):                "off",
+		int64(sessiondatapb.VectorizeOn):                 "on",
+		int64(sessiondatapb.VectorizeExperimentalAlways): "experimental_always",
 	},
 )
 


### PR DESCRIPTION
Originally, we disallowed it because it was hard to get out of that
state. Now we support `SET CLUSTER SETTING` in a more native manner in
the vectorized engine, so we can have an experimental value as the
cluster setting.

Also return the error that prompted us to wrap a row-execution processor
into the vectorized flow rather than the error that the wrapping is
prohibited.

Release note: None