### PR TITLE
builtins: make ST_EstimatedExtent always return NULL

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1708,6 +1708,13 @@ Bottom Left.</p>
 <p>This function utilizes the GEOS module.</p>
 <p>This function variant will attempt to utilize any available spatial index.</p>
 </span></td></tr>
+<tr><td><a name="st_estimatedextent"></a><code>st_estimatedextent(schema_name: <a href="string.html">string</a>, table_name: <a href="string.html">string</a>, geocolumn_name: <a href="string.html">string</a>) &rarr; box2d</code></td><td><span class="funcdesc"><p>Returns the estimated extent of the geometries in the column of the given table. This currently always returns NULL.</p>
+</span></td></tr>
+<tr><td><a name="st_estimatedextent"></a><code>st_estimatedextent(schema_name: <a href="string.html">string</a>, table_name: <a href="string.html">string</a>, geocolumn_name: <a href="string.html">string</a>, parent_only: <a href="bool.html">bool</a>) &rarr; box2d</code></td><td><span class="funcdesc"><p>Returns the estimated extent of the geometries in the column of the given table. This currently always returns NULL.</p>
+<p>The parent_only boolean is always ignored.</p>
+</span></td></tr>
+<tr><td><a name="st_estimatedextent"></a><code>st_estimatedextent(table_name: <a href="string.html">string</a>, geocolumn_name: <a href="string.html">string</a>) &rarr; box2d</code></td><td><span class="funcdesc"><p>Returns the estimated extent of the geometries in the column of the given table. This currently always returns NULL.</p>
+</span></td></tr>
 <tr><td><a name="st_expand"></a><code>st_expand(box2d: box2d, delta: <a href="float.html">float</a>) &rarr; box2d</code></td><td><span class="funcdesc"><p>Extends the box2d by delta units across all dimensions.</p>
 </span></td></tr>
 <tr><td><a name="st_expand"></a><code>st_expand(box2d: box2d, delta_x: <a href="float.html">float</a>, delta_y: <a href="float.html">float</a>) &rarr; box2d</code></td><td><span class="funcdesc"><p>Extends the box2d by delta_x units in the x dimension and delta_y units in the y dimension.</p>

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -5792,3 +5792,11 @@ FROM (SELECT
 	) tbl(poly, line);
 ----
 MULTIPOLYGON (((5 107, 26 200, 126 200, 126 125, 101 100, 54 84, 5 107), (51 150, 101 150, 76 175, 51 150)), ((151 100, 151 200, 176 175, 151 100)))
+
+query TTT
+SELECT
+  ST_EstimatedExtent('a', 'b', 'c', false),
+  ST_EstimatedExtent('a', 'b', 'c'),
+  ST_EstimatedExtent('a', 'b')
+----
+NULL  NULL  NULL

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -5813,6 +5813,66 @@ See http://developers.google.com/maps/documentation/utilities/polylinealgorithm`
 	),
 
 	//
+	// Table metadata
+	//
+
+	"st_estimatedextent": makeBuiltin(
+		tree.FunctionProperties{
+			Category: categorySpatial,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"schema_name", types.String},
+				{"table_name", types.String},
+				{"geocolumn_name", types.String},
+				{"parent_only", types.Bool},
+			},
+			ReturnType: tree.FixedReturnType(types.Box2D),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				// TODO(#64257): implement by looking at statistics.
+				return tree.DNull, nil
+			},
+			Info: infoBuilder{
+				info: `Returns the estimated extent of the geometries in the column of the given table. This currently always returns NULL.
+
+The parent_only boolean is always ignored.`,
+			}.String(),
+			Volatility: tree.VolatilityStable,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"schema_name", types.String},
+				{"table_name", types.String},
+				{"geocolumn_name", types.String},
+			},
+			ReturnType: tree.FixedReturnType(types.Box2D),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				// TODO(#64257): implement by looking at statistics.
+				return tree.DNull, nil
+			},
+			Info: infoBuilder{
+				info: `Returns the estimated extent of the geometries in the column of the given table. This currently always returns NULL.`,
+			}.String(),
+			Volatility: tree.VolatilityStable,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"table_name", types.String},
+				{"geocolumn_name", types.String},
+			},
+			ReturnType: tree.FixedReturnType(types.Box2D),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				// TODO(#64257): implement by looking at statistics.
+				return tree.DNull, nil
+			},
+			Info: infoBuilder{
+				info: `Returns the estimated extent of the geometries in the column of the given table. This currently always returns NULL.`,
+			}.String(),
+			Volatility: tree.VolatilityStable,
+		},
+	),
+
+	//
 	// Schema changes
 	//
 


### PR DESCRIPTION
NULL is always valid for ST_EstimatedExtent, and is the default if
statistics cannot be found for the given column. This allows tools which
use this function to progress.

Refs: #64257
Refs: #52013

Release note (sql change): Stub ST_EstimatedExtent, which always returns
NULL. This allows geoserver to make progress in certain cases, and is a
valid default return value for the function.