### PR TITLE
sql: implement ST_AsTWKB

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1449,6 +1449,12 @@ Precision specifies how many decimal places will be preserved in Encoded Polylin
 <tr><td><a name="st_astext"></a><code>st_astext(geometry_str: <a href="string.html">string</a>, max_decimal_digits: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the WKT representation of a given Geometry. The max_decimal_digits parameter controls the maximum decimal digits to print after the <code>.</code>. Use -1 to print as many digits as required to rebuild the same number.</p>
 <p>This variant will cast all geometry_str arguments into Geometry types.</p>
 </span></td></tr>
+<tr><td><a name="st_astwkb"></a><code>st_astwkb(geometry: geometry, precision_xy: <a href="int.html">int</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Returns the TWKB representation of a given geometry.</p>
+</span></td></tr>
+<tr><td><a name="st_astwkb"></a><code>st_astwkb(geometry: geometry, precision_xy: <a href="int.html">int</a>, precision_z: <a href="int.html">int</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Returns the TWKB representation of a given geometry.</p>
+</span></td></tr>
+<tr><td><a name="st_astwkb"></a><code>st_astwkb(geometry: geometry, precision_xy: <a href="int.html">int</a>, precision_z: <a href="int.html">int</a>, precision_m: <a href="int.html">int</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Returns the TWKB representation of a given geometry.</p>
+</span></td></tr>
 <tr><td><a name="st_azimuth"></a><code>st_azimuth(geography_a: geography, geography_b: geography) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the azimuth in radians of the segment defined by the given point geographies, or NULL if the two points are coincident. It is solved using the Inverse geodesic problem.</p>
 <p>The azimuth is angle is referenced from north, and is positive clockwise: North = 0; East = π/2; South = π; West = 3π/2.</p>
 <p>This function utilizes the GeographicLib library for spheroid calculations.</p>

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -70,6 +70,7 @@ ALL_TESTS = [
     "//pkg/geo/geoprojbase:geoprojbase_test",
     "//pkg/geo/geos:geos_test",
     "//pkg/geo/geotransform:geotransform_test",
+    "//pkg/geo/twkb:twkb_test",
     "//pkg/geo/wkt:wkt_test",
     "//pkg/geo:geo_test",
     "//pkg/gossip/resolver:resolver_test",

--- a/pkg/geo/twkb/BUILD.bazel
+++ b/pkg/geo/twkb/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "twkb",
+    srcs = ["twkb.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/geo/twkb",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_twpayne_go_geom//:go-geom",
+    ],
+)
+
+go_test(
+    name = "twkb_test",
+    srcs = ["twkb_test.go"],
+    embed = [":twkb"],
+    deps = [
+        "@com_github_stretchr_testify//require",
+        "@com_github_twpayne_go_geom//:go-geom",
+    ],
+)

--- a/pkg/geo/twkb/twkb.go
+++ b/pkg/geo/twkb/twkb.go
@@ -1,0 +1,360 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package twkb implements the Tiny Well-known Binary (TWKB) encoding
+// as described in https://github.com/TWKB/Specification/blob/master/twkb.md.
+package twkb
+
+import (
+	"bytes"
+	"math"
+
+	"github.com/cockroachdb/errors"
+	"github.com/twpayne/go-geom"
+)
+
+// twkbType is represents a TWKB byte.
+type twkbType uint8
+
+const (
+	twkbTypePoint              twkbType = 1
+	twkbTypeLineString         twkbType = 2
+	twkbTypePolygon            twkbType = 3
+	twkbTypeMultiPoint         twkbType = 4
+	twkbTypeMultiLineString    twkbType = 5
+	twkbTypeMultiPolygon       twkbType = 6
+	twkbTypeGeometryCollection twkbType = 7
+)
+
+type marshalOptions struct {
+	precisionXY int8
+	precisionZ  int8
+	precisionM  int8
+}
+
+type marshaller struct {
+	bytes.Buffer
+	o marshalOptions
+	// prevCoords keeps track of the previously written coordinates.
+	// This is needed as for Polygons, MultiLineString and MultiPolygons, the
+	// deltas written can be based off the previous ring/linestring/polygon.
+	prevCoords []int64
+}
+
+// MarshalOption is an option to pass into Marshal.
+type MarshalOption func(o *marshalOptions) error
+
+// MarshalOptionPrecisionXY sets the XY precision for the TWKB.
+func MarshalOptionPrecisionXY(p int64) MarshalOption {
+	return func(o *marshalOptions) error {
+		if p < -7 || p > 7 {
+			return errors.Newf(
+				"XY precision must be between -7 and 7 inclusive",
+			)
+		}
+		o.precisionXY = int8(p)
+		return nil
+	}
+}
+
+// MarshalOptionPrecisionZ sets the Z precision for the TWKB.
+func MarshalOptionPrecisionZ(p int64) MarshalOption {
+	return func(o *marshalOptions) error {
+		if p < 0 || p > 7 {
+			return errors.Newf(
+				"Z precision must not be negative or greater than 7",
+			)
+		}
+
+		o.precisionZ = int8(p)
+		return nil
+	}
+}
+
+// MarshalOptionPrecisionM sets the M precision for the TWKB.
+func MarshalOptionPrecisionM(p int64) MarshalOption {
+	return func(o *marshalOptions) error {
+		if p < 0 || p > 7 {
+			return errors.Newf(
+				"M precision must not be negative or greater than 7",
+			)
+		}
+
+		o.precisionM = int8(p)
+		return nil
+	}
+}
+
+// Marshal converts a geom.T into a TWKB encoded byte array.
+func Marshal(t geom.T, opts ...MarshalOption) ([]byte, error) {
+	var o marshalOptions
+	for _, opt := range opts {
+		if err := opt(&o); err != nil {
+			return nil, err
+		}
+	}
+	// TODO(#48886): PostGIS increases the precision by 5
+	// for all lat/lng SRIDs in certain cases.
+	m := marshaller{
+		o:          o,
+		prevCoords: make([]int64, t.Layout().Stride()),
+	}
+	if err := (&m).marshal(t); err != nil {
+		return nil, err
+	}
+	return m.Bytes(), nil
+}
+
+func (m *marshaller) marshal(t geom.T) error {
+	// Write metadata byte.
+	typeAndPrecisionHeader, err := typeAndPrecisionHeaderByte(t, m.o)
+	if err != nil {
+		return err
+	}
+	if err := m.WriteByte(typeAndPrecisionHeader); err != nil {
+		return err
+	}
+	if err := m.WriteByte(metadataByte(t, m.o)); err != nil {
+		return err
+	}
+	if t.Layout().Stride() > 2 {
+		if err := m.WriteByte(extendedDimensionsByte(t, m.o)); err != nil {
+			return err
+		}
+	}
+	if !t.Empty() {
+		// TODO(#48886): write bounding box if we support writing bounding boxes.
+		switch t := t.(type) {
+		case *geom.Point:
+			if err := m.writeFlatCoords(
+				t.FlatCoords(),
+				t.Layout(),
+				false, /* writeLen */
+			); err != nil {
+				return err
+			}
+		case *geom.LineString:
+			if err := m.writeFlatCoords(
+				t.FlatCoords(),
+				t.Layout(),
+				true, /* writeLen */
+			); err != nil {
+				return err
+			}
+		case *geom.Polygon:
+			if err := m.writeGeomWithEnds(
+				t.FlatCoords(),
+				t.Ends(),
+				t.Layout(),
+				0, /* startOffset */
+			); err != nil {
+				return err
+			}
+		case *geom.MultiPoint:
+			// TODO(#48886): write out the id list for MultiPoint.
+			if err := m.writeFlatCoords(
+				t.FlatCoords(),
+				t.Layout(),
+				true, /* writeLen */
+			); err != nil {
+				return err
+			}
+		case *geom.MultiLineString:
+			// TODO(#48886): write out the id list for MultiLineString.
+			if err := m.writeGeomWithEnds(
+				t.FlatCoords(),
+				t.Ends(),
+				t.Layout(),
+				0, /* startOffset */
+			); err != nil {
+				return err
+			}
+		case *geom.MultiPolygon:
+			// TODO(#48886): write out the id list for MultiPolygon.
+			flatCoords := t.FlatCoords()
+			endss := t.Endss()
+			// Write the number of MultiPolygons.
+			if err := m.putUvarint(uint64(len(endss))); err != nil {
+				return err
+			}
+			startOffset := 0
+			for _, ends := range endss {
+				// Write out each polygon.
+				if err := m.writeGeomWithEnds(
+					flatCoords,
+					ends,
+					t.Layout(),
+					startOffset,
+				); err != nil {
+					return err
+				}
+				// Update the start offset to be the last end we encountered.
+				if len(ends) > 0 {
+					startOffset = ends[len(ends)-1]
+				}
+			}
+		case *geom.GeometryCollection:
+			// Write the number of geometries.
+			if err := m.putUvarint(uint64(t.NumGeoms())); err != nil {
+				return err
+			}
+			for _, gcT := range t.Geoms() {
+				// Reset prev coords each time.
+				for i := range m.prevCoords {
+					m.prevCoords[i] = 0
+				}
+				if err := m.marshal(gcT); err != nil {
+					return err
+				}
+			}
+		default:
+			return errors.Newf("unknown TWKB type: %T", t)
+		}
+	}
+	return nil
+}
+
+func (m *marshaller) writeGeomWithEnds(
+	flatCoords []float64, ends []int, layout geom.Layout, startOffset int,
+) error {
+	// Write the number of elements.
+	if err := m.putUvarint(uint64(len(ends))); err != nil {
+		return err
+	}
+	start := startOffset
+	// Write each segment with the length of each ring at the beginning.
+	for _, end := range ends {
+		if err := m.writeFlatCoords(
+			flatCoords[start:end],
+			layout,
+			true, /* writeLen */
+		); err != nil {
+			return err
+		}
+		start = end
+	}
+	return nil
+}
+
+// writeFlatCoords writes the flat coordinates into the buffer.
+func (m *marshaller) writeFlatCoords(
+	flatCoords []float64, layout geom.Layout, writeLen bool,
+) error {
+	stride := layout.Stride()
+	if writeLen {
+		if err := m.putUvarint(uint64(len(flatCoords) / stride)); err != nil {
+			return err
+		}
+	}
+
+	zIndex := layout.ZIndex()
+	mIndex := layout.MIndex()
+	for i, coord := range flatCoords {
+		// Precision varies by coordinate.
+		precision := m.o.precisionXY
+		if i%stride == zIndex {
+			precision = m.o.precisionZ
+		}
+		if i%stride == mIndex {
+			precision = m.o.precisionM
+		}
+		curr := int64(math.Round(coord * math.Pow(10, float64(precision))))
+		prev := m.prevCoords[i%stride]
+
+		// The value written is the int version of the delta multiplied
+		// by 10^precision.
+		if err := m.putVarint(curr - prev); err != nil {
+			return err
+		}
+		m.prevCoords[i%stride] = curr
+	}
+	return nil
+}
+
+// putVarint encodes an int64 into buf and returns the number of bytes written.
+func (m *marshaller) putVarint(x int64) error {
+	ux := uint64(x) << 1
+	if x < 0 {
+		ux = ^ux
+	}
+	return m.putUvarint(ux)
+}
+
+// putUvarint encodes a uint64 into buf and returns the number of bytes written.
+func (m *marshaller) putUvarint(x uint64) error {
+	for x >= 0x80 {
+		if err := m.WriteByte(byte(x) | 0x80); err != nil {
+			return err
+		}
+		x >>= 7
+	}
+	return m.WriteByte(byte(x))
+}
+
+func typeAndPrecisionHeaderByte(t geom.T, o marshalOptions) (byte, error) {
+	var typ twkbType
+	switch t.(type) {
+	case *geom.Point:
+		typ = twkbTypePoint
+	case *geom.LineString:
+		typ = twkbTypeLineString
+	case *geom.Polygon:
+		typ = twkbTypePolygon
+	case *geom.MultiPoint:
+		typ = twkbTypeMultiPoint
+	case *geom.MultiLineString:
+		typ = twkbTypeMultiLineString
+	case *geom.MultiPolygon:
+		typ = twkbTypeMultiPolygon
+	case *geom.GeometryCollection:
+		typ = twkbTypeGeometryCollection
+	default:
+		return 0, errors.Newf("unknown TWKB type: %T", t)
+	}
+
+	precisionZigZagged := zigzagInt8(o.precisionXY)
+	return (uint8(typ) & 0x0F) | ((precisionZigZagged & 0x0F) << 4), nil
+}
+
+func metadataByte(t geom.T, o marshalOptions) byte {
+	var b byte
+	if t.Empty() {
+		b |= 0b10000
+	}
+	if t.Layout().Stride() > 2 {
+		b |= 0b1000
+	}
+	return b
+}
+
+func extendedDimensionsByte(t geom.T, o marshalOptions) byte {
+	var extDimByte byte
+	// Follow PostGIS and do no bounds checking for precision under/overflow.
+	switch t.Layout() {
+	case geom.XYZ:
+		extDimByte |= 0b1
+		extDimByte |= (byte(o.precisionZ) & 0b111) << 2
+	case geom.XYM:
+		extDimByte |= 0b10
+		extDimByte |= (byte(o.precisionM) & 0b111) << 5
+	case geom.XYZM:
+		extDimByte |= 0b11
+		extDimByte |= (byte(o.precisionZ) & 0b111) << 2
+		extDimByte |= (byte(o.precisionM) & 0b111) << 5
+	}
+	return extDimByte
+}
+
+func zigzagInt8(x int8) byte {
+	if x < 0 {
+		return (uint8(-1-x) << 1) | 0x01
+	}
+	return uint8(x) << 1
+}

--- a/pkg/geo/twkb/twkb_test.go
+++ b/pkg/geo/twkb/twkb_test.go
@@ -1,0 +1,389 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package twkb
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/twpayne/go-geom"
+)
+
+func TestMarshal(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		t        geom.T
+		opts     []MarshalOption
+		expected []byte
+	}{
+		// POINT
+		{
+			desc:     "empty point",
+			t:        geom.NewPointEmpty(geom.XY),
+			expected: mustDecodeHex("0110"),
+		},
+		{
+			desc:     "point",
+			t:        geom.NewPointFlat(geom.XY, []float64{1.5, 2.5}),
+			expected: mustDecodeHex("01000406"),
+		},
+		// LINESTRING
+		{
+			desc:     "empty linestring",
+			t:        geom.NewLineString(geom.XY),
+			expected: mustDecodeHex("0210"),
+		},
+		{
+			desc: "2D linestring",
+			t: geom.NewLineStringFlat(
+				geom.XY,
+				[]float64{
+					1.555, 2.666,
+					55.444, 66.555,
+					33.333, 21.211,
+				},
+			),
+			expected: mustDecodeHex("02000304066a80012b5b"),
+		},
+		{
+			desc: "2D linestring, precision 1",
+			t: geom.NewLineStringFlat(
+				geom.XY,
+				[]float64{
+					1.555, 2.666,
+					55.444, 66.555,
+					33.333, 21.211,
+				},
+			),
+			opts: []MarshalOption{
+				MarshalOptionPrecisionXY(1),
+			},
+			expected: mustDecodeHex("2200032036b408fe09b9038b07"),
+		},
+		{
+			desc: "2D linestring, precision -1",
+			t: geom.NewLineStringFlat(
+				geom.XY,
+				[]float64{
+					1.555, 2.666,
+					55.444, 66.555,
+					33.333, 21.211,
+				},
+			),
+			opts: []MarshalOption{
+				MarshalOptionPrecisionXY(-1),
+			},
+			expected: mustDecodeHex("12000300000c0e0509"),
+		},
+		{
+			desc: "3D linestring, precision XY 1",
+			t: geom.NewLineStringFlat(
+				geom.XYZ,
+				[]float64{
+					1.555, 2.666, 3.777,
+					55.444, 66.555, 4.699,
+					33.333, 21.211, 8.9111,
+				},
+			),
+			opts: []MarshalOption{
+				MarshalOptionPrecisionXY(1),
+			},
+			expected: mustDecodeHex("22080103203608b408fe0902b9038b0708"),
+		},
+		{
+			desc: "M linestring, precision XY 1",
+			t: geom.NewLineStringFlat(
+				geom.XYM,
+				[]float64{
+					1.555, 2.666, 3.777,
+					55.444, 66.555, 4.699,
+					33.333, 21.211, 8.9111,
+				},
+			),
+			opts: []MarshalOption{
+				MarshalOptionPrecisionXY(1),
+			},
+			expected: mustDecodeHex("22080203203608b408fe0902b9038b0708"),
+		},
+		{
+			desc: "4D linestring, precision XY 1, Z 2, M 3",
+			t: geom.NewLineStringFlat(
+				geom.XYZM,
+				[]float64{
+					1.555, 2.666, 3.777, -23232,
+					55.444, 66.555, 4.699, 323224,
+					33.333, 21.211, 8.9111, 231232132,
+				},
+			),
+			opts: []MarshalOption{
+				MarshalOptionPrecisionXY(1),
+				MarshalOptionPrecisionZ(2),
+				MarshalOptionPrecisionM(3),
+			},
+			expected: mustDecodeHex("22086b032036f405fff79316b408fe09b80180ffb3ca02b9038b07ca06c0c7f2b3b80d"),
+		},
+		// POLYGON
+		{
+			desc:     "POLYGON EMPTY",
+			t:        geom.NewPolygon(geom.XY),
+			expected: mustDecodeHex("0310"),
+		},
+		{
+			desc: "POLYGON",
+			t: geom.NewPolygonFlat(
+				geom.XY,
+				[]float64{
+					-1, -1,
+					10, 10,
+					10, 0,
+					-1, -1,
+				},
+				[]int{8},
+			),
+			expected: mustDecodeHex("030001040101161600131501"),
+		},
+		{
+			desc: "POLYGON with ring",
+			t: geom.NewPolygonFlat(
+				geom.XY,
+				[]float64{
+					-1, -1,
+					10, 10,
+					10, 0,
+					-1, -1,
+
+					1, 1,
+					5, 5,
+					5, 1,
+					1, 1,
+				},
+				[]int{8, 16},
+			),
+			expected: mustDecodeHex("030002040101161600131501040404080800070700"),
+		},
+		// MULTIPOINT
+		{
+			desc:     "MULTIPOINT EMPTY",
+			t:        geom.NewMultiPoint(geom.XY),
+			expected: mustDecodeHex("0410"),
+		},
+		{
+			desc:     "MULTIPOINT",
+			t:        geom.NewMultiPointFlat(geom.XY, []float64{10, 10, 15, 5}),
+			expected: mustDecodeHex("04000214140a09"),
+		},
+		{
+			desc: "MULTIPOINT with empty element",
+			t: geom.NewMultiPointFlat(
+				geom.XY,
+				[]float64{10, 10, 15, 5},
+				geom.NewMultiPointFlatOptionWithEnds([]int{2, 2, 4}),
+			),
+			expected: mustDecodeHex("04000214140a09"),
+		},
+		// MULTILINESTRING
+		{
+			desc:     "MULTILINESTRING EMPTY",
+			t:        geom.NewMultiLineString(geom.XY),
+			expected: mustDecodeHex("0510"),
+		},
+		{
+			desc: "MULTILINESTRING",
+			t: geom.NewMultiLineStringFlat(
+				geom.XY,
+				[]float64{
+					10, 10, 15, 5,
+					23, 13, -5, 77, 8, 33,
+				},
+				[]int{4, 10},
+			),
+			expected: mustDecodeHex("0500020214140a090310103780011a57"),
+		},
+		{
+			desc: "MULTILINESTRING with EMPTY element",
+			t: geom.NewMultiLineStringFlat(
+				geom.XY,
+				[]float64{
+					10, 10, 15, 5,
+					23, 13, -5, 77, 8, 33,
+				},
+				[]int{4, 10, 10},
+			),
+			expected: mustDecodeHex("0500030214140a090310103780011a5700"),
+		},
+		// MULTIPOLYGON
+		{
+			desc:     "MULTIPOLYGON EMPTY",
+			t:        geom.NewMultiPolygon(geom.XY),
+			expected: mustDecodeHex("0610"),
+		},
+		{
+			desc: "MULTIPOLYGON",
+			t: geom.NewMultiPolygonFlat(
+				geom.XY,
+				[]float64{
+					-1, -1,
+					10, 10,
+					10, 0,
+					-1, -1,
+
+					1, 1,
+					5, 5,
+					5, 1,
+					1, 1,
+
+					15, 15,
+					35, 15,
+					65, 65,
+					15, 15,
+				},
+				[][]int{
+					{8, 16},
+					{24},
+				},
+			),
+			expected: mustDecodeHex("0600020204010116160013150104040408080007070001041c1c28003c646363"),
+		},
+		{
+			desc: "MULTIPOLYGON with empty",
+			t: geom.NewMultiPolygonFlat(
+				geom.XY,
+				[]float64{
+					-1, -1,
+					10, 10,
+					10, 0,
+					-1, -1,
+
+					1, 1,
+					5, 5,
+					5, 1,
+					1, 1,
+
+					15, 15,
+					35, 15,
+					65, 65,
+					15, 15,
+				},
+				[][]int{
+					{8, 16},
+					{},
+					{24},
+				},
+			),
+			expected: mustDecodeHex("060003020401011616001315010404040808000707000001041c1c28003c646363"),
+		},
+		// GEOMETRYCOLLECTION
+		{
+			desc:     "GEOMETRYCOLLECTION EMPTY",
+			t:        geom.NewGeometryCollection().MustSetLayout(geom.XY),
+			expected: mustDecodeHex("0710"),
+		},
+		{
+			desc: "GEOMETRYCOLLECTION",
+			t: geom.NewGeometryCollection().MustSetLayout(geom.XY).MustPush(
+				geom.NewPointFlat(geom.XY, []float64{15, 25}),
+				geom.NewPointFlat(geom.XY, []float64{25, 35}),
+				geom.NewGeometryCollection().MustPush(
+					geom.NewLineStringFlat(
+						geom.XY,
+						[]float64{
+							-30, 60,
+							-15, -15,
+							30, 35,
+						},
+					),
+				),
+			),
+			expected: mustDecodeHex("07000301001e32010032460700010200033b781e95015a64"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			out, err := Marshal(tc.t, tc.opts...)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, out)
+		})
+	}
+
+	errorTestCases := []struct {
+		desc                string
+		t                   geom.T
+		opts                []MarshalOption
+		expectedErrorString string
+	}{
+		{
+			desc: "XY precision too small",
+			t:    geom.NewPointEmpty(geom.XYZM),
+			opts: []MarshalOption{
+				MarshalOptionPrecisionXY(-8),
+			},
+			expectedErrorString: "XY precision must be between -7 and 7 inclusive",
+		},
+		{
+			desc: "XY precision too large",
+			t:    geom.NewPointEmpty(geom.XYZM),
+			opts: []MarshalOption{
+				MarshalOptionPrecisionXY(8),
+			},
+			expectedErrorString: "XY precision must be between -7 and 7 inclusive",
+		},
+		{
+			desc: "Z precision too small",
+			t:    geom.NewPointEmpty(geom.XYZM),
+			opts: []MarshalOption{
+				MarshalOptionPrecisionZ(-1),
+			},
+			expectedErrorString: "Z precision must not be negative or greater than 7",
+		},
+		{
+			desc: "Z precision too large",
+			t:    geom.NewPointEmpty(geom.XYZM),
+			opts: []MarshalOption{
+				MarshalOptionPrecisionZ(8),
+			},
+			expectedErrorString: "Z precision must not be negative or greater than 7",
+		},
+		{
+			desc: "M precision too small",
+			t:    geom.NewPointEmpty(geom.XYZM),
+			opts: []MarshalOption{
+				MarshalOptionPrecisionM(-1),
+			},
+			expectedErrorString: "M precision must not be negative or greater than 7",
+		},
+		{
+			desc: "M precision too large",
+			t:    geom.NewPointEmpty(geom.XYZM),
+			opts: []MarshalOption{
+				MarshalOptionPrecisionM(8),
+			},
+			expectedErrorString: "M precision must not be negative or greater than 7",
+		},
+	}
+
+	for _, tc := range errorTestCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			_, err := Marshal(tc.t, tc.opts...)
+			require.Error(t, err)
+			require.EqualError(t, err, tc.expectedErrorString)
+		})
+	}
+}
+
+func mustDecodeHex(h string) []byte {
+	ret, err := hex.DecodeString(h)
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}

--- a/pkg/sql/logictest/testdata/logic_test/geospatial_zm
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial_zm
@@ -360,3 +360,18 @@ query R
 SELECT st_length('LINESTRING M(0 0 -25, 1 1 -50, 2 2 0)')
 ----
 2.82842712474619
+
+query TTT
+SELECT
+  encode(ST_AsTWKB(t, 5), 'hex'),
+  encode(ST_AsTWKB(t, 5, 3), 'hex'),
+  encode(ST_AsTWKB(t, 5, 3, 4), 'hex')
+FROM ( VALUES
+  ('POINT(2 1)'::geometry),
+  ('LINESTRING(2 1 7 2, 5 6 3 7)'::geometry),
+  ('POLYGON((2 3 1, 3 4 1, 1 3 6, 2 3 1))'::geometry)
+) AS t(t)
+----
+a10080b518c09a0c                                                a10080b518c09a0c                                                      a10080b518c09a0c
+a208030280b518c09a0c0e04c0cf24c0843d070a                        a2080f0280b518c09a0cb06d04c0cf24c0843dbf3e0a                          a2088f0280b518c09a0cb06dc0b802c0cf24c0843dbf3ea08d06
+a30801010480b518c0cf2402c09a0cc09a0c00ffb418bf9a0c0ac09a0c0009  a3080d010480b518c0cf24d00fc09a0cc09a0c00ffb418bf9a0c904ec09a0c008f4e  a3080d010480b518c0cf24d00fc09a0cc09a0c00ffb418bf9a0c904ec09a0c008f4e

--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/geo/geoprojbase",
         "//pkg/geo/geos",
         "//pkg/geo/geotransform",
+        "//pkg/geo/twkb",
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/kv/kvclient",

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/geo/geoprojbase"
 	"github.com/cockroachdb/cockroach/pkg/geo/geotransform"
+	"github.com/cockroachdb/cockroach/pkg/geo/twkb"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/paramparse"
@@ -1516,6 +1517,90 @@ SELECT ST_S2Covering(geography, 's2_max_level=15,s2_level_mod=3').
 			Info: infoBuilder{
 				info: "Returns the EWKB representation in hex of a given Geography. " +
 					"This variant has a second argument denoting the encoding - `xdr` for big endian and `ndr` for little endian.",
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+	),
+	"st_astwkb": makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"geometry", types.Geometry},
+				{"precision_xy", types.Int},
+			},
+			ReturnType: tree.FixedReturnType(types.Bytes),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				t, err := tree.MustBeDGeometry(args[0]).AsGeomT()
+				if err != nil {
+					return nil, err
+				}
+				ret, err := twkb.Marshal(
+					t,
+					twkb.MarshalOptionPrecisionXY(int64(tree.MustBeDInt(args[1]))),
+				)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDBytes(tree.DBytes(ret)), nil
+			},
+			Info: infoBuilder{
+				info: "Returns the TWKB representation of a given geometry.",
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"geometry", types.Geometry},
+				{"precision_xy", types.Int},
+				{"precision_z", types.Int},
+			},
+			ReturnType: tree.FixedReturnType(types.Bytes),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				t, err := tree.MustBeDGeometry(args[0]).AsGeomT()
+				if err != nil {
+					return nil, err
+				}
+				ret, err := twkb.Marshal(
+					t,
+					twkb.MarshalOptionPrecisionXY(int64(tree.MustBeDInt(args[1]))),
+					twkb.MarshalOptionPrecisionZ(int64(tree.MustBeDInt(args[2]))),
+				)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDBytes(tree.DBytes(ret)), nil
+			},
+			Info: infoBuilder{
+				info: "Returns the TWKB representation of a given geometry.",
+			}.String(),
+			Volatility: tree.VolatilityImmutable,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"geometry", types.Geometry},
+				{"precision_xy", types.Int},
+				{"precision_z", types.Int},
+				{"precision_m", types.Int},
+			},
+			ReturnType: tree.FixedReturnType(types.Bytes),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				t, err := tree.MustBeDGeometry(args[0]).AsGeomT()
+				if err != nil {
+					return nil, err
+				}
+				ret, err := twkb.Marshal(
+					t,
+					twkb.MarshalOptionPrecisionXY(int64(tree.MustBeDInt(args[1]))),
+					twkb.MarshalOptionPrecisionZ(int64(tree.MustBeDInt(args[2]))),
+					twkb.MarshalOptionPrecisionM(int64(tree.MustBeDInt(args[3]))),
+				)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDBytes(tree.DBytes(ret)), nil
+			},
+			Info: infoBuilder{
+				info: "Returns the TWKB representation of a given geometry.",
 			}.String(),
 			Volatility: tree.VolatilityImmutable,
 		},
@@ -6494,7 +6579,6 @@ May return a Point or LineString in the case of degenerate inputs.`,
 	"st_asgml":                 makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48877}),
 	"st_aslatlontext":          makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48882}),
 	"st_assvg":                 makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48883}),
-	"st_astwkb":                makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48886}),
 	"st_boundingdiagonal":      makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48889}),
 	"st_buildarea":             makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48892}),
 	"st_chaikinsmoothing":      makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 48894}),


### PR DESCRIPTION
Refs #48886, #52013

Release note (sql change): Implement a subset of variants for ST_AsTWKB,
which encodes a geometry into a TWKB format. This allows the use of
GeoServer with CRDB if the user selects "PreserveTopology" for their
"Method used to simplify geometries" option on the "Store" page.