### PR TITLE
ui: add average number of runnable goroutines to the runtime graphs

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -304,6 +304,7 @@ ALL_TESTS = [
     "//pkg/util/flagutil:flagutil_test",
     "//pkg/util/fsm:fsm_test",
     "//pkg/util/fuzzystrmatch:fuzzystrmatch_test",
+    "//pkg/util/goschedstats:goschedstats_test",
     "//pkg/util/grpcutil:grpcutil_test",
     "//pkg/util/hlc:hlc_test",
     "//pkg/util/humanizeutil:humanizeutil_test",

--- a/pkg/server/status/BUILD.bazel
+++ b/pkg/server/status/BUILD.bazel
@@ -53,6 +53,7 @@ go_library(
         "//pkg/ts/tspb",
         "//pkg/util/cgroups",
         "//pkg/util/envutil",
+        "//pkg/util/goschedstats",
         "//pkg/util/hlc",
         "//pkg/util/humanizeutil",
         "//pkg/util/log",

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1664,6 +1664,9 @@ func TestLint(t *testing.T) {
 				stream.GrepNot(`pkg/rpc/stats_handler.go:.*v.WireLength is deprecated: This field is never set.*`),
 				// rpc/codec.go imports the same proto package that grpc-go imports (as of crdb@dd87d1145 and grpc-go@7b167fd6).
 				stream.GrepNot(`pkg/rpc/codec.go:.*package github.com/golang/protobuf/proto is deprecated: Use the "google.golang.org/protobuf/proto" package instead.`),
+				// goschedstats contains partial copies of go runtime structures, with
+				// many fields that we're not using.
+				stream.GrepNot(`pkg/util/goschedstats/runtime.*\.go:.*is unused`),
 			), func(s string) {
 				t.Errorf("\n%s", s)
 			}); err != nil {

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -174,7 +174,7 @@ var charts = []sectionDescription{
 		Charts: []chartDescription{
 			{
 				Title:   "goroutines",
-				Metrics: []string{"sys.goroutines"},
+				Metrics: []string{"sys.goroutines", "sys.runnable.goroutines.per.cpu"},
 			},
 			{
 				Title: "Memory",

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
@@ -82,6 +82,23 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
+    <LineGraph
+      title="Runnable Goroutines per CPU"
+      sources={nodeSources}
+      tooltip={`The number of Goroutines waiting for CPU ${tooltipSelection}.
+           This count should rise and fall based on load.`}
+    >
+      <Axis label="goroutines">
+        {nodeIDs.map((nid) => (
+          <Metric
+            name="cr.node.sys.runnable.goroutines.per.cpu"
+            title={nodeDisplayName(nodesSummary, nid)}
+            sources={[nid]}
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
     // TODO(mrtracy): The following two graphs are a good first example of a graph with
     // two axes; the two series should be highly correlated, but have different units.
     <LineGraph

--- a/pkg/util/goschedstats/BUILD.bazel
+++ b/pkg/util/goschedstats/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "goschedstats",
+    srcs = [
+        "runnable.go",
+        "runtime_go1.15.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/pkg/util/goschedstats",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/util/timeutil"],
+)
+
+go_test(
+    name = "goschedstats_test",
+    srcs = ["runnable_test.go"],
+    embed = [":goschedstats"],
+    deps = ["//pkg/testutils"],
+)

--- a/pkg/util/goschedstats/runnable.go
+++ b/pkg/util/goschedstats/runnable.go
@@ -1,0 +1,118 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package goschedstats
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// CumulativeNormalizedRunnableGoroutines returns the sum, over all seconds
+// since the program started, of the average number of runnable goroutines per
+// GOMAXPROC.
+//
+// Runnable goroutines are goroutines which are ready to run but are waiting for
+// an available process. Sustained high numbers of waiting goroutines are a
+// potential indicator of high CPU saturation (overload).
+//
+// The number of runnable goroutines is sampled frequently, and an average is
+// calculated and accumulated once per second.
+func CumulativeNormalizedRunnableGoroutines() float64 {
+	return float64(atomic.LoadUint64(&total)) * fromFixedPoint
+}
+
+// RecentNormalizedRunnableGoroutines returns a recent average of the number of
+// runnable goroutines per GOMAXPROC.
+//
+// Runnable goroutines are goroutines which are ready to run but are waiting for
+// an available process. Sustained high numbers of waiting goroutines are a
+// potential indicator of high CPU saturation (overload).
+//
+// The number of runnable goroutines is sampled frequently, and an average is
+// calculated once per second. This function returns an exponentially weighted
+// moving average of these values.
+func RecentNormalizedRunnableGoroutines() float64 {
+	return float64(atomic.LoadUint64(&ewma)) * fromFixedPoint
+}
+
+// If you get a compilation error here, the Go version you are using is not
+// supported by this package. Cross-check the structures in runtime_go1.15.go
+// against those in the new Go's runtime, and if they are still accurate adjust
+// the build tag in that file to accept the version. If they don't match, you
+// will have to add a new version of that file.
+var _ = numRunnableGoroutines
+
+// We sample the number of runnable goroutines once per samplePeriod.
+const samplePeriod = time.Millisecond
+
+// We "report" the average value every reportingPeriod.
+// Note: if this is changed from 1s, CumulativeNormalizedRunnableGoroutines()
+// needs to be updated to scale the sum accordingly.
+const reportingPeriod = time.Second
+
+// For efficiency, we use "fixed point" arithmetic in the sampling loop: we
+// scale up values and use integers.
+const toFixedPoint = 65536
+const fromFixedPoint = 1.0 / toFixedPoint
+
+// total accumulates the sum of the number of runnable goroutines per CPU
+// (averaged over a reporting period), multiplied by toFixedPoint.
+var total uint64
+
+// ewma keeps an exponentially weighted moving average of the runnable
+// goroutines per CPU (averaged over a reporting period), multiplied by
+// toFixedPoint.
+// The EWMA coefficient is 0.5.
+var ewma uint64
+
+func init() {
+	go func() {
+		lastTime := timeutil.Now()
+		// sum accumulates the sum of the number of runnable goroutines per CPU,
+		// multiplied by toFixedPoint, for all samples since the last reporting.
+		var sum uint64
+		var numSamples int
+
+		ticker := time.NewTicker(samplePeriod)
+		// We keep local versions of "total" and "ewma" and we just Store the
+		// updated values to the globals.
+		var localTotal, localEWMA uint64
+		for {
+			t := <-ticker.C
+			if t.Sub(lastTime) > reportingPeriod {
+				if numSamples > 0 {
+					// We want the average value over the reporting period, so we divide
+					// by numSamples.
+					newValue := sum / uint64(numSamples)
+					localTotal += newValue
+					atomic.StoreUint64(&total, localTotal)
+
+					// ewma(t) = c * value(t) + (1 - c) * ewma(t-1)
+					// We use c = 0.5.
+					localEWMA = (newValue + localEWMA) / 2
+					atomic.StoreUint64(&ewma, localEWMA)
+				}
+				lastTime = t
+				sum = 0
+				numSamples = 0
+			}
+			runnable, numProcs := numRunnableGoroutines()
+			// The value of the sample is the ratio of runnable to numProcs (scaled
+			// for fixed-point arithmetic).
+			sum += uint64(runnable) * toFixedPoint / uint64(numProcs)
+			numSamples++
+		}
+	}()
+}
+
+var _ = RecentNormalizedRunnableGoroutines

--- a/pkg/util/goschedstats/runnable_test.go
+++ b/pkg/util/goschedstats/runnable_test.go
@@ -1,0 +1,41 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package goschedstats
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+)
+
+func TestNumRunnableGoroutines(t *testing.T) {
+	// Start 500 goroutines that never finish.
+	const n = 400
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			a := 1
+			for x := 0; x >= 0; x++ {
+				a = a*13 + x
+			}
+		}(i)
+	}
+	// When we run, we expect at most GOMAXPROCS-1 of the n goroutines to be
+	// running, with the rest waiting.
+	expected := n - runtime.GOMAXPROCS(0) + 1
+	testutils.SucceedsSoon(t, func() error {
+		if n, _ := numRunnableGoroutines(); n < expected {
+			return fmt.Errorf("only %d runnable goroutines, expected %d", n, expected)
+		}
+		return nil
+	})
+}

--- a/pkg/util/goschedstats/runtime_go1.15.go
+++ b/pkg/util/goschedstats/runtime_go1.15.go
@@ -1,0 +1,164 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+//
+// The structure definitions in this file have been cross-checked against
+// go1.15.5 and go1.16. Before allowing newer versions, please check that the
+// structures still match with those in go/src/runtime.
+// +build gc,go1.15,!go1.17
+
+package goschedstats
+
+import (
+	"sync/atomic"
+	_ "unsafe" // required by go:linkname
+)
+
+type puintptr uintptr
+
+type muintptr uintptr
+
+type guintptr uintptr
+
+type sysmontick struct {
+	schedtick   uint32
+	schedwhen   int64
+	syscalltick uint32
+	syscallwhen int64
+}
+
+type pageCache struct {
+	base  uintptr // base address of the chunk
+	cache uint64  // 64-bit bitmap representing free pages (1 means free)
+	scav  uint64  // 64-bit bitmap representing scavenged pages (1 means scavenged)
+}
+
+type p struct {
+	id          int32
+	status      uint32 // one of pidle/prunning/...
+	link        puintptr
+	schedtick   uint32     // incremented on every scheduler call
+	syscalltick uint32     // incremented on every system call
+	sysmontick  sysmontick // last tick observed by sysmon
+	m           muintptr   // back-link to associated m (nil if idle)
+	mcache      uintptr
+	pcache      pageCache
+	raceprocctx uintptr
+
+	deferpool    [5][]uintptr // pool of available defer structs of different sizes (see panic.go)
+	deferpoolbuf [5][32]uintptr
+
+	// Cache of goroutine ids, amortizes accesses to runtime·sched.goidgen.
+	goidcache    uint64
+	goidcacheend uint64
+
+	// Queue of runnable goroutines. Accessed without lock.
+	runqhead uint32
+	runqtail uint32
+	runq     [256]guintptr
+	// runnext, if non-nil, is a runnable G that was ready'd by
+	// the current G and should be run next instead of what's in
+	// runq if there's time remaining in the running G's time
+	// slice. It will inherit the time left in the current time
+	// slice. If a set of goroutines is locked in a
+	// communicate-and-wait pattern, this schedules that set as a
+	// unit and eliminates the (potentially large) scheduling
+	// latency that otherwise arises from adding the ready'd
+	// goroutines to the end of the run queue.
+	runnext guintptr
+
+	// The rest of the fields aren't important.
+}
+
+type mutex struct {
+	// Empty struct if lock ranking is disabled, otherwise includes the lock rank
+	//lockRankStruct
+	// Futex-based impl treats it as uint32 key,
+	// while sema-based impl as M* waitm.
+	// Used to be a union, but unions break precise GC.
+	key uintptr
+}
+
+type gQueue struct {
+	head guintptr
+	tail guintptr
+}
+
+type schedt struct {
+	// accessed atomically. keep at top to ensure alignment on 32-bit systems.
+	goidgen   uint64
+	lastpoll  uint64 // time of last network poll, 0 if currently polling
+	pollUntil uint64 // time to which current poll is sleeping
+
+	lock mutex
+
+	// When increasing nmidle, nmidlelocked, nmsys, or nmfreed, be
+	// sure to call checkdead().
+
+	midle        muintptr // idle m's waiting for work
+	nmidle       int32    // number of idle m's waiting for work
+	nmidlelocked int32    // number of locked m's waiting for work
+	mnext        int64    // number of m's that have been created and next M ID
+	maxmcount    int32    // maximum number of m's allowed (or die)
+	nmsys        int32    // number of system m's not counted for deadlock
+	nmfreed      int64    // cumulative number of freed m's
+
+	ngsys uint32 // number of system goroutines; updated atomically
+
+	pidle      puintptr // idle p's
+	npidle     uint32
+	nmspinning uint32 // See "Worker thread parking/unparking" comment in proc.go.
+
+	// Global runnable queue.
+	runq     gQueue
+	runqsize int32
+
+	// The rest of the fields aren't important.
+}
+
+//go:linkname allp runtime.allp
+var allp []*p
+
+//go:linkname sched runtime.sched
+var sched schedt
+
+//go:linkname lock runtime.lock
+func lock(l *mutex)
+
+//go:linkname unlock runtime.unlock
+func unlock(l *mutex)
+
+func numRunnableGoroutines() (numRunnable int, numProcs int) {
+	lock(&sched.lock)
+	numRunnable = int(sched.runqsize)
+	numProcs = len(allp)
+
+	// Note that holding sched.lock prevents the number of Ps from changing, so
+	// it's safe to loop over allp.
+	for _, p := range allp {
+		// Retry loop for concurrent updates.
+		for {
+			h := atomic.LoadUint32(&p.runqhead)
+			t := atomic.LoadUint32(&p.runqtail)
+			next := atomic.LoadUintptr((*uintptr)(&p.runnext))
+			runnable := int32(t - h)
+			if atomic.LoadUint32(&p.runqhead) != h || runnable < 0 {
+				// A concurrent update messed with us; try again.
+				continue
+			}
+			if next != 0 {
+				runnable++
+			}
+			numRunnable += int(runnable)
+			break
+		}
+	}
+	unlock(&sched.lock)
+	return numRunnable, numProcs
+}


### PR DESCRIPTION
#### util: introduce goschedstats

This commit adds an util package which sets up a background job which
monitors the average number of runnable goroutines per CPU. It exposes
functions to retrieve a cumulative sum and a recent moving average of
the value.

Release note: None

#### ui: add average number of runnable goroutines to the runtime graphs

Release note (UI change): a new metric for the average number of
runnable goroutines per CPU is now present in the runtime graphs.

----

I ran tpccbench a bunch of times to make sure there is no regression due to the overhead of maintaining this stat. I saw no difference in the max warehouses with and without this change.