### PR TITLE
logictest: temporarily disable vectorized flow assertion

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1356,8 +1356,9 @@ func (t *logicTest) newCluster(serverArgs TestServerArgs) {
 	}
 
 	distSQLKnobs := &execinfra.TestingKnobs{
-		MetadataTestLevel:                    execinfra.Off,
-		CheckVectorizedFlowIsClosedCorrectly: true,
+		MetadataTestLevel: execinfra.Off,
+		// TODO(yuzefovich): uncomment once #64248 is resolved.
+		//CheckVectorizedFlowIsClosedCorrectly: true,
 	}
 	cfg := t.cfg
 	if cfg.sqlExecUseDisk {


### PR DESCRIPTION
Informs: #64248.

Release note: None
