### PR TITLE
release-21.1: opt: disallow fast path for cascading deletes with subqueries

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -4352,3 +4352,12 @@ SELECT * FROM child
 
 statement ok
 DROP TABLE child, parent
+
+# Regression test for #64179. A cascading delete with a subquery should not
+# error.
+statement ok
+CREATE TABLE a (a INT UNIQUE);
+CREATE TABLE b (b INT, FOREIGN KEY (b) REFERENCES a (a) ON DELETE CASCADE);
+
+statement ok
+DELETE FROM a WHERE EXISTS (SELECT a FROM a)

--- a/pkg/sql/opt/optbuilder/fk_cascade.go
+++ b/pkg/sql/opt/optbuilder/fk_cascade.go
@@ -189,6 +189,9 @@ func tryNewOnDeleteFastCascadeBuilder(
 		if memo.CanBeCompositeSensitive(md, &sel.Filters) {
 			return nil, false
 		}
+		if sel.Relational().HasSubquery {
+			return nil, false
+		}
 		filters = sel.Filters
 
 	case opt.ScanOp:

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-delete-cascade
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-delete-cascade
@@ -65,6 +65,42 @@ root
                 └── filters
                      └── child.p:9 = p:11
 
+# Delete with subquery; no fast path.
+build-cascades
+DELETE FROM parent WHERE EXISTS (SELECT p FROM parent)
+----
+root
+ ├── delete parent
+ │    ├── columns: <none>
+ │    ├── fetch columns: p:3
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── fk_p_ref_parent
+ │    └── select
+ │         ├── columns: p:3!null crdb_internal_mvcc_timestamp:4
+ │         ├── scan parent
+ │         │    └── columns: p:3!null crdb_internal_mvcc_timestamp:4
+ │         └── filters
+ │              └── exists
+ │                   └── project
+ │                        ├── columns: p:5!null
+ │                        └── scan parent
+ │                             └── columns: p:5!null crdb_internal_mvcc_timestamp:6
+ └── cascade
+      └── delete child
+           ├── columns: <none>
+           ├── fetch columns: c:10 child.p:11
+           └── semi-join (hash)
+                ├── columns: c:10!null child.p:11!null
+                ├── scan child
+                │    └── columns: c:10!null child.p:11!null
+                ├── with-scan &1
+                │    ├── columns: p:13!null
+                │    └── mapping:
+                │         └──  parent.p:3 => p:13
+                └── filters
+                     └── child.p:11 = p:13
+
 # Delete everything.
 build-cascades
 DELETE FROM parent


### PR DESCRIPTION
Backport 1/1 commits from #64252.

/cc @cockroachdb/release

---

Previously, the optimizer would attempt to build a fast path cascading
delete for `DELETE`s with a subquery. This caused errors when copying
the original filters for the fast path query. The cascade query is built
using a separate memo with metadata that does not include tables in the
original memo's metadata. As a result, a Scan in a cascade fast path
subquery could reference a table ID that did not exist in the metadata.

This commit prevents building fast path cascading deletes if the
delete has any subqueries.

Fixes #64179

Release note (bug fix): Cascading `DELETE`s with subqueries no longer
error. This bug was present since v21.1.0-alpha.1.
