### PR TITLE
cli/zip: refer the user to extra flags upon large output files

### DIFF
--- a/pkg/cli/interactive_tests/test_zip_filter.tcl
+++ b/pkg/cli/interactive_tests/test_zip_filter.tcl
@@ -31,5 +31,18 @@ eexpect "skipping excluded log file: cockroach."
 eexpect ":/# "
 end_test
 
+start_test "Check that the zip command reports when large files are being transferred"
+# Create a fake large file.
+system "dd if=/dev/urandom of=logs/db/logs/heap_profiler/memprof.2021-04-26T14_19_50.909.26469048.pprof bs=1048576 count=15"
+# Retrieve all files, including a larger period of time so that the fake
+# file gets included.
+send "$argv debug zip --cpu-profile-duration=0 --files-from=2000-01-01 /dev/null >/dev/null\r"
+# Expect the warning and hint.
+eexpect "warning: output file size exceeds"
+eexpect "hint"
+eexpect "refine what data gets included"
+eexpect ":/# "
+end_test
+
 
 stop_server $argv

--- a/pkg/cli/zip_helpers.go
+++ b/pkg/cli/zip_helpers.go
@@ -15,7 +15,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -34,13 +33,11 @@ type zipper struct {
 	// goroutines to write concurrently to a zip.Writer.
 	syncutil.Mutex
 
-	f *os.File
 	z *zip.Writer
 }
 
-func newZipper(f *os.File) *zipper {
+func newZipper(f io.Writer) *zipper {
 	return &zipper{
-		f: f,
 		z: zip.NewWriter(f),
 	}
 }
@@ -49,9 +46,7 @@ func (z *zipper) close() error {
 	z.Lock()
 	defer z.Unlock()
 
-	err1 := z.z.Close()
-	err2 := z.f.Close()
-	return errors.CombineErrors(err1, err2)
+	return z.z.Close()
 }
 
 // createLocked opens a new entry in the zip file. The caller is

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -449,6 +449,11 @@ func TestZipRetries(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		defer func() {
+			if err := out.Close(); err != nil {
+				t.Fatal(err)
+			}
+		}()
 		z := newZipper(out)
 		defer func() {
 			if err := z.close(); err != nil {


### PR DESCRIPTION
Requested/suggested by @tbg and @stevendanna during the review of #64128. 

Example output:

```
warning: output file size exceeds 16 MB.
hint: consider using --include-files/--exclude-files or --files-from/--files-until to refine what data gets included.
```

Release note (cli change): The `debug zip` command now prints an
informational warning and hint that refers to the new command-line
flag whenever the output file grows beyonds multiples of 10MiB.