### PR TITLE
concurrency: include safe details in `discoveredLock()` assertion

### DIFF
--- a/pkg/kv/kvserver/concurrency/BUILD.bazel
+++ b/pkg/kv/kvserver/concurrency/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//pkg/util/tracing",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 
@@ -72,6 +73,7 @@ go_test(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_maruel_panicparse//stack",
         "@com_github_petermattis_goid//:goid",
         "@com_github_stretchr_testify//require",

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -34,6 +34,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/rand"
 	"golang.org/x/sync/errgroup"
 )
@@ -1298,3 +1300,23 @@ func BenchmarkLockTable(b *testing.B) {
 // - Test with concurrency in lockTable calls.
 //   - test for race in gc'ing lock that has since become non-empty or new
 //     non-empty one has been inserted.
+
+func TestLockStateSafeFormat(t *testing.T) {
+	l := &lockState{
+		id:     1,
+		key:    []byte("KEY"),
+		endKey: []byte("END"),
+	}
+	l.holder.locked = true
+	l.holder.holder[lock.Replicated] = lockHolderInfo{
+		txn:  &enginepb.TxnMeta{ID: uuid.NamespaceDNS},
+		ts:   hlc.Timestamp{WallTime: 123, Logical: 7},
+		seqs: []enginepb.TxnSeq{1},
+	}
+	require.EqualValues(t,
+		" lock: ‹\"KEY\"›\n  holder: txn: 6ba7b810-9dad-11d1-80b4-00c04fd430c8, ts: 0.000000123,7, info: repl epoch: 0, seqs: [1]\n",
+		redact.Sprint(l))
+	require.EqualValues(t,
+		" lock: ‹×›\n  holder: txn: 6ba7b810-9dad-11d1-80b4-00c04fd430c8, ts: 0.000000123,7, info: repl epoch: 0, seqs: [1]\n",
+		redact.Sprint(l).Redact())
+}


### PR DESCRIPTION
As seen in #63592, an assertion in `discoveredLock` occasionally fails,
but does not include enough details to debug the issue.

This patch implements `SafeFormatter` for `lockState`, and includes the
redacted lock state and txn in the assertion error message.

Release note: None