### PR TITLE
release-21.1: sql: limit internal executor memory use

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -504,6 +504,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		HistogramWindowInterval: cfg.HistogramWindowInterval(),
 		RangeDescriptorCache:    cfg.distSender.RangeDescriptorCache(),
 		RoleMemberCache:         &sql.MembershipCache{},
+		RootMemoryMonitor:       rootSQLMemoryMonitor,
 		TestingKnobs:            sqlExecutorTestingKnobs,
 
 		DistSQLPlanner: sql.NewDistSQLPlanner(

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -260,7 +260,7 @@ type Server struct {
 
 	reCache *tree.RegexpCache
 
-	// pool is the parent monitor for all session monitors except "internal" ones.
+	// pool is the parent monitor for all session monitors.
 	pool *mon.BytesMonitor
 
 	// Metrics is used to account normal queries.

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -78,6 +78,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
@@ -879,6 +880,11 @@ type ExecutorConfig struct {
 	// ContentionRegistry is a node-level registry of contention events used for
 	// contention observability.
 	ContentionRegistry *contention.Registry
+
+	// RootMemoryMonitor is the root memory monitor of the entire server. Do not
+	// use this for normal purposes. It is to be used to establish any new
+	// root-level memory accounts that are not related to a user sessions.
+	RootMemoryMonitor *mon.BytesMonitor
 }
 
 // Organization returns the value of cluster.organization.

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -98,15 +98,16 @@ func (ie *InternalExecutor) WithSyntheticDescriptors(
 func MakeInternalExecutor(
 	ctx context.Context, s *Server, memMetrics MemoryMetrics, settings *cluster.Settings,
 ) InternalExecutor {
-	monitor := mon.NewUnlimitedMonitor(
-		ctx,
+	monitor := mon.NewMonitor(
 		"internal SQL executor",
 		mon.MemoryResource,
 		memMetrics.CurBytesCount,
 		memMetrics.MaxBytesHist,
+		-1,            /* use default increment */
 		math.MaxInt64, /* noteworthy */
 		settings,
 	)
+	monitor.Start(ctx, s.pool, mon.BoundAccount{})
 	return InternalExecutor{
 		s:          s,
 		mon:        monitor,

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -347,11 +347,12 @@ func newInternalPlanner(
 	p.semaCtx.SearchPath = sd.SearchPath
 	p.semaCtx.TypeResolver = p
 
-	plannerMon := mon.NewUnlimitedMonitor(ctx,
-		fmt.Sprintf("internal-planner.%s.%s", user, opName),
+	plannerMon := mon.NewMonitor(fmt.Sprintf("internal-planner.%s.%s", user, opName),
 		mon.MemoryResource,
 		memMetrics.CurBytesCount, memMetrics.MaxBytesHist,
+		-1, /* increment */
 		noteworthyInternalMemoryUsageBytes, execCfg.Settings)
+	plannerMon.Start(ctx, execCfg.RootMemoryMonitor, mon.BoundAccount{})
 
 	p.extendedEvalCtx = internalExtendedEvalCtx(
 		ctx, sd, dataMutator, params.collection, txn, ts, ts, execCfg, plannerMon,

--- a/pkg/sql/values_test.go
+++ b/pkg/sql/values_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/bitarray"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
@@ -45,6 +46,7 @@ func makeTestPlanner() *planner {
 				return uuid.MakeV4()
 			},
 		},
+		RootMemoryMonitor: mon.NewUnlimitedMonitor(context.Background(), "test", mon.MemoryResource, nil, nil, 0, nil),
 	}
 
 	// TODO(andrei): pass the cleanup along to the caller.


### PR DESCRIPTION
Backport 1/1 commits from #63654.

/cc @cockroachdb/release

---

Closes #63619.

Previously, internal executors used unlimited memory. This was because,
although they had a memory monitor attached, they had an unlimited
budget and had no parent monitor.

This commit parents the internal executor's memory monitor under the
root sql memory monitor, but leaves it "unlimited". In practice, this
means that any internal executor queries will no longer OOM servers -
they'll instead bump up against the max sql memory even if many other
queries are running and consuming memory of their own.

Release note (bug fix): prevent some OOM conditions caused by schema
change validations concurrent with other high-memory-use queries.