### PR TITLE
release-20.2: sql: fix flaky test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1012,7 +1012,7 @@ ALTER TABLE check_table ADD CHECK (a >= 0)
 statement ok
 ALTER TABLE check_table ADD CHECK (a < 0)
 
-statement error pgcode XXA00 validation of CHECK \"a < 0:::INT8\" failed on row: k=0, a=0
+statement error pgcode XXA00 validation of CHECK \"a < 0:::INT8\" failed on row
 COMMIT
 
 query TTTTB


### PR DESCRIPTION
Backport 1/1 commits from #64183.

/cc @cockroachdb/release

---

Which row fails the validation in this test is nondeterministic due to
DistSQL. Remove the specificity.

Introduced by #64003
