### PR TITLE
opt: make placeholder fast path conditional on the estimated row count

### DIFF
--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -1457,21 +1457,29 @@ func (b *logicalPropsBuilder) buildFiltersItemProps(item *FiltersItem, scalar *p
 
 	// Functional Dependencies
 	// -----------------------
-	// Add constant columns. No need to add not null columns, because they
-	// are only relevant if there are lax FDs that can be made strict.
+	var constCols opt.ColSet
 	if scalar.Constraints != nil {
-		constCols := scalar.Constraints.ExtractConstCols(b.evalCtx)
-		scalar.FuncDeps.AddConstants(constCols)
+		constCols = scalar.Constraints.ExtractConstCols(b.evalCtx)
 	}
 
-	// Check for filter conjunct of the form: x = y.
 	if eq, ok := item.Condition.(*EqExpr); ok {
 		if leftVar, ok := eq.Left.(*VariableExpr); ok {
-			if rightVar, ok := eq.Right.(*VariableExpr); ok {
-				scalar.FuncDeps.AddEquivalency(leftVar.Col, rightVar.Col)
+			switch rhs := eq.Right.(type) {
+			case *VariableExpr:
+				// Filter conjunct of the form: x = y.
+				scalar.FuncDeps.AddEquivalency(leftVar.Col, rhs.Col)
+
+			case *PlaceholderExpr:
+				// Filter conjunct of the form x = $1. This filter cannot generate
+				// constraints, but still tell us that the column is constant.
+				constCols.Add(leftVar.Col)
 			}
 		}
 	}
+
+	// Add constant columns. No need to add not null columns, because they
+	// are only relevant if there are lax FDs that can be made strict.
+	scalar.FuncDeps.AddConstants(constCols)
 }
 
 func (b *logicalPropsBuilder) buildProjectionsItemProps(

--- a/pkg/sql/opt/optbuilder/testdata/delete
+++ b/pkg/sql/opt/optbuilder/testdata/delete
@@ -181,20 +181,19 @@ delete xyz
  └── limit
       ├── columns: x:5!null y:6 z:7 crdb_internal_mvcc_timestamp:8 column9:9
       ├── internal-ordering: -9
-      ├── sort
-      │    ├── columns: x:5!null y:6 z:7 crdb_internal_mvcc_timestamp:8 column9:9
+      ├── project
+      │    ├── columns: column9:9 x:5!null y:6 z:7 crdb_internal_mvcc_timestamp:8
       │    ├── ordering: -9
       │    ├── limit hint: 2.00
-      │    └── project
-      │         ├── columns: column9:9 x:5!null y:6 z:7 crdb_internal_mvcc_timestamp:8
-      │         ├── select
-      │         │    ├── columns: x:5!null y:6 z:7 crdb_internal_mvcc_timestamp:8
-      │         │    ├── scan xyz
-      │         │    │    └── columns: x:5!null y:6 z:7 crdb_internal_mvcc_timestamp:8
-      │         │    └── filters
-      │         │         └── x:5 = $1
-      │         └── projections
-      │              └── y:6 + $2 [as=column9:9]
+      │    ├── select
+      │    │    ├── columns: x:5!null y:6 z:7 crdb_internal_mvcc_timestamp:8
+      │    │    ├── limit hint: 2.00
+      │    │    ├── scan xyz
+      │    │    │    └── columns: x:5!null y:6 z:7 crdb_internal_mvcc_timestamp:8
+      │    │    └── filters
+      │    │         └── x:5 = $1
+      │    └── projections
+      │         └── y:6 + $2 [as=column9:9]
       └── 2
 
 

--- a/pkg/sql/opt/xform/optimizer_test.go
+++ b/pkg/sql/opt/xform/optimizer_test.go
@@ -224,7 +224,7 @@ func TestPlaceholderFastPath(t *testing.T) {
 	runDataDrivenTest(
 		t,
 		"testdata/placeholder-fast-path",
-		memo.ExprFmtHideStats|memo.ExprFmtHideCost|memo.ExprFmtHideRuleProps|
+		memo.ExprFmtHideCost|memo.ExprFmtHideRuleProps|
 			memo.ExprFmtHideQualifications|memo.ExprFmtHideScalars|memo.ExprFmtHideTypes,
 	)
 }

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -308,19 +308,19 @@ inner-join (cross)
  ├── columns: id1_4_0_:1!null id1_2_1_:8!null address2_4_0_:2!null createdo3_4_0_:3 name4_4_0_:4 nickname5_4_0_:5 version6_4_0_:6!null name2_2_1_:9!null version3_2_1_:10!null
  ├── has-placeholder
  ├── key: (1,8)
- ├── fd: ()-->(10), (1)-->(2-6), (8)-->(9)
+ ├── fd: ()-->(2,10), (1)-->(3-6), (8)-->(9)
  ├── project
  │    ├── columns: person0_.id:1!null address:2!null createdon:3 person0_.name:4 nickname:5 person0_.version:6!null
  │    ├── has-placeholder
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-6)
+ │    ├── fd: ()-->(2), (1)-->(3-6)
  │    └── inner-join (lookup person [as=person0_])
  │         ├── columns: person0_.id:1!null address:2!null createdon:3 person0_.name:4 nickname:5 person0_.version:6!null person_id:15!null
  │         ├── key columns: [15] = [1]
  │         ├── lookup columns are key
  │         ├── has-placeholder
  │         ├── key: (15)
- │         ├── fd: (1)-->(2-6), (1)==(15), (15)==(1)
+ │         ├── fd: ()-->(2), (1)-->(3-6), (1)==(15), (15)==(1)
  │         ├── distinct-on
  │         │    ├── columns: person_id:15
  │         │    ├── grouping columns: person_id:15
@@ -328,7 +328,7 @@ inner-join (cross)
  │         │    └── scan phone [as=phones2_]
  │         │         └── columns: person_id:15
  │         └── filters
- │              └── address:2 = $1 [outer=(2), constraints=(/2: (/NULL - ])]
+ │              └── address:2 = $1 [outer=(2), constraints=(/2: (/NULL - ]), fd=()-->(2)]
  ├── select
  │    ├── columns: partner1_.id:8!null partner1_.name:9!null partner1_.version:10!null
  │    ├── has-placeholder
@@ -739,7 +739,7 @@ project
       ├── columns: phone0_.id:1!null phone_number:2 phone_type:3 person_id:4 max:12!null
       ├── has-placeholder
       ├── key: (1)
-      ├── fd: (1)-->(2-4,12)
+      ├── fd: ()-->(12), (1)-->(2-4)
       ├── group-by
       │    ├── columns: phone0_.id:1!null phone_number:2 phone_type:3 person_id:4 max:12!null
       │    ├── grouping columns: phone0_.id:1!null
@@ -770,7 +770,7 @@ project
       │         └── const-agg [as=person_id:4, outer=(4)]
       │              └── person_id:4
       └── filters
-           └── max:12 = $1 [outer=(12), constraints=(/12: (/NULL - ])]
+           └── max:12 = $1 [outer=(12), constraints=(/12: (/NULL - ]), fd=()-->(12)]
 
 opt
 select
@@ -860,7 +860,7 @@ project
       ├── columns: phone0_.id:1!null phone_number:2 phone_type:3 person_id:4 min:12!null
       ├── has-placeholder
       ├── key: (1)
-      ├── fd: (1)-->(2-4,12)
+      ├── fd: ()-->(12), (1)-->(2-4)
       ├── group-by
       │    ├── columns: phone0_.id:1!null phone_number:2 phone_type:3 person_id:4 min:12!null
       │    ├── grouping columns: phone0_.id:1!null
@@ -891,7 +891,7 @@ project
       │         └── const-agg [as=person_id:4, outer=(4)]
       │              └── person_id:4
       └── filters
-           └── min:12 = $1 [outer=(12), constraints=(/12: (/NULL - ])]
+           └── min:12 = $1 [outer=(12), constraints=(/12: (/NULL - ]), fd=()-->(12)]
 
 opt
 select
@@ -983,30 +983,33 @@ project
  ├── has-placeholder
  ├── key: (1)
  ├── fd: (1)-->(2-6)
- └── inner-join (lookup person [as=person0_])
+ └── project
       ├── columns: person0_.id:1!null address:2 createdon:3 name:4 nickname:5 version:6!null person_id:11!null
-      ├── key columns: [11] = [1]
-      ├── lookup columns are key
+      ├── cardinality: [0 - 1]
       ├── has-placeholder
-      ├── key: (11)
-      ├── fd: (1)-->(2-6), (1)==(11), (11)==(1)
-      ├── distinct-on
-      │    ├── columns: person_id:11
-      │    ├── grouping columns: person_id:11
-      │    ├── has-placeholder
-      │    ├── key: (11)
-      │    └── select
-      │         ├── columns: phones1_.id:8!null person_id:11
-      │         ├── has-placeholder
-      │         ├── key: (8)
-      │         ├── fd: (8)-->(11)
-      │         ├── scan phone [as=phones1_]
-      │         │    ├── columns: phones1_.id:8!null person_id:11
-      │         │    ├── key: (8)
-      │         │    └── fd: (8)-->(11)
-      │         └── filters
-      │              └── phones1_.id:8 = $1 [outer=(8), constraints=(/8: (/NULL - ])]
-      └── filters (true)
+      ├── key: ()
+      ├── fd: ()-->(1-6,11), (1)==(11), (11)==(1)
+      └── inner-join (lookup person [as=person0_])
+           ├── columns: person0_.id:1!null address:2 createdon:3 name:4 nickname:5 version:6!null phones1_.id:8!null person_id:11!null
+           ├── key columns: [11] = [1]
+           ├── lookup columns are key
+           ├── cardinality: [0 - 1]
+           ├── has-placeholder
+           ├── key: ()
+           ├── fd: ()-->(1-6,8,11), (11)==(1), (1)==(11)
+           ├── select
+           │    ├── columns: phones1_.id:8!null person_id:11
+           │    ├── cardinality: [0 - 1]
+           │    ├── has-placeholder
+           │    ├── key: ()
+           │    ├── fd: ()-->(8,11)
+           │    ├── scan phone [as=phones1_]
+           │    │    ├── columns: phones1_.id:8!null person_id:11
+           │    │    ├── key: (8)
+           │    │    └── fd: (8)-->(11)
+           │    └── filters
+           │         └── phones1_.id:8 = $1 [outer=(8), constraints=(/8: (/NULL - ]), fd=()-->(8)]
+           └── filters (true)
 
 opt
 select
@@ -1033,30 +1036,33 @@ project
  ├── has-placeholder
  ├── key: (1)
  ├── fd: (1)-->(2-6)
- └── inner-join (lookup person [as=person0_])
+ └── project
       ├── columns: person0_.id:1!null address:2 createdon:3 name:4 nickname:5 version:6!null person_id:11!null
-      ├── key columns: [11] = [1]
-      ├── lookup columns are key
+      ├── cardinality: [0 - 1]
       ├── has-placeholder
-      ├── key: (11)
-      ├── fd: (1)-->(2-6), (1)==(11), (11)==(1)
-      ├── distinct-on
-      │    ├── columns: person_id:11
-      │    ├── grouping columns: person_id:11
-      │    ├── has-placeholder
-      │    ├── key: (11)
-      │    └── select
-      │         ├── columns: phones1_.id:8!null person_id:11
-      │         ├── has-placeholder
-      │         ├── key: (8)
-      │         ├── fd: (8)-->(11)
-      │         ├── scan phone [as=phones1_]
-      │         │    ├── columns: phones1_.id:8!null person_id:11
-      │         │    ├── key: (8)
-      │         │    └── fd: (8)-->(11)
-      │         └── filters
-      │              └── phones1_.id:8 = $1 [outer=(8), constraints=(/8: (/NULL - ])]
-      └── filters (true)
+      ├── key: ()
+      ├── fd: ()-->(1-6,11), (1)==(11), (11)==(1)
+      └── inner-join (lookup person [as=person0_])
+           ├── columns: person0_.id:1!null address:2 createdon:3 name:4 nickname:5 version:6!null phones1_.id:8!null person_id:11!null
+           ├── key columns: [11] = [1]
+           ├── lookup columns are key
+           ├── cardinality: [0 - 1]
+           ├── has-placeholder
+           ├── key: ()
+           ├── fd: ()-->(1-6,8,11), (11)==(1), (1)==(11)
+           ├── select
+           │    ├── columns: phones1_.id:8!null person_id:11
+           │    ├── cardinality: [0 - 1]
+           │    ├── has-placeholder
+           │    ├── key: ()
+           │    ├── fd: ()-->(8,11)
+           │    ├── scan phone [as=phones1_]
+           │    │    ├── columns: phones1_.id:8!null person_id:11
+           │    │    ├── key: (8)
+           │    │    └── fd: (8)-->(11)
+           │    └── filters
+           │         └── phones1_.id:8 = $1 [outer=(8), constraints=(/8: (/NULL - ]), fd=()-->(8)]
+           └── filters (true)
 
 opt
 select
@@ -1865,17 +1871,17 @@ project
  ├── columns: auctioni4_1_0_:4!null id1_1_0_:1!null id1_1_1_:1!null amount2_1_1_:2 createdd3_1_1_:3 auctioni4_1_1_:4!null formula41_1_:11!null
  ├── has-placeholder
  ├── key: (1)
- ├── fd: (1)-->(2-4,11)
+ ├── fd: ()-->(4), (1)-->(2,3,11)
  ├── group-by
  │    ├── columns: bids0_.id:1!null amount:2 createddatetime:3 auctionid:4!null true_agg:13
  │    ├── grouping columns: bids0_.id:1!null
  │    ├── has-placeholder
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-4,13)
+ │    ├── fd: ()-->(4), (1)-->(2-4,13)
  │    ├── right-join (hash)
  │    │    ├── columns: bids0_.id:1!null amount:2 createddatetime:3 auctionid:4!null successfulbid:9 true:12
  │    │    ├── has-placeholder
- │    │    ├── fd: (1)-->(2-4)
+ │    │    ├── fd: ()-->(4), (1)-->(2,3)
  │    │    ├── project
  │    │    │    ├── columns: true:12!null successfulbid:9
  │    │    │    ├── fd: ()-->(12)
@@ -1887,13 +1893,13 @@ project
  │    │    │    ├── columns: bids0_.id:1!null amount:2 createddatetime:3 auctionid:4!null
  │    │    │    ├── has-placeholder
  │    │    │    ├── key: (1)
- │    │    │    ├── fd: (1)-->(2-4)
+ │    │    │    ├── fd: ()-->(4), (1)-->(2,3)
  │    │    │    ├── scan tbid2 [as=bids0_]
  │    │    │    │    ├── columns: bids0_.id:1!null amount:2 createddatetime:3 auctionid:4
  │    │    │    │    ├── key: (1)
  │    │    │    │    └── fd: (1)-->(2-4)
  │    │    │    └── filters
- │    │    │         └── auctionid:4 = $1 [outer=(4), constraints=(/4: (/NULL - ])]
+ │    │    │         └── auctionid:4 = $1 [outer=(4), constraints=(/4: (/NULL - ]), fd=()-->(4)]
  │    │    └── filters
  │    │         └── successfulbid:9 = bids0_.id:1 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
  │    └── aggregations

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -160,125 +160,110 @@ order by anon_1.flavors_id asc
 project
  ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:31 flavor_extra_specs_1_updated_at:32 flavor_extra_specs_1_id:27 flavor_extra_specs_1_key:28 flavor_extra_specs_1_value:29 flavor_extra_specs_1_flavor_id:30
  ├── immutable, has-placeholder
- ├── key: (1,27)
- ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (27)-->(28-32), (28,30)-->(27,29,31,32)
- ├── ordering: +1
- └── left-join (merge)
+ ├── key: (27)
+ ├── fd: ()-->(1-12,14,15), (27)-->(28-32), (28,30)-->(27,29,31,32)
+ └── left-join (lookup flavor_extra_specs [as=flavor_extra_specs_1])
       ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25 flavor_extra_specs_1.id:27 key:28 value:29 flavor_extra_specs_1.flavor_id:30 flavor_extra_specs_1.created_at:31 flavor_extra_specs_1.updated_at:32
-      ├── left ordering: +1
-      ├── right ordering: +30
+      ├── key columns: [27] = [27]
+      ├── lookup columns are key
       ├── immutable, has-placeholder
-      ├── key: (1,27)
-      ├── fd: (1)-->(2-12,14,15,25), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (27)-->(28-32), (28,30)-->(27,29,31,32)
-      ├── ordering: +1
-      ├── limit
-      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25
-      │    ├── internal-ordering: +1
+      ├── key: (27)
+      ├── fd: ()-->(1-12,14,15,25), (27)-->(28-32), (28,30)-->(27,29,31,32)
+      ├── left-join (lookup flavor_extra_specs@flavor_extra_specs_flavor_id_key_idx [as=flavor_extra_specs_1])
+      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25 flavor_extra_specs_1.id:27 key:28 flavor_extra_specs_1.flavor_id:30
+      │    ├── key columns: [1] = [30]
       │    ├── immutable, has-placeholder
-      │    ├── key: (1)
-      │    ├── fd: (1)-->(2-12,14,15,25), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    ├── ordering: +1
-      │    ├── offset
-      │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25
-      │    │    ├── internal-ordering: +1
-      │    │    ├── has-placeholder
-      │    │    ├── key: (1)
-      │    │    ├── fd: (1)-->(2-12,14,15,25), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    ├── ordering: +1
-      │    │    ├── select
-      │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25
-      │    │    │    ├── has-placeholder
-      │    │    │    ├── key: (1)
-      │    │    │    ├── fd: (1)-->(2-12,14,15,25), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    ├── ordering: +1
-      │    │    │    ├── group-by
-      │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25
-      │    │    │    │    ├── grouping columns: flavors.id:1!null
-      │    │    │    │    ├── has-placeholder
-      │    │    │    │    ├── key: (1)
-      │    │    │    │    ├── fd: (1)-->(2-12,14,15,25), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    │    ├── ordering: +1
-      │    │    │    │    ├── left-join (merge)
-      │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:18 true:24
-      │    │    │    │    │    ├── left ordering: +1
-      │    │    │    │    │    ├── right ordering: +18
-      │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    │    │    ├── ordering: +1
-      │    │    │    │    │    ├── select
-      │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-      │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    │    │    │    ├── ordering: +1
-      │    │    │    │    │    │    ├── scan flavors
-      │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-      │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    │    │    │    │    └── ordering: +1
-      │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │         └── flavorid:7 = $2 [outer=(7), constraints=(/7: (/NULL - ])]
-      │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: true:24!null flavor_projects.flavor_id:18!null
-      │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    ├── fd: ()-->(24)
-      │    │    │    │    │    │    ├── ordering: +18 opt(24) [actual: +18]
-      │    │    │    │    │    │    ├── select
-      │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:18!null project_id:19!null
-      │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    ├── key: (18,19)
-      │    │    │    │    │    │    │    ├── ordering: +18
-      │    │    │    │    │    │    │    ├── scan flavor_projects@secondary
-      │    │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:18!null project_id:19!null
-      │    │    │    │    │    │    │    │    ├── key: (18,19)
-      │    │    │    │    │    │    │    │    └── ordering: +18
-      │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         └── project_id:19 = $1 [outer=(19), constraints=(/19: (/NULL - ])]
-      │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── true [as=true:24]
-      │    │    │    │    │    └── filters (true)
-      │    │    │    │    └── aggregations
-      │    │    │    │         ├── const-not-null-agg [as=true_agg:25, outer=(24)]
-      │    │    │    │         │    └── true:24
-      │    │    │    │         ├── const-agg [as=name:2, outer=(2)]
-      │    │    │    │         │    └── name:2
-      │    │    │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
-      │    │    │    │         │    └── memory_mb:3
-      │    │    │    │         ├── const-agg [as=vcpus:4, outer=(4)]
-      │    │    │    │         │    └── vcpus:4
-      │    │    │    │         ├── const-agg [as=root_gb:5, outer=(5)]
-      │    │    │    │         │    └── root_gb:5
-      │    │    │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-      │    │    │    │         │    └── ephemeral_gb:6
-      │    │    │    │         ├── const-agg [as=flavorid:7, outer=(7)]
-      │    │    │    │         │    └── flavorid:7
-      │    │    │    │         ├── const-agg [as=swap:8, outer=(8)]
-      │    │    │    │         │    └── swap:8
-      │    │    │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-      │    │    │    │         │    └── rxtx_factor:9
-      │    │    │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-      │    │    │    │         │    └── vcpu_weight:10
-      │    │    │    │         ├── const-agg [as=disabled:11, outer=(11)]
-      │    │    │    │         │    └── disabled:11
-      │    │    │    │         ├── const-agg [as=is_public:12, outer=(12)]
-      │    │    │    │         │    └── is_public:12
-      │    │    │    │         ├── const-agg [as=flavors.created_at:14, outer=(14)]
-      │    │    │    │         │    └── flavors.created_at:14
-      │    │    │    │         └── const-agg [as=flavors.updated_at:15, outer=(15)]
-      │    │    │    │              └── flavors.updated_at:15
-      │    │    │    └── filters
-      │    │    │         └── (is_public:12 = true) OR (true_agg:25 IS NOT NULL) [outer=(12,25)]
-      │    │    └── $3
-      │    └── $4
-      ├── sort
-      │    ├── columns: flavor_extra_specs_1.id:27!null key:28!null value:29 flavor_extra_specs_1.flavor_id:30!null flavor_extra_specs_1.created_at:31 flavor_extra_specs_1.updated_at:32
       │    ├── key: (27)
-      │    ├── fd: (27)-->(28-32), (28,30)-->(27,29,31,32)
-      │    ├── ordering: +30
-      │    └── scan flavor_extra_specs [as=flavor_extra_specs_1]
-      │         ├── columns: flavor_extra_specs_1.id:27!null key:28!null value:29 flavor_extra_specs_1.flavor_id:30!null flavor_extra_specs_1.created_at:31 flavor_extra_specs_1.updated_at:32
-      │         ├── key: (27)
-      │         └── fd: (27)-->(28-32), (28,30)-->(27,29,31,32)
+      │    ├── fd: ()-->(1-12,14,15,25), (27)-->(28,30), (28,30)-->(27)
+      │    ├── limit
+      │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25
+      │    │    ├── cardinality: [0 - 1]
+      │    │    ├── immutable, has-placeholder
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(1-12,14,15,25)
+      │    │    ├── offset
+      │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25
+      │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    ├── has-placeholder
+      │    │    │    ├── key: ()
+      │    │    │    ├── fd: ()-->(1-12,14,15,25)
+      │    │    │    ├── select
+      │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25
+      │    │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    │    ├── has-placeholder
+      │    │    │    │    ├── key: ()
+      │    │    │    │    ├── fd: ()-->(1-12,14,15,25)
+      │    │    │    │    ├── group-by
+      │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25
+      │    │    │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,25)
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: true:24 flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:18
+      │    │    │    │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15,18,24)
+      │    │    │    │    │    │    ├── left-join (lookup flavor_projects@secondary)
+      │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:18 project_id:19
+      │    │    │    │    │    │    │    ├── key columns: [1] = [18]
+      │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15,18,19)
+      │    │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
+      │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15)
+      │    │    │    │    │    │    │    │    ├── scan flavors
+      │    │    │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
+      │    │    │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    │    │    └── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │    │         └── flavorid:7 = $2 [outer=(7), constraints=(/7: (/NULL - ]), fd=()-->(7)]
+      │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │         └── project_id:19 = $1 [outer=(19), constraints=(/19: (/NULL - ]), fd=()-->(19)]
+      │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │         └── CASE flavor_projects.flavor_id:18 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:24, outer=(18)]
+      │    │    │    │    │    └── aggregations
+      │    │    │    │    │         ├── const-not-null-agg [as=true_agg:25, outer=(24)]
+      │    │    │    │    │         │    └── true:24
+      │    │    │    │    │         ├── const-agg [as=name:2, outer=(2)]
+      │    │    │    │    │         │    └── name:2
+      │    │    │    │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
+      │    │    │    │    │         │    └── memory_mb:3
+      │    │    │    │    │         ├── const-agg [as=vcpus:4, outer=(4)]
+      │    │    │    │    │         │    └── vcpus:4
+      │    │    │    │    │         ├── const-agg [as=root_gb:5, outer=(5)]
+      │    │    │    │    │         │    └── root_gb:5
+      │    │    │    │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
+      │    │    │    │    │         │    └── ephemeral_gb:6
+      │    │    │    │    │         ├── const-agg [as=flavorid:7, outer=(7)]
+      │    │    │    │    │         │    └── flavorid:7
+      │    │    │    │    │         ├── const-agg [as=swap:8, outer=(8)]
+      │    │    │    │    │         │    └── swap:8
+      │    │    │    │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
+      │    │    │    │    │         │    └── rxtx_factor:9
+      │    │    │    │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
+      │    │    │    │    │         │    └── vcpu_weight:10
+      │    │    │    │    │         ├── const-agg [as=disabled:11, outer=(11)]
+      │    │    │    │    │         │    └── disabled:11
+      │    │    │    │    │         ├── const-agg [as=is_public:12, outer=(12)]
+      │    │    │    │    │         │    └── is_public:12
+      │    │    │    │    │         ├── const-agg [as=flavors.created_at:14, outer=(14)]
+      │    │    │    │    │         │    └── flavors.created_at:14
+      │    │    │    │    │         ├── const-agg [as=flavors.updated_at:15, outer=(15)]
+      │    │    │    │    │         │    └── flavors.updated_at:15
+      │    │    │    │    │         └── const-agg [as=flavors.id:1, outer=(1)]
+      │    │    │    │    │              └── flavors.id:1
+      │    │    │    │    └── filters
+      │    │    │    │         └── (is_public:12 = true) OR (true_agg:25 IS NOT NULL) [outer=(12,25)]
+      │    │    │    └── $3
+      │    │    └── $4
+      │    └── filters (true)
       └── filters (true)
 
 opt
@@ -392,7 +377,8 @@ sort
            │    │    │         │    │    ├── left ordering: +1
            │    │    │         │    │    ├── right ordering: +25
            │    │    │         │    │    ├── has-placeholder
-           │    │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,32), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    │    │         │    │    ├── key: (1)
+           │    │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,25,32,34), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
            │    │    │         │    │    ├── ordering: +1 opt(11) [actual: +1]
            │    │    │         │    │    ├── select
            │    │    │         │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:32
@@ -412,7 +398,8 @@ sort
            │    │    │         │    │    │    │    │    ├── left ordering: +1
            │    │    │         │    │    │    │    │    ├── right ordering: +18
            │    │    │         │    │    │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    │    │         │    │    │    │    │    ├── key: (1)
+           │    │    │         │    │    │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,18,31), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
            │    │    │         │    │    │    │    │    ├── ordering: +1 opt(11) [actual: +1]
            │    │    │         │    │    │    │    │    ├── select
            │    │    │         │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15
@@ -429,19 +416,21 @@ sort
            │    │    │         │    │    │    │    │    ├── project
            │    │    │         │    │    │    │    │    │    ├── columns: true:31!null flavor_projects.flavor_id:18!null
            │    │    │         │    │    │    │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    │    │    │    ├── key: (18)
            │    │    │         │    │    │    │    │    │    ├── fd: ()-->(31)
            │    │    │         │    │    │    │    │    │    ├── ordering: +18 opt(31) [actual: +18]
            │    │    │         │    │    │    │    │    │    ├── select
            │    │    │         │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:18!null project_id:19!null
            │    │    │         │    │    │    │    │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    │    │    │    │    ├── key: (18,19)
-           │    │    │         │    │    │    │    │    │    │    ├── ordering: +18
+           │    │    │         │    │    │    │    │    │    │    ├── key: (18)
+           │    │    │         │    │    │    │    │    │    │    ├── fd: ()-->(19)
+           │    │    │         │    │    │    │    │    │    │    ├── ordering: +18 opt(19) [actual: +18]
            │    │    │         │    │    │    │    │    │    │    ├── scan flavor_projects@secondary
            │    │    │         │    │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:18!null project_id:19!null
            │    │    │         │    │    │    │    │    │    │    │    ├── key: (18,19)
-           │    │    │         │    │    │    │    │    │    │    │    └── ordering: +18
+           │    │    │         │    │    │    │    │    │    │    │    └── ordering: +18 opt(19) [actual: +18]
            │    │    │         │    │    │    │    │    │    │    └── filters
-           │    │    │         │    │    │    │    │    │    │         └── project_id:19 = $1 [outer=(19), constraints=(/19: (/NULL - ])]
+           │    │    │         │    │    │    │    │    │    │         └── project_id:19 = $1 [outer=(19), constraints=(/19: (/NULL - ]), fd=()-->(19)]
            │    │    │         │    │    │    │    │    │    └── projections
            │    │    │         │    │    │    │    │    │         └── true [as=true:31]
            │    │    │         │    │    │    │    │    └── filters (true)
@@ -479,19 +468,21 @@ sort
            │    │    │         │    │    ├── project
            │    │    │         │    │    │    ├── columns: true:34!null flavor_projects.flavor_id:25!null
            │    │    │         │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    ├── key: (25)
            │    │    │         │    │    │    ├── fd: ()-->(34)
            │    │    │         │    │    │    ├── ordering: +25 opt(34) [actual: +25]
            │    │    │         │    │    │    ├── select
            │    │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:25!null project_id:26!null
            │    │    │         │    │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    │    ├── key: (25,26)
-           │    │    │         │    │    │    │    ├── ordering: +25
+           │    │    │         │    │    │    │    ├── key: (25)
+           │    │    │         │    │    │    │    ├── fd: ()-->(26)
+           │    │    │         │    │    │    │    ├── ordering: +25 opt(26) [actual: +25]
            │    │    │         │    │    │    │    ├── scan flavor_projects@secondary
            │    │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:25!null project_id:26!null
            │    │    │         │    │    │    │    │    ├── key: (25,26)
-           │    │    │         │    │    │    │    │    └── ordering: +25
+           │    │    │         │    │    │    │    │    └── ordering: +25 opt(26) [actual: +25]
            │    │    │         │    │    │    │    └── filters
-           │    │    │         │    │    │    │         └── project_id:26 = $2 [outer=(26), constraints=(/26: (/NULL - ])]
+           │    │    │         │    │    │    │         └── project_id:26 = $2 [outer=(26), constraints=(/26: (/NULL - ]), fd=()-->(26)]
            │    │    │         │    │    │    └── projections
            │    │    │         │    │    │         └── true [as=true:34]
            │    │    │         │    │    └── filters (true)
@@ -595,98 +586,101 @@ sort
  ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:36 instance_type_extra_specs_1_updated_at:37 instance_type_extra_specs_1_deleted_at:35 instance_type_extra_specs_1_deleted:34 instance_type_extra_specs_1_id:30 instance_type_extra_specs_1_key:31 instance_type_extra_specs_1_value:32 instance_type_extra_specs_1_instance_type_id:33
  ├── immutable, has-placeholder
  ├── key: (1,30)
- ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
- ├── ordering: +7,+1
+ ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-33,35-37), (31,33,34)~~>(30,32,35-37), (1,30)-->(34)
+ ├── ordering: +7,+1 opt(13) [actual: +7,+1]
  └── project
       ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:30 key:31 value:32 instance_type_extra_specs_1.instance_type_id:33 instance_type_extra_specs_1.deleted:34 instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
       ├── immutable, has-placeholder
       ├── key: (1,30)
-      ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
+      ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-33,35-37), (31,33,34)~~>(30,32,35-37), (1,30)-->(34)
       └── right-join (hash)
            ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28 instance_type_extra_specs_1.id:30 key:31 value:32 instance_type_extra_specs_1.instance_type_id:33 instance_type_extra_specs_1.deleted:34 instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
            ├── immutable, has-placeholder
            ├── key: (1,30)
-           ├── fd: (1)-->(2-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
+           ├── fd: ()-->(13), (1)-->(2-12,14-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-33,35-37), (31,33,34)~~>(30,32,35-37), (1,30)-->(34)
            ├── select
            │    ├── columns: instance_type_extra_specs_1.id:30!null key:31 value:32 instance_type_extra_specs_1.instance_type_id:33!null instance_type_extra_specs_1.deleted:34!null instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
            │    ├── has-placeholder
            │    ├── key: (30)
-           │    ├── fd: (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
+           │    ├── fd: ()-->(34), (30)-->(31-33,35-37), (31,33,34)~~>(30,32,35-37)
            │    ├── scan instance_type_extra_specs [as=instance_type_extra_specs_1]
            │    │    ├── columns: instance_type_extra_specs_1.id:30!null key:31 value:32 instance_type_extra_specs_1.instance_type_id:33!null instance_type_extra_specs_1.deleted:34 instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
            │    │    ├── key: (30)
            │    │    └── fd: (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
            │    └── filters
-           │         └── instance_type_extra_specs_1.deleted:34 = $7 [outer=(34), constraints=(/34: (/NULL - ])]
+           │         └── instance_type_extra_specs_1.deleted:34 = $7 [outer=(34), constraints=(/34: (/NULL - ]), fd=()-->(34)]
            ├── limit
            │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
-           │    ├── internal-ordering: +7,+1
+           │    ├── internal-ordering: +7,+1 opt(13)
            │    ├── immutable, has-placeholder
            │    ├── key: (1)
-           │    ├── fd: (1)-->(2-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    ├── fd: ()-->(13), (1)-->(2-12,14-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    ├── offset
            │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
-           │    │    ├── internal-ordering: +7,+1
+           │    │    ├── internal-ordering: +7,+1 opt(13)
            │    │    ├── has-placeholder
            │    │    ├── key: (1)
-           │    │    ├── fd: (1)-->(2-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    ├── ordering: +7,+1
+           │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    ├── ordering: +7,+1 opt(13) [actual: +7,+1]
            │    │    ├── sort
            │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
            │    │    │    ├── has-placeholder
            │    │    │    ├── key: (1)
-           │    │    │    ├── fd: (1)-->(2-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │    ├── ordering: +7,+1
+           │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │    ├── ordering: +7,+1 opt(13) [actual: +7,+1]
            │    │    │    └── select
            │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
            │    │    │         ├── has-placeholder
            │    │    │         ├── key: (1)
-           │    │    │         ├── fd: (1)-->(2-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         ├── fd: ()-->(13), (1)-->(2-12,14-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    │         ├── group-by
            │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
            │    │    │         │    ├── grouping columns: instance_types.id:1!null
-           │    │    │         │    ├── internal-ordering: +1
+           │    │    │         │    ├── internal-ordering: +1 opt(13)
            │    │    │         │    ├── has-placeholder
            │    │    │         │    ├── key: (1)
-           │    │    │         │    ├── fd: (1)-->(2-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    ├── fd: ()-->(13), (1)-->(2-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    │         │    ├── left-join (merge)
            │    │    │         │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:19 true:27
            │    │    │         │    │    ├── left ordering: +1
            │    │    │         │    │    ├── right ordering: +19
            │    │    │         │    │    ├── has-placeholder
-           │    │    │         │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         │    │    ├── ordering: +1
+           │    │    │         │    │    ├── key: (1)
+           │    │    │         │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,19,27), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    │    ├── ordering: +1 opt(13) [actual: +1]
            │    │    │         │    │    ├── select
            │    │    │         │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
            │    │    │         │    │    │    ├── has-placeholder
            │    │    │         │    │    │    ├── key: (1)
-           │    │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         │    │    │    ├── ordering: +1
+           │    │    │         │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    │    │    ├── ordering: +1 opt(13) [actual: +1]
            │    │    │         │    │    │    ├── scan instance_types
            │    │    │         │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
            │    │    │         │    │    │    │    ├── key: (1)
            │    │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         │    │    │    │    └── ordering: +1
+           │    │    │         │    │    │    │    └── ordering: +1 opt(13) [actual: +1]
            │    │    │         │    │    │    └── filters
-           │    │    │         │    │    │         └── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ])]
+           │    │    │         │    │    │         └── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
            │    │    │         │    │    ├── project
            │    │    │         │    │    │    ├── columns: true:27!null instance_type_projects.instance_type_id:19!null
            │    │    │         │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    ├── key: (19)
            │    │    │         │    │    │    ├── fd: ()-->(27)
            │    │    │         │    │    │    ├── ordering: +19 opt(27) [actual: +19]
            │    │    │         │    │    │    ├── select
            │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:19!null project_id:20!null instance_type_projects.deleted:21!null
            │    │    │         │    │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    │    ├── key: (19-21)
-           │    │    │         │    │    │    │    ├── ordering: +19
+           │    │    │         │    │    │    │    ├── key: (19)
+           │    │    │         │    │    │    │    ├── fd: ()-->(20,21)
+           │    │    │         │    │    │    │    ├── ordering: +19 opt(20,21) [actual: +19]
            │    │    │         │    │    │    │    ├── scan instance_type_projects@secondary
            │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:19!null project_id:20 instance_type_projects.deleted:21
            │    │    │         │    │    │    │    │    ├── lax-key: (19-21)
-           │    │    │         │    │    │    │    │    └── ordering: +19
+           │    │    │         │    │    │    │    │    └── ordering: +19 opt(20,21) [actual: +19]
            │    │    │         │    │    │    │    └── filters
-           │    │    │         │    │    │    │         ├── instance_type_projects.deleted:21 = $2 [outer=(21), constraints=(/21: (/NULL - ])]
-           │    │    │         │    │    │    │         ├── instance_type_projects.deleted:21 = $3 [outer=(21), constraints=(/21: (/NULL - ])]
-           │    │    │         │    │    │    │         └── project_id:20 = $4 [outer=(20), constraints=(/20: (/NULL - ])]
+           │    │    │         │    │    │    │         ├── instance_type_projects.deleted:21 = $2 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
+           │    │    │         │    │    │    │         ├── instance_type_projects.deleted:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
+           │    │    │         │    │    │    │         └── project_id:20 = $4 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
            │    │    │         │    │    │    └── projections
            │    │    │         │    │    │         └── true [as=true:27]
            │    │    │         │    │    └── filters (true)
@@ -772,78 +766,81 @@ sort
  ├── columns: instance_types_created_at:15 instance_types_updated_at:16 instance_types_deleted_at:14 instance_types_deleted:13!null instance_types_id:1!null instance_types_name:2 instance_types_memory_mb:3!null instance_types_vcpus:4!null instance_types_root_gb:5 instance_types_ephemeral_gb:6 instance_types_flavorid:7 instance_types_swap:8!null instance_types_rxtx_factor:9 instance_types_vcpu_weight:10 instance_types_disabled:11 instance_types_is_public:12 instance_type_extra_specs_1_created_at:24 instance_type_extra_specs_1_updated_at:25 instance_type_extra_specs_1_deleted_at:23 instance_type_extra_specs_1_deleted:22 instance_type_extra_specs_1_id:18 instance_type_extra_specs_1_key:19 instance_type_extra_specs_1_value:20 instance_type_extra_specs_1_instance_type_id:21
  ├── has-placeholder
  ├── key: (1,18)
- ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (18)-->(19-25), (19,21,22)~~>(18,20,23-25)
- ├── ordering: +7,+1
+ ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (18)-->(19-21,23-25), (19,21,22)~~>(18,20,23-25), (1,18)-->(22)
+ ├── ordering: +7,+1 opt(13) [actual: +7,+1]
  └── project
       ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:18 key:19 value:20 instance_type_extra_specs_1.instance_type_id:21 instance_type_extra_specs_1.deleted:22 instance_type_extra_specs_1.deleted_at:23 instance_type_extra_specs_1.created_at:24 instance_type_extra_specs_1.updated_at:25
       ├── has-placeholder
       ├── key: (1,18)
-      ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (18)-->(19-25), (19,21,22)~~>(18,20,23-25)
+      ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (18)-->(19-21,23-25), (19,21,22)~~>(18,20,23-25), (1,18)-->(22)
       └── right-join (hash)
            ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:18 key:19 value:20 instance_type_extra_specs_1.instance_type_id:21 instance_type_extra_specs_1.deleted:22 instance_type_extra_specs_1.deleted_at:23 instance_type_extra_specs_1.created_at:24 instance_type_extra_specs_1.updated_at:25 true_agg:37
            ├── has-placeholder
            ├── key: (1,18)
-           ├── fd: (1)-->(2-16,37), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (18)-->(19-25), (19,21,22)~~>(18,20,23-25)
+           ├── fd: ()-->(13), (1)-->(2-12,14-16,37), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (18)-->(19-21,23-25), (19,21,22)~~>(18,20,23-25), (1,18)-->(22)
            ├── select
            │    ├── columns: instance_type_extra_specs_1.id:18!null key:19 value:20 instance_type_extra_specs_1.instance_type_id:21!null instance_type_extra_specs_1.deleted:22!null instance_type_extra_specs_1.deleted_at:23 instance_type_extra_specs_1.created_at:24 instance_type_extra_specs_1.updated_at:25
            │    ├── has-placeholder
            │    ├── key: (18)
-           │    ├── fd: (18)-->(19-25), (19,21,22)~~>(18,20,23-25)
+           │    ├── fd: ()-->(22), (18)-->(19-21,23-25), (19,21,22)~~>(18,20,23-25)
            │    ├── scan instance_type_extra_specs [as=instance_type_extra_specs_1]
            │    │    ├── columns: instance_type_extra_specs_1.id:18!null key:19 value:20 instance_type_extra_specs_1.instance_type_id:21!null instance_type_extra_specs_1.deleted:22 instance_type_extra_specs_1.deleted_at:23 instance_type_extra_specs_1.created_at:24 instance_type_extra_specs_1.updated_at:25
            │    │    ├── key: (18)
            │    │    └── fd: (18)-->(19-25), (19,21,22)~~>(18,20,23-25)
            │    └── filters
-           │         └── instance_type_extra_specs_1.deleted:22 = $1 [outer=(22), constraints=(/22: (/NULL - ])]
+           │         └── instance_type_extra_specs_1.deleted:22 = $1 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
            ├── select
            │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:37
            │    ├── has-placeholder
            │    ├── key: (1)
-           │    ├── fd: (1)-->(2-16,37), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    ├── fd: ()-->(13), (1)-->(2-12,14-16,37), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    ├── group-by
            │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:37
            │    │    ├── grouping columns: instance_types.id:1!null
-           │    │    ├── internal-ordering: +1
+           │    │    ├── internal-ordering: +1 opt(13)
            │    │    ├── has-placeholder
            │    │    ├── key: (1)
-           │    │    ├── fd: (1)-->(2-16,37), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    ├── fd: ()-->(13), (1)-->(2-16,37), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    ├── left-join (merge)
            │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:28 true:36
            │    │    │    ├── left ordering: +1
            │    │    │    ├── right ordering: +28
            │    │    │    ├── has-placeholder
-           │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │    ├── ordering: +1
+           │    │    │    ├── key: (1)
+           │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,28,36), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │    ├── ordering: +1 opt(13) [actual: +1]
            │    │    │    ├── select
            │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
            │    │    │    │    ├── has-placeholder
            │    │    │    │    ├── key: (1)
-           │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │    │    ├── ordering: +1
+           │    │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │    │    ├── ordering: +1 opt(13) [actual: +1]
            │    │    │    │    ├── scan instance_types
            │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
            │    │    │    │    │    ├── key: (1)
            │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │    │    │    └── ordering: +1
+           │    │    │    │    │    └── ordering: +1 opt(13) [actual: +1]
            │    │    │    │    └── filters
-           │    │    │    │         └── instance_types.deleted:13 = $2 [outer=(13), constraints=(/13: (/NULL - ])]
+           │    │    │    │         └── instance_types.deleted:13 = $2 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
            │    │    │    ├── project
            │    │    │    │    ├── columns: true:36!null instance_type_projects.instance_type_id:28!null
            │    │    │    │    ├── has-placeholder
+           │    │    │    │    ├── key: (28)
            │    │    │    │    ├── fd: ()-->(36)
            │    │    │    │    ├── ordering: +28 opt(36) [actual: +28]
            │    │    │    │    ├── select
            │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:28!null project_id:29!null instance_type_projects.deleted:30!null
            │    │    │    │    │    ├── has-placeholder
-           │    │    │    │    │    ├── key: (28-30)
-           │    │    │    │    │    ├── ordering: +28
+           │    │    │    │    │    ├── key: (28)
+           │    │    │    │    │    ├── fd: ()-->(29,30)
+           │    │    │    │    │    ├── ordering: +28 opt(29,30) [actual: +28]
            │    │    │    │    │    ├── scan instance_type_projects@secondary
            │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:28!null project_id:29 instance_type_projects.deleted:30
            │    │    │    │    │    │    ├── lax-key: (28-30)
-           │    │    │    │    │    │    └── ordering: +28
+           │    │    │    │    │    │    └── ordering: +28 opt(29,30) [actual: +28]
            │    │    │    │    │    └── filters
-           │    │    │    │    │         ├── instance_type_projects.deleted:30 = $3 [outer=(30), constraints=(/30: (/NULL - ])]
-           │    │    │    │    │         └── project_id:29 = $4 [outer=(29), constraints=(/29: (/NULL - ])]
+           │    │    │    │    │         ├── instance_type_projects.deleted:30 = $3 [outer=(30), constraints=(/30: (/NULL - ]), fd=()-->(30)]
+           │    │    │    │    │         └── project_id:29 = $4 [outer=(29), constraints=(/29: (/NULL - ]), fd=()-->(29)]
            │    │    │    │    └── projections
            │    │    │    │         └── true [as=true:36]
            │    │    │    └── filters (true)
@@ -945,126 +942,125 @@ from (select instance_types.created_at as instance_types_created_at,
 project
  ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2!null anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:36 instance_type_extra_specs_1_updated_at:37 instance_type_extra_specs_1_deleted_at:35 instance_type_extra_specs_1_deleted:34 instance_type_extra_specs_1_id:30 instance_type_extra_specs_1_key:31 instance_type_extra_specs_1_value:32 instance_type_extra_specs_1_instance_type_id:33
  ├── immutable, has-placeholder
- ├── key: (1,30)
- ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16), (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
- └── right-join (hash)
+ ├── key: (30)
+ ├── fd: ()-->(1-16), (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
+ └── left-join (lookup instance_type_extra_specs [as=instance_type_extra_specs_1])
       ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28 instance_type_extra_specs_1.id:30 key:31 value:32 instance_type_extra_specs_1.instance_type_id:33 instance_type_extra_specs_1.deleted:34 instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
+      ├── key columns: [30] = [30]
+      ├── lookup columns are key
       ├── immutable, has-placeholder
-      ├── key: (1,30)
-      ├── fd: (1)-->(2-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16), (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
-      ├── select
-      │    ├── columns: instance_type_extra_specs_1.id:30!null key:31 value:32 instance_type_extra_specs_1.instance_type_id:33!null instance_type_extra_specs_1.deleted:34!null instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
-      │    ├── has-placeholder
-      │    ├── key: (30)
-      │    ├── fd: (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
-      │    ├── scan instance_type_extra_specs [as=instance_type_extra_specs_1]
-      │    │    ├── columns: instance_type_extra_specs_1.id:30!null key:31 value:32 instance_type_extra_specs_1.instance_type_id:33!null instance_type_extra_specs_1.deleted:34 instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
-      │    │    ├── key: (30)
-      │    │    └── fd: (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
-      │    └── filters
-      │         └── instance_type_extra_specs_1.deleted:34 = $7 [outer=(34), constraints=(/34: (/NULL - ])]
-      ├── limit
-      │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
+      ├── key: (30)
+      ├── fd: ()-->(1-16,28), (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
+      ├── left-join (lookup instance_type_extra_specs@secondary [as=instance_type_extra_specs_1])
+      │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28 instance_type_extra_specs_1.id:30 key:31 instance_type_extra_specs_1.instance_type_id:33 instance_type_extra_specs_1.deleted:34
+      │    ├── key columns: [1] = [33]
       │    ├── immutable, has-placeholder
-      │    ├── key: (1)
-      │    ├── fd: (1)-->(2-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
-      │    ├── offset
+      │    ├── key: (30)
+      │    ├── fd: ()-->(1-16,28), (30)-->(31,33,34), (31,33,34)~~>(30)
+      │    ├── limit
       │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
-      │    │    ├── has-placeholder
-      │    │    ├── key: (1)
-      │    │    ├── fd: (1)-->(2-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
-      │    │    ├── select
+      │    │    ├── cardinality: [0 - 1]
+      │    │    ├── immutable, has-placeholder
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(1-16,28)
+      │    │    ├── offset
       │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
+      │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
-      │    │    │    ├── key: (1)
-      │    │    │    ├── fd: (1)-->(2-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
-      │    │    │    ├── group-by
+      │    │    │    ├── key: ()
+      │    │    │    ├── fd: ()-->(1-16,28)
+      │    │    │    ├── select
       │    │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
-      │    │    │    │    ├── grouping columns: instance_types.id:1!null
-      │    │    │    │    ├── internal-ordering: +1
+      │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
-      │    │    │    │    ├── key: (1)
-      │    │    │    │    ├── fd: (1)-->(2-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
-      │    │    │    │    ├── left-join (merge)
-      │    │    │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:19 true:27
-      │    │    │    │    │    ├── left ordering: +1
-      │    │    │    │    │    ├── right ordering: +19
+      │    │    │    │    ├── key: ()
+      │    │    │    │    ├── fd: ()-->(1-16,28)
+      │    │    │    │    ├── group-by
+      │    │    │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
+      │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
-      │    │    │    │    │    ├── ordering: +1
-      │    │    │    │    │    ├── select
-      │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-      │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)-->(1,3-12,14-16)
-      │    │    │    │    │    │    ├── ordering: +1
-      │    │    │    │    │    │    ├── scan instance_types
-      │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-      │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │    │    │    │    └── ordering: +1
-      │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │         ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ])]
-      │    │    │    │    │    │         └── name:2 = $4 [outer=(2), constraints=(/2: (/NULL - ])]
+      │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    ├── fd: ()-->(1-16,28)
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: true:27!null instance_type_projects.instance_type_id:19!null
+      │    │    │    │    │    │    ├── columns: true:27 instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:19
+      │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    ├── fd: ()-->(27)
-      │    │    │    │    │    │    ├── ordering: +19 opt(27) [actual: +19]
-      │    │    │    │    │    │    ├── select
-      │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:19!null project_id:20!null instance_type_projects.deleted:21!null
+      │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    ├── fd: ()-->(1-16,19,27)
+      │    │    │    │    │    │    ├── left-join (lookup instance_type_projects@secondary)
+      │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:19 project_id:20 instance_type_projects.deleted:21
+      │    │    │    │    │    │    │    ├── key columns: [1] = [19]
+      │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    ├── key: (19-21)
-      │    │    │    │    │    │    │    ├── ordering: +19
-      │    │    │    │    │    │    │    ├── scan instance_type_projects@secondary
-      │    │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:19!null project_id:20 instance_type_projects.deleted:21
-      │    │    │    │    │    │    │    │    ├── lax-key: (19-21)
-      │    │    │    │    │    │    │    │    └── ordering: +19
+      │    │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    │    ├── fd: ()-->(1-16,19-21)
+      │    │    │    │    │    │    │    ├── index-join instance_types
+      │    │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
+      │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    │    │    ├── fd: ()-->(1-16)
+      │    │    │    │    │    │    │    │    └── select
+      │    │    │    │    │    │    │    │         ├── columns: instance_types.id:1!null name:2!null instance_types.deleted:13!null
+      │    │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    │    │         ├── has-placeholder
+      │    │    │    │    │    │    │    │         ├── key: ()
+      │    │    │    │    │    │    │    │         ├── fd: ()-->(1,2,13)
+      │    │    │    │    │    │    │    │         ├── scan instance_types@secondary
+      │    │    │    │    │    │    │    │         │    ├── columns: instance_types.id:1!null name:2!null instance_types.deleted:13
+      │    │    │    │    │    │    │    │         │    ├── constraint: /2/13: (/NULL - ]
+      │    │    │    │    │    │    │    │         │    ├── key: (1)
+      │    │    │    │    │    │    │    │         │    └── fd: (1)-->(2,13), (2,13)~~>(1)
+      │    │    │    │    │    │    │    │         └── filters
+      │    │    │    │    │    │    │    │              ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
+      │    │    │    │    │    │    │    │              └── name:2 = $4 [outer=(2), constraints=(/2: (/NULL - ]), fd=()-->(2)]
       │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         ├── instance_type_projects.deleted:21 = $2 [outer=(21), constraints=(/21: (/NULL - ])]
-      │    │    │    │    │    │    │         └── project_id:20 = $3 [outer=(20), constraints=(/20: (/NULL - ])]
+      │    │    │    │    │    │    │         ├── instance_type_projects.deleted:21 = $2 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
+      │    │    │    │    │    │    │         └── project_id:20 = $3 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── true [as=true:27]
-      │    │    │    │    │    └── filters (true)
-      │    │    │    │    └── aggregations
-      │    │    │    │         ├── const-not-null-agg [as=true_agg:28, outer=(27)]
-      │    │    │    │         │    └── true:27
-      │    │    │    │         ├── const-agg [as=name:2, outer=(2)]
-      │    │    │    │         │    └── name:2
-      │    │    │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
-      │    │    │    │         │    └── memory_mb:3
-      │    │    │    │         ├── const-agg [as=vcpus:4, outer=(4)]
-      │    │    │    │         │    └── vcpus:4
-      │    │    │    │         ├── const-agg [as=root_gb:5, outer=(5)]
-      │    │    │    │         │    └── root_gb:5
-      │    │    │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-      │    │    │    │         │    └── ephemeral_gb:6
-      │    │    │    │         ├── const-agg [as=flavorid:7, outer=(7)]
-      │    │    │    │         │    └── flavorid:7
-      │    │    │    │         ├── const-agg [as=swap:8, outer=(8)]
-      │    │    │    │         │    └── swap:8
-      │    │    │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-      │    │    │    │         │    └── rxtx_factor:9
-      │    │    │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-      │    │    │    │         │    └── vcpu_weight:10
-      │    │    │    │         ├── const-agg [as=disabled:11, outer=(11)]
-      │    │    │    │         │    └── disabled:11
-      │    │    │    │         ├── const-agg [as=is_public:12, outer=(12)]
-      │    │    │    │         │    └── is_public:12
-      │    │    │    │         ├── const-agg [as=instance_types.deleted:13, outer=(13)]
-      │    │    │    │         │    └── instance_types.deleted:13
-      │    │    │    │         ├── const-agg [as=instance_types.deleted_at:14, outer=(14)]
-      │    │    │    │         │    └── instance_types.deleted_at:14
-      │    │    │    │         ├── const-agg [as=instance_types.created_at:15, outer=(15)]
-      │    │    │    │         │    └── instance_types.created_at:15
-      │    │    │    │         └── const-agg [as=instance_types.updated_at:16, outer=(16)]
-      │    │    │    │              └── instance_types.updated_at:16
-      │    │    │    └── filters
-      │    │    │         └── (is_public:12 = true) OR (true_agg:28 IS NOT NULL) [outer=(12,28)]
-      │    │    └── $5
-      │    └── $6
-      └── filters
-           └── instance_type_extra_specs_1.instance_type_id:33 = instance_types.id:1 [outer=(1,33), constraints=(/1: (/NULL - ]; /33: (/NULL - ]), fd=(1)==(33), (33)==(1)]
+      │    │    │    │    │    │         └── CASE instance_type_projects.instance_type_id:19 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:27, outer=(19)]
+      │    │    │    │    │    └── aggregations
+      │    │    │    │    │         ├── const-not-null-agg [as=true_agg:28, outer=(27)]
+      │    │    │    │    │         │    └── true:27
+      │    │    │    │    │         ├── const-agg [as=name:2, outer=(2)]
+      │    │    │    │    │         │    └── name:2
+      │    │    │    │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
+      │    │    │    │    │         │    └── memory_mb:3
+      │    │    │    │    │         ├── const-agg [as=vcpus:4, outer=(4)]
+      │    │    │    │    │         │    └── vcpus:4
+      │    │    │    │    │         ├── const-agg [as=root_gb:5, outer=(5)]
+      │    │    │    │    │         │    └── root_gb:5
+      │    │    │    │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
+      │    │    │    │    │         │    └── ephemeral_gb:6
+      │    │    │    │    │         ├── const-agg [as=flavorid:7, outer=(7)]
+      │    │    │    │    │         │    └── flavorid:7
+      │    │    │    │    │         ├── const-agg [as=swap:8, outer=(8)]
+      │    │    │    │    │         │    └── swap:8
+      │    │    │    │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
+      │    │    │    │    │         │    └── rxtx_factor:9
+      │    │    │    │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
+      │    │    │    │    │         │    └── vcpu_weight:10
+      │    │    │    │    │         ├── const-agg [as=disabled:11, outer=(11)]
+      │    │    │    │    │         │    └── disabled:11
+      │    │    │    │    │         ├── const-agg [as=is_public:12, outer=(12)]
+      │    │    │    │    │         │    └── is_public:12
+      │    │    │    │    │         ├── const-agg [as=instance_types.deleted:13, outer=(13)]
+      │    │    │    │    │         │    └── instance_types.deleted:13
+      │    │    │    │    │         ├── const-agg [as=instance_types.deleted_at:14, outer=(14)]
+      │    │    │    │    │         │    └── instance_types.deleted_at:14
+      │    │    │    │    │         ├── const-agg [as=instance_types.created_at:15, outer=(15)]
+      │    │    │    │    │         │    └── instance_types.created_at:15
+      │    │    │    │    │         ├── const-agg [as=instance_types.updated_at:16, outer=(16)]
+      │    │    │    │    │         │    └── instance_types.updated_at:16
+      │    │    │    │    │         └── const-agg [as=instance_types.id:1, outer=(1)]
+      │    │    │    │    │              └── instance_types.id:1
+      │    │    │    │    └── filters
+      │    │    │    │         └── (is_public:12 = true) OR (true_agg:28 IS NOT NULL) [outer=(12,28)]
+      │    │    │    └── $5
+      │    │    └── $6
+      │    └── filters
+      │         └── instance_type_extra_specs_1.deleted:34 = $7 [outer=(34), constraints=(/34: (/NULL - ]), fd=()-->(34)]
+      └── filters (true)
 
 opt
 select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
@@ -1126,127 +1122,119 @@ from (select instance_types.created_at as instance_types_created_at,
 project
  ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:36 instance_type_extra_specs_1_updated_at:37 instance_type_extra_specs_1_deleted_at:35 instance_type_extra_specs_1_deleted:34 instance_type_extra_specs_1_id:30 instance_type_extra_specs_1_key:31 instance_type_extra_specs_1_value:32 instance_type_extra_specs_1_instance_type_id:33
  ├── immutable, has-placeholder
- ├── key: (1,30)
- ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
- └── right-join (hash)
+ ├── key: (30)
+ ├── fd: ()-->(1-16), (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
+ └── left-join (lookup instance_type_extra_specs [as=instance_type_extra_specs_1])
       ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28 instance_type_extra_specs_1.id:30 key:31 value:32 instance_type_extra_specs_1.instance_type_id:33 instance_type_extra_specs_1.deleted:34 instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
+      ├── key columns: [30] = [30]
+      ├── lookup columns are key
       ├── immutable, has-placeholder
-      ├── key: (1,30)
-      ├── fd: (1)-->(2-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
-      ├── select
-      │    ├── columns: instance_type_extra_specs_1.id:30!null key:31 value:32 instance_type_extra_specs_1.instance_type_id:33!null instance_type_extra_specs_1.deleted:34!null instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
-      │    ├── has-placeholder
-      │    ├── key: (30)
-      │    ├── fd: (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
-      │    ├── scan instance_type_extra_specs [as=instance_type_extra_specs_1]
-      │    │    ├── columns: instance_type_extra_specs_1.id:30!null key:31 value:32 instance_type_extra_specs_1.instance_type_id:33!null instance_type_extra_specs_1.deleted:34 instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
-      │    │    ├── key: (30)
-      │    │    └── fd: (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
-      │    └── filters
-      │         └── instance_type_extra_specs_1.deleted:34 = $7 [outer=(34), constraints=(/34: (/NULL - ])]
-      ├── limit
-      │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
+      ├── key: (30)
+      ├── fd: ()-->(1-16,28), (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
+      ├── left-join (lookup instance_type_extra_specs@secondary [as=instance_type_extra_specs_1])
+      │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28 instance_type_extra_specs_1.id:30 key:31 instance_type_extra_specs_1.instance_type_id:33 instance_type_extra_specs_1.deleted:34
+      │    ├── key columns: [1] = [33]
       │    ├── immutable, has-placeholder
-      │    ├── key: (1)
-      │    ├── fd: (1)-->(2-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    ├── offset
+      │    ├── key: (30)
+      │    ├── fd: ()-->(1-16,28), (30)-->(31,33,34), (31,33,34)~~>(30)
+      │    ├── limit
       │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
-      │    │    ├── has-placeholder
-      │    │    ├── key: (1)
-      │    │    ├── fd: (1)-->(2-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    ├── select
+      │    │    ├── cardinality: [0 - 1]
+      │    │    ├── immutable, has-placeholder
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(1-16,28)
+      │    │    ├── offset
       │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
+      │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
-      │    │    │    ├── key: (1)
-      │    │    │    ├── fd: (1)-->(2-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    ├── group-by
+      │    │    │    ├── key: ()
+      │    │    │    ├── fd: ()-->(1-16,28)
+      │    │    │    ├── select
       │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
-      │    │    │    │    ├── grouping columns: instance_types.id:1!null
-      │    │    │    │    ├── internal-ordering: +1
+      │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
-      │    │    │    │    ├── key: (1)
-      │    │    │    │    ├── fd: (1)-->(2-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │    ├── left-join (merge)
-      │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:19 true:27
-      │    │    │    │    │    ├── left ordering: +1
-      │    │    │    │    │    ├── right ordering: +19
+      │    │    │    │    ├── key: ()
+      │    │    │    │    ├── fd: ()-->(1-16,28)
+      │    │    │    │    ├── group-by
+      │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
+      │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │    │    ├── ordering: +1
-      │    │    │    │    │    ├── select
-      │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-      │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │    │    │    ├── ordering: +1
-      │    │    │    │    │    │    ├── scan instance_types
-      │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-      │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │    │    │    │    └── ordering: +1
-      │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │         ├── instance_types.id:1 = $4 [outer=(1), constraints=(/1: (/NULL - ])]
-      │    │    │    │    │    │         └── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ])]
+      │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    ├── fd: ()-->(1-16,28)
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: true:27!null instance_type_projects.instance_type_id:19!null
+      │    │    │    │    │    │    ├── columns: true:27 instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:19
+      │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    ├── fd: ()-->(27)
-      │    │    │    │    │    │    ├── ordering: +19 opt(27) [actual: +19]
-      │    │    │    │    │    │    ├── select
-      │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:19!null project_id:20!null instance_type_projects.deleted:21!null
+      │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    ├── fd: ()-->(1-16,19,27)
+      │    │    │    │    │    │    ├── left-join (lookup instance_type_projects@secondary)
+      │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:19 project_id:20 instance_type_projects.deleted:21
+      │    │    │    │    │    │    │    ├── key columns: [1] = [19]
+      │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    ├── key: (19-21)
-      │    │    │    │    │    │    │    ├── ordering: +19
-      │    │    │    │    │    │    │    ├── scan instance_type_projects@secondary
-      │    │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:19!null project_id:20 instance_type_projects.deleted:21
-      │    │    │    │    │    │    │    │    ├── lax-key: (19-21)
-      │    │    │    │    │    │    │    │    └── ordering: +19
+      │    │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    │    ├── fd: ()-->(1-16,19-21)
+      │    │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
+      │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    │    │    ├── fd: ()-->(1-16)
+      │    │    │    │    │    │    │    │    ├── scan instance_types
+      │    │    │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
+      │    │    │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    │    │    └── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+      │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │    │         ├── instance_types.id:1 = $4 [outer=(1), constraints=(/1: (/NULL - ]), fd=()-->(1)]
+      │    │    │    │    │    │    │    │         └── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
       │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         ├── instance_type_projects.deleted:21 = $2 [outer=(21), constraints=(/21: (/NULL - ])]
-      │    │    │    │    │    │    │         ├── project_id:20 = $3 [outer=(20), constraints=(/20: (/NULL - ])]
-      │    │    │    │    │    │    │         └── instance_type_projects.instance_type_id:19 = $4 [outer=(19), constraints=(/19: (/NULL - ])]
+      │    │    │    │    │    │    │         ├── instance_type_projects.deleted:21 = $2 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
+      │    │    │    │    │    │    │         ├── project_id:20 = $3 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
+      │    │    │    │    │    │    │         └── instance_type_projects.instance_type_id:19 = $4 [outer=(19), constraints=(/19: (/NULL - ]), fd=()-->(19)]
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── true [as=true:27]
-      │    │    │    │    │    └── filters (true)
-      │    │    │    │    └── aggregations
-      │    │    │    │         ├── const-not-null-agg [as=true_agg:28, outer=(27)]
-      │    │    │    │         │    └── true:27
-      │    │    │    │         ├── const-agg [as=name:2, outer=(2)]
-      │    │    │    │         │    └── name:2
-      │    │    │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
-      │    │    │    │         │    └── memory_mb:3
-      │    │    │    │         ├── const-agg [as=vcpus:4, outer=(4)]
-      │    │    │    │         │    └── vcpus:4
-      │    │    │    │         ├── const-agg [as=root_gb:5, outer=(5)]
-      │    │    │    │         │    └── root_gb:5
-      │    │    │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-      │    │    │    │         │    └── ephemeral_gb:6
-      │    │    │    │         ├── const-agg [as=flavorid:7, outer=(7)]
-      │    │    │    │         │    └── flavorid:7
-      │    │    │    │         ├── const-agg [as=swap:8, outer=(8)]
-      │    │    │    │         │    └── swap:8
-      │    │    │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-      │    │    │    │         │    └── rxtx_factor:9
-      │    │    │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-      │    │    │    │         │    └── vcpu_weight:10
-      │    │    │    │         ├── const-agg [as=disabled:11, outer=(11)]
-      │    │    │    │         │    └── disabled:11
-      │    │    │    │         ├── const-agg [as=is_public:12, outer=(12)]
-      │    │    │    │         │    └── is_public:12
-      │    │    │    │         ├── const-agg [as=instance_types.deleted:13, outer=(13)]
-      │    │    │    │         │    └── instance_types.deleted:13
-      │    │    │    │         ├── const-agg [as=instance_types.deleted_at:14, outer=(14)]
-      │    │    │    │         │    └── instance_types.deleted_at:14
-      │    │    │    │         ├── const-agg [as=instance_types.created_at:15, outer=(15)]
-      │    │    │    │         │    └── instance_types.created_at:15
-      │    │    │    │         └── const-agg [as=instance_types.updated_at:16, outer=(16)]
-      │    │    │    │              └── instance_types.updated_at:16
-      │    │    │    └── filters
-      │    │    │         └── (is_public:12 = true) OR (true_agg:28 IS NOT NULL) [outer=(12,28)]
-      │    │    └── $5
-      │    └── $6
-      └── filters
-           └── instance_type_extra_specs_1.instance_type_id:33 = instance_types.id:1 [outer=(1,33), constraints=(/1: (/NULL - ]; /33: (/NULL - ]), fd=(1)==(33), (33)==(1)]
+      │    │    │    │    │    │         └── CASE instance_type_projects.instance_type_id:19 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:27, outer=(19)]
+      │    │    │    │    │    └── aggregations
+      │    │    │    │    │         ├── const-not-null-agg [as=true_agg:28, outer=(27)]
+      │    │    │    │    │         │    └── true:27
+      │    │    │    │    │         ├── const-agg [as=name:2, outer=(2)]
+      │    │    │    │    │         │    └── name:2
+      │    │    │    │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
+      │    │    │    │    │         │    └── memory_mb:3
+      │    │    │    │    │         ├── const-agg [as=vcpus:4, outer=(4)]
+      │    │    │    │    │         │    └── vcpus:4
+      │    │    │    │    │         ├── const-agg [as=root_gb:5, outer=(5)]
+      │    │    │    │    │         │    └── root_gb:5
+      │    │    │    │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
+      │    │    │    │    │         │    └── ephemeral_gb:6
+      │    │    │    │    │         ├── const-agg [as=flavorid:7, outer=(7)]
+      │    │    │    │    │         │    └── flavorid:7
+      │    │    │    │    │         ├── const-agg [as=swap:8, outer=(8)]
+      │    │    │    │    │         │    └── swap:8
+      │    │    │    │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
+      │    │    │    │    │         │    └── rxtx_factor:9
+      │    │    │    │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
+      │    │    │    │    │         │    └── vcpu_weight:10
+      │    │    │    │    │         ├── const-agg [as=disabled:11, outer=(11)]
+      │    │    │    │    │         │    └── disabled:11
+      │    │    │    │    │         ├── const-agg [as=is_public:12, outer=(12)]
+      │    │    │    │    │         │    └── is_public:12
+      │    │    │    │    │         ├── const-agg [as=instance_types.deleted:13, outer=(13)]
+      │    │    │    │    │         │    └── instance_types.deleted:13
+      │    │    │    │    │         ├── const-agg [as=instance_types.deleted_at:14, outer=(14)]
+      │    │    │    │    │         │    └── instance_types.deleted_at:14
+      │    │    │    │    │         ├── const-agg [as=instance_types.created_at:15, outer=(15)]
+      │    │    │    │    │         │    └── instance_types.created_at:15
+      │    │    │    │    │         ├── const-agg [as=instance_types.updated_at:16, outer=(16)]
+      │    │    │    │    │         │    └── instance_types.updated_at:16
+      │    │    │    │    │         └── const-agg [as=instance_types.id:1, outer=(1)]
+      │    │    │    │    │              └── instance_types.id:1
+      │    │    │    │    └── filters
+      │    │    │    │         └── (is_public:12 = true) OR (true_agg:28 IS NOT NULL) [outer=(12,28)]
+      │    │    │    └── $5
+      │    │    └── $6
+      │    └── filters
+      │         └── instance_type_extra_specs_1.deleted:34 = $7 [outer=(34), constraints=(/34: (/NULL - ]), fd=()-->(34)]
+      └── filters (true)
 
 opt
 select anon_1.flavors_created_at as anon_1_flavors_created_at,
@@ -1299,113 +1287,111 @@ from (select flavors.created_at as flavors_created_at,
 project
  ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:31 flavor_extra_specs_1_updated_at:32 flavor_extra_specs_1_id:27 flavor_extra_specs_1_key:28 flavor_extra_specs_1_value:29 flavor_extra_specs_1_flavor_id:30
  ├── immutable, has-placeholder
- ├── key: (1,27)
- ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (27)-->(28-32), (28,30)-->(27,29,31,32)
- └── right-join (hash)
+ ├── key: (27)
+ ├── fd: ()-->(1-12,14,15), (27)-->(28-32), (28,30)-->(27,29,31,32)
+ └── left-join (lookup flavor_extra_specs [as=flavor_extra_specs_1])
       ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25 flavor_extra_specs_1.id:27 key:28 value:29 flavor_extra_specs_1.flavor_id:30 flavor_extra_specs_1.created_at:31 flavor_extra_specs_1.updated_at:32
+      ├── key columns: [27] = [27]
+      ├── lookup columns are key
       ├── immutable, has-placeholder
-      ├── key: (1,27)
-      ├── fd: (1)-->(2-12,14,15,25), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (27)-->(28-32), (28,30)-->(27,29,31,32)
-      ├── scan flavor_extra_specs [as=flavor_extra_specs_1]
-      │    ├── columns: flavor_extra_specs_1.id:27!null key:28!null value:29 flavor_extra_specs_1.flavor_id:30!null flavor_extra_specs_1.created_at:31 flavor_extra_specs_1.updated_at:32
-      │    ├── key: (27)
-      │    └── fd: (27)-->(28-32), (28,30)-->(27,29,31,32)
-      ├── limit
-      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25
+      ├── key: (27)
+      ├── fd: ()-->(1-12,14,15,25), (27)-->(28-32), (28,30)-->(27,29,31,32)
+      ├── left-join (lookup flavor_extra_specs@flavor_extra_specs_flavor_id_key_idx [as=flavor_extra_specs_1])
+      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25 flavor_extra_specs_1.id:27 key:28 flavor_extra_specs_1.flavor_id:30
+      │    ├── key columns: [1] = [30]
       │    ├── immutable, has-placeholder
-      │    ├── key: (1)
-      │    ├── fd: (1)-->(2-12,14,15,25), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    ├── offset
+      │    ├── key: (27)
+      │    ├── fd: ()-->(1-12,14,15,25), (27)-->(28,30), (28,30)-->(27)
+      │    ├── limit
       │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25
-      │    │    ├── has-placeholder
-      │    │    ├── key: (1)
-      │    │    ├── fd: (1)-->(2-12,14,15,25), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    ├── select
+      │    │    ├── cardinality: [0 - 1]
+      │    │    ├── immutable, has-placeholder
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(1-12,14,15,25)
+      │    │    ├── offset
       │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25
+      │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
-      │    │    │    ├── key: (1)
-      │    │    │    ├── fd: (1)-->(2-12,14,15,25), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    ├── group-by
+      │    │    │    ├── key: ()
+      │    │    │    ├── fd: ()-->(1-12,14,15,25)
+      │    │    │    ├── select
       │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25
-      │    │    │    │    ├── grouping columns: flavors.id:1!null
-      │    │    │    │    ├── internal-ordering: +1
+      │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
-      │    │    │    │    ├── key: (1)
-      │    │    │    │    ├── fd: (1)-->(2-12,14,15,25), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    │    ├── left-join (merge)
-      │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:18 true:24
-      │    │    │    │    │    ├── left ordering: +1
-      │    │    │    │    │    ├── right ordering: +18
+      │    │    │    │    ├── key: ()
+      │    │    │    │    ├── fd: ()-->(1-12,14,15,25)
+      │    │    │    │    ├── group-by
+      │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25
+      │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    │    │    ├── ordering: +1
-      │    │    │    │    │    ├── select
-      │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-      │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    │    │    │    ├── ordering: +1
-      │    │    │    │    │    │    ├── scan flavors
-      │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-      │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    │    │    │    │    └── ordering: +1
-      │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │         └── name:2 = $2 [outer=(2), constraints=(/2: (/NULL - ])]
+      │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,25)
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: true:24!null flavor_projects.flavor_id:18!null
+      │    │    │    │    │    │    ├── columns: true:24 flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:18
+      │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    ├── fd: ()-->(24)
-      │    │    │    │    │    │    ├── ordering: +18 opt(24) [actual: +18]
-      │    │    │    │    │    │    ├── select
-      │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:18!null project_id:19!null
+      │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15,18,24)
+      │    │    │    │    │    │    ├── left-join (lookup flavor_projects@secondary)
+      │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:18 project_id:19
+      │    │    │    │    │    │    │    ├── key columns: [1] = [18]
+      │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    ├── key: (18,19)
-      │    │    │    │    │    │    │    ├── ordering: +18
-      │    │    │    │    │    │    │    ├── scan flavor_projects@secondary
-      │    │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:18!null project_id:19!null
-      │    │    │    │    │    │    │    │    ├── key: (18,19)
-      │    │    │    │    │    │    │    │    └── ordering: +18
+      │    │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15,18,19)
+      │    │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
+      │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15)
+      │    │    │    │    │    │    │    │    ├── scan flavors
+      │    │    │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
+      │    │    │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    │    │    └── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │    │         └── name:2 = $2 [outer=(2), constraints=(/2: (/NULL - ]), fd=()-->(2)]
       │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         └── project_id:19 = $1 [outer=(19), constraints=(/19: (/NULL - ])]
+      │    │    │    │    │    │    │         └── project_id:19 = $1 [outer=(19), constraints=(/19: (/NULL - ]), fd=()-->(19)]
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── true [as=true:24]
-      │    │    │    │    │    └── filters (true)
-      │    │    │    │    └── aggregations
-      │    │    │    │         ├── const-not-null-agg [as=true_agg:25, outer=(24)]
-      │    │    │    │         │    └── true:24
-      │    │    │    │         ├── const-agg [as=name:2, outer=(2)]
-      │    │    │    │         │    └── name:2
-      │    │    │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
-      │    │    │    │         │    └── memory_mb:3
-      │    │    │    │         ├── const-agg [as=vcpus:4, outer=(4)]
-      │    │    │    │         │    └── vcpus:4
-      │    │    │    │         ├── const-agg [as=root_gb:5, outer=(5)]
-      │    │    │    │         │    └── root_gb:5
-      │    │    │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-      │    │    │    │         │    └── ephemeral_gb:6
-      │    │    │    │         ├── const-agg [as=flavorid:7, outer=(7)]
-      │    │    │    │         │    └── flavorid:7
-      │    │    │    │         ├── const-agg [as=swap:8, outer=(8)]
-      │    │    │    │         │    └── swap:8
-      │    │    │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-      │    │    │    │         │    └── rxtx_factor:9
-      │    │    │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-      │    │    │    │         │    └── vcpu_weight:10
-      │    │    │    │         ├── const-agg [as=disabled:11, outer=(11)]
-      │    │    │    │         │    └── disabled:11
-      │    │    │    │         ├── const-agg [as=is_public:12, outer=(12)]
-      │    │    │    │         │    └── is_public:12
-      │    │    │    │         ├── const-agg [as=flavors.created_at:14, outer=(14)]
-      │    │    │    │         │    └── flavors.created_at:14
-      │    │    │    │         └── const-agg [as=flavors.updated_at:15, outer=(15)]
-      │    │    │    │              └── flavors.updated_at:15
-      │    │    │    └── filters
-      │    │    │         └── (is_public:12 = true) OR (true_agg:25 IS NOT NULL) [outer=(12,25)]
-      │    │    └── $3
-      │    └── $4
-      └── filters
-           └── flavor_extra_specs_1.flavor_id:30 = flavors.id:1 [outer=(1,30), constraints=(/1: (/NULL - ]; /30: (/NULL - ]), fd=(1)==(30), (30)==(1)]
+      │    │    │    │    │    │         └── CASE flavor_projects.flavor_id:18 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:24, outer=(18)]
+      │    │    │    │    │    └── aggregations
+      │    │    │    │    │         ├── const-not-null-agg [as=true_agg:25, outer=(24)]
+      │    │    │    │    │         │    └── true:24
+      │    │    │    │    │         ├── const-agg [as=name:2, outer=(2)]
+      │    │    │    │    │         │    └── name:2
+      │    │    │    │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
+      │    │    │    │    │         │    └── memory_mb:3
+      │    │    │    │    │         ├── const-agg [as=vcpus:4, outer=(4)]
+      │    │    │    │    │         │    └── vcpus:4
+      │    │    │    │    │         ├── const-agg [as=root_gb:5, outer=(5)]
+      │    │    │    │    │         │    └── root_gb:5
+      │    │    │    │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
+      │    │    │    │    │         │    └── ephemeral_gb:6
+      │    │    │    │    │         ├── const-agg [as=flavorid:7, outer=(7)]
+      │    │    │    │    │         │    └── flavorid:7
+      │    │    │    │    │         ├── const-agg [as=swap:8, outer=(8)]
+      │    │    │    │    │         │    └── swap:8
+      │    │    │    │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
+      │    │    │    │    │         │    └── rxtx_factor:9
+      │    │    │    │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
+      │    │    │    │    │         │    └── vcpu_weight:10
+      │    │    │    │    │         ├── const-agg [as=disabled:11, outer=(11)]
+      │    │    │    │    │         │    └── disabled:11
+      │    │    │    │    │         ├── const-agg [as=is_public:12, outer=(12)]
+      │    │    │    │    │         │    └── is_public:12
+      │    │    │    │    │         ├── const-agg [as=flavors.created_at:14, outer=(14)]
+      │    │    │    │    │         │    └── flavors.created_at:14
+      │    │    │    │    │         ├── const-agg [as=flavors.updated_at:15, outer=(15)]
+      │    │    │    │    │         │    └── flavors.updated_at:15
+      │    │    │    │    │         └── const-agg [as=flavors.id:1, outer=(1)]
+      │    │    │    │    │              └── flavors.id:1
+      │    │    │    │    └── filters
+      │    │    │    │         └── (is_public:12 = true) OR (true_agg:25 IS NOT NULL) [outer=(12,25)]
+      │    │    │    └── $3
+      │    │    └── $4
+      │    └── filters (true)
+      └── filters (true)
 
 opt
 select anon_1.flavors_created_at as anon_1_flavors_created_at,
@@ -1458,113 +1444,111 @@ from (select flavors.created_at as flavors_created_at,
 project
  ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:31 flavor_extra_specs_1_updated_at:32 flavor_extra_specs_1_id:27 flavor_extra_specs_1_key:28 flavor_extra_specs_1_value:29 flavor_extra_specs_1_flavor_id:30
  ├── immutable, has-placeholder
- ├── key: (1,27)
- ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (27)-->(28-32), (28,30)-->(27,29,31,32)
- └── right-join (hash)
+ ├── key: (27)
+ ├── fd: ()-->(1-12,14,15), (27)-->(28-32), (28,30)-->(27,29,31,32)
+ └── left-join (lookup flavor_extra_specs [as=flavor_extra_specs_1])
       ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25 flavor_extra_specs_1.id:27 key:28 value:29 flavor_extra_specs_1.flavor_id:30 flavor_extra_specs_1.created_at:31 flavor_extra_specs_1.updated_at:32
+      ├── key columns: [27] = [27]
+      ├── lookup columns are key
       ├── immutable, has-placeholder
-      ├── key: (1,27)
-      ├── fd: (1)-->(2-12,14,15,25), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (27)-->(28-32), (28,30)-->(27,29,31,32)
-      ├── scan flavor_extra_specs [as=flavor_extra_specs_1]
-      │    ├── columns: flavor_extra_specs_1.id:27!null key:28!null value:29 flavor_extra_specs_1.flavor_id:30!null flavor_extra_specs_1.created_at:31 flavor_extra_specs_1.updated_at:32
-      │    ├── key: (27)
-      │    └── fd: (27)-->(28-32), (28,30)-->(27,29,31,32)
-      ├── limit
-      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25
+      ├── key: (27)
+      ├── fd: ()-->(1-12,14,15,25), (27)-->(28-32), (28,30)-->(27,29,31,32)
+      ├── left-join (lookup flavor_extra_specs@flavor_extra_specs_flavor_id_key_idx [as=flavor_extra_specs_1])
+      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25 flavor_extra_specs_1.id:27 key:28 flavor_extra_specs_1.flavor_id:30
+      │    ├── key columns: [1] = [30]
       │    ├── immutable, has-placeholder
-      │    ├── key: (1)
-      │    ├── fd: (1)-->(2-12,14,15,25), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    ├── offset
+      │    ├── key: (27)
+      │    ├── fd: ()-->(1-12,14,15,25), (27)-->(28,30), (28,30)-->(27)
+      │    ├── limit
       │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25
-      │    │    ├── has-placeholder
-      │    │    ├── key: (1)
-      │    │    ├── fd: (1)-->(2-12,14,15,25), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    ├── select
+      │    │    ├── cardinality: [0 - 1]
+      │    │    ├── immutable, has-placeholder
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(1-12,14,15,25)
+      │    │    ├── offset
       │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25
+      │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
-      │    │    │    ├── key: (1)
-      │    │    │    ├── fd: (1)-->(2-12,14,15,25), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    ├── group-by
+      │    │    │    ├── key: ()
+      │    │    │    ├── fd: ()-->(1-12,14,15,25)
+      │    │    │    ├── select
       │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25
-      │    │    │    │    ├── grouping columns: flavors.id:1!null
-      │    │    │    │    ├── internal-ordering: +1
+      │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
-      │    │    │    │    ├── key: (1)
-      │    │    │    │    ├── fd: (1)-->(2-12,14,15,25), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    │    ├── left-join (merge)
-      │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:18 true:24
-      │    │    │    │    │    ├── left ordering: +1
-      │    │    │    │    │    ├── right ordering: +18
+      │    │    │    │    ├── key: ()
+      │    │    │    │    ├── fd: ()-->(1-12,14,15,25)
+      │    │    │    │    ├── group-by
+      │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25
+      │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    │    │    ├── ordering: +1
-      │    │    │    │    │    ├── select
-      │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-      │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    │    │    │    ├── ordering: +1
-      │    │    │    │    │    │    ├── scan flavors
-      │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-      │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    │    │    │    │    └── ordering: +1
-      │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │         └── flavorid:7 = $2 [outer=(7), constraints=(/7: (/NULL - ])]
+      │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,25)
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: true:24!null flavor_projects.flavor_id:18!null
+      │    │    │    │    │    │    ├── columns: true:24 flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:18
+      │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    ├── fd: ()-->(24)
-      │    │    │    │    │    │    ├── ordering: +18 opt(24) [actual: +18]
-      │    │    │    │    │    │    ├── select
-      │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:18!null project_id:19!null
+      │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15,18,24)
+      │    │    │    │    │    │    ├── left-join (lookup flavor_projects@secondary)
+      │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:18 project_id:19
+      │    │    │    │    │    │    │    ├── key columns: [1] = [18]
+      │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    ├── key: (18,19)
-      │    │    │    │    │    │    │    ├── ordering: +18
-      │    │    │    │    │    │    │    ├── scan flavor_projects@secondary
-      │    │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:18!null project_id:19!null
-      │    │    │    │    │    │    │    │    ├── key: (18,19)
-      │    │    │    │    │    │    │    │    └── ordering: +18
+      │    │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15,18,19)
+      │    │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
+      │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15)
+      │    │    │    │    │    │    │    │    ├── scan flavors
+      │    │    │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
+      │    │    │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    │    │    └── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │    │         └── flavorid:7 = $2 [outer=(7), constraints=(/7: (/NULL - ]), fd=()-->(7)]
       │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         └── project_id:19 = $1 [outer=(19), constraints=(/19: (/NULL - ])]
+      │    │    │    │    │    │    │         └── project_id:19 = $1 [outer=(19), constraints=(/19: (/NULL - ]), fd=()-->(19)]
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── true [as=true:24]
-      │    │    │    │    │    └── filters (true)
-      │    │    │    │    └── aggregations
-      │    │    │    │         ├── const-not-null-agg [as=true_agg:25, outer=(24)]
-      │    │    │    │         │    └── true:24
-      │    │    │    │         ├── const-agg [as=name:2, outer=(2)]
-      │    │    │    │         │    └── name:2
-      │    │    │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
-      │    │    │    │         │    └── memory_mb:3
-      │    │    │    │         ├── const-agg [as=vcpus:4, outer=(4)]
-      │    │    │    │         │    └── vcpus:4
-      │    │    │    │         ├── const-agg [as=root_gb:5, outer=(5)]
-      │    │    │    │         │    └── root_gb:5
-      │    │    │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-      │    │    │    │         │    └── ephemeral_gb:6
-      │    │    │    │         ├── const-agg [as=flavorid:7, outer=(7)]
-      │    │    │    │         │    └── flavorid:7
-      │    │    │    │         ├── const-agg [as=swap:8, outer=(8)]
-      │    │    │    │         │    └── swap:8
-      │    │    │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-      │    │    │    │         │    └── rxtx_factor:9
-      │    │    │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-      │    │    │    │         │    └── vcpu_weight:10
-      │    │    │    │         ├── const-agg [as=disabled:11, outer=(11)]
-      │    │    │    │         │    └── disabled:11
-      │    │    │    │         ├── const-agg [as=is_public:12, outer=(12)]
-      │    │    │    │         │    └── is_public:12
-      │    │    │    │         ├── const-agg [as=flavors.created_at:14, outer=(14)]
-      │    │    │    │         │    └── flavors.created_at:14
-      │    │    │    │         └── const-agg [as=flavors.updated_at:15, outer=(15)]
-      │    │    │    │              └── flavors.updated_at:15
-      │    │    │    └── filters
-      │    │    │         └── (is_public:12 = true) OR (true_agg:25 IS NOT NULL) [outer=(12,25)]
-      │    │    └── $3
-      │    └── $4
-      └── filters
-           └── flavor_extra_specs_1.flavor_id:30 = flavors.id:1 [outer=(1,30), constraints=(/1: (/NULL - ]; /30: (/NULL - ]), fd=(1)==(30), (30)==(1)]
+      │    │    │    │    │    │         └── CASE flavor_projects.flavor_id:18 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:24, outer=(18)]
+      │    │    │    │    │    └── aggregations
+      │    │    │    │    │         ├── const-not-null-agg [as=true_agg:25, outer=(24)]
+      │    │    │    │    │         │    └── true:24
+      │    │    │    │    │         ├── const-agg [as=name:2, outer=(2)]
+      │    │    │    │    │         │    └── name:2
+      │    │    │    │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
+      │    │    │    │    │         │    └── memory_mb:3
+      │    │    │    │    │         ├── const-agg [as=vcpus:4, outer=(4)]
+      │    │    │    │    │         │    └── vcpus:4
+      │    │    │    │    │         ├── const-agg [as=root_gb:5, outer=(5)]
+      │    │    │    │    │         │    └── root_gb:5
+      │    │    │    │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
+      │    │    │    │    │         │    └── ephemeral_gb:6
+      │    │    │    │    │         ├── const-agg [as=flavorid:7, outer=(7)]
+      │    │    │    │    │         │    └── flavorid:7
+      │    │    │    │    │         ├── const-agg [as=swap:8, outer=(8)]
+      │    │    │    │    │         │    └── swap:8
+      │    │    │    │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
+      │    │    │    │    │         │    └── rxtx_factor:9
+      │    │    │    │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
+      │    │    │    │    │         │    └── vcpu_weight:10
+      │    │    │    │    │         ├── const-agg [as=disabled:11, outer=(11)]
+      │    │    │    │    │         │    └── disabled:11
+      │    │    │    │    │         ├── const-agg [as=is_public:12, outer=(12)]
+      │    │    │    │    │         │    └── is_public:12
+      │    │    │    │    │         ├── const-agg [as=flavors.created_at:14, outer=(14)]
+      │    │    │    │    │         │    └── flavors.created_at:14
+      │    │    │    │    │         ├── const-agg [as=flavors.updated_at:15, outer=(15)]
+      │    │    │    │    │         │    └── flavors.updated_at:15
+      │    │    │    │    │         └── const-agg [as=flavors.id:1, outer=(1)]
+      │    │    │    │    │              └── flavors.id:1
+      │    │    │    │    └── filters
+      │    │    │    │         └── (is_public:12 = true) OR (true_agg:25 IS NOT NULL) [outer=(12,25)]
+      │    │    │    └── $3
+      │    │    └── $4
+      │    └── filters (true)
+      └── filters (true)
 
 opt
 select anon_1.flavors_created_at as anon_1_flavors_created_at,
@@ -1674,7 +1658,8 @@ sort
            │    │    │         │    │    ├── left ordering: +1
            │    │    │         │    │    ├── right ordering: +18
            │    │    │         │    │    ├── has-placeholder
-           │    │    │         │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │         │    │    ├── key: (1)
+           │    │    │         │    │    ├── fd: (1)-->(2-12,14,15,18,24), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    │    │         │    │    ├── ordering: +1
            │    │    │         │    │    ├── select
            │    │    │         │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
@@ -1692,19 +1677,21 @@ sort
            │    │    │         │    │    ├── project
            │    │    │         │    │    │    ├── columns: true:24!null flavor_projects.flavor_id:18!null
            │    │    │         │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    ├── key: (18)
            │    │    │         │    │    │    ├── fd: ()-->(24)
            │    │    │         │    │    │    ├── ordering: +18 opt(24) [actual: +18]
            │    │    │         │    │    │    ├── select
            │    │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:18!null project_id:19!null
            │    │    │         │    │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    │    ├── key: (18,19)
-           │    │    │         │    │    │    │    ├── ordering: +18
+           │    │    │         │    │    │    │    ├── key: (18)
+           │    │    │         │    │    │    │    ├── fd: ()-->(19)
+           │    │    │         │    │    │    │    ├── ordering: +18 opt(19) [actual: +18]
            │    │    │         │    │    │    │    ├── scan flavor_projects@secondary
            │    │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:18!null project_id:19!null
            │    │    │         │    │    │    │    │    ├── key: (18,19)
-           │    │    │         │    │    │    │    │    └── ordering: +18
+           │    │    │         │    │    │    │    │    └── ordering: +18 opt(19) [actual: +18]
            │    │    │         │    │    │    │    └── filters
-           │    │    │         │    │    │    │         └── project_id:19 = $1 [outer=(19), constraints=(/19: (/NULL - ])]
+           │    │    │         │    │    │    │         └── project_id:19 = $1 [outer=(19), constraints=(/19: (/NULL - ]), fd=()-->(19)]
            │    │    │         │    │    │    └── projections
            │    │    │         │    │    │         └── true [as=true:24]
            │    │    │         │    │    └── filters (true)
@@ -1807,97 +1794,100 @@ sort
  ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:36 instance_type_extra_specs_1_updated_at:37 instance_type_extra_specs_1_deleted_at:35 instance_type_extra_specs_1_deleted:34 instance_type_extra_specs_1_id:30 instance_type_extra_specs_1_key:31 instance_type_extra_specs_1_value:32 instance_type_extra_specs_1_instance_type_id:33
  ├── immutable, has-placeholder
  ├── key: (1,30)
- ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
- ├── ordering: +7,+1
+ ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-33,35-37), (31,33,34)~~>(30,32,35-37), (1,30)-->(34)
+ ├── ordering: +7,+1 opt(13) [actual: +7,+1]
  └── project
       ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:30 key:31 value:32 instance_type_extra_specs_1.instance_type_id:33 instance_type_extra_specs_1.deleted:34 instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
       ├── immutable, has-placeholder
       ├── key: (1,30)
-      ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
+      ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-33,35-37), (31,33,34)~~>(30,32,35-37), (1,30)-->(34)
       └── right-join (hash)
            ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28 instance_type_extra_specs_1.id:30 key:31 value:32 instance_type_extra_specs_1.instance_type_id:33 instance_type_extra_specs_1.deleted:34 instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
            ├── immutable, has-placeholder
            ├── key: (1,30)
-           ├── fd: (1)-->(2-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
+           ├── fd: ()-->(13), (1)-->(2-12,14-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-33,35-37), (31,33,34)~~>(30,32,35-37), (1,30)-->(34)
            ├── select
            │    ├── columns: instance_type_extra_specs_1.id:30!null key:31 value:32 instance_type_extra_specs_1.instance_type_id:33!null instance_type_extra_specs_1.deleted:34!null instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
            │    ├── has-placeholder
            │    ├── key: (30)
-           │    ├── fd: (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
+           │    ├── fd: ()-->(34), (30)-->(31-33,35-37), (31,33,34)~~>(30,32,35-37)
            │    ├── scan instance_type_extra_specs [as=instance_type_extra_specs_1]
            │    │    ├── columns: instance_type_extra_specs_1.id:30!null key:31 value:32 instance_type_extra_specs_1.instance_type_id:33!null instance_type_extra_specs_1.deleted:34 instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
            │    │    ├── key: (30)
            │    │    └── fd: (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
            │    └── filters
-           │         └── instance_type_extra_specs_1.deleted:34 = $6 [outer=(34), constraints=(/34: (/NULL - ])]
+           │         └── instance_type_extra_specs_1.deleted:34 = $6 [outer=(34), constraints=(/34: (/NULL - ]), fd=()-->(34)]
            ├── limit
            │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
-           │    ├── internal-ordering: +7,+1
+           │    ├── internal-ordering: +7,+1 opt(13)
            │    ├── immutable, has-placeholder
            │    ├── key: (1)
-           │    ├── fd: (1)-->(2-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    ├── fd: ()-->(13), (1)-->(2-12,14-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    ├── offset
            │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
-           │    │    ├── internal-ordering: +7,+1
+           │    │    ├── internal-ordering: +7,+1 opt(13)
            │    │    ├── has-placeholder
            │    │    ├── key: (1)
-           │    │    ├── fd: (1)-->(2-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    ├── ordering: +7,+1
+           │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    ├── ordering: +7,+1 opt(13) [actual: +7,+1]
            │    │    ├── sort
            │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
            │    │    │    ├── has-placeholder
            │    │    │    ├── key: (1)
-           │    │    │    ├── fd: (1)-->(2-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │    ├── ordering: +7,+1
+           │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │    ├── ordering: +7,+1 opt(13) [actual: +7,+1]
            │    │    │    └── select
            │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
            │    │    │         ├── has-placeholder
            │    │    │         ├── key: (1)
-           │    │    │         ├── fd: (1)-->(2-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         ├── fd: ()-->(13), (1)-->(2-12,14-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    │         ├── group-by
            │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
            │    │    │         │    ├── grouping columns: instance_types.id:1!null
-           │    │    │         │    ├── internal-ordering: +1
+           │    │    │         │    ├── internal-ordering: +1 opt(13)
            │    │    │         │    ├── has-placeholder
            │    │    │         │    ├── key: (1)
-           │    │    │         │    ├── fd: (1)-->(2-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    ├── fd: ()-->(13), (1)-->(2-16,28), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    │         │    ├── left-join (merge)
            │    │    │         │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:19 true:27
            │    │    │         │    │    ├── left ordering: +1
            │    │    │         │    │    ├── right ordering: +19
            │    │    │         │    │    ├── has-placeholder
-           │    │    │         │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         │    │    ├── ordering: +1
+           │    │    │         │    │    ├── key: (1)
+           │    │    │         │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,19,27), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    │    ├── ordering: +1 opt(13) [actual: +1]
            │    │    │         │    │    ├── select
            │    │    │         │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
            │    │    │         │    │    │    ├── has-placeholder
            │    │    │         │    │    │    ├── key: (1)
-           │    │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         │    │    │    ├── ordering: +1
+           │    │    │         │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    │    │    ├── ordering: +1 opt(13) [actual: +1]
            │    │    │         │    │    │    ├── scan instance_types
            │    │    │         │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
            │    │    │         │    │    │    │    ├── key: (1)
            │    │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         │    │    │    │    └── ordering: +1
+           │    │    │         │    │    │    │    └── ordering: +1 opt(13) [actual: +1]
            │    │    │         │    │    │    └── filters
-           │    │    │         │    │    │         └── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ])]
+           │    │    │         │    │    │         └── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
            │    │    │         │    │    ├── project
            │    │    │         │    │    │    ├── columns: true:27!null instance_type_projects.instance_type_id:19!null
            │    │    │         │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    ├── key: (19)
            │    │    │         │    │    │    ├── fd: ()-->(27)
            │    │    │         │    │    │    ├── ordering: +19 opt(27) [actual: +19]
            │    │    │         │    │    │    ├── select
            │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:19!null project_id:20!null instance_type_projects.deleted:21!null
            │    │    │         │    │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    │    ├── key: (19-21)
-           │    │    │         │    │    │    │    ├── ordering: +19
+           │    │    │         │    │    │    │    ├── key: (19)
+           │    │    │         │    │    │    │    ├── fd: ()-->(20,21)
+           │    │    │         │    │    │    │    ├── ordering: +19 opt(20,21) [actual: +19]
            │    │    │         │    │    │    │    ├── scan instance_type_projects@secondary
            │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:19!null project_id:20 instance_type_projects.deleted:21
            │    │    │         │    │    │    │    │    ├── lax-key: (19-21)
-           │    │    │         │    │    │    │    │    └── ordering: +19
+           │    │    │         │    │    │    │    │    └── ordering: +19 opt(20,21) [actual: +19]
            │    │    │         │    │    │    │    └── filters
-           │    │    │         │    │    │    │         ├── instance_type_projects.deleted:21 = $2 [outer=(21), constraints=(/21: (/NULL - ])]
-           │    │    │         │    │    │    │         └── project_id:20 = $3 [outer=(20), constraints=(/20: (/NULL - ])]
+           │    │    │         │    │    │    │         ├── instance_type_projects.deleted:21 = $2 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
+           │    │    │         │    │    │    │         └── project_id:20 = $3 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
            │    │    │         │    │    │    └── projections
            │    │    │         │    │    │         └── true [as=true:27]
            │    │    │         │    │    └── filters (true)
@@ -2001,126 +1991,125 @@ from (select instance_types.created_at as instance_types_created_at,
 project
  ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7!null anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:36 instance_type_extra_specs_1_updated_at:37 instance_type_extra_specs_1_deleted_at:35 instance_type_extra_specs_1_deleted:34 instance_type_extra_specs_1_id:30 instance_type_extra_specs_1_key:31 instance_type_extra_specs_1_value:32 instance_type_extra_specs_1_instance_type_id:33
  ├── immutable, has-placeholder
- ├── key: (1,30)
- ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
- └── right-join (hash)
+ ├── key: (30)
+ ├── fd: ()-->(1-16), (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
+ └── left-join (lookup instance_type_extra_specs [as=instance_type_extra_specs_1])
       ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28 instance_type_extra_specs_1.id:30 key:31 value:32 instance_type_extra_specs_1.instance_type_id:33 instance_type_extra_specs_1.deleted:34 instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
+      ├── key columns: [30] = [30]
+      ├── lookup columns are key
       ├── immutable, has-placeholder
-      ├── key: (1,30)
-      ├── fd: (1)-->(2-16,28), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
-      ├── select
-      │    ├── columns: instance_type_extra_specs_1.id:30!null key:31 value:32 instance_type_extra_specs_1.instance_type_id:33!null instance_type_extra_specs_1.deleted:34!null instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
-      │    ├── has-placeholder
-      │    ├── key: (30)
-      │    ├── fd: (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
-      │    ├── scan instance_type_extra_specs [as=instance_type_extra_specs_1]
-      │    │    ├── columns: instance_type_extra_specs_1.id:30!null key:31 value:32 instance_type_extra_specs_1.instance_type_id:33!null instance_type_extra_specs_1.deleted:34 instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
-      │    │    ├── key: (30)
-      │    │    └── fd: (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
-      │    └── filters
-      │         └── instance_type_extra_specs_1.deleted:34 = $7 [outer=(34), constraints=(/34: (/NULL - ])]
-      ├── limit
-      │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
+      ├── key: (30)
+      ├── fd: ()-->(1-16,28), (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
+      ├── left-join (lookup instance_type_extra_specs@secondary [as=instance_type_extra_specs_1])
+      │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28 instance_type_extra_specs_1.id:30 key:31 instance_type_extra_specs_1.instance_type_id:33 instance_type_extra_specs_1.deleted:34
+      │    ├── key columns: [1] = [33]
       │    ├── immutable, has-placeholder
-      │    ├── key: (1)
-      │    ├── fd: (1)-->(2-16,28), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    ├── offset
+      │    ├── key: (30)
+      │    ├── fd: ()-->(1-16,28), (30)-->(31,33,34), (31,33,34)~~>(30)
+      │    ├── limit
       │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
-      │    │    ├── has-placeholder
-      │    │    ├── key: (1)
-      │    │    ├── fd: (1)-->(2-16,28), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    ├── select
+      │    │    ├── cardinality: [0 - 1]
+      │    │    ├── immutable, has-placeholder
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(1-16,28)
+      │    │    ├── offset
       │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
+      │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
-      │    │    │    ├── key: (1)
-      │    │    │    ├── fd: (1)-->(2-16,28), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    ├── group-by
+      │    │    │    ├── key: ()
+      │    │    │    ├── fd: ()-->(1-16,28)
+      │    │    │    ├── select
       │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
-      │    │    │    │    ├── grouping columns: instance_types.id:1!null
-      │    │    │    │    ├── internal-ordering: +1
+      │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
-      │    │    │    │    ├── key: (1)
-      │    │    │    │    ├── fd: (1)-->(2-16,28), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │    ├── left-join (merge)
-      │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:19 true:27
-      │    │    │    │    │    ├── left ordering: +1
-      │    │    │    │    │    ├── right ordering: +19
+      │    │    │    │    ├── key: ()
+      │    │    │    │    ├── fd: ()-->(1-16,28)
+      │    │    │    │    ├── group-by
+      │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
+      │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │    │    ├── ordering: +1
-      │    │    │    │    │    ├── select
-      │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-      │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │    │    │    ├── ordering: +1
-      │    │    │    │    │    │    ├── scan instance_types
-      │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-      │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │    │    │    │    └── ordering: +1
-      │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │         ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ])]
-      │    │    │    │    │    │         └── flavorid:7 = $4 [outer=(7), constraints=(/7: (/NULL - ])]
+      │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    ├── fd: ()-->(1-16,28)
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: true:27!null instance_type_projects.instance_type_id:19!null
+      │    │    │    │    │    │    ├── columns: true:27 instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:19
+      │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    ├── fd: ()-->(27)
-      │    │    │    │    │    │    ├── ordering: +19 opt(27) [actual: +19]
-      │    │    │    │    │    │    ├── select
-      │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:19!null project_id:20!null instance_type_projects.deleted:21!null
+      │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    ├── fd: ()-->(1-16,19,27)
+      │    │    │    │    │    │    ├── left-join (lookup instance_type_projects@secondary)
+      │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:19 project_id:20 instance_type_projects.deleted:21
+      │    │    │    │    │    │    │    ├── key columns: [1] = [19]
+      │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    ├── key: (19-21)
-      │    │    │    │    │    │    │    ├── ordering: +19
-      │    │    │    │    │    │    │    ├── scan instance_type_projects@secondary
-      │    │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:19!null project_id:20 instance_type_projects.deleted:21
-      │    │    │    │    │    │    │    │    ├── lax-key: (19-21)
-      │    │    │    │    │    │    │    │    └── ordering: +19
+      │    │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    │    ├── fd: ()-->(1-16,19-21)
+      │    │    │    │    │    │    │    ├── index-join instance_types
+      │    │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
+      │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    │    │    ├── fd: ()-->(1-16)
+      │    │    │    │    │    │    │    │    └── select
+      │    │    │    │    │    │    │    │         ├── columns: instance_types.id:1!null flavorid:7!null instance_types.deleted:13!null
+      │    │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    │    │         ├── has-placeholder
+      │    │    │    │    │    │    │    │         ├── key: ()
+      │    │    │    │    │    │    │    │         ├── fd: ()-->(1,7,13)
+      │    │    │    │    │    │    │    │         ├── scan instance_types@secondary
+      │    │    │    │    │    │    │    │         │    ├── columns: instance_types.id:1!null flavorid:7!null instance_types.deleted:13
+      │    │    │    │    │    │    │    │         │    ├── constraint: /7/13: (/NULL - ]
+      │    │    │    │    │    │    │    │         │    ├── key: (1)
+      │    │    │    │    │    │    │    │         │    └── fd: (1)-->(7,13), (7,13)~~>(1)
+      │    │    │    │    │    │    │    │         └── filters
+      │    │    │    │    │    │    │    │              ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
+      │    │    │    │    │    │    │    │              └── flavorid:7 = $4 [outer=(7), constraints=(/7: (/NULL - ]), fd=()-->(7)]
       │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         ├── instance_type_projects.deleted:21 = $2 [outer=(21), constraints=(/21: (/NULL - ])]
-      │    │    │    │    │    │    │         └── project_id:20 = $3 [outer=(20), constraints=(/20: (/NULL - ])]
+      │    │    │    │    │    │    │         ├── instance_type_projects.deleted:21 = $2 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
+      │    │    │    │    │    │    │         └── project_id:20 = $3 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── true [as=true:27]
-      │    │    │    │    │    └── filters (true)
-      │    │    │    │    └── aggregations
-      │    │    │    │         ├── const-not-null-agg [as=true_agg:28, outer=(27)]
-      │    │    │    │         │    └── true:27
-      │    │    │    │         ├── const-agg [as=name:2, outer=(2)]
-      │    │    │    │         │    └── name:2
-      │    │    │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
-      │    │    │    │         │    └── memory_mb:3
-      │    │    │    │         ├── const-agg [as=vcpus:4, outer=(4)]
-      │    │    │    │         │    └── vcpus:4
-      │    │    │    │         ├── const-agg [as=root_gb:5, outer=(5)]
-      │    │    │    │         │    └── root_gb:5
-      │    │    │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-      │    │    │    │         │    └── ephemeral_gb:6
-      │    │    │    │         ├── const-agg [as=flavorid:7, outer=(7)]
-      │    │    │    │         │    └── flavorid:7
-      │    │    │    │         ├── const-agg [as=swap:8, outer=(8)]
-      │    │    │    │         │    └── swap:8
-      │    │    │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-      │    │    │    │         │    └── rxtx_factor:9
-      │    │    │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-      │    │    │    │         │    └── vcpu_weight:10
-      │    │    │    │         ├── const-agg [as=disabled:11, outer=(11)]
-      │    │    │    │         │    └── disabled:11
-      │    │    │    │         ├── const-agg [as=is_public:12, outer=(12)]
-      │    │    │    │         │    └── is_public:12
-      │    │    │    │         ├── const-agg [as=instance_types.deleted:13, outer=(13)]
-      │    │    │    │         │    └── instance_types.deleted:13
-      │    │    │    │         ├── const-agg [as=instance_types.deleted_at:14, outer=(14)]
-      │    │    │    │         │    └── instance_types.deleted_at:14
-      │    │    │    │         ├── const-agg [as=instance_types.created_at:15, outer=(15)]
-      │    │    │    │         │    └── instance_types.created_at:15
-      │    │    │    │         └── const-agg [as=instance_types.updated_at:16, outer=(16)]
-      │    │    │    │              └── instance_types.updated_at:16
-      │    │    │    └── filters
-      │    │    │         └── (is_public:12 = true) OR (true_agg:28 IS NOT NULL) [outer=(12,28)]
-      │    │    └── $5
-      │    └── $6
-      └── filters
-           └── instance_type_extra_specs_1.instance_type_id:33 = instance_types.id:1 [outer=(1,33), constraints=(/1: (/NULL - ]; /33: (/NULL - ]), fd=(1)==(33), (33)==(1)]
+      │    │    │    │    │    │         └── CASE instance_type_projects.instance_type_id:19 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:27, outer=(19)]
+      │    │    │    │    │    └── aggregations
+      │    │    │    │    │         ├── const-not-null-agg [as=true_agg:28, outer=(27)]
+      │    │    │    │    │         │    └── true:27
+      │    │    │    │    │         ├── const-agg [as=name:2, outer=(2)]
+      │    │    │    │    │         │    └── name:2
+      │    │    │    │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
+      │    │    │    │    │         │    └── memory_mb:3
+      │    │    │    │    │         ├── const-agg [as=vcpus:4, outer=(4)]
+      │    │    │    │    │         │    └── vcpus:4
+      │    │    │    │    │         ├── const-agg [as=root_gb:5, outer=(5)]
+      │    │    │    │    │         │    └── root_gb:5
+      │    │    │    │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
+      │    │    │    │    │         │    └── ephemeral_gb:6
+      │    │    │    │    │         ├── const-agg [as=flavorid:7, outer=(7)]
+      │    │    │    │    │         │    └── flavorid:7
+      │    │    │    │    │         ├── const-agg [as=swap:8, outer=(8)]
+      │    │    │    │    │         │    └── swap:8
+      │    │    │    │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
+      │    │    │    │    │         │    └── rxtx_factor:9
+      │    │    │    │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
+      │    │    │    │    │         │    └── vcpu_weight:10
+      │    │    │    │    │         ├── const-agg [as=disabled:11, outer=(11)]
+      │    │    │    │    │         │    └── disabled:11
+      │    │    │    │    │         ├── const-agg [as=is_public:12, outer=(12)]
+      │    │    │    │    │         │    └── is_public:12
+      │    │    │    │    │         ├── const-agg [as=instance_types.deleted:13, outer=(13)]
+      │    │    │    │    │         │    └── instance_types.deleted:13
+      │    │    │    │    │         ├── const-agg [as=instance_types.deleted_at:14, outer=(14)]
+      │    │    │    │    │         │    └── instance_types.deleted_at:14
+      │    │    │    │    │         ├── const-agg [as=instance_types.created_at:15, outer=(15)]
+      │    │    │    │    │         │    └── instance_types.created_at:15
+      │    │    │    │    │         ├── const-agg [as=instance_types.updated_at:16, outer=(16)]
+      │    │    │    │    │         │    └── instance_types.updated_at:16
+      │    │    │    │    │         └── const-agg [as=instance_types.id:1, outer=(1)]
+      │    │    │    │    │              └── instance_types.id:1
+      │    │    │    │    └── filters
+      │    │    │    │         └── (is_public:12 = true) OR (true_agg:28 IS NOT NULL) [outer=(12,28)]
+      │    │    │    └── $5
+      │    │    └── $6
+      │    └── filters
+      │         └── instance_type_extra_specs_1.deleted:34 = $7 [outer=(34), constraints=(/34: (/NULL - ]), fd=()-->(34)]
+      └── filters (true)
 
 opt
 select flavors.created_at as flavors_created_at,
@@ -2190,7 +2179,8 @@ sort
            │    │    │    ├── left ordering: +1
            │    │    │    ├── right ordering: +25
            │    │    │    ├── has-placeholder
-           │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │    ├── key: (1)
+           │    │    │    ├── fd: (1)-->(2-12,14,15,25,31), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    │    │    ├── ordering: +1
            │    │    │    ├── scan flavors
            │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
@@ -2200,19 +2190,21 @@ sort
            │    │    │    ├── project
            │    │    │    │    ├── columns: true:31!null flavor_projects.flavor_id:25!null
            │    │    │    │    ├── has-placeholder
+           │    │    │    │    ├── key: (25)
            │    │    │    │    ├── fd: ()-->(31)
            │    │    │    │    ├── ordering: +25 opt(31) [actual: +25]
            │    │    │    │    ├── select
            │    │    │    │    │    ├── columns: flavor_projects.flavor_id:25!null project_id:26!null
            │    │    │    │    │    ├── has-placeholder
-           │    │    │    │    │    ├── key: (25,26)
-           │    │    │    │    │    ├── ordering: +25
+           │    │    │    │    │    ├── key: (25)
+           │    │    │    │    │    ├── fd: ()-->(26)
+           │    │    │    │    │    ├── ordering: +25 opt(26) [actual: +25]
            │    │    │    │    │    ├── scan flavor_projects@secondary
            │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:25!null project_id:26!null
            │    │    │    │    │    │    ├── key: (25,26)
-           │    │    │    │    │    │    └── ordering: +25
+           │    │    │    │    │    │    └── ordering: +25 opt(26) [actual: +25]
            │    │    │    │    │    └── filters
-           │    │    │    │    │         └── project_id:26 = $1 [outer=(26), constraints=(/26: (/NULL - ])]
+           │    │    │    │    │         └── project_id:26 = $1 [outer=(26), constraints=(/26: (/NULL - ]), fd=()-->(26)]
            │    │    │    │    └── projections
            │    │    │    │         └── true [as=true:31]
            │    │    │    └── filters (true)
@@ -2316,98 +2308,101 @@ sort
  ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7!null anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:36 instance_type_extra_specs_1_updated_at:37 instance_type_extra_specs_1_deleted_at:35 instance_type_extra_specs_1_deleted:34 instance_type_extra_specs_1_id:30 instance_type_extra_specs_1_key:31 instance_type_extra_specs_1_value:32 instance_type_extra_specs_1_instance_type_id:33
  ├── immutable, has-placeholder
  ├── key: (1,30)
- ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
- ├── ordering: +7,+1
+ ├── fd: ()-->(13), (1)-->(2-12,14-16), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-33,35-37), (31,33,34)~~>(30,32,35-37), (1,30)-->(34)
+ ├── ordering: +7 opt(13) [actual: +7]
  └── project
       ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:30 key:31 value:32 instance_type_extra_specs_1.instance_type_id:33 instance_type_extra_specs_1.deleted:34 instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
       ├── immutable, has-placeholder
       ├── key: (1,30)
-      ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
+      ├── fd: ()-->(13), (1)-->(2-12,14-16), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-33,35-37), (31,33,34)~~>(30,32,35-37), (1,30)-->(34)
       └── right-join (hash)
            ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28 instance_type_extra_specs_1.id:30 key:31 value:32 instance_type_extra_specs_1.instance_type_id:33 instance_type_extra_specs_1.deleted:34 instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
            ├── immutable, has-placeholder
            ├── key: (1,30)
-           ├── fd: (1)-->(2-16,28), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
+           ├── fd: ()-->(13), (1)-->(2-12,14-16,28), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-33,35-37), (31,33,34)~~>(30,32,35-37), (1,30)-->(34)
            ├── select
            │    ├── columns: instance_type_extra_specs_1.id:30!null key:31 value:32 instance_type_extra_specs_1.instance_type_id:33!null instance_type_extra_specs_1.deleted:34!null instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
            │    ├── has-placeholder
            │    ├── key: (30)
-           │    ├── fd: (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
+           │    ├── fd: ()-->(34), (30)-->(31-33,35-37), (31,33,34)~~>(30,32,35-37)
            │    ├── scan instance_type_extra_specs [as=instance_type_extra_specs_1]
            │    │    ├── columns: instance_type_extra_specs_1.id:30!null key:31 value:32 instance_type_extra_specs_1.instance_type_id:33!null instance_type_extra_specs_1.deleted:34 instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
            │    │    ├── key: (30)
            │    │    └── fd: (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
            │    └── filters
-           │         └── instance_type_extra_specs_1.deleted:34 = $9 [outer=(34), constraints=(/34: (/NULL - ])]
+           │         └── instance_type_extra_specs_1.deleted:34 = $9 [outer=(34), constraints=(/34: (/NULL - ]), fd=()-->(34)]
            ├── limit
            │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
-           │    ├── internal-ordering: +7,+1
+           │    ├── internal-ordering: +7 opt(13)
            │    ├── immutable, has-placeholder
            │    ├── key: (1)
-           │    ├── fd: (1)-->(2-16,28), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    ├── fd: ()-->(13), (1)-->(2-12,14-16,28), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    ├── offset
            │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
-           │    │    ├── internal-ordering: +7,+1
+           │    │    ├── internal-ordering: +7 opt(13)
            │    │    ├── has-placeholder
            │    │    ├── key: (1)
-           │    │    ├── fd: (1)-->(2-16,28), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    ├── ordering: +7,+1
+           │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,28), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    ├── ordering: +7 opt(13) [actual: +7]
            │    │    ├── sort
            │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
            │    │    │    ├── has-placeholder
            │    │    │    ├── key: (1)
-           │    │    │    ├── fd: (1)-->(2-16,28), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │    ├── ordering: +7,+1
+           │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,28), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │    ├── ordering: +7 opt(13) [actual: +7]
            │    │    │    └── select
            │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
            │    │    │         ├── has-placeholder
            │    │    │         ├── key: (1)
-           │    │    │         ├── fd: (1)-->(2-16,28), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         ├── fd: ()-->(13), (1)-->(2-12,14-16,28), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    │         ├── group-by
            │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
            │    │    │         │    ├── grouping columns: instance_types.id:1!null
-           │    │    │         │    ├── internal-ordering: +1
+           │    │    │         │    ├── internal-ordering: +1 opt(13)
            │    │    │         │    ├── has-placeholder
            │    │    │         │    ├── key: (1)
-           │    │    │         │    ├── fd: (1)-->(2-16,28), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    ├── fd: ()-->(13), (1)-->(2-16,28), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    │         │    ├── left-join (merge)
            │    │    │         │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:19 true:27
            │    │    │         │    │    ├── left ordering: +1
            │    │    │         │    │    ├── right ordering: +19
            │    │    │         │    │    ├── has-placeholder
-           │    │    │         │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         │    │    ├── ordering: +1
+           │    │    │         │    │    ├── key: (1)
+           │    │    │         │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,19,27), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    │    ├── ordering: +1 opt(13) [actual: +1]
            │    │    │         │    │    ├── select
            │    │    │         │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
            │    │    │         │    │    │    ├── has-placeholder
            │    │    │         │    │    │    ├── key: (1)
-           │    │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         │    │    │    ├── ordering: +1
+           │    │    │         │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    │    │    ├── ordering: +1 opt(13) [actual: +1]
            │    │    │         │    │    │    ├── scan instance_types
            │    │    │         │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
            │    │    │         │    │    │    │    ├── key: (1)
            │    │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         │    │    │    │    └── ordering: +1
+           │    │    │         │    │    │    │    └── ordering: +1 opt(13) [actual: +1]
            │    │    │         │    │    │    └── filters
-           │    │    │         │    │    │         ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ])]
+           │    │    │         │    │    │         ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
            │    │    │         │    │    │         └── (flavorid:7 > $4) OR ((flavorid:7 = $5) AND (instance_types.id:1 > $6)) [outer=(1,7), constraints=(/7: (/NULL - ])]
            │    │    │         │    │    ├── project
            │    │    │         │    │    │    ├── columns: true:27!null instance_type_projects.instance_type_id:19!null
            │    │    │         │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    ├── key: (19)
            │    │    │         │    │    │    ├── fd: ()-->(27)
            │    │    │         │    │    │    ├── ordering: +19 opt(27) [actual: +19]
            │    │    │         │    │    │    ├── select
            │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:19!null project_id:20!null instance_type_projects.deleted:21!null
            │    │    │         │    │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    │    ├── key: (19-21)
-           │    │    │         │    │    │    │    ├── ordering: +19
+           │    │    │         │    │    │    │    ├── key: (19)
+           │    │    │         │    │    │    │    ├── fd: ()-->(20,21)
+           │    │    │         │    │    │    │    ├── ordering: +19 opt(20,21) [actual: +19]
            │    │    │         │    │    │    │    ├── scan instance_type_projects@secondary
            │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:19!null project_id:20 instance_type_projects.deleted:21
            │    │    │         │    │    │    │    │    ├── lax-key: (19-21)
-           │    │    │         │    │    │    │    │    └── ordering: +19
+           │    │    │         │    │    │    │    │    └── ordering: +19 opt(20,21) [actual: +19]
            │    │    │         │    │    │    │    └── filters
-           │    │    │         │    │    │    │         ├── instance_type_projects.deleted:21 = $2 [outer=(21), constraints=(/21: (/NULL - ])]
-           │    │    │         │    │    │    │         └── project_id:20 = $3 [outer=(20), constraints=(/20: (/NULL - ])]
+           │    │    │         │    │    │    │         ├── instance_type_projects.deleted:21 = $2 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
+           │    │    │         │    │    │    │         └── project_id:20 = $3 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
            │    │    │         │    │    │    └── projections
            │    │    │         │    │    │         └── true [as=true:27]
            │    │    │         │    │    └── filters (true)
@@ -2556,7 +2551,8 @@ sort
            │    │    │         │    │    ├── left ordering: +1
            │    │    │         │    │    ├── right ordering: +18
            │    │    │         │    │    ├── has-placeholder
-           │    │    │         │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │         │    │    ├── key: (1)
+           │    │    │         │    │    ├── fd: (1)-->(2-12,14,15,18,24), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    │    │         │    │    ├── ordering: +1
            │    │    │         │    │    ├── scan flavors
            │    │    │         │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
@@ -2566,19 +2562,21 @@ sort
            │    │    │         │    │    ├── project
            │    │    │         │    │    │    ├── columns: true:24!null flavor_projects.flavor_id:18!null
            │    │    │         │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    ├── key: (18)
            │    │    │         │    │    │    ├── fd: ()-->(24)
            │    │    │         │    │    │    ├── ordering: +18 opt(24) [actual: +18]
            │    │    │         │    │    │    ├── select
            │    │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:18!null project_id:19!null
            │    │    │         │    │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    │    ├── key: (18,19)
-           │    │    │         │    │    │    │    ├── ordering: +18
+           │    │    │         │    │    │    │    ├── key: (18)
+           │    │    │         │    │    │    │    ├── fd: ()-->(19)
+           │    │    │         │    │    │    │    ├── ordering: +18 opt(19) [actual: +18]
            │    │    │         │    │    │    │    ├── scan flavor_projects@secondary
            │    │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:18!null project_id:19!null
            │    │    │         │    │    │    │    │    ├── key: (18,19)
-           │    │    │         │    │    │    │    │    └── ordering: +18
+           │    │    │         │    │    │    │    │    └── ordering: +18 opt(19) [actual: +18]
            │    │    │         │    │    │    │    └── filters
-           │    │    │         │    │    │    │         └── project_id:19 = $1 [outer=(19), constraints=(/19: (/NULL - ])]
+           │    │    │         │    │    │    │         └── project_id:19 = $1 [outer=(19), constraints=(/19: (/NULL - ]), fd=()-->(19)]
            │    │    │         │    │    │    └── projections
            │    │    │         │    │    │         └── true [as=true:24]
            │    │    │         │    │    └── filters (true)
@@ -2689,113 +2687,117 @@ project
  ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11!null anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:48 instance_type_extra_specs_1_updated_at:49 instance_type_extra_specs_1_deleted_at:47 instance_type_extra_specs_1_deleted:46 instance_type_extra_specs_1_id:42 instance_type_extra_specs_1_key:43 instance_type_extra_specs_1_value:44 instance_type_extra_specs_1_instance_type_id:45
  ├── immutable, has-placeholder
  ├── key: (1,42)
- ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (42)-->(43-49), (43,45,46)~~>(42,44,47-49)
- ├── ordering: +7,+1 opt(11) [actual: +7,+1]
+ ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (42)-->(43-45,47-49), (43,45,46)~~>(42,44,47-49), (1,42)-->(46)
+ ├── ordering: +7,+1 opt(11,13) [actual: +7,+1]
  └── left-join (lookup instance_type_extra_specs [as=instance_type_extra_specs_1])
       ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:40 instance_type_extra_specs_1.id:42 key:43 value:44 instance_type_extra_specs_1.instance_type_id:45 instance_type_extra_specs_1.deleted:46 instance_type_extra_specs_1.deleted_at:47 instance_type_extra_specs_1.created_at:48 instance_type_extra_specs_1.updated_at:49
       ├── key columns: [42] = [42]
       ├── lookup columns are key
       ├── immutable, has-placeholder
       ├── key: (1,42)
-      ├── fd: ()-->(11), (1)-->(2-10,12-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (42)-->(43-49), (43,45,46)~~>(42,44,47-49)
-      ├── ordering: +7,+1 opt(11) [actual: +7,+1]
+      ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (42)-->(43-45,47-49), (43,45,46)~~>(42,44,47-49), (1,42)-->(46)
+      ├── ordering: +7,+1 opt(11,13) [actual: +7,+1]
       ├── left-join (lookup instance_type_extra_specs@secondary [as=instance_type_extra_specs_1])
       │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:40 instance_type_extra_specs_1.id:42 key:43 instance_type_extra_specs_1.instance_type_id:45 instance_type_extra_specs_1.deleted:46
       │    ├── key columns: [1] = [45]
       │    ├── immutable, has-placeholder
       │    ├── key: (1,42)
-      │    ├── fd: ()-->(11), (1)-->(2-10,12-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (42)-->(43,45,46), (43,45,46)~~>(42)
-      │    ├── ordering: +7,+1 opt(11) [actual: +7,+1]
+      │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (42)-->(43,45,46), (43,45,46)~~>(42)
+      │    ├── ordering: +7,+1 opt(11,13) [actual: +7,+1]
       │    ├── limit
       │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:40
-      │    │    ├── internal-ordering: +7,+1 opt(11)
+      │    │    ├── internal-ordering: +7,+1 opt(11,13)
       │    │    ├── immutable, has-placeholder
       │    │    ├── key: (1)
-      │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │    │    ├── ordering: +7,+1 opt(11) [actual: +7,+1]
+      │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │    │    ├── ordering: +7,+1 opt(11,13) [actual: +7,+1]
       │    │    ├── offset
       │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:40
-      │    │    │    ├── internal-ordering: +7,+1 opt(11)
+      │    │    │    ├── internal-ordering: +7,+1 opt(11,13)
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: (1)
-      │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │    │    │    ├── ordering: +7,+1 opt(11) [actual: +7,+1]
+      │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │    │    │    ├── ordering: +7,+1 opt(11,13) [actual: +7,+1]
       │    │    │    ├── sort
       │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:40
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: (1)
-      │    │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │    │    │    │    ├── ordering: +7,+1 opt(11) [actual: +7,+1]
+      │    │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │    │    │    │    ├── ordering: +7,+1 opt(11,13) [actual: +7,+1]
       │    │    │    │    └── select
       │    │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:40
       │    │    │    │         ├── has-placeholder
       │    │    │    │         ├── key: (1)
-      │    │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │    │    │    │         ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
       │    │    │    │         ├── group-by
       │    │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:40
       │    │    │    │         │    ├── grouping columns: instance_types.id:1!null
-      │    │    │    │         │    ├── internal-ordering: +1 opt(11)
+      │    │    │    │         │    ├── internal-ordering: +1 opt(11,13)
       │    │    │    │         │    ├── has-placeholder
       │    │    │    │         │    ├── key: (1)
-      │    │    │    │         │    ├── fd: ()-->(11), (1)-->(2-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │    │    │    │         │    ├── fd: ()-->(11,13), (1)-->(2-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
       │    │    │    │         │    ├── left-join (merge)
       │    │    │    │         │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:28 true_agg:37 true:39
       │    │    │    │         │    │    ├── left ordering: +1
       │    │    │    │         │    │    ├── right ordering: +28
       │    │    │    │         │    │    ├── has-placeholder
-      │    │    │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │    │    │    │         │    │    ├── ordering: +1 opt(11) [actual: +1]
+      │    │    │    │         │    │    ├── key: (1)
+      │    │    │    │         │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,28,37,39), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │    │    │    │         │    │    ├── ordering: +1 opt(11,13) [actual: +1]
       │    │    │    │         │    │    ├── select
       │    │    │    │         │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:37
       │    │    │    │         │    │    │    ├── has-placeholder
       │    │    │    │         │    │    │    ├── key: (1)
-      │    │    │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │    │    │    │         │    │    │    ├── ordering: +1 opt(11) [actual: +1]
+      │    │    │    │         │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │    │    │    │         │    │    │    ├── ordering: +1 opt(11,13) [actual: +1]
       │    │    │    │         │    │    │    ├── group-by
       │    │    │    │         │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:37
       │    │    │    │         │    │    │    │    ├── grouping columns: instance_types.id:1!null
       │    │    │    │         │    │    │    │    ├── has-placeholder
       │    │    │    │         │    │    │    │    ├── key: (1)
-      │    │    │    │         │    │    │    │    ├── fd: ()-->(11), (1)-->(2-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │    │    │    │         │    │    │    │    ├── ordering: +1 opt(11) [actual: +1]
+      │    │    │    │         │    │    │    │    ├── fd: ()-->(11,13), (1)-->(2-16,37), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │    │    │    │         │    │    │    │    ├── ordering: +1 opt(11,13) [actual: +1]
       │    │    │    │         │    │    │    │    ├── left-join (merge)
       │    │    │    │         │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:19 true:36
       │    │    │    │         │    │    │    │    │    ├── left ordering: +1
       │    │    │    │         │    │    │    │    │    ├── right ordering: +19
       │    │    │    │         │    │    │    │    │    ├── has-placeholder
-      │    │    │    │         │    │    │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │    │    │    │         │    │    │    │    │    ├── ordering: +1 opt(11) [actual: +1]
+      │    │    │    │         │    │    │    │    │    ├── key: (1)
+      │    │    │    │         │    │    │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,19,36), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │    │    │    │         │    │    │    │    │    ├── ordering: +1 opt(11,13) [actual: +1]
       │    │    │    │         │    │    │    │    │    ├── select
       │    │    │    │         │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
       │    │    │    │         │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │         │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │         │    │    │    │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-      │    │    │    │         │    │    │    │    │    │    ├── ordering: +1 opt(11) [actual: +1]
+      │    │    │    │         │    │    │    │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+      │    │    │    │         │    │    │    │    │    │    ├── ordering: +1 opt(11,13) [actual: +1]
       │    │    │    │         │    │    │    │    │    │    ├── scan instance_types
       │    │    │    │         │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
       │    │    │    │         │    │    │    │    │    │    │    ├── key: (1)
       │    │    │    │         │    │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │         │    │    │    │    │    │    │    └── ordering: +1 opt(11) [actual: +1]
+      │    │    │    │         │    │    │    │    │    │    │    └── ordering: +1 opt(11,13) [actual: +1]
       │    │    │    │         │    │    │    │    │    │    └── filters
-      │    │    │    │         │    │    │    │    │    │         ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ])]
+      │    │    │    │         │    │    │    │    │    │         ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
       │    │    │    │         │    │    │    │    │    │         └── disabled:11 = false [outer=(11), constraints=(/11: [/false - /false]; tight), fd=()-->(11)]
       │    │    │    │         │    │    │    │    │    ├── project
       │    │    │    │         │    │    │    │    │    │    ├── columns: true:36!null instance_type_projects.instance_type_id:19!null
       │    │    │    │         │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │         │    │    │    │    │    │    ├── key: (19)
       │    │    │    │         │    │    │    │    │    │    ├── fd: ()-->(36)
       │    │    │    │         │    │    │    │    │    │    ├── ordering: +19 opt(36) [actual: +19]
       │    │    │    │         │    │    │    │    │    │    ├── select
       │    │    │    │         │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:19!null project_id:20!null instance_type_projects.deleted:21!null
       │    │    │    │         │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │         │    │    │    │    │    │    │    ├── key: (19-21)
-      │    │    │    │         │    │    │    │    │    │    │    ├── ordering: +19
+      │    │    │    │         │    │    │    │    │    │    │    ├── key: (19)
+      │    │    │    │         │    │    │    │    │    │    │    ├── fd: ()-->(20,21)
+      │    │    │    │         │    │    │    │    │    │    │    ├── ordering: +19 opt(20,21) [actual: +19]
       │    │    │    │         │    │    │    │    │    │    │    ├── scan instance_type_projects@secondary
       │    │    │    │         │    │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:19!null project_id:20 instance_type_projects.deleted:21
       │    │    │    │         │    │    │    │    │    │    │    │    ├── lax-key: (19-21)
-      │    │    │    │         │    │    │    │    │    │    │    │    └── ordering: +19
+      │    │    │    │         │    │    │    │    │    │    │    │    └── ordering: +19 opt(20,21) [actual: +19]
       │    │    │    │         │    │    │    │    │    │    │    └── filters
-      │    │    │    │         │    │    │    │    │    │    │         ├── instance_type_projects.deleted:21 = $2 [outer=(21), constraints=(/21: (/NULL - ])]
-      │    │    │    │         │    │    │    │    │    │    │         └── project_id:20 = $3 [outer=(20), constraints=(/20: (/NULL - ])]
+      │    │    │    │         │    │    │    │    │    │    │         ├── instance_type_projects.deleted:21 = $2 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
+      │    │    │    │         │    │    │    │    │    │    │         └── project_id:20 = $3 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
       │    │    │    │         │    │    │    │    │    │    └── projections
       │    │    │    │         │    │    │    │    │    │         └── true [as=true:36]
       │    │    │    │         │    │    │    │    │    └── filters (true)
@@ -2837,21 +2839,23 @@ project
       │    │    │    │         │    │    ├── project
       │    │    │    │         │    │    │    ├── columns: true:39!null instance_type_projects.instance_type_id:28!null
       │    │    │    │         │    │    │    ├── has-placeholder
+      │    │    │    │         │    │    │    ├── key: (28)
       │    │    │    │         │    │    │    ├── fd: ()-->(39)
       │    │    │    │         │    │    │    ├── ordering: +28 opt(39) [actual: +28]
       │    │    │    │         │    │    │    ├── select
       │    │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:28!null project_id:29!null instance_type_projects.deleted:30!null
       │    │    │    │         │    │    │    │    ├── has-placeholder
-      │    │    │    │         │    │    │    │    ├── key: (28-30)
-      │    │    │    │         │    │    │    │    ├── ordering: +28
+      │    │    │    │         │    │    │    │    ├── key: (28)
+      │    │    │    │         │    │    │    │    ├── fd: ()-->(29,30)
+      │    │    │    │         │    │    │    │    ├── ordering: +28 opt(29,30) [actual: +28]
       │    │    │    │         │    │    │    │    ├── scan instance_type_projects@secondary
       │    │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:28!null project_id:29 instance_type_projects.deleted:30
       │    │    │    │         │    │    │    │    │    ├── lax-key: (28-30)
-      │    │    │    │         │    │    │    │    │    └── ordering: +28
+      │    │    │    │         │    │    │    │    │    └── ordering: +28 opt(29,30) [actual: +28]
       │    │    │    │         │    │    │    │    └── filters
-      │    │    │    │         │    │    │    │         ├── instance_type_projects.deleted:30 = $4 [outer=(30), constraints=(/30: (/NULL - ])]
-      │    │    │    │         │    │    │    │         ├── instance_type_projects.deleted:30 = $5 [outer=(30), constraints=(/30: (/NULL - ])]
-      │    │    │    │         │    │    │    │         └── project_id:29 = $6 [outer=(29), constraints=(/29: (/NULL - ])]
+      │    │    │    │         │    │    │    │         ├── instance_type_projects.deleted:30 = $4 [outer=(30), constraints=(/30: (/NULL - ]), fd=()-->(30)]
+      │    │    │    │         │    │    │    │         ├── instance_type_projects.deleted:30 = $5 [outer=(30), constraints=(/30: (/NULL - ]), fd=()-->(30)]
+      │    │    │    │         │    │    │    │         └── project_id:29 = $6 [outer=(29), constraints=(/29: (/NULL - ]), fd=()-->(29)]
       │    │    │    │         │    │    │    └── projections
       │    │    │    │         │    │    │         └── true [as=true:39]
       │    │    │    │         │    │    └── filters (true)
@@ -2893,7 +2897,7 @@ project
       │    │    │    └── $7
       │    │    └── $8
       │    └── filters
-      │         └── instance_type_extra_specs_1.deleted:46 = $9 [outer=(46), constraints=(/46: (/NULL - ])]
+      │         └── instance_type_extra_specs_1.deleted:46 = $9 [outer=(46), constraints=(/46: (/NULL - ]), fd=()-->(46)]
       └── filters (true)
 
 opt
@@ -2956,144 +2960,128 @@ from (select instance_types.created_at as instance_types_created_at,
 order by anon_1.instance_types_deleted asc,
          anon_1.instance_types_id asc
 ----
-sort
+project
  ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7!null anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:36 instance_type_extra_specs_1_updated_at:37 instance_type_extra_specs_1_deleted_at:35 instance_type_extra_specs_1_deleted:34 instance_type_extra_specs_1_id:30 instance_type_extra_specs_1_key:31 instance_type_extra_specs_1_value:32 instance_type_extra_specs_1_instance_type_id:33
  ├── immutable, has-placeholder
- ├── key: (1,30)
- ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
- ├── ordering: +13,+1
- └── project
-      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:30 key:31 value:32 instance_type_extra_specs_1.instance_type_id:33 instance_type_extra_specs_1.deleted:34 instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
+ ├── key: (30)
+ ├── fd: ()-->(1-16), (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
+ └── left-join (lookup instance_type_extra_specs [as=instance_type_extra_specs_1])
+      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28 instance_type_extra_specs_1.id:30 key:31 value:32 instance_type_extra_specs_1.instance_type_id:33 instance_type_extra_specs_1.deleted:34 instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
+      ├── key columns: [30] = [30]
+      ├── lookup columns are key
       ├── immutable, has-placeholder
-      ├── key: (1,30)
-      ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
-      └── right-join (hash)
-           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28 instance_type_extra_specs_1.id:30 key:31 value:32 instance_type_extra_specs_1.instance_type_id:33 instance_type_extra_specs_1.deleted:34 instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
-           ├── immutable, has-placeholder
-           ├── key: (1,30)
-           ├── fd: (1)-->(2-16,28), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
-           ├── select
-           │    ├── columns: instance_type_extra_specs_1.id:30!null key:31 value:32 instance_type_extra_specs_1.instance_type_id:33!null instance_type_extra_specs_1.deleted:34!null instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
-           │    ├── has-placeholder
-           │    ├── key: (30)
-           │    ├── fd: (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
-           │    ├── scan instance_type_extra_specs [as=instance_type_extra_specs_1]
-           │    │    ├── columns: instance_type_extra_specs_1.id:30!null key:31 value:32 instance_type_extra_specs_1.instance_type_id:33!null instance_type_extra_specs_1.deleted:34 instance_type_extra_specs_1.deleted_at:35 instance_type_extra_specs_1.created_at:36 instance_type_extra_specs_1.updated_at:37
-           │    │    ├── key: (30)
-           │    │    └── fd: (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
-           │    └── filters
-           │         └── instance_type_extra_specs_1.deleted:34 = $7 [outer=(34), constraints=(/34: (/NULL - ])]
-           ├── limit
-           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
-           │    ├── internal-ordering: +13,+1
-           │    ├── immutable, has-placeholder
-           │    ├── key: (1)
-           │    ├── fd: (1)-->(2-16,28), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    ├── offset
-           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
-           │    │    ├── internal-ordering: +13,+1
-           │    │    ├── has-placeholder
-           │    │    ├── key: (1)
-           │    │    ├── fd: (1)-->(2-16,28), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    ├── ordering: +13,+1
-           │    │    ├── sort
-           │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
-           │    │    │    ├── has-placeholder
-           │    │    │    ├── key: (1)
-           │    │    │    ├── fd: (1)-->(2-16,28), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │    ├── ordering: +13,+1
-           │    │    │    └── select
-           │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
-           │    │    │         ├── has-placeholder
-           │    │    │         ├── key: (1)
-           │    │    │         ├── fd: (1)-->(2-16,28), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         ├── group-by
-           │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
-           │    │    │         │    ├── grouping columns: instance_types.id:1!null
-           │    │    │         │    ├── internal-ordering: +1
-           │    │    │         │    ├── has-placeholder
-           │    │    │         │    ├── key: (1)
-           │    │    │         │    ├── fd: (1)-->(2-16,28), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         │    ├── left-join (merge)
-           │    │    │         │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:19 true:27
-           │    │    │         │    │    ├── left ordering: +1
-           │    │    │         │    │    ├── right ordering: +19
-           │    │    │         │    │    ├── has-placeholder
-           │    │    │         │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         │    │    ├── ordering: +1
-           │    │    │         │    │    ├── select
-           │    │    │         │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-           │    │    │         │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    ├── key: (1)
-           │    │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         │    │    │    ├── ordering: +1
-           │    │    │         │    │    │    ├── scan instance_types
-           │    │    │         │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-           │    │    │         │    │    │    │    ├── key: (1)
-           │    │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         │    │    │    │    └── ordering: +1
-           │    │    │         │    │    │    └── filters
-           │    │    │         │    │    │         ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ])]
-           │    │    │         │    │    │         └── flavorid:7 = $4 [outer=(7), constraints=(/7: (/NULL - ])]
-           │    │    │         │    │    ├── project
-           │    │    │         │    │    │    ├── columns: true:27!null instance_type_projects.instance_type_id:19!null
-           │    │    │         │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    ├── fd: ()-->(27)
-           │    │    │         │    │    │    ├── ordering: +19 opt(27) [actual: +19]
-           │    │    │         │    │    │    ├── select
-           │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:19!null project_id:20!null instance_type_projects.deleted:21!null
-           │    │    │         │    │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    │    ├── key: (19-21)
-           │    │    │         │    │    │    │    ├── ordering: +19
-           │    │    │         │    │    │    │    ├── scan instance_type_projects@secondary
-           │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:19!null project_id:20 instance_type_projects.deleted:21
-           │    │    │         │    │    │    │    │    ├── lax-key: (19-21)
-           │    │    │         │    │    │    │    │    └── ordering: +19
-           │    │    │         │    │    │    │    └── filters
-           │    │    │         │    │    │    │         ├── instance_type_projects.deleted:21 = $2 [outer=(21), constraints=(/21: (/NULL - ])]
-           │    │    │         │    │    │    │         └── project_id:20 = $3 [outer=(20), constraints=(/20: (/NULL - ])]
-           │    │    │         │    │    │    └── projections
-           │    │    │         │    │    │         └── true [as=true:27]
-           │    │    │         │    │    └── filters (true)
-           │    │    │         │    └── aggregations
-           │    │    │         │         ├── const-not-null-agg [as=true_agg:28, outer=(27)]
-           │    │    │         │         │    └── true:27
-           │    │    │         │         ├── const-agg [as=name:2, outer=(2)]
-           │    │    │         │         │    └── name:2
-           │    │    │         │         ├── const-agg [as=memory_mb:3, outer=(3)]
-           │    │    │         │         │    └── memory_mb:3
-           │    │    │         │         ├── const-agg [as=vcpus:4, outer=(4)]
-           │    │    │         │         │    └── vcpus:4
-           │    │    │         │         ├── const-agg [as=root_gb:5, outer=(5)]
-           │    │    │         │         │    └── root_gb:5
-           │    │    │         │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-           │    │    │         │         │    └── ephemeral_gb:6
-           │    │    │         │         ├── const-agg [as=flavorid:7, outer=(7)]
-           │    │    │         │         │    └── flavorid:7
-           │    │    │         │         ├── const-agg [as=swap:8, outer=(8)]
-           │    │    │         │         │    └── swap:8
-           │    │    │         │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-           │    │    │         │         │    └── rxtx_factor:9
-           │    │    │         │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-           │    │    │         │         │    └── vcpu_weight:10
-           │    │    │         │         ├── const-agg [as=disabled:11, outer=(11)]
-           │    │    │         │         │    └── disabled:11
-           │    │    │         │         ├── const-agg [as=is_public:12, outer=(12)]
-           │    │    │         │         │    └── is_public:12
-           │    │    │         │         ├── const-agg [as=instance_types.deleted:13, outer=(13)]
-           │    │    │         │         │    └── instance_types.deleted:13
-           │    │    │         │         ├── const-agg [as=instance_types.deleted_at:14, outer=(14)]
-           │    │    │         │         │    └── instance_types.deleted_at:14
-           │    │    │         │         ├── const-agg [as=instance_types.created_at:15, outer=(15)]
-           │    │    │         │         │    └── instance_types.created_at:15
-           │    │    │         │         └── const-agg [as=instance_types.updated_at:16, outer=(16)]
-           │    │    │         │              └── instance_types.updated_at:16
-           │    │    │         └── filters
-           │    │    │              └── (is_public:12 = true) OR (true_agg:28 IS NOT NULL) [outer=(12,28)]
-           │    │    └── $5
-           │    └── $6
-           └── filters
-                └── instance_type_extra_specs_1.instance_type_id:33 = instance_types.id:1 [outer=(1,33), constraints=(/1: (/NULL - ]; /33: (/NULL - ]), fd=(1)==(33), (33)==(1)]
+      ├── key: (30)
+      ├── fd: ()-->(1-16,28), (30)-->(31-37), (31,33,34)~~>(30,32,35-37)
+      ├── left-join (lookup instance_type_extra_specs@secondary [as=instance_type_extra_specs_1])
+      │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28 instance_type_extra_specs_1.id:30 key:31 instance_type_extra_specs_1.instance_type_id:33 instance_type_extra_specs_1.deleted:34
+      │    ├── key columns: [1] = [33]
+      │    ├── immutable, has-placeholder
+      │    ├── key: (30)
+      │    ├── fd: ()-->(1-16,28), (30)-->(31,33,34), (31,33,34)~~>(30)
+      │    ├── limit
+      │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
+      │    │    ├── cardinality: [0 - 1]
+      │    │    ├── immutable, has-placeholder
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(1-16,28)
+      │    │    ├── offset
+      │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
+      │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    ├── has-placeholder
+      │    │    │    ├── key: ()
+      │    │    │    ├── fd: ()-->(1-16,28)
+      │    │    │    ├── select
+      │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
+      │    │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    │    ├── has-placeholder
+      │    │    │    │    ├── key: ()
+      │    │    │    │    ├── fd: ()-->(1-16,28)
+      │    │    │    │    ├── group-by
+      │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:28
+      │    │    │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    ├── fd: ()-->(1-16,28)
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: true:27 instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:19
+      │    │    │    │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    ├── fd: ()-->(1-16,19,27)
+      │    │    │    │    │    │    ├── left-join (lookup instance_type_projects@secondary)
+      │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:19 project_id:20 instance_type_projects.deleted:21
+      │    │    │    │    │    │    │    ├── key columns: [1] = [19]
+      │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    │    ├── fd: ()-->(1-16,19-21)
+      │    │    │    │    │    │    │    ├── index-join instance_types
+      │    │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
+      │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    │    │    ├── fd: ()-->(1-16)
+      │    │    │    │    │    │    │    │    └── select
+      │    │    │    │    │    │    │    │         ├── columns: instance_types.id:1!null flavorid:7!null instance_types.deleted:13!null
+      │    │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    │    │         ├── has-placeholder
+      │    │    │    │    │    │    │    │         ├── key: ()
+      │    │    │    │    │    │    │    │         ├── fd: ()-->(1,7,13)
+      │    │    │    │    │    │    │    │         ├── scan instance_types@secondary
+      │    │    │    │    │    │    │    │         │    ├── columns: instance_types.id:1!null flavorid:7!null instance_types.deleted:13
+      │    │    │    │    │    │    │    │         │    ├── constraint: /7/13: (/NULL - ]
+      │    │    │    │    │    │    │    │         │    ├── key: (1)
+      │    │    │    │    │    │    │    │         │    └── fd: (1)-->(7,13), (7,13)~~>(1)
+      │    │    │    │    │    │    │    │         └── filters
+      │    │    │    │    │    │    │    │              ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
+      │    │    │    │    │    │    │    │              └── flavorid:7 = $4 [outer=(7), constraints=(/7: (/NULL - ]), fd=()-->(7)]
+      │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │         ├── instance_type_projects.deleted:21 = $2 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
+      │    │    │    │    │    │    │         └── project_id:20 = $3 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
+      │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │         └── CASE instance_type_projects.instance_type_id:19 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:27, outer=(19)]
+      │    │    │    │    │    └── aggregations
+      │    │    │    │    │         ├── const-not-null-agg [as=true_agg:28, outer=(27)]
+      │    │    │    │    │         │    └── true:27
+      │    │    │    │    │         ├── const-agg [as=name:2, outer=(2)]
+      │    │    │    │    │         │    └── name:2
+      │    │    │    │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
+      │    │    │    │    │         │    └── memory_mb:3
+      │    │    │    │    │         ├── const-agg [as=vcpus:4, outer=(4)]
+      │    │    │    │    │         │    └── vcpus:4
+      │    │    │    │    │         ├── const-agg [as=root_gb:5, outer=(5)]
+      │    │    │    │    │         │    └── root_gb:5
+      │    │    │    │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
+      │    │    │    │    │         │    └── ephemeral_gb:6
+      │    │    │    │    │         ├── const-agg [as=flavorid:7, outer=(7)]
+      │    │    │    │    │         │    └── flavorid:7
+      │    │    │    │    │         ├── const-agg [as=swap:8, outer=(8)]
+      │    │    │    │    │         │    └── swap:8
+      │    │    │    │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
+      │    │    │    │    │         │    └── rxtx_factor:9
+      │    │    │    │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
+      │    │    │    │    │         │    └── vcpu_weight:10
+      │    │    │    │    │         ├── const-agg [as=disabled:11, outer=(11)]
+      │    │    │    │    │         │    └── disabled:11
+      │    │    │    │    │         ├── const-agg [as=is_public:12, outer=(12)]
+      │    │    │    │    │         │    └── is_public:12
+      │    │    │    │    │         ├── const-agg [as=instance_types.deleted:13, outer=(13)]
+      │    │    │    │    │         │    └── instance_types.deleted:13
+      │    │    │    │    │         ├── const-agg [as=instance_types.deleted_at:14, outer=(14)]
+      │    │    │    │    │         │    └── instance_types.deleted_at:14
+      │    │    │    │    │         ├── const-agg [as=instance_types.created_at:15, outer=(15)]
+      │    │    │    │    │         │    └── instance_types.created_at:15
+      │    │    │    │    │         ├── const-agg [as=instance_types.updated_at:16, outer=(16)]
+      │    │    │    │    │         │    └── instance_types.updated_at:16
+      │    │    │    │    │         └── const-agg [as=instance_types.id:1, outer=(1)]
+      │    │    │    │    │              └── instance_types.id:1
+      │    │    │    │    └── filters
+      │    │    │    │         └── (is_public:12 = true) OR (true_agg:28 IS NOT NULL) [outer=(12,28)]
+      │    │    │    └── $5
+      │    │    └── $6
+      │    └── filters
+      │         └── instance_type_extra_specs_1.deleted:34 = $7 [outer=(34), constraints=(/34: (/NULL - ]), fd=()-->(34)]
+      └── filters (true)
 
 opt
 select anon_1.flavors_created_at as anon_1_flavors_created_at,
@@ -3146,114 +3134,112 @@ from (select flavors.created_at as flavors_created_at,
 project
  ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:31 flavor_extra_specs_1_updated_at:32 flavor_extra_specs_1_id:27 flavor_extra_specs_1_key:28 flavor_extra_specs_1_value:29 flavor_extra_specs_1_flavor_id:30
  ├── immutable, has-placeholder
- ├── key: (1,27)
- ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (27)-->(28-32), (28,30)-->(27,29,31,32)
- └── right-join (hash)
+ ├── key: (27)
+ ├── fd: ()-->(1-12,14,15), (27)-->(28-32), (28,30)-->(27,29,31,32)
+ └── left-join (lookup flavor_extra_specs [as=flavor_extra_specs_1])
       ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25 flavor_extra_specs_1.id:27 key:28 value:29 flavor_extra_specs_1.flavor_id:30 flavor_extra_specs_1.created_at:31 flavor_extra_specs_1.updated_at:32
+      ├── key columns: [27] = [27]
+      ├── lookup columns are key
       ├── immutable, has-placeholder
-      ├── key: (1,27)
-      ├── fd: (1)-->(2-12,14,15,25), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (27)-->(28-32), (28,30)-->(27,29,31,32)
-      ├── scan flavor_extra_specs [as=flavor_extra_specs_1]
-      │    ├── columns: flavor_extra_specs_1.id:27!null key:28!null value:29 flavor_extra_specs_1.flavor_id:30!null flavor_extra_specs_1.created_at:31 flavor_extra_specs_1.updated_at:32
-      │    ├── key: (27)
-      │    └── fd: (27)-->(28-32), (28,30)-->(27,29,31,32)
-      ├── limit
-      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25
+      ├── key: (27)
+      ├── fd: ()-->(1-12,14,15,25), (27)-->(28-32), (28,30)-->(27,29,31,32)
+      ├── left-join (lookup flavor_extra_specs@flavor_extra_specs_flavor_id_key_idx [as=flavor_extra_specs_1])
+      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25 flavor_extra_specs_1.id:27 key:28 flavor_extra_specs_1.flavor_id:30
+      │    ├── key columns: [1] = [30]
       │    ├── immutable, has-placeholder
-      │    ├── key: (1)
-      │    ├── fd: (1)-->(2-12,14,15,25), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    ├── offset
+      │    ├── key: (27)
+      │    ├── fd: ()-->(1-12,14,15,25), (27)-->(28,30), (28,30)-->(27)
+      │    ├── limit
       │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25
-      │    │    ├── has-placeholder
-      │    │    ├── key: (1)
-      │    │    ├── fd: (1)-->(2-12,14,15,25), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    ├── select
+      │    │    ├── cardinality: [0 - 1]
+      │    │    ├── immutable, has-placeholder
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(1-12,14,15,25)
+      │    │    ├── offset
       │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25
+      │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
-      │    │    │    ├── key: (1)
-      │    │    │    ├── fd: (1)-->(2-12,14,15,25), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    ├── group-by
+      │    │    │    ├── key: ()
+      │    │    │    ├── fd: ()-->(1-12,14,15,25)
+      │    │    │    ├── select
       │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25
-      │    │    │    │    ├── grouping columns: flavors.id:1!null
-      │    │    │    │    ├── internal-ordering: +1
+      │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
-      │    │    │    │    ├── key: (1)
-      │    │    │    │    ├── fd: (1)-->(2-12,14,15,25), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    │    ├── left-join (merge)
-      │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:18 true:24
-      │    │    │    │    │    ├── left ordering: +1
-      │    │    │    │    │    ├── right ordering: +18
+      │    │    │    │    ├── key: ()
+      │    │    │    │    ├── fd: ()-->(1-12,14,15,25)
+      │    │    │    │    ├── group-by
+      │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:25
+      │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    │    │    ├── ordering: +1
-      │    │    │    │    │    ├── select
-      │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-      │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    │    │    │    ├── ordering: +1
-      │    │    │    │    │    │    ├── scan flavors
-      │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-      │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    │    │    │    │    └── ordering: +1
-      │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │         └── flavors.id:1 = $2 [outer=(1), constraints=(/1: (/NULL - ])]
+      │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,25)
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: true:24!null flavor_projects.flavor_id:18!null
+      │    │    │    │    │    │    ├── columns: true:24 flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:18
+      │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    ├── fd: ()-->(24)
-      │    │    │    │    │    │    ├── ordering: +18 opt(24) [actual: +18]
-      │    │    │    │    │    │    ├── select
-      │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:18!null project_id:19!null
+      │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15,18,24)
+      │    │    │    │    │    │    ├── left-join (lookup flavor_projects@secondary)
+      │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:18 project_id:19
+      │    │    │    │    │    │    │    ├── key columns: [1] = [18]
+      │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    ├── key: (18,19)
-      │    │    │    │    │    │    │    ├── ordering: +18
-      │    │    │    │    │    │    │    ├── scan flavor_projects@secondary
-      │    │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:18!null project_id:19!null
-      │    │    │    │    │    │    │    │    ├── key: (18,19)
-      │    │    │    │    │    │    │    │    └── ordering: +18
+      │    │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15,18,19)
+      │    │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
+      │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15)
+      │    │    │    │    │    │    │    │    ├── scan flavors
+      │    │    │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
+      │    │    │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    │    │    └── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+      │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │    │         └── flavors.id:1 = $2 [outer=(1), constraints=(/1: (/NULL - ]), fd=()-->(1)]
       │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         ├── project_id:19 = $1 [outer=(19), constraints=(/19: (/NULL - ])]
-      │    │    │    │    │    │    │         └── flavor_projects.flavor_id:18 = $2 [outer=(18), constraints=(/18: (/NULL - ])]
+      │    │    │    │    │    │    │         ├── project_id:19 = $1 [outer=(19), constraints=(/19: (/NULL - ]), fd=()-->(19)]
+      │    │    │    │    │    │    │         └── flavor_projects.flavor_id:18 = $2 [outer=(18), constraints=(/18: (/NULL - ]), fd=()-->(18)]
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── true [as=true:24]
-      │    │    │    │    │    └── filters (true)
-      │    │    │    │    └── aggregations
-      │    │    │    │         ├── const-not-null-agg [as=true_agg:25, outer=(24)]
-      │    │    │    │         │    └── true:24
-      │    │    │    │         ├── const-agg [as=name:2, outer=(2)]
-      │    │    │    │         │    └── name:2
-      │    │    │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
-      │    │    │    │         │    └── memory_mb:3
-      │    │    │    │         ├── const-agg [as=vcpus:4, outer=(4)]
-      │    │    │    │         │    └── vcpus:4
-      │    │    │    │         ├── const-agg [as=root_gb:5, outer=(5)]
-      │    │    │    │         │    └── root_gb:5
-      │    │    │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-      │    │    │    │         │    └── ephemeral_gb:6
-      │    │    │    │         ├── const-agg [as=flavorid:7, outer=(7)]
-      │    │    │    │         │    └── flavorid:7
-      │    │    │    │         ├── const-agg [as=swap:8, outer=(8)]
-      │    │    │    │         │    └── swap:8
-      │    │    │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-      │    │    │    │         │    └── rxtx_factor:9
-      │    │    │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-      │    │    │    │         │    └── vcpu_weight:10
-      │    │    │    │         ├── const-agg [as=disabled:11, outer=(11)]
-      │    │    │    │         │    └── disabled:11
-      │    │    │    │         ├── const-agg [as=is_public:12, outer=(12)]
-      │    │    │    │         │    └── is_public:12
-      │    │    │    │         ├── const-agg [as=flavors.created_at:14, outer=(14)]
-      │    │    │    │         │    └── flavors.created_at:14
-      │    │    │    │         └── const-agg [as=flavors.updated_at:15, outer=(15)]
-      │    │    │    │              └── flavors.updated_at:15
-      │    │    │    └── filters
-      │    │    │         └── (is_public:12 = true) OR (true_agg:25 IS NOT NULL) [outer=(12,25)]
-      │    │    └── $3
-      │    └── $4
-      └── filters
-           └── flavor_extra_specs_1.flavor_id:30 = flavors.id:1 [outer=(1,30), constraints=(/1: (/NULL - ]; /30: (/NULL - ]), fd=(1)==(30), (30)==(1)]
+      │    │    │    │    │    │         └── CASE flavor_projects.flavor_id:18 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:24, outer=(18)]
+      │    │    │    │    │    └── aggregations
+      │    │    │    │    │         ├── const-not-null-agg [as=true_agg:25, outer=(24)]
+      │    │    │    │    │         │    └── true:24
+      │    │    │    │    │         ├── const-agg [as=name:2, outer=(2)]
+      │    │    │    │    │         │    └── name:2
+      │    │    │    │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
+      │    │    │    │    │         │    └── memory_mb:3
+      │    │    │    │    │         ├── const-agg [as=vcpus:4, outer=(4)]
+      │    │    │    │    │         │    └── vcpus:4
+      │    │    │    │    │         ├── const-agg [as=root_gb:5, outer=(5)]
+      │    │    │    │    │         │    └── root_gb:5
+      │    │    │    │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
+      │    │    │    │    │         │    └── ephemeral_gb:6
+      │    │    │    │    │         ├── const-agg [as=flavorid:7, outer=(7)]
+      │    │    │    │    │         │    └── flavorid:7
+      │    │    │    │    │         ├── const-agg [as=swap:8, outer=(8)]
+      │    │    │    │    │         │    └── swap:8
+      │    │    │    │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
+      │    │    │    │    │         │    └── rxtx_factor:9
+      │    │    │    │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
+      │    │    │    │    │         │    └── vcpu_weight:10
+      │    │    │    │    │         ├── const-agg [as=disabled:11, outer=(11)]
+      │    │    │    │    │         │    └── disabled:11
+      │    │    │    │    │         ├── const-agg [as=is_public:12, outer=(12)]
+      │    │    │    │    │         │    └── is_public:12
+      │    │    │    │    │         ├── const-agg [as=flavors.created_at:14, outer=(14)]
+      │    │    │    │    │         │    └── flavors.created_at:14
+      │    │    │    │    │         ├── const-agg [as=flavors.updated_at:15, outer=(15)]
+      │    │    │    │    │         │    └── flavors.updated_at:15
+      │    │    │    │    │         └── const-agg [as=flavors.id:1, outer=(1)]
+      │    │    │    │    │              └── flavors.id:1
+      │    │    │    │    └── filters
+      │    │    │    │         └── (is_public:12 = true) OR (true_agg:25 IS NOT NULL) [outer=(12,25)]
+      │    │    │    └── $3
+      │    │    └── $4
+      │    └── filters (true)
+      └── filters (true)
 
 opt
 select anon_1.flavors_created_at as anon_1_flavors_created_at,
@@ -3354,7 +3340,8 @@ sort
            │    │         │    │    ├── left ordering: +1
            │    │         │    │    ├── right ordering: +18
            │    │         │    │    ├── has-placeholder
-           │    │         │    │    ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15)
+           │    │         │    │    ├── key: (1)
+           │    │         │    │    ├── fd: (1)-->(2-15,18,24), (7)-->(1-6,8-15), (2)-->(1,3-15)
            │    │         │    │    ├── ordering: +1
            │    │         │    │    ├── scan flavors
            │    │         │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15
@@ -3364,19 +3351,21 @@ sort
            │    │         │    │    ├── project
            │    │         │    │    │    ├── columns: true:24!null flavor_projects.flavor_id:18!null
            │    │         │    │    │    ├── has-placeholder
+           │    │         │    │    │    ├── key: (18)
            │    │         │    │    │    ├── fd: ()-->(24)
            │    │         │    │    │    ├── ordering: +18 opt(24) [actual: +18]
            │    │         │    │    │    ├── select
            │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:18!null project_id:19!null
            │    │         │    │    │    │    ├── has-placeholder
-           │    │         │    │    │    │    ├── key: (18,19)
-           │    │         │    │    │    │    ├── ordering: +18
+           │    │         │    │    │    │    ├── key: (18)
+           │    │         │    │    │    │    ├── fd: ()-->(19)
+           │    │         │    │    │    │    ├── ordering: +18 opt(19) [actual: +18]
            │    │         │    │    │    │    ├── scan flavor_projects@secondary
            │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:18!null project_id:19!null
            │    │         │    │    │    │    │    ├── key: (18,19)
-           │    │         │    │    │    │    │    └── ordering: +18
+           │    │         │    │    │    │    │    └── ordering: +18 opt(19) [actual: +18]
            │    │         │    │    │    │    └── filters
-           │    │         │    │    │    │         └── project_id:19 = $1 [outer=(19), constraints=(/19: (/NULL - ])]
+           │    │         │    │    │    │         └── project_id:19 = $1 [outer=(19), constraints=(/19: (/NULL - ]), fd=()-->(19)]
            │    │         │    │    │    └── projections
            │    │         │    │    │         └── true [as=true:24]
            │    │         │    │    └── filters (true)

--- a/pkg/sql/opt/xform/testdata/placeholder-fast-path/scan
+++ b/pkg/sql/opt/xform/testdata/placeholder-fast-path/scan
@@ -87,13 +87,32 @@ SELECT v+1 FROM kv WHERE k = $1
 ----
 no fast path
 
+# The fast path should not kick in because the estimated row count is too high.
+placeholder-fast-path
+SELECT a, b, c FROM abcd WHERE a=$1 AND b=$2
+----
+no fast path
+
+# Now inject statistics so that the estimated row count is small.
+exec-ddl
+ALTER TABLE abcd INJECT STATISTICS '[
+  {
+    "columns": ["a"],
+    "created_at": "2018-05-01 1:00:00.00000+00:00",
+    "row_count": 10,
+    "distinct_count": 5
+  }
+]'
+----
+
+# The fast path should now kick in.
 placeholder-fast-path
 SELECT a, b, c FROM abcd WHERE a=$1 AND b=$2
 ----
 placeholder-scan abcd@secondary
  ├── columns: a:1!null b:2!null c:3
  ├── has-placeholder
- ├── stats: [rows=109.89, distinct(1)=100, null(1)=0, distinct(2)=100, null(2)=0, distinct(1,2)=109.89, null(1,2)=0]
+ ├── stats: [rows=1.1, distinct(1)=1.1, null(1)=0, distinct(2)=1, null(2)=0]
  ├── fd: ()-->(1,2)
  └── span
       ├── $1
@@ -105,7 +124,7 @@ SELECT a, b, c FROM abcd WHERE b=$1 AND a=$2
 placeholder-scan abcd@secondary
  ├── columns: a:1!null b:2!null c:3
  ├── has-placeholder
- ├── stats: [rows=109.89, distinct(1)=100, null(1)=0, distinct(2)=100, null(2)=0, distinct(1,2)=109.89, null(1,2)=0]
+ ├── stats: [rows=1.1, distinct(1)=1.1, null(1)=0, distinct(2)=1, null(2)=0]
  ├── fd: ()-->(1,2)
  └── span
       ├── $2
@@ -118,7 +137,7 @@ SELECT a, b, c FROM abcd WHERE a=0 AND b=$1
 placeholder-scan abcd@secondary
  ├── columns: a:1!null b:2!null c:3
  ├── has-placeholder
- ├── stats: [rows=3.33, distinct(1)=1, null(1)=0, distinct(2)=3.33, null(2)=0, distinct(1,2)=3.33, null(1,2)=0]
+ ├── stats: [rows=0.666, distinct(1)=0.666, null(1)=0, distinct(2)=0.666, null(2)=0, distinct(1,2)=0.666, null(1,2)=0]
  ├── fd: ()-->(1,2)
  └── span
       ├── 0
@@ -130,7 +149,7 @@ SELECT a, b, c FROM abcd WHERE a=$1 AND b=0
 placeholder-scan abcd@secondary
  ├── columns: a:1!null b:2!null c:3
  ├── has-placeholder
- ├── stats: [rows=3.33, distinct(1)=3.33, null(1)=0, distinct(2)=1, null(2)=0, distinct(1,2)=3.33, null(1,2)=0]
+ ├── stats: [rows=3.3, distinct(1)=3.3, null(1)=0, distinct(2)=1, null(2)=0]
  ├── fd: ()-->(1,2)
  └── span
       ├── $1
@@ -143,7 +162,7 @@ SELECT a, b, c FROM abcd WHERE a=1+2 AND b=$1
 placeholder-scan abcd@secondary
  ├── columns: a:1!null b:2!null c:3
  ├── has-placeholder
- ├── stats: [rows=3.33, distinct(1)=1, null(1)=0, distinct(2)=3.33, null(2)=0, distinct(1,2)=3.33, null(1,2)=0]
+ ├── stats: [rows=0.666, distinct(1)=0.666, null(1)=0, distinct(2)=0.666, null(2)=0, distinct(1,2)=0.666, null(1,2)=0]
  ├── fd: ()-->(1,2)
  └── span
       ├── 3
@@ -155,7 +174,7 @@ SELECT a, b, c FROM abcd WHERE a=fnv32a('foo') AND b=$1
 placeholder-scan abcd@secondary
  ├── columns: a:1!null b:2!null c:3
  ├── has-placeholder
- ├── stats: [rows=3.33, distinct(1)=1, null(1)=0, distinct(2)=3.33, null(2)=0, distinct(1,2)=3.33, null(1,2)=0]
+ ├── stats: [rows=0.666, distinct(1)=0.666, null(1)=0, distinct(2)=0.666, null(2)=0, distinct(1,2)=0.666, null(1,2)=0]
  ├── fd: ()-->(1,2)
  └── span
       ├── 2851307223
@@ -203,7 +222,7 @@ SELECT a, d FROM abcd WHERE d=$1 AND c=$2
 placeholder-scan abcd@secondary
  ├── columns: a:1 d:4!null
  ├── has-placeholder
- ├── stats: [rows=109.89]
+ ├── stats: [rows=1.0989]
  ├── fd: ()-->(4)
  └── span
       ├── $1
@@ -235,6 +254,19 @@ CREATE TABLE partial1 (
 )
 ----
 
+# The fast path is conditional on having a small estimated row count. Inject
+# statistics so that we don't have to worry about this aspect in tests.
+exec-ddl
+ALTER TABLE partial1 INJECT STATISTICS '[
+  {
+    "columns": ["k"],
+    "created_at": "2018-05-01 1:00:00.00000+00:00",
+    "row_count": 10,
+    "distinct_count": 10
+  }
+]'
+----
+
 # Make sure the fast path doesn't choose the cab index, getting in the way of
 # using partial_ab (which might be the better index when the placeholder is 0).
 placeholder-fast-path
@@ -250,7 +282,7 @@ SELECT a, b FROM partial1 WHERE a = $1
 placeholder-scan partial1@pseudo_ab,partial
  ├── columns: a:2!null b:3
  ├── has-placeholder
- ├── stats: [rows=330, distinct(2)=100, null(2)=0]
+ ├── stats: [rows=3.3, distinct(2)=1, null(2)=0]
  ├── fd: ()-->(2)
  └── span
       └── $1

--- a/pkg/sql/opt/xform/testdata/placeholder-fast-path/scan
+++ b/pkg/sql/opt/xform/testdata/placeholder-fast-path/scan
@@ -21,6 +21,7 @@ SELECT * FROM kv WHERE k = $1
 placeholder-scan kv
  ├── columns: k:1!null v:2
  ├── has-placeholder
+ ├── stats: [rows=333.333333, distinct(1)=333.333333, null(1)=0]
  ├── key: (1)
  ├── fd: (1)-->(2)
  └── span
@@ -33,6 +34,7 @@ placeholder-scan kv
  ├── columns: k:1!null v:2
  ├── locking: for-update
  ├── volatile, has-placeholder
+ ├── stats: [rows=333.333333, distinct(1)=333.333333, null(1)=0]
  ├── key: (1)
  ├── fd: (1)-->(2)
  └── span
@@ -44,6 +46,7 @@ SELECT k FROM kv WHERE k = $1
 placeholder-scan kv
  ├── columns: k:1!null
  ├── has-placeholder
+ ├── stats: [rows=333.333333, distinct(1)=333.333333, null(1)=0]
  ├── key: (1)
  └── span
       └── $1
@@ -54,6 +57,7 @@ SELECT k FROM kv WHERE k IN ($1)
 placeholder-scan kv
  ├── columns: k:1!null
  ├── has-placeholder
+ ├── stats: [rows=333.333333, distinct(1)=333.333333, null(1)=0]
  ├── key: (1)
  └── span
       └── $1
@@ -64,6 +68,7 @@ SELECT v FROM kv WHERE k = $1
 placeholder-scan kv
  ├── columns: v:2
  ├── has-placeholder
+ ├── stats: [rows=333.333333]
  └── span
       └── $1
 
@@ -79,6 +84,7 @@ SELECT a, b, c FROM abcd WHERE a=$1 AND b=$2
 placeholder-scan abcd@secondary
  ├── columns: a:1!null b:2!null c:3
  ├── has-placeholder
+ ├── stats: [rows=109.89, distinct(1)=100, null(1)=0, distinct(2)=100, null(2)=0, distinct(1,2)=109.89, null(1,2)=0]
  └── span
       ├── $1
       └── $2
@@ -89,6 +95,7 @@ SELECT a, b, c FROM abcd WHERE b=$1 AND a=$2
 placeholder-scan abcd@secondary
  ├── columns: a:1!null b:2!null c:3
  ├── has-placeholder
+ ├── stats: [rows=109.89, distinct(1)=100, null(1)=0, distinct(2)=100, null(2)=0, distinct(1,2)=109.89, null(1,2)=0]
  └── span
       ├── $2
       └── $1
@@ -100,6 +107,7 @@ SELECT a, b, c FROM abcd WHERE a=0 AND b=$1
 placeholder-scan abcd@secondary
  ├── columns: a:1!null b:2!null c:3
  ├── has-placeholder
+ ├── stats: [rows=3.33, distinct(1)=1, null(1)=0, distinct(2)=3.33, null(2)=0, distinct(1,2)=3.33, null(1,2)=0]
  ├── fd: ()-->(1)
  └── span
       ├── 0
@@ -111,6 +119,7 @@ SELECT a, b, c FROM abcd WHERE a=$1 AND b=0
 placeholder-scan abcd@secondary
  ├── columns: a:1!null b:2!null c:3
  ├── has-placeholder
+ ├── stats: [rows=3.33, distinct(1)=3.33, null(1)=0, distinct(2)=1, null(2)=0, distinct(1,2)=3.33, null(1,2)=0]
  ├── fd: ()-->(2)
  └── span
       ├── $1
@@ -123,6 +132,7 @@ SELECT a, b, c FROM abcd WHERE a=1+2 AND b=$1
 placeholder-scan abcd@secondary
  ├── columns: a:1!null b:2!null c:3
  ├── has-placeholder
+ ├── stats: [rows=3.33, distinct(1)=1, null(1)=0, distinct(2)=3.33, null(2)=0, distinct(1,2)=3.33, null(1,2)=0]
  ├── fd: ()-->(1)
  └── span
       ├── 3
@@ -134,6 +144,7 @@ SELECT a, b, c FROM abcd WHERE a=fnv32a('foo') AND b=$1
 placeholder-scan abcd@secondary
  ├── columns: a:1!null b:2!null c:3
  ├── has-placeholder
+ ├── stats: [rows=3.33, distinct(1)=1, null(1)=0, distinct(2)=3.33, null(2)=0, distinct(1,2)=3.33, null(1,2)=0]
  ├── fd: ()-->(1)
  └── span
       ├── 2851307223
@@ -181,6 +192,7 @@ SELECT a, d FROM abcd WHERE d=$1 AND c=$2
 placeholder-scan abcd@secondary
  ├── columns: a:1 d:4!null
  ├── has-placeholder
+ ├── stats: [rows=109.89]
  └── span
       ├── $1
       └── $2
@@ -226,5 +238,6 @@ SELECT a, b FROM partial1 WHERE a = $1
 placeholder-scan partial1@pseudo_ab,partial
  ├── columns: a:2!null b:3
  ├── has-placeholder
+ ├── stats: [rows=330, distinct(2)=100, null(2)=0]
  └── span
       └── $1

--- a/pkg/sql/opt/xform/testdata/placeholder-fast-path/scan
+++ b/pkg/sql/opt/xform/testdata/placeholder-fast-path/scan
@@ -20,10 +20,11 @@ SELECT * FROM kv WHERE k = $1
 ----
 placeholder-scan kv
  ├── columns: k:1!null v:2
+ ├── cardinality: [0 - 1]
  ├── has-placeholder
- ├── stats: [rows=333.333333, distinct(1)=333.333333, null(1)=0]
- ├── key: (1)
- ├── fd: (1)-->(2)
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+ ├── key: ()
+ ├── fd: ()-->(1,2)
  └── span
       └── $1
 
@@ -33,10 +34,11 @@ SELECT * FROM kv WHERE k = $1 FOR UPDATE
 placeholder-scan kv
  ├── columns: k:1!null v:2
  ├── locking: for-update
+ ├── cardinality: [0 - 1]
  ├── volatile, has-placeholder
- ├── stats: [rows=333.333333, distinct(1)=333.333333, null(1)=0]
- ├── key: (1)
- ├── fd: (1)-->(2)
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+ ├── key: ()
+ ├── fd: ()-->(1,2)
  └── span
       └── $1
 
@@ -45,9 +47,11 @@ SELECT k FROM kv WHERE k = $1
 ----
 placeholder-scan kv
  ├── columns: k:1!null
+ ├── cardinality: [0 - 1]
  ├── has-placeholder
- ├── stats: [rows=333.333333, distinct(1)=333.333333, null(1)=0]
- ├── key: (1)
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+ ├── key: ()
+ ├── fd: ()-->(1)
  └── span
       └── $1
 
@@ -56,9 +60,11 @@ SELECT k FROM kv WHERE k IN ($1)
 ----
 placeholder-scan kv
  ├── columns: k:1!null
+ ├── cardinality: [0 - 1]
  ├── has-placeholder
- ├── stats: [rows=333.333333, distinct(1)=333.333333, null(1)=0]
- ├── key: (1)
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+ ├── key: ()
+ ├── fd: ()-->(1)
  └── span
       └── $1
 
@@ -67,8 +73,11 @@ SELECT v FROM kv WHERE k = $1
 ----
 placeholder-scan kv
  ├── columns: v:2
+ ├── cardinality: [0 - 1]
  ├── has-placeholder
- ├── stats: [rows=333.333333]
+ ├── stats: [rows=1]
+ ├── key: ()
+ ├── fd: ()-->(2)
  └── span
       └── $1
 
@@ -85,6 +94,7 @@ placeholder-scan abcd@secondary
  ├── columns: a:1!null b:2!null c:3
  ├── has-placeholder
  ├── stats: [rows=109.89, distinct(1)=100, null(1)=0, distinct(2)=100, null(2)=0, distinct(1,2)=109.89, null(1,2)=0]
+ ├── fd: ()-->(1,2)
  └── span
       ├── $1
       └── $2
@@ -96,6 +106,7 @@ placeholder-scan abcd@secondary
  ├── columns: a:1!null b:2!null c:3
  ├── has-placeholder
  ├── stats: [rows=109.89, distinct(1)=100, null(1)=0, distinct(2)=100, null(2)=0, distinct(1,2)=109.89, null(1,2)=0]
+ ├── fd: ()-->(1,2)
  └── span
       ├── $2
       └── $1
@@ -108,7 +119,7 @@ placeholder-scan abcd@secondary
  ├── columns: a:1!null b:2!null c:3
  ├── has-placeholder
  ├── stats: [rows=3.33, distinct(1)=1, null(1)=0, distinct(2)=3.33, null(2)=0, distinct(1,2)=3.33, null(1,2)=0]
- ├── fd: ()-->(1)
+ ├── fd: ()-->(1,2)
  └── span
       ├── 0
       └── $1
@@ -120,7 +131,7 @@ placeholder-scan abcd@secondary
  ├── columns: a:1!null b:2!null c:3
  ├── has-placeholder
  ├── stats: [rows=3.33, distinct(1)=3.33, null(1)=0, distinct(2)=1, null(2)=0, distinct(1,2)=3.33, null(1,2)=0]
- ├── fd: ()-->(2)
+ ├── fd: ()-->(1,2)
  └── span
       ├── $1
       └── 0
@@ -133,7 +144,7 @@ placeholder-scan abcd@secondary
  ├── columns: a:1!null b:2!null c:3
  ├── has-placeholder
  ├── stats: [rows=3.33, distinct(1)=1, null(1)=0, distinct(2)=3.33, null(2)=0, distinct(1,2)=3.33, null(1,2)=0]
- ├── fd: ()-->(1)
+ ├── fd: ()-->(1,2)
  └── span
       ├── 3
       └── $1
@@ -145,7 +156,7 @@ placeholder-scan abcd@secondary
  ├── columns: a:1!null b:2!null c:3
  ├── has-placeholder
  ├── stats: [rows=3.33, distinct(1)=1, null(1)=0, distinct(2)=3.33, null(2)=0, distinct(1,2)=3.33, null(1,2)=0]
- ├── fd: ()-->(1)
+ ├── fd: ()-->(1,2)
  └── span
       ├── 2851307223
       └── $1
@@ -193,6 +204,7 @@ placeholder-scan abcd@secondary
  ├── columns: a:1 d:4!null
  ├── has-placeholder
  ├── stats: [rows=109.89]
+ ├── fd: ()-->(4)
  └── span
       ├── $1
       └── $2
@@ -239,5 +251,6 @@ placeholder-scan partial1@pseudo_ab,partial
  ├── columns: a:2!null b:3
  ├── has-placeholder
  ├── stats: [rows=330, distinct(2)=100, null(2)=0]
+ ├── fd: ()-->(2)
  └── span
       └── $1


### PR DESCRIPTION
#### opt: show statistics in placeholder-fast-path tests

This highlights a problem with the fast path: we use statistics that
are derived using placeholders, which are usually terrible.

Release note: None

#### opt: mark columns as constant for equality with placeholder

This commit improves the FD generation for Select when we have filters
like `x = $1`. Because these filters have placeholders, they do not
generate constraints (which is the normal mechanism for detecting
constant columns).

This improves the cardinality property and row count estimate. The
estimate will be used for the placeholder fast path.

Release note: None

#### opt: make placeholder fast path conditional on the estimated row count

This change is best explained by this comment:

```
// We are dealing with a memo that still contains placeholders. The statistics
// for such a memo can be wildly overestimated. Even if our plan is correct,
// the estimated row count for a scan is passed to the execution engine which
// uses it to make sizing decisions. Passing a very high count can affect
// performance significantly (see #64214). So we only use the fast path if the
// estimated row count is small; typically this will happen when we constrain
// columns that form a key and we know there will be at most one row.
```

Fixes #64214.

Release note (bug fix): fixed a performance regression for very simple
queries.