### PR TITLE
release-21.1: testutils: fix a nil pointer panic in TestCluster.GetRaftLeader

### DIFF
--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -1419,6 +1419,9 @@ func (tc *TestCluster) GetRaftLeader(t testing.TB, key roachpb.RKey) *kvserver.R
 					return nil
 				}
 				raftStatus := repl.RaftStatus()
+				if raftStatus == nil {
+					return errors.Errorf("raft group is not initialized for replica with key %s", key)
+				}
 				if raftStatus.Term > latestTerm || (raftLeaderRepl == nil && raftStatus.Term == latestTerm) {
 					// If we find any newer term, it means any previous election is
 					// invalid.


### PR DESCRIPTION
Backport 1/1 commits from #61868.

/cc @cockroachdb/release

---

Fixes #61485

TestReplicateRemovedNodeDisruptiveElection exposed a nil pointer panic
in TestCluster.GetRaftLeader. Replica.RaftStatus could return nil
if the raft group is not yet initilized. This commit adds a guard for
that condition.

Release note: None
