### PR TITLE
lint: run GCAssert on recently created colexec packages

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1915,6 +1915,12 @@ func TestLint(t *testing.T) {
 			"../../sql/colconv",
 			"../../sql/colexec",
 			"../../sql/colexec/colexecagg",
+			"../../sql/colexec/colexecbase",
+			"../../sql/colexec/colexechash",
+			"../../sql/colexec/colexecjoin",
+			"../../sql/colexec/colexecproj",
+			"../../sql/colexec/colexecsel",
+			"../../sql/colexec/colexecwindow",
 			"../../sql/colfetcher",
 		); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Release note: None