### PR TITLE
bazel: rebase `rules_foreign_cc` atop version 0.2.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -166,11 +166,11 @@ c_deps()
 # aforementioned PRs.
 git_repository(
     name = "rules_foreign_cc",
-    commit = "6127817283221408069d4ae6765f2d8144f09b9f",
+    commit = "a3b0e5eaa723259458f5c85285f58e46ae7f25a2",
     remote = "https://github.com/cockroachdb/rules_foreign_cc",
 )
 
-load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 
 rules_foreign_cc_dependencies()
 

--- a/c-deps/BUILD.bazel
+++ b/c-deps/BUILD.bazel
@@ -1,6 +1,6 @@
 # Load the components that lets us use cmake/make in third party deps.
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
-load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
+load("@rules_foreign_cc//foreign_cc:cmake.bzl", "cmake")
+load("@rules_foreign_cc//foreign_cc:configure.bzl", "configure_make")
 
 # TODO(irfansharif): All the cmake cache entries below were cargo-culted from
 # the Makefile. We may need to programatically set them depending on the
@@ -24,39 +24,24 @@ configure_make(
         "cp lib/libjemalloc.a libjemalloc/lib",
         "cp -r include libjemalloc",
     ],
-    static_libraries = ["libjemalloc.a"],
+    out_static_libs = ["libjemalloc.a"],
     visibility = ["//visibility:public"],
-)
-
-# Define the build targets for libprotobuf and protoc.
-cmake_external(
-    name = "libprotobuf",
-    binaries = ["protoc"],
-    cache_entries = {
-        "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_TARGET_MESSAGES": "OFF",
-        "protobuf_BUILD_TESTS": "OFF",
-    },
-    lib_source = "@protobuf//:all",
-    static_libraries = ["libprotobuf.a"],
-    visibility = ["//visibility:public"],
-    working_directory = "cmake",
 )
 
 # Define the build target for libproj.
-cmake_external(
+cmake(
     name = "libproj",
     cache_entries = {
         "CMAKE_BUILD_TYPE": "Release",
         "BUILD_LIBPROJ_SHARED": "OFF",
     },
     lib_source = "@proj//:all",
-    static_libraries = ["libproj.a"],
+    out_static_libs = ["libproj.a"],
     visibility = ["//visibility:public"],
 )
 
 # Define the targets for libgeos.
-cmake_external(
+cmake(
     name = "libgeos",
     cache_entries = {
         "CMAKE_BUILD_TYPE": "Release",
@@ -84,7 +69,7 @@ cmake_external(
             # TODO(#bazel): patchelf is also required here for release.
         ],
     }),
-    shared_libraries = select({
+    out_shared_libs = select({
         "@io_bazel_rules_go//go/platform:darwin": [
             "libgeos_c.dylib",
             "libgeos.dylib",
@@ -105,7 +90,7 @@ cmake_external(
 #
 # Bazel also expects the library archive and the include headers to be placed
 # in a certain path, so we fix it all up accordingly within make_commands.
-cmake_external(
+cmake(
     name = "libroach",
     cache_entries = {
         "CMAKE_TARGET_MESSAGES": "OFF",
@@ -118,7 +103,7 @@ cmake_external(
         "cp libroach.a libroach/lib/libroach.a",
         "cp -r $EXT_BUILD_ROOT/external/libroach/include libroach",
     ],
-    static_libraries = ["libroach.a"],
+    out_static_libs = ["libroach.a"],
     tools_deps = [
         "@libroach//:all",
     ],
@@ -150,6 +135,6 @@ configure_make(
         "mkdir -p libkrb5/lib",
         "cp libkrb5/libgssapi_krb5.a libkrb5/lib",
     ],
-    static_libraries = ["libgssapi_krb5.a"],
+    out_static_libs = ["libgssapi_krb5.a"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Some stuff was moved around/renamed, so I had to make the corresponding
changes. Also delete the `protobuf` build in `c-deps` because it's not
used.

Release note: None