### PR TITLE
colexec: be defensive about nil ctx when closing the materializer

### DIFF
--- a/pkg/sql/colexec/materializer.go
+++ b/pkg/sql/colexec/materializer.go
@@ -332,6 +332,14 @@ func (m *Materializer) close() {
 		if m.cancelFlow != nil {
 			m.cancelFlow()()
 		}
+		if m.Ctx == nil {
+			// In some edge cases (like when Init of an operator above this
+			// materializer encounters a panic), the materializer might never be
+			// started, yet it still will attempt to close its Closers. This
+			// context is only used for logging purposes, so it is ok to grab
+			// the background context in order to prevent a NPE below.
+			m.Ctx = context.Background()
+		}
 		m.closers.CloseAndLogOnErr(m.Ctx, "materializer")
 	}
 }


### PR DESCRIPTION
In some edge cases (like when Init of an operator above a
materializer encounters a panic), the materializer might never be
started, yet it still will attempt to close its Closers. In such
scenario the materializer will have a nil ctx, and it'll encounter a NPE
when closing the closers. To prevent that we grab the background context
which is safe given that the context is only needed for logging
purposes.

Fixes: #64100.

Release note: None