### PR TITLE
cliccl/debug_backup.go: add `--with-revisions` flag to allow debugging revisions of data

### DIFF
--- a/pkg/ccl/cliccl/BUILD.bazel
+++ b/pkg/ccl/cliccl/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//pkg/server",
         "//pkg/settings/cluster",
         "//pkg/sql/catalog",
+        "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/row",

--- a/pkg/ccl/cliccl/debug_backup_test.go
+++ b/pkg/ccl/cliccl/debug_backup_test.go
@@ -540,9 +540,10 @@ func TestExportDataAOST(t *testing.T) {
 		require.NoError(t, err)
 		expectedError := fmt.Sprintf(
 			"ERROR: fetching entry: unknown read time: %s\n"+
-				"HINT: reading data for requested time requires that BACKUP was created with \"revision_history\" "+
+				"HINT: reading data for requested time requires that BACKUP was created with %q "+
 				"or should specify the time to be an exact backup time, nearest backup time is %s\n",
 			timeutil.Unix(0, ts.WallTime).UTC(),
+			backupOptRevisionHistory,
 			timeutil.Unix(0, ts1.WallTime).UTC())
 		checkExpectedOutput(t, expectedError, out)
 	})
@@ -686,6 +687,140 @@ func TestExportDataAOST(t *testing.T) {
 				strings.Join(tc.backupPaths, " "),
 				tc.tableName,
 				tc.asof,
+				dir))
+			require.NoError(t, err)
+			checkExpectedOutput(t, tc.expectedData, out)
+		})
+	}
+}
+
+func TestExportDataWithRevisions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	c := cli.NewCLITest(cli.TestCLIParams{T: t, NoServer: true})
+	defer c.Cleanup()
+
+	ctx := context.Background()
+	dir, cleanFn := testutils.TempDir(t)
+	defer cleanFn()
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{ExternalIODir: dir, Insecure: true})
+	defer srv.Stopper().Stop(ctx)
+
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, `CREATE DATABASE testDB`)
+	sqlDB.Exec(t, `USE testDB`)
+	sqlDB.Exec(t, `CREATE TABLE fooTable (id INT PRIMARY KEY, value INT, tag STRING)`)
+
+	const backupPath = "nodelocal://0/fooFolder"
+	const backupPathWithRev = "nodelocal://0/fooFolderRev"
+
+	sqlDB.Exec(t, `INSERT INTO fooTable VALUES (1, 123, 'cat')`)
+	var tsInsert time.Time
+	sqlDB.QueryRow(t, `SELECT crdb_internal.approximate_timestamp(crdb_internal_mvcc_timestamp) from fooTable where id=1`).Scan(&tsInsert)
+
+	sqlDB.Exec(t, `INSERT INTO fooTable VALUES (2, 223, 'dog')`)
+	var tsInsert2 time.Time
+	sqlDB.QueryRow(t, `SELECT crdb_internal.approximate_timestamp(crdb_internal_mvcc_timestamp) from fooTable where id=2`).Scan(&tsInsert2)
+
+	ts1 := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
+	sqlDB.Exec(t, fmt.Sprintf(`BACKUP TO $1 AS OF SYSTEM TIME '%s'`, ts1.AsOfSystemTime()), backupPath)
+	sqlDB.Exec(t, fmt.Sprintf(`BACKUP TO $1 AS OF SYSTEM TIME '%s' WITH revision_history`, ts1.AsOfSystemTime()), backupPathWithRev)
+
+	sqlDB.Exec(t, `ALTER TABLE fooTable ADD COLUMN active BOOL`)
+	sqlDB.Exec(t, `INSERT INTO fooTable VALUES (3, 323, 'mickey mouse', true)`)
+	var tsInsert3 time.Time
+	sqlDB.QueryRow(t, `SELECT crdb_internal.approximate_timestamp(crdb_internal_mvcc_timestamp) from fooTable where id=3`).Scan(&tsInsert3)
+	ts2 := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
+	sqlDB.Exec(t, fmt.Sprintf(`BACKUP TO $1 AS OF SYSTEM TIME '%s' WITH revision_history`, ts2.AsOfSystemTime()), backupPathWithRev)
+
+	sqlDB.Exec(t, `SET sql_safe_updates=false`)
+	sqlDB.Exec(t, `ALTER TABLE fooTable DROP COLUMN value`)
+	var tsDropColumn time.Time
+	sqlDB.QueryRow(t, `SELECT crdb_internal.approximate_timestamp(crdb_internal_mvcc_timestamp) from fooTable where id=3`).Scan(&tsDropColumn)
+
+	sqlDB.Exec(t, `UPDATE fooTable SET tag=('lion') WHERE id = 1`)
+	var tsUpdate time.Time
+	sqlDB.QueryRow(t, `SELECT crdb_internal.approximate_timestamp(crdb_internal_mvcc_timestamp) from fooTable where id=1`).Scan(&tsUpdate)
+
+	ts3 := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
+	sqlDB.Exec(t, fmt.Sprintf(`BACKUP TO $1 AS OF SYSTEM TIME '%s' WITH revision_history`, ts3.AsOfSystemTime()), backupPathWithRev)
+
+	sqlDB.Exec(t, `CREATE INDEX extra ON fooTable (id)`)
+	ts4 := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
+	sqlDB.Exec(t, fmt.Sprintf(`BACKUP TO $1 AS OF SYSTEM TIME '%s' WITH revision_history`, ts4.AsOfSystemTime()), backupPathWithRev)
+
+	t.Run("show-data-revisions-of-backup-without-revision-history", func(t *testing.T) {
+		setDebugContextDefault()
+		out, err := c.RunWithCapture(fmt.Sprintf("debug backup export %s --table=%s  --with-revisions --external-io-dir=%s",
+			backupPath,
+			"testDB.public.fooTable",
+			dir))
+		require.NoError(t, err)
+		expectedError := "ERROR: invalid flag: with-revisions\nHINT: requires backup created with \"revision_history\"\n"
+		checkExpectedOutput(t, expectedError, out)
+	})
+
+	testCases := []struct {
+		name          string
+		tableName     string
+		backupPaths   []string
+		expectedData  string
+		upToTimestamp string
+	}{
+		{
+			"show-data-revisions-of-a-single-full-backup",
+			"testDB.public.fooTable",
+			[]string{
+				backupPathWithRev,
+			},
+			fmt.Sprintf("1,123,'cat',%s\n2,223,'dog',%s\n", tsInsert.UTC(), tsInsert2.UTC()),
+			"",
+		},
+		{
+			"show-data-revisions-after-adding-an-colum",
+			"testDB.public.fooTable",
+			[]string{
+				backupPathWithRev,
+				backupPathWithRev + ts2.GoTime().Format(backupccl.DateBasedIncFolderName),
+				backupPathWithRev + ts3.GoTime().Format(backupccl.DateBasedIncFolderName),
+			},
+			fmt.Sprintf("3,323,'mickey mouse',true,%s\n", tsInsert3.UTC()),
+			ts2.AsOfSystemTime(),
+		},
+		{
+			"show-data-revisions-after-dropping-an-colum-and-update-value",
+			"testDB.public.fooTable",
+			[]string{
+				backupPathWithRev,
+				backupPathWithRev + ts2.GoTime().Format(backupccl.DateBasedIncFolderName),
+				backupPathWithRev + ts3.GoTime().Format(backupccl.DateBasedIncFolderName),
+			},
+			fmt.Sprintf("1,'lion',null,%s\n1,'cat',null,%s\n2,'dog',null,%s\n3,'mickey mouse',true,%s\n",
+				tsUpdate.UTC(), tsDropColumn.UTC(), tsDropColumn.UTC(), tsDropColumn.UTC()),
+			ts3.AsOfSystemTime(),
+		}, {
+			"show-data-revisions-after-adding-index",
+			"testDB.public.fooTable",
+			[]string{
+				backupPathWithRev,
+				backupPathWithRev + ts2.GoTime().Format(backupccl.DateBasedIncFolderName),
+				backupPathWithRev + ts3.GoTime().Format(backupccl.DateBasedIncFolderName),
+				backupPathWithRev + ts4.GoTime().Format(backupccl.DateBasedIncFolderName),
+			},
+			fmt.Sprintf("1,'lion',null,%s\n1,'cat',null,%s\n2,'dog',null,%s\n3,'mickey mouse',true,%s\n",
+				tsUpdate.UTC(), tsDropColumn.UTC(), tsDropColumn.UTC(), tsDropColumn.UTC()),
+			ts4.AsOfSystemTime(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			setDebugContextDefault()
+			out, err := c.RunWithCapture(fmt.Sprintf("debug backup export %s --table=%s --with-revisions --up-to=%s --external-io-dir=%s",
+				strings.Join(tc.backupPaths, " "),
+				tc.tableName,
+				tc.upToTimestamp,
 				dir))
 			require.NoError(t, err)
 			checkExpectedOutput(t, tc.expectedData, out)

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1572,4 +1572,14 @@ The bytekey format does not require table-key prefix.`,
 		Name:        "max-rows",
 		Description: `Maximum number of rows to return (Default 0 is unlimited).`,
 	}
+
+	ExportRevisions = FlagInfo{
+		Name:        "with-revisions",
+		Description: `Export revisions of data from a backup table since the last schema change.`,
+	}
+
+	ExportRevisionsUpTo = FlagInfo{
+		Name:        "up-to",
+		Description: `Export revisions of data from a backup table up to a specific timestamp.`,
+	}
 )

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -169,22 +169,30 @@ func (f *SpanKVFetcher) nextBatch(
 func (f *SpanKVFetcher) close(context.Context) {}
 
 // BackupSSTKVFetcher is a kvBatchFetcher that wraps storage.SimpleMVCCIterator
-// and returns a single kv from backupSST.
+// and returns a batch of kv from backupSST.
 type BackupSSTKVFetcher struct {
-	iter       storage.SimpleMVCCIterator
-	endKeyMVCC storage.MVCCKey
-	endTime    hlc.Timestamp
+	iter          storage.SimpleMVCCIterator
+	endKeyMVCC    storage.MVCCKey
+	startTime     hlc.Timestamp
+	endTime       hlc.Timestamp
+	withRevisions bool
 }
 
 // MakeBackupSSTKVFetcher creates a BackupSSTKVFetcher and
 // advances the iter to the first key >= startKeyMVCC
 func MakeBackupSSTKVFetcher(
-	startKeyMVCC, endKeyMVCC storage.MVCCKey, iter storage.SimpleMVCCIterator, endTime hlc.Timestamp,
+	startKeyMVCC, endKeyMVCC storage.MVCCKey,
+	iter storage.SimpleMVCCIterator,
+	startTime hlc.Timestamp,
+	endTime hlc.Timestamp,
+	withRev bool,
 ) BackupSSTKVFetcher {
 	res := BackupSSTKVFetcher{
 		iter,
 		endKeyMVCC,
+		startTime,
 		endTime,
+		withRev,
 	}
 	res.iter.SeekGE(startKeyMVCC)
 	return res
@@ -193,6 +201,18 @@ func MakeBackupSSTKVFetcher(
 func (f *BackupSSTKVFetcher) nextBatch(
 	_ context.Context,
 ) (ok bool, kvs []roachpb.KeyValue, batchResponse []byte, span roachpb.Span, err error) {
+	res := make([]roachpb.KeyValue, 0)
+
+	copyKV := func(mvccKey storage.MVCCKey, value []byte) roachpb.KeyValue {
+		keyCopy := make([]byte, len(mvccKey.Key))
+		copy(keyCopy, mvccKey.Key)
+		valueCopy := make([]byte, len(value))
+		copy(valueCopy, value)
+		return roachpb.KeyValue{
+			Key:   keyCopy,
+			Value: roachpb.Value{RawBytes: valueCopy, Timestamp: mvccKey.Timestamp},
+		}
+	}
 
 	for {
 		valid, err := f.iter.Valid()
@@ -200,46 +220,49 @@ func (f *BackupSSTKVFetcher) nextBatch(
 			err = errors.Wrapf(err, "iter key value of table data")
 			return false, nil, nil, roachpb.Span{}, err
 		}
+
 		if !valid || !f.iter.UnsafeKey().Less(f.endKeyMVCC) {
-			return false, nil, nil, roachpb.Span{}, nil
+			break
 		}
+
 		if !f.endTime.IsEmpty() {
 			if f.endTime.Less(f.iter.UnsafeKey().Timestamp) {
 				f.iter.Next()
 				continue
 			}
 		}
-		if len(f.iter.UnsafeValue()) == 0 {
-			if f.endTime.IsEmpty() || f.iter.UnsafeKey().Timestamp.Less(f.endTime) {
-				// Value is deleted at endTime.
+
+		if f.withRevisions {
+			if f.iter.UnsafeKey().Timestamp.Less(f.startTime) {
 				f.iter.NextKey()
 				continue
-			} else {
-				// Otherwise we call Next to trace back the correct revision.
-				f.iter.Next()
-				continue
+			}
+		} else {
+			if len(f.iter.UnsafeValue()) == 0 {
+				if f.endTime.IsEmpty() || f.iter.UnsafeKey().Timestamp.Less(f.endTime) {
+					// Value is deleted at endTime.
+					f.iter.NextKey()
+					continue
+				} else {
+					// Otherwise we call Next to trace back the correct revision.
+					f.iter.Next()
+					continue
+				}
 			}
 		}
-		break
+
+		res = append(res, copyKV(f.iter.UnsafeKey(), f.iter.UnsafeValue()))
+
+		if f.withRevisions {
+			f.iter.Next()
+		} else {
+			f.iter.NextKey()
+		}
+
 	}
-
-	keyScratch := f.iter.UnsafeKey().Key
-	keyCopy := make([]byte, len(keyScratch))
-	copy(keyCopy, keyScratch)
-
-	valueScratch := f.iter.UnsafeValue()
-	valueCopy := make([]byte, len(valueScratch))
-	copy(valueCopy, valueScratch)
-
-	value := roachpb.Value{RawBytes: valueCopy, Timestamp: f.iter.UnsafeKey().Timestamp}
-
-	res := []roachpb.KeyValue{{
-		Key:   keyCopy,
-		Value: value,
-	}}
-
-	f.iter.NextKey()
-
+	if len(res) == 0 {
+		return false, nil, nil, roachpb.Span{}, err
+	}
 	return true, res, nil, roachpb.Span{}, nil
 }
 


### PR DESCRIPTION
This patch adds `--with-revisions` on `debug export` to allow users
to export revisions of table data. If `--with-revisions` is specified,
revisions of data are returned to users, with an extra column
displaying the revision time of that record.

Note: 
Schema changes make it hard to maintain correct display of columns at different timestamps in one shot,
So this feature:
- do not display schema changes across revisions. 
- display data changes since last schema change only. 

That is, `--with-revisons` only display *part of* revisions history instead of *all* revision history.
We migitate this by giving message saying `DETECTED SCHEMA CHANGE AT t1, ONLY SHOWING UPDATES IN RANGE [t1,t2]`.
Then users are able to take exploratory steps to trace back to revision history of data by repeatedly running 
`cockroach debug backup export <backup_url> --table=<table> --with-revisions --up-to=t1-1`

----------------------------------------

Example usage:
```
$cockroach debug backup export <backup_url> --table=<table> --with-revisions 
Data changes happened between t1 and t2 :
DETECTED SCHEMA CHANGE AT t1, ONLY SHOWING UPDATES IN RANGE [t1,t2]
1,null,2021-04-22 18:12:47.685284 +0000 UTC
2,'3rd update',2021-04-22 18:13:41.27284 +0000 UTC
2,'2nd update',2021-04-22 18:13:34.718665 +0000 UTC
2,'1st update',2021-04-22 18:13:28.966741 +0000 UTC
2,null,2021-04-22 18:12:50.053996 +0000 UTC
```
```
$cockroach debug backup export <backup_url> --table=<table> --with-revisions --up-to=’2021-04-22 18:13:40’
DETECTED SCHEMA CHANGE AT t1, ONLY SHOWING UPDATES IN RANGE [t1,2021-04-22 18:13:40]
1,null,2021-04-22 18:12:47.685284 +0000 UTC
2,'2nd update',2021-04-22 18:13:34.718665 +0000 UTC
2,'1st update',2021-04-22 18:13:28.966741 +0000 UTC
2,null,2021-04-22 18:12:50.053996 +0000 UTC
```
*t1 is the last schema changes before the time specified by --up-to*
*t2 is the endtime of backup*

--------------------

Release note (cli change): 
This is an experimenal/beta feature of backup debug tool to
 allow users to export revisions of data from backup. We add 
`--with-revisions` on `debug export` to allow users to  export 
revisions of table data. If `--with-revisions` is specified, revisions
of data are returned to users, with an extra column displaying the 
revision time of that record.