### PR TITLE
bazel: tweak patch we apply to `cockroachdb/errors`

### DIFF
--- a/build/patches/com_github_cockroachdb_errors.patch
+++ b/build/patches/com_github_cockroachdb_errors.patch
@@ -5,8 +5,8 @@ diff -urN a/errorspb/BUILD.bazel b/errorspb/BUILD.bazel
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +load("@rules_proto//proto:defs.bzl", "proto_library")
  
- filegroup(
-     name = "go_default_library_protos",
+ go_library(
+     name = "errorspb",
 @@ -36,3 +37,14 @@
      actual = ":errorspb",
      visibility = ["//visibility:public"],


### PR DESCRIPTION
This patch became outdated as a result of a Gazelle upgrade.
Resolves #64299.

Release note: None