### PR TITLE
release-21.1: coldata: fix Nulls.Or in some edge cases

### DIFF
--- a/pkg/col/coldata/nulls.go
+++ b/pkg/col/coldata/nulls.go
@@ -360,22 +360,29 @@ func (n *Nulls) Or(n2 *Nulls) *Nulls {
 	if len(n.nulls) > len(n2.nulls) {
 		n, n2 = n2, n
 	}
-	nulls := make([]byte, len(n2.nulls))
+	res := &Nulls{
+		maybeHasNulls: n.maybeHasNulls || n2.maybeHasNulls,
+		nulls:         make([]byte, len(n2.nulls)),
+	}
 	if n.maybeHasNulls && n2.maybeHasNulls {
 		for i := 0; i < len(n.nulls); i++ {
-			nulls[i] = n.nulls[i] & n2.nulls[i]
+			res.nulls[i] = n.nulls[i] & n2.nulls[i]
 		}
 		// If n2 is longer, we can just copy the remainder.
-		copy(nulls[len(n.nulls):], n2.nulls[len(n.nulls):])
+		copy(res.nulls[len(n.nulls):], n2.nulls[len(n.nulls):])
 	} else if n.maybeHasNulls {
-		copy(nulls, n.nulls)
+		copy(res.nulls, n.nulls)
+		// We need to set all positions after len(n.nulls) to valid.
+		res.UnsetNullsAfter(8 * len(n.nulls))
 	} else if n2.maybeHasNulls {
-		copy(nulls, n2.nulls)
+		// Since n2 is not of a smaller length, we can copy its bitmap without
+		// having to do anything extra.
+		copy(res.nulls, n2.nulls)
+	} else {
+		// We need to set the whole bitmap to valid.
+		res.UnsetNulls()
 	}
-	return &Nulls{
-		maybeHasNulls: n.maybeHasNulls || n2.maybeHasNulls,
-		nulls:         nulls,
-	}
+	return res
 }
 
 // makeCopy returns a copy of n which can be modified independently.


### PR DESCRIPTION
Backport 1/1 commits from #64116.

/cc @cockroachdb/release

---

Previously, `Nulls.Or` function incorrectly computed its result in some
edge cases. Namely:
- if both original `Nulls` objects had `maybeHasNulls` set to `false`
(indicating all valid values), `Or` would return a new `Nulls` object
with all values being invalid
- if the smaller `Nulls` object had invalid values whereas larger
didn't, all values after the length of the smaller object would be
incorrectly set to invalid.

AFAICT in production these issues shouldn't represent themselves in any
way because in reality we always check whether at least one of `Nulls`
objects might have nulls before calling `Or` (addressing the first
point) and usually have vectors of the same length. Still, I imagine it
is possible to come up with a scenario where the second problem somehow
is reproduced, so I'll be backporting this fix.

Release note: None
