### PR TITLE
changefeedccl: support arrays in avro encoding

### DIFF
--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -59,6 +59,7 @@ import (
 type avroSchemaType interface{}
 
 const (
+	avroSchemaArray   = `array`
 	avroSchemaBoolean = `boolean`
 	avroSchemaBytes   = `bytes`
 	avroSchemaDouble  = `double`
@@ -75,12 +76,19 @@ type avroLogicalType struct {
 	Scale       int            `json:"scale,omitempty"`
 }
 
+type avroArrayType struct {
+	SchemaType avroSchemaType `json:"type"`
+	Items      avroSchemaType `json:"items"`
+}
+
 func avroUnionKey(t avroSchemaType) string {
 	switch s := t.(type) {
 	case string:
 		return s
 	case avroLogicalType:
 		return avroUnionKey(s.SchemaType) + `.` + s.LogicalType
+	case avroArrayType:
+		return avroUnionKey(s.SchemaType)
 	case *avroRecord:
 		if s.Namespace == "" {
 			return s.Name
@@ -159,14 +167,12 @@ type avroEnvelopeRecord struct {
 	before, after *avroDataRecord
 }
 
-// columnToAvroSchema converts a column descriptor into its corresponding
-// avro field schema.
-func columnToAvroSchema(col catalog.Column) (*avroSchemaField, error) {
+// typeToAvroSchema converts a database type to an avro field
+// reuseMap is false for nested elements since the same key may occur multiple times
+// we may need a map pool or a streaming serializer if elements get too big
+func typeToAvroSchema(typ *types.T, reuseMap bool) (*avroSchemaField, error) {
 	schema := &avroSchemaField{
-		Name:     SQLNameToAvroName(col.GetName()),
-		Metadata: col.ColumnDesc().SQLStringNotHumanReadable(),
-		Default:  nil,
-		typ:      col.GetType(),
+		typ: typ,
 	}
 
 	// Make every field optional by unioning it with null, so that all schema
@@ -193,8 +199,11 @@ func columnToAvroSchema(col catalog.Column) (*avroSchemaField, error) {
 			if err != nil {
 				return nil, err
 			}
-			schema.nativeEncoded[unionKey] = encoded
-			return schema.nativeEncoded, nil
+			if reuseMap {
+				schema.nativeEncoded[unionKey] = encoded
+				return schema.nativeEncoded, nil
+			}
+			return map[string]interface{}{unionKey: encoded}, nil
 		}
 		schema.decodeFn = func(x interface{}) (tree.Datum, error) {
 			if x == nil {
@@ -204,7 +213,7 @@ func columnToAvroSchema(col catalog.Column) (*avroSchemaField, error) {
 		}
 	}
 
-	switch col.GetType().Family() {
+	switch typ.Family() {
 	case types.IntFamily:
 		setNullable(
 			avroSchemaLong,
@@ -307,7 +316,7 @@ func columnToAvroSchema(col catalog.Column) (*avroSchemaField, error) {
 				date := *d.(*tree.DDate)
 				if !date.IsFinite() {
 					return nil, errors.Errorf(
-						`column %s: infinite date not yet supported with avro`, col.GetName())
+						`infinite date not yet supported with avro`)
 				}
 				// The avro library requires us to return this as a time.Time.
 				return date.ToTime()
@@ -374,13 +383,13 @@ func columnToAvroSchema(col catalog.Column) (*avroSchemaField, error) {
 			},
 		)
 	case types.DecimalFamily:
-		if col.GetType().Precision() == 0 {
+		if typ.Precision() == 0 {
 			return nil, errors.Errorf(
-				`column %s: decimal with no precision not yet supported with avro`, col.GetName())
+				`decimal with no precision not yet supported with avro`)
 		}
 
-		width := int(col.GetType().Width())
-		prec := int(col.GetType().Precision())
+		width := int(typ.Width())
+		prec := int(typ.Precision())
 		setNullable(
 			avroLogicalType{
 				SchemaType:  avroSchemaBytes,
@@ -393,7 +402,7 @@ func columnToAvroSchema(col catalog.Column) (*avroSchemaField, error) {
 
 				// If the decimal happens to fit a smaller width than the
 				// column allows, add trailing zeroes so the scale is constant
-				if col.GetType().Width() > -dec.Exponent {
+				if typ.Width() > -dec.Exponent {
 					_, err := tree.DecimalCtx.WithPrecision(uint32(prec)).Quantize(&dec, &dec, -int32(width))
 					if err != nil {
 						// This should always be possible without rounding since we're using the column def,
@@ -449,10 +458,65 @@ func columnToAvroSchema(col catalog.Column) (*avroSchemaField, error) {
 				return tree.ParseDJSON(x.(string))
 			},
 		)
+	case types.ArrayFamily:
+		itemSchema, err := typeToAvroSchema(typ.ArrayContents(), false /*reuse map*/)
+		if err != nil {
+			return nil, errors.Wrapf(err, `could not create item schema for %s`,
+				typ)
+		}
+		setNullable(
+			avroArrayType{
+				SchemaType: avroSchemaArray,
+				Items:      itemSchema.SchemaType,
+			},
+			func(d tree.Datum) (interface{}, error) {
+				datumArr := d.(*tree.DArray)
+				avroArr := make([]interface{}, datumArr.Len())
+				for i, elt := range datumArr.Array {
+					encoded, err := itemSchema.encodeFn(elt)
+					if err != nil {
+						return nil, err
+					}
+					avroArr[i] = encoded
+				}
+				return avroArr, nil
+
+			},
+			func(x interface{}) (tree.Datum, error) {
+				datumArr := tree.NewDArray(itemSchema.typ)
+				avroArr := x.([]interface{})
+				for _, item := range avroArr {
+					itemDatum, err := itemSchema.decodeFn(item)
+					if err != nil {
+						return nil, err
+					}
+					err = datumArr.Append(itemDatum)
+					if err != nil {
+						return nil, err
+					}
+				}
+				return datumArr, nil
+			},
+		)
+
 	default:
-		return nil, errors.Errorf(`column %s: type %s not yet supported with avro`,
-			col.GetName(), col.GetType().SQLString())
+		return nil, errors.Errorf(`type %s not yet supported with avro`,
+			typ.SQLString())
 	}
+
+	return schema, nil
+}
+
+// columnToAvroSchema converts a column descriptor into its corresponding
+// avro field schema.
+func columnToAvroSchema(col catalog.Column) (*avroSchemaField, error) {
+	schema, err := typeToAvroSchema(col.GetType(), true /*reuse map */)
+	if err != nil {
+		return nil, errors.Wrapf(err, "column %s", col.GetName())
+	}
+	schema.Name = SQLNameToAvroName(col.GetName())
+	schema.Metadata = col.ColumnDesc().SQLStringNotHumanReadable()
+	schema.Default = nil
 
 	return schema, nil
 }

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -173,24 +173,12 @@ func TestAvroSchema(t *testing.T) {
 			values: `(1, 1.23, 4.5)`,
 		},
 	}
-	// Generate a test for each column type with a random datum of that type.
-	for _, typ := range types.OidToType {
-		switch typ.Family() {
-		case types.AnyFamily, types.OidFamily, types.TupleFamily:
-			// These aren't expected to be needed for changefeeds.
-			continue
-		case types.IntervalFamily, types.ArrayFamily, types.BitFamily,
-			types.CollatedStringFamily:
-			// Implement these as customer demand dictates.
-			continue
-		}
-		datum := randgen.RandDatum(rng, typ, false /* nullOk */)
-		if datum == tree.DNull {
-			// DNull is returned by RandDatum for types.UNKNOWN or if the
-			// column type is unimplemented in RandDatum. In either case, the
-			// correct thing to do is skip this one.
-			continue
-		}
+
+	// Type-specific random logic for when we can't use the randgen library
+	// and/or need to modify the type to add random user-defined values
+	// The returned datum will be nil if we can just use randgen
+	var overrideRandGen func(typ *types.T) (tree.Datum, *types.T)
+	overrideRandGen = func(typ *types.T) (tree.Datum, *types.T) {
 		switch typ.Family() {
 		case types.TimestampFamily:
 			// Truncate to millisecond instead of microsecond because of a bug
@@ -202,31 +190,95 @@ func TestAvroSchema(t *testing.T) {
 			// whose nanosecond representation overflows an
 			// int64, so restrict input to fit.
 			t := randTime(rng).Truncate(time.Millisecond)
-			datum = tree.MustMakeDTimestamp(t, time.Microsecond)
+			return tree.MustMakeDTimestamp(t, time.Microsecond), typ
 		case types.TimestampTZFamily:
 			// See comments above for TimestampFamily.
 			t := randTime(rng).Truncate(time.Millisecond)
-			datum = tree.MustMakeDTimestampTZ(t, time.Microsecond)
+			return tree.MustMakeDTimestampTZ(t, time.Microsecond), typ
 		case types.DecimalFamily:
 			// TODO(dan): Make RandDatum respect Precision and Width instead.
 			// TODO(dan): The precision is really meant to be in [1,10], but it
 			// sure looks like there's an off by one error in the avro library
 			// that makes this test flake if it picks precision of 1.
-			precision := rng.Int31n(10) + 2
-			scale := rng.Int31n(precision + 1)
-			typ = types.MakeDecimal(precision, scale)
+			var precision, scale int32
+			if typ.Precision() < 2 {
+				precision = rng.Int31n(10) + 2
+				scale = rng.Int31n(precision + 1)
+				typ = types.MakeDecimal(precision, scale)
+			} else {
+				precision = typ.Precision()
+				scale = typ.Scale()
+			}
 			coeff := rng.Int63n(int64(math.Pow10(int(precision))))
-			datum = &tree.DDecimal{Decimal: *apd.New(coeff, -scale)}
+			return &tree.DDecimal{Decimal: *apd.New(coeff, -scale)}, typ
 		case types.DateFamily:
 			// TODO(mjibson): goavro mishandles dates whose
 			// nanosecond representation overflows an int64,
 			// so restrict input to fit.
 			var err error
-			datum, err = tree.NewDDateFromTime(randTime(rng))
+			datum, err := tree.NewDDateFromTime(randTime(rng))
 			if err != nil {
 				panic(err)
 			}
+			return datum, typ
+		case types.ArrayFamily:
+			// Apply the other cases in this function
+			// to the contents of the array
+			contentType := typ.ArrayContents()
+			el, contentType := overrideRandGen(contentType)
+			if el == nil {
+				return nil, typ
+			}
+			typ.InternalType.ArrayContents = contentType
+			datum := randgen.RandDatum(rng, typ, false /* nullOk */)
+			for i := range datum.(*tree.DArray).Array {
+				datum.(*tree.DArray).Array[i], _ = overrideRandGen(contentType)
+			}
+			return datum, typ
+
 		}
+		return nil, typ
+	}
+
+	// Types we don't support that are present in types.OidToType
+	var skipType func(typ *types.T) bool
+	skipType = func(typ *types.T) bool {
+		switch typ.Family() {
+		case types.AnyFamily, types.OidFamily, types.TupleFamily:
+			// These aren't expected to be needed for changefeeds.
+			return true
+		case types.IntervalFamily, types.BitFamily,
+			types.CollatedStringFamily:
+			// Implement these as customer demand dictates.
+			return true
+		case types.ArrayFamily:
+			if !randgen.IsAllowedForArray(typ.ArrayContents()) {
+				return true
+			}
+			if skipType(typ.ArrayContents()) {
+				return true
+			}
+		}
+		return !randgen.IsLegalColumnType(typ)
+	}
+
+	// Generate a test for each column type with a random datum of that type.
+	for _, typ := range types.OidToType {
+		if skipType(typ) {
+			continue
+		}
+		var datum tree.Datum
+		datum, typ = overrideRandGen(typ)
+		if datum == nil {
+			datum = randgen.RandDatum(rng, typ, false /* nullOk */)
+		}
+		if datum == tree.DNull {
+			// DNull is returned by RandDatum for types.UNKNOWN or if the
+			// column type is unimplemented in RandDatum. In either case, the
+			// correct thing to do is skip this one.
+			continue
+		}
+
 		serializedDatum := tree.Serialize(datum)
 		// name can be "char" (with quotes), so needs to be escaped.
 		escapedName := fmt.Sprintf("%s_table", strings.Replace(typ.String(), "\"", "", -1))
@@ -301,6 +353,7 @@ func TestAvroSchema(t *testing.T) {
 	t.Run("type_goldens", func(t *testing.T) {
 		goldens := map[string]string{
 			`BOOL`:         `["null","boolean"]`,
+			`BOOL[]`:       `["null",{"type":"array","items":["null","boolean"]}]`,
 			`BOX2D`:        `["null","string"]`,
 			`BYTES`:        `["null","bytes"]`,
 			`DATE`:         `["null",{"type":"int","logicalType":"date"}]`,
@@ -319,7 +372,7 @@ func TestAvroSchema(t *testing.T) {
 			`DECIMAL(3,2)`: `["null",{"type":"bytes","logicalType":"decimal","precision":3,"scale":2}]`,
 		}
 
-		for _, typ := range types.Scalar {
+		for _, typ := range append(types.Scalar, types.BoolArray) {
 			switch typ.Family() {
 			case types.IntervalFamily, types.OidFamily, types.BitFamily:
 				continue
@@ -443,6 +496,9 @@ func TestAvroSchema(t *testing.T) {
 			{sqlType: `JSONB`,
 				sql:  `'{"b": 1}'`,
 				avro: `{"string":"{\"b\": 1}"}`},
+			{sqlType: `BOOL[]`,
+				sql:  `'{true, true, false, null}'`,
+				avro: `{"array":[{"boolean":true},{"boolean":true},{"boolean":false},null]}`},
 		}
 
 		for _, test := range goldens {
@@ -709,6 +765,10 @@ func randEncDatumRow(typ *types.T) rowenc.EncDatumRow {
 		rowenc.DatumToEncDatum(typ, randgen.RandDatum(rnd, typ, allowNull)),
 		rowenc.DatumToEncDatum(types.Int, randgen.RandDatum(rnd, types.Int, notNull)),
 	}
+}
+
+func BenchmarkEncodeIntArray(b *testing.B) {
+	benchmarkEncodeType(b, types.IntArray, randEncDatumRow(types.IntArray))
 }
 
 func BenchmarkEncodeInt(b *testing.B) {

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -313,6 +313,40 @@ func TestAvroEncoder(t *testing.T) {
 	t.Run(`enterprise`, enterpriseTest(testFn))
 }
 
+func TestAvroArray(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		reg := cdctest.MakeTestSchemaRegistry()
+		defer reg.Close()
+
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b INT[])`)
+		sqlDB.Exec(t,
+			`INSERT INTO foo VALUES 
+			(1, ARRAY[10,20,30]), 
+			(2, NULL), 
+			(3, ARRAY[42, NULL, 42, 43]),
+			(4, ARRAY[])`,
+		)
+
+		foo := feed(t, f, `CREATE CHANGEFEED FOR foo `+
+			`WITH format=$1, confluent_schema_registry=$2, diff, resolved`,
+			changefeedbase.OptFormatAvro, reg.URL())
+		defer closeFeed(t, foo)
+		assertPayloadsAvro(t, reg, foo, []string{
+			`foo: {"a":{"long":1}}->{"after":{"foo":{"a":{"long":1},"b":{"array":[{"long":10},{"long":20},{"long":30}]}}},"before":null}`,
+			`foo: {"a":{"long":2}}->{"after":{"foo":{"a":{"long":2},"b":null}},"before":null}`,
+			`foo: {"a":{"long":3}}->{"after":{"foo":{"a":{"long":3},"b":{"array":[{"long":42},null,{"long":42},{"long":43}]}}},"before":null}`,
+			`foo: {"a":{"long":4}}->{"after":{"foo":{"a":{"long":4},"b":{"array":[]}}},"before":null}`,
+		})
+	}
+
+	t.Run(`sinkless`, sinklessTest(testFn))
+	t.Run(`enterprise`, enterpriseTest(testFn))
+}
+
 func TestAvroSchemaNaming(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)


### PR DESCRIPTION
Arrays are one of a few remaining types we don't support
in avro changefeeds. This serializes them.
Sadly can't use @miretskiy's new optimization since we
need to load multiple maps with the same key into an array.

Release note (bug fix): Changefeeds on tables with array columns support avro