### PR TITLE
changefeedccl: Implement kafka feed for tests.

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -191,7 +191,6 @@ go_test(
         "@com_github_cockroachdb_apd_v2//:apd",
         "@com_github_cockroachdb_cockroach_go//crdb",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_linkedin_goavro_v2//:goavro",
         "@com_github_shopify_sarama//:sarama",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/pkg/ccl/changefeedccl/cdctest/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/cdctest/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "cdctest",
     srcs = [
+        "avro.go",
         "nemeses.go",
         "testfeed.go",
         "validator.go",
@@ -10,6 +11,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/ccl/changefeedccl/changefeedbase",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/roachpb",
@@ -24,10 +26,12 @@ go_library(
         "//pkg/util/protoutil",
         "//pkg/util/randutil",
         "//pkg/util/retry",
+        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_cockroach_go//crdb",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_jackc_pgx//:pgx",
+        "@com_github_linkedin_goavro_v2//:goavro",
     ],
 )
 

--- a/pkg/ccl/changefeedccl/cdctest/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/cdctest/BUILD.bazel
@@ -3,8 +3,8 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "cdctest",
     srcs = [
-        "avro.go",
         "nemeses.go",
+        "schema_registry.go",
         "testfeed.go",
         "validator.go",
     ],
@@ -15,9 +15,11 @@ go_library(
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/roachpb",
+        "//pkg/settings/cluster",
         "//pkg/sql",
         "//pkg/sql/parser",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/types",
         "//pkg/testutils/serverutils",
         "//pkg/util/fsm",
         "//pkg/util/hlc",
@@ -32,6 +34,7 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_jackc_pgx//:pgx",
         "@com_github_linkedin_goavro_v2//:goavro",
+        "@com_github_shopify_sarama//:sarama",
     ],
 )
 

--- a/pkg/ccl/changefeedccl/cdctest/avro.go
+++ b/pkg/ccl/changefeedccl/cdctest/avro.go
@@ -1,0 +1,132 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package cdctest
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
+	"github.com/linkedin/goavro/v2"
+)
+
+// SchemaRegistry is the kafka schema registry used in tests.
+type SchemaRegistry struct {
+	server *httptest.Server
+	mu     struct {
+		syncutil.Mutex
+		idAlloc  int32
+		schemas  map[int32]string
+		subjects map[string]int32
+	}
+}
+
+// MakeTestSchemaRegistry creates and starts schema registry for tests.
+func MakeTestSchemaRegistry() *SchemaRegistry {
+	r := &SchemaRegistry{}
+	r.mu.schemas = make(map[int32]string)
+	r.mu.subjects = make(map[string]int32)
+	r.server = httptest.NewServer(http.HandlerFunc(r.register))
+	return r
+}
+
+// Close closes this schema registry.
+func (r *SchemaRegistry) Close() {
+	r.server.Close()
+}
+
+// URL returns the http address of this schema registry.
+func (r *SchemaRegistry) URL() string {
+	return r.server.URL
+}
+
+// Subjects returns a copy of currently registered subjects.
+func (r *SchemaRegistry) Subjects() (subjects []string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for subject := range r.mu.subjects {
+		subjects = append(subjects, subject)
+	}
+	return
+}
+
+// SchemaForSubject returns schema name for the specified subject.
+func (r *SchemaRegistry) SchemaForSubject(subject string) string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.mu.schemas[r.mu.subjects[subject]]
+}
+
+// register is an http hander for the underlying server which registers schemas.
+func (r *SchemaRegistry) register(hw http.ResponseWriter, hr *http.Request) {
+	type confluentSchemaVersionRequest struct {
+		Schema string `json:"schema"`
+	}
+	type confluentSchemaVersionResponse struct {
+		ID int32 `json:"id"`
+	}
+	if err := func() (err error) {
+		defer func() {
+			err = hr.Body.Close()
+		}()
+
+		var req confluentSchemaVersionRequest
+		if err := json.NewDecoder(hr.Body).Decode(&req); err != nil {
+			return err
+		}
+
+		r.mu.Lock()
+		subject := strings.Split(hr.URL.Path, "/")[2]
+		id := r.mu.idAlloc
+		r.mu.idAlloc++
+		r.mu.schemas[id] = req.Schema
+		r.mu.subjects[subject] = id
+		r.mu.Unlock()
+
+		res, err := json.Marshal(confluentSchemaVersionResponse{ID: id})
+		if err != nil {
+			return err
+		}
+
+		hw.Header().Set(`Content-type`, `application/json`)
+		_, _ = hw.Write(res)
+		return nil
+	}(); err != nil {
+		http.Error(hw, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// EncodedAvroToNative decodes bytes that were previously encoded by
+// confluent avro encoder, into GO native representation.
+func (r *SchemaRegistry) EncodedAvroToNative(b []byte) (interface{}, error) {
+	if len(b) == 0 || b[0] != changefeedbase.ConfluentAvroWireFormatMagic {
+		return ``, errors.Errorf(`bad magic byte`)
+	}
+	b = b[1:]
+	if len(b) < 4 {
+		return ``, errors.Errorf(`missing registry id`)
+	}
+	id := int32(binary.BigEndian.Uint32(b[:4]))
+	b = b[4:]
+
+	r.mu.Lock()
+	jsonSchema := r.mu.schemas[id]
+	r.mu.Unlock()
+	codec, err := goavro.NewCodec(jsonSchema)
+	if err != nil {
+		return ``, err
+	}
+	native, _, err := codec.NativeFromBinary(b)
+	return native, err
+}

--- a/pkg/ccl/changefeedccl/cdctest/schema_registry.go
+++ b/pkg/ccl/changefeedccl/cdctest/schema_registry.go
@@ -130,3 +130,18 @@ func (r *SchemaRegistry) EncodedAvroToNative(b []byte) (interface{}, error) {
 	native, _, err := codec.NativeFromBinary(b)
 	return native, err
 }
+
+// AvroToJSON converts avro bytes to their JSON representation.
+func (r *SchemaRegistry) AvroToJSON(avroBytes []byte) ([]byte, error) {
+	if len(avroBytes) == 0 {
+		return nil, nil
+	}
+	native, err := r.EncodedAvroToNative(avroBytes)
+	if err != nil {
+		return nil, err
+	}
+	// The avro textual format is a more natural fit, but it's non-deterministic
+	// because of go's randomized map ordering. Instead, we use json.Marshal,
+	// which sorts its object keys and so is deterministic.
+	return json.Marshal(native)
+}

--- a/pkg/ccl/changefeedccl/cdctest/testfeed.go
+++ b/pkg/ccl/changefeedccl/cdctest/testfeed.go
@@ -24,11 +24,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Shopify/sarama"
 	"github.com/cockroachdb/cockroach-go/crdb"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
@@ -61,6 +65,22 @@ func (m TestFeedMessage) String() string {
 		return string(m.Resolved)
 	}
 	return fmt.Sprintf(`%s: %s->%s`, m.Topic, m.Key, m.Value)
+}
+
+type seenTracker map[string]struct{}
+
+func (t seenTracker) markSeen(m *TestFeedMessage) (isNew bool) {
+	// TODO(dan): This skips duplicates, since they're allowed by the
+	// semantics of our changefeeds. Now that we're switching to RangeFeed,
+	// this can actually happen (usually because of splits) and cause flakes.
+	// However, we really should be de-duping key+ts, this is too coarse.
+	// Fixme.
+	seenKey := m.Topic + m.Partition + string(m.Key) + string(m.Value)
+	if _, ok := t[seenKey]; ok {
+		return false
+	}
+	t[seenKey] = struct{}{}
+	return true
 }
 
 // TestFeed abstracts over reading from the various types of
@@ -135,7 +155,7 @@ type sinklessFeed struct {
 
 	conn           *pgx.Conn
 	rows           *pgx.Rows
-	seen           map[string]struct{}
+	seen           seenTracker
 	latestResolved hlc.Timestamp
 }
 
@@ -155,16 +175,9 @@ func (c *sinklessFeed) Next() (*TestFeedMessage, error) {
 		}
 		if len(maybeTopic.String) > 0 {
 			m.Topic = maybeTopic.String
-			// TODO(dan): This skips duplicates, since they're allowed by the
-			// semantics of our changefeeds. Now that we're switching to RangeFeed,
-			// this can actually happen (usually because of splits) and cause flakes.
-			// However, we really should be de-duping key+ts, this is too coarse.
-			// Fixme.
-			seenKey := m.Topic + m.Partition + string(m.Key) + string(m.Value)
-			if _, ok := c.seen[seenKey]; ok {
+			if isNew := c.seen.markSeen(m); !isNew {
 				continue
 			}
-			c.seen[seenKey] = struct{}{}
 			return m, nil
 		}
 		m.Resolved = m.Value
@@ -218,12 +231,26 @@ func (c *sinklessFeed) Close() error {
 	return c.conn.Close()
 }
 
+// FeedJob is an interface describing job related information for
+// feeds that use jobs (anything but sinkless).
+type FeedJob interface {
+	// JobID returns job id for the feed.
+	JobID() jobspb.JobID
+	// Details returns changefeed details for the feed.
+	Details() (*jobspb.ChangefeedDetails, error)
+}
+
 type jobFeed struct {
 	db      *gosql.DB
 	flushCh chan struct{}
 
-	JobID  jobspb.JobID
+	jobID  jobspb.JobID
 	jobErr error
+}
+
+// JobID implements FeedJob interface.
+func (f *jobFeed) JobID() jobspb.JobID {
+	return f.jobID
 }
 
 func (f *jobFeed) fetchJobError() error {
@@ -231,6 +258,7 @@ func (f *jobFeed) fetchJobError() error {
 	// after results are flushed to a sink) in between polls. It is required
 	// that this is hooked up to `flushCh`, which is usually handled by the
 	// `enterpriseTest` helper.
+	// TODO(yevgeniy): Stop relying on flushCh to synchrnize job state.
 	//
 	// The trickiest bit is handling errors in the changefeed. The tests want to
 	// eventually notice them, but want to return all generated results before
@@ -255,7 +283,7 @@ func (f *jobFeed) fetchJobError() error {
 	// above.
 	var errorStr gosql.NullString
 	if err := f.db.QueryRow(
-		`SELECT error FROM [SHOW JOBS] WHERE job_id=$1`, f.JobID,
+		`SELECT error FROM [SHOW JOBS] WHERE job_id=$1`, f.jobID,
 	).Scan(&errorStr); err != nil {
 		return err
 	}
@@ -265,8 +293,9 @@ func (f *jobFeed) fetchJobError() error {
 	return nil
 }
 
+// Pause implements the TestFeed interface.
 func (f *jobFeed) Pause() error {
-	_, err := f.db.Exec(`PAUSE JOB $1`, f.JobID)
+	_, err := f.db.Exec(`PAUSE JOB $1`, f.jobID)
 	if err != nil {
 		return err
 	}
@@ -280,7 +309,7 @@ func (f *jobFeed) Pause() error {
 	ctx := context.Background()
 	return retry.WithMaxAttempts(ctx, opts, 10, func() error {
 		var status string
-		if err := f.db.QueryRowContext(ctx, `SELECT status FROM system.jobs WHERE id = $1`, f.JobID).Scan(&status); err != nil {
+		if err := f.db.QueryRowContext(ctx, `SELECT status FROM system.jobs WHERE id = $1`, f.jobID).Scan(&status); err != nil {
 			return err
 		}
 		if jobs.Status(status) != jobs.StatusPaused {
@@ -290,16 +319,24 @@ func (f *jobFeed) Pause() error {
 	})
 }
 
+// Resume implements the TestFeed interface.
 func (f *jobFeed) Resume() error {
-	_, err := f.db.Exec(`RESUME JOB $1`, f.JobID)
+	_, err := f.db.Exec(`RESUME JOB $1`, f.jobID)
 	f.jobErr = nil
 	return err
 }
 
+func (f *jobFeed) cancelJob() {
+	if _, err := f.db.Exec(`CANCEL JOB $1`, f.jobID); err != nil {
+		log.Infof(context.Background(), `could not cancel feed %d: %v`, f.jobID, err)
+	}
+}
+
+// Details implements FeedJob interface.
 func (f *jobFeed) Details() (*jobspb.ChangefeedDetails, error) {
 	var payloadBytes []byte
 	if err := f.db.QueryRow(
-		`SELECT payload FROM system.jobs WHERE id=$1`, f.JobID,
+		`SELECT payload FROM system.jobs WHERE id=$1`, f.jobID,
 	).Scan(&payloadBytes); err != nil {
 		return nil, err
 	}
@@ -364,7 +401,7 @@ func (f *tableFeedFactory) Feed(create string, args ...interface{}) (_ TestFeed,
 	}
 	createStmt.SinkURI = tree.NewStrVal(c.sinkURI)
 
-	if err := f.db.QueryRow(createStmt.String(), args...).Scan(&c.JobID); err != nil {
+	if err := f.db.QueryRow(createStmt.String(), args...).Scan(&c.jobID); err != nil {
 		return nil, err
 	}
 	return c, nil
@@ -381,7 +418,7 @@ type TableFeed struct {
 	sinkURI string
 
 	toSend []*TestFeedMessage
-	seen   map[string]struct{}
+	seen   seenTracker
 }
 
 // ResetSeen is useful when manually pausing and resuming a TableFeed.
@@ -453,16 +490,9 @@ func (c *TableFeed) Next() (*TestFeedMessage, error) {
 				// array, which is pretty unexpected. Nil them out before returning.
 				// Either key+value or payload will be set, but not both.
 				if len(m.Key) > 0 || len(m.Value) > 0 {
-					// TODO(dan): This skips duplicates, since they're allowed by the
-					// semantics of our changefeeds. Now that we're switching to RangeFeed,
-					// this can actually happen (usually because of splits) and cause
-					// flakes. However, we really should be de-duping key+ts, this is too
-					// coarse. Fixme.
-					seenKey := m.Topic + m.Partition + string(m.Key) + string(m.Value)
-					if _, ok := c.seen[seenKey]; ok {
+					if isNew := c.seen.markSeen(m); !isNew {
 						continue
 					}
-					c.seen[seenKey] = struct{}{}
 
 					m.Resolved = nil
 				} else {
@@ -480,9 +510,7 @@ func (c *TableFeed) Next() (*TestFeedMessage, error) {
 
 // Close implements the TestFeed interface.
 func (c *TableFeed) Close() error {
-	if _, err := c.db.Exec(`CANCEL JOB $1`, c.JobID); err != nil {
-		log.Infof(context.Background(), `could not cancel feed %d: %v`, c.JobID, err)
-	}
+	c.cancelJob()
 	return c.db.Close()
 }
 
@@ -538,7 +566,7 @@ func (f *cloudFeedFactory) Feed(create string, args ...interface{}) (TestFeed, e
 		dir:  feedDir,
 		seen: make(map[string]struct{}),
 	}
-	if err := f.db.QueryRow(createStmt.String(), args...).Scan(&c.JobID); err != nil {
+	if err := f.db.QueryRow(createStmt.String(), args...).Scan(&c.jobID); err != nil {
 		return nil, err
 	}
 	return c, nil
@@ -561,7 +589,7 @@ type cloudFeed struct {
 	resolved string
 	rows     []cloudFeedEntry
 
-	seen map[string]struct{}
+	seen seenTracker
 }
 
 const cloudFeedPartition = ``
@@ -638,12 +666,9 @@ func (c *cloudFeed) Next() (*TestFeedMessage, error) {
 				if m.Key, m.Value, err = extractKeyFromJSONValue(m.Value); err != nil {
 					return nil, err
 				}
-
-				seenKey := m.Topic + m.Partition + string(m.Key) + string(m.Value)
-				if _, ok := c.seen[seenKey]; ok {
+				if isNew := c.seen.markSeen(m); !isNew {
 					continue
 				}
-				c.seen[seenKey] = struct{}{}
 				m.Resolved = nil
 				return m, nil
 			}
@@ -722,8 +747,181 @@ func (c *cloudFeed) walkDir(path string, info os.FileInfo, err error) error {
 
 // Close implements the TestFeed interface.
 func (c *cloudFeed) Close() error {
-	if _, err := c.db.Exec(`CANCEL JOB $1`, c.JobID); err != nil {
-		log.Infof(context.Background(), `could not cancel feed %d: %v`, c.JobID, err)
+	c.cancelJob()
+	return nil
+}
+
+// feedSetupFn setups necessary state to run kafkaFeed.
+type feedSetupFn func() (feedCh chan *sarama.ProducerMessage, stopFeed func())
+
+type kafkaFeedFactory struct {
+	s         serverutils.TestServerInterface
+	db        *gosql.DB
+	setupFeed feedSetupFn
+}
+
+var _ TestFeedFactory = (*kafkaFeedFactory)(nil)
+
+// MakeKafkaFeedFactory returns a TestFeedFactory implementation using the `kafka` sink.
+func MakeKafkaFeedFactory(
+	s serverutils.TestServerInterface, db *gosql.DB, setup feedSetupFn,
+) TestFeedFactory {
+	return &kafkaFeedFactory{s: s, db: db, setupFeed: setup}
+}
+
+func exprAsString(expr tree.Expr) (string, error) {
+	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
+	semaCtx := tree.MakeSemaContext()
+	te, err := expr.TypeCheck(context.Background(), &semaCtx, types.String)
+	if err != nil {
+		return "", err
 	}
-	return c.db.Close()
+	datum, err := te.Eval(evalCtx)
+	if err != nil {
+		return "", err
+	}
+	return string(tree.MustBeDString(datum)), nil
+}
+
+// Feed implements cdctest.TestFeedFactory
+func (k *kafkaFeedFactory) Feed(create string, args ...interface{}) (TestFeed, error) {
+	parsed, err := parser.ParseOne(create)
+	if err != nil {
+		return nil, err
+	}
+	createStmt := parsed.AST.(*tree.CreateChangefeed)
+
+	// Set SinkURI if it wasn't provided.  It's okay if it is -- since we may
+	// want to set some kafka specific URI parameters.
+	if createStmt.SinkURI == nil {
+		createStmt.SinkURI = tree.NewStrVal(
+			fmt.Sprintf("%s://does.not.matter/", changefeedbase.SinkSchemeKafka))
+	}
+
+	var registry *SchemaRegistry
+	for _, opt := range createStmt.Options {
+		if opt.Key == changefeedbase.OptFormat {
+			format, err := exprAsString(opt.Value)
+			if err != nil {
+				return nil, err
+			}
+			if format == string(changefeedbase.OptFormatAvro) {
+				// Must use confluent schema registry so that we register our schema
+				// in order to be able to decode kafka messages.
+				registry = MakeTestSchemaRegistry()
+				registryOption := tree.KVOption{
+					Key:   changefeedbase.OptConfluentSchemaRegistry,
+					Value: tree.NewStrVal(registry.server.URL),
+				}
+				createStmt.Options = append(createStmt.Options, registryOption)
+				break
+			}
+		}
+	}
+
+	// setupFeed must be invoked before we create changefeed.
+	sourceCh, stopFeed := k.setupFeed()
+	c := &kafkaFeed{
+		jobFeed: jobFeed{
+			db: k.db,
+			// TODO: kill this: flushCh: flushCh,
+		},
+		seen:       make(map[string]struct{}),
+		source:     sourceCh,
+		stopSource: stopFeed,
+		registry:   registry,
+	}
+	createChangefeed := createStmt.String()
+	if err := k.db.QueryRow(createChangefeed, args...).Scan(&c.jobID); err != nil {
+		stopFeed()
+		return nil, err
+	}
+	return c, nil
+}
+
+// Server implements TestFeedFactory
+func (k *kafkaFeedFactory) Server() serverutils.TestServerInterface {
+	return k.s
+}
+
+type kafkaFeed struct {
+	jobFeed
+	source     chan *sarama.ProducerMessage
+	stopSource func()
+	seen       seenTracker
+	// Registry is set if we're emitting avro.
+	registry *SchemaRegistry
+}
+
+var _ TestFeed = (*kafkaFeed)(nil)
+
+// Partitions implements TestFeed
+func (k *kafkaFeed) Partitions() []string {
+	// TODO(yevgeniy): Support multiple partitions.
+	return []string{`kafka`}
+}
+
+// Next implements TestFeed
+func (k *kafkaFeed) Next() (*TestFeedMessage, error) {
+	for {
+		msg := <-k.source
+
+		fm := &TestFeedMessage{
+			Topic:     msg.Topic,
+			Partition: `kafka`, // TODO(yevgeniy): support multiple partitions.
+		}
+
+		decode := func(encoded sarama.Encoder, dest *[]byte) error {
+			// It's a bit weird to use encoder to get decoded bytes.
+			// But it's correct: we produce messages to sarama, and we set
+			// key/value to sarama.ByteEncoder(payload) -- and sarama ByteEncoder
+			// is just the type alias to []byte -- alas, we can't cast it, so just "encode"
+			// it to get back our original byte array.
+			decoded, err := encoded.Encode()
+			if err != nil {
+				return err
+			}
+			if k.registry == nil {
+				*dest = decoded
+			} else {
+				// Convert avro record to json.
+				jsonBytes, err := k.registry.AvroToJSON(decoded)
+				if err != nil {
+					return err
+				}
+				*dest = jsonBytes
+			}
+			return nil
+		}
+
+		if msg.Key == nil {
+			// It's a resolved timestamp
+			if err := decode(msg.Value, &fm.Resolved); err != nil {
+				return nil, err
+			}
+			return fm, nil
+		}
+		// It's a regular message
+		if err := decode(msg.Key, &fm.Key); err != nil {
+			return nil, err
+		}
+		if err := decode(msg.Value, &fm.Value); err != nil {
+			return nil, err
+		}
+
+		if isNew := k.seen.markSeen(fm); isNew {
+			return fm, nil
+		}
+
+	}
+}
+
+// Close implements TestFeed interface.
+func (k *kafkaFeed) Close() error {
+	if k.registry != nil {
+		k.registry.Close()
+	}
+	k.jobFeed.cancelJob()
+	k.stopSource()
+	return nil
 }

--- a/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "changefeedbase",
     srcs = [
+        "avro.go",
         "options.go",
         "settings.go",
         "validate.go",

--- a/pkg/ccl/changefeedccl/changefeedbase/avro.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/avro.go
@@ -1,0 +1,12 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedbase
+
+// ConfluentAvroWireFormatMagic is the "magic" header bytes for kafka messages.
+const ConfluentAvroWireFormatMagic = byte(0)

--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -35,10 +35,9 @@ import (
 )
 
 const (
-	confluentSchemaContentType   = `application/vnd.schemaregistry.v1+json`
-	confluentSubjectSuffixKey    = `-key`
-	confluentSubjectSuffixValue  = `-value`
-	confluentAvroWireFormatMagic = byte(0)
+	confluentSchemaContentType  = `application/vnd.schemaregistry.v1+json`
+	confluentSubjectSuffixKey   = `-key`
+	confluentSubjectSuffixValue = `-value`
 )
 
 // encodeRow holds all the pieces necessary to encode a row change into a key or
@@ -378,7 +377,7 @@ func (e *confluentAvroEncoder) EncodeKey(ctx context.Context, row encodeRow) ([]
 
 	// https://docs.confluent.io/current/schema-registry/docs/serializer-formatter.html#wire-format
 	header := []byte{
-		confluentAvroWireFormatMagic,
+		changefeedbase.ConfluentAvroWireFormatMagic,
 		0, 0, 0, 0, // Placeholder for the ID.
 	}
 	binary.BigEndian.PutUint32(header[1:5], uint32(registered.registryID))
@@ -444,7 +443,7 @@ func (e *confluentAvroEncoder) EncodeValue(ctx context.Context, row encodeRow) (
 	}
 	// https://docs.confluent.io/current/schema-registry/docs/serializer-formatter.html#wire-format
 	header := []byte{
-		confluentAvroWireFormatMagic,
+		changefeedbase.ConfluentAvroWireFormatMagic,
 		0, 0, 0, 0, // Placeholder for the ID.
 	}
 	binary.BigEndian.PutUint32(header[1:5], uint32(registered.registryID))
@@ -482,7 +481,7 @@ func (e *confluentAvroEncoder) EncodeResolvedTimestamp(
 	}
 	// https://docs.confluent.io/current/schema-registry/docs/serializer-formatter.html#wire-format
 	header := []byte{
-		confluentAvroWireFormatMagic,
+		changefeedbase.ConfluentAvroWireFormatMagic,
 		0, 0, 0, 0, // Placeholder for the ID.
 	}
 	binary.BigEndian.PutUint32(header[1:5], uint32(registered.registryID))

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -118,11 +118,11 @@ func assertPayloadsStripTs(t testing.TB, f cdctest.TestFeed, expected []string) 
 	assertPayloadsBase(t, f, expected, true)
 }
 
-func avroToJSON(t testing.TB, reg *testSchemaRegistry, avroBytes []byte) []byte {
+func avroToJSON(t testing.TB, reg *cdctest.SchemaRegistry, avroBytes []byte) []byte {
 	if len(avroBytes) == 0 {
 		return nil
 	}
-	native, err := reg.encodedAvroToNative(avroBytes)
+	native, err := reg.EncodedAvroToNative(avroBytes)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -137,7 +137,7 @@ func avroToJSON(t testing.TB, reg *testSchemaRegistry, avroBytes []byte) []byte 
 }
 
 func assertPayloadsAvro(
-	t testing.TB, reg *testSchemaRegistry, f cdctest.TestFeed, expected []string,
+	t testing.TB, reg *cdctest.SchemaRegistry, f cdctest.TestFeed, expected []string,
 ) {
 	t.Helper()
 
@@ -164,15 +164,10 @@ func assertPayloadsAvro(
 	}
 }
 
-func assertRegisteredSubjects(t testing.TB, reg *testSchemaRegistry, expected []string) {
+func assertRegisteredSubjects(t testing.TB, reg *cdctest.SchemaRegistry, expected []string) {
 	t.Helper()
 
-	actual := make([]string, 0, len(reg.mu.subjects))
-
-	for subject := range reg.mu.subjects {
-		actual = append(actual, subject)
-	}
-
+	actual := reg.Subjects()
 	sort.Strings(expected)
 	sort.Strings(actual)
 	if !reflect.DeepEqual(expected, actual) {
@@ -225,7 +220,7 @@ func extractResolvedTimestamp(t testing.TB, m *cdctest.TestFeedMessage) hlc.Time
 }
 
 func expectResolvedTimestampAvro(
-	t testing.TB, reg *testSchemaRegistry, f cdctest.TestFeed,
+	t testing.TB, reg *cdctest.SchemaRegistry, f cdctest.TestFeed,
 ) hlc.Timestamp {
 	t.Helper()
 	m, err := f.Next()
@@ -241,7 +236,7 @@ func expectResolvedTimestampAvro(
 	if m.Resolved == nil {
 		t.Fatal(`expected a resolved timestamp notification`)
 	}
-	resolvedNative, err := reg.encodedAvroToNative(m.Resolved)
+	resolvedNative, err := reg.EncodedAvroToNative(m.Resolved)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Shopify/sarama"
 	"github.com/cockroachdb/apd/v2"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
@@ -34,8 +35,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
 )
 
 var testSinkFlushFrequency = 100 * time.Millisecond
@@ -119,20 +122,8 @@ func assertPayloadsStripTs(t testing.TB, f cdctest.TestFeed, expected []string) 
 }
 
 func avroToJSON(t testing.TB, reg *cdctest.SchemaRegistry, avroBytes []byte) []byte {
-	if len(avroBytes) == 0 {
-		return nil
-	}
-	native, err := reg.EncodedAvroToNative(avroBytes)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// The avro textual format is a more natural fit, but it's non-deterministic
-	// because of go's randomized map ordering. Instead, we use gojson.Marshal,
-	// which sorts its object keys and so is deterministic.
-	json, err := gojson.Marshal(native)
-	if err != nil {
-		t.Fatal(err)
-	}
+	json, err := reg.AvroToJSON(avroBytes)
+	require.NoError(t, err)
 	return json
 }
 
@@ -244,9 +235,10 @@ func expectResolvedTimestampAvro(
 	return parseTimeToHLC(t, resolved.(map[string]interface{})[`string`].(string))
 }
 
+type cdcTestFn func(*testing.T, *gosql.DB, cdctest.TestFeedFactory)
+
 func sinklessTestWithServerArgs(
-	argsFn func(args *base.TestServerArgs),
-	testFn func(*testing.T, *gosql.DB, cdctest.TestFeedFactory),
+	argsFn func(args *base.TestServerArgs), testFn cdcTestFn,
 ) func(*testing.T) {
 	return func(t *testing.T) {
 		defer changefeedbase.TestingSetDefaultFlushFrequency(testSinkFlushFrequency)()
@@ -288,17 +280,16 @@ func sinklessTestWithServerArgs(
 	}
 }
 
-func sinklessTest(testFn func(*testing.T, *gosql.DB, cdctest.TestFeedFactory)) func(*testing.T) {
+func sinklessTest(testFn cdcTestFn) func(*testing.T) {
 	return sinklessTestWithServerArgs(nil, testFn)
 }
 
-func enterpriseTest(testFn func(*testing.T, *gosql.DB, cdctest.TestFeedFactory)) func(*testing.T) {
+func enterpriseTest(testFn cdcTestFn) func(*testing.T) {
 	return enterpriseTestWithServerArgs(nil, testFn)
 }
 
 func enterpriseTestWithServerArgs(
-	argsFn func(args *base.TestServerArgs),
-	testFn func(*testing.T, *gosql.DB, cdctest.TestFeedFactory),
+	argsFn func(args *base.TestServerArgs), testFn cdcTestFn,
 ) func(*testing.T) {
 	return func(t *testing.T) {
 		defer changefeedbase.TestingSetDefaultFlushFrequency(testSinkFlushFrequency)()
@@ -351,9 +342,7 @@ func serverArgsRegion(args base.TestServerArgs) string {
 	return ""
 }
 
-func cloudStorageTest(
-	testFn func(*testing.T, *gosql.DB, cdctest.TestFeedFactory),
-) func(*testing.T) {
+func cloudStorageTest(testFn cdcTestFn) func(*testing.T) {
 	return func(t *testing.T) {
 		defer changefeedbase.TestingSetDefaultFlushFrequency(testSinkFlushFrequency)()
 		defer jobs.TestingSetAdoptAndCancelIntervals(10*time.Millisecond, 10*time.Millisecond)()
@@ -387,6 +376,166 @@ func cloudStorageTest(
 		sqlDB.Exec(t, `CREATE DATABASE d`)
 
 		f := cdctest.MakeCloudFeedFactory(s, db, dir, flushCh)
+		testFn(t, db, f)
+	}
+}
+
+type fakeKafkaClient struct{}
+
+func (c *fakeKafkaClient) Partitions(topic string) ([]int32, error) {
+	return []int32{0}, nil
+}
+
+func (c *fakeKafkaClient) RefreshMetadata(topics ...string) error {
+	return nil
+}
+
+func (c *fakeKafkaClient) Close() error {
+	return nil
+}
+
+var _ kafkaClient = (*fakeKafkaClient)(nil)
+
+type ignoreCloseProducer struct {
+	*asyncProducerMock
+}
+
+func (p *ignoreCloseProducer) Close() error {
+	return nil
+}
+
+// teeGroup facilitates reading messages from input channel
+// and sending them to one or more output channels.
+type teeGroup struct {
+	g    ctxgroup.Group
+	done chan struct{}
+}
+
+func newTeeGroup() *teeGroup {
+	return &teeGroup{
+		g:    ctxgroup.WithContext(context.Background()),
+		done: make(chan struct{}),
+	}
+}
+
+// tee reads incoming messages from input channel and sends them out to one or more output channels.
+func (tg *teeGroup) tee(in <-chan *sarama.ProducerMessage, out ...chan<- *sarama.ProducerMessage) {
+	tg.g.Go(func() error {
+		for {
+			select {
+			case <-tg.done:
+				return nil
+			case m := <-in:
+				for i := range out {
+					select {
+					case <-tg.done:
+						return nil
+					case out[i] <- m:
+					}
+				}
+			}
+		}
+	})
+}
+
+// wait shuts down tee group.
+func (tg *teeGroup) wait() error {
+	close(tg.done)
+	return tg.g.Wait()
+}
+
+// kafkaFeedState ties together state necessary for synchronization between
+// this helper, kafka test feed, and the kafka sink.
+// It exists in order to support creating of multiple instances of Feed()s started
+// from the same TestFeedFactory (as happens when creating subtests inside cdcTestFn).
+type kafkaFeedState struct {
+	feedCh chan *sarama.ProducerMessage
+	tg     *teeGroup
+}
+
+func kafkaTest(testFn cdcTestFn) func(t *testing.T) {
+	return kafkaTestWithServerArgs(nil, testFn)
+}
+
+func kafkaTestWithServerArgs(
+	argsFn func(args *base.TestServerArgs), testFn cdcTestFn,
+) func(*testing.T) {
+	return func(t *testing.T) {
+		defer changefeedbase.TestingSetDefaultFlushFrequency(testSinkFlushFrequency)()
+		defer jobs.TestingSetAdoptAndCancelIntervals(10*time.Millisecond, 10*time.Millisecond)()
+		ctx := context.Background()
+
+		var activeFeed *kafkaFeedState
+
+		// setupFeed is a callback given to kafka feed to setup new feed state.
+		setupFeed := func() (feedCh chan *sarama.ProducerMessage, cleanup func()) {
+			fs := &kafkaFeedState{
+				feedCh: make(chan *sarama.ProducerMessage),
+				tg:     newTeeGroup(),
+			}
+			activeFeed = fs
+
+			return fs.feedCh, func() {
+				require.NoError(t, fs.tg.wait())
+				close(feedCh)
+			}
+		}
+
+		knobs := base.TestingKnobs{DistSQL: &execinfra.TestingKnobs{Changefeed: &TestingKnobs{
+			// Note: even though we will create a single changefeed, the changefeed itself
+			// will create multiple instances of Sink.  Thus, this Dial override will execute
+			// multiple times.  Therefore, we ensure that the producer we give to kafka
+			// does not close its channels, nor, do we close feedCh until the end of this
+			// test function.
+			Dial: func(s Sink) {
+				kafka := s.(*kafkaSink)
+				kafka.client = &fakeKafkaClient{}
+				// The producer we give to kafka sink ignores close call.
+				// This is because normally, kafka sinks owns the producer and so it closes it.
+				// But in this case, if we let the sink close this producer, the test will panic
+				// because we will attempt to send acknowledgements on a closed channel.
+				producer := &ignoreCloseProducer{newAsyncProducerMock(unbuffered)}
+
+				// TODO(yevgeniy): Support error injection either by acknowledging on the "errors"
+				//  channel, or by injecting error message into sarama.ProducerMessage.Metadata.
+				activeFeed.tg.tee(producer.inputCh, activeFeed.feedCh, producer.successesCh)
+				kafka.producer = producer
+				kafka.start()
+			},
+			// TODO(yevgeniy): This test does not set "AfterSinkFlush".  Unfortunately, this knob
+			//  is misused to also setup the feed implementation such that feed.Next() returns an
+			//  error if the job itself had an error.  This synchronization is very subtle; and
+			//  very brittle.  It is also very racy, particularly in the face of multiple feeds
+			//  started by a single feed factory.  Because of this, kafkaFeed does not pay attention
+			//  to jobs table, and any test that relies on feed.Next() returning an error due to
+			//  job failure, will not work.  We should fix feed & job synchronization to be more
+			//  explicit, and not to rely on sink flush knob.
+		}}}
+
+		args := base.TestServerArgs{
+			UseDatabase: "d",
+			Knobs:       knobs,
+		}
+		if argsFn != nil {
+			argsFn(&args)
+		}
+		s, db, _ := serverutils.StartServer(t, args)
+
+		defer func() {
+			s.Stopper().Stop(ctx)
+		}()
+
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
+		sqlDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '1s'`)
+		sqlDB.Exec(t, `SET CLUSTER SETTING changefeed.experimental_poll_interval = '10ms'`)
+		sqlDB.Exec(t, `CREATE DATABASE d`)
+
+		if region := serverArgsRegion(args); region != "" {
+			sqlDB.Exec(t, fmt.Sprintf(`ALTER DATABASE d PRIMARY REGION "%s"`, region))
+		}
+
+		f := cdctest.MakeKafkaFeedFactory(s, db, setupFeed)
 		testFn(t, db, f)
 	}
 }

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -96,7 +96,9 @@ func getSink(
 		return nil, err
 	}
 
-	if err := sink.Dial(); err != nil {
+	if knobs, ok := serverCfg.TestingKnobs.Changefeed.(*TestingKnobs); ok && knobs.Dial != nil {
+		knobs.Dial(sink)
+	} else if err := sink.Dial(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/Shopify/sarama"
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/security"
@@ -556,11 +557,11 @@ func TestKafkaSinkTracksMemory(t *testing.T) {
 	// regular messages since it doesn't have Key set.
 	// We bypass majority of EmitResolvedTimestamp logic since we don't have
 	// a real kafka client instantiated.  Instead, we call emitMessage directly.
-	reg := makeTestSchemaRegistry()
+	reg := cdctest.MakeTestSchemaRegistry()
 	defer reg.Close()
 	opts := map[string]string{
 		changefeedbase.OptEnvelope:                string(changefeedbase.OptEnvelopeWrapped),
-		changefeedbase.OptConfluentSchemaRegistry: reg.server.URL,
+		changefeedbase.OptConfluentSchemaRegistry: reg.URL(),
 	}
 	encoder, err := newConfluentAvroEncoder(opts, makeChangefeedTargets("t"))
 	require.NoError(t, err)

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -23,6 +23,8 @@ type TestingKnobs struct {
 	AfterSinkFlush func() error
 	// MemMonitor, if non-nil, overrides memory monitor to use for changefeed..
 	MemMonitor *mon.BytesMonitor
+	// Dial, if set, is a function that overrides normal sink "dial" functionality.
+	Dial func(s Sink)
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
Make it possible to write light weight unit tests targetting
changefeeds emitting to kafka by implementing a kafka specific
TestFeed implementation.

Significantly extend test coverage by enabling majority of the
existing changefeed tests to use newly added `kafkaTest`.

Release Notes: None