### PR TITLE
kv/kvserver: skip TestMergeQueue

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -4073,6 +4073,7 @@ func verifyUnmerged(t *testing.T, store *kvserver.Store, lhsStartKey, rhsStartKe
 
 func TestMergeQueue(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 64056, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()


### PR DESCRIPTION
Refs: #64056

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None