### PR TITLE
build/bootstrap: clone submodules as well

### DIFF
--- a/build/bootstrap/bootstrap-debian.sh
+++ b/build/bootstrap/bootstrap-debian.sh
@@ -54,6 +54,7 @@ sudo tar -C /usr/local -zxf /tmp/go.tgz && rm /tmp/go.tgz
 
 # Clone CockroachDB.
 git clone https://github.com/cockroachdb/cockroach "$(go env GOPATH)/src/github.com/cockroachdb/cockroach"
+git -C "$(go env GOPATH)/src/github.com/cockroachdb/cockroach" submodule update --init
 
 # Install the Unison file-syncer.
 . bootstrap/bootstrap-unison.sh


### PR DESCRIPTION
The Debian bootstrap script, used to set up e.g. gceworkers, clones the
CRDB Git repo but not its submodules. Since the submodules are required
to build CRDB, this patch adds a command to clone them as well.

Release note: None