### PR TITLE
libroach: make DumpThreadStacks thread-safe

### DIFF
--- a/c-deps/libroach/stack_trace.cc
+++ b/c-deps/libroach/stack_trace.cc
@@ -30,6 +30,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <mutex>
 
 namespace {
 
@@ -306,6 +307,11 @@ std::string DumpThreadStacksHelper() {
 }  // namespace
 
 std::string DumpThreadStacks() {
+  // This code is not thread-safe: ensure we have only one concurrent call to
+  // DumpThreadStacks ongoing at a time.
+  static std::mutex s_mutex;
+  std::lock_guard<std::mutex> lock(s_mutex);
+
   struct sigaction action;
   struct sigaction oldaction;
   memset(&action, 0, sizeof(action));


### PR DESCRIPTION
Fixes #64079.

Note: I am not including unit tests in this PR, as the change here will be suitably validated by a green CI in #59863.

Release note (bug fix): Fixed a bug where multiple concurrent
invocations of `debug zip` could yield cluster instability. This bug
had been present since CockroachDB v20.1.