### PR TITLE
bazel: generate additional `stringer` files in the Bazel sandbox

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -91,6 +91,7 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 # gazelle:exclude pkg/cli/keytype_string.go
 # gazelle:exclude pkg/clusterversion/key_string.go
 # gazelle:exclude pkg/kv/kvclient/kvcoord/txnstate_string.go
+# gazelle:exclude pkg/kv/kvserver/closedts/sidetransport/cantclosereason_string.go
 # gazelle:exclude pkg/kv/kvserver/refreshraftreason_string.go
 # gazelle:exclude pkg/roachpb/errordetailtype_string.go
 # gazelle:exclude pkg/roachpb/method_string.go
@@ -117,6 +118,7 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 # gazelle:exclude pkg/sql/schemachanger/scop/type_string.go
 # gazelle:exclude pkg/sql/sem/tree/createtypevariety_string.go
 # gazelle:exclude pkg/sql/sem/tree/statementreturntype_string.go
+# gazelle:exclude pkg/sql/sem/tree/statementtype_string.go
 # gazelle:exclude pkg/sql/txnevent_string.go
 # gazelle:exclude pkg/sql/txntype_string.go
 # gazelle:exclude pkg/util/encoding/type_string.go

--- a/build/bazelutil/check-genfiles.sh
+++ b/build/bazelutil/check-genfiles.sh
@@ -4,8 +4,6 @@ set -euo pipefail
 
 # Avoid adding new exclusions unless necessary.
 STRINGER_EXCLUSIONS="
-pkg/kv/kvserver/closedts/sidetransport/cantclosereason_string.go
-pkg/sql/sem/tree/statementtype_string.go
 "
 
 git grep 'go:generate stringer' pkg | while read LINE; do

--- a/pkg/kv/kvserver/closedts/sidetransport/BUILD.bazel
+++ b/pkg/kv/kvserver/closedts/sidetransport/BUILD.bazel
@@ -1,12 +1,13 @@
+load("//build:STRINGER.bzl", "stringer")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "sidetransport",
     srcs = [
-        "cantclosereason_string.go",
         "debug.go",
         "receiver.go",
         "sender.go",
+        ":gen-cantclosereason-stringer",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/sidetransport",
     visibility = ["//visibility:public"],
@@ -53,4 +54,10 @@ go_test(
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//:go_default_library",
     ],
+)
+
+stringer(
+    name = "gen-cantclosereason-stringer",
+    src = "sender.go",
+    typ = "CantCloseReason",
 )

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -81,7 +81,6 @@ go_library(
         "set.go",
         "show.go",
         "split.go",
-        "statementtype_string.go",
         "stmt.go",
         "stream_ingestion.go",
         "survival_goal.go",
@@ -107,6 +106,7 @@ go_library(
         "zone.go",
         ":gen-createtypevariety-stringer",  # keep
         ":gen-statementreturntype-stringer",  # keep
+        ":gen-statementtype-stringer",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/sem/tree",
     visibility = ["//visibility:public"],
@@ -252,4 +252,10 @@ stringer(
     name = "gen-statementreturntype-stringer",
     src = "stmt.go",
     typ = "StatementReturnType",
+)
+
+stringer(
+    name = "gen-statementtype-stringer",
+    src = "stmt.go",
+    typ = "StatementType",
 )


### PR DESCRIPTION
This removes the final exclusions, so there are no un-Bazelfied
`stringer` files in tree, and the linter will catch it if any are added
in the future :)

Release note: None