### PR TITLE
sql: make a unit test around apply join from a logic test

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -404,6 +404,7 @@ go_test(
         "admin_audit_log_test.go",
         "alter_column_type_test.go",
         "ambiguous_commit_test.go",
+        "apply_join_test.go",
         "as_of_test.go",
         "builtin_mem_usage_test.go",
         "builtin_test.go",

--- a/pkg/sql/apply_join_test.go
+++ b/pkg/sql/apply_join_test.go
@@ -1,0 +1,74 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApplyJoinError is a regression test for not closing the subqueries in the
+// apply join if they hit an error (#54166). The underlying error is returned
+// because of a known limitation of apply joins with subqueries (#39433).
+func TestApplyJoinError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testClusterArgs := base.TestClusterArgs{
+		ReplicationMode: base.ReplicationAuto,
+	}
+	tc := testcluster.StartTestCluster(t, 1, testClusterArgs)
+	ctx := context.Background()
+	defer tc.Stopper().Stop(ctx)
+
+	conn := tc.Conns[0]
+
+	for _, vectorizeOption := range []string{"on", "off"} {
+		_, err := conn.Exec("SET vectorize=$1", vectorizeOption)
+		require.NoError(t, err)
+		_, err = conn.Exec(`
+SELECT
+  (
+    SELECT
+      tab_4.col_4
+    FROM
+      (VALUES (1)) AS tab_1 (col_1)
+      JOIN (
+          VALUES
+            (
+              (
+                SELECT
+                  1
+                FROM
+                  (SELECT 1)
+                WHERE
+                  EXISTS(SELECT 1 / (SELECT 0))
+              )
+            )
+        )
+          AS tab_6 (col_6) ON (tab_1.col_1) = (tab_6.col_6)
+  )
+FROM
+  (VALUES (NULL)) AS tab_4 (col_4),
+  (VALUES (NULL), (NULL)) AS tab_5 (col_5)
+`)
+		// We expect that an internal error is returned.
+		require.Error(t, err)
+		require.True(t, strings.Contains(err.Error(), "internal error"))
+	}
+}

--- a/pkg/sql/logictest/testdata/logic_test/apply_join
+++ b/pkg/sql/logictest/testdata/logic_test/apply_join
@@ -377,31 +377,3 @@ UPDATE cpk SET extra = (
     WHERE k='k1'
 )
 WHERE ((cpk.key, cpk.value) IN (SELECT new_values.k, new_values.v FROM new_values))
-
-# Regression test for not closing the subqueries in the apply join if they hit
-# an error (#54166).
-query error pgcode XX000 invalid index .*
-SELECT
-  (
-    SELECT
-      tab_4.col_4
-    FROM
-      (VALUES (1)) AS tab_1 (col_1)
-      JOIN (
-          VALUES
-            (
-              (
-                SELECT
-                  1
-                FROM
-                  (SELECT 1)
-                WHERE
-                  EXISTS(SELECT 1)
-              )
-            )
-        )
-          AS tab_6 (col_6) ON (tab_1.col_1) = (tab_6.col_6)
-  )
-FROM
-  (VALUES (NULL)) AS tab_4 (col_4),
-  (VALUES (NULL), (NULL)) AS tab_5 (col_5)


### PR DESCRIPTION
The test expects an internal error, and when executing the test as
a logic test, it'll include the stack trace which is annoying given than
the stack trace is expected.

Release note: None