### PR TITLE
release-21.1: pkg/kv/kvserver: don't redact LSM compaction stats

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2659,7 +2659,7 @@ func (s *Store) ComputeMetrics(ctx context.Context, tick int) error {
 	// non-periodic callers of this method don't trigger expensive
 	// stats.
 	if tick%logSSTInfoTicks == 1 /* every 10m */ {
-		log.Infof(ctx, "%s", s.engine.GetCompactionStats())
+		log.Infof(ctx, "%s", redact.Safe(s.engine.GetCompactionStats()))
 	}
 	return nil
 }


### PR DESCRIPTION
Release note (bug fix): Fixes an issue where store information would be
incorrectly redacted from the Cockroach logs, when configured with
redaction.