### PR TITLE
release-21.1: tree: fix comparing an infinite date from subquery as a timestamp

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -1756,3 +1756,10 @@ NULL                             NULL
 
 statement ok
 RESET TIME ZONE
+
+# Regression test for panicking when comparing an infinite date coming from a
+# subquery to a timestamp (#64015).
+query B
+SELECT ((SELECT '-infinity'::DATE)) < '2021-04-21':::TIMESTAMP
+----
+true

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1866,12 +1866,12 @@ func (d *DDate) Next(_ *EvalContext) (Datum, bool) {
 
 // IsMax implements the Datum interface.
 func (d *DDate) IsMax(_ *EvalContext) bool {
-	return d.Date == pgdate.PosInfDate
+	return d.PGEpochDays() == pgdate.PosInfDate.PGEpochDays()
 }
 
 // IsMin implements the Datum interface.
 func (d *DDate) IsMin(_ *EvalContext) bool {
-	return d.Date == pgdate.NegInfDate
+	return d.PGEpochDays() == pgdate.NegInfDate.PGEpochDays()
 }
 
 // Max implements the Datum interface.
@@ -2264,7 +2264,49 @@ func timeFromDatumForComparison(ctx *EvalContext, d Datum) (time.Time, bool) {
 	}
 }
 
+type infiniteDateComparison int
+
+const (
+	// Note: the order of the constants here is important.
+	negativeInfinity infiniteDateComparison = iota
+	finite
+	positiveInfinity
+)
+
+func checkInfiniteDate(ctx *EvalContext, d Datum) infiniteDateComparison {
+	if _, isDate := d.(*DDate); isDate {
+		if d.IsMax(ctx) {
+			return positiveInfinity
+		}
+		if d.IsMin(ctx) {
+			return negativeInfinity
+		}
+	}
+	return finite
+}
+
+// compareTimestamps takes in two time-related datums and compares them as
+// timestamps while paying attention to time zones if needed. It returns -1, 0,
+// or +1 for "less", "equal", and "greater", respectively.
+//
+// Datums are allowed to be one of DDate, DTimestamp, DTimestampTZ, DTime,
+// DTimeTZ. For all other datum types it will panic; also, comparing two DDates
+// is not supported.
 func compareTimestamps(ctx *EvalContext, l Datum, r Datum) int {
+	leftInf := checkInfiniteDate(ctx, l)
+	rightInf := checkInfiniteDate(ctx, r)
+	if leftInf != finite || rightInf != finite {
+		// At least one of the datums is an infinite date.
+		if leftInf != finite && rightInf != finite {
+			// Both datums cannot be infinite dates at the same time because we
+			// wouldn't use this method.
+			panic(errors.AssertionFailedf("unexpectedly two infinite dates in compareTimestamps"))
+		}
+		// Exactly one of the datums is an infinite date and another is a finite
+		// datums (not necessarily a date). We can just subtract the returned
+		// values to get the desired result for comparison.
+		return int(leftInf - rightInf)
+	}
 	lTime, lOk := timeFromDatumForComparison(ctx, l)
 	rTime, rOk := timeFromDatumForComparison(ctx, r)
 	if !lOk || !rOk {

--- a/pkg/sql/sem/tree/datum_test.go
+++ b/pkg/sql/sem/tree/datum_test.go
@@ -121,6 +121,18 @@ func TestCompareTimestamps(t *testing.T) {
 			right:    NewDTimeTZFromOffset(timeofday.New(5, 0, 0, 0), pacificTimeZone),
 			expected: 1,
 		},
+		{
+			desc:     "positive infinite date",
+			left:     dMaxDate,
+			right:    MakeDTime(timeofday.New(12, 0, 0, 0)),
+			expected: 1,
+		},
+		{
+			desc:     "negative infinite date",
+			left:     dMinDate,
+			right:    MakeDTime(timeofday.New(12, 0, 0, 0)),
+			expected: -1,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -137,6 +149,8 @@ func TestCompareTimestamps(t *testing.T) {
 			},
 		)
 	}
+
+	assert.Panics(t, func() { compareTimestamps(nil /* ctx */, dMaxDate, dMinDate) })
 }
 
 func TestCastStringToRegClassTableName(t *testing.T) {


### PR DESCRIPTION
Backport 1/1 commits from #64036.

/cc @cockroachdb/release

---

Fixes: #64015.

Release note (bug fix): Previously, CockroachDB would either return an
error or crash when comparing an infinite date coming from a subquery
against a timestamp.
