### PR TITLE
concurrency: consult finalizedTxnCache when adding discovered lock

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -596,9 +596,18 @@ type lockTableGuard interface {
 	CurState() waitingState
 
 	// ResolveBeforeScanning lists the locks to resolve before scanning again.
-	// This must be called after the waiting state has transitioned to
-	// doneWaiting.
+	// This must be called after:
+	// - the waiting state has transitioned to doneWaiting.
+	// - if locks were discovered during evaluation, it must be called after all
+	//   the discovered locks have been added.
 	ResolveBeforeScanning() []roachpb.LockUpdate
+
+	// DiscoveredLocks provides guidance to the lock table, that discoveredCount
+	// locks have been discovered. This allows for an internal optimization on
+	// whether to consult the finalized txn cache. It is recommended to call
+	// before iterating over the discovered locks and calling AddDiscoveredLock,
+	// though it is not essential (and some tests don't).
+	DiscoveredLocks(discoveredCount int)
 }
 
 // lockTableWaiter is concerned with waiting in lock wait-queues for locks held
@@ -657,6 +666,11 @@ type lockTableWaiter interface {
 	// and, in turn, remove this method. This will likely fall out of pulling
 	// all replicated locks into the lockTable.
 	WaitOnLock(context.Context, Request, *roachpb.Intent) *Error
+
+	// ResolveDeferredIntents resolves the batch of intents if the provided
+	// error is nil. The batch of intents may be resolved more efficiently than
+	// if they were resolved individually.
+	ResolveDeferredIntents(context.Context, []roachpb.LockUpdate) *Error
 }
 
 // txnWaitQueue holds a collection of wait-queues for transaction records.

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -73,9 +73,7 @@ func (c *Config) initDefaults() {
 func NewManager(cfg Config) Manager {
 	cfg.initDefaults()
 	m := new(managerImpl)
-	lt := &lockTableImpl{
-		maxLocks: cfg.MaxLockTableSize,
-	}
+	lt := newLockTable(cfg.MaxLockTableSize)
 	*m = managerImpl{
 		// TODO(nvanbenschoten): move pkg/storage/spanlatch to a new
 		// pkg/storage/concurrency/latch package. Make it implement the

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -70,6 +70,8 @@ import (
 // on-merge
 // on-snapshot-applied
 //
+// set-consult-finalized-txn-cache-for-discovered-count n=<count>
+//
 // debug-latch-manager
 // debug-lock-table
 // debug-disable-txn-pushes
@@ -443,6 +445,12 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 					m.OnReplicaSnapshotApplied()
 				})
 				return c.waitAndCollect(t, mon)
+
+			case "set-consult-finalized-txn-cache-for-discovered-count":
+				var n int
+				d.ScanArgs(t, "n", &n)
+				concurrency.LockTableConsultFinalizedTxnCacheForDiscoveredCount.Override(&c.st.SV, int64(n))
+				return ""
 
 			case "debug-latch-manager":
 				global, local := m.LatchMetrics()

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -297,7 +297,7 @@ func (w *lockTableWaiterImpl) WaitOn(
 				// the comment in lockTableImpl.tryActiveWait for the proper way to
 				// remove this and other evaluation races.
 				toResolve := guard.ResolveBeforeScanning()
-				return w.resolveDeferredIntents(ctx, toResolve)
+				return w.ResolveDeferredIntents(ctx, toResolve)
 
 			default:
 				panic("unexpected waiting state")
@@ -607,10 +607,8 @@ func (w *lockTableWaiterImpl) pushHeader(req Request) roachpb.Header {
 	return h
 }
 
-// resolveDeferredIntents resolves the batch of intents if the provided error is
-// nil. The batch of intents may be resolved more efficiently than if they were
-// resolved individually.
-func (w *lockTableWaiterImpl) resolveDeferredIntents(
+// ResolveDeferredIntents implements the lockTableWaiter interface.
+func (w *lockTableWaiterImpl) ResolveDeferredIntents(
 	ctx context.Context, deferredResolution []roachpb.LockUpdate,
 ) *Error {
 	if len(deferredResolution) == 0 {

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
@@ -78,7 +78,8 @@ func (g *mockLockTableGuard) CurState() waitingState {
 func (g *mockLockTableGuard) ResolveBeforeScanning() []roachpb.LockUpdate {
 	return g.toResolve
 }
-func (g *mockLockTableGuard) notify() { g.signal <- struct{}{} }
+func (g *mockLockTableGuard) DiscoveredLocks(discoveredCount int) {}
+func (g *mockLockTableGuard) notify()                             { g.signal <- struct{}{} }
 
 // mockLockTable overrides TransactionIsFinalized, which is the only LockTable
 // method that should be called in this test.

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
@@ -1,0 +1,131 @@
+# -------------------------------------------------------------------------
+# A scan finds many abandoned intents from same txn that don't get added to
+# the lock table, and get resolved.
+# -------------------------------------------------------------------------
+
+# This setting causes the finalized txn cache to be consulted when discovered
+# locks > 1.
+set-consult-finalized-txn-cache-for-discovered-count n=1
+----
+
+new-txn name=txn1 ts=10,1 epoch=0
+----
+
+new-txn name=txn2 ts=10,1 epoch=0
+----
+
+new-request name=req1 txn=txn1 ts=10,1
+  scan key=a endkey=b
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+handle-write-intent-error req=req1 lease-seq=1
+  intent txn=txn2 key=a
+----
+[2] handle write intent error req1: handled conflicting intents on "a", released latches
+
+debug-lock-table
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+local: num=0
+
+sequence req=req1
+----
+[3] sequence req1: re-sequencing request
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: waiting in lock wait-queues
+[3] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
+[3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+debug-lock-table
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000002-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+   waiting readers:
+    req: 1, txn: 00000001-0000-0000-0000-000000000000
+   distinguished req: 1
+local: num=0
+
+# txn1 is the distinguished waiter on key "a". It will push txn2, notice that it
+# is aborted, and then resolve key "a". This places txn2 in the finalizedTxnCache.
+on-txn-updated txn=txn2 status=aborted
+----
+[-] update txn: aborting txn2
+[3] sequence req1: resolving intent "a" for txn 00000002 with ABORTED status
+[3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on "a" for 1.23s
+[3] sequence req1: acquiring latches
+[3] sequence req1: scanning lock table for conflicting locks
+[3] sequence req1: sequencing complete, returned guard
+
+debug-lock-table
+----
+global: num=0
+local: num=0
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+new-request name=req2 txn=txn1 ts=10,1
+  scan key=b endkey=z
+----
+
+sequence req=req2
+----
+[4] sequence req2: sequencing request
+[4] sequence req2: acquiring latches
+[4] sequence req2: scanning lock table for conflicting locks
+[4] sequence req2: sequencing complete, returned guard
+
+# The intents get resolved instead of being added to the lock table.
+handle-write-intent-error req=req2 lease-seq=1
+  intent txn=txn2 key=b
+  intent txn=txn2 key=c
+  intent txn=txn2 key=d
+  intent txn=txn2 key=e
+  intent txn=txn2 key=f
+  intent txn=txn2 key=g
+  intent txn=txn2 key=h
+  intent txn=txn2 key=i
+  intent txn=txn2 key=j
+----
+[5] handle write intent error req2: resolving a batch of 9 intent(s)
+[5] handle write intent error req2: resolving intent "b" for txn 00000002 with ABORTED status
+[5] handle write intent error req2: resolving intent "c" for txn 00000002 with ABORTED status
+[5] handle write intent error req2: resolving intent "d" for txn 00000002 with ABORTED status
+[5] handle write intent error req2: resolving intent "e" for txn 00000002 with ABORTED status
+[5] handle write intent error req2: resolving intent "f" for txn 00000002 with ABORTED status
+[5] handle write intent error req2: resolving intent "g" for txn 00000002 with ABORTED status
+[5] handle write intent error req2: resolving intent "h" for txn 00000002 with ABORTED status
+[5] handle write intent error req2: resolving intent "i" for txn 00000002 with ABORTED status
+[5] handle write intent error req2: resolving intent "j" for txn 00000002 with ABORTED status
+[5] handle write intent error req2: handled conflicting intents on "b", "c", "d", "e", "f", "g", "h", "i", "j", released latches
+
+debug-lock-table
+----
+global: num=0
+local: num=0
+
+sequence req=req2
+----
+[6] sequence req2: re-sequencing request
+[6] sequence req2: acquiring latches
+[6] sequence req2: scanning lock table for conflicting locks
+[6] sequence req2: sequencing complete, returned guard
+
+finish req=req2
+----
+[-] finish req2: finishing request
+
+reset namespace
+----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/discovered_locks_consults_txn_cache
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/discovered_locks_consults_txn_cache
@@ -1,0 +1,126 @@
+# With 20 locks, up to 1 discovered lock will not trigger consultation of the
+# finalizedTxnCache when calling AddDiscoveredLock
+
+new-lock-table maxlocks=10000
+----
+
+set-consult-finalized-txn-cache-for-discovered-count n=1
+----
+
+new-txn txn=txn1 ts=10 epoch=0
+----
+
+new-txn txn=txn2 ts=10 epoch=0
+----
+
+new-txn txn=txn3 ts=10 epoch=0
+----
+
+new-txn txn=txn4 ts=10 epoch=0
+----
+
+new-request r=req1 txn=txn1 ts=10 spans=w@a,e
+----
+
+scan r=req1
+----
+start-waiting: false
+
+txn-finalized txn=txn2 status=aborted
+----
+
+discovered-locks r=req1 count=1
+----
+
+add-discovered r=req1 k=a txn=txn2
+----
+global: num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 10.000000000,0, info: repl [holder finalized: aborted] epoch: 0, seqs: [0]
+   queued writers:
+    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+local: num=0
+
+# Nothing to resolve yet.
+resolve-before-scanning r=req1
+----
+
+scan r=req1
+----
+start-waiting: true
+
+# The scan picks up the intent to resolve.
+guard-state r=req1
+----
+new: state=doneWaiting
+Intents to resolve:
+ key="a" txn=00000000 status=ABORTED
+
+print
+----
+global: num=1
+ lock: "a"
+  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, seq: 0
+local: num=0
+
+scan r=req1
+----
+start-waiting: false
+
+txn-finalized txn=txn3 status=aborted
+----
+
+# Now discovered 3 locks, so finalizedTxnCache will be consulted.
+
+discovered-locks r=req1 count=3
+----
+
+# Txn is finalized.
+add-discovered r=req1 k=b txn=txn3
+----
+global: num=1
+ lock: "a"
+  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, seq: 0
+local: num=0
+
+# Txn is finalized.
+add-discovered r=req1 k=c txn=txn3
+----
+global: num=1
+ lock: "a"
+  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, seq: 0
+local: num=0
+
+# Txn is not finalized.
+add-discovered r=req1 k=d txn=txn4
+----
+global: num=2
+ lock: "a"
+  res: req: 1, txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,0, seq: 0
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000004, ts: 10.000000000,0, info: repl epoch: 0, seqs: [0]
+   queued writers:
+    active: false req: 1, txn: 00000000-0000-0000-0000-000000000001
+local: num=0
+
+# Locks for b and c were not added to lock table.
+resolve-before-scanning r=req1
+----
+Intents to resolve:
+ key="b" txn=00000000 status=ABORTED
+ key="c" txn=00000000 status=ABORTED
+
+scan r=req1
+----
+start-waiting: true
+
+guard-state r=req1
+----
+new: state=waitForDistinguished txn=txn4 key="d" held=true guard-access=write
+
+dequeue r=req1
+----
+global: num=1
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000004, ts: 10.000000000,0, info: repl epoch: 0, seqs: [0]
+local: num=0


### PR DESCRIPTION
The finalizedTxnCache is consulted only when the number of
discovered locks being added is above a certain fraction of
the lock table capacity. When below that fraction, we prefer
to add the lock and consult the finalizedTxnCache in the
following call to ScanAndEnqueue, since that provides some
coordination that de-duplicates intent resolution.

Informs #62470

Release note: None