### PR TITLE
colexec: make sure that parallel unordered sync closes everything

### DIFF
--- a/pkg/sql/colexec/parallel_unordered_synchronizer.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer.go
@@ -102,6 +102,9 @@ type ParallelUnorderedSynchronizer struct {
 	bufferedMeta []execinfrapb.ProducerMetadata
 }
 
+var _ colexecop.DrainableOperator = &ParallelUnorderedSynchronizer{}
+var _ colexecop.ClosableOperator = &ParallelUnorderedSynchronizer{}
+
 // ChildCount implements the execinfra.OpNode interface.
 func (s *ParallelUnorderedSynchronizer) ChildCount(verbose bool) int {
 	return len(s.inputs)
@@ -414,4 +417,30 @@ func (s *ParallelUnorderedSynchronizer) DrainMeta() []execinfrapb.ProducerMetada
 	// Done.
 	s.setState(parallelUnorderedSynchronizerStateDone)
 	return s.bufferedMeta
+}
+
+// Close is part of the colexecop.ClosableOperator interface.
+func (s *ParallelUnorderedSynchronizer) Close(context.Context) error {
+	if state := s.getState(); state != parallelUnorderedSynchronizerStateUninitialized {
+		// Input goroutines have been started and will take care of closing the
+		// closers from the corresponding input trees, so we don't need to do
+		// anything.
+		return nil
+	}
+	// If the synchronizer is in "uninitialized" state, it means that the
+	// goroutines for each input haven't been started, so they won't be able to
+	// close the Closers from the corresponding trees. In such a scenario the
+	// synchronizer must close all of them from all input trees. Note that it is
+	// ok to close some input trees even if they haven't been initialized.
+	//
+	// Note that at this point we know that the input goroutines won't be
+	// spawned up (our consumer won't call Next/DrainMeta after calling Close),
+	// so it is safe to close all closers from this goroutine.
+	var lastErr error
+	for _, input := range s.inputs {
+		if err := input.ToClose.Close(s.Ctx); err != nil {
+			lastErr = err
+		}
+	}
+	return lastErr
 }

--- a/pkg/sql/colexecop/operator.go
+++ b/pkg/sql/colexecop/operator.go
@@ -138,6 +138,9 @@ type BufferingInMemoryOperator interface {
 // if we have a simple project on top of a disk-backed operator, that simple
 // project needs to implement this interface so that Close() call could be
 // propagated correctly).
+// TODO(yuzefovich): clarify the contract that Close must be safe to call even
+// if the Operator - when it implements the Closer interface - hasn't been
+// initialized.
 type Closer interface {
 	Close(ctx context.Context) error
 }

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -896,11 +896,7 @@ func (s *vectorizedFlowCreator) setupInput(
 				opWithMetaInfo = colexecargs.OpWithMetaInfo{
 					Root:            sync,
 					MetadataSources: colexecop.MetadataSources{sync},
-					// ToClose is set to nil because the
-					// ParallelUnorderedSynchronizer takes care of closing these
-					// components itself since they need to be closed from the
-					// same goroutine as Next.
-					ToClose: nil,
+					ToClose:         colexecop.Closers{sync},
 				}
 				s.operatorConcurrency = true
 			}

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -285,7 +285,7 @@ func (f *vectorizedFlow) Cleanup(ctx context.Context) {
 	// This cleans up all the memory and disk monitoring of the vectorized flow.
 	f.creator.cleanup(ctx)
 
-	if f.Cfg.TestingKnobs.CheckVectorizedFlowIsClosedCorrectly {
+	if util.CrdbTestBuild {
 		if numClosed := atomic.LoadInt32(f.testingInfo.numClosed); numClosed != f.testingInfo.numClosers {
 			colexecerror.InternalError(errors.AssertionFailedf("expected %d components to be closed, but found that only %d were", f.testingInfo.numClosers, numClosed))
 		}
@@ -1088,7 +1088,7 @@ func (s *vectorizedFlowCreator) setupFlow(
 			if flowCtx.EvalCtx.SessionData.TestingVectorizeInjectPanics {
 				result.Root = newPanicInjector(result.Root)
 			}
-			if flowCtx.Cfg != nil && flowCtx.Cfg.TestingKnobs.CheckVectorizedFlowIsClosedCorrectly {
+			if util.CrdbTestBuild {
 				toCloseCopy := append(colexecop.Closers{}, result.ToClose...)
 				for i := range toCloseCopy {
 					func(idx int) {

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -213,10 +213,6 @@ type TestingKnobs struct {
 	// checked by a test receiver on the gateway.
 	MetadataTestLevel MetadataTestLevel
 
-	// CheckVectorizedFlowIsClosedCorrectly checks that all components in a flow
-	// were closed explicitly in flow.Cleanup.
-	CheckVectorizedFlowIsClosedCorrectly bool
-
 	// Changefeed contains testing knobs specific to the changefeed system.
 	Changefeed base.ModuleTestingKnobs
 

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1357,8 +1357,6 @@ func (t *logicTest) newCluster(serverArgs TestServerArgs) {
 
 	distSQLKnobs := &execinfra.TestingKnobs{
 		MetadataTestLevel: execinfra.Off,
-		// TODO(yuzefovich): uncomment once #64248 is resolved.
-		//CheckVectorizedFlowIsClosedCorrectly: true,
 	}
 	cfg := t.cfg
 	if cfg.sqlExecUseDisk {


### PR DESCRIPTION
**colexec: make sure that parallel unordered sync closes everything**

Previously, it was possible for the parallel unordered synchronizer to
not close some of the `Closer`s from its input trees. Namely, if `Next`
or `DrainMeta` is never called on the synchronizer, the input goroutines
are never spawned up, so no components actually get closed. This could
be problematic when the synchronizer was `Init`ialized but then never
used. This is now fixed by making the parallel unordered synchronizer
implements `Closer` interface and handle this scenario gracefully.

I can't think of any "happy" scenarios when such situation would arise,
but one possibility is when the synchronizer was able to initialize some
of its inputs (which started using resources and, thus, need to be
closed), but then encountered a panic upon initialization another input.
From the perspective of the consumer of the synchronizer, the
initialization wasn't successful, so it won't try to call `Next` or
`DrainMeta`.

The issue has been present for a couple of releases now. The impact of
not properly closing some components is that temp disk resources might
not be released (like files not closed) or tracing spans not finished.
I'm a bit on the fence about backporting this change.

Fixes: #64248.

Release note: None

**colflow: use crdb_test build tag to enable a testing assertion**

Previously, we had a custom testing knob that would enable a testing
assertion that all `Closer`s are actually closed when the vectorized
flow is cleaned up. The knob was only set in the logic tests. This
commit switches the assertion to be checked whenever `crdb_test` build
tag is used (which is a superset of the logic tests) giving us better
coverage.

Release note: None