### PR TITLE
concurrency: improvements to lock garbage collection

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -74,6 +74,7 @@ import (
 // debug-lock-table
 // debug-disable-txn-pushes
 // debug-set-clock           ts=<secs>
+// debug-set-discovered-locks-threshold-to-consult-finalized-txn-cache n=<count>
 // reset
 //
 func TestConcurrencyManagerBasic(t *testing.T) {
@@ -470,6 +471,12 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				c.manual.Set(nanos)
 				return ""
 
+			case "debug-set-discovered-locks-threshold-to-consult-finalized-txn-cache":
+				var n int
+				d.ScanArgs(t, "n", &n)
+				c.setDiscoveredLocksThresholdToConsultFinalizedTxnCache(n)
+				return ""
+
 			case "reset":
 				if n := mon.numMonitored(); n > 0 {
 					d.Fatalf(t, "%d requests still in flight", n)
@@ -799,6 +806,10 @@ func (c *cluster) enableTxnPushes() {
 func (c *cluster) disableTxnPushes() {
 	concurrency.LockTableLivenessPushDelay.Override(&c.st.SV, time.Hour)
 	concurrency.LockTableDeadlockDetectionPushDelay.Override(&c.st.SV, time.Hour)
+}
+
+func (c *cluster) setDiscoveredLocksThresholdToConsultFinalizedTxnCache(n int) {
+	concurrency.DiscoveredLocksThresholdToConsultFinalizedTxnCache.Override(&c.st.SV, int64(n))
 }
 
 // reset clears all request state in the cluster. This avoids portions of tests

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -89,7 +89,7 @@ txn-finalized txn=<name> status=committed|aborted
 
  Informs the lock table that the named transaction is finalized.
 
-add-discovered r=<name> k=<key> txn=<name> [lease-seq=<seq>]
+add-discovered r=<name> k=<key> txn=<name> [lease-seq=<seq>] [consult-finalized-txn-cache=<bool>]
 ----
 <error string>
 
@@ -114,6 +114,10 @@ should-wait r=<name>
 <bool>
 
  Calls lockTableGuard.ShouldWait.
+
+resolve-before-scanning r=<name>
+----
+<intents to resolve>
 
 enable [lease-seq=<seq>]
 ----
@@ -148,11 +152,11 @@ func TestLockTableBasic(t *testing.T) {
 			case "new-lock-table":
 				var maxLocks int
 				d.ScanArgs(t, "maxlocks", &maxLocks)
-				lt = &lockTableImpl{
-					enabled:    true,
-					enabledSeq: 1,
-					maxLocks:   int64(maxLocks),
-				}
+				ltImpl := newLockTable(int64(maxLocks))
+				ltImpl.enabled = true
+				ltImpl.enabledSeq = 1
+				ltImpl.minLocks = 0
+				lt = ltImpl
 				txnsByName = make(map[string]*enginepb.TxnMeta)
 				txnCounter = uint128.FromInts(0, 0)
 				requestsByName = make(map[string]Request)
@@ -369,8 +373,13 @@ func TestLockTableBasic(t *testing.T) {
 				if d.HasArg("lease-seq") {
 					d.ScanArgs(t, "lease-seq", &seq)
 				}
+				consultFinalizedTxnCache := false
+				if d.HasArg("consult-finalized-txn-cache") {
+					d.ScanArgs(t, "consult-finalized-txn-cache", &consultFinalizedTxnCache)
+				}
 				leaseSeq := roachpb.LeaseSequence(seq)
-				if _, err := lt.AddDiscoveredLock(&intent, leaseSeq, g); err != nil {
+				if _, err := lt.AddDiscoveredLock(
+					&intent, leaseSeq, consultFinalizedTxnCache, g); err != nil {
 					return err.Error()
 				}
 				return lt.(*lockTableImpl).String()
@@ -426,15 +435,7 @@ func TestLockTableBasic(t *testing.T) {
 				case doneWaiting:
 					var toResolveStr string
 					if stateTransition {
-						if toResolve := g.ResolveBeforeScanning(); len(toResolve) > 0 {
-							var buf strings.Builder
-							fmt.Fprintf(&buf, "\nIntents to resolve:")
-							for i := range toResolve {
-								fmt.Fprintf(&buf, "\n key=%s txn=%s status=%s", toResolve[i].Key,
-									toResolve[i].Txn.ID.Short(), toResolve[i].Status)
-							}
-							toResolveStr = buf.String()
-						}
+						toResolveStr = intentsToResolveToStr(g.ResolveBeforeScanning(), true)
 					}
 					return str + "state=doneWaiting" + toResolveStr
 				}
@@ -451,6 +452,15 @@ func TestLockTableBasic(t *testing.T) {
 				}
 				return fmt.Sprintf("%sstate=%s txn=%s key=%s held=%t guard-access=%s",
 					str, typeStr, txnS, state.key, state.held, state.guardAccess)
+
+			case "resolve-before-scanning":
+				var reqName string
+				d.ScanArgs(t, "r", &reqName)
+				g := guardsByReqName[reqName]
+				if g == nil {
+					d.Fatalf(t, "unknown guard: %s", reqName)
+				}
+				return intentsToResolveToStr(g.ResolveBeforeScanning(), false)
 
 			case "enable":
 				seq := int(1)
@@ -523,6 +533,217 @@ func scanSpans(t *testing.T, d *datadriven.TestData, ts hlc.Timestamp) *spanset.
 		spans.AddMVCC(sa, getSpan(t, d, p), ts)
 	}
 	return spans
+}
+
+func intentsToResolveToStr(toResolve []roachpb.LockUpdate, startOnNewLine bool) string {
+	if len(toResolve) == 0 {
+		return ""
+	}
+	var buf strings.Builder
+	if startOnNewLine {
+		fmt.Fprintf(&buf, "\n")
+	}
+	fmt.Fprintf(&buf, "Intents to resolve:")
+	for i := range toResolve {
+		fmt.Fprintf(&buf, "\n key=%s txn=%s status=%s", toResolve[i].Key,
+			toResolve[i].Txn.ID.Short(), toResolve[i].Status)
+	}
+	return buf.String()
+}
+
+func TestLockTableMaxLocks(t *testing.T) {
+	lt := newLockTable(5)
+	lt.minLocks = 0
+	lt.enabled = true
+	var keys []roachpb.Key
+	var guards []lockTableGuard
+	var reqs []Request
+	// 10 requests, each with 10 discovered locks. Only 1 will be considered
+	// notRemovable per request.
+	for i := 0; i < 10; i++ {
+		spans := &spanset.SpanSet{}
+		for j := 0; j < 20; j++ {
+			k := roachpb.Key(fmt.Sprintf("%08d", i*20+j))
+			keys = append(keys, k)
+			spans.AddMVCC(spanset.SpanReadWrite, roachpb.Span{Key: k}, hlc.Timestamp{WallTime: 1})
+		}
+		req := Request{
+			Timestamp:  hlc.Timestamp{WallTime: 1},
+			LatchSpans: spans,
+			LockSpans:  spans,
+		}
+		reqs = append(reqs, req)
+		ltg := lt.ScanAndEnqueue(req, nil)
+		require.Nil(t, ltg.ResolveBeforeScanning())
+		require.False(t, ltg.ShouldWait())
+		guards = append(guards, ltg)
+	}
+	for i := range guards {
+		for j := 0; j < 10; j++ {
+			k := i*20 + j
+			added, err := lt.AddDiscoveredLock(
+				&roachpb.Intent{Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[k]}},
+				0, false, guards[i])
+			require.True(t, added)
+			require.NoError(t, err)
+		}
+	}
+	// Only the notRemovable locks survive after addition.
+	require.Equal(t, int64(10), lt.lockCountForTesting())
+	// Two guards are dequeued.
+	lt.Dequeue(guards[0])
+	lt.Dequeue(guards[1])
+	require.Equal(t, int64(10), lt.lockCountForTesting())
+	// Two guards do ScanAndEnqueue.
+	for i := 2; i < 4; i++ {
+		guards[i] = lt.ScanAndEnqueue(reqs[i], guards[i])
+		require.True(t, guards[i].ShouldWait())
+	}
+	require.Equal(t, int64(10), lt.lockCountForTesting())
+	// Add another discovered lock, to trigger tryClearLocks.
+	added, err := lt.AddDiscoveredLock(
+		&roachpb.Intent{Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[9*20+10]}},
+		0, false, guards[9])
+	require.True(t, added)
+	require.NoError(t, err)
+	// The 6 notRemovable locks remain.
+	require.Equal(t, int64(6), lt.lockCountForTesting())
+	require.Equal(t, int64(101), int64(lt.locks[spanset.SpanGlobal].lockIDSeqNum))
+	// Add another discovered lock, to trigger tryClearLocks.
+	added, err = lt.AddDiscoveredLock(
+		&roachpb.Intent{Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[9*20+11]}},
+		0, false, guards[9])
+	require.True(t, added)
+	require.NoError(t, err)
+	// Still the 6 notRemovable locks remain.
+	require.Equal(t, int64(6), lt.lockCountForTesting())
+	require.Equal(t, int64(102), int64(lt.locks[spanset.SpanGlobal].lockIDSeqNum))
+	// Two more guards are dequeued, so we are down to 4 notRemovable locks.
+	lt.Dequeue(guards[4])
+	lt.Dequeue(guards[5])
+	// Bump up the enforcement interval manually.
+	lt.locks[spanset.SpanGlobal].lockAddMaxLocksCheckInterval = 2
+	// Add another discovered lock.
+	added, err = lt.AddDiscoveredLock(
+		&roachpb.Intent{Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[9*20+12]}},
+		0, false, guards[9])
+	require.True(t, added)
+	require.NoError(t, err)
+	// This notRemovable=false lock is also added, since enforcement not done.
+	require.Equal(t, int64(7), lt.lockCountForTesting())
+	// Add another discovered lock, to trigger tryClearLocks.
+	added, err = lt.AddDiscoveredLock(
+		&roachpb.Intent{Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[9*20+13]}},
+		0, false, guards[9])
+	require.True(t, added)
+	require.NoError(t, err)
+	// Now enforcement is done, so only 4 remain.
+	require.Equal(t, int64(4), lt.lockCountForTesting())
+	// Bump down the enforcement interval manually, and bump up minLocks
+	lt.locks[spanset.SpanGlobal].lockAddMaxLocksCheckInterval = 1
+	lt.minLocks = 2
+	// Three more guards dequeued.
+	lt.Dequeue(guards[6])
+	lt.Dequeue(guards[7])
+	lt.Dequeue(guards[8])
+	// Add another discovered lock.
+	added, err = lt.AddDiscoveredLock(
+		&roachpb.Intent{Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[9*20+14]}},
+		0, false, guards[9])
+	require.True(t, added)
+	require.NoError(t, err)
+	require.Equal(t, int64(5), lt.lockCountForTesting())
+	// Add another discovered lock, to trigger tryClearLocks, and push us over 5
+	// locks.
+	added, err = lt.AddDiscoveredLock(
+		&roachpb.Intent{Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[9*20+15]}},
+		0, false, guards[9])
+	require.True(t, added)
+	require.NoError(t, err)
+	// Enforcement keeps the 1 notRemovable lock, and another, since minLocks=2.
+	require.Equal(t, int64(2), lt.lockCountForTesting())
+	// Restore minLocks to 0.
+	lt.minLocks = 0
+	// Add locks to push us over 5 locks.
+	for i := 16; i < 20; i++ {
+		added, err = lt.AddDiscoveredLock(
+			&roachpb.Intent{Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[9*20+i]}},
+			0, false, guards[9])
+		require.True(t, added)
+		require.NoError(t, err)
+	}
+	// Only the 1 notRemovable lock remains.
+	require.Equal(t, int64(1), lt.lockCountForTesting())
+}
+
+// TestLockTableMaxLocksWithMultipleNotRemovableRefs tests the notRemovable
+// ref counting.
+func TestLockTableMaxLocksWithMultipleNotRemovableRefs(t *testing.T) {
+	lt := newLockTable(2)
+	lt.minLocks = 0
+	lt.enabled = true
+	var keys []roachpb.Key
+	var guards []lockTableGuard
+	// 10 requests. Every pair of requests have the same span.
+	for i := 0; i < 10; i++ {
+		spans := &spanset.SpanSet{}
+		key := roachpb.Key(fmt.Sprintf("%08d", i/2))
+		if i%2 == 0 {
+			keys = append(keys, key)
+		}
+		spans.AddMVCC(spanset.SpanReadWrite, roachpb.Span{Key: key}, hlc.Timestamp{WallTime: 1})
+		req := Request{
+			Timestamp:  hlc.Timestamp{WallTime: 1},
+			LatchSpans: spans,
+			LockSpans:  spans,
+		}
+		ltg := lt.ScanAndEnqueue(req, nil)
+		require.Nil(t, ltg.ResolveBeforeScanning())
+		require.False(t, ltg.ShouldWait())
+		guards = append(guards, ltg)
+	}
+	// The first 6 requests discover 3 locks total.
+	for i := 0; i < 6; i++ {
+		added, err := lt.AddDiscoveredLock(
+			&roachpb.Intent{Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[i/2]}},
+			0, false, guards[i])
+		require.True(t, added)
+		require.NoError(t, err)
+	}
+	// All the 3 locks are there.
+	require.Equal(t, int64(3), lt.lockCountForTesting())
+	// Remove one of the notRemovable refs from each lock.
+	for i := 0; i < 6; i++ {
+		if i%2 == 0 {
+			lt.Dequeue(guards[i])
+		}
+	}
+	// Add another lock using request 6.
+	added, err := lt.AddDiscoveredLock(
+		&roachpb.Intent{Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[6/2]}},
+		0, false, guards[6])
+	require.True(t, added)
+	require.NoError(t, err)
+	// There are 4 locks.
+	require.Equal(t, int64(4), lt.lockCountForTesting())
+	// Remove the remaining notRemovable refs.
+	for i := 0; i < 6; i++ {
+		if i%2 == 1 {
+			lt.Dequeue(guards[i])
+		}
+	}
+	lt.Dequeue(guards[6])
+	// There are still 4 locks since tryClearLocks has not happened since the
+	// ref counts went to 0.
+	require.Equal(t, int64(4), lt.lockCountForTesting())
+	// Add another lock using request 8.
+	added, err = lt.AddDiscoveredLock(
+		&roachpb.Intent{Intent_SingleKeySpan: roachpb.Intent_SingleKeySpan{Key: keys[8/2]}},
+		0, false, guards[8])
+	require.True(t, added)
+	require.NoError(t, err)
+	// There is only 1 lock.
+	require.Equal(t, int64(1), lt.lockCountForTesting())
 }
 
 type workItem struct {
@@ -693,12 +914,12 @@ type workloadExecutor struct {
 }
 
 func newWorkLoadExecutor(items []workloadItem, concurrency int) *workloadExecutor {
+	const maxLocks = 100000
+	lt := newLockTable(maxLocks)
+	lt.enabled = true
 	return &workloadExecutor{
-		lm: spanlatch.Manager{},
-		lt: &lockTableImpl{
-			enabled:  true,
-			maxLocks: 100000,
-		},
+		lm:           spanlatch.Manager{},
+		lt:           lt,
 		items:        items,
 		transactions: make(map[uuid.UUID]*transactionState),
 		doneWork:     make(chan *workItem),
@@ -1256,12 +1477,12 @@ func BenchmarkLockTable(b *testing.B) {
 					func(b *testing.B) {
 						var numRequestsWaited uint64
 						var numScanCalls uint64
+						const maxLocks = 100000
+						lt := newLockTable(maxLocks)
+						lt.enabled = true
 						env := benchEnv{
-							lm: &spanlatch.Manager{},
-							lt: &lockTableImpl{
-								enabled:  true,
-								maxLocks: 100000,
-							},
+							lm:                &spanlatch.Manager{},
+							lt:                lt,
 							numRequestsWaited: &numRequestsWaited,
 							numScanCalls:      &numScanCalls,
 						}

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -297,7 +297,7 @@ func (w *lockTableWaiterImpl) WaitOn(
 				// the comment in lockTableImpl.tryActiveWait for the proper way to
 				// remove this and other evaluation races.
 				toResolve := guard.ResolveBeforeScanning()
-				return w.resolveDeferredIntents(ctx, toResolve)
+				return w.ResolveDeferredIntents(ctx, toResolve)
 
 			default:
 				panic("unexpected waiting state")
@@ -624,10 +624,8 @@ func (w *lockTableWaiterImpl) pushHeader(req Request) roachpb.Header {
 	return h
 }
 
-// resolveDeferredIntents resolves the batch of intents if the provided error is
-// nil. The batch of intents may be resolved more efficiently than if they were
-// resolved individually.
-func (w *lockTableWaiterImpl) resolveDeferredIntents(
+// ResolveDeferredIntents implements the lockTableWaiter interface.
+func (w *lockTableWaiterImpl) ResolveDeferredIntents(
 	ctx context.Context, deferredResolution []roachpb.LockUpdate,
 ) *Error {
 	if len(deferredResolution) == 0 {

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
@@ -1,0 +1,131 @@
+# -------------------------------------------------------------------------
+# A scan finds many abandoned intents from same txn that don't get added to
+# the lock table, and get resolved.
+# -------------------------------------------------------------------------
+
+# This setting causes the finalized txn cache to be consulted when discovered
+# locks > 1.
+debug-set-discovered-locks-threshold-to-consult-finalized-txn-cache n=1
+----
+
+new-txn name=txn1 ts=10,1 epoch=0
+----
+
+new-txn name=txn2 ts=10,1 epoch=0
+----
+
+new-request name=req1 txn=txn1 ts=10,1
+  scan key=a endkey=b
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+handle-write-intent-error req=req1 lease-seq=1
+  intent txn=txn2 key=a
+----
+[2] handle write intent error req1: handled conflicting intents on "a", released latches
+
+debug-lock-table
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+local: num=0
+
+sequence req=req1
+----
+[3] sequence req1: re-sequencing request
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: waiting in lock wait-queues
+[3] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
+[3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+debug-lock-table
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+   waiting readers:
+    req: 1, txn: 00000001-0000-0000-0000-000000000000
+   distinguished req: 1
+local: num=0
+
+# txn1 is the distinguished waiter on key "a". It will push txn2, notice that it
+# is aborted, and then resolve key "a". This places txn2 in the finalizedTxnCache.
+on-txn-updated txn=txn2 status=aborted
+----
+[-] update txn: aborting txn2
+[3] sequence req1: resolving intent "a" for txn 00000002 with ABORTED status
+[3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on "a" for 1.23s
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: sequencing complete, returned guard
+
+debug-lock-table
+----
+global: num=0
+local: num=0
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+new-request name=req2 txn=txn1 ts=10,1
+  scan key=b endkey=z
+----
+
+sequence req=req2
+----
+[4] sequence req2: sequencing request
+[4] sequence req2: acquiring latches
+[4] sequence req2: scanning lock table for conflicting locks
+[4] sequence req2: sequencing complete, returned guard
+
+# The intents get resolved instead of being added to the lock table.
+handle-write-intent-error req=req2 lease-seq=1
+  intent txn=txn2 key=b
+  intent txn=txn2 key=c
+  intent txn=txn2 key=d
+  intent txn=txn2 key=e
+  intent txn=txn2 key=f
+  intent txn=txn2 key=g
+  intent txn=txn2 key=h
+  intent txn=txn2 key=i
+  intent txn=txn2 key=j
+----
+[5] handle write intent error req2: resolving a batch of 9 intent(s)
+[5] handle write intent error req2: resolving intent "b" for txn 00000002 with ABORTED status
+[5] handle write intent error req2: resolving intent "c" for txn 00000002 with ABORTED status
+[5] handle write intent error req2: resolving intent "d" for txn 00000002 with ABORTED status
+[5] handle write intent error req2: resolving intent "e" for txn 00000002 with ABORTED status
+[5] handle write intent error req2: resolving intent "f" for txn 00000002 with ABORTED status
+[5] handle write intent error req2: resolving intent "g" for txn 00000002 with ABORTED status
+[5] handle write intent error req2: resolving intent "h" for txn 00000002 with ABORTED status
+[5] handle write intent error req2: resolving intent "i" for txn 00000002 with ABORTED status
+[5] handle write intent error req2: resolving intent "j" for txn 00000002 with ABORTED status
+[5] handle write intent error req2: handled conflicting intents on "b", "c", "d", "e", "f", "g", "h", "i", "j", released latches
+
+debug-lock-table
+----
+global: num=0
+local: num=0
+
+sequence req=req2
+----
+[6] sequence req2: re-sequencing request
+[6] sequence req2: acquiring latches
+[6] sequence req2: scanning lock table for conflicting locks
+[6] sequence req2: sequencing complete, returned guard
+
+finish req=req2
+----
+[-] finish req2: finishing request
+
+reset namespace
+----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/discovered_locks_consults_txn_cache
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/discovered_locks_consults_txn_cache
@@ -1,0 +1,114 @@
+
+new-lock-table maxlocks=10000
+----
+
+new-txn txn=txn1 ts=10 epoch=0
+----
+
+new-txn txn=txn2 ts=10 epoch=0
+----
+
+new-txn txn=txn3 ts=10 epoch=0
+----
+
+new-txn txn=txn4 ts=10 epoch=0
+----
+
+new-request r=req1 txn=txn1 ts=10 spans=w@a,e
+----
+
+scan r=req1
+----
+start-waiting: false
+
+txn-finalized txn=txn2 status=aborted
+----
+
+# Don't consult finalizedTxnCache.
+add-discovered r=req1 k=a txn=txn2 consult-finalized-txn-cache=false
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl [holder finalized: aborted] epoch: 0, seqs: [0]
+   queued writers:
+    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+local: num=0
+
+# Nothing to resolve yet.
+resolve-before-scanning r=req1
+----
+
+scan r=req1
+----
+start-waiting: true
+
+# The scan picks up the intent to resolve.
+guard-state r=req1
+----
+new: state=doneWaiting
+Intents to resolve:
+ key="a" txn=00000000 status=ABORTED
+
+print
+----
+global: num=1
+ lock: "a"
+  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, seq: 0
+local: num=0
+
+scan r=req1
+----
+start-waiting: false
+
+txn-finalized txn=txn3 status=aborted
+----
+
+# Txn is finalized and finalizedTxnCache is consulted.
+add-discovered r=req1 k=b txn=txn3 consult-finalized-txn-cache=true
+----
+global: num=1
+ lock: "a"
+  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, seq: 0
+local: num=0
+
+# Txn is finalized and finalizedTxnCache is consulted.
+add-discovered r=req1 k=c txn=txn3 consult-finalized-txn-cache=true
+----
+global: num=1
+ lock: "a"
+  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, seq: 0
+local: num=0
+
+# Txn is not finalized and finalizedTxnCache is consulted.
+add-discovered r=req1 k=d txn=txn4 consult-finalized-txn-cache=true
+----
+global: num=2
+ lock: "a"
+  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, seq: 0
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000004, ts: 10.000000000,0, info: repl epoch: 0, seqs: [0]
+   queued writers:
+    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+local: num=0
+
+# Locks for b and c were not added to lock table.
+resolve-before-scanning r=req1
+----
+Intents to resolve:
+ key="b" txn=00000000 status=ABORTED
+ key="c" txn=00000000 status=ABORTED
+
+scan r=req1
+----
+start-waiting: true
+
+guard-state r=req1
+----
+new: state=waitForDistinguished txn=txn4 key="d" held=true guard-access=write
+
+dequeue r=req1
+----
+global: num=1
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000004, ts: 10.000000000,0, info: repl epoch: 0, seqs: [0]
+local: num=0


### PR DESCRIPTION
This includes improvements to lock garbage collection, and
reduces the number of locks by consulting the
finalizedTxnCache when adding large numbers of discovered
locks.

Previously, AddDiscoveredLock could result in locks that
were never garbage collected, since we had a very loose
mechanism for ensuring liveness of requests. This could
blow up the lock table size to much higher than the limit.
Additionally, we have seen (in a roachtest), tryClearLocks
consuming excessive CPU.

This makes the following improvements to garbage collection:
- At most one lock per Request, added by AddDiscoveredLock,
  is transiently not removable. Even that lock becomes
  removable once the request does another ScanAndEnqueue
  or Dequeues. This should allow most locks to be garbage
  collected.
- We no longer clear all locks when the max size is exceeded,
  and instead go down to max locks/2. This preserves some
  fidelity wrt ordering, while avoiding the cost of frequent
  enforcement.
- Enforcement is throttled such that it happens in increments
  of 5% of the max count, so that if we end up in a situation
  where most locks are not removable, we reduce the amount of
  cpu spent in unsuccessful enforcement.

To prevent huge numbers of discoverd locks from already
finalized transactions from being added to the lock table,
the finalizedTxnCache is consulted above a certain threshold
of discovered lock count. When below that threshold, we
continue to prefer to add the lock and consult the
finalizedTxnCache in the following call to ScanAndEnqueue,
since that provides some coordination that de-duplicates
intent resolution.

Fixes #62470

Release note (performance improvement): Peak memory usage in
the lock table is significantly reduced. Runaway CPU usage due
to wasted quadratic time complexity in clearing unclearable
locks is addressed.
