### PR TITLE
release-21.1: kvserver: add safeguard against spurious calls to AdminRelocateRange

### DIFF
--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -2657,6 +2657,25 @@ func (s *Store) AdminRelocateRange(
 	rangeDesc roachpb.RangeDescriptor,
 	voterTargets, nonVoterTargets []roachpb.ReplicationTarget,
 ) error {
+	if containsDuplicates(voterTargets) {
+		return errors.AssertionFailedf(
+			"list of desired voter targets contains duplicates: %+v",
+			voterTargets,
+		)
+	}
+	if containsDuplicates(nonVoterTargets) {
+		return errors.AssertionFailedf(
+			"list of desired non-voter targets contains duplicates: %+v",
+			nonVoterTargets,
+		)
+	}
+	if containsDuplicates(append(voterTargets, nonVoterTargets...)) {
+		return errors.AssertionFailedf(
+			"list of voter targets overlaps with the list of non-voter targets: voters: %+v, non-voters: %+v",
+			voterTargets, nonVoterTargets,
+		)
+	}
+
 	// Remove learners so we don't have to think about relocating them, and leave
 	// the joint config if we're in one.
 	newDesc, err := maybeLeaveAtomicChangeReplicasAndRemoveLearners(ctx, s, &rangeDesc)
@@ -3088,6 +3107,17 @@ func getRelocationArgs(
 		args.targetType = nonVoterTarget
 	}
 	return args
+}
+
+func containsDuplicates(targets []roachpb.ReplicationTarget) bool {
+	for i := range targets {
+		for j := i + 1; j < len(targets); j++ {
+			if targets[i] == targets[j] {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // subtractTargets returns the set of replica descriptors in `left` but not in

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -12,6 +12,7 @@ package kvserver
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"math/rand"
 	"sort"
@@ -309,8 +310,18 @@ func (sr *StoreRebalancer) rebalanceStore(
 		}
 
 		descBeforeRebalance := replWithStats.repl.Desc()
-		log.VEventf(ctx, 1, "rebalancing r%d (%.2f qps) from %v to %v to better balance load",
-			replWithStats.repl.RangeID, replWithStats.qps, descBeforeRebalance.Replicas(), voterTargets)
+		log.VEventf(
+			ctx,
+			1,
+			"rebalancing r%d (%.2f qps) to better balance load: voters from %v to %v; non-voters from %v to %v",
+			replWithStats.repl.RangeID,
+			replWithStats.qps,
+			descBeforeRebalance.Replicas().Voters(),
+			voterTargets,
+			descBeforeRebalance.Replicas().NonVoters(),
+			nonVoterTargets,
+		)
+
 		timeout := sr.rq.processTimeoutFunc(sr.st, replWithStats.repl)
 		if err := contextutil.RunWithTimeout(ctx, "relocate range", timeout, func(ctx context.Context) error {
 			return sr.rq.store.AdminRelocateRange(ctx, *descBeforeRebalance, voterTargets, nonVoterTargets)
@@ -470,6 +481,17 @@ type rangeRebalanceContext struct {
 	zone                                  *zonepb.ZoneConfig
 	clusterNodes                          int
 	numDesiredVoters, numDesiredNonVoters int
+}
+
+func (rbc *rangeRebalanceContext) numDesiredReplicas(targetType targetReplicaType) int {
+	switch targetType {
+	case voterTarget:
+		return rbc.numDesiredVoters
+	case nonVoterTarget:
+		return rbc.numDesiredNonVoters
+	default:
+		panic(fmt.Sprintf("unknown targetReplicaType %s", targetType))
+	}
 }
 
 func (sr *StoreRebalancer) chooseRangeToRebalance(
@@ -729,20 +751,21 @@ func (sr *StoreRebalancer) pickRemainingRepls(
 	options scorerOptions,
 	minQPS, maxQPS float64,
 	targetType targetReplicaType,
-) (finalTargetsForType []roachpb.ReplicaDescriptor) {
-	var numDesiredReplsForType int
+) []roachpb.ReplicaDescriptor {
+	// Alias the slice that corresponds to the set of replicas that is being
+	// appended to. This is because we want subsequent calls to
+	// `allocateTargetFromList` to observe the results of previous calls (note the
+	// append to the slice referenced by `finalTargetsForType`).
+	var finalTargetsForType *[]roachpb.ReplicaDescriptor
 	switch targetType {
 	case voterTarget:
-		finalTargetsForType = partialVoterTargets
-		numDesiredReplsForType = rebalanceCtx.numDesiredVoters
+		finalTargetsForType = &partialVoterTargets
 	case nonVoterTarget:
-		finalTargetsForType = partialNonVoterTargets
-		numDesiredReplsForType = rebalanceCtx.numDesiredNonVoters
+		finalTargetsForType = &partialNonVoterTargets
 	default:
-		log.Fatalf(ctx, "unknown targetReplicaType %s", targetType)
+		log.Fatalf(ctx, "unknown targetReplicaType: %s", targetType)
 	}
-
-	for len(finalTargetsForType) < numDesiredReplsForType {
+	for len(*finalTargetsForType) < rebalanceCtx.numDesiredReplicas(targetType) {
 		// Use the preexisting Allocate{Non}Voter logic to ensure that
 		// considerations such as zone constraints, locality diversity, and full
 		// disk come into play.
@@ -780,12 +803,12 @@ func (sr *StoreRebalancer) pickRemainingRepls(
 			break
 		}
 
-		finalTargetsForType = append(finalTargetsForType, roachpb.ReplicaDescriptor{
+		*finalTargetsForType = append(*finalTargetsForType, roachpb.ReplicaDescriptor{
 			NodeID:  target.Node.NodeID,
 			StoreID: target.StoreID,
 		})
 	}
-	return finalTargetsForType
+	return *finalTargetsForType
 }
 
 // pickReplsToKeep determines the set of existing replicas for a range which


### PR DESCRIPTION
Backport 2/2 commits from #64170.

/cc @cockroachdb/release

---

This PR contains 2 commits:

**kvserver: add safeguard against spurious calls to AdminRelocateRange**

This commit adds checks inside of `AdminRelocateRange` to fail if the
lists of relocation targets passed in by the caller contain duplicates.
This is supposed to act as a safeguard against catastrophic outcomes
like a range getting spuriously downreplicated due to malformed input.

Release note: None

**kvserver: prevent the StoreRebalancer from downreplicating a range**

Prior to this commit, we had a bug inside one of the methods used by the
`StoreRebalancer` where we had two variables referring to a slice that
was subsequently being appended to.

The code was making the implicit assumption that both of these slices
would point to the same underlying array, which is not true since any of
the additions mentioned above could result in the underlying array for
one of the slices being resized.

This commit fixes this bug.

Resolves #64064

Release note (bug fix): A bug in previous 21.1 betas allowed the store
rebalancer to spuriously downreplicate a range during normal operation.
This bug is now fixed.

