### PR TITLE
roachtest: add link to clusters' admin ui from the roachtest webui

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1091,17 +1091,21 @@ func (r *testRunner) serveHTTP(wr http.ResponseWriter, req *http.Request) {
 				clusterReused = "no"
 			}
 		}
-		var clusterName string
+		var clusterName, clusterAdminUIAddr string
 		if w.Cluster() != nil {
 			clusterName = w.Cluster().name
+			clusterAdminUIAddr = w.Cluster().ExternalAdminUIAddr(
+				req.Context(),
+				w.Cluster().Node(1),
+			)[0]
 		}
 		t := w.Test()
 		testStatus := "N/A"
 		if t != nil {
 			testStatus = t.GetStatus()
 		}
-		fmt.Fprintf(wr, "<tr><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>\n",
-			w.name, w.Status(), testName, clusterName, clusterReused, testStatus)
+		fmt.Fprintf(wr, "<tr><td>%s</td><td>%s</td><td>%s</td><td><a href='//%s'>%s</a></td><td>%s</td><td>%s</td></tr>\n",
+			w.name, w.Status(), testName, clusterAdminUIAddr, clusterName, clusterReused, testStatus)
 	}
 	fmt.Fprintf(wr, "</table>")
 


### PR DESCRIPTION
This commit makes the roachtest web ui link to respective clusters'
admin UI.

![adminuifromroachtest](https://user-images.githubusercontent.com/10788754/115942550-c6024380-a478-11eb-85ca-596a76d7ac0e.png)

Release note: None