### PR TITLE
release-21.1: sql: add CREATE STATISTICS regression test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -1080,3 +1080,14 @@ job.typedesc_schema_change.successful
 job.schema_change.successful
 job.create_stats.successful
 job.auto_create_stats.successful
+
+# Regression test for #63387. Stats collection should succeed when partial index
+# predicates reference inverted-type columns.
+statement ok
+CREATE TABLE t63387 (
+    i INT,
+    j JSONB,
+    INDEX (i) WHERE j->>'a' = 'b'
+);
+INSERT INTO t63387 VALUES (1, '{}');
+CREATE STATISTICS s FROM t63387;


### PR DESCRIPTION
Backport 1/1 commits from #64229.

/cc @cockroachdb/release

---

This is a "forward-port" of regression tests from #64226. This commit
contains no code changes because the bug was already been fixed on
master by #59687.

Release note: None
