### PR TITLE
Intent resolve int test

### DIFF
--- a/pkg/ccl/backupccl/backup_intents_test.go
+++ b/pkg/ccl/backupccl/backup_intents_test.go
@@ -1,0 +1,82 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package backupccl_test
+
+import (
+	"context"
+	"errors"
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestBackupPerformanceRegression(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	defer utilccl.TestingEnableEnterprise()()
+
+	const rowCount = 10000
+	const transactionSize = 1000
+
+	// Interceptor catches requests that cleanup transactions of size 1000 which are
+	// test data transactions. All other transaction commits pass though.
+	interceptor := func(ctx context.Context, req roachpb.BatchRequest) *roachpb.Error {
+		if req.Txn == nil || req.Txn.Name != "sql txn" {
+			return nil
+		}
+		endTxn := req.Requests[0].GetEndTxn()
+		if endTxn == nil {
+			return nil
+		}
+		if endTxn.InFlightWrites != nil {
+			return nil
+		}
+		if len(endTxn.LockSpans) != transactionSize {
+			return nil
+		}
+		return roachpb.NewError(errors.New("blocking intent cleanup for our transaction only"))
+	}
+	serverKnobs := kvserver.StoreTestingKnobs{TestingRequestFilter: interceptor}
+
+	s, sqlDb, _ := serverutils.StartServer(t,
+		base.TestServerArgs{Knobs: base.TestingKnobs{Store: &serverKnobs}})
+	defer s.Stopper().Stop(context.Background())
+
+	_, err := sqlDb.Exec("create table foo(v int)")
+	require.NoError(t, err)
+
+	for i := 0; i < rowCount;  {
+		tx, err := sqlDb.Begin()
+		require.NoError(t, err)
+		ps, err := tx.Prepare("insert into foo (v) values ($1)")
+		require.NoError(t, err)
+		for j := 0; j < transactionSize; j++ {
+			_, err = ps.Exec(i)
+			require.NoError(t, err)
+			i++
+		}
+		require.NoError(t, tx.Commit())
+	}
+
+	start := time.Now()
+	_, err = sqlDb.Exec("backup table foo to 'userfile:///test.foo'")
+	require.NoError(t, err, "Failed to run backup")
+	// Time to cleanup intents differs roughly 10x so some arbitrary number is picked which is 2x higher
+	// than current backup time on current hardware.
+	require.WithinDuration(t, time.Now(), start, time.Second * 10, "Time to make backup")
+}

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -13,6 +13,7 @@ package storage
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -541,4 +542,122 @@ func BenchmarkMVCCKeyCompare(b *testing.B) {
 	if testing.Verbose() {
 		fmt.Fprint(ioutil.Discard, c)
 	}
+}
+
+type TestValue struct {
+	key roachpb.Key
+	value roachpb.Value
+	timestamp hlc.Timestamp
+	txn *roachpb.Transaction
+}
+
+func intent(key roachpb.Key, val string, ts hlc.Timestamp) TestValue {
+	var value = roachpb.MakeValueFromString(val)
+	value.InitChecksum(key)
+	tx := roachpb.MakeTransaction(fmt.Sprintf("txn-%v", key), key, roachpb.NormalUserPriority, ts, 1000)
+	var txn = &tx
+	return TestValue{key, value, ts, txn}
+}
+
+func value(key roachpb.Key, val string, ts hlc.Timestamp) TestValue {
+	var value = roachpb.MakeValueFromString(val)
+	value.InitChecksum(key)
+	return TestValue{key, value, ts, nil}
+}
+
+func fillInData(ctx context.Context, engine Engine, data []TestValue) error {
+	batch := engine.NewBatch()
+	for _, val := range data {
+		if err := MVCCPut(ctx, batch, nil, val.key, val.timestamp, val.value, val.txn); err != nil {
+			return err
+		}
+	}
+	return batch.Commit(true)
+}
+
+func ts(ts int64) hlc.Timestamp {
+	return hlc.Timestamp{WallTime: ts}
+}
+
+func key(k uint32) roachpb.Key {
+	var key roachpb.Key = make([]byte, 4)
+	binary.LittleEndian.PutUint32(key, k)
+	return key
+}
+
+func requireTxnForValue(t *testing.T, val TestValue, intent roachpb.Intent) {
+	require.Equal(t, val.txn.Key, intent.Txn.Key)
+}
+
+func TestIntentFailureHandling(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Test function uses a fixed time and key range to produce SST.
+	// Use varying inserted keys for values and intents to putting them in and out of ranges.
+	test := func (data []TestValue, failures []int) func(*testing.T) {
+		return func (t *testing.T) {
+			ctx := context.Background()
+
+			engine := createTestPebbleEngine()
+			defer engine.Close()
+
+			require.NoError(t, fillInData(ctx, engine, data))
+
+			_, _, _, err := engine.ExportMVCCToSst(key(10), key(20), ts(999), ts(2000),
+				true, 0, 0, true)
+			if len(failures) == 0 {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				switch e := err.(type) {
+				case *roachpb.WriteIntentError:
+					require.Equal(t, len(failures), len(e.Intents))
+					for i, dataIdx := range failures {
+						requireTxnForValue(t, data[dataIdx], e.Intents[i])
+					}
+				default:
+					require.Fail(t, "Expected WriteIntentFailure, got %v", err)
+				}
+			}
+		}
+	}
+
+	// Export range is fixed to k:[10, 20), ts:(999, 2000] for all tests.
+
+	t.Run("Report multiple intents", test([]TestValue{
+		value(key(10), "hi", ts(1000)),
+		intent(key(11), "err", ts(1001)),
+		intent(key(12), "err2", ts(1002)),
+	}, []int{1, 2}))
+
+	t.Run("Ensure values are correctly skipped after first intent", test([]TestValue{
+		value(key(10), "hi", ts(1000)),
+		intent(key(11), "err", ts(1001)),
+		value(key(12), "surprise", ts(1005)),
+		intent(key(13), "err2", ts(1002)),
+	}, []int{1, 3}))
+
+	t.Run("Filter some failing intents by time", test([]TestValue{
+		value(key(10), "hi", ts(1000)),
+		intent(key(11), "err", ts(1001)),
+		intent(key(12), "err2", ts(2002)),
+	}, []int{1}))
+
+	t.Run("Filter all failing intents by time", test([]TestValue{
+		value(key(10), "hi", ts(1000)),
+		intent(key(11), "not in scope", ts(2001)),
+		intent(key(12), "not in scope too", ts(2002)),
+	}, []int{}))
+
+	t.Run("Filter some failing intents by key range", test([]TestValue{
+		value(key(10), "hi", ts(1000)),
+		intent(key(7), "outside of key range", ts(1001)),
+		intent(key(12), "err", ts(1002)),
+	}, []int{2}))
+
+	t.Run("Filter all failing intents by key range", test([]TestValue{
+		value(key(10), "hi", ts(1000)),
+		intent(key(7), "before start", ts(1001)),
+		intent(key(22), "after end", ts(1002)),
+	}, []int{}))
 }


### PR DESCRIPTION
WIP

I tried to make things fail predictably to generate intents for all rows ignoring any other requests and it works reliably as far as I can see.
The bad thing is that test time between cases where we fail intents 1 by 1 or fail everything at once is only 2x time.
When running on a big table in a cluster the results are significantly more pronounced and backup could take hours to progress. It may be down to more network chatter and generated sst being large and generating more waste.

Any ideas how could we make it fail "better"?