### PR TITLE
vendor: Bump pebble to b62f7661545760c4bc435db28b93433d66eb236a

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -563,8 +563,8 @@ def go_deps():
         name = "com_github_cockroachdb_pebble",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/pebble",
-        sum = "h1:5wi3lgnXMQNmfCJ/0+VQxFm0jQ1P5U5WVfs9h5yQ0xM=",
-        version = "v0.0.0-20210406003833-3d4c32f510a8",
+        sum = "h1:HQPE1RrXA1A8MPZrIv90t1KyYYEf07uYA+E7cCjgdPs=",
+        version = "v0.0.0-20210423210359-b62f76615457",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
-	github.com/cockroachdb/pebble v0.0.0-20210406003833-3d4c32f510a8
+	github.com/cockroachdb/pebble v0.0.0-20210423210359-b62f76615457
 	github.com/cockroachdb/redact v1.0.9
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249 h1:pZu
 github.com/cockroachdb/grpc-gateway v1.14.6-0.20200519165156-52697fc4a249/go.mod h1:UJ0EZAp832vCd54Wev9N1BMKEyvcZ5+IM0AwDrnlkEc=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20210406003833-3d4c32f510a8 h1:5wi3lgnXMQNmfCJ/0+VQxFm0jQ1P5U5WVfs9h5yQ0xM=
-github.com/cockroachdb/pebble v0.0.0-20210406003833-3d4c32f510a8/go.mod h1:1XpB4cLQcF189RAcWi4gUc110zJgtOfT7SVNGY8sOe0=
+github.com/cockroachdb/pebble v0.0.0-20210423210359-b62f76615457 h1:HQPE1RrXA1A8MPZrIv90t1KyYYEf07uYA+E7cCjgdPs=
+github.com/cockroachdb/pebble v0.0.0-20210423210359-b62f76615457/go.mod h1:1XpB4cLQcF189RAcWi4gUc110zJgtOfT7SVNGY8sOe0=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.0.9 h1:sjlUvGorKMIVQfo+w2RqDi5eewCHn453C/vdIXMzjzI=
 github.com/cockroachdb/redact v1.0.9/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=


### PR DESCRIPTION
Changes pulled in:
```
b62f7661545760c4bc435db28b93433d66eb236a internal/manifest: Let L0Sublevels get GCd on non-newest Versions
bee0c60e96bc1f12308484c9789c10cb4b19f77a db: reduce getInternal allocations of getIter
```

Release note (performance improvement): Reduce memory usage in some write-heavy
workloads.