### PR TITLE
release-20.2: pkg/kv/kvserver: don't redact LSM compaction stats

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2622,8 +2622,8 @@ func (s *Store) ComputeMetrics(ctx context.Context, tick int) error {
 	// non-periodic callers of this method don't trigger expensive
 	// stats.
 	if tick%logSSTInfoTicks == 1 /* every 10m */ {
-		log.Infof(ctx, "sstables (read amplification = %d):\n%s", readAmp, sstables)
-		log.Infof(ctx, "%s", s.engine.GetCompactionStats())
+		log.Infof(ctx, "sstables (read amplification = %d):\n%s", readAmp, redact.Safe(sstables))
+		log.Infof(ctx, "%s", redact.Safe(s.engine.GetCompactionStats()))
 	}
 	return nil
 }


### PR DESCRIPTION
For the backports, I used the `Safe` escape hatch.

Release note (bug fix): Fixes an issue where store information would be
incorrectly redacted from the Cockroach logs, when configured with
redaction.