### PR TITLE
colbuilder,colflow: fixes around stats collection of uninitialized components

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -550,6 +550,23 @@ func (r opResult) makeDiskBackedSorterConstructor(
 	}
 }
 
+// TODO(yuzefovich): introduce some way to unit test that the meta info tracking
+// works correctly. See #64256 for more details.
+
+// takeOverMetaInfo iterates over all meta components from the input trees and
+// passes the responsibility of handling those to target. The input objects are
+// updated in-place accordingly.
+func takeOverMetaInfo(target *colexecargs.OpWithMetaInfo, inputs []colexecargs.OpWithMetaInfo) {
+	for i := range inputs {
+		target.StatsCollectors = append(target.StatsCollectors, inputs[i].StatsCollectors...)
+		target.MetadataSources = append(target.MetadataSources, inputs[i].MetadataSources...)
+		target.ToClose = append(target.ToClose, inputs[i].ToClose...)
+		inputs[i].MetadataSources = nil
+		inputs[i].StatsCollectors = nil
+		inputs[i].ToClose = nil
+	}
+}
+
 // createAndWrapRowSource takes a processor spec, creating the row source and
 // wrapping it using wrapRowSources. Note that the post process spec is included
 // in the processor creation, so make sure to clear it if it will be inspected
@@ -628,6 +645,7 @@ func (r opResult) createAndWrapRowSource(
 	if args.TestingKnobs.PlanInvariantsCheckers {
 		r.Root = colexec.NewInvariantsChecker(r.Root)
 	}
+	takeOverMetaInfo(&r.OpWithMetaInfo, inputs)
 	r.MetadataSources = append(r.MetadataSources, r.Root.(colexecop.MetadataSource))
 	r.ToClose = append(r.ToClose, c)
 	r.Releasables = append(r.Releasables, releasables...)
@@ -1404,14 +1422,7 @@ func NewColOperator(
 			r.Root = colexec.NewInvariantsChecker(r.Root)
 		}
 	}
-	// Handle the metadata components from the input trees. Note that it is
-	// possible that we have created materializers which took over the
-	// responsibility over those objects.
-	for i := range inputs {
-		r.StatsCollectors = append(r.StatsCollectors, inputs[i].StatsCollectors...)
-		r.MetadataSources = append(r.MetadataSources, inputs[i].MetadataSources...)
-		r.ToClose = append(r.ToClose, inputs[i].ToClose...)
-	}
+	takeOverMetaInfo(&result.OpWithMetaInfo, inputs)
 	if util.CrdbTestBuild {
 		r.AssertInvariants()
 	}
@@ -1452,9 +1463,11 @@ func (r opResult) planAndMaybeWrapFilter(
 			ProcessorID: processorID,
 			ResultTypes: args.Spec.ResultTypes,
 		}
+		inputToMaterializer := colexecargs.OpWithMetaInfo{Root: r.Root}
+		takeOverMetaInfo(&inputToMaterializer, args.Inputs)
 		return r.createAndWrapRowSource(
-			ctx, flowCtx, args, []colexecargs.OpWithMetaInfo{r.OpWithMetaInfo}, [][]*types.T{r.ColumnTypes},
-			filtererSpec, factory, err,
+			ctx, flowCtx, args, []colexecargs.OpWithMetaInfo{inputToMaterializer},
+			[][]*types.T{r.ColumnTypes}, filtererSpec, factory, err,
 		)
 	}
 	r.Root = op
@@ -1482,9 +1495,11 @@ func (r opResult) wrapPostProcessSpec(
 		Post:        *post,
 		ResultTypes: resultTypes,
 	}
+	inputToMaterializer := colexecargs.OpWithMetaInfo{Root: r.Root}
+	takeOverMetaInfo(&inputToMaterializer, args.Inputs)
 	return r.createAndWrapRowSource(
-		ctx, flowCtx, args, []colexecargs.OpWithMetaInfo{r.OpWithMetaInfo}, [][]*types.T{r.ColumnTypes},
-		noopSpec, factory, causeToWrap,
+		ctx, flowCtx, args, []colexecargs.OpWithMetaInfo{inputToMaterializer},
+		[][]*types.T{r.ColumnTypes}, noopSpec, factory, causeToWrap,
 	)
 }
 

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -1433,13 +1433,13 @@ func (r opResult) planAndMaybeWrapFilter(
 		ctx, flowCtx, evalCtx, r.Root, r.ColumnTypes, filter, args.StreamingMemAccount, factory, args.ExprHelper,
 	)
 	if err != nil {
-		// ON expression planning failed. Fall back to planning the filter
+		// Filter expression planning failed. Fall back to planning the filter
 		// using row execution.
 		if log.V(2) {
 			log.Infof(
 				ctx,
-				"vectorized join ON expr planning failed with error %v ON expr is %s, attempting to wrap as a row source",
-				err, filter.String(),
+				"filter expr %s planning failed with error, attempting to wrap as a row source: %v",
+				filter.String(), err,
 			)
 		}
 

--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -177,12 +177,13 @@ func (c *Columnarizer) GetStats() *execinfrapb.ComponentStats {
 			"unexpectedly the columnarizer was removed from the flow when stats are being collected",
 		))
 	}
-	if !c.removedFromFlow && c.ExecStatsForTrace != nil {
-		s := c.ExecStatsForTrace()
-		s.Component = c.FlowCtx.ProcessorComponentID(c.ProcessorID)
-		return s
+	componentID := c.FlowCtx.ProcessorComponentID(c.ProcessorID)
+	if c.removedFromFlow || c.ExecStatsForTrace == nil {
+		return &execinfrapb.ComponentStats{Component: componentID}
 	}
-	return nil
+	s := c.ExecStatsForTrace()
+	s.Component = componentID
+	return s
 }
 
 // Next is part of the Operator interface.

--- a/pkg/sql/colexecop/operator.go
+++ b/pkg/sql/colexecop/operator.go
@@ -398,6 +398,7 @@ func (s MetadataSources) DrainMeta(ctx context.Context) []execinfrapb.ProducerMe
 // "network" option (strictly for colrpc.Inboxes).
 type VectorizedStatsCollector interface {
 	Operator
-	// GetStats returns the execution statistics of a single Operator.
+	// GetStats returns the execution statistics of a single Operator. It will
+	// always return non-nil (but possibly empty) object.
 	GetStats() *execinfrapb.ComponentStats
 }


### PR DESCRIPTION
**colbuilder: fix logging message when planning a filter expression**

Originally, a filter expression was handled by a wrapped row-execution
processor only when planning ON expression filter for inner merge and
hash joins, so the logging message mentioned the ON expr explicitly.
However, since then we reused the same code in a couple of other places,
so the message no longer made sense.

Release note: None

**colbuilder: fix passing of the responsibility over meta objects**

Previously, in some edge cases we didn't pass the responsibility over
the meta objects to the materializers that are created in order to wrap
row-execution processors into the vectorized flows. For example, if we
had a Filterer processor core that is supported by the vectorized
engine, but we had some render expressions that weren't supported, the
materializer created to wrap a noop processor (that would handle the
render expressions) wouldn't take over the responsibility of the meta
objects in the input tree to the filterer core. This is now fixed.

This commit is missing any regression testing since verifying that the
internal state is as expected is hard. I imagine that we might want to
introduce something like `EXPLAIN (VEC, DEBUG)` where we would annotate
the operator chains with some information about the meta objects
"assigned" to each operator. This seems non-trivial, however, so it is
left as a TODO.

Informs: #64256.

Release note: None

**colflow: handle uninitialized op gracefully during stats collection**

Previously, the vectorized stats collector wrapper would always attempt
to get stats from the wrapped operator. However, in some edge cases that
operator might not be properly initialized, and we could encounter a NPE
during the stats retrieval. Now the wrapper tracks whether Init was
successful and will get stats only if so. This strategy was chosen over
teaching each operator to handle uninitialized state itself since it is
cleaner this way and more extensible.

This commit additionally clarifies the VectorizedStatsCollector interface
a bit.

Fixes: #64180.
Fixes: #64192.
Fixes: #64193.
Fixes: #64232.
Fixes: #64236.

Release note: None