### PR TITLE
tracing: reduce memory pressure throughout

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -728,7 +728,7 @@ func (ctx *Context) grpcDialOptions(
 		// is in setupSpanForIncomingRPC().
 		//
 		tagger := func(span *tracing.Span) {
-			span.SetTag("node", ctx.NodeID.String())
+			span.SetTag("node", ctx.NodeID.Get().String())
 		}
 		unaryInterceptors = append(unaryInterceptors,
 			tracing.ClientInterceptor(tracer, tagger))

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -59,7 +59,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/streaming"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
@@ -3732,30 +3731,17 @@ may increase either contention or retry errors, or both.`,
 				traceID := uint64(*(args[0].(*tree.DInt)))
 				verbosity := bool(*(args[1].(*tree.DBool)))
 
-				const query = `SELECT span_id
-  	 									FROM crdb_internal.node_inflight_trace_spans
- 		 									WHERE trace_id = $1
-											AND parent_span_id = 0`
+				var rootSpan *tracing.Span
+				if err := ctx.Settings.Tracer.VisitSpans(func(span *tracing.Span) error {
+					if span.TraceID() == traceID && rootSpan == nil {
+						rootSpan = span
+					}
 
-				ie := ctx.InternalExecutor.(sqlutil.InternalExecutor)
-				row, err := ie.QueryRowEx(
-					ctx.Ctx(),
-					"crdb_internal.set_trace_verbose",
-					ctx.Txn,
-					sessiondata.NoSessionDataOverride,
-					query,
-					traceID,
-				)
-				if err != nil {
+					return nil
+				}); err != nil {
 					return nil, err
 				}
-				if row == nil {
-					return tree.DBoolFalse, nil
-				}
-				rootSpanID := uint64(*row[0].(*tree.DInt))
-
-				rootSpan, found := ctx.Settings.Tracer.GetActiveSpanFromID(rootSpanID)
-				if !found {
+				if rootSpan == nil { // not found
 					return tree.DBoolFalse, nil
 				}
 

--- a/pkg/util/tracing/alloc_test.go
+++ b/pkg/util/tracing/alloc_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/logtags"
-	"github.com/opentracing/opentracing-go"
 )
 
 // BenchmarkTracer_StartSpanCtx primarily helps keep
@@ -35,10 +34,6 @@ func BenchmarkTracer_StartSpanCtx(b *testing.B) {
 	staticLogTags := logtags.Buffer{}
 	staticLogTags.Add("foo", "bar")
 
-	staticTag := opentracing.Tag{
-		Key:   "statictag",
-		Value: "staticvalue",
-	}
 	b.ResetTimer()
 
 	parSp := tr.StartSpan("one-off", WithForceRealSpan())
@@ -54,9 +49,6 @@ func BenchmarkTracer_StartSpanCtx(b *testing.B) {
 		}},
 		{"real,logtag", []SpanOption{
 			WithForceRealSpan(), WithLogTags(&staticLogTags),
-		}},
-		{"real,tag", []SpanOption{
-			WithForceRealSpan(), WithTags(staticTag),
 		}},
 		{"real,autoparent", []SpanOption{
 			WithForceRealSpan(), WithParentAndAutoCollection(parSp),

--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -29,6 +29,13 @@ import (
 // crdbSpan is a span for internal crdb usage. This is used to power SQL session
 // tracing.
 type crdbSpan struct {
+	rootSpan *crdbSpan // root span of the containing trace; could be itself
+	// traceEmpty indicates whether or not the trace rooted at this span
+	// (provided it is a root span) contains any recordings or baggage. All
+	// spans hold a reference to the rootSpan; this field is accessed
+	// through that reference.
+	traceEmpty int32 // accessed atomically, through markTraceAsNonEmpty and inAnEmptyTrace
+
 	traceID      uint64 // probabilistically unique
 	spanID       uint64 // probabilistically unique
 	parentSpanID uint64
@@ -76,22 +83,65 @@ type crdbSpanMu struct {
 
 		// children contains the list of child spans started after this Span
 		// started recording.
-		children []*crdbSpan
+		children childSpanRefs
 		// remoteSpan contains the list of remote child span recordings that
 		// were manually imported.
 		remoteSpans []tracingpb.RecordedSpan
 	}
 
-	// tags are only set when recording. These are tags that have been added to
-	// this Span, and will be appended to the tags in logTags when someone
-	// needs to actually observe the total set of tags that is a part of this
-	// Span.
+	// tags are only captured when recording. These are tags that have been
+	// added to this Span, and will be appended to the tags in logTags when
+	// someone needs to actually observe the total set of tags that is a part of
+	// this Span.
 	// TODO(radu): perhaps we want a recording to capture all the tags (even
 	// those that were set before recording started)?
 	tags opentracing.Tags
 
 	// The Span's associated baggage.
 	baggage map[string]string
+}
+
+type childSpanRefs struct {
+	refCount     int
+	preAllocated [4]*crdbSpan
+	overflow     []*crdbSpan
+}
+
+func (c *childSpanRefs) len() int {
+	return c.refCount
+}
+
+func (c *childSpanRefs) add(ref *crdbSpan) {
+	if c.refCount < len(c.preAllocated) {
+		c.preAllocated[c.refCount] = ref
+		c.refCount++
+		return
+	}
+
+	// Only record the child if the parent still has room.
+	if c.refCount < maxChildrenPerSpan {
+		c.overflow = append(c.overflow, ref)
+		c.refCount++
+	}
+}
+
+func (c *childSpanRefs) get(idx int) *crdbSpan {
+	if idx < len(c.preAllocated) {
+		ref := c.preAllocated[idx]
+		if ref == nil {
+			panic(fmt.Sprintf("idx %d out of bounds", idx))
+		}
+		return ref
+	}
+	return c.overflow[idx-len(c.preAllocated)]
+}
+
+func (c *childSpanRefs) reset() {
+	for i := 0; i < len(c.preAllocated); i++ {
+		c.preAllocated[i] = nil
+	}
+	c.overflow = nil
+	c.refCount = 0
 }
 
 func newSizeLimitedBuffer(limit int64) sizeLimitedBuffer {
@@ -151,8 +201,7 @@ func (s *crdbSpan) resetRecording() {
 	s.mu.recording.logs.Reset()
 	s.mu.recording.structured.Reset()
 	s.mu.recording.dropped = false
-
-	s.mu.recording.children = nil
+	s.mu.recording.children.reset()
 	s.mu.recording.remoteSpans = nil
 }
 
@@ -178,8 +227,6 @@ func (s *crdbSpan) getRecording(everyoneIsV211 bool, wantTags bool) Recording {
 		return nil // noop span
 	}
 
-	s.mu.Lock()
-
 	if !everyoneIsV211 {
 		// The cluster may contain nodes that are running v20.2. Unfortunately that
 		// version can easily crash when a peer returns a recording that that node
@@ -189,16 +236,27 @@ func (s *crdbSpan) getRecording(everyoneIsV211 bool, wantTags bool) Recording {
 		//
 		// TODO(tbg): remove this in the v21.2 cycle.
 		if s.recordingType() == RecordingOff {
-			s.mu.Unlock()
 			return nil
 		}
 	}
 
-	// The capacity here is approximate since we don't know how many grandchildren
-	// there are.
-	result := make(Recording, 0, 1+len(s.mu.recording.children)+len(s.mu.recording.remoteSpans))
+	// Return early (without allocating) if the trace is empty, i.e. there are
+	// no recordings or baggage. If the trace is verbose, we'll still recurse in
+	// order to pick up all the operations that were part of the trace, despite
+	// nothing having any actual data in them.
+	if s.recordingType() != RecordingVerbose && s.inAnEmptyTrace() {
+		return nil
+	}
+
+	s.mu.Lock()
+	// The capacity here is approximate since we don't know how many
+	// grandchildren there are.
+	result := make(Recording, 0, 1+s.mu.recording.children.len()+len(s.mu.recording.remoteSpans))
 	// Shallow-copy the children so we can process them without the lock.
-	children := s.mu.recording.children
+	var children []*crdbSpan
+	for i := 0; i < s.mu.recording.children.len(); i++ {
+		children = append(children, s.mu.recording.children.get(i))
+	}
 	result = append(result, s.getRecordingLocked(wantTags))
 	result = append(result, s.mu.recording.remoteSpans...)
 	s.mu.Unlock()
@@ -218,6 +276,11 @@ func (s *crdbSpan) getRecording(everyoneIsV211 bool, wantTags bool) Recording {
 }
 
 func (s *crdbSpan) importRemoteSpans(remoteSpans []tracingpb.RecordedSpan) {
+	if len(remoteSpans) == 0 {
+		return
+	}
+
+	s.markTraceAsNonEmpty()
 	// Change the root of the remote recording to be a child of this Span. This is
 	// usually already the case, except with DistSQL traces where remote
 	// processors run in spans that FollowFrom an RPC Span that we don't collect.
@@ -229,6 +292,11 @@ func (s *crdbSpan) importRemoteSpans(remoteSpans []tracingpb.RecordedSpan) {
 }
 
 func (s *crdbSpan) setTagLocked(key string, value interface{}) {
+	if s.recordingType() != RecordingVerbose {
+		// Don't bother storing tags if we're unlikely to retrieve them.
+		return
+	}
+
 	if s.mu.tags == nil {
 		s.mu.tags = make(opentracing.Tags)
 	}
@@ -266,10 +334,21 @@ type sizable interface {
 	Size() int
 }
 
+// inAnEmptyTrace indicates whether or not the containing trace is "empty" (i.e.
+// has any recordings or baggage).
+func (s *crdbSpan) inAnEmptyTrace() bool {
+	val := atomic.LoadInt32(&s.rootSpan.traceEmpty)
+	return val == 0
+}
+
+func (s *crdbSpan) markTraceAsNonEmpty() {
+	atomic.StoreInt32(&s.rootSpan.traceEmpty, 1)
+}
+
 func (s *crdbSpan) recordInternal(payload sizable, buffer *sizeLimitedBuffer) {
+	s.markTraceAsNonEmpty()
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
 	size := int64(payload.Size())
 	if size > buffer.limit {
 		// The incoming payload alone blows past the memory limit. Let's just
@@ -291,6 +370,7 @@ func (s *crdbSpan) recordInternal(payload sizable, buffer *sizeLimitedBuffer) {
 }
 
 func (s *crdbSpan) setBaggageItemAndTag(restrictedKey, value string) {
+	s.markTraceAsNonEmpty()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.setBaggageItemLocked(restrictedKey, value)
@@ -405,11 +485,9 @@ func (s *crdbSpan) getRecordingLocked(wantTags bool) tracingpb.RecordedSpan {
 
 func (s *crdbSpan) addChild(child *crdbSpan) {
 	s.mu.Lock()
-	// Only record the child if the parent still has room.
-	if len(s.mu.recording.children) < maxChildrenPerSpan {
-		s.mu.recording.children = append(s.mu.recording.children, child)
-	}
-	s.mu.Unlock()
+	defer s.mu.Unlock()
+
+	s.mu.recording.children.add(child)
 }
 
 // setVerboseRecursively sets the verbosity of the crdbSpan appropriately and
@@ -422,7 +500,10 @@ func (s *crdbSpan) setVerboseRecursively(to bool) {
 	}
 
 	s.mu.Lock()
-	children := s.mu.recording.children
+	var children []*crdbSpan
+	for i := 0; i < s.mu.recording.children.len(); i++ {
+		children = append(children, s.mu.recording.children.get(i))
+	}
 	s.mu.Unlock()
 
 	for _, child := range children {

--- a/pkg/util/tracing/grpc_interceptor_test.go
+++ b/pkg/util/tracing/grpc_interceptor_test.go
@@ -29,6 +29,23 @@ import (
 	"google.golang.org/grpc"
 )
 
+// testStructuredImpl is a testing implementation of Structured event.
+type testStructuredImpl struct {
+	*types.StringValue
+}
+
+var _ tracing.Structured = &testStructuredImpl{}
+
+func (t *testStructuredImpl) String() string {
+	return fmt.Sprintf("structured=%s", t.Value)
+}
+
+func newTestStructured(s string) *testStructuredImpl {
+	return &testStructuredImpl{
+		&types.StringValue{Value: s},
+	}
+}
+
 // TestGRPCInterceptors verifies that the streaming and unary tracing
 // interceptors work as advertised. We expect to see a span on the client side
 // and a span on the server side.
@@ -38,7 +55,7 @@ func TestGRPCInterceptors(t *testing.T) {
 	const (
 		k          = "test-baggage-key"
 		v          = "test-baggage-value"
-		magicValue = 150
+		magicValue = "magic-value"
 	)
 
 	checkForSpanAndReturnRecording := func(ctx context.Context) (*types.Any, error) {
@@ -54,7 +71,7 @@ func TestGRPCInterceptors(t *testing.T) {
 			return nil, errors.Newf("expected %v, got %v instead", v, actV)
 		}
 
-		sp.RecordStructured(&types.Int32Value{Value: magicValue})
+		sp.RecordStructured(newTestStructured(magicValue))
 		sp.SetVerbose(true) // want the tags
 		recs := sp.GetRecording()
 		sp.SetVerbose(false)
@@ -187,6 +204,7 @@ func TestGRPCInterceptors(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, sp := tr.StartSpanCtx(context.Background(), tc.name, tracing.WithForceRealSpan())
+			sp.SetVerbose(true) // to set the tags
 			recAny, err := tc.do(ctx)
 			require.NoError(t, err)
 			var rec tracingpb.RecordedSpan
@@ -195,7 +213,6 @@ func TestGRPCInterceptors(t *testing.T) {
 			sp.ImportRemoteSpans([]tracingpb.RecordedSpan{rec})
 			sp.Finish()
 			var n int
-			sp.SetVerbose(true) // to get the tags
 			finalRecs := sp.GetRecording()
 			sp.SetVerbose(false)
 			for _, rec := range finalRecs {
@@ -217,7 +234,8 @@ func TestGRPCInterceptors(t *testing.T) {
 					span: /cockroach.testutils.grpcutils.GRPCTest/%[1]s
 						tags: component=gRPC span.kind=client test-baggage-key=test-baggage-value
 					span: /cockroach.testutils.grpcutils.GRPCTest/%[1]s
-						tags: component=gRPC span.kind=server test-baggage-key=test-baggage-value`, tc.name)
+						tags: component=gRPC span.kind=server test-baggage-key=test-baggage-value
+						event: structured=magic-value`, tc.name)
 			require.NoError(t, tracing.TestingCheckRecordedSpans(finalRecs, exp))
 		})
 	}

--- a/pkg/util/tracing/recording.go
+++ b/pkg/util/tracing/recording.go
@@ -476,7 +476,7 @@ func TestingCheckRecordedSpans(rec Recording, expected string) error {
 			Context:  4,
 		}
 		diffText, _ := difflib.GetUnifiedDiffString(diff)
-		return errors.Newf("unexpected diff:\n%s\n%s", diffText, rec.String())
+		return errors.Newf("unexpected diff:\n%s\n\nrecording:\n%s", diffText, rec.String())
 	}
 	return nil
 }

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -113,7 +113,7 @@ func (sp *Span) ImportRemoteSpans(remoteSpans []tracingpb.RecordedSpan) {
 // boundaries in order to derive child spans from this Span. This may return
 // nil, which is a valid input to `WithParentAndManualCollection`, if the Span
 // has been optimized out.
-func (sp *Span) Meta() *SpanMeta {
+func (sp *Span) Meta() SpanMeta {
 	// It shouldn't be done in practice, but it is allowed to call Meta on
 	// a finished span.
 	return sp.i.Meta()
@@ -248,6 +248,11 @@ type SpanMeta struct {
 
 	// The Span's associated baggage.
 	Baggage map[string]string
+}
+
+// Empty returns whether or not the SpanMeta is a zero value.
+func (sm SpanMeta) Empty() bool {
+	return sm.spanID == 0 && sm.traceID == 0
 }
 
 func (sm *SpanMeta) String() string {

--- a/pkg/util/tracing/span_inner.go
+++ b/pkg/util/tracing/span_inner.go
@@ -97,6 +97,10 @@ func (s *spanInner) Finish() {
 		return
 	}
 	finishTime := timeutil.Now()
+	duration := finishTime.Sub(s.crdb.startTime)
+	if duration == 0 {
+		duration = time.Nanosecond
+	}
 
 	s.crdb.mu.Lock()
 	if alreadyFinished := s.crdb.mu.duration >= 0; alreadyFinished {
@@ -106,10 +110,7 @@ func (s *spanInner) Finish() {
 		// finished twice, but it may happen so let's be resilient to it.
 		return
 	}
-	s.crdb.mu.duration = finishTime.Sub(s.crdb.startTime)
-	if s.crdb.mu.duration == 0 {
-		s.crdb.mu.duration = time.Nanosecond
-	}
+	s.crdb.mu.duration = duration
 	s.crdb.mu.Unlock()
 
 	if s.ot.shadowSpan != nil {
@@ -118,12 +119,14 @@ func (s *spanInner) Finish() {
 	if s.netTr != nil {
 		s.netTr.Finish()
 	}
-	s.tracer.activeSpans.Lock()
-	delete(s.tracer.activeSpans.m, s.crdb.spanID)
-	s.tracer.activeSpans.Unlock()
+	if s.crdb.rootSpan.spanID == s.crdb.spanID {
+		s.tracer.activeSpans.Lock()
+		delete(s.tracer.activeSpans.m, s.crdb.spanID)
+		s.tracer.activeSpans.Unlock()
+	}
 }
 
-func (s *spanInner) Meta() *SpanMeta {
+func (s *spanInner) Meta() SpanMeta {
 	var traceID uint64
 	var spanID uint64
 	var recordingType RecordingType
@@ -157,9 +160,9 @@ func (s *spanInner) Meta() *SpanMeta {
 		shadowCtx == nil &&
 		recordingType == 0 &&
 		baggage == nil {
-		return nil
+		return SpanMeta{}
 	}
-	return &SpanMeta{
+	return SpanMeta{
 		traceID:          traceID,
 		spanID:           spanID,
 		shadowTracerType: shadowTrTyp,

--- a/pkg/util/tracing/span_options.go
+++ b/pkg/util/tracing/span_options.go
@@ -21,7 +21,7 @@ import (
 // See the SpanOption interface for a synopsis.
 type spanOptions struct {
 	Parent        *Span                         // see WithParentAndAutoCollection
-	RemoteParent  *SpanMeta                     // see WithParentAndManualCollection
+	RemoteParent  SpanMeta                      // see WithParentAndManualCollection
 	RefType       opentracing.SpanReferenceType // see WithFollowsFrom
 	LogTags       *logtags.Buffer               // see WithLogTags
 	Tags          map[string]interface{}        // see WithTags
@@ -31,7 +31,7 @@ type spanOptions struct {
 func (opts *spanOptions) parentTraceID() uint64 {
 	if opts.Parent != nil && !opts.Parent.i.isNoop() {
 		return opts.Parent.i.crdb.traceID
-	} else if opts.RemoteParent != nil {
+	} else if !opts.RemoteParent.Empty() {
 		return opts.RemoteParent.traceID
 	}
 	return 0
@@ -40,17 +40,24 @@ func (opts *spanOptions) parentTraceID() uint64 {
 func (opts *spanOptions) parentSpanID() uint64 {
 	if opts.Parent != nil && !opts.Parent.i.isNoop() {
 		return opts.Parent.i.crdb.spanID
-	} else if opts.RemoteParent != nil {
+	} else if !opts.RemoteParent.Empty() {
 		return opts.RemoteParent.spanID
 	}
 	return 0
+}
+
+func (opts *spanOptions) deriveRootSpan() *crdbSpan {
+	if opts.Parent != nil && !opts.Parent.i.isNoop() {
+		return opts.Parent.i.crdb.rootSpan
+	}
+	return nil
 }
 
 func (opts *spanOptions) recordingType() RecordingType {
 	recordingType := RecordingOff
 	if opts.Parent != nil && !opts.Parent.i.isNoop() {
 		recordingType = opts.Parent.i.crdb.recordingType()
-	} else if opts.RemoteParent != nil {
+	} else if !opts.RemoteParent.Empty() {
 		recordingType = opts.RemoteParent.recordingType
 	}
 	return recordingType
@@ -59,7 +66,7 @@ func (opts *spanOptions) recordingType() RecordingType {
 func (opts *spanOptions) shadowTrTyp() (string, bool) {
 	if opts.Parent != nil {
 		return opts.Parent.i.ot.shadowTr.Type()
-	} else if opts.RemoteParent != nil {
+	} else if !opts.RemoteParent.Empty() {
 		s := opts.RemoteParent.shadowTracerType
 		return s, s != ""
 	}
@@ -70,7 +77,7 @@ func (opts *spanOptions) shadowContext() opentracing.SpanContext {
 	if opts.Parent != nil && opts.Parent.i.ot.shadowSpan != nil {
 		return opts.Parent.i.ot.shadowSpan.Context()
 	}
-	if opts.RemoteParent != nil && opts.RemoteParent.shadowCtx != nil {
+	if !opts.RemoteParent.Empty() && opts.RemoteParent.shadowCtx != nil {
 		return opts.RemoteParent.shadowCtx
 	}
 	return nil
@@ -147,33 +154,12 @@ type parentAndManualCollectionOption SpanMeta
 // which corresponds to the expectation that the parent span will
 // wait for the child to Finish(). If this expectation does not hold,
 // WithFollowsFrom should be added to the StartSpan invocation.
-func WithParentAndManualCollection(parent *SpanMeta) SpanOption {
-	return (*parentAndManualCollectionOption)(parent)
+func WithParentAndManualCollection(parent SpanMeta) SpanOption {
+	return (parentAndManualCollectionOption)(parent)
 }
 
-func (p *parentAndManualCollectionOption) apply(opts spanOptions) spanOptions {
-	opts.RemoteParent = (*SpanMeta)(p)
-	return opts
-}
-
-type tagsOption []opentracing.Tag
-
-// WithTags is an option to Tracer.StartSpan which populates the
-// tags on the newly created Span.
-func WithTags(tags ...opentracing.Tag) SpanOption {
-	return (tagsOption)(tags)
-}
-
-func (o tagsOption) apply(opts spanOptions) spanOptions {
-	if len(o) == 0 {
-		return opts
-	}
-	if opts.Tags == nil {
-		opts.Tags = map[string]interface{}{}
-	}
-	for _, tag := range o {
-		opts.Tags[tag.Key] = tag.Value
-	}
+func (p parentAndManualCollectionOption) apply(opts spanOptions) spanOptions {
+	opts.RemoteParent = (SpanMeta)(p)
 	return opts
 }
 

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -284,7 +284,7 @@ func (t *Tracer) startSpanGeneric(
 	}
 
 	if opts.Parent != nil {
-		if opts.RemoteParent != nil {
+		if !opts.RemoteParent.Empty() {
 			panic("can't specify both Parent and RemoteParent")
 		}
 	}
@@ -396,6 +396,20 @@ func (t *Tracer) startSpanGeneric(
 		netTr:  netTr,
 	}
 
+	// Copy over the parent span's root span reference, and if there isn't one
+	// (we're creating a new root span), set a reference to ourselves.
+	//
+	// TODO(irfansharif): Given we have a handle on the root span, we should
+	// reconsider the maxChildrenPerSpan limit, which only limits the branching
+	// factor. To bound the total memory usage for pkg/tracing, we could instead
+	// limit the number of spans per trace (no-oping all subsequent ones) and
+	// do the same for the total number of root spans.
+	if rootSpan := opts.deriveRootSpan(); rootSpan != nil {
+		helper.crdbSpan.rootSpan = rootSpan
+	} else {
+		helper.crdbSpan.rootSpan = &helper.crdbSpan
+	}
+
 	s := &helper.span
 
 	{
@@ -410,8 +424,8 @@ func (t *Tracer) startSpanGeneric(
 		s.i.crdb.enableRecording(p, opts.recordingType())
 	}
 
-	// Set initial tags. These will propagate to the crdbSpan, ot, and netTr
-	// as appropriate.
+	// Set initial tags (has to happen after instantiating the recording type).
+	// These will propagate to the crdbSpan, ot, and netTr as appropriate.
 	//
 	// NB: this could be optimized.
 	for k, v := range opts.Tags {
@@ -426,10 +440,11 @@ func (t *Tracer) startSpanGeneric(
 		if !opts.Parent.i.isNoop() {
 			opts.Parent.i.crdb.mu.Lock()
 			m := opts.Parent.i.crdb.mu.baggage
+			opts.Parent.i.crdb.mu.Unlock()
+
 			for k, v := range m {
 				s.SetBaggageItem(k, v)
 			}
-			opts.Parent.i.crdb.mu.Unlock()
 		}
 	} else {
 		// Local root span - put it into the registry of active local root
@@ -452,7 +467,7 @@ func (t *Tracer) startSpanGeneric(
 		t.activeSpans.m[spanID] = s
 		t.activeSpans.Unlock()
 
-		if opts.RemoteParent != nil {
+		if !opts.RemoteParent.Empty() {
 			for k, v := range opts.RemoteParent.Baggage {
 				s.SetBaggageItem(k, v)
 			}
@@ -536,8 +551,8 @@ func (fn textMapWriterFn) Set(key, val string) {
 // InjectMetaInto is used to serialize the given span metadata into the given
 // Carrier. This, alongside ExtractMetaFrom, can be used to carry span metadata
 // across process boundaries. See serializationFormat for more details.
-func (t *Tracer) InjectMetaInto(sm *SpanMeta, carrier Carrier) error {
-	if sm == nil {
+func (t *Tracer) InjectMetaInto(sm SpanMeta, carrier Carrier) error {
+	if sm.Empty() {
 		// Fast path when tracing is disabled. ExtractMetaFrom will accept an
 		// empty map as a noop context.
 		return nil
@@ -580,32 +595,20 @@ func (t *Tracer) InjectMetaInto(sm *SpanMeta, carrier Carrier) error {
 	return nil
 }
 
-var noopSpanMeta = (*SpanMeta)(nil)
+// var noopSpanMeta = (*SpanMeta)(nil)
+var noopSpanMeta = SpanMeta{}
 
 // ExtractMetaFrom is used to deserialize a span metadata (if any) from the
 // given Carrier. This, alongside InjectMetaFrom, can be used to carry span
 // metadata across process boundaries. See serializationFormat for more details.
-func (t *Tracer) ExtractMetaFrom(carrier Carrier) (*SpanMeta, error) {
-	var format serializationFormat
-	switch carrier.(type) {
-	case MapCarrier:
-		format = mapFormat
-	case metadataCarrier:
-		format = metadataFormat
-	default:
-		return noopSpanMeta, errors.New("unsupported carrier")
-	}
-
+func (t *Tracer) ExtractMetaFrom(carrier Carrier) (SpanMeta, error) {
 	var shadowType string
 	var shadowCarrier opentracing.TextMapCarrier
-
 	var traceID uint64
 	var spanID uint64
 	var baggage map[string]string
 
-	// TODO(tbg): ForeachKey forces things on the heap. We can do better
-	// by using an explicit carrier.
-	err := carrier.ForEach(func(k, v string) error {
+	iterFn := func(k, v string) error {
 		switch k = strings.ToLower(k); k {
 		case fieldNameTraceID:
 			var err error
@@ -636,10 +639,23 @@ func (t *Tracer) ExtractMetaFrom(carrier Carrier) (*SpanMeta, error) {
 			}
 		}
 		return nil
-	})
-	if err != nil {
-		return noopSpanMeta, err
 	}
+
+	// Instead of iterating through the interface type, we prefer to do so with
+	// the explicit types to avoid heap allocations.
+	switch c := carrier.(type) {
+	case MapCarrier:
+		if err := c.ForEach(iterFn); err != nil {
+			return noopSpanMeta, err
+		}
+	case metadataCarrier:
+		if err := c.ForEach(iterFn); err != nil {
+			return noopSpanMeta, err
+		}
+	default:
+		return noopSpanMeta, errors.New("unsupported carrier")
+	}
+
 	if traceID == 0 && spanID == 0 {
 		return noopSpanMeta, nil
 	}
@@ -660,10 +676,20 @@ func (t *Tracer) ExtractMetaFrom(carrier Carrier) (*SpanMeta, error) {
 			// consideration.
 			shadowType = ""
 		} else {
+			var format serializationFormat
+			switch carrier.(type) {
+			case MapCarrier:
+				format = mapFormat
+			case metadataCarrier:
+				format = metadataFormat
+			default:
+				return noopSpanMeta, errors.New("unsupported carrier")
+			}
 			// Shadow tracing is active on this node and the incoming information
 			// was created using the same type of tracer.
 			//
 			// Extract the shadow context using the un-encapsulated textmap.
+			var err error
 			shadowCtx, err = shadowTr.Extract(format, shadowCarrier)
 			if err != nil {
 				return noopSpanMeta, err
@@ -671,7 +697,7 @@ func (t *Tracer) ExtractMetaFrom(carrier Carrier) (*SpanMeta, error) {
 		}
 	}
 
-	return &SpanMeta{
+	return SpanMeta{
 		traceID:          traceID,
 		spanID:           spanID,
 		shadowTracerType: shadowType,
@@ -681,7 +707,7 @@ func (t *Tracer) ExtractMetaFrom(carrier Carrier) (*SpanMeta, error) {
 	}, nil
 }
 
-// GetActiveSpanFromID retrieves any active span given its span ID.
+// GetActiveSpanFromID retrieves any active root span given its ID.
 func (t *Tracer) GetActiveSpanFromID(spanID uint64) (*Span, bool) {
 	t.activeSpans.Lock()
 	span, found := t.activeSpans.m[spanID]

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -32,7 +32,7 @@ func TestStartSpanAlwaysTrace(t *testing.T) {
 	tr._useNetTrace = 1
 	require.True(t, tr.AlwaysTrace())
 	nilMeta := tr.noopSpan.Meta()
-	require.Nil(t, nilMeta)
+	require.True(t, nilMeta.Empty())
 	sp := tr.StartSpan("foo", WithParentAndManualCollection(nilMeta))
 	require.False(t, sp.IsVerbose()) // parent was not verbose, so neither is sp
 	require.False(t, sp.i.isNoop())
@@ -69,11 +69,18 @@ func TestTracerRecording(t *testing.T) {
 	}
 
 	// Initial recording of this fresh (real) span.
+	if err := TestingCheckRecordedSpans(s1.GetRecording(), ``); err != nil {
+		t.Fatal(err)
+	}
+
+	s1.SetVerbose(true)
 	if err := TestingCheckRecordedSpans(s1.GetRecording(), `
 		span: a
+			tags: _unfinished=1 _verbose=1
 	`); err != nil {
 		t.Fatal(err)
 	}
+	s1.SetVerbose(false)
 
 	// Real parent --> real child.
 	real3 := tr.StartSpan("noop3", WithParentAndManualCollection(s1.Meta()))
@@ -237,8 +244,8 @@ func TestTracerInjectExtract(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if wireSpanMeta != nil {
-		t.Errorf("expected noop context: %v", wireSpanMeta)
+	if !wireSpanMeta.Empty() {
+		t.Errorf("expected no-op span meta: %v", wireSpanMeta)
 	}
 	noop2 := tr2.StartSpan("remote op", WithParentAndManualCollection(wireSpanMeta))
 	if !noop2.i.isNoop() {


### PR DESCRIPTION
This commit attempts to reduce the memory overhead of tracing by doing a
few things, guided mostly by BenchmarkTracing and kv95 (see results
below). In decreasing order of impact:

- We no longer materialize recordings when the trace is "empty" or
  non-verbose. When traces straddle RPC boundaries, we serialize the
  recording and to send it over the wire. For "empty" traces (ones with
  no structured recordings or log messages), this is needlessly
  allocation-heavy. We end up shipping the trace skeleton (parent-child
  span relationships, and the operation names + metadata that identify
  each span). Not only does this allocate within pkg/util/tracing, it
  also incurs allocations within gRPC where all this serialization is
  taking place. This commit takes the (opinionated) stance that we can
  avoid materializing these recordings altogether.
  We do this by having each span hold onto a reference to the rootspan,
  and updating an atomic value on the rootspan whenever anything is
  recorded. When materializing the recording, from any span in the tree,
  we can consult the root span to see if the trace was non-empty, and
  allocate if so.

- We pre-allocate a small list of child pointer slots for spans to refer
  to, instead of allocating every time a child span is created.

- Span tags aren't rendered unless the span is verbose, but we were
  still collecting them previously in order to render them if verbosity
  was toggled. Toggling an active span's verbosity rarely every happens,
  so now we don't allocate for tags unless the span is already verbose.
  This also lets us avoid the WithTags option, which allocates even if
  the span will end up dropping tags.

- We were previously allocating SpanMeta, despite the objects being
  extremely shortlived in practice (they existed primarily to pass on
  the parent span's metadata to the newly created child spans). We now
  pass SpanMetas by value.

- We can make use of explicit carriers when extracting SpanMeta from
  remote spans, instead of accessing data through the Carrier interface.
  This helps reduce SpanMeta allocations, at the cost of duplicating some
  code.

- metadata.MD, used to carry span metadata across gRPC, is also
  relatively short-lived (existing only for the duration of the RPC).
  Its API is also relatively allocation-heavy (improved with
  https://github.com/grpc/grpc-go/pull/4360), allocating for every key
  being written. Tracing has a very specific usage pattern (adding to
  the metadata.MD only the trace and span ID), so we can pool our
  allocations here.

- We can slightly improve lock contention around the tracing registry by
  locking only when we're dealing with rootspans. We can also avoid
  computing the span duration outside the critical area.

---

Before this PR, comparing traced scans vs. not:

    name                                 old time/op    new time/op    delta
    Tracing/Cockroach/Scan1-24              403µs ± 3%     415µs ± 1%   +2.82%  (p=0.000 n=10+9)
    Tracing/MultinodeCockroach/Scan1-24     878µs ± 1%     975µs ± 6%  +11.07%  (p=0.000 n=10+10)

    name                                 old alloc/op   new alloc/op   delta
    Tracing/Cockroach/Scan1-24             23.2kB ± 2%    29.8kB ± 2%  +28.64%  (p=0.000 n=10+10)
    Tracing/MultinodeCockroach/Scan1-24    76.5kB ± 5%    95.1kB ± 1%  +24.31%  (p=0.000 n=10+10)

    name                                 old allocs/op  new allocs/op  delta
    Tracing/Cockroach/Scan1-24                235 ± 2%       258 ± 1%   +9.50%  (p=0.000 n=10+9)
    Tracing/MultinodeCockroach/Scan1-24       760 ± 1%       891 ± 1%  +17.20%  (p=0.000 n=9+10)

After this PR:

    name                                 old time/op    new time/op    delta
    Tracing/Cockroach/Scan1-24              437µs ± 4%     443µs ± 3%     ~     (p=0.315 n=10+10)
    Tracing/MultinodeCockroach/Scan1-24     925µs ± 2%     968µs ± 1%   +4.62%  (p=0.000 n=10+10)

    name                                 old alloc/op   new alloc/op   delta
    Tracing/Cockroach/Scan1-24             23.3kB ± 3%    26.3kB ± 2%  +13.24%  (p=0.000 n=10+10)
    Tracing/MultinodeCockroach/Scan1-24    77.0kB ± 4%    81.7kB ± 3%   +6.08%  (p=0.000 n=10+10)

    name                                 old allocs/op  new allocs/op  delta
    Tracing/Cockroach/Scan1-24                236 ± 1%       241 ± 1%   +2.45%  (p=0.000 n=9+9)
    Tracing/MultinodeCockroach/Scan1-24       758 ± 1%       793 ± 2%   +4.67%  (p=0.000 n=10+10)

---

kv95/enc=false/nodes=1/cpu=32 across a few runs also shows a modest
improvement before and after this PR, using a sampling rate of 10%:

    36929.02 v. 37415.52  (reads/s)   +1.30%
     1944.38 v.  1968.94  (writes/s)  +1.24%

Release note: None
