### PR TITLE
opt: use exact prefix to improve scan ordering

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -683,7 +683,7 @@ func (b *Builder) buildPlaceholderScan(scan *memo.PlaceholderScanExpr) (execPlan
 	c.Init(&keyCtx, &spans)
 
 	private := scan.ScanPrivate
-	private.Constraint = &c
+	private.SetConstraint(b.evalCtx, &c)
 
 	params, outputCols, err := b.scanParams(tab, &private, scan.Relational(), scan.RequiredPhysical())
 	if err != nil {

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -432,82 +432,50 @@ vectorized: true
     │   │   │   │   │   ├── • union
     │   │   │   │   │   │   │ estimated row count: 10
     │   │   │   │   │   │   │
-    │   │   │   │   │   │   ├── • sort
-    │   │   │   │   │   │   │   │ estimated row count: 5
-    │   │   │   │   │   │   │   │ order: +date_should_be_completed
-    │   │   │   │   │   │   │   │
-    │   │   │   │   │   │   │   └── • scan
-    │   │   │   │   │   │   │         estimated row count: 5 (0.05% of the table; stats collected <hidden> ago)
-    │   │   │   │   │   │   │         table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
-    │   │   │   │   │   │   │         spans: [/0/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /0/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
-    │   │   │   │   │   │   │         limit: 5
+    │   │   │   │   │   │   ├── • scan
+    │   │   │   │   │   │   │     estimated row count: 5 (0.05% of the table; stats collected <hidden> ago)
+    │   │   │   │   │   │   │     table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
+    │   │   │   │   │   │   │     spans: [/0/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /0/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
+    │   │   │   │   │   │   │     limit: 5
     │   │   │   │   │   │   │
-    │   │   │   │   │   │   └── • sort
-    │   │   │   │   │   │       │ estimated row count: 5
-    │   │   │   │   │   │       │ order: +date_should_be_completed
-    │   │   │   │   │   │       │
-    │   │   │   │   │   │       └── • scan
-    │   │   │   │   │   │             estimated row count: 5 (0.05% of the table; stats collected <hidden> ago)
-    │   │   │   │   │   │             table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
-    │   │   │   │   │   │             spans: [/1/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /1/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
-    │   │   │   │   │   │             limit: 5
+    │   │   │   │   │   │   └── • scan
+    │   │   │   │   │   │         estimated row count: 5 (0.05% of the table; stats collected <hidden> ago)
+    │   │   │   │   │   │         table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
+    │   │   │   │   │   │         spans: [/1/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /1/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
+    │   │   │   │   │   │         limit: 5
     │   │   │   │   │   │
-    │   │   │   │   │   └── • sort
-    │   │   │   │   │       │ estimated row count: 5
-    │   │   │   │   │       │ order: +date_should_be_completed
-    │   │   │   │   │       │
-    │   │   │   │   │       └── • scan
-    │   │   │   │   │             estimated row count: 5 (0.05% of the table; stats collected <hidden> ago)
-    │   │   │   │   │             table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
-    │   │   │   │   │             spans: [/2/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /2/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
-    │   │   │   │   │             limit: 5
+    │   │   │   │   │   └── • scan
+    │   │   │   │   │         estimated row count: 5 (0.05% of the table; stats collected <hidden> ago)
+    │   │   │   │   │         table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
+    │   │   │   │   │         spans: [/2/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /2/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
+    │   │   │   │   │         limit: 5
     │   │   │   │   │
-    │   │   │   │   └── • sort
-    │   │   │   │       │ estimated row count: 5
-    │   │   │   │       │ order: +date_should_be_completed
-    │   │   │   │       │
-    │   │   │   │       └── • scan
-    │   │   │   │             estimated row count: 5 (0.05% of the table; stats collected <hidden> ago)
-    │   │   │   │             table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
-    │   │   │   │             spans: [/3/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /3/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
-    │   │   │   │             limit: 5
+    │   │   │   │   └── • scan
+    │   │   │   │         estimated row count: 5 (0.05% of the table; stats collected <hidden> ago)
+    │   │   │   │         table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
+    │   │   │   │         spans: [/3/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /3/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
+    │   │   │   │         limit: 5
     │   │   │   │
-    │   │   │   └── • sort
-    │   │   │       │ estimated row count: 5
-    │   │   │       │ order: +date_should_be_completed
-    │   │   │       │
-    │   │   │       └── • scan
-    │   │   │             estimated row count: 5 (0.05% of the table; stats collected <hidden> ago)
-    │   │   │             table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
-    │   │   │             spans: [/4/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /4/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
-    │   │   │             limit: 5
+    │   │   │   └── • scan
+    │   │   │         estimated row count: 5 (0.05% of the table; stats collected <hidden> ago)
+    │   │   │         table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
+    │   │   │         spans: [/4/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /4/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
+    │   │   │         limit: 5
     │   │   │
-    │   │   └── • sort
-    │   │       │ estimated row count: 5
-    │   │       │ order: +date_should_be_completed
-    │   │       │
-    │   │       └── • scan
-    │   │             estimated row count: 5 (0.05% of the table; stats collected <hidden> ago)
-    │   │             table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
-    │   │             spans: [/5/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /5/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
-    │   │             limit: 5
+    │   │   └── • scan
+    │   │         estimated row count: 5 (0.05% of the table; stats collected <hidden> ago)
+    │   │         table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
+    │   │         spans: [/5/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /5/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
+    │   │         limit: 5
     │   │
-    │   └── • sort
-    │       │ estimated row count: 5
-    │       │ order: +date_should_be_completed
-    │       │
-    │       └── • scan
-    │             estimated row count: 5 (0.05% of the table; stats collected <hidden> ago)
-    │             table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
-    │             spans: [/6/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /6/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
-    │             limit: 5
+    │   └── • scan
+    │         estimated row count: 5 (0.05% of the table; stats collected <hidden> ago)
+    │         table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
+    │         spans: [/6/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /6/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
+    │         limit: 5
     │
-    └── • sort
-        │ estimated row count: 5
-        │ order: +date_should_be_completed
-        │
-        └── • scan
-              estimated row count: 5 (0.05% of the table; stats collected <hidden> ago)
-              table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
-              spans: [/7/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /7/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
-              limit: 5
+    └── • scan
+          estimated row count: 5 (0.05% of the table; stats collected <hidden> ago)
+          table: user_checklist_items@userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem
+          spans: [/7/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f'/'2020-10-01' - /7/'a2a0dd49-23cf-4cf2-b823-61701c416e60'/'01603523-c6f0-4e12-a43f-524c76b0fa8f']
+          limit: 5

--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -76,6 +76,13 @@ func (m *Memo) CheckExpr(e opt.Expr) {
 		if t.Flags.NoIndexJoin && t.Flags.ForceIndex {
 			panic(errors.AssertionFailedf("NoIndexJoin and ForceIndex set"))
 		}
+		if evalCtx := m.logPropsBuilder.evalCtx; evalCtx != nil && t.Constraint != nil {
+			if expected := t.Constraint.ExactPrefix(evalCtx); expected != t.ExactPrefix {
+				panic(errors.AssertionFailedf(
+					"expected exact prefix %d but found %d", expected, t.ExactPrefix,
+				))
+			}
+		}
 
 	case *ProjectExpr:
 		if !t.Passthrough.SubsetOf(t.Input.Relational().OutputCols) {

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -665,6 +666,18 @@ func (s *ScanPrivate) PartialIndexPredicate(md *opt.Metadata) FiltersExpr {
 		return nil
 	}
 	return *p.(*FiltersExpr)
+}
+
+// SetConstraint sets the constraint in the ScanPrivate and caches the exact
+// prefix. This function should always be used instead of modifying the
+// constraint directly.
+func (s *ScanPrivate) SetConstraint(evalCtx *tree.EvalContext, c *constraint.Constraint) {
+	s.Constraint = c
+	if c == nil {
+		s.ExactPrefix = 0
+	} else {
+		s.ExactPrefix = c.ExactPrefix(evalCtx)
+	}
 }
 
 // UsesPartialIndex returns true if the LookupJoinPrivate looks-up via a

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -92,6 +92,9 @@ define ScanPrivate {
     # to constrain the lookup spans further. This flag is used to record telemetry
     # about how often this optimization is getting applied.
     PartitionConstrainedScan bool
+
+    # ExactPrefix caches the exact prefix of the Constraint.
+    ExactPrefix int
 }
 
 # PlaceholderScan is a special variant of Scan. It scans exactly one span of a

--- a/pkg/sql/opt/ordering/scan_test.go
+++ b/pkg/sql/opt/ordering/scan_test.go
@@ -65,6 +65,7 @@ func TestScan(t *testing.T) {
 
 	type testGroup struct {
 		p     memo.ScanPrivate
+		c     *constraint.Constraint
 		cases []testCase
 	}
 
@@ -149,11 +150,11 @@ func TestScan(t *testing.T) {
 		},
 		{ // group 5: scan with constraint.
 			p: memo.ScanPrivate{
-				Table:      tab,
-				Index:      1,
-				Cols:       opt.MakeColSet(1, 2, 3, 4),
-				Constraint: &c,
+				Table: tab,
+				Index: 1,
+				Cols:  opt.MakeColSet(1, 2, 3, 4),
 			},
+			c: &c,
 			cases: []testCase{
 				{req: "-3", exp: "fwd", prov: ""},                   // case 1
 				{req: "-3,+4", exp: "fwd", prov: "+4"},              // case 2
@@ -169,6 +170,7 @@ func TestScan(t *testing.T) {
 			for tcIdx, tc := range g.cases {
 				t.Run(fmt.Sprintf("case%d", tcIdx+1), func(t *testing.T) {
 					req := physical.ParseOrderingChoice(tc.req)
+					g.p.SetConstraint(evalCtx, g.c)
 					ok, rev := ScanPrivateCanProvide(md, &g.p, &req)
 					res := "no"
 					if ok {

--- a/pkg/sql/opt/xform/limit_funcs.go
+++ b/pkg/sql/opt/xform/limit_funcs.go
@@ -329,10 +329,10 @@ func (c *CustomFuncs) SplitScanIntoUnionScans(
 	// If any spans could not be used to generate limited Scans, use them to
 	// construct an unlimited Scan and add it to the Union tree.
 	newScanPrivate := c.DuplicateScanPrivate(sp)
-	newScanPrivate.Constraint = &constraint.Constraint{
+	newScanPrivate.SetConstraint(c.e.evalCtx, &constraint.Constraint{
 		Columns: sp.Constraint.Columns.RemapColumns(sp.Table, newScanPrivate.Table),
 		Spans:   noLimitSpans,
-	}
+	})
 	newScan := c.e.f.ConstructScan(newScanPrivate)
 	return makeNewUnion(last, newScan, sp.Cols.ToList())
 }
@@ -423,7 +423,7 @@ func (c *CustomFuncs) makeNewScan(
 		Columns: columns.RemapColumns(sp.Table, newScanPrivate.Table),
 		Spans:   newSpans,
 	}
-	newScanPrivate.Constraint = newConstraint
+	newScanPrivate.SetConstraint(c.e.evalCtx, newConstraint)
 
 	return c.e.f.ConstructScan(newScanPrivate)
 }

--- a/pkg/sql/opt/xform/scan_funcs.go
+++ b/pkg/sql/opt/xform/scan_funcs.go
@@ -188,14 +188,14 @@ func (c *CustomFuncs) GenerateLocalityOptimizedScan(
 	localScanPrivate := c.DuplicateScanPrivate(scanPrivate)
 	localScanPrivate.LocalityOptimized = true
 	localConstraint.Columns = localConstraint.Columns.RemapColumns(scanPrivate.Table, localScanPrivate.Table)
-	localScanPrivate.Constraint = &localConstraint
+	localScanPrivate.SetConstraint(c.e.evalCtx, &localConstraint)
 	localScan := c.e.f.ConstructScan(localScanPrivate)
 
 	// Create the remote scan.
 	remoteScanPrivate := c.DuplicateScanPrivate(scanPrivate)
 	remoteScanPrivate.LocalityOptimized = true
 	remoteConstraint.Columns = remoteConstraint.Columns.RemapColumns(scanPrivate.Table, remoteScanPrivate.Table)
-	remoteScanPrivate.Constraint = &remoteConstraint
+	remoteScanPrivate.SetConstraint(c.e.evalCtx, &remoteConstraint)
 	remoteScan := c.e.f.ConstructScan(remoteScanPrivate)
 
 	// Add the LocalityOptimizedSearchExpr to the same group as the original scan.

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -338,7 +338,7 @@ func (c *CustomFuncs) GenerateConstrainedScans(
 		newScanPrivate := *scanPrivate
 		newScanPrivate.Index = index.Ordinal()
 		newScanPrivate.Cols = indexCols.Intersection(scanPrivate.Cols)
-		newScanPrivate.Constraint = constraint
+		newScanPrivate.SetConstraint(c.e.evalCtx, constraint)
 		// Record whether we were able to use partitions to constrain the scan.
 		newScanPrivate.PartitionConstrainedScan = (len(partitionFilters) > 0)
 
@@ -776,7 +776,7 @@ func (c *CustomFuncs) GenerateInvertedIndexScans(
 		// Construct new ScanOpDef with the new index and constraint.
 		newScanPrivate := *scanPrivate
 		newScanPrivate.Index = index.Ordinal()
-		newScanPrivate.Constraint = constraint
+		newScanPrivate.SetConstraint(c.e.evalCtx, constraint)
 		newScanPrivate.InvertedConstraint = spansToRead
 
 		// Calculate the PK columns once.

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -21,6 +21,10 @@ exec-ddl
 CREATE TABLE abcd (a INT, b INT, c INT, d INT, INDEX ab(a, b) STORING (c, d), INDEX cd(c, d) STORING (a, b))
 ----
 
+exec-ddl
+CREATE TABLE def (d INT NOT NULL CHECK (d IN (1, 3)), e INT, f INT, INDEX (d, e, f))
+----
+
 # --------------------------------------------------
 # Scan operator.
 # --------------------------------------------------
@@ -78,6 +82,37 @@ sort
  ├── ordering: -2
  └── scan a
       └── columns: y:2!null
+
+opt
+SELECT f FROM def ORDER BY e LIMIT 5
+----
+limit
+ ├── columns: f:3  [hidden: e:2]
+ ├── internal-ordering: +2
+ ├── cardinality: [0 - 5]
+ ├── ordering: +2
+ ├── union
+ │    ├── columns: e:2 f:3
+ │    ├── left columns: e:7 f:8
+ │    ├── right columns: e:12 f:13
+ │    ├── cardinality: [0 - 10]
+ │    ├── key: (2,3)
+ │    ├── ordering: +2
+ │    ├── limit hint: 5.00
+ │    ├── scan def@secondary
+ │    │    ├── columns: e:7 f:8
+ │    │    ├── constraint: /6/7/8/9: [/1 - /1]
+ │    │    ├── limit: 5
+ │    │    ├── ordering: +7,+8
+ │    │    └── limit hint: 5.00
+ │    └── scan def@secondary
+ │         ├── columns: e:12 f:13
+ │         ├── constraint: /11/12/13/14: [/3 - /3]
+ │         ├── limit: 5
+ │         ├── ordering: +12,+13
+ │         └── limit hint: 5.00
+ └── 5
+
 
 # --------------------------------------------------
 # Select operator (pass through).

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -1470,7 +1470,7 @@ memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4])
 memo
 SELECT DISTINCT ON (u) u, v, w FROM kuvw
 ----
-memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4])
+memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4])
  ├── G1: (distinct-on G2 G3 cols=(2)) (distinct-on G2 G3 cols=(2),ordering=+2)
  │    └── [presentation: u:2,v:3,w:4]
  │         ├── best: (distinct-on G2="[ordering: +2]" G3 cols=(2),ordering=+2)
@@ -1492,7 +1492,7 @@ memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4])
 memo
 SELECT DISTINCT ON (v) u, v, w FROM kuvw
 ----
-memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4])
+memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4])
  ├── G1: (distinct-on G2 G3 cols=(3)) (distinct-on G2 G3 cols=(3),ordering=+3)
  │    └── [presentation: u:2,v:3,w:4]
  │         ├── best: (distinct-on G2="[ordering: +3]" G3 cols=(3),ordering=+3)
@@ -1514,7 +1514,7 @@ memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4])
 memo
 SELECT DISTINCT ON (w) u, v, w FROM kuvw
 ----
-memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4])
+memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4])
  ├── G1: (distinct-on G2 G3 cols=(4)) (distinct-on G2 G3 cols=(4),ordering=+4)
  │    └── [presentation: u:2,v:3,w:4]
  │         ├── best: (distinct-on G2="[ordering: +4]" G3 cols=(4),ordering=+4)
@@ -1536,7 +1536,7 @@ memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4])
 memo
 SELECT DISTINCT ON (u) u, v, w FROM kuvw ORDER BY u, w
 ----
-memo (optimized, ~4KB, required=[presentation: u:2,v:3,w:4] [ordering: +2])
+memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4] [ordering: +2])
  ├── G1: (distinct-on G2 G3 cols=(2),ordering=+4 opt(2)) (distinct-on G2 G3 cols=(2),ordering=+4)
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +2]
  │    │    ├── best: (sort G1)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -2097,7 +2097,7 @@ memo (optimized, ~14KB, required=[presentation: a:1,b:2,c:3,x:6,y:7,z:8])
 memo
 SELECT * FROM abc INNER HASH JOIN xyz ON a=x
 ----
-memo (optimized, ~8KB, required=[presentation: a:1,b:2,c:3,x:6,y:7,z:8])
+memo (optimized, ~9KB, required=[presentation: a:1,b:2,c:3,x:6,y:7,z:8])
  ├── G1: (inner-join G2 G3 G4)
  │    └── [presentation: a:1,b:2,c:3,x:6,y:7,z:8]
  │         ├── best: (inner-join G2 G3 G4)

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -410,7 +410,7 @@ memo (optimized, ~24KB, required=[presentation: b:1,x:2,c:4,y:5,a:7,b:8,c:9,d:10
 memo join-limit=2
 SELECT * FROM bx, cy, abc WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
-memo (optimized, ~43KB, required=[presentation: b:1,x:2,c:4,y:5,a:7,b:8,c:9,d:10])
+memo (optimized, ~44KB, required=[presentation: b:1,x:2,c:4,y:5,a:7,b:8,c:9,d:10])
  ├── G1: (inner-join G2 G3 G4) (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G7) (inner-join G6 G5 G7) (merge-join G2 G3 G8 inner-join,+1,+8) (merge-join G2 G3 G8 inner-join,+1,+8) (lookup-join G3 G8 bx,keyCols=[8],outCols=(1,2,4,5,7-10)) (merge-join G5 G6 G8 inner-join,+4,+9) (lookup-join G6 G8 cy,keyCols=[9],outCols=(1,2,4,5,7-10))
  │    └── [presentation: b:1,x:2,c:4,y:5,a:7,b:8,c:9,d:10]
  │         ├── best: (lookup-join G3 G8 bx,keyCols=[8],outCols=(1,2,4,5,7-10))

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -597,7 +597,7 @@ project
 memo
 SELECT k FROM a WHERE u = 1 AND k = 5
 ----
-memo (optimized, ~7KB, required=[presentation: k:1])
+memo (optimized, ~8KB, required=[presentation: k:1])
  ├── G1: (project G2 G3 k)
  │    └── [presentation: k:1]
  │         ├── best: (project G2 G3 k)
@@ -695,7 +695,7 @@ project
 memo
 SELECT k FROM a WHERE u = 1 AND v = 5
 ----
-memo (optimized, ~8KB, required=[presentation: k:1])
+memo (optimized, ~9KB, required=[presentation: k:1])
  ├── G1: (project G2 G3 k)
  │    └── [presentation: k:1]
  │         ├── best: (project G2 G3 k)
@@ -787,7 +787,7 @@ index-join b
 memo
 SELECT * FROM b WHERE v >= 1 AND v <= 10
 ----
-memo (optimized, ~5KB, required=[presentation: k:1,u:2,v:3,j:4])
+memo (optimized, ~6KB, required=[presentation: k:1,u:2,v:3,j:4])
  ├── G1: (select G2 G3) (index-join G4 b,cols=(1-4))
  │    └── [presentation: k:1,u:2,v:3,j:4]
  │         ├── best: (index-join G4 b,cols=(1-4))
@@ -7433,7 +7433,7 @@ CREATE TABLE t58390 (
 memo
 SELECT * FROM t58390 WHERE a > 1 OR b > 1
 ----
-memo (optimized, ~18KB, required=[presentation: k:1,a:2,b:3,c:4])
+memo (optimized, ~19KB, required=[presentation: k:1,a:2,b:3,c:4])
  ├── G1: (select G2 G3) (index-join G4 t58390,cols=(1-4)) (distinct-on G5 G6 cols=(1))
  │    └── [presentation: k:1,a:2,b:3,c:4]
  │         ├── best: (select G2 G3)


### PR DESCRIPTION
This commit caches the exact prefix of a `ScanPrivate`'s `Constraint` as an
additional field on the `ScanPrivate` so it can be used from
`ordering.ScanPrivateCanProvide` (where a `*tree.EvalContext` is not readily
available to extract the exact prefix from the `Constraint` directly). This
is important for cases where the first index column is held constant
by the scan, but it is not one of the output columns. In order for the
optimizer to determine that the scan can provide an ordering on the
remaining columns in the index, it must track the fact that the first
column is constant.

Informs #56201

Release note (performance improvement): Increased the intelligence
of the optimizer around the ability of a scan to provide certain
requested orderings when some of the columns are held constant. This
can eliminate unneeded sort operations in some cases, resulting in
improved performance.