### PR TITLE
changefeedccl: remove flaky assertion

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1693,10 +1693,6 @@ func TestChangefeedMonitoring(t *testing.T) {
 			if c := s.MustGetSQLCounter(`changefeed.buffer_entries.out`); c <= 0 {
 				return errors.Errorf(`expected > 0 got %d`, c)
 			}
-			if c := s.MustGetSQLCounter(`changefeed.table_metadata_nanos`); c <= 0 {
-				t.Errorf(`expected > 0 got %d`, c)
-			}
-
 			return nil
 		})
 


### PR DESCRIPTION
This was failing on unrelated PRs:

    Failed
    === RUN   TestChangefeedMonitoring/sinkless
    changefeed_test.go:1697: expected > 0 got 0
    --- FAIL: TestChangefeedMonitoring/sinkless (12.04s)

I believe this is because the test setup for the metrics isn't
guaranteed to produce any wait time in the schema feed. We could hit
the fast path or our waiter could complete before we even start the
timer.

Release note: None