### PR TITLE
importccl,backupccl,changefeedccl: use Descriptor interface

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -355,7 +355,7 @@ func spansForAllTableIndexes(
 		// state. We want (and do) ignore tables that have been dropped for the
 		// entire interval. DROPPED tables should never later become PUBLIC.
 		rawTbl, _, _, _ := descpb.FromDescriptor(rev.Desc)
-		if rawTbl != nil && rawTbl.State == descpb.DescriptorState_PUBLIC {
+		if rawTbl != nil && rawTbl.Public() {
 			tbl := tabledesc.NewBuilder(rawTbl).BuildImmutableTable()
 			revSpans, err := getLogicallyMergedTableSpans(tbl, added, execCfg.Codec, rev.Time,
 				checkForKVInBounds)

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -369,7 +369,7 @@ func fullClusterTargets(
 				}
 			} else {
 				// Add all user tables that are not in a DROP state.
-				if desc.GetState() != descpb.DescriptorState_DROP {
+				if !desc.Dropped() {
 					fullClusterDescs = append(fullClusterDescs, desc)
 				}
 			}

--- a/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//pkg/settings",
         "//pkg/sql",
         "//pkg/sql/catalog",
-        "//pkg/sql/catalog/descpb",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/ccl/changefeedccl/changefeedbase/validate.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/validate.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/errors"
 )
 
@@ -49,7 +48,7 @@ func ValidateTable(targets jobspb.ChangefeedTargets, tableDesc catalog.TableDesc
 			tableDesc.GetName(), len(tableDesc.GetFamilies()))
 	}
 
-	if tableDesc.GetState() == descpb.DescriptorState_DROP {
+	if tableDesc.Dropped() {
 		return errors.Errorf(`"%s" was dropped`, t.StatementTimeName)
 	}
 

--- a/pkg/ccl/importccl/import_table_creation.go
+++ b/pkg/ccl/importccl/import_table_creation.go
@@ -193,7 +193,7 @@ func MakeSimpleTableDescriptor(
 // and mark references an validated. This function sets the table to PUBLIC
 // and the FKs to unvalidated.
 func fixDescriptorFKState(tableDesc *tabledesc.Mutable) error {
-	tableDesc.State = descpb.DescriptorState_PUBLIC
+	tableDesc.SetPublic()
 	for i := range tableDesc.OutboundFKs {
 		tableDesc.OutboundFKs[i].Validity = descpb.ConstraintValidity_Unvalidated
 	}

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -262,8 +262,7 @@ func createPostgresSchemas(
 		// We didn't allocate an ID above, so we must assign it a mock ID until it
 		// is assigned an actual ID later in the import.
 		desc.ID = getNextPlaceholderDescID()
-		desc.State = descpb.DescriptorState_OFFLINE
-		desc.OfflineReason = "importing"
+		desc.SetOffline("importing")
 		return desc, nil
 	}
 	var schemaDescs []*schemadesc.Mutable


### PR DESCRIPTION
This uses the Descriptor interface methods added in 40789fb3000.

In the cases of SetDropped(), it is the case that OfflineReason will
be getting cleared when it wasn't being cleared before.

I left some instances in the tests where I felt that inspecting the
State directly would probably lead to better test failure output.

There are also a few cases in pkg/sql that could probably be converted
to use these as well, but those aren't handled here.

Release note: None