### PR TITLE
release-20.2: sql: fix CREATE STATISTICS for partial indexes

### DIFF
--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -410,7 +410,12 @@ func createStatsDefaultColumns(
 
 			// Generate stats for each column individually.
 			for _, colID := range colIDs.Ordered() {
-				addIndexColumnStatsIfNotExists(colID, isInverted)
+				col, err := desc.FindColumnByID(colID)
+				if err != nil {
+					return nil, err
+				}
+				isInvertedCol := colinfo.ColumnTypeIsInvertedIndexable(col.Type)
+				addIndexColumnStatsIfNotExists(colID, isInvertedCol)
 			}
 		}
 	}

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -1036,3 +1036,14 @@ SHOW STATISTICS USING JSON FOR TABLE greeting_stats
 
 statement ok
 ALTER TABLE greeting_stats INJECT STATISTICS '$stats'
+
+# Regression test for #63387. Stats collection should succeed when partial index
+# predicates reference inverted-type columns.
+statement ok
+CREATE TABLE t63387 (
+    i INT,
+    j JSONB,
+    INDEX (i) WHERE j->>'a' = 'b'
+);
+INSERT INTO t63387 VALUES (1, '{}');
+CREATE STATISTICS s FROM t63387;


### PR DESCRIPTION
This commit fixes a bug that caused errors when creating stats for a
table with a partial index predicate containing references to
inverted-type columns, like JSON and ARRAY.

Fixes #63387

Release note (bug fix): The `CREATE STATISTICS` command no longer fails
when creating statistics on a table with a partial index predicate
containing references to an inverted-type column, such as `JSON`,
`ARRAY`, `GEOMETRY`, or `GEOGRAPHY`. This bug was present since partial
indexes were introduced in version 20.2.0.