### PR TITLE
kvserver: prevent the StoreRebalancer from downreplicating a range

### DIFF
--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -2657,6 +2657,25 @@ func (s *Store) AdminRelocateRange(
 	rangeDesc roachpb.RangeDescriptor,
 	voterTargets, nonVoterTargets []roachpb.ReplicationTarget,
 ) error {
+	if containsDuplicates(voterTargets) {
+		return errors.AssertionFailedf(
+			"list of desired voter targets contains duplicates: %+v",
+			voterTargets,
+		)
+	}
+	if containsDuplicates(nonVoterTargets) {
+		return errors.AssertionFailedf(
+			"list of desired non-voter targets contains duplicates: %+v",
+			nonVoterTargets,
+		)
+	}
+	if containsDuplicates(append(voterTargets, nonVoterTargets...)) {
+		return errors.AssertionFailedf(
+			"list of voter targets overlaps with the list of non-voter targets: voters: %+v, non-voters: %+v",
+			voterTargets, nonVoterTargets,
+		)
+	}
+
 	// Remove learners so we don't have to think about relocating them, and leave
 	// the joint config if we're in one.
 	newDesc, err := maybeLeaveAtomicChangeReplicasAndRemoveLearners(ctx, s, &rangeDesc)
@@ -3088,6 +3107,17 @@ func getRelocationArgs(
 		args.targetType = nonVoterTarget
 	}
 	return args
+}
+
+func containsDuplicates(targets []roachpb.ReplicationTarget) bool {
+	for i := range targets {
+		for j := i + 1; j < len(targets); j++ {
+			if targets[i] == targets[j] {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // subtractTargets returns the set of replica descriptors in `left` but not in


### PR DESCRIPTION
This PR contains 2 commits:

**kvserver: add safeguard against spurious calls to AdminRelocateRange**

This commit adds checks inside of `AdminRelocateRange` to fail if the
lists of relocation targets passed in by the caller contain duplicates.
This is supposed to act as a safeguard against catastrophic outcomes
like a range getting spuriously downreplicated due to malformed input.

Release note: None

**kvserver: prevent the StoreRebalancer from downreplicating a range**

Prior to this commit, we had a bug inside one of the methods used by the
`StoreRebalancer` where we had two variables referring to a slice that
was subsequently being appended to.

The code was making the implicit assumption that both of these slices
would point to the same underlying array, which is not true since any of
the additions mentioned above could result in the underlying array for
one of the slices being resized.

This commit fixes this bug.

Resolves #64064

Release note (bug fix): A bug in previous 21.1 betas allowed the store
rebalancer to spuriously downreplicate a range during normal operation.
This bug is now fixed.
