### PR TITLE
sql: fix bug where view exprs using enum arrays could prevent enum drops

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type
@@ -578,3 +578,44 @@ query T noticetrace
 CREATE TYPE IF NOT EXISTS ifNotExists AS ENUM();
 ----
 NOTICE: type "ifnotexists" already exists, skipping
+
+subtest regression_64101
+
+statement ok
+CREATE TYPE reg_64101 AS ENUM('a', 'b', 'c')
+
+statement ok
+CREATE VIEW v_64101 AS SELECT ARRAY['a']:::_reg_64101
+
+statement ok
+ALTER TYPE reg_64101 DROP VALUE 'b'
+
+statement error could not validate removal of enum value "a": count-array-type-value-usage: enum value "a" is not yet public
+ALTER TYPE reg_64101 DROP VALUE 'a'
+
+statement ok
+DROP VIEW v_64101;
+CREATE VIEW v_64101 AS SELECT ARRAY['c'::reg_64101]
+
+statement ok
+ALTER TYPE reg_64101 DROP VALUE 'a'
+
+statement error could not validate removal of enum value "c": count-array-type-value-usage: enum value "c" is not yet public
+ALTER TYPE reg_64101 DROP VALUE 'c'
+
+statement ok
+CREATE TYPE typ_64101 AS ENUM('a', 'b', 'c');
+CREATE TABLE t1_64101("bob""b" typ_64101);
+CREATE TABLE t2_64101("bob""''b" typ_64101[]);
+INSERT INTO t1_64101 VALUES ('a');
+INSERT INTO t2_64101 VALUES(ARRAY['b'])
+
+statement ok
+ALTER TYPE typ_64101 DROP VALUE 'c'
+
+statement error could not remove enum value "a" as it is being used by "t1_64101" in row: bob"b='a'
+ALTER TYPE typ_64101 DROP VALUE 'a'
+
+statement error could not remove enum value "b" as it is being used by table "test.public.t2_64101"
+ALTER TYPE typ_64101 DROP VALUE 'b'
+

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -696,7 +696,12 @@ func (t *typeSchemaChanger) canRemoveEnumValue(
 				if err != nil {
 					return err
 				}
-				query.WriteString(fmt.Sprintf(" t.%s = %s", col.GetName(), sqlPhysRep))
+				colName := col.ColName()
+				query.WriteString(fmt.Sprintf(
+					" t.%s = %s",
+					colName.String(),
+					sqlPhysRep,
+				))
 				firstClause = false
 				validationQueryConstructed = true
 			}
@@ -773,8 +778,8 @@ func (t *typeSchemaChanger) canRemoveEnumValueFromArrayUsages(
 ) error {
 	const validationErr = "could not validate removal of enum value %q"
 	for i := 0; i < arrayTypeDesc.NumReferencingDescriptors(); i++ {
-		ID := arrayTypeDesc.GetReferencingDescriptorID(i)
-		desc, err := descsCol.GetImmutableTableByID(ctx, txn, ID, tree.ObjectLookupFlags{})
+		id := arrayTypeDesc.GetReferencingDescriptorID(i)
+		desc, err := descsCol.GetImmutableTableByID(ctx, txn, id, tree.ObjectLookupFlags{})
 		if err != nil {
 			return errors.Wrapf(err, validationErr, member.LogicalRepresentation)
 		}
@@ -794,7 +799,12 @@ func (t *typeSchemaChanger) canRemoveEnumValueFromArrayUsages(
 				if !firstClause {
 					unionUnnests.WriteString(" UNION ")
 				}
-				unionUnnests.WriteString(fmt.Sprintf("SELECT unnest(%s) FROM [%d AS t]", col.GetName(), ID))
+				colName := col.ColName()
+				unionUnnests.WriteString(fmt.Sprintf(
+					"SELECT unnest(t.%s) FROM [%d AS t]",
+					colName.String(),
+					id,
+				))
 				firstClause = false
 			}
 		}


### PR DESCRIPTION
Fixes #64101

Release note (bug fix): Fix a bug where view expressions created
using an array enum, without a name for the column, could cause
failures when dropping unrelated enum values.