### PR TITLE
release-20.2: kvserver: synchronize replica removal with read-only requests

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
+	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -234,14 +235,11 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 
 func mergeWithData(t *testing.T, retries int64) {
 	ctx := context.Background()
-	storeCfg := kvserver.TestStoreConfig(nil)
-	storeCfg.TestingKnobs.DisableReplicateQueue = true
-	storeCfg.TestingKnobs.DisableMergeQueue = true
-	storeCfg.Clock = nil // manual clock
 
+	manualClock := hlc.NewHybridManualClock()
+	var store *kvserver.Store
 	// Maybe inject some retryable errors when the merge transaction commits.
-	var mtc *multiTestContext
-	storeCfg.TestingKnobs.TestingRequestFilter = func(_ context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+	testingRequestFilter := func(_ context.Context, ba roachpb.BatchRequest) *roachpb.Error {
 		for _, req := range ba.Requests {
 			if et := req.GetEndTxn(); et != nil && et.InternalCommitTrigger.GetMergeTrigger() != nil {
 				if atomic.AddInt64(&retries, -1) >= 0 {
@@ -254,148 +252,114 @@ func mergeWithData(t *testing.T, retries int64) {
 				// Subsume can execute. This triggers an unusual code path where the
 				// lease acquisition, not Subsume, notices the merge and installs a
 				// mergeComplete channel on the replica.
-				mtc.advanceClock(ctx)
+				manualClock.Increment(store.GetStoreConfig().LeaseExpiration())
 			}
 		}
 		return nil
 	}
 
-	mtc = &multiTestContext{
-		storeConfig: &storeCfg,
-		// This test was written before the multiTestContext started creating many
-		// system ranges at startup, and hasn't been update to take that into
-		// account.
-		startWithSingleRange: true,
-	}
+	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			Store: &kvserver.StoreTestingKnobs{
+				DisableMergeQueue:    true,
+				DisableSplitQueue:    true,
+				TestingRequestFilter: testingRequestFilter,
+			},
+			Server: &server.TestingKnobs{
+				ClockSource: manualClock.UnixNano,
+			},
+		},
+	})
+	s := serv.(*server.TestServer)
+	defer s.Stopper().Stop(ctx)
+	store, err := s.Stores().GetStore(s.GetFirstStoreID())
+	require.NoError(t, err)
 
-	var store1, store2 *kvserver.Store
-	mtc.Start(t, 1)
-	store1, store2 = mtc.stores[0], mtc.stores[0]
-	defer mtc.Stop()
+	scratchKey, err := s.ScratchRangeWithExpirationLease()
+	repl := store.LookupReplica(roachpb.RKey(scratchKey))
+	require.NoError(t, err)
 
-	lhsDesc, rhsDesc, pErr := createSplitRanges(ctx, store1)
-	if pErr != nil {
-		t.Fatal(pErr)
-	}
+	lhsDesc, rhsDesc, pErr := s.SplitRange(scratchKey.Next().Next())
+	require.NoError(t, pErr)
 
 	content := []byte("testing!")
 
 	// Write some values left and right of the proposed split key.
-	pArgs := putArgs(roachpb.Key("aaa"), content)
-	if _, pErr := kv.SendWrapped(ctx, store1.TestSender(), pArgs); pErr != nil {
-		t.Fatal(pErr)
-	}
-	pArgs = putArgs(roachpb.Key("ccc"), content)
-	if _, pErr := kv.SendWrappedWith(ctx, store2.TestSender(), roachpb.Header{
-		RangeID: rhsDesc.RangeID,
-	}, pArgs); pErr != nil {
-		t.Fatal(pErr)
+
+	put := func(key roachpb.Key, rangeID roachpb.RangeID, value []byte) {
+		pArgs := putArgs(key, value)
+		if _, pErr := kv.SendWrappedWith(ctx, store.TestSender(), roachpb.Header{
+			RangeID: rangeID,
+		}, pArgs); pErr != nil {
+			t.Fatal(pErr)
+		}
 	}
 
-	// Confirm the values are there.
-	gArgs := getArgs(roachpb.Key("aaa"))
-	if reply, pErr := kv.SendWrapped(ctx, store1.TestSender(), gArgs); pErr != nil {
-		t.Fatal(pErr)
-	} else if replyBytes, err := reply.(*roachpb.GetResponse).Value.GetBytes(); err != nil {
-		t.Fatal(err)
-	} else if !bytes.Equal(replyBytes, content) {
-		t.Fatalf("actual value %q did not match expected value %q", replyBytes, content)
+	verify := func(key roachpb.Key, rangeID roachpb.RangeID, value []byte) {
+		// Confirm the values are there.
+		gArgs := getArgs(key)
+		if reply, pErr := kv.SendWrappedWith(ctx, store.TestSender(), roachpb.Header{
+			RangeID: rangeID,
+		}, gArgs); pErr != nil {
+		} else if replyBytes, err := reply.(*roachpb.GetResponse).Value.GetBytes(); err != nil {
+			t.Fatal(err)
+		} else if !bytes.Equal(replyBytes, value) {
+			t.Fatalf("actual value %q did not match expected value %q", replyBytes, content)
+		}
 	}
-	gArgs = getArgs(roachpb.Key("ccc"))
-	if reply, pErr := kv.SendWrappedWith(ctx, store2.TestSender(), roachpb.Header{
-		RangeID: rhsDesc.RangeID,
-	}, gArgs); pErr != nil {
-		t.Fatal(pErr)
-	} else if replyBytes, err := reply.(*roachpb.GetResponse).Value.GetBytes(); err != nil {
-		t.Fatal(err)
-	} else if !bytes.Equal(replyBytes, content) {
-		t.Fatalf("actual value %q did not match expected value %q", replyBytes, content)
-	}
+
+	put(lhsDesc.StartKey.Next().AsRawKey(), lhsDesc.RangeID, content)
+	put(rhsDesc.StartKey.Next().AsRawKey(), rhsDesc.RangeID, content)
+
+	verify(lhsDesc.StartKey.Next().AsRawKey(), lhsDesc.RangeID, content)
+	verify(rhsDesc.StartKey.Next().AsRawKey(), rhsDesc.RangeID, content)
 
 	// Merge the b range back into the a range.
 	args := adminMergeArgs(lhsDesc.StartKey.AsRawKey())
-	if _, pErr := kv.SendWrapped(ctx, store1.TestSender(), args); pErr != nil {
+	if _, pErr := kv.SendWrapped(ctx, store.TestSender(), args); pErr != nil {
 		t.Fatal(pErr)
 	}
 
 	// Verify no intents remains on range descriptor keys.
 	for _, key := range []roachpb.Key{keys.RangeDescriptorKey(lhsDesc.StartKey), keys.RangeDescriptorKey(rhsDesc.StartKey)} {
 		if _, _, err := storage.MVCCGet(
-			ctx, store1.Engine(), key, store1.Clock().Now(), storage.MVCCGetOptions{},
+			ctx, store.Engine(), key, store.Clock().Now(), storage.MVCCGetOptions{},
 		); err != nil {
 			t.Fatal(err)
 		}
 	}
 
 	// Verify the merge by looking up keys from both ranges.
-	lhsRepl := store1.LookupReplica(roachpb.RKey("a"))
-	rhsRepl := store1.LookupReplica(roachpb.RKey("c"))
+	lhsRepl := store.LookupReplica(lhsDesc.StartKey.Next())
+	rhsRepl := store.LookupReplica(rhsDesc.StartKey.Next())
 
 	if lhsRepl != rhsRepl {
 		t.Fatalf("ranges were not merged %+v=%+v", lhsRepl.Desc(), rhsRepl.Desc())
 	}
-	if startKey := lhsRepl.Desc().StartKey; !bytes.Equal(startKey, roachpb.RKeyMin) {
+	if startKey := lhsRepl.Desc().StartKey; !bytes.Equal(startKey, repl.Desc().StartKey) {
 		t.Fatalf("The start key is not equal to KeyMin %q=%q", startKey, roachpb.RKeyMin)
 	}
-	if endKey := rhsRepl.Desc().EndKey; !bytes.Equal(endKey, roachpb.RKeyMax) {
+	if endKey := rhsRepl.Desc().EndKey; !bytes.Equal(endKey, repl.Desc().EndKey) {
 		t.Fatalf("The end key is not equal to KeyMax %q=%q", endKey, roachpb.RKeyMax)
 	}
 
-	// Try to get values from after the merge.
-	gArgs = getArgs(roachpb.Key("aaa"))
-	if reply, pErr := kv.SendWrapped(ctx, store1.TestSender(), gArgs); pErr != nil {
-		t.Fatal(pErr)
-	} else if replyBytes, err := reply.(*roachpb.GetResponse).Value.GetBytes(); err != nil {
-		t.Fatal(err)
-	} else if !bytes.Equal(replyBytes, content) {
-		t.Fatalf("actual value %q did not match expected value %q", replyBytes, content)
-	}
-	gArgs = getArgs(roachpb.Key("ccc"))
-	if reply, pErr := kv.SendWrappedWith(ctx, store1.TestSender(), roachpb.Header{
-		RangeID: rhsRepl.RangeID,
-	}, gArgs); pErr != nil {
-		t.Fatal(pErr)
-	} else if replyBytes, err := reply.(*roachpb.GetResponse).Value.GetBytes(); err != nil {
-		t.Fatal(err)
-	} else if !bytes.Equal(replyBytes, content) {
-		t.Fatalf("actual value %q did not match expected value %q", replyBytes, content)
-	}
+	verify(lhsDesc.StartKey.Next().AsRawKey(), lhsRepl.RangeID, content)
+	verify(rhsDesc.StartKey.Next().AsRawKey(), rhsRepl.RangeID, content)
 
+	newContent := []byte("testing!better!")
 	// Put new values after the merge on both sides.
-	pArgs = putArgs(roachpb.Key("aaaa"), content)
-	if _, pErr := kv.SendWrapped(ctx, store1.TestSender(), pArgs); pErr != nil {
-		t.Fatal(pErr)
-	}
-	pArgs = putArgs(roachpb.Key("cccc"), content)
-	if _, pErr := kv.SendWrappedWith(ctx, store1.TestSender(), roachpb.Header{
-		RangeID: rhsRepl.RangeID,
-	}, pArgs); pErr != nil {
-		t.Fatal(pErr)
-	}
+	put(lhsDesc.StartKey.Next().AsRawKey(), lhsRepl.RangeID, newContent)
+	put(rhsDesc.StartKey.Next().AsRawKey(), rhsRepl.RangeID, newContent)
 
 	// Try to get the newly placed values.
-	gArgs = getArgs(roachpb.Key("aaaa"))
-	if reply, pErr := kv.SendWrapped(ctx, store1.TestSender(), gArgs); pErr != nil {
-		t.Fatal(pErr)
-	} else if replyBytes, err := reply.(*roachpb.GetResponse).Value.GetBytes(); err != nil {
-		t.Fatal(err)
-	} else if !bytes.Equal(replyBytes, content) {
-		t.Fatalf("actual value %q did not match expected value %q", replyBytes, content)
-	}
-	gArgs = getArgs(roachpb.Key("cccc"))
-	if reply, pErr := kv.SendWrapped(ctx, store1.TestSender(), gArgs); pErr != nil {
-		t.Fatal(pErr)
-	} else if replyBytes, err := reply.(*roachpb.GetResponse).Value.GetBytes(); err != nil {
-		t.Fatal(err)
-	} else if !bytes.Equal(replyBytes, content) {
-		t.Fatalf("actual value %q did not match expected value %q", replyBytes, content)
-	}
+	verify(lhsDesc.StartKey.Next().AsRawKey(), lhsRepl.RangeID, newContent)
+	verify(rhsDesc.StartKey.Next().AsRawKey(), rhsRepl.RangeID, newContent)
 
-	gArgs = getArgs(roachpb.Key("cccc"))
-	if _, pErr := kv.SendWrappedWith(ctx, store2, roachpb.Header{
+	gArgs := getArgs(lhsDesc.StartKey.Next().AsRawKey())
+	if _, pErr := kv.SendWrappedWith(ctx, store, roachpb.Header{
 		RangeID: rhsDesc.RangeID,
 	}, gArgs); !testutils.IsPError(
-		pErr, `r2 was not found`,
+		pErr, `was not found on s`,
 	) {
 		t.Fatalf("expected get on rhs to fail after merge, but got err=%v", pErr)
 	}

--- a/pkg/kv/kvserver/client_relocate_range_test.go
+++ b/pkg/kv/kvserver/client_relocate_range_test.go
@@ -14,16 +14,22 @@ import (
 	"context"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -200,4 +206,109 @@ func TestAdminRelocateRange(t *testing.T) {
 			return relocateAndCheck(t, tc, k, tc.Targets(2, 4))
 		})
 	}
+}
+
+// Regression test for https://github.com/cockroachdb/cockroach/issues/64325
+// which makes sure an in-flight read operation during replica removal won't
+// return empty results.
+func TestReplicaRemovalDuringRequestEvaluation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	type magicKey struct{}
+
+	// delayReadC is used to synchronize the in-flight read request with the main
+	// test goroutine. It is read from twice:
+	//
+	// 1. The first read allows the test to block until the request eval filter
+	//    is called, i.e. when the read request is ready.
+	// 2. The second read allows the test to close the channel to unblock
+	//    the eval filter, causing the read request to be evaluated.
+	delayReadC := make(chan struct{})
+	evalFilter := func(args kvserverbase.FilterArgs) *roachpb.Error {
+		if args.Ctx.Value(magicKey{}) != nil {
+			<-delayReadC
+			<-delayReadC
+		}
+		return nil
+	}
+
+	ctx := context.Background()
+	manual := hlc.NewHybridManualClock()
+	args := base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Store: &kvserver.StoreTestingKnobs{
+					EvalKnobs: kvserverbase.BatchEvalTestingKnobs{
+						TestingEvalFilter: evalFilter,
+					},
+					// Required by TestCluster.MoveRangeLeaseNonCooperatively.
+					AllowLeaseRequestProposalsWhenNotLeader: true,
+				},
+				Server: &server.TestingKnobs{
+					ClockSource: manual.UnixNano,
+				},
+			},
+		},
+	}
+	tc := testcluster.StartTestCluster(t, 2, args)
+	defer tc.Stopper().Stop(ctx)
+
+	// Create range and upreplicate.
+	key := tc.ScratchRange(t)
+	tc.AddReplicasOrFatal(t, key, tc.Target(1))
+
+	// Perform write.
+	pArgs := putArgs(key, []byte("foo"))
+	_, pErr := kv.SendWrapped(ctx, tc.Servers[0].DistSender(), pArgs)
+	require.Nil(t, pErr)
+
+	// Perform read on write and wait for read to block.
+	type reply struct {
+		resp roachpb.Response
+		err  *roachpb.Error
+	}
+	readResC := make(chan reply)
+	err := tc.Stopper().RunAsyncTask(ctx, "get", func(ctx context.Context) {
+		readCtx := context.WithValue(ctx, magicKey{}, struct{}{})
+		gArgs := getArgs(key)
+		resp, pErr := kv.SendWrapped(readCtx, tc.Servers[0].DistSender(), gArgs)
+		readResC <- reply{resp, pErr}
+	})
+	require.NoError(t, err)
+	delayReadC <- struct{}{}
+
+	// Transfer leaseholder to other store.
+	rangeDesc, err := tc.LookupRange(key)
+	require.NoError(t, err)
+	repl, err := tc.GetFirstStoreFromServer(t, 0).GetReplica(rangeDesc.RangeID)
+	require.NoError(t, err)
+	err = tc.MoveRangeLeaseNonCooperatively(rangeDesc, tc.Target(1), manual)
+	require.NoError(t, err)
+
+	// Remove first store from raft group.
+	tc.RemoveReplicasOrFatal(t, key, tc.Target(0))
+
+	// This is a bit iffy. We want to make sure that, in the buggy case, we
+	// will typically fail (i.e. the read returns empty because the replica was
+	// removed). However, in the non-buggy case the in-flight read request will
+	// be holding readOnlyCmdMu until evaluated, blocking the replica removal,
+	// so waiting for replica removal would deadlock. We therefore take the
+	// easy way out by starting an async replica GC and sleeping for a bit.
+	err = tc.Stopper().RunAsyncTask(ctx, "replicaGC", func(ctx context.Context) {
+		assert.NoError(t, tc.GetFirstStoreFromServer(t, 0).ManualReplicaGC(repl))
+	})
+	require.NoError(t, err)
+	time.Sleep(500 * time.Millisecond)
+
+	// Allow read to resume. Should return "foo".
+	close(delayReadC)
+	r := <-readResC
+	require.Nil(t, r.err)
+	require.NotNil(t, r.resp)
+	require.NotNil(t, r.resp.(*roachpb.GetResponse).Value)
+	val, err := r.resp.(*roachpb.GetResponse).Value.GetBytes()
+	require.NoError(t, err)
+	require.Equal(t, []byte("foo"), val)
 }

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -256,7 +256,8 @@ type Replica struct {
 		syncutil.RWMutex
 		// The destroyed status of a replica indicating if it's alive, corrupt,
 		// scheduled for destruction or has been GCed.
-		// destroyStatus should only be set while also holding the raftMu.
+		// destroyStatus should only be set while also holding the raftMu and
+		// readOnlyCmdMu.
 		destroyStatus
 		// Is the range quiescent? Quiescent ranges are not Tick()'d and unquiesce
 		// whenever a Raft operation is performed.

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -655,11 +655,13 @@ func (b *replicaAppBatch) runPreApplyTriggersAfterStagingWriteBatch(
 		// We mark the replica as destroyed so that new commands are not
 		// accepted. This destroy status will be detected after the batch
 		// commits by handleMergeResult() to finish the removal.
+		rhsRepl.readOnlyCmdMu.Lock()
 		rhsRepl.mu.Lock()
 		rhsRepl.mu.destroyStatus.Set(
 			roachpb.NewRangeNotFoundError(rhsRepl.RangeID, rhsRepl.store.StoreID()),
 			destroyReasonRemoved)
 		rhsRepl.mu.Unlock()
+		rhsRepl.readOnlyCmdMu.Unlock()
 
 		// Use math.MaxInt32 (mergedTombstoneReplicaID) as the nextReplicaID as an
 		// extra safeguard against creating new replicas of the RHS. This isn't
@@ -740,11 +742,13 @@ func (b *replicaAppBatch) runPreApplyTriggersAfterStagingWriteBatch(
 		//
 		// NB: we must be holding the raftMu here because we're in the midst of
 		// application.
+		b.r.readOnlyCmdMu.Lock()
 		b.r.mu.Lock()
 		b.r.mu.destroyStatus.Set(
 			roachpb.NewRangeNotFoundError(b.r.RangeID, b.r.store.StoreID()),
 			destroyReasonRemoved)
 		b.r.mu.Unlock()
+		b.r.readOnlyCmdMu.Unlock()
 		b.changeRemovesReplica = true
 
 		// Delete all of the local data. We're going to delete the hard state too.

--- a/pkg/kv/kvserver/replica_corruption.go
+++ b/pkg/kv/kvserver/replica_corruption.go
@@ -48,6 +48,8 @@ func (r *Replica) maybeSetCorrupt(ctx context.Context, pErr *roachpb.Error) *roa
 func (r *Replica) setCorruptRaftMuLocked(
 	ctx context.Context, cErr *roachpb.ReplicaCorruptionError,
 ) *roachpb.Error {
+	r.readOnlyCmdMu.Lock()
+	defer r.readOnlyCmdMu.Unlock()
 	r.mu.Lock()
 	defer r.mu.Unlock()
 

--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -203,8 +203,6 @@ func (r *Replica) destroyRaftMuLocked(ctx context.Context, nextReplicaID roachpb
 // is one, and removes the in-memory raft state.
 func (r *Replica) disconnectReplicationRaftMuLocked(ctx context.Context) {
 	r.raftMu.AssertHeld()
-	r.readOnlyCmdMu.Lock()
-	defer r.readOnlyCmdMu.Unlock()
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	// NB: In the very rare scenario that we're being removed but currently

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -1028,11 +1028,13 @@ func (r *Replica) clearSubsumedReplicaDiskData(
 		// We mark the replica as destroyed so that new commands are not
 		// accepted. This destroy status will be detected after the batch
 		// commits by clearSubsumedReplicaInMemoryData() to finish the removal.
+		sr.readOnlyCmdMu.Lock()
 		sr.mu.Lock()
 		sr.mu.destroyStatus.Set(
 			roachpb.NewRangeNotFoundError(sr.RangeID, sr.store.StoreID()),
 			destroyReasonRemoved)
 		sr.mu.Unlock()
+		sr.readOnlyCmdMu.Unlock()
 
 		// We have to create an SST for the subsumed replica's range-id local keys.
 		subsumedReplSSTFile := &storage.MemFile{}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -780,6 +780,11 @@ func (sc *StoreConfig) SetDefaults() {
 	}
 }
 
+// GetStoreConfig exposes the config used for this store.
+func (s *Store) GetStoreConfig() *StoreConfig {
+	return &s.cfg
+}
+
 // LeaseExpiration returns an int64 to increment a manual clock with to
 // make sure that all active range leases expire.
 func (sc *StoreConfig) LeaseExpiration() int64 {

--- a/pkg/kv/kvserver/store_create_replica.go
+++ b/pkg/kv/kvserver/store_create_replica.go
@@ -159,6 +159,9 @@ func (s *Store) tryGetOrCreateReplica(
 	repl.creatingReplica = creatingReplica
 	repl.raftMu.Lock() // not unlocked
 
+	// Take out read-only lock. Not strictly necessary here, but follows the
+	// normal lock protocol for destroyStatus.Set().
+	repl.readOnlyCmdMu.Lock()
 	// Install the replica in the store's replica map. The replica is in an
 	// inconsistent state, but nobody will be accessing it while we hold its
 	// locks.
@@ -187,6 +190,7 @@ func (s *Store) tryGetOrCreateReplica(
 	if err := s.addReplicaToRangeMapLocked(repl); err != nil {
 		repl.mu.Unlock()
 		s.mu.Unlock()
+		repl.readOnlyCmdMu.Unlock()
 		repl.raftMu.Unlock()
 		return nil, false, errRetry
 	}
@@ -226,10 +230,12 @@ func (s *Store) tryGetOrCreateReplica(
 		s.mu.Lock()
 		s.unlinkReplicaByRangeIDLocked(rangeID)
 		s.mu.Unlock()
+		repl.readOnlyCmdMu.Unlock()
 		repl.raftMu.Unlock()
 		return nil, false, err
 	}
 	repl.mu.Unlock()
+	repl.readOnlyCmdMu.Unlock()
 	return repl, true, nil
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -228,6 +228,10 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 			return nil, errors.Wrap(err, "instantiating clock source")
 		}
 		clock = hlc.NewClock(clockSrc.UnixNano, time.Duration(cfg.MaxOffset))
+	} else if cfg.TestingKnobs.Server != nil &&
+		cfg.TestingKnobs.Server.(*TestingKnobs).ClockSource != nil {
+		clock = hlc.NewClock(cfg.TestingKnobs.Server.(*TestingKnobs).ClockSource,
+			time.Duration(cfg.MaxOffset))
 	} else {
 		clock = hlc.NewClock(hlc.UnixNano, time.Duration(cfg.MaxOffset))
 	}

--- a/pkg/server/testing_knobs.go
+++ b/pkg/server/testing_knobs.go
@@ -73,6 +73,9 @@ type TestingKnobs struct {
 	// TODO(irfansharif): Update users of this testing knob to use the
 	// appropriate clusterversion.Handle instead.
 	BinaryVersionOverride roachpb.Version
+	// Clock Source used to an inject a custom clock for testing the server. It is
+	// typically either an hlc.HybridManualClock or hlc.ManualClock.
+	ClockSource func() int64
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -11,6 +11,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -1270,9 +1271,6 @@ func (ts *TestServer) ForceTableGC(
 
 // ScratchRangeEx splits off a range suitable to be used as KV scratch space.
 // (it doesn't overlap system spans or SQL tables).
-//
-// Calling this multiple times is undefined (but see TestCluster.ScratchRange()
-// which is idempotent).
 func (ts *TestServer) ScratchRangeEx() (roachpb.RangeDescriptor, error) {
 	scratchKey := keys.TableDataMax
 	_, rngDesc, err := ts.SplitRange(scratchKey)
@@ -1290,6 +1288,18 @@ func (ts *TestServer) ScratchRange() (roachpb.Key, error) {
 		return nil, err
 	}
 	return desc.StartKey.AsRawKey(), nil
+}
+
+// ScratchRangeWithExpirationLease is like ScratchRange but creates a range with
+// an expiration based lease.
+func (ts *TestServer) ScratchRangeWithExpirationLease() (roachpb.Key, error) {
+	scratchKey := roachpb.Key(bytes.Join([][]byte{keys.SystemPrefix,
+		roachpb.RKey("\x00aaa-testing")}, nil))
+	_, _, err := ts.SplitRange(scratchKey)
+	if err != nil {
+		return nil, err
+	}
+	return scratchKey, nil
 }
 
 // MetricsRecorder is part of TestServerInterface.

--- a/pkg/testutils/serverutils/test_cluster_shim.go
+++ b/pkg/testutils/serverutils/test_cluster_shim.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
@@ -104,6 +105,21 @@ type TestClusterInterface interface {
 	// new lease holder).
 	TransferRangeLease(
 		rangeDesc roachpb.RangeDescriptor, dest roachpb.ReplicationTarget,
+	) error
+
+	// MoveRangeLeaseNonCooperatively performs a non-cooperative transfer of the
+	// lease for a range from whoever has it to a particular store. That store
+	// must already have a replica of the range. If that replica already has the
+	// (active) lease, this method is a no-op.
+	//
+	// The transfer is non-cooperative in that the lease is made to expire by
+	// advancing the manual clock. The target is then instructed to acquire the
+	// ownerless lease. Most tests should use the cooperative version of this
+	// method, TransferRangeLease.
+	MoveRangeLeaseNonCooperatively(
+		rangeDesc roachpb.RangeDescriptor,
+		dest roachpb.ReplicationTarget,
+		manual *hlc.HybridManualClock,
 	) error
 
 	// LookupRange returns the descriptor of the range containing key.

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -119,6 +119,9 @@ type TestServerInterface interface {
 	// interface{}.
 	NodeLiveness() interface{}
 
+	// HeartbeatNodeLiveness heartbeats the server's NodeLiveness record.
+	HeartbeatNodeLiveness() error
+
 	// SetDistSQLSpanResolver changes the SpanResolver used for DistSQL inside the
 	// server's executor. The argument must be a physicalplan.SpanResolver
 	// instance.

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -655,7 +656,7 @@ func (tc *TestCluster) RemoveReplicasOrFatal(
 	return desc
 }
 
-// TransferRangeLease is part of the TestServerInterface.
+// TransferRangeLease is part of the TestClusterInterface.
 func (tc *TestCluster) TransferRangeLease(
 	rangeDesc roachpb.RangeDescriptor, dest roachpb.ReplicationTarget,
 ) error {
@@ -665,6 +666,93 @@ func (tc *TestCluster) TransferRangeLease(
 		return errors.Wrapf(err, "%q: transfer lease unexpected error", rangeDesc.StartKey)
 	}
 	return nil
+}
+
+// MoveRangeLeaseNonCooperatively is part of the TestClusterInterface.
+func (tc *TestCluster) MoveRangeLeaseNonCooperatively(
+	rangeDesc roachpb.RangeDescriptor, dest roachpb.ReplicationTarget, manual *hlc.HybridManualClock,
+) error {
+	destServer, err := tc.findMemberServer(dest.StoreID)
+	if err != nil {
+		return err
+	}
+	destStore, err := destServer.Stores().GetStore(dest.StoreID)
+	if err != nil {
+		return err
+	}
+
+	for i, srv := range tc.Servers {
+		if srv.NodeID() == destServer.NodeID() {
+			knobs := tc.serverArgs[i].Knobs.Store.(*kvserver.StoreTestingKnobs)
+			if !knobs.AllowLeaseRequestProposalsWhenNotLeader {
+				// Without this knob, we'd have to architect a Raft leadership change
+				// too in order to let the replica get the lease. It's easier to just
+				// require that callers set it.
+				return errors.Errorf("must set StoreTestingKnobs.AllowLeaseRequestProposalsWhenNotLeader")
+			}
+			break
+		}
+	}
+
+	// We are going to advance the manual clock so that the current lease
+	// expires and then issue a request to the target in hopes that it grabs the
+	// lease. But it is possible that another replica grabs the lease before us
+	// when it's up for grabs. To handle that case, we wrap the entire operation
+	// in an outer retry loop.
+	const retryDur = testutils.DefaultSucceedsSoonDuration
+	return retry.ForDuration(retryDur, func() error {
+		// Find the current lease.
+		prevLease, _, err := tc.FindRangeLease(rangeDesc, nil /* hint */)
+		if err != nil {
+			return err
+		}
+		if prevLease.Replica.StoreID == dest.StoreID {
+			return nil
+		}
+
+		// Advance the manual clock past the lease's expiration.
+		lhStore, err := tc.findMemberStore(prevLease.Replica.StoreID)
+		if err != nil {
+			return err
+		}
+		manual.Increment(lhStore.GetStoreConfig().LeaseExpiration())
+
+		// Heartbeat the destination server's liveness record so that if we are
+		// attempting to acquire an epoch-based lease, the server will be live.
+		err = destServer.HeartbeatNodeLiveness()
+		if err != nil {
+			return err
+		}
+
+		// Issue a request to the target replica, which should notice that the
+		// old lease has expired and that it can acquire the lease.
+		var newLease *roachpb.Lease
+		ctx := context.Background()
+		req := &roachpb.LeaseInfoRequest{
+			RequestHeader: roachpb.RequestHeader{
+				Key: rangeDesc.StartKey.AsRawKey(),
+			},
+		}
+		h := roachpb.Header{RangeID: rangeDesc.RangeID}
+		reply, pErr := kv.SendWrappedWith(ctx, destStore, h, req)
+		if pErr != nil {
+			log.Infof(ctx, "LeaseInfoRequest failed: %v", pErr)
+			if lErr, ok := pErr.GetDetail().(*roachpb.NotLeaseHolderError); ok && lErr.Lease != nil {
+				newLease = lErr.Lease
+			} else {
+				return pErr.GoError()
+			}
+		} else {
+			newLease = &reply.(*roachpb.LeaseInfoResponse).Lease
+		}
+
+		// Is the lease in the right place?
+		if newLease.Replica.StoreID != dest.StoreID {
+			return errors.Errorf("LeaseInfoRequest succeeded, "+
+				"but lease in wrong location, want %v, got %v", dest, newLease.Replica)
+		}
+		return nil
+	})
 }
 
 // FindRangeLease is similar to FindRangeLeaseHolder but returns a Lease proto
@@ -687,15 +775,9 @@ func (tc *TestCluster) FindRangeLease(
 
 	// Find the server indicated by the hint and send a LeaseInfoRequest through
 	// it.
-	var hintServer *server.TestServer
-	for _, s := range tc.Servers {
-		if s.GetNode().Descriptor.NodeID == hint.NodeID {
-			hintServer = s
-			break
-		}
-	}
-	if hintServer == nil {
-		return roachpb.Lease{}, hlc.Timestamp{}, errors.Errorf("bad hint: %+v; no such node", hint)
+	hintServer, err := tc.findMemberServer(hint.StoreID)
+	if err != nil {
+		return roachpb.Lease{}, hlc.Timestamp{}, errors.Wrapf(err, "bad hint: %+v; no such node", hint)
 	}
 
 	return hintServer.GetRangeLease(context.TODO(), rangeDesc.StartKey.AsRawKey())
@@ -783,6 +865,16 @@ func (tc *TestCluster) WaitForSplitAndInitialization(startKey roachpb.Key) error
 		}
 		return nil
 	})
+}
+
+// findMemberServer returns the server containing a given store.
+func (tc *TestCluster) findMemberServer(storeID roachpb.StoreID) (*server.TestServer, error) {
+	for _, server := range tc.Servers {
+		if server.Stores().HasStore(storeID) {
+			return server, nil
+		}
+	}
+	return nil, errors.Errorf("store not found")
 }
 
 // findMemberStore returns the store containing a given replica.
@@ -997,6 +1089,11 @@ func (tc *TestCluster) GetFirstStoreFromServer(t testing.TB, server int) *kvserv
 		t.Fatal(pErr)
 	}
 	return store
+}
+
+// HeartbeatNodeLiveness sends a liveness heartbeat on a particular store.
+func (tc *TestCluster) HeartbeatNodeLiveness(storeIdx int) error {
+	return tc.Servers[storeIdx].HeartbeatNodeLiveness()
 }
 
 type testClusterFactoryImpl struct{}

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -50,7 +50,6 @@ type TestCluster struct {
 	Conns           []*gosql.DB
 	stopper         *stop.Stopper
 	replicationMode base.TestClusterReplicationMode
-	scratchRangeKey roachpb.Key
 	mu              struct {
 		syncutil.Mutex
 		serverStoppers []*stop.Stopper
@@ -730,14 +729,21 @@ func (tc *TestCluster) FindRangeLeaseHolder(
 // kv scratch space (it doesn't overlap system spans or SQL tables). The range
 // is lazily split off on the first call to ScratchRange.
 func (tc *TestCluster) ScratchRange(t testing.TB) roachpb.Key {
-	if tc.scratchRangeKey != nil {
-		return tc.scratchRangeKey
-	}
 	scratchKey, err := tc.Servers[0].ScratchRange()
 	if err != nil {
 		t.Fatal(err)
 	}
-	tc.scratchRangeKey = scratchKey
+	return scratchKey
+}
+
+// ScratchRangeWithExpirationLease returns the start key of a span of keyspace
+// suitable for use as kv scratch space and that has an expiration based lease.
+// The range is lazily split off on the first call to ScratchRangeWithExpirationLease.
+func (tc *TestCluster) ScratchRangeWithExpirationLease(t testing.TB) roachpb.Key {
+	scratchKey, err := tc.Servers[0].ScratchRangeWithExpirationLease()
+	if err != nil {
+		t.Fatal(err)
+	}
 	return scratchKey
 }
 

--- a/pkg/util/hlc/hlc.go
+++ b/pkg/util/hlc/hlc.go
@@ -122,26 +122,40 @@ func (m *ManualClock) Set(nanos int64) {
 // HybridManualClock is a convenience type to facilitate
 // creating a hybrid logical clock whose physical clock
 // ticks with the wall clock, but that can be moved arbitrarily
-// into the future. HybridManualClock is thread safe.
+// into the future or paused. HybridManualClock is thread safe.
 type HybridManualClock struct {
 	nanos         int64
 	physicalClock func() int64
+	// nanosAtPause records the timestamp of the clock if it was paused. A 0 value
+	// indicates the clock was never paused.
+	nanosAtPause int64
 }
 
 // NewHybridManualClock returns a new instance, initialized with
 // specified timestamp.
 func NewHybridManualClock() *HybridManualClock {
-	return &HybridManualClock{nanos: 0, physicalClock: UnixNano}
+	return &HybridManualClock{nanos: 0, physicalClock: UnixNano, nanosAtPause: 0}
 }
 
 // UnixNano returns the underlying hybrid manual clock's timestamp.
 func (m *HybridManualClock) UnixNano() int64 {
-	return atomic.LoadInt64(&m.nanos) + m.physicalClock()
+	nanosAtPause := atomic.LoadInt64(&m.nanosAtPause)
+	nanos := atomic.LoadInt64(&m.nanos)
+	if nanosAtPause > 0 {
+		return nanos + nanosAtPause
+	}
+	return nanos + m.physicalClock()
 }
 
 // Increment atomically increments the hybrid manual clock's timestamp.
 func (m *HybridManualClock) Increment(incr int64) {
 	atomic.AddInt64(&m.nanos, incr)
+}
+
+// Pause pauses the hybrid manual clock and forces it to always return the
+// current timestamp.
+func (m *HybridManualClock) Pause() {
+	atomic.StoreInt64(&m.nanosAtPause, m.physicalClock())
 }
 
 // UnixNano returns the local machine's physical nanosecond

--- a/pkg/util/hlc/hlc.go
+++ b/pkg/util/hlc/hlc.go
@@ -124,38 +124,49 @@ func (m *ManualClock) Set(nanos int64) {
 // ticks with the wall clock, but that can be moved arbitrarily
 // into the future or paused. HybridManualClock is thread safe.
 type HybridManualClock struct {
-	nanos         int64
 	physicalClock func() int64
-	// nanosAtPause records the timestamp of the clock if it was paused. A 0 value
-	// indicates the clock was never paused.
-	nanosAtPause int64
+	mu            struct {
+		syncutil.RWMutex
+		// nanos, if not 0, is the amount of time the clock was manually incremented
+		// by; it is added to physicalClock.
+		nanos int64
+		// nanosAtPause records the timestamp of the physical clock when it gets
+		// paused. 0 means that the clock is not paused.
+		nanosAtPause int64
+	}
 }
 
 // NewHybridManualClock returns a new instance, initialized with
 // specified timestamp.
 func NewHybridManualClock() *HybridManualClock {
-	return &HybridManualClock{nanos: 0, physicalClock: UnixNano, nanosAtPause: 0}
+	return &HybridManualClock{physicalClock: UnixNano}
 }
 
 // UnixNano returns the underlying hybrid manual clock's timestamp.
 func (m *HybridManualClock) UnixNano() int64 {
-	nanosAtPause := atomic.LoadInt64(&m.nanosAtPause)
-	nanos := atomic.LoadInt64(&m.nanos)
+	m.mu.RLock()
+	nanosAtPause := m.mu.nanosAtPause
+	nanos := m.mu.nanos
+	m.mu.RUnlock()
 	if nanosAtPause > 0 {
 		return nanos + nanosAtPause
 	}
 	return nanos + m.physicalClock()
 }
 
-// Increment atomically increments the hybrid manual clock's timestamp.
-func (m *HybridManualClock) Increment(incr int64) {
-	atomic.AddInt64(&m.nanos, incr)
+// Increment increments the hybrid manual clock's timestamp.
+func (m *HybridManualClock) Increment(nanos int64) {
+	m.mu.Lock()
+	m.mu.nanos += nanos
+	m.mu.Unlock()
 }
 
-// Pause pauses the hybrid manual clock and forces it to always return the
-// current timestamp.
+// Pause pauses the hybrid manual clock; the passage of time no longer causes
+// the clock to tick. Increment can still be used, though.
 func (m *HybridManualClock) Pause() {
-	atomic.StoreInt64(&m.nanosAtPause, m.physicalClock())
+	m.mu.Lock()
+	m.mu.nanosAtPause = m.physicalClock()
+	m.mu.Unlock()
 }
 
 // UnixNano returns the local machine's physical nanosecond

--- a/pkg/util/hlc/hlc.go
+++ b/pkg/util/hlc/hlc.go
@@ -124,8 +124,7 @@ func (m *ManualClock) Set(nanos int64) {
 // ticks with the wall clock, but that can be moved arbitrarily
 // into the future or paused. HybridManualClock is thread safe.
 type HybridManualClock struct {
-	physicalClock func() int64
-	mu            struct {
+	mu struct {
 		syncutil.RWMutex
 		// nanos, if not 0, is the amount of time the clock was manually incremented
 		// by; it is added to physicalClock.
@@ -139,7 +138,7 @@ type HybridManualClock struct {
 // NewHybridManualClock returns a new instance, initialized with
 // specified timestamp.
 func NewHybridManualClock() *HybridManualClock {
-	return &HybridManualClock{physicalClock: UnixNano}
+	return &HybridManualClock{}
 }
 
 // UnixNano returns the underlying hybrid manual clock's timestamp.
@@ -151,7 +150,7 @@ func (m *HybridManualClock) UnixNano() int64 {
 	if nanosAtPause > 0 {
 		return nanos + nanosAtPause
 	}
-	return nanos + m.physicalClock()
+	return nanos + UnixNano()
 }
 
 // Increment increments the hybrid manual clock's timestamp.
@@ -165,7 +164,7 @@ func (m *HybridManualClock) Increment(nanos int64) {
 // the clock to tick. Increment can still be used, though.
 func (m *HybridManualClock) Pause() {
 	m.mu.Lock()
-	m.mu.nanosAtPause = m.physicalClock()
+	m.mu.nanosAtPause = UnixNano()
 	m.mu.Unlock()
 }
 

--- a/pkg/util/hlc/hlc.go
+++ b/pkg/util/hlc/hlc.go
@@ -119,6 +119,31 @@ func (m *ManualClock) Set(nanos int64) {
 	atomic.StoreInt64(&m.nanos, nanos)
 }
 
+// HybridManualClock is a convenience type to facilitate
+// creating a hybrid logical clock whose physical clock
+// ticks with the wall clock, but that can be moved arbitrarily
+// into the future. HybridManualClock is thread safe.
+type HybridManualClock struct {
+	nanos         int64
+	physicalClock func() int64
+}
+
+// NewHybridManualClock returns a new instance, initialized with
+// specified timestamp.
+func NewHybridManualClock() *HybridManualClock {
+	return &HybridManualClock{nanos: 0, physicalClock: UnixNano}
+}
+
+// UnixNano returns the underlying hybrid manual clock's timestamp.
+func (m *HybridManualClock) UnixNano() int64 {
+	return atomic.LoadInt64(&m.nanos) + m.physicalClock()
+}
+
+// Increment atomically increments the hybrid manual clock's timestamp.
+func (m *HybridManualClock) Increment(incr int64) {
+	atomic.AddInt64(&m.nanos, incr)
+}
+
 // UnixNano returns the local machine's physical nanosecond
 // unix epoch timestamp as a convenience to create a HLC via
 // c := hlc.NewClock(hlc.UnixNano, ...).

--- a/pkg/util/hlc/hlc_test.go
+++ b/pkg/util/hlc/hlc_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type Event uint8
@@ -354,6 +355,24 @@ func TestExampleManualClock(t *testing.T) {
 	if wallNanos := c.Now().WallTime; wallNanos != 20 {
 		t.Fatalf("unexpected wall time: %d", wallNanos)
 	}
+}
+
+// TestHybridManualClock test the basic functionality of the
+// TestHybridManualClock.
+func TestHybridManualClock(t *testing.T) {
+	m := NewHybridManualClock()
+	c := NewClock(m.UnixNano, time.Nanosecond)
+
+	// We do a two sided test to make sure that the physical clock matches
+	// the hybrid value. Since we cant pull a value off both clocks at the same
+	// time, we use two LessOrEqual comparisons with reverse order, to establish
+	// that the values are roughly equal.
+	require.LessOrEqual(t, c.Now().WallTime, UnixNano())
+	require.LessOrEqual(t, UnixNano(), c.Now().WallTime)
+
+	m.Increment(10)
+	require.LessOrEqual(t, c.Now().WallTime, UnixNano()+10)
+	require.LessOrEqual(t, UnixNano()+10, c.Now().WallTime)
 }
 
 func TestHLCMonotonicityCheck(t *testing.T) {

--- a/pkg/util/hlc/hlc_test.go
+++ b/pkg/util/hlc/hlc_test.go
@@ -375,6 +375,23 @@ func TestHybridManualClock(t *testing.T) {
 	require.LessOrEqual(t, UnixNano()+10, c.Now().WallTime)
 }
 
+// TestHybridManualClockPause test the Pause() functionality of the
+// HybridManualClock.
+func TestHybridManualClockPause(t *testing.T) {
+	m := NewHybridManualClock()
+	c := NewClock(m.UnixNano, time.Nanosecond)
+	now := c.Now().WallTime
+	time.Sleep(10 * time.Millisecond)
+	require.Less(t, now, c.Now().WallTime)
+	m.Pause()
+	now = c.Now().WallTime
+	require.Equal(t, now, c.Now().WallTime)
+	time.Sleep(10 * time.Millisecond)
+	require.Equal(t, now, c.Now().WallTime)
+	m.Increment(10)
+	require.Equal(t, now+10, c.Now().WallTime)
+}
+
 func TestHLCMonotonicityCheck(t *testing.T) {
 	m := NewManualClock(100000)
 	c := NewClock(m.UnixNano, 100*time.Nanosecond)


### PR DESCRIPTION
Backport 1/1 commits from #64324. Also backport necessary test infrastructure from #59059, #59086 (partial), #59333 (partial), and #64242.

/cc @cockroachdb/release @cockroachdb/kv

---

Replica removal did not synchronize with in-flight read-only requests,
which could cause them to be evaluated on a removed (empty) replica,
returning an empty result.

This patch fixes the problem by locking `Replica.readOnlyCmdMu` during
replica removal, thus either waiting for read-only requests to complete
or not evaluating them.

Resolves #64325.

Release note (bug fix): Fixed a race condition where read-only requests
during replica removal (e.g. during range merges or rebalancing) could
be evaluated on the removed replica, returning an empty result.