### PR TITLE
release-20.1: tree: make password formatting anonymization round-trippable

### DIFF
--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -1324,7 +1324,7 @@ func (o *KVOptions) formatAsRoleOptions(ctx *FmtCtx) {
 			if ctx.flags.HasFlags(FmtShowPasswords) {
 				ctx.FormatNode(option.Value)
 			} else {
-				ctx.WriteString("*****")
+				ctx.WriteString("'*****'")
 			}
 		} else if option.Value == DNull {
 			ctx.WriteString(" ")

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -32,7 +32,7 @@ func TestFormatStatement(t *testing.T) {
 		expected string
 	}{
 		{`CREATE USER foo WITH PASSWORD 'bar'`, tree.FmtSimple,
-			`CREATE USER 'foo' WITH PASSWORD *****`},
+			`CREATE USER 'foo' WITH PASSWORD '*****'`},
 		{`CREATE USER foo WITH PASSWORD 'bar'`, tree.FmtShowPasswords,
 			`CREATE USER 'foo' WITH PASSWORD 'bar'`},
 


### PR DESCRIPTION
Backport 1/1 commits from #64345.

/cc @cockroachdb/release

---

Previously, a password was anonymized during formatting of an AST as
`*****`. This password cannot be parsed successfully, so the formatted
AST was not round-trippable. This commit formats an anonymized password
with single quotes as `'*****'` so that the formatted AST is
round-trippable.

This is related to #60676 which fixes this issue but could not be
backported to `release-20.2`.

Fixes #64146

Release note (bug fix): Previously, passwords in SQL statements in
telemetry updates and crash reports were anonymized as `*****`.
Passwords are now anonymized as `'*****'` so that the SQL statements do
not result in parsing errors when executed.