### PR TITLE
release-21.1: block concurrent ADD/DROP REGION and REGIONAL BY ROW changes

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
+++ b/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
@@ -2625,7 +2625,7 @@ CREATE TABLE hash_sharded_idx_table (
   pk INT PRIMARY KEY USING HASH WITH BUCKET_COUNT = 8
 )
 
-statement error cannot convert a table to REGIONAL BY ROW if table table contains hash sharded indexes
+statement error cannot convert hash_sharded_idx_table to REGIONAL BY ROW as the table contains hash sharded indexes
 ALTER TABLE hash_sharded_idx_table SET LOCALITY REGIONAL BY ROW
 
 statement ok

--- a/pkg/ccl/multiregionccl/multiregionccltestutils/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/multiregionccltestutils/BUILD.bazel
@@ -9,5 +9,6 @@ go_library(
         "//pkg/base",
         "//pkg/roachpb",
         "//pkg/testutils/serverutils",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/ccl/multiregionccl/multiregionccltestutils/testutils.go
+++ b/pkg/ccl/multiregionccl/multiregionccltestutils/testutils.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/errors"
 )
 
 // TestingCreateMultiRegionCluster creates a test cluster with numServers number
@@ -59,4 +60,73 @@ func TestingCreateMultiRegionCluster(
 	sqlDB := tc.ServerConn(0)
 
 	return tc, sqlDB, cleanup
+}
+
+// TestingEnsureCorrectPartitioning ensures that the table referenced by the
+// supplied FQN has the expected indexes and that all of those indexes have the
+// expected partitions.
+func TestingEnsureCorrectPartitioning(
+	sqlDB *gosql.DB, dbName string, tableName string, expectedIndexes []string,
+) error {
+	rows, err := sqlDB.Query("SELECT region FROM [SHOW REGIONS FROM DATABASE db] ORDER BY region")
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	var expectedPartitions []string
+	for rows.Next() {
+		var regionName string
+		if err := rows.Scan(&regionName); err != nil {
+			return err
+		}
+		expectedPartitions = append(expectedPartitions, regionName)
+	}
+
+	rows, err = sqlDB.Query(
+		fmt.Sprintf(
+			"SELECT index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE %s.%s] ORDER BY partition_name",
+			dbName,
+			tableName,
+		),
+	)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	indexPartitions := make(map[string][]string)
+	for rows.Next() {
+		var indexName string
+		var partitionName string
+		if err := rows.Scan(&indexName, &partitionName); err != nil {
+			return err
+		}
+
+		indexPartitions[indexName] = append(indexPartitions[indexName], partitionName)
+	}
+
+	for _, expectedIndex := range expectedIndexes {
+		partitions, found := indexPartitions[expectedIndex]
+		if !found {
+			return errors.AssertionFailedf("did not find index %s", expectedIndex)
+		}
+
+		if len(partitions) != len(expectedPartitions) {
+			return errors.AssertionFailedf(
+				"unexpected number of partitions; expected %d, found %d",
+				len(partitions),
+				len(expectedPartitions),
+			)
+		}
+		for i, expectedPartition := range expectedPartitions {
+			if expectedPartition != partitions[i] {
+				return errors.AssertionFailedf(
+					"unexpected partitions; expected %v, found %v",
+					expectedPartitions,
+					partitions,
+				)
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/ccl/multiregionccl/region_test.go
+++ b/pkg/ccl/multiregionccl/region_test.go
@@ -9,6 +9,7 @@
 package multiregionccl_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -158,12 +159,12 @@ CREATE TABLE db.rbr () LOCALITY REGIONAL BY ROW`)
 
 			// Start the second operation.
 			_, err = sqlDB.Exec(tc.secondOp)
+			close(secondOpFinished)
 			if tc.secondOpErr == "" {
 				require.NoError(t, err)
 			} else {
 				require.True(t, testutils.IsError(err, tc.secondOpErr))
 			}
-			close(secondOpFinished)
 
 			<-firstOpFinished
 
@@ -280,7 +281,7 @@ func TestRegionAddDropFailureEnclosingRegionalByRowAlters(t *testing.T) {
 
 	for _, tc := range testCases {
 		for _, regionAlterCmd := range regionAlterCmds {
-			t.Run(regionAlterCmd.name+tc.name, func(t *testing.T) {
+			t.Run(fmt.Sprintf("%s/%s", regionAlterCmd.name, tc.name), func(t *testing.T) {
 
 				_, err := sqlDB.Exec(`
 DROP DATABASE IF EXISTS db;

--- a/pkg/ccl/multiregionccl/region_test.go
+++ b/pkg/ccl/multiregionccl/region_test.go
@@ -9,8 +9,6 @@
 package multiregionccl_test
 
 import (
-	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -203,124 +201,6 @@ CREATE TABLE db.rbr () LOCALITY REGIONAL BY ROW`)
 	}
 }
 
-// TestRegionAddDropEnclosingRegionalByRowAlters tests adding/dropping regions
-// (expected to fail) with a concurrent alter to a regional by row table. The
-// sketch of the test is as follows:
-// - Client 1 performs an ALTER ADD / DROP REGION. Let the user txn commit.
-// - Block in the type schema changer.
-// - Client 2 alters a REGIONAL / GLOBAL table to a REGIONAL BY ROW table. Let
-// this operation finish.
-// - Force a rollback on the REGION ADD / DROP by injecting an error.
-// - Ensure the partitions on the REGIONAL BY ROW table are sane.
-func TestRegionAddDropFailureEnclosingRegionalByRowAlters(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	skip.UnderRace(t, "times out under race")
-
-	// Decrease the adopt loop interval so that retries happen quickly.
-	defer sqltestutils.SetTestJobsAdoptInterval()()
-
-	regionAlterCmds := []struct {
-		name string
-		cmd  string
-	}{
-		{
-			name: "drop-region",
-			cmd:  `ALTER DATABASE db DROP REGION "us-east3"`,
-		},
-		{
-			name: "add-region",
-			cmd:  `ALTER DATABASE db ADD REGION "us-east4"`,
-		},
-	}
-
-	testCases := []struct {
-		name  string
-		setup string
-	}{
-		{
-			name:  "alter-from-global",
-			setup: `CREATE TABLE db.t () LOCALITY GLOBAL`,
-		},
-		{
-			name:  "alter-from-explicit-regional",
-			setup: `CREATE TABLE db.t () LOCALITY REGIONAL IN "us-east2"`,
-		},
-		{
-			name:  "alter-from-regional",
-			setup: `CREATE TABLE db.t () LOCALITY REGIONAL IN PRIMARY REGION`,
-		},
-		{
-			name:  "alter-from-rbr",
-			setup: `CREATE TABLE db.t (reg db.crdb_internal_region) LOCALITY REGIONAL BY ROW AS reg`,
-		},
-	}
-
-	var mu syncutil.Mutex
-	typeChangeStarted := make(chan struct{}, 1)
-	typeChangeFinished := make(chan struct{}, 1)
-	rbrOpFinished := make(chan struct{}, 1)
-
-	knobs := base.TestingKnobs{
-		SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
-			RunBeforeEnumMemberPromotion: func() error {
-				mu.Lock()
-				defer mu.Unlock()
-				typeChangeStarted <- struct{}{}
-				<-rbrOpFinished
-				// Trigger a roll-back.
-				return errors.New("boom")
-			},
-		},
-	}
-
-	_, sqlDB, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
-		t, 4 /* numServers */, knobs, nil, /* baseDir */
-	)
-	defer cleanup()
-
-	for _, tc := range testCases {
-		for _, regionAlterCmd := range regionAlterCmds {
-			t.Run(fmt.Sprintf("%s/%s", regionAlterCmd.name, tc.name), func(t *testing.T) {
-
-				_, err := sqlDB.Exec(`
-DROP DATABASE IF EXISTS db;
-CREATE DATABASE db WITH PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3";
-`)
-				require.NoError(t, err)
-
-				_, err = sqlDB.Exec(tc.setup)
-				require.NoError(t, err)
-
-				go func() {
-					_, err := sqlDB.Exec(regionAlterCmd.cmd)
-					if !testutils.IsError(err, "boom") {
-						t.Errorf("expected error boom, found %v", err)
-					}
-					typeChangeFinished <- struct{}{}
-				}()
-
-				<-typeChangeStarted
-
-				_, err = sqlDB.Exec(`ALTER TABLE db.t SET LOCALITY REGIONAL BY ROW`)
-				rbrOpFinished <- struct{}{}
-				require.NoError(t, err)
-
-				testutils.SucceedsSoon(t, func() error {
-					return multiregionccltestutils.TestingEnsureCorrectPartitioning(
-						sqlDB,
-						"db",                  /* dbName */
-						"t",                   /* tableName */
-						[]string{"t@primary"}, /* expectedIndexes */
-					)
-				})
-				<-typeChangeFinished
-			})
-		}
-	}
-}
-
 // TestRegionAddDropEnclosingRegionalByRowOps tests adding/dropping regions
 // (which may or may not succeed) with a concurrent operation on a regional by
 // row table. The sketch of the test is as follows:
@@ -366,6 +246,8 @@ func TestRegionAddDropEnclosingRegionalByRowOps(t *testing.T) {
 		},
 	}
 
+	// We only have one test case for now as we only allow CREATE TABLE
+	// to race with ADD/DROP regions.
 	testCases := []struct {
 		name            string
 		op              string
@@ -373,33 +255,8 @@ func TestRegionAddDropEnclosingRegionalByRowOps(t *testing.T) {
 	}{
 		{
 			name:            "create-rbr-table",
-			op:              `DROP TABLE db.rbr; CREATE TABLE db.rbr() LOCALITY REGIONAL BY ROW`,
+			op:              `DROP TABLE IF EXISTS db.rbr; CREATE TABLE db.rbr() LOCALITY REGIONAL BY ROW`,
 			expectedIndexes: []string{"rbr@primary"},
-		},
-		{
-			name:            "create-index",
-			op:              `CREATE INDEX idx ON db.rbr(v)`,
-			expectedIndexes: []string{"rbr@primary", "rbr@idx"},
-		},
-		{
-			name:            "add-column",
-			op:              `ALTER TABLE db.rbr ADD COLUMN v2 INT`,
-			expectedIndexes: []string{"rbr@primary"},
-		},
-		{
-			name:            "alter-pk",
-			op:              `ALTER TABLE db.rbr ALTER PRIMARY KEY USING COLUMNS (k, v)`,
-			expectedIndexes: []string{"rbr@primary"},
-		},
-		{
-			name:            "drop-column",
-			op:              `ALTER TABLE db.rbr DROP COLUMN v`,
-			expectedIndexes: []string{"rbr@primary"},
-		},
-		{
-			name:            "unique-index",
-			op:              `CREATE UNIQUE INDEX uniq ON db.rbr(v)`,
-			expectedIndexes: []string{"rbr@primary", "rbr@uniq"},
 		},
 	}
 
@@ -467,208 +324,6 @@ CREATE TABLE db.rbr(k INT PRIMARY KEY, v INT NOT NULL) LOCALITY REGIONAL BY ROW;
 				testutils.SucceedsSoon(t, func() error {
 					return multiregionccltestutils.TestingEnsureCorrectPartitioning(
 						sqlDB, "db" /* dbName */, "rbr" /* tableName */, tc.expectedIndexes,
-					)
-				})
-			})
-		}
-	}
-}
-
-// TestAlterRegionalByRowEnclosingRegionAddDrop tests altering a
-// (which may or may not succeed) with a concurrent operation on a regional by
-// row table. The sketch of the test is as follows:
-// - Client 1 performs an ALTER TABLE ... SET LOCALITY REGIONAL BY ROW TABLE.
-// Let the user txn commit.
-// - Block in the (table) schema changer.
-// - Client 2 performs an ALTER ADD / DROP REGION. Let the operation complete
-// (succeed or fail, depending on the particular setup).
-// - Resume the ALTER operation in the schema changer.
-// Currently, this ALTER operation is bound to fail because of
-// https://github.com/cockroachdb/cockroach/issues/64011. This test ensures that
-// the rollback completes successfully. Once the issue is addressed, this test
-// should be updated to assert the correct partitioning values (in all cases).
-func TestAlterRegionalByRowEnclosingRegionAddDrop(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	skip.UnderRace(t, "times out under race")
-
-	// Decrease the adopt loop interval so that retries happen quickly.
-	defer sqltestutils.SetTestJobsAdoptInterval()()
-
-	// If the schema change succeeds, the alter may fail. The reason for the alter
-	// failing is dependent on the particular region change operation being
-	// performed. That is why we have the `expectedErrorRe` field on this struct.
-	// See https://github.com/cockroachdb/cockroach/issues/64011 for more details.
-	regionAlterCmds := []struct {
-		name            string
-		cmd             string
-		shouldSucceed   bool
-		expectedErrorRE string
-	}{
-		{
-			name:          "drop-region-fail",
-			cmd:           `ALTER DATABASE db DROP REGION "us-east3"`,
-			shouldSucceed: false,
-		},
-		{
-			name:            "drop-region-succeed",
-			cmd:             `ALTER DATABASE db DROP REGION "us-east3"`,
-			shouldSucceed:   true,
-			expectedErrorRE: "in enum \"public.crdb_internal_region\"",
-		},
-		{
-			name:          "add-region-fail",
-			cmd:           `ALTER DATABASE db ADD REGION "us-east4"`,
-			shouldSucceed: false,
-		},
-		{
-			name:            "add-region-succeed",
-			cmd:             `ALTER DATABASE db ADD REGION "us-east4"`,
-			shouldSucceed:   true,
-			expectedErrorRE: "missing partition us-east4 on PRIMARY INDEX of table t",
-		},
-	}
-
-	testCases := []struct {
-		name  string
-		setup string
-	}{
-		{
-			name:  "alter-from-global",
-			setup: `CREATE TABLE db.t () LOCALITY GLOBAL`,
-		},
-		{
-			name:  "alter-from-explicit-regional",
-			setup: `CREATE TABLE db.t () LOCALITY REGIONAL IN "us-east2"`,
-		},
-		{
-			name:  "alter-from-regional",
-			setup: `CREATE TABLE db.t () LOCALITY REGIONAL IN PRIMARY REGION`,
-		},
-		// TODO(arul): Add a test for RBR -> RBR transition here. That test is more
-		// complex because unlike the other scenarios, the region change job is
-		// bound to fail in this test setup. This is because region finalization
-		// tries to re-partition tables but is unable to create the partitioning.
-		// Not sure what's going on there completely.
-	}
-
-	for _, tc := range testCases {
-		for _, regionAlterCmd := range regionAlterCmds {
-			t.Run(tc.name+"-"+regionAlterCmd.name, func(t *testing.T) {
-				var mu syncutil.Mutex
-				alterStarted := make(chan struct{})
-				alterFinished := make(chan struct{})
-				regionAlterFinished := make(chan struct{})
-
-				knobs := base.TestingKnobs{
-					SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
-						RunBeforeEnumMemberPromotion: func() error {
-							if regionAlterCmd.shouldSucceed {
-								return nil
-							}
-							return errors.New("boom")
-						},
-					},
-					SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
-						RunBeforePublishWriteAndDelete: func() {
-							mu.Lock()
-							defer mu.Unlock()
-							if alterStarted != nil {
-								close(alterStarted)
-								alterStarted = nil
-							}
-							<-regionAlterFinished
-						},
-					},
-				}
-
-				_, sqlDB, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
-					t, 4 /* numServers */, knobs, nil, /* baseDir */
-				)
-				defer cleanup()
-
-				_, err := sqlDB.Exec(`
-CREATE DATABASE db WITH PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3";
-`)
-				require.NoError(t, err)
-
-				_, err = sqlDB.Exec(tc.setup)
-				require.NoError(t, err)
-
-				go func() {
-					defer func() {
-						close(alterFinished)
-					}()
-					_, err = sqlDB.Exec(`ALTER TABLE db.t SET LOCALITY REGIONAL BY ROW`)
-					if !testutils.IsError(err, regionAlterCmd.expectedErrorRE) {
-						t.Errorf("unexpected error; exected %q, got %v", regionAlterCmd.expectedErrorRE, err)
-					}
-				}()
-
-				<-alterStarted
-
-				_, err = sqlDB.Exec(regionAlterCmd.cmd)
-				close(regionAlterFinished)
-				if regionAlterCmd.shouldSucceed {
-					require.NoError(t, err)
-				} else {
-					require.Error(t, err)
-					require.True(t, testutils.IsError(err, "boom"))
-				}
-				<-alterFinished
-
-				testutils.SucceedsSoon(t, func() error {
-					rows := sqlDB.QueryRow("SELECT status, error FROM [SHOW JOBS] WHERE job_type = 'SCHEMA CHANGE'")
-					var jobStatus, jobErr string
-					if err := rows.Scan(&jobStatus, &jobErr); err != nil {
-						return err
-					}
-
-					if regionAlterCmd.expectedErrorRE != "" {
-						matched, err := regexp.MatchString("failed", jobStatus)
-						if err != nil {
-							return err
-						}
-						if !matched {
-							return errors.Newf("expected job to fail, but got status %q", jobStatus)
-						}
-
-						matched, err = regexp.MatchString(regionAlterCmd.expectedErrorRE, jobErr)
-						if err != nil {
-							return err
-						}
-						if !matched {
-							return errors.Newf(
-								"expected jobErr %q but got %q",
-								regionAlterCmd.expectedErrorRE,
-								jobErr,
-							)
-						}
-
-						// Ensure that a manual cleanup isn't required.
-						matched, err = regexp.MatchString("manual cleanup", jobErr)
-						if err != nil {
-							return err
-						}
-						if matched {
-							return errors.Newf("should not require manual cleanup, but got %q", jobErr)
-						}
-						return nil
-					}
-
-					matched, err := regexp.MatchString("succeeded", jobStatus)
-					if err != nil {
-						return err
-					}
-					if !matched {
-						return errors.Newf("expected job to succeed, but found %q", jobStatus)
-					}
-					return multiregionccltestutils.TestingEnsureCorrectPartitioning(
-						sqlDB,
-						"db",                  /* dbName */
-						"t",                   /* tableName */
-						[]string{"t@primary"}, /* expectedIndexes */
 					)
 				})
 			})

--- a/pkg/ccl/multiregionccl/region_test.go
+++ b/pkg/ccl/multiregionccl/region_test.go
@@ -302,45 +302,17 @@ CREATE DATABASE db WITH PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3"
 
 				<-typeChangeStarted
 
-				_, err = sqlDB.Exec(`BEGIN; SET TRANSACTION PRIORITY HIGH; ALTER TABLE db.t SET LOCALITY REGIONAL BY ROW; COMMIT;`)
+				_, err = sqlDB.Exec(`ALTER TABLE db.t SET LOCALITY REGIONAL BY ROW`)
 				rbrOpFinished <- struct{}{}
 				require.NoError(t, err)
 
 				testutils.SucceedsSoon(t, func() error {
-					rows, err := sqlDB.Query("SELECT partition_name FROM [SHOW PARTITIONS FROM TABLE db.t] ORDER BY partition_name")
-					if err != nil {
-						return err
-					}
-					defer rows.Close()
-
-					var partitionNames []string
-					for rows.Next() {
-						var partitionName string
-						if err := rows.Scan(&partitionName); err != nil {
-							return err
-						}
-
-						partitionNames = append(partitionNames, partitionName)
-					}
-
-					expectedPartitions := []string{"us-east1", "us-east2", "us-east3"}
-					if len(partitionNames) != len(expectedPartitions) {
-						return errors.AssertionFailedf(
-							"unexpected number of partitions; expected %d, found %d",
-							len(expectedPartitions),
-							len(partitionNames),
-						)
-					}
-					for i := range expectedPartitions {
-						if expectedPartitions[i] != partitionNames[i] {
-							return errors.AssertionFailedf(
-								"unexpected partitions; expected %v, found %v",
-								expectedPartitions,
-								partitionNames,
-							)
-						}
-					}
-					return nil
+					return multiregionccltestutils.TestingEnsureCorrectPartitioning(
+						sqlDB,
+						"db",                  /* dbName */
+						"t",                   /* tableName */
+						[]string{"t@primary"}, /* expectedIndexes */
+					)
 				})
 				<-typeChangeFinished
 			})
@@ -367,34 +339,29 @@ func TestRegionAddDropEnclosingRegionalByRowOps(t *testing.T) {
 	defer sqltestutils.SetTestJobsAdoptInterval()()
 
 	regionAlterCmds := []struct {
-		name               string
-		cmd                string
-		shouldSucceed      bool
-		expectedPartitions []string
+		name          string
+		cmd           string
+		shouldSucceed bool
 	}{
 		{
-			name:               "drop-region-fail",
-			cmd:                `ALTER DATABASE db DROP REGION "us-east3"`,
-			shouldSucceed:      false,
-			expectedPartitions: []string{"us-east1", "us-east2", "us-east3"},
+			name:          "drop-region-fail",
+			cmd:           `ALTER DATABASE db DROP REGION "us-east3"`,
+			shouldSucceed: false,
 		},
 		{
-			name:               "drop-region-succeed",
-			cmd:                `ALTER DATABASE db DROP REGION "us-east3"`,
-			shouldSucceed:      true,
-			expectedPartitions: []string{"us-east1", "us-east2"},
+			name:          "drop-region-succeed",
+			cmd:           `ALTER DATABASE db DROP REGION "us-east3"`,
+			shouldSucceed: true,
 		},
 		{
-			name:               "add-region",
-			cmd:                `ALTER DATABASE db ADD REGION "us-east4"`,
-			shouldSucceed:      false,
-			expectedPartitions: []string{"us-east1", "us-east2", "us-east3"},
+			name:          "add-region",
+			cmd:           `ALTER DATABASE db ADD REGION "us-east4"`,
+			shouldSucceed: false,
 		},
 		{
-			name:               "add-region",
-			cmd:                `ALTER DATABASE db ADD REGION "us-east4"`,
-			shouldSucceed:      true,
-			expectedPartitions: []string{"us-east1", "us-east2", "us-east3", "us-east4"},
+			name:          "add-region",
+			cmd:           `ALTER DATABASE db ADD REGION "us-east4"`,
+			shouldSucceed: true,
 		},
 	}
 
@@ -495,47 +462,9 @@ CREATE TABLE db.rbr(k INT PRIMARY KEY, v INT NOT NULL) LOCALITY REGIONAL BY ROW;
 				require.NoError(t, err)
 
 				testutils.SucceedsSoon(t, func() error {
-					rows, err := sqlDB.Query("SELECT index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE db.rbr] ORDER BY partition_name")
-					if err != nil {
-						return err
-					}
-					defer rows.Close()
-
-					indexPartitions := make(map[string][]string)
-					for rows.Next() {
-						var indexName string
-						var partitionName string
-						if err := rows.Scan(&indexName, &partitionName); err != nil {
-							return err
-						}
-
-						indexPartitions[indexName] = append(indexPartitions[indexName], partitionName)
-					}
-
-					for _, expectedIndex := range tc.expectedIndexes {
-						partitions, found := indexPartitions[expectedIndex]
-						if !found {
-							return errors.AssertionFailedf("did not find index %s", expectedIndex)
-						}
-
-						if len(partitions) != len(regionAlterCmd.expectedPartitions) {
-							return errors.AssertionFailedf(
-								"unexpected number of partitions; expected %d, found %d",
-								len(partitions),
-								len(regionAlterCmd.expectedPartitions),
-							)
-						}
-						for i, expectedPartition := range regionAlterCmd.expectedPartitions {
-							if expectedPartition != partitions[i] {
-								return errors.AssertionFailedf(
-									"unexpected partitions; expected %v, found %v",
-									regionAlterCmd.expectedPartitions,
-									partitions,
-								)
-							}
-						}
-					}
-					return nil
+					return multiregionccltestutils.TestingEnsureCorrectPartitioning(
+						sqlDB, "db" /* dbName */, "rbr" /* tableName */, tc.expectedIndexes,
+					)
 				})
 				<-typeChangeFinished
 			})

--- a/pkg/ccl/multiregionccl/regional_by_row_test.go
+++ b/pkg/ccl/multiregionccl/regional_by_row_test.go
@@ -701,43 +701,51 @@ func TestRegionChangeRacingRegionalByRowChange(t *testing.T) {
 
 	regionalByRowChanges := []struct {
 		setup                          string
-		alterCmd                       string
+		cmd                            string
 		errorOnAddOrDropRegionSandwich string
+		errorOnTableChangeSandwich     string
 	}{
 		{
 			setup:                          `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY GLOBAL`,
-			alterCmd:                       `ALTER TABLE t.test SET LOCALITY REGIONAL BY ROW`,
+			cmd:                            `ALTER TABLE t.test SET LOCALITY REGIONAL BY ROW`,
 			errorOnAddOrDropRegionSandwich: "pq: cannot perform database region changes while a REGIONAL BY ROW transition is underway",
+			errorOnTableChangeSandwich:     "pq: cannot perform this locality change while a region is being added or dropped on the database",
 		},
 		{
 			setup:                          `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY REGIONAL BY ROW`,
-			alterCmd:                       `ALTER TABLE t.test SET LOCALITY GLOBAL`,
+			cmd:                            `ALTER TABLE t.test SET LOCALITY GLOBAL`,
 			errorOnAddOrDropRegionSandwich: "pq: cannot perform database region changes while a REGIONAL BY ROW transition is underway",
+			errorOnTableChangeSandwich:     "pq: cannot perform this locality change while a region is being added or dropped on the database",
 		},
 		{
 			setup:                          `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY REGIONAL BY ROW`,
-			alterCmd:                       `CREATE INDEX v_idx ON t.test(v)`,
+			cmd:                            `CREATE INDEX v_idx ON t.test(v)`,
 			errorOnAddOrDropRegionSandwich: "pq: cannot perform database region changes while an index is being created or dropped on a REGIONAL BY ROW table",
+			errorOnTableChangeSandwich:     "pq: cannot CREATE INDEX on a REGIONAL BY ROW table while a region is being added or dropped on the database",
 		},
 		{
 			setup:                          `CREATE TABLE t.test (k INT NOT NULL, v INT, INDEX v_idx (v)) LOCALITY REGIONAL BY ROW`,
-			alterCmd:                       `DROP INDEX t.test@v_idx`,
+			cmd:                            `DROP INDEX t.test@v_idx`,
 			errorOnAddOrDropRegionSandwich: "pq: cannot perform database region changes while an index is being created or dropped on a REGIONAL BY ROW table",
+			errorOnTableChangeSandwich:     "pq: cannot DROP INDEX on a REGIONAL BY ROW table while a region is being added or dropped on the database",
 		},
 		{
 			setup:                          `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY REGIONAL BY ROW`,
-			alterCmd:                       `ALTER TABLE t.test ADD CONSTRAINT v_uniq UNIQUE (v)`,
+			cmd:                            `ALTER TABLE t.test ADD CONSTRAINT v_uniq UNIQUE (v)`,
 			errorOnAddOrDropRegionSandwich: "pq: cannot perform database region changes while an index is being created or dropped on a REGIONAL BY ROW table",
+			errorOnTableChangeSandwich:     "pq: cannot create an UNIQUE CONSTRAINT on a REGIONAL BY ROW table while a region is being added or dropped on the database",
 		},
 		{
 			setup:                          `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY REGIONAL BY ROW`,
-			alterCmd:                       `ALTER TABLE t.test ADD COLUMN z INT UNIQUE`,
+			cmd:                            `ALTER TABLE t.test ADD COLUMN z INT UNIQUE`,
 			errorOnAddOrDropRegionSandwich: "pq: cannot perform database region changes while an index is being created or dropped on a REGIONAL BY ROW table",
+			errorOnTableChangeSandwich:     "pq: cannot add an UNIQUE COLUMN on a REGIONAL BY ROW table while a region is being added or dropped on the database",
 		},
 		{
 			setup:                          `CREATE TABLE t.test (k INT NOT NULL, v INT NOT NULL) LOCALITY REGIONAL BY ROW`,
-			alterCmd:                       `ALTER TABLE t.test ALTER PRIMARY KEY USING COLUMNS (v)`,
+			cmd:                            `ALTER TABLE t.test ALTER PRIMARY KEY USING COLUMNS (v)`,
 			errorOnAddOrDropRegionSandwich: "pq: cannot perform database region changes while a ALTER PRIMARY KEY is underway",
+			errorOnTableChangeSandwich:     "pq: cannot perform a primary key change on a REGIONAL BY ROW table while a region is being added or dropped on the database",
 		},
 	}
 
@@ -771,7 +779,7 @@ USE t;
 	// Tests ADD/DROP REGION during a REGIONAL BY ROW index-related change.
 	for _, rbrChange := range regionalByRowChanges {
 		for _, regionChange := range regionChanges {
-			t.Run(fmt.Sprintf("from %s to %s with racing %s", rbrChange.setup, rbrChange.alterCmd, regionChange.cmd), func(t *testing.T) {
+			t.Run(fmt.Sprintf("setup %s executing %s with racing %s", rbrChange.setup, rbrChange.cmd, regionChange.cmd), func(t *testing.T) {
 				interruptStartCh := make(chan struct{})
 				interruptEndCh := make(chan struct{})
 				performInterrupt := false
@@ -801,7 +809,7 @@ USE t;
 				rbrErrCh := make(chan error, 1)
 				performInterrupt = true
 				go func() {
-					_, err := sqlDB.Exec(rbrChange.alterCmd)
+					_, err := sqlDB.Exec(rbrChange.cmd)
 					rbrErrCh <- err
 				}()
 
@@ -816,6 +824,60 @@ USE t;
 
 				// Now finish up and ensure no errors.
 				require.NoError(t, <-rbrErrCh)
+
+				// Validate the zone configuration.
+				_, err = sqlDB.Exec(`SELECT crdb_internal.validate_multi_region_zone_configs()`)
+				require.NoError(t, err)
+			})
+		}
+	}
+
+	// Tests REGIONAL BY ROW during a ADD/DROP REGION index-related change.
+	for _, regionChange := range regionChanges {
+		for _, rbrChange := range regionalByRowChanges {
+			t.Run(fmt.Sprintf("setup %s executing %s with racing %s", rbrChange.setup, regionChange.cmd, rbrChange.cmd), func(t *testing.T) {
+				interruptStartCh := make(chan struct{})
+				interruptEndCh := make(chan struct{})
+				performInterrupt := false
+
+				_, sqlDB, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
+					t,
+					3, /* numServers */
+					base.TestingKnobs{
+						SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
+							RunBeforeExec: func() error {
+								if performInterrupt {
+									performInterrupt = false
+									close(interruptStartCh)
+									<-interruptEndCh
+								}
+								return nil
+							},
+						},
+					},
+					nil, /* baseDir */
+				)
+				defer cleanup()
+				setupDB(sqlDB, rbrChange.setup)
+				performInterrupt = true
+
+				regionChangeErr := make(chan error, 1)
+				go func() {
+					_, err := sqlDB.Exec(regionChange.cmd)
+					regionChangeErr <- err
+				}()
+
+				// Wait for the enum change to start.
+				<-interruptStartCh
+
+				// Perform the REGIONAL BY ROW transformation.
+				_, err := sqlDB.Exec(rbrChange.cmd)
+				close(interruptEndCh)
+				require.Error(t, err)
+				require.EqualError(t, err, rbrChange.errorOnTableChangeSandwich)
+
+				// Ensure the region change does not error.
+				require.NoError(t, <-regionChangeErr)
 
 				// Validate the zone configuration.
 				_, err = sqlDB.Exec(`SELECT crdb_internal.validate_multi_region_zone_configs()`)

--- a/pkg/ccl/multiregionccl/regional_by_row_test.go
+++ b/pkg/ccl/multiregionccl/regional_by_row_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -688,5 +689,138 @@ CREATE TABLE regional_by_row (
 			err = queryIndexGCJobsAndValidateCount(`running`, 0)
 			require.NoError(t, err)
 		})
+	}
+}
+
+// TestRegionChangeRacingAlterTableRegionalByRow tests regional by row changes
+// conflicting with ADD/DROP region changes.
+func TestRegionChangeRacingRegionalByRowChange(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	skip.UnderRace(t, "too slow under race (>10min)")
+
+	regionalByRowChanges := []struct {
+		setup                          string
+		alterCmd                       string
+		errorOnAddOrDropRegionSandwich string
+	}{
+		{
+			setup:                          `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY GLOBAL`,
+			alterCmd:                       `ALTER TABLE t.test SET LOCALITY REGIONAL BY ROW`,
+			errorOnAddOrDropRegionSandwich: "pq: cannot perform database region changes while a REGIONAL BY ROW transition is underway",
+		},
+		{
+			setup:                          `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY REGIONAL BY ROW`,
+			alterCmd:                       `ALTER TABLE t.test SET LOCALITY GLOBAL`,
+			errorOnAddOrDropRegionSandwich: "pq: cannot perform database region changes while a REGIONAL BY ROW transition is underway",
+		},
+		{
+			setup:                          `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY REGIONAL BY ROW`,
+			alterCmd:                       `CREATE INDEX v_idx ON t.test(v)`,
+			errorOnAddOrDropRegionSandwich: "pq: cannot perform database region changes while an index is being created or dropped on a REGIONAL BY ROW table",
+		},
+		{
+			setup:                          `CREATE TABLE t.test (k INT NOT NULL, v INT, INDEX v_idx (v)) LOCALITY REGIONAL BY ROW`,
+			alterCmd:                       `DROP INDEX t.test@v_idx`,
+			errorOnAddOrDropRegionSandwich: "pq: cannot perform database region changes while an index is being created or dropped on a REGIONAL BY ROW table",
+		},
+		{
+			setup:                          `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY REGIONAL BY ROW`,
+			alterCmd:                       `ALTER TABLE t.test ADD CONSTRAINT v_uniq UNIQUE (v)`,
+			errorOnAddOrDropRegionSandwich: "pq: cannot perform database region changes while an index is being created or dropped on a REGIONAL BY ROW table",
+		},
+		{
+			setup:                          `CREATE TABLE t.test (k INT NOT NULL, v INT) LOCALITY REGIONAL BY ROW`,
+			alterCmd:                       `ALTER TABLE t.test ADD COLUMN z INT UNIQUE`,
+			errorOnAddOrDropRegionSandwich: "pq: cannot perform database region changes while an index is being created or dropped on a REGIONAL BY ROW table",
+		},
+		{
+			setup:                          `CREATE TABLE t.test (k INT NOT NULL, v INT NOT NULL) LOCALITY REGIONAL BY ROW`,
+			alterCmd:                       `ALTER TABLE t.test ALTER PRIMARY KEY USING COLUMNS (v)`,
+			errorOnAddOrDropRegionSandwich: "pq: cannot perform database region changes while a ALTER PRIMARY KEY is underway",
+		},
+	}
+
+	regionChanges := []struct {
+		cmd string
+	}{
+		{
+			cmd: `ALTER DATABASE t ADD REGION "us-east3"`,
+		},
+		{
+			cmd: `ALTER DATABASE t DROP REGION "us-east2"`,
+		},
+	}
+
+	setupDB := func(sqlDB *gosql.DB, setupSQL string) {
+		// Drop the closed timestamp target lead for GLOBAL tables for speed-up improvements.
+		// TODO(nvanbenschoten): We can remove this when that issue
+		// is addressed.
+		_, err := sqlDB.Exec(`SET CLUSTER SETTING kv.closed_timestamp.lead_for_global_reads_override = '5ms'`)
+		require.NoError(t, err)
+
+		_, err = sqlDB.Exec(fmt.Sprintf(`
+DROP DATABASE IF EXISTS t;
+CREATE DATABASE t PRIMARY REGION "us-east1" REGION "us-east2";
+USE t;
+%s;
+`, setupSQL))
+		require.NoError(t, err)
+	}
+
+	// Tests ADD/DROP REGION during a REGIONAL BY ROW index-related change.
+	for _, rbrChange := range regionalByRowChanges {
+		for _, regionChange := range regionChanges {
+			t.Run(fmt.Sprintf("from %s to %s with racing %s", rbrChange.setup, rbrChange.alterCmd, regionChange.cmd), func(t *testing.T) {
+				interruptStartCh := make(chan struct{})
+				interruptEndCh := make(chan struct{})
+				performInterrupt := false
+
+				_, sqlDB, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
+					t,
+					3, /* numServers */
+					base.TestingKnobs{
+						SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+							RunBeforeBackfill: func() error {
+								if performInterrupt {
+									performInterrupt = false
+									close(interruptStartCh)
+									<-interruptEndCh
+								}
+								return nil
+							},
+						},
+					},
+					nil, /* baseDir */
+				)
+				defer cleanup()
+
+				setupDB(sqlDB, rbrChange.setup)
+
+				// Perform the alter table command asynchronously; this will be interrupted.
+				rbrErrCh := make(chan error, 1)
+				performInterrupt = true
+				go func() {
+					_, err := sqlDB.Exec(rbrChange.alterCmd)
+					rbrErrCh <- err
+				}()
+
+				// Wait for the backfill to start.
+				<-interruptStartCh
+
+				// Now run the alter command on the database.
+				_, err := sqlDB.Exec(regionChange.cmd)
+				close(interruptEndCh)
+				require.Error(t, err)
+				require.EqualError(t, err, rbrChange.errorOnAddOrDropRegionSandwich)
+
+				// Now finish up and ensure no errors.
+				require.NoError(t, <-rbrErrCh)
+
+				// Validate the zone configuration.
+				_, err = sqlDB.Exec(`SELECT crdb_internal.validate_multi_region_zone_configs()`)
+				require.NoError(t, err)
+			})
+		}
 	}
 }

--- a/pkg/sql/add_column.go
+++ b/pkg/sql/add_column.go
@@ -83,6 +83,16 @@ func (p *planner) addColumnImpl(
 
 	// Ensure all new indexes are partitioned appropriately.
 	if idx != nil {
+		if n.tableDesc.IsLocalityRegionalByRow() {
+			if err := params.p.checkNoRegionChangeUnderway(
+				params.ctx,
+				n.tableDesc.GetParentID(),
+				"add an UNIQUE COLUMN on a REGIONAL BY ROW table",
+			); err != nil {
+				return err
+			}
+		}
+
 		*idx, err = p.configureIndexDescForNewIndexPartitioning(
 			params.ctx,
 			desc,

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -158,6 +158,13 @@ func (p *planner) AlterDatabaseAddRegion(
 		return nil, err
 	}
 
+	if err := p.checkNoRegionalByRowChangeUnderway(
+		ctx,
+		&dbDesc.Immutable,
+	); err != nil {
+		return nil, err
+	}
+
 	// Adding a region also involves repartitioning all REGIONAL BY ROW tables
 	// underneath the hood, so we must ensure the user has the requisite
 	// privileges.
@@ -290,6 +297,14 @@ func (p *planner) AlterDatabaseDropRegion(
 	if err := p.checkPrivilegesForMultiRegionOp(ctx, dbDesc); err != nil {
 		return nil, err
 	}
+
+	if err := p.checkNoRegionalByRowChangeUnderway(
+		ctx,
+		&dbDesc.Immutable,
+	); err != nil {
+		return nil, err
+	}
+
 	// Dropping a region also involves repartitioning all REGIONAL BY ROW tables
 	// underneath the hood, so we must ensure the user has the requisite
 	// privileges.

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -746,7 +746,7 @@ func checkCanConvertTableToMultiRegion(
 			tableDesc.GetName(),
 		)
 	}
-	for _, idx := range tableDesc.NonDropIndexes() {
+	for _, idx := range tableDesc.AllIndexes() {
 		if idx.GetPartitioning().NumColumns > 0 {
 			return errors.WithDetailf(
 				pgerror.Newf(

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -430,7 +430,7 @@ func (p *planner) checkPrivilegesForRepartitioningRegionalByRowTables(
 	ctx context.Context, dbDesc *dbdesc.Immutable,
 ) error {
 	return p.forEachMutableTableInDatabase(ctx, dbDesc,
-		func(ctx context.Context, tbDesc *tabledesc.Mutable) error {
+		func(ctx context.Context, scName string, tbDesc *tabledesc.Mutable) error {
 			if tbDesc.IsLocalityRegionalByRow() {
 				err := p.checkPrivilegesForMultiRegionOp(ctx, tbDesc)
 				// Return a better error message here.
@@ -459,48 +459,52 @@ func removeLocalityConfigFromAllTablesInDB(
 		)
 	}
 	b := p.Txn().NewBatch()
-	if err := p.forEachMutableTableInDatabase(ctx, desc, func(ctx context.Context, tbDesc *tabledesc.Mutable) error {
-		// The user must either be an admin or have the requisite privileges.
-		if err := p.checkPrivilegesForMultiRegionOp(ctx, tbDesc); err != nil {
-			return err
-		}
-
-		switch t := tbDesc.LocalityConfig.Locality.(type) {
-		case *descpb.TableDescriptor_LocalityConfig_Global_:
-			if err := ApplyZoneConfigForMultiRegionTable(
-				ctx,
-				p.txn,
-				p.ExecCfg(),
-				multiregion.RegionConfig{}, // pass dummy config as it is not used.
-				tbDesc,
-				applyZoneConfigForMultiRegionTableOptionRemoveGlobalZoneConfig,
-			); err != nil {
+	if err := p.forEachMutableTableInDatabase(
+		ctx,
+		desc,
+		func(ctx context.Context, scName string, tbDesc *tabledesc.Mutable) error {
+			// The user must either be an admin or have the requisite privileges.
+			if err := p.checkPrivilegesForMultiRegionOp(ctx, tbDesc); err != nil {
 				return err
 			}
-		case *descpb.TableDescriptor_LocalityConfig_RegionalByTable_:
-			if t.RegionalByTable.Region != nil {
+
+			switch t := tbDesc.LocalityConfig.Locality.(type) {
+			case *descpb.TableDescriptor_LocalityConfig_Global_:
+				if err := ApplyZoneConfigForMultiRegionTable(
+					ctx,
+					p.txn,
+					p.ExecCfg(),
+					multiregion.RegionConfig{}, // pass dummy config as it is not used.
+					tbDesc,
+					applyZoneConfigForMultiRegionTableOptionRemoveGlobalZoneConfig,
+				); err != nil {
+					return err
+				}
+			case *descpb.TableDescriptor_LocalityConfig_RegionalByTable_:
+				if t.RegionalByTable.Region != nil {
+					// This should error during the type descriptor changes.
+					return errors.AssertionFailedf(
+						"unexpected REGIONAL BY TABLE IN <region> on table %s during DROP REGION",
+						tbDesc.Name,
+					)
+				}
+			case *descpb.TableDescriptor_LocalityConfig_RegionalByRow_:
 				// This should error during the type descriptor changes.
 				return errors.AssertionFailedf(
-					"unexpected REGIONAL BY TABLE IN <region> on table %s during DROP REGION",
+					"unexpected REGIONAL BY ROW on table %s during DROP REGION",
+					tbDesc.Name,
+				)
+			default:
+				return errors.AssertionFailedf(
+					"unexpected locality %T on table %s during DROP REGION",
+					t,
 					tbDesc.Name,
 				)
 			}
-		case *descpb.TableDescriptor_LocalityConfig_RegionalByRow_:
-			// This should error during the type descriptor changes.
-			return errors.AssertionFailedf(
-				"unexpected REGIONAL BY ROW on table %s during DROP REGION",
-				tbDesc.Name,
-			)
-		default:
-			return errors.AssertionFailedf(
-				"unexpected locality %T on table %s during DROP REGION",
-				t,
-				tbDesc.Name,
-			)
-		}
-		tbDesc.LocalityConfig = nil
-		return p.writeSchemaChangeToBatch(ctx, tbDesc, b)
-	}); err != nil {
+			tbDesc.LocalityConfig = nil
+			return p.writeSchemaChangeToBatch(ctx, tbDesc, b)
+		},
+	); err != nil {
 		return err
 	}
 	return p.Txn().Run(ctx, b)
@@ -698,33 +702,37 @@ func addDefaultLocalityConfigToAllTables(
 		)
 	}
 	b := p.Txn().NewBatch()
-	if err := p.forEachMutableTableInDatabase(ctx, dbDesc, func(ctx context.Context, tbDesc *tabledesc.Mutable) error {
-		if err := p.checkPrivilegesForMultiRegionOp(ctx, tbDesc); err != nil {
-			return err
-		}
-
-		if err := checkCanConvertTableToMultiRegion(dbDesc, tbDesc); err != nil {
-			return err
-		}
-
-		if tbDesc.MaterializedView() {
-			if err := p.alterTableDescLocalityToGlobal(
-				ctx, tbDesc, regionEnumID,
-			); err != nil {
+	if err := p.forEachMutableTableInDatabase(
+		ctx,
+		dbDesc,
+		func(ctx context.Context, scName string, tbDesc *tabledesc.Mutable) error {
+			if err := p.checkPrivilegesForMultiRegionOp(ctx, tbDesc); err != nil {
 				return err
 			}
-		} else {
-			if err := p.alterTableDescLocalityToRegionalByTable(
-				ctx, tree.PrimaryRegionNotSpecifiedName, tbDesc, regionEnumID,
-			); err != nil {
+
+			if err := checkCanConvertTableToMultiRegion(dbDesc, tbDesc); err != nil {
 				return err
 			}
-		}
-		if err := p.writeSchemaChangeToBatch(ctx, tbDesc, b); err != nil {
-			return err
-		}
-		return nil
-	}); err != nil {
+
+			if tbDesc.MaterializedView() {
+				if err := p.alterTableDescLocalityToGlobal(
+					ctx, tbDesc, regionEnumID,
+				); err != nil {
+					return err
+				}
+			} else {
+				if err := p.alterTableDescLocalityToRegionalByTable(
+					ctx, tree.PrimaryRegionNotSpecifiedName, tbDesc, regionEnumID,
+				); err != nil {
+					return err
+				}
+			}
+			if err := p.writeSchemaChangeToBatch(ctx, tbDesc, b); err != nil {
+				return err
+			}
+			return nil
+		},
+	); err != nil {
 		return err
 	}
 	return p.Txn().Run(ctx, b)

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -51,6 +51,24 @@ func (p *planner) AlterPrimaryKey(
 	alterPKNode tree.AlterTableAlterPrimaryKey,
 	alterPrimaryKeyLocalitySwap *alterPrimaryKeyLocalitySwap,
 ) error {
+	if alterPrimaryKeyLocalitySwap != nil {
+		if err := p.checkNoRegionChangeUnderway(
+			ctx,
+			tableDesc.GetParentID(),
+			"perform this locality change",
+		); err != nil {
+			return err
+		}
+	} else if tableDesc.IsLocalityRegionalByRow() {
+		if err := p.checkNoRegionChangeUnderway(
+			ctx,
+			tableDesc.GetParentID(),
+			"perform a primary key change on a REGIONAL BY ROW table",
+		); err != nil {
+			return err
+		}
+	}
+
 	if alterPKNode.Interleave != nil {
 		if err := interleavedTableDeprecationAction(p.RunParams(ctx)); err != nil {
 			return err

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -277,6 +277,16 @@ func (n *alterTableNode) startExec(params runParams) error {
 				); err != nil {
 					return err
 				}
+
+				if n.tableDesc.IsLocalityRegionalByRow() {
+					if err := params.p.checkNoRegionChangeUnderway(
+						params.ctx,
+						n.tableDesc.GetParentID(),
+						"create an UNIQUE CONSTRAINT on a REGIONAL BY ROW table",
+					); err != nil {
+						return err
+					}
+				}
 			case *tree.CheckConstraintTableDef:
 				var err error
 				params.p.runWithOptions(resolveFlags{contextDatabaseID: n.tableDesc.ParentID}, func() {

--- a/pkg/sql/alter_table_locality.go
+++ b/pkg/sql/alter_table_locality.go
@@ -240,9 +240,13 @@ func (n *alterTableSetLocalityNode) alterTableLocalityToRegionalByRow(
 		return interleaveOnRegionalByRowError()
 	}
 
-	for _, idx := range n.tableDesc.NonDropIndexes() {
+	for _, idx := range n.tableDesc.AllIndexes() {
 		if idx.IsSharded() {
-			return pgerror.New(pgcode.FeatureNotSupported, "cannot convert a table to REGIONAL BY ROW if table table contains hash sharded indexes")
+			return pgerror.Newf(
+				pgcode.FeatureNotSupported,
+				"cannot convert %s to REGIONAL BY ROW as the table contains hash sharded indexes",
+				tree.Name(n.tableDesc.GetName()),
+			)
 		}
 	}
 

--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -1312,12 +1312,61 @@ func (desc *wrapper) validateTableLocalityConfig(
 		if !desc.IsPartitionAllBy() {
 			return errors.AssertionFailedf("expected REGIONAL BY ROW table to have PartitionAllBy set")
 		}
+		// For REGIONAL BY ROW tables, ensure partitions in the PRIMARY KEY match
+		// the database descriptor. Ensure each public region has a partition,
+		// and each transitioning region name to possibly have a partition.
+		// We do validation that ensures all index partitions are the same on
+		// PARTITION ALL BY.
+		regions, err := regionsEnumDesc.RegionNames()
+		if err != nil {
+			return err
+		}
+		regionNames := make(map[descpb.RegionName]struct{}, len(regions))
+		for _, region := range regions {
+			regionNames[region] = struct{}{}
+		}
+		transitioningRegions, err := regionsEnumDesc.TransitioningRegionNames()
+		if err != nil {
+			return err
+		}
+		transitioningRegionNames := make(map[descpb.RegionName]struct{}, len(regions))
+		for _, region := range transitioningRegions {
+			transitioningRegionNames[region] = struct{}{}
+		}
+
+		for _, partitioning := range desc.GetPrimaryIndex().GetPartitioning().List {
+			regionName := descpb.RegionName(partitioning.Name)
+			// Any transitioning region names may exist.
+			if _, ok := transitioningRegionNames[regionName]; ok {
+				continue
+			}
+			// If a region is not found in any of the region names, we have an unknown
+			// partition.
+			if _, ok := regionNames[regionName]; !ok {
+				return errors.AssertionFailedf(
+					"unknown partition %s on PRIMARY INDEX of table %s",
+					partitioning.Name,
+					desc.GetName(),
+				)
+			}
+			delete(regionNames, regionName)
+		}
+
+		// Any regions that are not deleted from the above loop is missing.
+		for regionName := range regionNames {
+			return errors.AssertionFailedf(
+				"missing partition %s on PRIMARY INDEX of table %s",
+				regionName,
+				desc.GetName(),
+			)
+		}
+
 	case *descpb.TableDescriptor_LocalityConfig_RegionalByTable_:
 
 		// Table is homed in an explicit (non-primary) region.
 		if lc.RegionalByTable.Region != nil {
 			foundRegion := false
-			regions, err := regionsEnumDesc.RegionNamesIncludingTransitioning()
+			regions, err := regionsEnumDesc.RegionNamesForValidation()
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -78,6 +78,16 @@ func (p *planner) CreateIndex(ctx context.Context, n *tree.CreateIndex) (planNod
 		return nil, err
 	}
 
+	if tableDesc.IsLocalityRegionalByRow() {
+		if err := p.checkNoRegionChangeUnderway(
+			ctx,
+			tableDesc.GetParentID(),
+			"CREATE INDEX on a REGIONAL BY ROW table",
+		); err != nil {
+			return nil, err
+		}
+	}
+
 	return &createIndexNode{tableDesc: tableDesc, n: n}, nil
 }
 

--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -102,7 +102,7 @@ func (p *planner) writeDatabaseChangeToBatch(
 func (p *planner) forEachMutableTableInDatabase(
 	ctx context.Context,
 	dbDesc *dbdesc.Immutable,
-	fn func(ctx context.Context, tbDesc *tabledesc.Mutable) error,
+	fn func(ctx context.Context, scName string, tbDesc *tabledesc.Mutable) error,
 ) error {
 	allDescs, err := p.Descriptors().GetAllDescriptors(ctx, p.txn)
 	if err != nil {
@@ -116,7 +116,7 @@ func (p *planner) forEachMutableTableInDatabase(
 			continue
 		}
 		mutable := tabledesc.NewBuilder(desc.TableDesc()).BuildExistingMutableTable()
-		if err := fn(ctx, mutable); err != nil {
+		if err := fn(ctx, lCtx.schemaNames[desc.GetParentSchemaID()], mutable); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/database_region_change_finalizer.go
+++ b/pkg/sql/database_region_change_finalizer.go
@@ -79,7 +79,7 @@ func newDatabaseRegionChangeFinalizer(
 		return localPlanner.forEachMutableTableInDatabase(
 			ctx,
 			dbDesc,
-			func(ctx context.Context, tableDesc *tabledesc.Mutable) error {
+			func(ctx context.Context, scName string, tableDesc *tabledesc.Mutable) error {
 				if !tableDesc.IsLocalityRegionalByRow() || tableDesc.Dropped() {
 					// We only need to re-partition REGIONAL BY ROW tables. Even then, we
 					// don't need to (can't) repartition a REGIONAL BY ROW table if it has

--- a/pkg/sql/database_region_change_finalizer.go
+++ b/pkg/sql/database_region_change_finalizer.go
@@ -20,8 +20,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
@@ -31,62 +33,24 @@ import (
 // to update partitions and zone configurations as well as leases on REGIONAL BY
 // ROW tables.
 type databaseRegionChangeFinalizer struct {
-	dbID                descpb.ID
-	typeID              descpb.ID
-	regionalByRowTables []descpb.ID
+	dbID   descpb.ID
+	typeID descpb.ID
+
+	localPlanner        *planner
+	cleanupFunc         func()
+	regionalByRowTables []*tabledesc.Mutable
 }
 
 // newDatabaseRegionChangeFinalizer returns a databaseRegionChangeFinalizer.
+// It pre-fetches all REGIONAL BY ROW tables from the database.
 func newDatabaseRegionChangeFinalizer(
-	dbID descpb.ID, typeID descpb.ID,
-) *databaseRegionChangeFinalizer {
-	return &databaseRegionChangeFinalizer{
-		dbID:   dbID,
-		typeID: typeID,
-	}
-}
-
-// finalize updates the zone configurations of the database and all enclosed
-// REGIONAL BY ROW tables once the region promotion/demotion is complete. The
-// caller must call waitToUpdateLeases once the provided transaction commits.
-func (r *databaseRegionChangeFinalizer) finalize(
-	ctx context.Context, txn *kv.Txn, descsCol *descs.Collection, execCfg *ExecutorConfig,
-) error {
-	if err := r.updateDatabaseZoneConfig(ctx, txn, descsCol, execCfg); err != nil {
-		return err
-	}
-	return r.repartitionRegionalByRowTables(ctx, txn, descsCol, execCfg)
-}
-
-// updateDatabaseZoneConfig updates the zone config of the database that
-// encloses the multi-region enum such that there is an entry for all PUBLIC
-// region values.
-func (r *databaseRegionChangeFinalizer) updateDatabaseZoneConfig(
-	ctx context.Context, txn *kv.Txn, descsCol *descs.Collection, execCfg *ExecutorConfig,
-) error {
-
-	regionConfig, err := SynthesizeRegionConfig(ctx, txn, r.dbID, descsCol)
-	if err != nil {
-		return err
-	}
-	return ApplyZoneConfigFromDatabaseRegionConfig(
-		ctx,
-		r.dbID,
-		regionConfig,
-		txn,
-		execCfg,
-	)
-}
-
-// repartitionRegionalByRowTables re-partitions all REGIONAL BY ROW tables
-// contained in the database. repartitionRegionalByRowTables adds a partition
-// and corresponding zone configuration for all PUBLIC enum members (regions)
-// on the multi-region enum.
-func (r *databaseRegionChangeFinalizer) repartitionRegionalByRowTables(
-	ctx context.Context, txn *kv.Txn, descsCol *descs.Collection, execCfg *ExecutorConfig,
-) error {
-	var repartitionedTableIDs []descpb.ID
-
+	ctx context.Context,
+	txn *kv.Txn,
+	execCfg *ExecutorConfig,
+	descsCol *descs.Collection,
+	dbID descpb.ID,
+	typeID descpb.ID,
+) (*databaseRegionChangeFinalizer, error) {
 	p, cleanup := NewInternalPlanner(
 		"repartition-regional-by-row-tables",
 		txn,
@@ -96,112 +60,195 @@ func (r *databaseRegionChangeFinalizer) repartitionRegionalByRowTables(
 		sessiondatapb.SessionData{},
 		WithDescCollection(descsCol),
 	)
-	defer cleanup()
 	localPlanner := p.(*planner)
 
-	_, dbDesc, err := descsCol.GetImmutableDatabaseByID(
-		ctx, txn, r.dbID, tree.DatabaseLookupFlags{
-			Required: true,
-		})
-	if err != nil {
-		return err
-	}
+	var regionalByRowTables []*tabledesc.Mutable
+	if err := func() error {
+		_, dbDesc, err := descsCol.GetImmutableDatabaseByID(
+			ctx,
+			txn,
+			dbID,
+			tree.DatabaseLookupFlags{
+				Required: true,
+			},
+		)
+		if err != nil {
+			return err
+		}
 
-	b := txn.NewBatch()
-	regionConfig, err := SynthesizeRegionConfig(ctx, txn, r.dbID, descsCol)
-	if err != nil {
-		return err
-	}
-
-	err = localPlanner.forEachMutableTableInDatabase(ctx, dbDesc,
-		func(ctx context.Context, tableDesc *tabledesc.Mutable) error {
-			if !tableDesc.IsLocalityRegionalByRow() || tableDesc.Dropped() {
-				// We only need to re-partition REGIONAL BY ROW tables. Even then, we
-				// don't need to (can't) repartition a REGIONAL BY ROW table if it has
-				// been dropped.
+		return localPlanner.forEachMutableTableInDatabase(
+			ctx,
+			dbDesc,
+			func(ctx context.Context, tableDesc *tabledesc.Mutable) error {
+				if !tableDesc.IsLocalityRegionalByRow() || tableDesc.Dropped() {
+					// We only need to re-partition REGIONAL BY ROW tables. Even then, we
+					// don't need to (can't) repartition a REGIONAL BY ROW table if it has
+					// been dropped.
+					return nil
+				}
+				regionalByRowTables = append(regionalByRowTables, tableDesc)
 				return nil
-			}
+			},
+		)
+	}(); err != nil {
+		cleanup()
+		return nil, err
+	}
 
-			colName, err := tableDesc.GetRegionalByRowTableRegionColumnName()
+	return &databaseRegionChangeFinalizer{
+		dbID:                dbID,
+		typeID:              typeID,
+		localPlanner:        localPlanner,
+		cleanupFunc:         cleanup,
+		regionalByRowTables: regionalByRowTables,
+	}, nil
+}
+
+// cleanup cleans up remaining objects on the databaseRegionChangeFinalizer.
+func (r *databaseRegionChangeFinalizer) cleanup() {
+	if r.cleanupFunc != nil {
+		r.cleanupFunc()
+		r.cleanupFunc = nil
+	}
+}
+
+// finalize updates the zone configurations of the database and all enclosed
+// REGIONAL BY ROW tables once the region promotion/demotion is complete. The
+// caller must call waitToUpdateLeases once the provided transaction commits.
+func (r *databaseRegionChangeFinalizer) finalize(ctx context.Context, txn *kv.Txn) error {
+	if err := r.updateDatabaseZoneConfig(ctx, txn); err != nil {
+		return err
+	}
+	return r.repartitionRegionalByRowTables(ctx, txn)
+}
+
+// updateDatabaseZoneConfig updates the zone config of the database that
+// encloses the multi-region enum such that there is an entry for all PUBLIC
+// region values.
+func (r *databaseRegionChangeFinalizer) updateDatabaseZoneConfig(
+	ctx context.Context, txn *kv.Txn,
+) error {
+	regionConfig, err := SynthesizeRegionConfig(ctx, txn, r.dbID, r.localPlanner.Descriptors())
+	if err != nil {
+		return err
+	}
+	return ApplyZoneConfigFromDatabaseRegionConfig(
+		ctx,
+		r.dbID,
+		regionConfig,
+		txn,
+		r.localPlanner.ExecCfg(),
+	)
+}
+
+// repartitionRegionalByRowTables re-partitions all REGIONAL BY ROW tables
+// contained in the database. repartitionRegionalByRowTables adds a partition
+// and corresponding zone configuration for all PUBLIC enum members (regions)
+// on the multi-region enum.
+func (r *databaseRegionChangeFinalizer) repartitionRegionalByRowTables(
+	ctx context.Context, txn *kv.Txn,
+) error {
+	b := txn.NewBatch()
+	regionConfig, err := SynthesizeRegionConfig(ctx, txn, r.dbID, r.localPlanner.Descriptors())
+	if err != nil {
+		return err
+	}
+
+	for _, tableDesc := range r.regionalByRowTables {
+		// Since we hydrated the columns with the old enum, and now that the enum
+		// has transitioned the read-only members to public, we have to re-hydrate
+		// the table descriptor with the new type metadata.
+		for i := range tableDesc.Columns {
+			col := &tableDesc.Columns[i]
+			if col.Type.UserDefined() && typedesc.UserDefinedTypeOIDToID(col.Type.Oid()) == r.typeID {
+				col.Type.TypeMeta = types.UserDefinedTypeMetadata{}
+			}
+		}
+		if err := typedesc.HydrateTypesInTableDescriptor(
+			ctx,
+			tableDesc.TableDesc(),
+			r.localPlanner,
+		); err != nil {
+			return err
+		}
+
+		colName, err := tableDesc.GetRegionalByRowTableRegionColumnName()
+		if err != nil {
+			return err
+		}
+		partitionAllBy := partitionByForRegionalByRow(regionConfig, colName)
+
+		// oldPartitioningDescs saves the old partitioning descriptors for each
+		// index that is repartitioned. This is later used to remove zone
+		// configurations from any partitions that are removed.
+		oldPartitioningDescs := make(map[descpb.IndexID]descpb.PartitioningDescriptor)
+
+		// Update the partitioning on all indexes of the table that aren't being
+		// dropped.
+		for _, index := range tableDesc.NonDropIndexes() {
+			newIdx, err := CreatePartitioning(
+				ctx,
+				r.localPlanner.extendedEvalCtx.Settings,
+				r.localPlanner.EvalContext(),
+				tableDesc,
+				*index.IndexDesc(),
+				partitionAllBy,
+				nil,  /* allowedNewColumnName*/
+				true, /* allowImplicitPartitioning */
+			)
 			if err != nil {
 				return err
 			}
-			partitionAllBy := partitionByForRegionalByRow(regionConfig, colName)
 
-			// oldPartitioningDescs saves the old partitioning descriptors for each
-			// index that is repartitioned. This is later used to remove zone
-			// configurations from any partitions that are removed.
-			oldPartitioningDescs := make(map[descpb.IndexID]descpb.PartitioningDescriptor)
+			oldPartitioningDescs[index.GetID()] = index.IndexDesc().Partitioning
 
-			// Update the partitioning on all indexes of the table that aren't being
-			// dropped.
-			for _, index := range tableDesc.NonDropIndexes() {
-				newIdx, err := CreatePartitioning(
-					ctx,
-					localPlanner.extendedEvalCtx.Settings,
-					localPlanner.EvalContext(),
-					tableDesc,
-					*index.IndexDesc(),
-					partitionAllBy,
-					nil,  /* allowedNewColumnName*/
-					true, /* allowImplicitPartitioning */
-				)
-				if err != nil {
-					return err
-				}
+			// Update the index descriptor proto's partitioning.
+			index.IndexDesc().Partitioning = newIdx.Partitioning
+		}
 
-				oldPartitioningDescs[index.GetID()] = index.IndexDesc().Partitioning
+		// Remove zone configurations that applied to partitions that were removed
+		// in the previous step. This requires all indexes to have been
+		// repartitioned such that there is no partitioning on the removed enum
+		// value. This is because `deleteRemovedPartitionZoneConfigs` generates
+		// subzone spans for the entire table (all indexes) downstream for each
+		// index. Spans can only be generated if partitioning values are present on
+		// the type descriptor (removed enum values obviously aren't), so we must
+		// remove the partition from all indexes before trying to delete zone
+		// configurations.
+		for _, index := range tableDesc.NonDropIndexes() {
+			oldPartitioning := oldPartitioningDescs[index.GetID()]
 
-				// Update the index descriptor proto's partitioning.
-				index.IndexDesc().Partitioning = newIdx.Partitioning
-			}
-
-			// Remove zone configurations that applied to partitions that were removed
-			// in the previous step. This requires all indexes to have been
-			// repartitioned such that there is no partitioning on the removed enum
-			// value. This is because `deleteRemovedPartitionZoneConfigs` generates
-			// subzone spans for the entire table (all indexes) downstream for each
-			// index. Spans can only be generated if partitioning values are present on
-			// the type descriptor (removed enum values obviously aren't), so we must
-			// remove the partition from all indexes before trying to delete zone
-			// configurations.
-			for _, index := range tableDesc.NonDropIndexes() {
-				oldPartitioning := oldPartitioningDescs[index.GetID()]
-
-				// Remove zone configurations that reference partition values we removed
-				// in the previous step.
-				if err = deleteRemovedPartitionZoneConfigs(
-					ctx,
-					txn,
-					tableDesc,
-					index.IndexDesc(),
-					&oldPartitioning,
-					&index.IndexDesc().Partitioning,
-					execCfg,
-				); err != nil {
-					return err
-				}
-			}
-
-			// Update the zone configurations now that the partition's been added.
-			if err := ApplyZoneConfigForMultiRegionTable(
+			// Remove zone configurations that reference partition values we removed
+			// in the previous step.
+			if err = deleteRemovedPartitionZoneConfigs(
 				ctx,
 				txn,
-				localPlanner.ExecCfg(),
-				regionConfig,
 				tableDesc,
-				ApplyZoneConfigForMultiRegionTableOptionTableAndIndexes,
+				index.IndexDesc(),
+				&oldPartitioning,
+				&index.IndexDesc().Partitioning,
+				r.localPlanner.ExecCfg(),
 			); err != nil {
 				return err
 			}
+		}
 
-			if err := localPlanner.Descriptors().WriteDescToBatch(ctx, false /* kvTrace */, tableDesc, b); err != nil {
-				return err
-			}
+		// Update the zone configurations now that the partition's been added.
+		if err := ApplyZoneConfigForMultiRegionTable(
+			ctx,
+			txn,
+			r.localPlanner.ExecCfg(),
+			regionConfig,
+			tableDesc,
+			ApplyZoneConfigForMultiRegionTableOptionTableAndIndexes,
+		); err != nil {
+			return err
+		}
 
-			repartitionedTableIDs = append(repartitionedTableIDs, tableDesc.GetID())
-			return nil
-		})
+		if err := r.localPlanner.Descriptors().WriteDescToBatch(ctx, false /* kvTrace */, tableDesc, b); err != nil {
+			return err
+		}
+	}
 	if err != nil {
 		return err
 	}
@@ -209,8 +256,6 @@ func (r *databaseRegionChangeFinalizer) repartitionRegionalByRowTables(
 	if err := txn.Run(ctx, b); err != nil {
 		return err
 	}
-
-	r.regionalByRowTables = repartitionedTableIDs
 
 	return nil
 }
@@ -221,7 +266,8 @@ func (r *databaseRegionChangeFinalizer) repartitionRegionalByRowTables(
 func (r *databaseRegionChangeFinalizer) waitToUpdateLeases(
 	ctx context.Context, leaseMgr *lease.Manager,
 ) error {
-	for _, tbID := range r.regionalByRowTables {
+	for _, tb := range r.regionalByRowTables {
+		tbID := tb.GetID()
 		if err := WaitToUpdateLeases(ctx, leaseMgr, tbID); err != nil {
 			if !errors.Is(err, catalog.ErrDescriptorNotFound) {
 				return err

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -255,6 +255,16 @@ func (p *planner) dropIndexByName(
 		return nil
 	}
 
+	if tableDesc.IsLocalityRegionalByRow() {
+		if err := p.checkNoRegionChangeUnderway(
+			ctx,
+			tableDesc.GetParentID(),
+			"DROP INDEX on a REGIONAL BY ROW table",
+		); err != nil {
+			return err
+		}
+	}
+
 	idx := idxI.IndexDesc()
 	if idx.Unique && behavior != tree.DropCascade && constraintBehavior != ignoreIdxConstraint && !idx.CreatedExplicitly {
 		return errors.WithHint(

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -55,7 +55,7 @@ Query {"String": "DROP INDEX t_x_idx"}
 until crdb_only
 CommandComplete
 ----
-{"Severity":"NOTICE","SeverityUnlocalized":"","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":519,"Routine":"dropIndexByName","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":529,"Routine":"dropIndexByName","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 
 until noncrdb_only

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -739,7 +739,7 @@ func (p *planner) updateZoneConfigsForAllTables(ctx context.Context, desc *dbdes
 	return p.forEachMutableTableInDatabase(
 		ctx,
 		&desc.Immutable,
-		func(ctx context.Context, tbDesc *tabledesc.Mutable) error {
+		func(ctx context.Context, scName string, tbDesc *tabledesc.Mutable) error {
 			regionConfig, err := SynthesizeRegionConfig(ctx, p.txn, desc.ID, p.Descriptors())
 			if err != nil {
 				return err
@@ -865,7 +865,7 @@ func (p *planner) validateAllMultiRegionZoneConfigsInDatabase(
 	if err := p.forEachMutableTableInDatabase(
 		ctx,
 		dbDesc,
-		func(ctx context.Context, tbDesc *tabledesc.Mutable) error {
+		func(ctx context.Context, scName string, tbDesc *tabledesc.Mutable) error {
 			ids = append(ids, tbDesc.GetID())
 			return nil
 		},
@@ -895,7 +895,7 @@ func (p *planner) validateAllMultiRegionZoneConfigsInDatabase(
 	return p.forEachMutableTableInDatabase(
 		ctx,
 		dbDesc,
-		func(ctx context.Context, tbDesc *tabledesc.Mutable) error {
+		func(ctx context.Context, scName string, tbDesc *tabledesc.Mutable) error {
 			return p.validateZoneConfigForMultiRegionTable(
 				tbDesc,
 				zoneConfigs[tbDesc.GetID()],

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -1626,3 +1626,68 @@ func (p *planner) validateZoneConfigForMultiRegionTable(
 
 	return nil
 }
+
+// checkNoRegionalByRowChangeUnderway checks that no REGIONAL BY ROW
+// tables are undergoing a schema change that affect their partitions
+// and no tables are transitioning to or from REGIONAL BY ROW.
+func (p *planner) checkNoRegionalByRowChangeUnderway(
+	ctx context.Context, dbDesc *dbdesc.Immutable,
+) error {
+	// forEachTableDesc touches all the table keys, which prevents a race
+	// with ADD/REGION committing at the same time as the user transaction.
+	return p.forEachMutableTableInDatabase(
+		ctx,
+		dbDesc,
+		func(ctx context.Context, scName string, table *tabledesc.Mutable) error {
+			wrapErr := func(err error, detailSuffix string) error {
+				return errors.WithHintf(
+					errors.WithDetailf(
+						err,
+						"table %s.%s %s",
+						tree.Name(scName),
+						tree.Name(table.GetName()),
+						detailSuffix,
+					),
+					"cancel the existing job or try again when the change is complete",
+				)
+			}
+			for _, mut := range table.AllMutations() {
+				// Disallow any locality related swaps.
+				if pkSwap := mut.AsPrimaryKeySwap(); pkSwap != nil {
+					if lcSwap := pkSwap.PrimaryKeySwapDesc().LocalityConfigSwap; lcSwap != nil {
+						return wrapErr(
+							pgerror.Newf(
+								pgcode.ObjectNotInPrerequisiteState,
+								"cannot perform database region changes while a REGIONAL BY ROW transition is underway",
+							),
+							"is currently transitioning to or from REGIONAL BY ROW",
+						)
+					}
+					return wrapErr(
+						pgerror.Newf(
+							pgcode.ObjectNotInPrerequisiteState,
+							"cannot perform database region changes while a ALTER PRIMARY KEY is underway",
+						),
+						"is currently undergoing an ALTER PRIMARY KEY change",
+					)
+				}
+			}
+			// Disallow index changes for REGIONAL BY ROW tables.
+			// We do this on the second loop, as index changes may be a precede to the actual PRIMARY KEY swap.
+			for _, mut := range table.AllMutations() {
+				if table.IsLocalityRegionalByRow() {
+					if idx := mut.AsIndex(); idx != nil {
+						return wrapErr(
+							pgerror.Newf(
+								pgcode.ObjectNotInPrerequisiteState,
+								"cannot perform database region changes while an index is being created or dropped on a REGIONAL BY ROW table",
+							),
+							fmt.Sprintf("is currently modifying index %s", tree.Name(idx.GetName())),
+						)
+					}
+				}
+			}
+			return nil
+		},
+	)
+}

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -1673,7 +1673,9 @@ func (p *planner) checkNoRegionalByRowChangeUnderway(
 				}
 			}
 			// Disallow index changes for REGIONAL BY ROW tables.
-			// We do this on the second loop, as index changes may be a precede to the actual PRIMARY KEY swap.
+			// We do this on the second loop, as ALTER PRIMARY KEY may push
+			// CREATE/DROP INDEX before the ALTER PRIMARY KEY mutation itself.
+			// We should catch ALTER PRIMARY KEY before this ADD/DROP INDEX.
 			for _, mut := range table.AllMutations() {
 				if table.IsLocalityRegionalByRow() {
 					if idx := mut.AsIndex(); idx != nil {
@@ -1690,4 +1692,37 @@ func (p *planner) checkNoRegionalByRowChangeUnderway(
 			return nil
 		},
 	)
+}
+
+// checkNoRegionChangeUnderway checks whether the regions on the current
+// database are currently being modified.
+func (p *planner) checkNoRegionChangeUnderway(
+	ctx context.Context, dbID descpb.ID, op string,
+) error {
+	// SynthesizeRegionConfig touches the type descriptor row, which
+	// prevents a race with a racing conflicting schema change.
+	r, err := SynthesizeRegionConfig(
+		ctx,
+		p.txn,
+		dbID,
+		p.Descriptors(),
+	)
+	if err != nil {
+		return err
+	}
+	if len(r.TransitioningRegions()) > 0 {
+		return errors.WithDetailf(
+			errors.WithHintf(
+				pgerror.Newf(
+					pgcode.ObjectNotInPrerequisiteState,
+					"cannot %s while a region is being added or dropped on the database",
+					op,
+				),
+				"cancel the job which is adding or dropping the region or try again later",
+			),
+			"region %s is currently being added or dropped",
+			r.TransitioningRegions()[0],
+		)
+	}
+	return nil
 }

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -330,6 +330,25 @@ func (t *typeSchemaChanger) exec(ctx context.Context) error {
 				return t.isTransitioningInCurrentJob(member) && enumMemberIsRemoving(member)
 			})
 
+			// We need to initialize the finalizer before we write the type descriptor.
+			// Otherwise, we run into a chicken and egg problem:
+			// * If we write the type descriptor first, the validator expects all the
+			//   regions in the type enum to be a partition on the table descriptor,
+			//   failing validation.
+			// * We cannot write the partitions first as the members are not yet public.
+			regionChangeFinalizer, err = newDatabaseRegionChangeFinalizer(
+				ctx,
+				txn,
+				t.execCfg,
+				descsCol,
+				typeDesc.GetParentID(),
+				typeDesc.GetID(),
+			)
+			if err != nil {
+				return err
+			}
+			defer regionChangeFinalizer.cleanup()
+
 			b := txn.NewBatch()
 			if err := descsCol.WriteDescToBatch(
 				ctx, true /* kvTrace */, typeDesc, b,
@@ -364,8 +383,7 @@ func (t *typeSchemaChanger) exec(ctx context.Context) error {
 						return err
 					}
 				}
-				regionChangeFinalizer = newDatabaseRegionChangeFinalizer(typeDesc.GetParentID(), typeDesc.GetID())
-				if err := regionChangeFinalizer.finalize(ctx, txn, descsCol, t.execCfg); err != nil {
+				if err := regionChangeFinalizer.finalize(ctx, txn); err != nil {
 					return err
 				}
 			}
@@ -456,6 +474,21 @@ func (t *typeSchemaChanger) cleanupEnumValues(ctx context.Context) error {
 			return nil
 		}
 
+		if typeDesc.Kind == descpb.TypeDescriptor_MULTIREGION_ENUM {
+			regionChangeFinalizer, err = newDatabaseRegionChangeFinalizer(
+				ctx,
+				txn,
+				t.execCfg,
+				descsCol,
+				typeDesc.GetParentID(),
+				typeDesc.GetID(),
+			)
+			if err != nil {
+				return err
+			}
+			defer regionChangeFinalizer.cleanup()
+		}
+
 		// Deal with all members that we initially hoped to remove but now need to
 		// be promoted back to writable.
 		for i := range typeDesc.EnumMembers {
@@ -475,10 +508,8 @@ func (t *typeSchemaChanger) cleanupEnumValues(ctx context.Context) error {
 			return err
 		}
 
-		if typeDesc.Kind == descpb.TypeDescriptor_MULTIREGION_ENUM {
-			regionChangeFinalizer = newDatabaseRegionChangeFinalizer(typeDesc.GetParentID(), typeDesc.GetID())
-
-			if err := regionChangeFinalizer.finalize(ctx, txn, descsCol, t.execCfg); err != nil {
+		if regionChangeFinalizer != nil {
+			if err := regionChangeFinalizer.finalize(ctx, txn); err != nil {
 				return err
 			}
 		}

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -360,7 +360,9 @@ func (t *typeSchemaChanger) exec(ctx context.Context) error {
 			// available.
 			if typeDesc.Kind == descpb.TypeDescriptor_MULTIREGION_ENUM {
 				if fn := t.execCfg.TypeSchemaChangerTestingKnobs.RunBeforeMultiRegionUpdates; fn != nil {
-					return fn()
+					if err := fn(); err != nil {
+						return err
+					}
 				}
 				regionChangeFinalizer = newDatabaseRegionChangeFinalizer(typeDesc.GetParentID(), typeDesc.GetID())
 				if err := regionChangeFinalizer.finalize(ctx, txn, descsCol, t.execCfg); err != nil {


### PR DESCRIPTION
Backport:
  * 1/1 commits from "sql: fix multi-region test knob" (#63506)
  * 2/2 commits from "sql: add validation for partitions matching REGIONAL BY ROW" (#63898)
  * 2/2 commits from "sql: add test TestAlterRegionalByRowEnclosingRegionAddDrop" (#64017)
  * 1/1 commits from "sql: disallow RBR transforms if transitioning indexes are incompatible" (#64027)
  * 3/3 commits from "sql: prevent REGIONAL BY ROW and ADD/DROP REGION concurrent transitions" (#64117)

Please see individual PRs for details.

/cc @cockroachdb/release
