### PR TITLE
geoproj/BUILD.bazel: add the missing linker flags

### DIFF
--- a/pkg/geo/geoproj/BUILD.bazel
+++ b/pkg/geo/geoproj/BUILD.bazel
@@ -17,6 +17,15 @@ go_library(
     cgo = True,
     # keep
     clinkopts = select({
+        "@io_bazel_rules_go//go/platform:android": [
+            "-lrt -lm -lpthread",
+        ],
+        "@io_bazel_rules_go//go/platform:dragonfly": [
+            "-lm",
+        ],
+        "@io_bazel_rules_go//go/platform:freebsd": [
+            "-lm",
+        ],
         "@io_bazel_rules_go//go/platform:linux": [
             "-lrt -lm -lpthread",
         ],


### PR DESCRIPTION
Fixes #64335.

This mimics the definitions in `cli/BUILD.bazel`.

Release note: None