### PR TITLE
opt: remove non-equivalent group columns in OrderingChoice.Simplify

### DIFF
--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -745,9 +745,9 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 				reqStr := required.Ordering.String()
 				provStr := provided.String()
 				if provStr == reqStr {
-					tp.Childf("ordering: %s", required.Ordering.String())
+					tp.Childf("ordering: %s", reqStr)
 				} else {
-					tp.Childf("ordering: %s [actual: %s]", required.Ordering.String(), provided.String())
+					tp.Childf("ordering: %s [actual: %s]", reqStr, provStr)
 				}
 			}
 		}

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -848,6 +848,63 @@ semi-join (hash)
  └── filters
       └── v:5 = s:11 [outer=(5,11), constraints=(/5: (/NULL - ]; /11: (/NULL - ]), fd=(5)==(11), (11)==(5)]
 
+# Regression test for #63794. Inlining filters on virtual columns during
+# exploration should not violate the ordering choice that all columns in an
+# ordering column group should be equal according to the expression's FD.
+exec-ddl
+CREATE TABLE t63794_a (a INT)
+----
+
+exec-ddl
+CREATE TABLE t63794_bc (b INT, c INT AS (b % 2) VIRTUAL, INDEX (b))
+----
+
+opt format=hide-all
+SELECT a.a
+FROM t63794_a AS a
+  JOIN t63794_bc AS bc1
+    JOIN t63794_bc AS bc2 ON true
+  ON a.a = bc1.b AND
+    bc1.b = bc2.b AND
+    bc1.c = bc2.c
+  JOIN t63794_bc AS bc3 ON
+    bc1.b = bc3.b AND bc2.b = bc3.c
+----
+project
+ └── inner-join (hash)
+      ├── scan t63794_a [as=a]
+      ├── inner-join (hash)
+      │    ├── project
+      │    │    ├── scan t63794_bc
+      │    │    │    └── computed column expressions
+      │    │    │         └── c
+      │    │    │              └── b % 2
+      │    │    └── projections
+      │    │         └── b % 2
+      │    ├── inner-join (hash)
+      │    │    ├── project
+      │    │    │    ├── scan t63794_bc
+      │    │    │    │    └── computed column expressions
+      │    │    │    │         └── c
+      │    │    │    │              └── b % 2
+      │    │    │    └── projections
+      │    │    │         └── b % 2
+      │    │    ├── project
+      │    │    │    ├── scan t63794_bc
+      │    │    │    │    └── computed column expressions
+      │    │    │    │         └── c
+      │    │    │    │              └── b % 2
+      │    │    │    └── projections
+      │    │    │         └── b % 2
+      │    │    └── filters
+      │    │         ├── b = b
+      │    │         └── c = c
+      │    └── filters
+      │         ├── b = b
+      │         └── b = c
+      └── filters
+           └── a = b
+
 # --------------------------------------------------
 # InlineProjectInProject
 # --------------------------------------------------


### PR DESCRIPTION
Previously, `OrderingChoice.Simplify` would add but never remove columns
from ordering column groups based on equivalency in an FD. In rare
cases, this could cause the optimizer to generate expressions which
violated an invariant that all columns in an ordering column group are
equivalent according to the expression's FD.

Violation of this invariant only panics in test builds, and in the test
cases found that trigger this panic, there is likely no correctness
issues with the expression. Therefore, there was probably no impact in
any release builds.

This commit updates `OrderingChoice.Simplify` so that non-equivalent
columns in an ordering column group are removed from the group,
satisfying the invariant.

Fixes #63794

Release note: None