### PR TITLE
ui: fix time delta in range report 

### DIFF
--- a/pkg/ui/src/views/reports/containers/range/print.ts
+++ b/pkg/ui/src/views/reports/containers/range/print.ts
@@ -110,10 +110,10 @@ export function PrintTimestampDeltaFromNow(
   }
   const time: moment.Moment = LongToMoment(timestamp.wall_time);
   if (now.isAfter(time)) {
-    const diff = moment.duration(moment().diff(time));
+    const diff = moment.duration(now.diff(time));
     return `${PrintDuration(diff)} ago`;
   }
-  const diff = moment.duration(time.diff(moment()));
+  const diff = moment.duration(time.diff(now));
   return `${PrintDuration(diff)} in the future`;
 }
 

--- a/pkg/ui/src/views/reports/containers/range/rangeTable.tsx
+++ b/pkg/ui/src/views/reports/containers/range/rangeTable.tsx
@@ -401,7 +401,7 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
       };
     }
     const humanized = Print.Timestamp(timestamp);
-    const delta = `(${Print.TimestampDeltaFromNow(timestamp, now)})`;
+    const delta = Print.TimestampDeltaFromNow(timestamp, now);
     return {
       value: [humanized, delta],
       title: [humanized, FixLong(timestamp.wall_time).toString()],


### PR DESCRIPTION
The function computing the delta from a timestamp to present time was
mistakingly not using the passed-in now, but was reading the clock. This
led to the same timestamp being computed as different deltas across
replicas, which makes the report highlight the row.

Release note: None