### PR TITLE
sql: open a transaction for BindCmd

### DIFF
--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -695,6 +695,9 @@ func (txn *Txn) UpdateDeadlineMaybe(ctx context.Context, deadline hlc.Timestamp)
 
 	txn.mu.Lock()
 	defer txn.mu.Unlock()
+	if txn.status().IsFinalized() {
+		panic(errors.WithContextTags(errors.AssertionFailedf("UpdateDeadlineMaybe() called on finalized txn"), ctx))
+	}
 	if txn.mu.deadline == nil || deadline.Less(*txn.mu.deadline) {
 		readTimestamp := txn.readTimestampLocked()
 		if deadline.Less(txn.readTimestampLocked()) {


### PR DESCRIPTION
Bind needs to evaluate casts for oid types and look up user-defined types.
It needs a transaction to do that. It's a miracle that this ever works. We get
away with it for the most part because we allow calling `UpdateDeadlineMaybe`
on a txn which is finalized (see next commit) and in all of our tests we use
leasable tables.

This is so subtle I'm omitting a release note.

Fixes #64140.

Release note: None