### PR TITLE
kvserver: speed up intent resolution for aborted txns

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_resolve_intent_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_resolve_intent_range.go
@@ -44,12 +44,8 @@ func ResolveIntentRange(
 
 	update := args.AsLockUpdate()
 
-	iterAndBuf := storage.GetIterAndBuf(readWriter, storage.IterOptions{UpperBound: args.EndKey})
-	defer iterAndBuf.Cleanup()
-
-	numKeys, resumeSpan, err := storage.MVCCResolveWriteIntentRangeUsingIter(
-		ctx, readWriter, iterAndBuf, ms, update, h.MaxSpanRequestKeys,
-	)
+	numKeys, resumeSpan, err := storage.MVCCResolveWriteIntentRange(
+		ctx, readWriter, ms, update, h.MaxSpanRequestKeys)
 	if err != nil {
 		return result.Result{}, err
 	}


### PR DESCRIPTION
### kvserver: speed up intent resolution for aborted txns

Cleaning up intents for aborted txns during `EndTxn` could be very slow
for intents that had already been removed by a concurrent process, due
to suboptimal iterator reuse.

This patch changes this intent resolution path to instead create a new
iterator with `Prefix:true` for each intent rather than seeking a
reusable iterator. This reduces intent resolution time by two orders of
magnitude (~200s → ~1s in tests). A simple performance regression test
has been added for this.

Resolves #64092.

Release note (performance improvement): improved intent cleanup
performance for aborted transactions.

### intentresolver: reduce ranged resolution batch size

This patch adds the constants `intentResolverRangeBatchSize` and
`intentResolverRangeRequestSize` to control the number of requests and
number of intents per request for ranged intent resolution. It also
reduces the number of range requests per batch from 100 to 10, since
ranged requests can fan out to hit 200 intents each (via range scans)
which is significantly more expensive than single-intent requests.

Release note: None

/cc @cockroachdb/kv 