### PR TITLE
release-20.2: coldata: fix Nulls.Or in some edge cases

### DIFF
--- a/pkg/col/coldata/nulls.go
+++ b/pkg/col/coldata/nulls.go
@@ -381,22 +381,29 @@ func (n *Nulls) Or(n2 *Nulls) *Nulls {
 	if len(n.nulls) > len(n2.nulls) {
 		n, n2 = n2, n
 	}
-	nulls := make([]byte, len(n2.nulls))
+	res := &Nulls{
+		maybeHasNulls: n.maybeHasNulls || n2.maybeHasNulls,
+		nulls:         make([]byte, len(n2.nulls)),
+	}
 	if n.maybeHasNulls && n2.maybeHasNulls {
 		for i := 0; i < len(n.nulls); i++ {
-			nulls[i] = n.nulls[i] & n2.nulls[i]
+			res.nulls[i] = n.nulls[i] & n2.nulls[i]
 		}
 		// If n2 is longer, we can just copy the remainder.
-		copy(nulls[len(n.nulls):], n2.nulls[len(n.nulls):])
+		copy(res.nulls[len(n.nulls):], n2.nulls[len(n.nulls):])
 	} else if n.maybeHasNulls {
-		copy(nulls, n.nulls)
+		copy(res.nulls, n.nulls)
+		// We need to set all positions after len(n.nulls) to valid.
+		res.UnsetNullsAfter(8 * len(n.nulls))
 	} else if n2.maybeHasNulls {
-		copy(nulls, n2.nulls)
+		// Since n2 is not of a smaller length, we can copy its bitmap without
+		// having to do anything extra.
+		copy(res.nulls, n2.nulls)
+	} else {
+		// We need to set the whole bitmap to valid.
+		res.UnsetNulls()
 	}
-	return &Nulls{
-		maybeHasNulls: n.maybeHasNulls || n2.maybeHasNulls,
-		nulls:         nulls,
-	}
+	return res
 }
 
 // Copy returns a copy of n which can be modified independently.

--- a/pkg/col/coldata/nulls_test.go
+++ b/pkg/col/coldata/nulls_test.go
@@ -15,8 +15,12 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/stretchr/testify/require"
 )
+
+// noNulls is a nulls vector with no value set to null.
+var noNulls Nulls
 
 // nulls3 is a nulls vector with every third value set to null.
 var nulls3 Nulls
@@ -31,6 +35,7 @@ var nulls10 Nulls
 var pos = []int{0, 1, 63, 64, 65, BatchSize() - 1, BatchSize()}
 
 func init() {
+	noNulls = NewNulls(BatchSize())
 	nulls3 = NewNulls(BatchSize())
 	nulls5 = NewNulls(BatchSize())
 	nulls10 = NewNulls(BatchSize() * 2)
@@ -295,16 +300,30 @@ func TestSlice(t *testing.T) {
 }
 
 func TestNullsOr(t *testing.T) {
-	length1, length2 := 300, 400
-	n1 := nulls3.Slice(0, length1)
-	n2 := nulls5.Slice(0, length2)
+	rng, _ := randutil.NewPseudoRand()
+	randomNulls := NewNulls(BatchSize())
+	for i := 0; i < BatchSize(); i++ {
+		if rng.Float64() < 0.5 {
+			randomNulls.SetNull(i)
+		}
+	}
+	nullsToChooseFrom := []Nulls{noNulls, nulls3, nulls5, nulls10, randomNulls}
+
+	length1, length2 := 1+rng.Intn(BatchSize()), 1+rng.Intn(BatchSize())
+	n1Choice, n2Choice := rng.Intn(len(nullsToChooseFrom)), rng.Intn(len(nullsToChooseFrom))
+	n1 := nullsToChooseFrom[n1Choice].Slice(0, length1)
+	n2 := nullsToChooseFrom[n2Choice].Slice(0, length2)
 	or := n1.Or(&n2)
-	require.True(t, or.maybeHasNulls)
-	for i := 0; i < length2; i++ {
+	require.Equal(t, or.maybeHasNulls, n1.maybeHasNulls || n2.maybeHasNulls)
+	maxLength := length1
+	if length2 > length1 {
+		maxLength = length2
+	}
+	for i := 0; i < maxLength; i++ {
 		if i < length1 && n1.NullAt(i) || i < length2 && n2.NullAt(i) {
-			require.True(t, or.NullAt(i), "or.NullAt(%d) should be true", i)
+			require.True(t, or.NullAt(i), "or.NullAt(%d) should be true\nn1 %v\nn2 %v\n or %v", i, n1.nulls, n2.nulls, or.nulls)
 		} else {
-			require.False(t, or.NullAt(i), "or.NullAt(%d) should be false", i)
+			require.False(t, or.NullAt(i), "or.NullAt(%d) should be false\nn1 %v\nn2 %v\n or %v", i, n1.nulls, n2.nulls, or.nulls)
 		}
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #64116.

/cc @cockroachdb/release

---

Previously, `Nulls.Or` function incorrectly computed its result in some
edge cases. Namely:
- if both original `Nulls` objects had `maybeHasNulls` set to `false`
(indicating all valid values), `Or` would return a new `Nulls` object
with all values being invalid
- if the smaller `Nulls` object had invalid values whereas larger
didn't, all values after the length of the smaller object would be
incorrectly set to invalid.

AFAICT in production these issues shouldn't represent themselves in any
way because in reality we always check whether at least one of `Nulls`
objects might have nulls before calling `Or` (addressing the first
point) and usually have vectors of the same length. Still, I imagine it
is possible to come up with a scenario where the second problem somehow
is reproduced, so I'll be backporting this fix.

Release note: None
