### PR TITLE
build/patches: update `com_github_cockroachdb_errors.patch`

### DIFF
--- a/build/patches/com_github_cockroachdb_errors.patch
+++ b/build/patches/com_github_cockroachdb_errors.patch
@@ -5,8 +5,8 @@ diff -urN a/errorspb/BUILD.bazel b/errorspb/BUILD.bazel
  load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +load("@rules_proto//proto:defs.bzl", "proto_library")
  
- filegroup(
-     name = "go_default_library_protos",
+ go_library(
+     name = "errorspb", filegroup(
 @@ -36,3 +37,14 @@
      actual = ":errorspb",
      visibility = ["//visibility:public"],


### PR DESCRIPTION
Fixes #64299.

Needed due to some past Gazelle upgrade.

Thanks to @rickystewart for figuring out the solution.