### PR TITLE
sql: prevent REGIONAL BY ROW and ADD/DROP REGION concurrent transitions

### DIFF
--- a/pkg/ccl/multiregionccl/regional_by_row_test.go
+++ b/pkg/ccl/multiregionccl/regional_by_row_test.go
@@ -705,43 +705,51 @@ func TestRegionChangeRacingRegionalByRowChange(t *testing.T) {
 
 	regionalByRowChanges := []struct {
 		setup                          string
-		alterCmd                       string
+		cmd                            string
 		errorOnAddOrDropRegionSandwich string
+		errorOnTableChangeSandwich     string
 	}{
 		{
 			setup:                          `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY GLOBAL`,
-			alterCmd:                       `ALTER TABLE t.test SET LOCALITY REGIONAL BY ROW`,
+			cmd:                            `ALTER TABLE t.test SET LOCALITY REGIONAL BY ROW`,
 			errorOnAddOrDropRegionSandwich: "pq: cannot perform database region changes while a REGIONAL BY ROW transition is underway",
+			errorOnTableChangeSandwich:     "pq: cannot perform this locality change while a region is being added or dropped on the database",
 		},
 		{
 			setup:                          `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY REGIONAL BY ROW`,
-			alterCmd:                       `ALTER TABLE t.test SET LOCALITY GLOBAL`,
+			cmd:                            `ALTER TABLE t.test SET LOCALITY GLOBAL`,
 			errorOnAddOrDropRegionSandwich: "pq: cannot perform database region changes while a REGIONAL BY ROW transition is underway",
+			errorOnTableChangeSandwich:     "pq: cannot perform this locality change while a region is being added or dropped on the database",
 		},
 		{
 			setup:                          `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY REGIONAL BY ROW`,
-			alterCmd:                       `CREATE INDEX v_idx ON t.test(v)`,
+			cmd:                            `CREATE INDEX v_idx ON t.test(v)`,
 			errorOnAddOrDropRegionSandwich: "pq: cannot perform database region changes while an index is being created or dropped on a REGIONAL BY ROW table",
+			errorOnTableChangeSandwich:     "pq: cannot CREATE INDEX on a REGIONAL BY ROW table while a region is being added or dropped on the database",
 		},
 		{
 			setup:                          `CREATE TABLE t.test (k INT NOT NULL, v INT, INDEX v_idx (v)) LOCALITY REGIONAL BY ROW`,
-			alterCmd:                       `DROP INDEX t.test@v_idx`,
+			cmd:                            `DROP INDEX t.test@v_idx`,
 			errorOnAddOrDropRegionSandwich: "pq: cannot perform database region changes while an index is being created or dropped on a REGIONAL BY ROW table",
+			errorOnTableChangeSandwich:     "pq: cannot DROP INDEX on a REGIONAL BY ROW table while a region is being added or dropped on the database",
 		},
 		{
 			setup:                          `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY REGIONAL BY ROW`,
-			alterCmd:                       `ALTER TABLE t.test ADD CONSTRAINT v_uniq UNIQUE (v)`,
+			cmd:                            `ALTER TABLE t.test ADD CONSTRAINT v_uniq UNIQUE (v)`,
 			errorOnAddOrDropRegionSandwich: "pq: cannot perform database region changes while an index is being created or dropped on a REGIONAL BY ROW table",
+			errorOnTableChangeSandwich:     "pq: cannot create an UNIQUE CONSTRAINT on a REGIONAL BY ROW table while a region is being added or dropped on the database",
 		},
 		{
 			setup:                          `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY REGIONAL BY ROW`,
-			alterCmd:                       `ALTER TABLE t.test ADD COLUMN z INT UNIQUE`,
+			cmd:                            `ALTER TABLE t.test ADD COLUMN z INT UNIQUE`,
 			errorOnAddOrDropRegionSandwich: "pq: cannot perform database region changes while an index is being created or dropped on a REGIONAL BY ROW table",
+			errorOnTableChangeSandwich:     "pq: cannot add an UNIQUE COLUMN on a REGIONAL BY ROW table while a region is being added or dropped on the database",
 		},
 		{
 			setup:                          `CREATE TABLE t.test (k INT NOT NULL, v INT NOT NULL) LOCALITY REGIONAL BY ROW`,
-			alterCmd:                       `ALTER TABLE t.test ALTER PRIMARY KEY USING COLUMNS (v)`,
+			cmd:                            `ALTER TABLE t.test ALTER PRIMARY KEY USING COLUMNS (v)`,
 			errorOnAddOrDropRegionSandwich: "pq: cannot perform database region changes while a ALTER PRIMARY KEY is underway",
+			errorOnTableChangeSandwich:     "pq: cannot perform a primary key change on a REGIONAL BY ROW table while a region is being added or dropped on the database",
 		},
 	}
 
@@ -775,7 +783,7 @@ USE t;
 	// Tests ADD/DROP REGION during a REGIONAL BY ROW index-related change.
 	for _, rbrChange := range regionalByRowChanges {
 		for _, regionChange := range regionChanges {
-			t.Run(fmt.Sprintf("from %s to %s with racing %s", rbrChange.setup, rbrChange.alterCmd, regionChange.cmd), func(t *testing.T) {
+			t.Run(fmt.Sprintf("setup %s executing %s with racing %s", rbrChange.setup, rbrChange.cmd, regionChange.cmd), func(t *testing.T) {
 				interruptStartCh := make(chan struct{})
 				interruptEndCh := make(chan struct{})
 				performInterrupt := false
@@ -805,7 +813,7 @@ USE t;
 				rbrErrCh := make(chan error, 1)
 				performInterrupt = true
 				go func() {
-					_, err := sqlDB.Exec(rbrChange.alterCmd)
+					_, err := sqlDB.Exec(rbrChange.cmd)
 					rbrErrCh <- err
 				}()
 
@@ -820,6 +828,60 @@ USE t;
 
 				// Now finish up and ensure no errors.
 				require.NoError(t, <-rbrErrCh)
+
+				// Validate the zone configuration.
+				_, err = sqlDB.Exec(`SELECT crdb_internal.validate_multi_region_zone_configs()`)
+				require.NoError(t, err)
+			})
+		}
+	}
+
+	// Tests REGIONAL BY ROW during a ADD/DROP REGION index-related change.
+	for _, regionChange := range regionChanges {
+		for _, rbrChange := range regionalByRowChanges {
+			t.Run(fmt.Sprintf("setup %s executing %s with racing %s", rbrChange.setup, regionChange.cmd, rbrChange.cmd), func(t *testing.T) {
+				interruptStartCh := make(chan struct{})
+				interruptEndCh := make(chan struct{})
+				performInterrupt := false
+
+				_, sqlDB, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
+					t,
+					3, /* numServers */
+					base.TestingKnobs{
+						SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
+							RunBeforeExec: func() error {
+								if performInterrupt {
+									performInterrupt = false
+									close(interruptStartCh)
+									<-interruptEndCh
+								}
+								return nil
+							},
+						},
+					},
+					nil, /* baseDir */
+				)
+				defer cleanup()
+				setupDB(sqlDB, rbrChange.setup)
+				performInterrupt = true
+
+				regionChangeErr := make(chan error, 1)
+				go func() {
+					_, err := sqlDB.Exec(regionChange.cmd)
+					regionChangeErr <- err
+				}()
+
+				// Wait for the enum change to start.
+				<-interruptStartCh
+
+				// Perform the REGIONAL BY ROW transformation.
+				_, err := sqlDB.Exec(rbrChange.cmd)
+				close(interruptEndCh)
+				require.Error(t, err)
+				require.EqualError(t, err, rbrChange.errorOnTableChangeSandwich)
+
+				// Ensure the region change does not error.
+				require.NoError(t, <-regionChangeErr)
 
 				// Validate the zone configuration.
 				_, err = sqlDB.Exec(`SELECT crdb_internal.validate_multi_region_zone_configs()`)

--- a/pkg/ccl/multiregionccl/regional_by_row_test.go
+++ b/pkg/ccl/multiregionccl/regional_by_row_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -692,5 +693,138 @@ CREATE TABLE regional_by_row (
 			err = queryIndexGCJobsAndValidateCount(`running`, 0)
 			require.NoError(t, err)
 		})
+	}
+}
+
+// TestRegionChangeRacingAlterTableRegionalByRow tests regional by row changes
+// conflicting with ADD/DROP region changes.
+func TestRegionChangeRacingRegionalByRowChange(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	skip.UnderRace(t, "too slow under race (>10min)")
+
+	regionalByRowChanges := []struct {
+		setup                          string
+		alterCmd                       string
+		errorOnAddOrDropRegionSandwich string
+	}{
+		{
+			setup:                          `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY GLOBAL`,
+			alterCmd:                       `ALTER TABLE t.test SET LOCALITY REGIONAL BY ROW`,
+			errorOnAddOrDropRegionSandwich: "pq: cannot perform database region changes while a REGIONAL BY ROW transition is underway",
+		},
+		{
+			setup:                          `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY REGIONAL BY ROW`,
+			alterCmd:                       `ALTER TABLE t.test SET LOCALITY GLOBAL`,
+			errorOnAddOrDropRegionSandwich: "pq: cannot perform database region changes while a REGIONAL BY ROW transition is underway",
+		},
+		{
+			setup:                          `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY REGIONAL BY ROW`,
+			alterCmd:                       `CREATE INDEX v_idx ON t.test(v)`,
+			errorOnAddOrDropRegionSandwich: "pq: cannot perform database region changes while an index is being created or dropped on a REGIONAL BY ROW table",
+		},
+		{
+			setup:                          `CREATE TABLE t.test (k INT NOT NULL, v INT, INDEX v_idx (v)) LOCALITY REGIONAL BY ROW`,
+			alterCmd:                       `DROP INDEX t.test@v_idx`,
+			errorOnAddOrDropRegionSandwich: "pq: cannot perform database region changes while an index is being created or dropped on a REGIONAL BY ROW table",
+		},
+		{
+			setup:                          `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY REGIONAL BY ROW`,
+			alterCmd:                       `ALTER TABLE t.test ADD CONSTRAINT v_uniq UNIQUE (v)`,
+			errorOnAddOrDropRegionSandwich: "pq: cannot perform database region changes while an index is being created or dropped on a REGIONAL BY ROW table",
+		},
+		{
+			setup:                          `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY REGIONAL BY ROW`,
+			alterCmd:                       `ALTER TABLE t.test ADD COLUMN z INT UNIQUE`,
+			errorOnAddOrDropRegionSandwich: "pq: cannot perform database region changes while an index is being created or dropped on a REGIONAL BY ROW table",
+		},
+		{
+			setup:                          `CREATE TABLE t.test (k INT NOT NULL, v INT NOT NULL) LOCALITY REGIONAL BY ROW`,
+			alterCmd:                       `ALTER TABLE t.test ALTER PRIMARY KEY USING COLUMNS (v)`,
+			errorOnAddOrDropRegionSandwich: "pq: cannot perform database region changes while a ALTER PRIMARY KEY is underway",
+		},
+	}
+
+	regionChanges := []struct {
+		cmd string
+	}{
+		{
+			cmd: `ALTER DATABASE t ADD REGION "us-east3"`,
+		},
+		{
+			cmd: `ALTER DATABASE t DROP REGION "us-east2"`,
+		},
+	}
+
+	setupDB := func(sqlDB *gosql.DB, setupSQL string) {
+		// Drop the closed timestamp target lead for GLOBAL tables for speed-up improvements.
+		// TODO(nvanbenschoten): We can remove this when that issue
+		// is addressed.
+		_, err := sqlDB.Exec(`SET CLUSTER SETTING kv.closed_timestamp.lead_for_global_reads_override = '5ms'`)
+		require.NoError(t, err)
+
+		_, err = sqlDB.Exec(fmt.Sprintf(`
+DROP DATABASE IF EXISTS t;
+CREATE DATABASE t PRIMARY REGION "us-east1" REGION "us-east2";
+USE t;
+%s;
+`, setupSQL))
+		require.NoError(t, err)
+	}
+
+	// Tests ADD/DROP REGION during a REGIONAL BY ROW index-related change.
+	for _, rbrChange := range regionalByRowChanges {
+		for _, regionChange := range regionChanges {
+			t.Run(fmt.Sprintf("from %s to %s with racing %s", rbrChange.setup, rbrChange.alterCmd, regionChange.cmd), func(t *testing.T) {
+				interruptStartCh := make(chan struct{})
+				interruptEndCh := make(chan struct{})
+				performInterrupt := false
+
+				_, sqlDB, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
+					t,
+					3, /* numServers */
+					base.TestingKnobs{
+						SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+							RunBeforeBackfill: func() error {
+								if performInterrupt {
+									performInterrupt = false
+									close(interruptStartCh)
+									<-interruptEndCh
+								}
+								return nil
+							},
+						},
+					},
+					nil, /* baseDir */
+				)
+				defer cleanup()
+
+				setupDB(sqlDB, rbrChange.setup)
+
+				// Perform the alter table command asynchronously; this will be interrupted.
+				rbrErrCh := make(chan error, 1)
+				performInterrupt = true
+				go func() {
+					_, err := sqlDB.Exec(rbrChange.alterCmd)
+					rbrErrCh <- err
+				}()
+
+				// Wait for the backfill to start.
+				<-interruptStartCh
+
+				// Now run the alter command on the database.
+				_, err := sqlDB.Exec(regionChange.cmd)
+				close(interruptEndCh)
+				require.Error(t, err)
+				require.EqualError(t, err, rbrChange.errorOnAddOrDropRegionSandwich)
+
+				// Now finish up and ensure no errors.
+				require.NoError(t, <-rbrErrCh)
+
+				// Validate the zone configuration.
+				_, err = sqlDB.Exec(`SELECT crdb_internal.validate_multi_region_zone_configs()`)
+				require.NoError(t, err)
+			})
+		}
 	}
 }

--- a/pkg/sql/add_column.go
+++ b/pkg/sql/add_column.go
@@ -83,6 +83,16 @@ func (p *planner) addColumnImpl(
 
 	// Ensure all new indexes are partitioned appropriately.
 	if idx != nil {
+		if n.tableDesc.IsLocalityRegionalByRow() {
+			if err := params.p.checkNoRegionChangeUnderway(
+				params.ctx,
+				n.tableDesc.GetParentID(),
+				"add an UNIQUE COLUMN on a REGIONAL BY ROW table",
+			); err != nil {
+				return err
+			}
+		}
+
 		*idx, err = p.configureIndexDescForNewIndexPartitioning(
 			params.ctx,
 			desc,

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -158,6 +158,13 @@ func (p *planner) AlterDatabaseAddRegion(
 		return nil, err
 	}
 
+	if err := p.checkNoRegionalByRowChangeUnderway(
+		ctx,
+		dbDesc,
+	); err != nil {
+		return nil, err
+	}
+
 	// Adding a region also involves repartitioning all REGIONAL BY ROW tables
 	// underneath the hood, so we must ensure the user has the requisite
 	// privileges.
@@ -290,6 +297,14 @@ func (p *planner) AlterDatabaseDropRegion(
 	if err := p.checkPrivilegesForMultiRegionOp(ctx, dbDesc); err != nil {
 		return nil, err
 	}
+
+	if err := p.checkNoRegionalByRowChangeUnderway(
+		ctx,
+		dbDesc,
+	); err != nil {
+		return nil, err
+	}
+
 	// Dropping a region also involves repartitioning all REGIONAL BY ROW tables
 	// underneath the hood, so we must ensure the user has the requisite
 	// privileges.

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -51,6 +51,24 @@ func (p *planner) AlterPrimaryKey(
 	alterPKNode tree.AlterTableAlterPrimaryKey,
 	alterPrimaryKeyLocalitySwap *alterPrimaryKeyLocalitySwap,
 ) error {
+	if alterPrimaryKeyLocalitySwap != nil {
+		if err := p.checkNoRegionChangeUnderway(
+			ctx,
+			tableDesc.GetParentID(),
+			"perform this locality change",
+		); err != nil {
+			return err
+		}
+	} else if tableDesc.IsLocalityRegionalByRow() {
+		if err := p.checkNoRegionChangeUnderway(
+			ctx,
+			tableDesc.GetParentID(),
+			"perform a primary key change on a REGIONAL BY ROW table",
+		); err != nil {
+			return err
+		}
+	}
+
 	if alterPKNode.Interleave != nil {
 		if err := interleavedTableDeprecationAction(p.RunParams(ctx)); err != nil {
 			return err

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -281,6 +281,16 @@ func (n *alterTableNode) startExec(params runParams) error {
 				); err != nil {
 					return err
 				}
+
+				if n.tableDesc.IsLocalityRegionalByRow() {
+					if err := params.p.checkNoRegionChangeUnderway(
+						params.ctx,
+						n.tableDesc.GetParentID(),
+						"create an UNIQUE CONSTRAINT on a REGIONAL BY ROW table",
+					); err != nil {
+						return err
+					}
+				}
 			case *tree.CheckConstraintTableDef:
 				var err error
 				params.p.runWithOptions(resolveFlags{contextDatabaseID: n.tableDesc.ParentID}, func() {

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -79,6 +79,16 @@ func (p *planner) CreateIndex(ctx context.Context, n *tree.CreateIndex) (planNod
 		return nil, err
 	}
 
+	if tableDesc.IsLocalityRegionalByRow() {
+		if err := p.checkNoRegionChangeUnderway(
+			ctx,
+			tableDesc.GetParentID(),
+			"CREATE INDEX on a REGIONAL BY ROW table",
+		); err != nil {
+			return nil, err
+		}
+	}
+
 	return &createIndexNode{tableDesc: tableDesc, n: n}, nil
 }
 

--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -103,7 +103,7 @@ func (p *planner) writeDatabaseChangeToBatch(
 func (p *planner) forEachMutableTableInDatabase(
 	ctx context.Context,
 	dbDesc catalog.DatabaseDescriptor,
-	fn func(ctx context.Context, tbDesc *tabledesc.Mutable) error,
+	fn func(ctx context.Context, scName string, tbDesc *tabledesc.Mutable) error,
 ) error {
 	allDescs, err := p.Descriptors().GetAllDescriptors(ctx, p.txn)
 	if err != nil {
@@ -117,7 +117,7 @@ func (p *planner) forEachMutableTableInDatabase(
 			continue
 		}
 		mutable := tabledesc.NewBuilder(desc.TableDesc()).BuildExistingMutableTable()
-		if err := fn(ctx, mutable); err != nil {
+		if err := fn(ctx, lCtx.schemaNames[desc.GetParentSchemaID()], mutable); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/database_region_change_finalizer.go
+++ b/pkg/sql/database_region_change_finalizer.go
@@ -79,7 +79,7 @@ func newDatabaseRegionChangeFinalizer(
 		return localPlanner.forEachMutableTableInDatabase(
 			ctx,
 			dbDesc,
-			func(ctx context.Context, tableDesc *tabledesc.Mutable) error {
+			func(ctx context.Context, scName string, tableDesc *tabledesc.Mutable) error {
 				if !tableDesc.IsLocalityRegionalByRow() || tableDesc.Dropped() {
 					// We only need to re-partition REGIONAL BY ROW tables. Even then, we
 					// don't need to (can't) repartition a REGIONAL BY ROW table if it has

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -255,6 +255,16 @@ func (p *planner) dropIndexByName(
 		return nil
 	}
 
+	if tableDesc.IsLocalityRegionalByRow() {
+		if err := p.checkNoRegionChangeUnderway(
+			ctx,
+			tableDesc.GetParentID(),
+			"DROP INDEX on a REGIONAL BY ROW table",
+		); err != nil {
+			return err
+		}
+	}
+
 	if idx.IsUnique() && behavior != tree.DropCascade && constraintBehavior != ignoreIdxConstraint && !idx.IsCreatedExplicitly() {
 		return errors.WithHint(
 			pgerror.Newf(pgcode.DependentObjectsStillExist,

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -55,7 +55,7 @@ Query {"String": "DROP INDEX t_x_idx"}
 until crdb_only
 CommandComplete
 ----
-{"Severity":"NOTICE","SeverityUnlocalized":"","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":518,"Routine":"dropIndexByName","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":528,"Routine":"dropIndexByName","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 
 until noncrdb_only

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -730,7 +730,7 @@ func (p *planner) updateZoneConfigsForAllTables(ctx context.Context, desc *dbdes
 	return p.forEachMutableTableInDatabase(
 		ctx,
 		desc,
-		func(ctx context.Context, tbDesc *tabledesc.Mutable) error {
+		func(ctx context.Context, scName string, tbDesc *tabledesc.Mutable) error {
 			regionConfig, err := SynthesizeRegionConfig(ctx, p.txn, desc.ID, p.Descriptors())
 			if err != nil {
 				return err
@@ -856,7 +856,7 @@ func (p *planner) validateAllMultiRegionZoneConfigsInDatabase(
 	if err := p.forEachMutableTableInDatabase(
 		ctx,
 		dbDesc,
-		func(ctx context.Context, tbDesc *tabledesc.Mutable) error {
+		func(ctx context.Context, scName string, tbDesc *tabledesc.Mutable) error {
 			ids = append(ids, tbDesc.GetID())
 			return nil
 		},
@@ -886,7 +886,7 @@ func (p *planner) validateAllMultiRegionZoneConfigsInDatabase(
 	return p.forEachMutableTableInDatabase(
 		ctx,
 		dbDesc,
-		func(ctx context.Context, tbDesc *tabledesc.Mutable) error {
+		func(ctx context.Context, scName string, tbDesc *tabledesc.Mutable) error {
 			return p.validateZoneConfigForMultiRegionTable(
 				tbDesc,
 				zoneConfigs[tbDesc.GetID()],

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -1685,3 +1685,68 @@ func (p *planner) validateZoneConfigForMultiRegionTable(
 
 	return nil
 }
+
+// checkNoRegionalByRowChangeUnderway checks that no REGIONAL BY ROW
+// tables are undergoing a schema change that affect their partitions
+// and no tables are transitioning to or from REGIONAL BY ROW.
+func (p *planner) checkNoRegionalByRowChangeUnderway(
+	ctx context.Context, dbDesc catalog.DatabaseDescriptor,
+) error {
+	// forEachTableDesc touches all the table keys, which prevents a race
+	// with ADD/REGION committing at the same time as the user transaction.
+	return p.forEachMutableTableInDatabase(
+		ctx,
+		dbDesc,
+		func(ctx context.Context, scName string, table *tabledesc.Mutable) error {
+			wrapErr := func(err error, detailSuffix string) error {
+				return errors.WithHintf(
+					errors.WithDetailf(
+						err,
+						"table %s.%s %s",
+						tree.Name(scName),
+						tree.Name(table.GetName()),
+						detailSuffix,
+					),
+					"cancel the existing job or try again when the change is complete",
+				)
+			}
+			for _, mut := range table.AllMutations() {
+				// Disallow any locality related swaps.
+				if pkSwap := mut.AsPrimaryKeySwap(); pkSwap != nil {
+					if lcSwap := pkSwap.PrimaryKeySwapDesc().LocalityConfigSwap; lcSwap != nil {
+						return wrapErr(
+							pgerror.Newf(
+								pgcode.ObjectNotInPrerequisiteState,
+								"cannot perform database region changes while a REGIONAL BY ROW transition is underway",
+							),
+							"is currently transitioning to or from REGIONAL BY ROW",
+						)
+					}
+					return wrapErr(
+						pgerror.Newf(
+							pgcode.ObjectNotInPrerequisiteState,
+							"cannot perform database region changes while a ALTER PRIMARY KEY is underway",
+						),
+						"is currently undergoing an ALTER PRIMARY KEY change",
+					)
+				}
+			}
+			// Disallow index changes for REGIONAL BY ROW tables.
+			// We do this on the second loop, as index changes may be a precede to the actual PRIMARY KEY swap.
+			for _, mut := range table.AllMutations() {
+				if table.IsLocalityRegionalByRow() {
+					if idx := mut.AsIndex(); idx != nil {
+						return wrapErr(
+							pgerror.Newf(
+								pgcode.ObjectNotInPrerequisiteState,
+								"cannot perform database region changes while an index is being created or dropped on a REGIONAL BY ROW table",
+							),
+							fmt.Sprintf("is currently modifying index %s", tree.Name(idx.GetName())),
+						)
+					}
+				}
+			}
+			return nil
+		},
+	)
+}


### PR DESCRIPTION
see individual commits for details

resolves #63368
resolves #63462 
resolves #64011
resolves #63974