### PR TITLE
cliccl/debug_backup.go: add `--max-rows` and `--start-key` flag

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1556,6 +1556,20 @@ Only csv is supported at the moment.
 
 	ExportCSVNullas = FlagInfo{
 		Name:        "nullas",
-		Description: `The string that should be used to represent NULL values. `,
+		Description: `The string that should be used to represent NULL values.`,
+	}
+
+	StartKey = FlagInfo{
+		Name: "start-key",
+		Description: `
+Start key and format as [<format>:]<key>. Supported formats: raw, hex, bytekey. 
+The raw format supports escaped text. For example, "raw:\x01k" is
+the prefix for range local keys. 
+The bytekey format does not require table-key prefix.`,
+	}
+
+	MaxRows = FlagInfo{
+		Name:        "max-rows",
+		Description: `Maximum number of rows to return (Default 0 is unlimited).`,
 	}
 )


### PR DESCRIPTION
This patch adds `--max-rows` and `--start-key` of backup debug tool
for users to specify on export row number and start key
when they inspect data in backup.

Note: `--start-key`is of format `[<format>:]<key>`. Three types of key are
acceptable. `hex`, `raw` are hex and raw format of the key with table and index
prefix. 

Release note (cli change): Add `--max-rows` and `--start-key`
of backup debug tool for users to specify on export
row number and start key when they inspect data from backup.