### PR TITLE
ccl/sqlproxyccl: connection cache

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -23,6 +23,7 @@ ALL_TESTS = [
     "//pkg/ccl/oidcccl:oidcccl_test",
     "//pkg/ccl/partitionccl:partitionccl_test",
     "//pkg/ccl/serverccl:serverccl_test",
+    "//pkg/ccl/sqlproxyccl/cache:cache_test",
     "//pkg/ccl/sqlproxyccl:sqlproxyccl_test",
     "//pkg/ccl/storageccl/engineccl:engineccl_test",
     "//pkg/ccl/storageccl:storageccl_test",

--- a/pkg/ccl/sqlproxyccl/cache/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/cache/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "cache",
+    srcs = ["cache.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/cache",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/roachpb",
+        "//pkg/util/syncutil",
+    ],
+)
+
+go_test(
+    name = "cache_test",
+    srcs = ["cache_test.go"],
+    embed = [":cache"],
+    deps = [
+        "//pkg/roachpb",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/ccl/sqlproxyccl/cache/cache.go
+++ b/pkg/ccl/sqlproxyccl/cache/cache.go
@@ -1,0 +1,80 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package cache
+
+import (
+	"math/rand"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// ConnCache is interface for caching connections from IP and tenant ID pairs.
+// TODO(spaskob): once we have more clients of this interface split it in a
+// separate package.
+type ConnCache interface {
+	Insert(key *ConnKey)
+	Exists(key *ConnKey) bool
+}
+
+// ConnKey is the key for a connection for TenantID and IPAddress.
+type ConnKey struct {
+	TenantID  roachpb.TenantID
+	IPAddress string
+}
+
+// cappedConnCache implements the ConnCache interface.
+type cappedConnCache struct {
+	maxMapSize int
+
+	mu struct {
+		syncutil.Mutex
+		conns map[ConnKey]struct{}
+	}
+}
+
+// NewCappedConnCache returns a cache service that has a limit on the total entries.
+func NewCappedConnCache(maxMapSize int) ConnCache {
+	c := &cappedConnCache{
+		maxMapSize: maxMapSize,
+	}
+	c.mu.conns = make(map[ConnKey]struct{})
+	return c
+}
+
+// Exists checks is the connection with the given key is in the cache.
+func (c *cappedConnCache) Exists(conn *ConnKey) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	_, ok := c.mu.conns[*conn]
+	return ok
+}
+
+// Insert the given connection.
+func (c *cappedConnCache) Insert(conn *ConnKey) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if len(c.mu.conns) >= c.maxMapSize {
+		toEvict, pos := rand.Intn(len(c.mu.conns)), 0
+		for k := range c.mu.conns {
+			// Choose a random key to evict by iterating through the keys in the map.
+			// As we expect that eviction will be a very rare event, it is fine to pay
+			// the penalty of iterating through potentially map's elements.
+			if pos < toEvict {
+				pos++
+				continue
+			}
+			delete(c.mu.conns, k)
+			break
+		}
+	}
+	c.mu.conns[*conn] = struct{}{}
+}

--- a/pkg/ccl/sqlproxyccl/cache/cache_test.go
+++ b/pkg/ccl/sqlproxyccl/cache/cache_test.go
@@ -1,0 +1,45 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package cache
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCappedConnCache_Eviction(t *testing.T) {
+	keys := []ConnKey{
+		{TenantID: roachpb.MakeTenantID(1)},
+		{TenantID: roachpb.MakeTenantID(2)},
+		{TenantID: roachpb.MakeTenantID(3)},
+	}
+	newKey := ConnKey{TenantID: roachpb.MakeTenantID(4)}
+	c := NewCappedConnCache(3).(*cappedConnCache)
+
+	for _, key := range keys {
+		c.Insert(&key)
+		require.True(t, c.Exists(&key))
+	}
+	// Inserting a new key forces an existing key to be evicted to keep size at 3.
+	c.Insert(&newKey)
+	require.Equal(t, 3, len(c.mu.conns))
+	// the new key should be in the cache.
+	require.True(t, c.Exists(&newKey))
+
+	var cnt int
+	for _, key := range keys {
+		if c.Exists(&key) {
+			cnt++
+		}
+	}
+	// One of the old keys should not be in the cache.
+	require.Equal(t, 3-1, cnt)
+}


### PR DESCRIPTION
Moved from the CC repo. Implements a simple cache to track incoming
connections by IP address and tenant ID.

Release note: None